### PR TITLE
Deprecate domains

### DIFF
--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -1,6 +1,9 @@
 # Domain
 
-    Stability: 2 - Unstable
+    Stability: 0 - Deprecated
+
+**IMPORTANT:** The domain module is deprecated and may be removed in
+the future.
 
 Domains provide a way to handle multiple different IO operations as a
 single group.  If any of the event emitters or callbacks registered to a

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -52,9 +52,9 @@ process._setupDomainUse(_domain, _domain_flag);
 
 exports.Domain = Domain;
 
-exports.create = exports.createDomain = function() {
+exports.create = exports.createDomain = util.deprecate(function() {
   return new Domain();
-};
+}, 'The domain module is deprecated and may be removed in future versions.');
 
 // it's possible to enter one domain while already inside
 // another one.  the stack is each entered domain.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -50,7 +50,7 @@ var path = require('path');
 var fs = require('fs');
 var rl = require('readline');
 var Console = require('console').Console;
-var domain = require('domain');
+var Domain = require('domain').Domain;
 var debug = util.debuglog('repl');
 
 // If obj.hasOwnProperty has been overridden, then calling
@@ -102,7 +102,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
 
   var self = this;
 
-  self._domain = dom || domain.create();
+  self._domain = dom || new Domain();
 
   self.useGlobal = !!useGlobal;
   self.ignoreUndefined = !!ignoreUndefined;

--- a/test/simple/test-repl-no-deprecation-messages.js
+++ b/test/simple/test-repl-no-deprecation-messages.js
@@ -1,0 +1,35 @@
+// Copyright io.js contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+var child = spawn(process.execPath, [ '-i' ]);
+
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', function (stderr) {
+  assert.equal(stderr, '');
+});
+
+child.stdout.once('data', function () {
+  child.kill('SIGINT');
+});


### PR DESCRIPTION
ref https://github.com/iojs/io.js/issues/66

Also, I did notice that `domain.dispose()` is deprecated but missing a deprecation message. So it includes a commit which fixes it. Please inform me if you want it as a separate pull request.

I've also changed two test assertions. I belive usage of domain in `lib/repl.js` was swallowing the assert errors and that those are currently broken.
