### PR TITLE
test: don't remove empty.txt on win32

### DIFF
--- a/test/simple/test-net-pipe-connect-errors.js
+++ b/test/simple/test-net-pipe-connect-errors.js
@@ -42,19 +42,20 @@ if (process.platform === 'win32') {
   // use common.PIPE to ensure we stay within POSIX socket path length
   // restrictions, even on CI
   emptyTxt = common.PIPE + '.txt';
+
+  function cleanup() {
+    try {
+      fs.unlinkSync(emptyTxt);
+    } catch (e) {
+      if (e.code != 'ENOENT')
+        throw e;
+    }
+  }
+  process.on('exit', cleanup);
+  cleanup();
+  fs.writeFileSync(emptyTxt, '');
 }
 
-function cleanup() {
-  try {
-    fs.unlinkSync(emptyTxt);
-  } catch (e) {
-    if (e.code != 'ENOENT')
-      throw e;
-  }
-}
-process.on('exit', cleanup);
-cleanup();
-fs.writeFileSync(emptyTxt, '');
 var notSocketClient = net.createConnection(emptyTxt, function() {
   assert.ok(false);
 });


### PR DESCRIPTION
Take 3: on win32 we use empty.txt in the fixtures directory, otherwise we use a file constructed specifically for this test due to POSIX socket path length limitations, in which case we need to do appropriate cleanup. Cleaning up empty.txt in fixtures causes downstream problems for other tests using it (currently the next test is test-zlib).
