### PR TITLE
Add support for building with shared OpenSSL lacking SSLv3.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -326,11 +326,23 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
       return env->ThrowError("SSLv2 methods disabled");
 #endif
     } else if (strcmp(*sslmethod, "SSLv3_method") == 0) {
+#ifndef OPENSSL_NO_SSL3
       method = SSLv3_method();
+#else
+      return env->ThrowError("SSLv3 methods disabled");
+#endif
     } else if (strcmp(*sslmethod, "SSLv3_server_method") == 0) {
+#ifndef OPENSSL_NO_SSL3
       method = SSLv3_server_method();
+#else
+      return env->ThrowError("SSLv3 methods disabled");
+#endif
     } else if (strcmp(*sslmethod, "SSLv3_client_method") == 0) {
+#ifndef OPENSSL_NO_SSL3
       method = SSLv3_client_method();
+#else
+      return env->ThrowError("SSLv3 methods disabled");
+#endif
     } else if (strcmp(*sslmethod, "SSLv23_method") == 0) {
       method = SSLv23_method();
     } else if (strcmp(*sslmethod, "SSLv23_server_method") == 0) {


### PR DESCRIPTION
Some distributions are disabling SSLv3 due to the POODLE attack.  For example, the OpenSSL in Debian experimental has removed support for SSLv3_method and friends.  If OpenSSL has SSLv3 disabled, throw an exception, just like when SSLv2 is disabled.
