### PR TITLE
test-require-resolve: use case insensitive compare

### DIFF
--- a/test/simple/test-require-resolve.js
+++ b/test/simple/test-require-resolve.js
@@ -24,12 +24,15 @@ var fixturesDir = common.fixturesDir;
 var assert = require('assert');
 var path = require('path');
 
-assert.equal(path.join(__dirname, '../fixtures/a.js'),
-             path.normalize(require.resolve('../fixtures/a')));
-assert.equal(path.join(fixturesDir, 'a.js'),
-             path.normalize(require.resolve(path.join(fixturesDir, 'a'))));
-assert.equal(path.join(fixturesDir, 'nested-index', 'one', 'index.js'),
-             path.normalize(require.resolve('../fixtures/nested-index/one')));
+assert.equal(
+    path.join(__dirname, '../fixtures/a.js').toLowerCase(),
+    require.resolve('../fixtures/a').toLowerCase());
+assert.equal(
+    path.join(fixturesDir, 'a.js').toLowerCase(),
+    require.resolve(path.join(fixturesDir, 'a')).toLowerCase());
+assert.equal(
+    path.join(fixturesDir, 'nested-index', 'one', 'index.js').toLowerCase(),
+    require.resolve('../fixtures/nested-index/one').toLowerCase());
 assert.equal('path', require.resolve('path'));
 
 console.log('ok');


### PR DESCRIPTION
This is an alternative fix for the issue that f6e5740 had intended to fix.
It's needed because f6e5740 has been reverted in e24fa83.
See also https://github.com/node-forward/node/issues/20 and #100

@indutny or @bnoordhuis, can I get your review on this?

Because node-forward is closed, here's the text:

---

The patch joyent/node@a05f973 was landed to make some tests pass, but I can't really reconstruct what the motivation was. What I can tell is that the test failure wasn't really related to path.normalize() and path.resolve() [not] changing the drive letter case.

This patch has caused a lot of issues, including joyent/node#7031 and joyent/node#7806 and lots of bikeshedding about whether uppercase is the right case or lowercase.

I propose reverting the offending patch, and just doing what node does everywhere else (which is: path functions don't touch the case) and take another look at the cause of those test failures.
