### PR TITLE
Fix cpplint warning for src/node_crypto.cc:153   Using sizeof(type).

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -150,8 +150,7 @@ template int SSLWrap<TLSCallbacks>::TLSExtStatusCallback(SSL* s, void* arg);
 
 
 static void crypto_threadid_cb(CRYPTO_THREADID* tid) {
-  static uv_thread_t uv_thread_inhibit_warning;
-  static_assert(sizeof(uv_thread_inhibit_warning) <= sizeof(tid),
+  static_assert(sizeof(uv_thread_t) <= sizeof(tid),
                 "uv_thread_t does not fit in a pointer");
   CRYPTO_THREADID_set_pointer(tid, reinterpret_cast<void*>(uv_thread_self()));
 }


### PR DESCRIPTION
Use sizeof(varname) instead if possible [runtime/sizeof]
