### PR TITLE
modules: adding load linked modules feature

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -339,6 +339,7 @@ typedef void (*addon_context_register_func)(
     void* priv);
 
 #define NM_F_BUILTIN 0x01
+#define NM_F_LINKED  0x02
 
 struct node_module {
   int nm_version;
@@ -353,6 +354,7 @@ struct node_module {
 };
 
 node_module* get_builtin_module(const char *name);
+node_module* get_linked_module(const char *name);
 
 extern "C" NODE_EXTERN void node_module_register(void* mod);
 


### PR DESCRIPTION
 _refiling [PR from node-fwd](https://github.com/node-forward/node/pull/49)_
- introduced NM_F_LINKED flag to identify linked modules
- setting node_is_initialized after calling V8::Initialize in order to
  make the right decision during initial module registration
- introduced modlist_linked in order to track modules that were
  pre-registered in order to complete it once node is initialized
- completing registration of linked module similarly to the way it's
  done inside DLOpen
