### PR TITLE
docs: changed example in streams for write() after end()

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -585,11 +585,10 @@ Calling [`write()`][] after calling [`end()`][] will raise an error.
 
 ```javascript
 // write 'hello, ' and then end with 'world!'
-http.createServer(function (req, res) {
-  res.write('hello, ');
-  res.end('world!');
-  // writing more now is not allowed!
-});
+var file = fs.createWriteStream('example.txt');
+file.write('hello, ');
+file.end('world!');
+// writing more now is not allowed!
 ```
 
 #### Event: 'finish'


### PR DESCRIPTION
Currently there's an example using http.ServerResponse stream, which
has a known bug and will not throw an error while writing after end().
Changed to a writable stream from fs which behaves as expected.

fixes https://github.com/joyent/node/issues/8814
