### PR TITLE
rename node.js -> io.js

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ property, trademark and high level project questions should move to the
 
 ## CODE CONTRIBUTIONS
 
-The node.js project welcomes new contributors.  This document will guide you
+The io.js project welcomes new contributors.  This document will guide you
 through the process.
 
 
@@ -31,7 +31,7 @@ Now decide if you want your feature or bug fix to go into the master branch
 or the stable branch.  As a rule of thumb, bug fixes go into the stable branch
 while new features go into the master branch.
 
-The stable branch is effectively frozen; patches that change the node.js
+The stable branch is effectively frozen; patches that change the io.js
 API/ABI or affect the run-time behavior of applications get rejected.
 
 The rules for the master branch are less strict; consult the
@@ -41,7 +41,7 @@ In a nutshell, modules are at varying levels of API stability.  Bug fixes are
 always welcome but API or behavioral  changes to modules at stability level 3
 and up are off-limits.
 
-Node.js has several bundled dependencies in the deps/ and the tools/
+io.js has several bundled dependencies in the deps/ and the tools/
 directories that are not part of the project proper.  Any changes to files
 in those directories or its subdirectories should be sent to their respective
 projects.  Do not send your patch to us, we cannot accept it.
@@ -162,6 +162,6 @@ not send out notifications when you add commits.
 [stability index page]: https://github.com/joyent/node/blob/master/doc/api/documentation.markdown
 [issue tracker]: https://github.com/joyent/node/issues
 [node.js mailing list]: http://groups.google.com/group/nodejs
-[IRC]: http://webchat.freenode.net/?channels=node.js
+[IRC]: http://webchat.freenode.net/?channels=io.js
 [project maintainers]: https://github.com/joyent/node/wiki/Project-Organization
 [node-forward discussion repository]: https://github.com/node-forward/discussions/issues


### PR DESCRIPTION
This updates CONTRIBUTING.md to reference io.js, not node.js.  One question though: will we be using the same google group, or should a new one be created?
