### PR TITLE
Revert "openssl: don't define SIXTY_FOUR_BIT_LONG on Windows"

### DIFF
--- a/deps/openssl/config/opensslconf.h
+++ b/deps/openssl/config/opensslconf.h
@@ -221,7 +221,7 @@
 # undef SIXTEEN_BIT
 # undef EIGHT_BIT
 # if defined(_M_X64) || defined(__x86_64__)
-#  if !defined(_WIN32) && !defined(_LP64)
+#  if defined(_WIN64) || defined(_LP64)
 #   define SIXTY_FOUR_BIT_LONG
 #  else
 #   define SIXTY_FOUR_BIT


### PR DESCRIPTION
This reverts commit 878cc3e532ec5feb7145ba0523db2c6383df748b.

Reverted for breaking the x86_64 Linux build:

```
In file included from ../deps/openssl/openssl/include/openssl/bn.h:1:0,
                 from ../deps/openssl/openssl/crypto/bn/asm/../bn_lcl.h:115,
                 from ../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:1:
../deps/openssl/openssl/include/openssl/../../crypto/bn/bn.h:813:20: note: previous declaration of 'bn_add_words' was here
 BN_ULONG bn_add_words(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,int num);
                    ^
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:210:15: error: conflicting types for 'bn_sub_words'
 BN_ULONG bn_sub_words (BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,int n)
```

R=@piscisaureus
