### PR TITLE
benchmark: pre-optimize url.parse() before start

### DIFF
--- a/benchmark/url/url.js
+++ b/benchmark/url/url.js
@@ -1,5 +1,6 @@
 var common = require('../common.js');
 var url = require('url');
+var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: 'one two three four five six'.split(' '),
@@ -19,6 +20,14 @@ function main(conf) {
     six: 'https://user:pass@example.com/',
   };
   var input = inputs[type] || '';
+
+  // Force-optimize url.parse() so that the benchmark doesn't get
+  // disrupted by the optimizer kicking in halfway through.
+  for (var name in inputs)
+    url.parse(inputs[name]);
+
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(url.parse)');
 
   bench.start();
   for (var i = 0; i < n; i += 1)


### PR DESCRIPTION
Force V8 to optimize url.parse() before starting the actual benchmark.
Tries to minimize variance between successive runs caused by the
optimizer kicking in at different points.

It does not seem to have much impact, CPU times are roughly the same
before and afterwards; url.parse() quickly plateaus at a local optimum
where most time is spent in V8 builtins, notably Runtime_StringSplit()
and Object::GetElementWithReceiver() calls originating from
deps/v8/src/uri.js, with no recurring optimize/deoptimize cycles that
I could spot.

Still, I don't see any downsides to pre-optimizing the function being
benchmarked so in it goes.

R=@chrisdickinson.  Please ignore the first commit, that's #131 (which is a prerequisite of this PR, however.)
