### PR TITLE
fs: deprecate exists() and existsSync()

### DIFF
--- a/benchmark/misc/module-loader.js
+++ b/benchmark/misc/module-loader.js
@@ -56,7 +56,7 @@ function measure(n) {
 }
 
 function rmrf(location) {
-  if (fs.existsSync(location)) {
+  try {
     var things = fs.readdirSync(location);
     things.forEach(function(thing) {
       var cur = path.join(location, thing),
@@ -68,5 +68,7 @@ function rmrf(location) {
       fs.unlinkSync(cur);
     });
     fs.rmdirSync(location);
+  } catch (err) {
+    // Ignore error
   }
 }

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -656,13 +656,13 @@ that leaves you vulnerable to race conditions: another process may remove the
 file between the calls to `fs.exists()` and `fs.open()`.  Just open the file
 and handle the error when it's not there.
 
-`fs.exists()` will be deprecated.
+`fs.exists()` is **deprecated**.
 
 ## fs.existsSync(path)
 
 Synchronous version of `fs.exists`.
 
-`fs.existsSync()` will be deprecated.
+`fs.existsSync()` is **deprecated**.
 
 ## fs.access(path[, mode], callback)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -220,7 +220,7 @@ fs.accessSync = function(path, mode) {
   binding.access(pathModule._makeLong(path), mode);
 };
 
-fs.exists = function(path, callback) {
+fs.exists = util.deprecate(function(path, callback) {
   if (!nullCheck(path, cb)) return;
   var req = new FSReqWrap();
   req.oncomplete = cb;
@@ -228,9 +228,9 @@ fs.exists = function(path, callback) {
   function cb(err, stats) {
     if (callback) callback(err ? false : true);
   }
-};
+}, 'fs.exists() is deprecated. Use fs.access() instead.');
 
-fs.existsSync = function(path) {
+fs.existsSync = util.deprecate(function(path) {
   try {
     nullCheck(path);
     binding.stat(pathModule._makeLong(path));
@@ -238,7 +238,7 @@ fs.existsSync = function(path) {
   } catch (e) {
     return false;
   }
-};
+}, 'fs.existsSync() is deprecated. Use fs.accessSync() instead.');
 
 fs.readFile = function(path, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);

--- a/test/common.js
+++ b/test/common.js
@@ -58,8 +58,11 @@ if (process.env.NODE_COMMON_PIPE) {
   }
 }
 
-if (!fs.existsSync(exports.opensslCli))
+try {
+  fs.accessSync(exports.opensslCli);
+} catch (err) {
   exports.opensslCli = false;
+}
 
 if (process.platform === 'win32') {
   exports.faketimeCli = false;
@@ -319,3 +322,12 @@ exports.isValidHostname = function(str) {
 
   return !!str.match(re) && str.length <= 255;
 }
+
+exports.fileExists = function(pathname) {
+  try {
+    fs.accessSync(pathname);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -19,6 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var common = require('../common');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var assert = require('assert');
@@ -26,7 +27,7 @@ var assert = require('assert');
 var errors = 0;
 
 var enoentPath = 'foo123';
-assert.equal(fs.existsSync(enoentPath), false);
+assert.equal(common.fileExists(enoentPath), false);
 
 var enoentChild = spawn(enoentPath);
 enoentChild.on('error', function (err) {

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -38,7 +38,7 @@ function unlink(pathname) {
 
   fs.mkdir(pathname, function(err) {
     assert.equal(err, null);
-    assert.equal(fs.existsSync(pathname), true);
+    assert.equal(common.fileExists(pathname), true);
     ncalls++;
   });
 
@@ -56,7 +56,7 @@ function unlink(pathname) {
 
   fs.mkdir(pathname, 511 /*=0777*/, function(err) {
     assert.equal(err, null);
-    assert.equal(fs.existsSync(pathname), true);
+    assert.equal(common.fileExists(pathname), true);
     ncalls++;
   });
 
@@ -72,7 +72,7 @@ function unlink(pathname) {
   unlink(pathname);
   fs.mkdirSync(pathname);
 
-  var exists = fs.existsSync(pathname);
+  var exists = common.fileExists(pathname);
   unlink(pathname);
 
   assert.equal(exists, true);

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -54,8 +54,8 @@ fs.symlink(linkData, linkPath, 'junction', function(err) {
 
       fs.unlink(linkPath, function(err) {
         if (err) throw err;
-        assert(!fs.existsSync(linkPath));
-        assert(fs.existsSync(linkData));
+        assert(!common.fileExists(linkPath));
+        assert(common.fileExists(linkData));
         completed++;
       });
     });

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -40,14 +40,14 @@ fs.watchFile(FILENAME, {interval:TIMEOUT - 250}, function(curr, prev) {
   console.log([curr, prev]);
   switch (++nevents) {
   case 1:
-    assert.equal(fs.existsSync(FILENAME), false);
+    assert.equal(common.fileExists(FILENAME), false);
     break;
   case 2:
   case 3:
-    assert.equal(fs.existsSync(FILENAME), true);
+    assert.equal(common.fileExists(FILENAME), true);
     break;
   case 4:
-    assert.equal(fs.existsSync(FILENAME), false);
+    assert.equal(common.fileExists(FILENAME), false);
     fs.unwatchFile(FILENAME);
     break;
   default:

--- a/test/sequential/test-regress-GH-3739.js
+++ b/test/sequential/test-regress-GH-3739.js
@@ -44,17 +44,17 @@ for (var i = 0; i < 50; i++) {
 }
 
 // Test existsSync
-var r = fs.existsSync(dir);
+var r = common.fileExists(dir);
 if (r !== true) {
   cleanup();
-  throw new Error('fs.existsSync returned false');
+  throw new Error('fs.accessSync returned false');
 }
 
 // Text exists
-fs.exists(dir, function(r) {
+fs.access(dir, function(err) {
   cleanup();
-  if (r !== true) {
-    throw new Error('fs.exists reported false');
+  if (err) {
+    throw new Error('fs.access reported false');
   }
 });
 


### PR DESCRIPTION
These methods don't follow standard conventions, and shouldn't be used anyway.

This closes #103
