### PR TITLE
fs: fix fd leak on early readstream destroy

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1523,6 +1523,9 @@ ReadStream.prototype.open = function() {
       return;
     }
 
+    if (self.destroyed && !self.closed)
+      self.close()
+
     self.fd = fd;
     self.emit('open', fd);
     // start the flow of data.


### PR DESCRIPTION
Currently the following leaks a file descriptor

``` js
var fs = require('fs')

var rs = fs.createReadStream('my-file.txt')

rs.on('close', function() {
  console.log('i am never fired')
})

rs.destroy()
```

In fact if you call `rs.destroy()` before `open` has been emitted in general the read stream never closes.

This PR fixes that by calling `.close()` when the file descriptor is opened incase the stream has been destroyed in the meanwhile
