### PR TITLE
test: extend timeout for failure on cluster worker init test

### DIFF
--- a/test/simple/test-child-process-execsync.js
+++ b/test/simple/test-child-process-execsync.js
@@ -28,7 +28,7 @@ var execSync = require('child_process').execSync;
 var execFileSync = require('child_process').execFileSync;
 
 var TIMER = 200;
-var SLEEP = 1000;
+var SLEEP = 2000;
 
 var start = Date.now();
 var err;

--- a/test/simple/test-cluster-worker-init.js
+++ b/test/simple/test-cluster-worker-init.js
@@ -33,7 +33,7 @@ if (cluster.isMaster) {
   var worker = cluster.fork();
   var timer = setTimeout(function() {
     assert(false, 'message not received');
-  }, 1000);
+  }, 5000);
 
   timer.unref();
 


### PR DESCRIPTION
Blame Windows, Debug builds are so slow, this is one of a few intermittent timing-related failures I'm trying to squash.
