### PR TITLE
doc: fix grammar in tls and timers

### DIFF
--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -28,7 +28,7 @@ you can also pass arguments to the callback.
 
 ## clearInterval(intervalObject)
 
-Stops a interval from triggering.
+Stops an interval from triggering.
 
 ## unref()
 

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -221,7 +221,7 @@ automatically set as a listener for the [secureConnection][] event.  The
 
     NOTE: Automatically shared between `cluster` module workers.
 
-  - `sessionIdContext`: A string containing a opaque identifier for session
+  - `sessionIdContext`: A string containing an opaque identifier for session
     resumption. If `requestCert` is `true`, the default is MD5 hash value
     generated from command-line. Otherwise, the default is not provided.
 
@@ -503,7 +503,7 @@ connections using TLS or SSL.
 `function (tlsSocket) {}`
 
 This event is emitted after a new connection has been successfully
-handshaked. The argument is a instance of [tls.TLSSocket][]. It has all the
+handshaked. The argument is an instance of [tls.TLSSocket][]. It has all the
 common stream methods and events.
 
 `socket.authorized` is a boolean value which indicates if the


### PR DESCRIPTION
Replace 'a' with 'an' where appropriate
