### PR TITLE
configure: remove compiler detection

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -9,8 +9,6 @@
     'library%': 'static_library',     # allow override to 'shared_library' for DLL/.so builds
     'component%': 'static_library',   # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
-    'gcc_version%': 'unknown',
-    'clang%': 0,
     'python%': 'python',
 
     'node_tag%': '',
@@ -37,6 +35,11 @@
       }, {
         'OBJ_DIR': '<(PRODUCT_DIR)/obj.target',
         'V8_BASE': '<(PRODUCT_DIR)/obj.target/deps/v8/tools/gyp/libv8_base.a',
+      }],
+      ['OS=="mac"', {
+        'clang%': 1,
+      }, {
+        'clang%': 0,
       }],
     ],
   },

--- a/configure
+++ b/configure
@@ -398,22 +398,6 @@ def host_arch_win():
   return matchup.get(arch, 'ia32')
 
 
-def compiler_version():
-  try:
-    proc = subprocess.Popen(shlex.split(CC) + ['--version'],
-                            stdout=subprocess.PIPE)
-  except WindowsError:
-    return (0, False)
-
-  is_clang = 'clang' in proc.communicate()[0].split('\n')[0]
-
-  proc = subprocess.Popen(shlex.split(CC) + ['-dumpversion'],
-                          stdout=subprocess.PIPE)
-  version = tuple(map(int, proc.communicate()[0].split('.')))
-
-  return (version, is_clang)
-
-
 def configure_arm(o):
   if options.arm_float_abi:
     arm_float_abi = options.arm_float_abi
@@ -454,12 +438,6 @@ def configure_node(o):
 
   if target_arch == 'arm':
     configure_arm(o)
-
-  cc_version, is_clang = compiler_version()
-  o['variables']['clang'] = 1 if is_clang else 0
-
-  if not is_clang and cc_version != 0:
-    o['variables']['gcc_version'] = 10 * cc_version[0] + cc_version[1]
 
   if flavor in ('solaris', 'mac', 'linux', 'freebsd'):
     use_dtrace = not options.without_dtrace


### PR DESCRIPTION
The GCC version is no longer relevant since only 4.8 and newer are supported. It's probably safe to assume clang on mac since V8 does so too.
