### PR TITLE
test: increase --stack-size to prevent child process failure on ARM

### DIFF
--- a/test/simple/test-child-process-fork-exec-argv.js
+++ b/test/simple/test-child-process-fork-exec-argv.js
@@ -31,7 +31,7 @@ if (process.argv[2] === 'fork') {
 } else if (process.argv[2] === 'child') {
   fork(__filename, ['fork']);
 } else {
-  var execArgv = ['--harmony_proxies', '--stack-size=64'];
+  var execArgv = ['--harmony_proxies', '--stack-size=256'];
   var args = [__filename, 'child', 'arg0'];
 
   var child = spawn(process.execPath, execArgv.concat(args));

--- a/test/simple/test-process-exec-argv.js
+++ b/test/simple/test-process-exec-argv.js
@@ -25,7 +25,7 @@ var spawn = require('child_process').spawn;
 if (process.argv[2] === 'child') {
   process.stdout.write(JSON.stringify(process.execArgv));
 } else {
-  var execArgv = ['--harmony_proxies', '--stack-size=64'];
+  var execArgv = ['--harmony_proxies', '--stack-size=256'];
   var args = [__filename, 'child', 'arg0'];
   var child = spawn(process.execPath, execArgv.concat(args));
   var out = '';


### PR DESCRIPTION
This one is a bit odd as an architecture-specific problem, but on ARM, we get a `Maximum call stack size exceeded` when using require() in the child process. I've bumped it up a bit to avoid the failures so we can test what we are actually after--the stack size isn't actually part of what's being tested.

In both of these tests, the manifestation of the problem is in an `SyntaxError: Unexpected end of input` because the child processes don't end up pushing any stdout so there's nothing to `JSON.parse()`, only stderr with the stack trace.
