### PR TITLE
debugger: improve clearBreakpoint error and docs

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -107,7 +107,8 @@ prints the active watchers. To remove a watcher, type
 functions body
 * `setBreakpoint('script.js', 1)`, `sb(...)` - Set breakpoint on first line of
 script.js
-* `clearBreakpoint`, `cb(...)` - Clear breakpoint
+* `clearBreakpoint('script.js', 1)`, `cb(...)` - Clear breakpoint in script.js
+on line 1
 
 It is also possible to set a breakpoint in a file (module) that
 isn't loaded yet:

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1375,9 +1375,7 @@ Interface.prototype.setBreakpoint = function(script, line,
     // setBreakpoint('scriptname')
     if (script != +script && !this.client.scripts[script]) {
       var scripts = this.client.scripts;
-      var keys = Object.keys(scripts);
-      for (var v = 0; v < keys.length; v++) {
-        var id = keys[v];
+      for (var id in scripts) {
         if (scripts[id] &&
             scripts[id].name &&
             scripts[id].name.indexOf(script) !== -1) {
@@ -1452,6 +1450,7 @@ Interface.prototype.clearBreakpoint = function(script, line) {
 
   var ambiguous,
       breakpoint,
+      scriptId,
       index;
 
   this.client.breakpoints.some(function(bp, i) {
@@ -1461,6 +1460,7 @@ Interface.prototype.clearBreakpoint = function(script, line) {
       if (!util.isUndefined(index)) {
         ambiguous = true;
       }
+      scriptId = script;
       if (bp.line === line) {
         index = i;
         breakpoint = bp.id;
@@ -1469,10 +1469,28 @@ Interface.prototype.clearBreakpoint = function(script, line) {
     }
   });
 
+  if (!scriptId && !this.client.scripts[script]) {
+    var scripts = this.client.scripts;
+    for (var id in scripts) {
+      if (scripts[id] &&
+          scripts[id].name &&
+          scripts[id].name.indexOf(script) !== -1) {
+        if (scriptId) {
+          ambiguous = true;
+        }
+        scriptId = id;
+      }
+    }
+  }
+
   if (ambiguous) return this.error('Script name is ambiguous');
 
+  if (util.isUndefined(scriptId)) {
+    return this.error('Script ' + script + ' not found');
+  }
+
   if (util.isUndefined(breakpoint)) {
-    return this.error('Script : ' + script + ' not found');
+    return this.error('Breakpoint not found on line ' + line);
   }
 
   var self = this,


### PR DESCRIPTION
Currently clearBreakpoint error is confusing, it says script not found when there is no breakpoint, also
documentation doesn't include signature for clearBreakpoint.
