### PR TITLE
crypto: add generatePublicKey to ECDH, fix corner cases

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -550,6 +550,18 @@ Format specifies point encoding and can be `'compressed'`, `'uncompressed'`, or
 Encoding can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided,
 then a buffer is returned.
 
+### ECDH.generatePublicKey([encoding[, format]])
+
+Generates public EC Diffie-Hellman key value based on the provided private key
+value. Returns the public key in the specified format and encoding.
+
+Format specifies point encoding and can be `'compressed'`, `'uncompressed'`, or
+`'hybrid'`. If no format is provided - the point will be returned in
+`'uncompressed'` format.
+
+Encoding can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided,
+then a buffer is returned.
+
 ### ECDH.computeSecret(other_public_key[, input_encoding][, output_encoding])
 
 Computes the shared secret using `other_public_key` as the other

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -535,7 +535,7 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
   return this.getPublicKey(encoding, format);
 };
 
-ECDH.prototype.generatePublicKey = function generateKeys(encoding, format) {
+ECDH.prototype.generatePublicKey = function generatePublicKey(encoding, format) {
   this._handle.generatePublicKey();
 
   return this.getPublicKey(encoding, format);

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -535,6 +535,12 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
   return this.getPublicKey(encoding, format);
 };
 
+ECDH.prototype.generatePublicKey = function generateKeys(encoding, format) {
+  this._handle.generatePublicKey();
+
+  return this.getPublicKey(encoding, format);
+};
+
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   var f;
   if (format) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4025,6 +4025,7 @@ void ECDH::Initialize(Environment* env, Handle<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   env->SetProtoMethod(t, "generateKeys", GenerateKeys);
+  env->SetProtoMethod(t, "generatePublicKey", GeneratePublicKey);
   env->SetProtoMethod(t, "computeSecret", ComputeSecret);
   env->SetProtoMethod(t, "getPublicKey", GetPublicKey);
   env->SetProtoMethod(t, "getPrivateKey", GetPrivateKey);
@@ -4062,10 +4063,33 @@ void ECDH::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
 
   if (!EC_KEY_generate_key(ecdh->key_))
     return env->ThrowError("Failed to generate EC_KEY");
-
-  ecdh->generated_ = true;
 }
 
+void ECDH::GeneratePublicKey(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  ECDH* ecdh = Unwrap<ECDH>(args.Holder());
+
+  const BIGNUM* priv = EC_KEY_get0_private_key(ecdh->key_);
+  if (priv == nullptr)
+    return env->ThrowError("Failed to get ECDH private key");
+
+  EC_POINT* pub = EC_POINT_new(ecdh->group_);
+  if (pub == nullptr)
+    return env->ThrowError("Failed to allocate EC_POINT for a public key");
+
+  if(EC_POINT_mul(ecdh->group_, pub, priv, nullptr, nullptr, nullptr) <= 0) {
+    EC_POINT_free(pub);
+    return env->ThrowError("Failed to generate ECDH public key");
+  }
+
+  if(!EC_KEY_set_public_key(ecdh->key_, pub)) {
+    EC_POINT_free(pub);
+    return env->ThrowError("Failed to convert EC_POINT to a public key");
+  }
+
+  EC_POINT_free(pub);
+}
 
 EC_POINT* ECDH::BufferToPoint(char* data, size_t len) {
   EC_POINT* pub;
@@ -4095,7 +4119,6 @@ EC_POINT* ECDH::BufferToPoint(char* data, size_t len) {
   return nullptr;
 }
 
-
 void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -4124,7 +4147,6 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(Buffer::Use(env, out, out_len));
 }
 
-
 void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -4132,9 +4154,6 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
-
-  if (!ecdh->generated_)
-    return env->ThrowError("You should generate ECDH keys first");
 
   const EC_POINT* pub = EC_KEY_get0_public_key(ecdh->key_);
   if (pub == nullptr)
@@ -4167,9 +4186,6 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
-
-  if (!ecdh->generated_)
-    return env->ThrowError("You should generate ECDH keys first");
 
   const BIGNUM* b = EC_KEY_get0_private_key(ecdh->key_);
   if (b == nullptr)
@@ -4224,7 +4240,7 @@ void ECDH::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   int r = EC_KEY_set_public_key(ecdh->key_, pub);
   EC_POINT_free(pub);
   if (!r)
-    return env->ThrowError("Failed to convert BN to a private key");
+    return env->ThrowError("Failed to convert EC_POINT to a public key");
 }
 
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -635,7 +635,6 @@ class ECDH : public BaseObject {
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, EC_KEY* key)
       : BaseObject(env, wrap),
-        generated_(false),
         key_(key),
         group_(EC_KEY_get0_group(key_)) {
     MakeWeak<ECDH>(this);
@@ -644,6 +643,7 @@ class ECDH : public BaseObject {
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GenerateKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GeneratePublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ComputeSecret(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -652,7 +652,6 @@ class ECDH : public BaseObject {
 
   EC_POINT* BufferToPoint(char* data, size_t len);
 
-  bool generated_;
   EC_KEY* key_;
   const EC_GROUP* group_;
 };

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -178,3 +178,9 @@ ecdh4.setPublicKey(ecdh1.getPublicKey());
 assert.throws(function() {
   ecdh4.setPublicKey(ecdh3.getPublicKey());
 });
+
+// ECDH should be able to generate public key from private key
+var ecdh5 = crypto.createECDH('prime256v1');
+ecdh5.setPrivateKey(ecdh4.getPrivateKey());
+
+assert(ecdh5.generatePublicKey('hex') === ecdh5.getPublicKey('hex'));


### PR DESCRIPTION
ECDH.generatePublicKey can get the public key using the curve
and private key. This allows usage of the crypto module where
a developer imports a private key, and then generates a public
key without needing it stored.

Removed the generated_ boolean from the ECDH class, and stopped
checking for it with getPrivateKey() and getPublicKey(). This
allows you to import public and private keys without having to
generate first, which would just rewrite the generated keys
regardless.

An error message was changed to accurately reflect what the error
was.