### PR TITLE
build: fix dtrace-enabled build on os x

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -466,7 +466,7 @@
       'target_name': 'node_dtrace_header',
       'type': 'none',
       'conditions': [
-        [ 'node_use_dtrace=="true" and OS!="mac" and OS!="linux"', {
+        [ 'node_use_dtrace=="true" and OS!="linux"', {
           'actions': [
             {
               'action_name': 'node_dtrace_header',


### PR DESCRIPTION
Commit 691d55f introduces a regression on OS X when dtrace is enabled
(the default.)  This commit rectifies that by removing the erroneous
platform check.

Fixes the following build error:

```
CXX(target) /Users/bnoordhuis/src/iojs/out/Release/obj.target/node/src/node_dtrace.o
../src/node_dtrace.cc:27:10: fatal error: 'node_provider.h' file not found
```

R=@bajtos, /cc @evantorrie
