### PR TITLE
debugger: use requireRepl() to load debugger repl

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -25,7 +25,8 @@ var util = require('util'),
     path = require('path'),
     net = require('net'),
     vm = require('vm'),
-    repl = require('repl'),
+    module = require('module'),
+    repl = module.requireRepl(),
     inherits = util.inherits,
     assert = require('assert'),
     spawn = require('child_process').spawn;
@@ -776,6 +777,7 @@ function Interface(stdin, stdout, args) {
   if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {
     opts.useColors = false;
   }
+
   this.repl = repl.start(opts);
 
   // Do not print useless warning
@@ -1129,7 +1131,7 @@ Interface.prototype.list = function(delta) {
       if (lineno == 1) {
         // The first line needs to have the module wrapper filtered out of
         // it.
-        var wrapper = require('module').wrapper[0];
+        var wrapper = module.wrapper[0];
         lines[i] = lines[i].slice(wrapper.length);
 
         client.currentSourceColumn -= wrapper.length;

--- a/test/simple/test-repl-tab-complete.js
+++ b/test/simple/test-repl-tab-complete.js
@@ -211,3 +211,18 @@ testMe.complete(' ', function(error, data) {
 testMe.complete('toSt', function(error, data) {
   assert.deepEqual(data, [['toString'], 'toSt']);
 });
+
+// Tab complete provides built in libs for require()
+putIn.run(['.clear']);
+
+testMe.complete('require(\'', function(error, data) {
+  assert.strictEqual(error, null);
+  repl._builtinLibs.forEach(function(lib) {
+    assert.notStrictEqual(data[0].indexOf(lib), -1, lib + ' not found');
+  });
+});
+
+testMe.complete('require(\'n', function(error, data) {
+  assert.strictEqual(error, null);
+  assert.deepEqual(data, [['net'], 'n']);
+});


### PR DESCRIPTION
Currently, the debugger uses `require('repl')` to setup the repl. However, `require.extensions` is not available yet, causing a crash on tab completion of `require('`. This commit uses the `module.requireRepl()` method to bootstrap the repl.

Closes https://github.com/joyent/node/issues/8359.
Same PR on joyent/node -  https://github.com/joyent/node/pull/8784
