### PR TITLE
doc: Fix v8 doc headings so 'make doc' passes

### DIFF
--- a/doc/api/v8.markdown
+++ b/doc/api/v8.markdown
@@ -6,7 +6,7 @@ This module exposes events and interfaces specific to the version of [V8][]
 built with node.  These interfaces are subject to change by upstream and are
 therefore not covered under the stability index.
 
-### getHeapStatistics()
+## getHeapStatistics()
 
 Returns an object with the following properties
 
@@ -20,7 +20,7 @@ Returns an object with the following properties
 }
 ```
 
-### setFlagsFromString()
+## setFlagsFromString()
 
 Set additional V8 command line flags.  Use with care; changing settings
 after the VM has started may result in unpredictable behavior, including


### PR DESCRIPTION
Previously the code that builds the Table of Contents threw
an exception because of jump from an H1 heading directly to an H3
heading. This happened when running `make doc`.

By changing the H3 heading to an H2, 'make doc' works again. This is
also consistent with other docs like console.markdown which use
H2 for method call documentation.
