### PR TITLE
module: fix regression in require ../

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -187,6 +187,10 @@ Module._findPath = function(request, paths) {
     }
 
     if (!filename) {
+      filename = tryPackage(basePath, exts);
+    }
+
+    if (!filename) {
       // try it with each of the extensions at "index"
       filename = tryExtensions(path.resolve(basePath, 'index'), exts);
     }

--- a/test/fixtures/require-bin/bin/req.js
+++ b/test/fixtures/require-bin/bin/req.js
@@ -1,0 +1,1 @@
+module.exports = require('../');

--- a/test/fixtures/require-bin/lib/req.js
+++ b/test/fixtures/require-bin/lib/req.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/test/fixtures/require-bin/package.json
+++ b/test/fixtures/require-bin/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "req",
+  "main": "./lib/req.js"
+}

--- a/test/simple/test-require-extensions-main.js
+++ b/test/simple/test-require-extensions-main.js
@@ -1,0 +1,4 @@
+var common = require('../common');
+var assert = require('assert');
+
+require(common.fixturesDir + '/require-bin/bin/req.js');


### PR DESCRIPTION
Fixes regression in require system that prevented loading relative
packages via main property in package.json where the file is not
index.{ext}. The regression was introduced via cfc1272637dbbd24e79d78c9aafeab67e1ca695d

An example of a package affected by this is `node-gyp`. 
