### PR TITLE
Util(.is*) Deprecations

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -546,8 +546,7 @@ exports.isUndefined = deprecate(isUndefined,
 
 // note: the isRegExp function is still used here in util
 function isRegExp(re) {
-  return re !== null && typeof re === 'object' &&
-         objectToString(re) === '[object RegExp]';
+  return objectToString(re) === '[object RegExp]';
 }
 exports.isRegExp = deprecate(isRegExp,
     'util.isRegExp is deprecated, please use a user-land alternative.');
@@ -560,14 +559,12 @@ exports.isObject = deprecate(isObject,
 
 // still used in assert and fs
 function isDate(d) {
-  return d !== null && typeof d === 'object' &&
-         objectToString(d) === '[object Date]';
+  return objectToString(d) === '[object Date]';
 }
 exports.isDate = isDate;
 
 function isError(e) {
-  return e !== null && typeof e === 'object' &&
-      (objectToString(e) === '[object Error]' || e instanceof Error);
+  return objectToString(e) === '[object Error]' || e instanceof Error;
 }
 exports.isError = deprecate(isError,
     'util.isError is deprecated, please use a user-land alternative.');

--- a/lib/util.js
+++ b/lib/util.js
@@ -505,49 +505,60 @@ const isArray = exports.isArray = Array.isArray;
 function isBoolean(arg) {
   return typeof arg === 'boolean';
 }
-exports.isBoolean = isBoolean;
+exports.isBoolean = deprecate(isBoolean,
+    'util.isBoolean is deprecated, please use a user-land alternative.');
 
 function isNull(arg) {
   return arg === null;
 }
-exports.isNull = isNull;
+exports.isNull = deprecate(isNull,
+    'util.isNull is deprecated, please use a user-land alternative.');
 
 function isNullOrUndefined(arg) {
   return arg === null || arg === undefined;
 }
-exports.isNullOrUndefined = isNullOrUndefined;
+exports.isNullOrUndefined = deprecate(isNullOrUndefined,
+    'util.isNullOrUndefined is deprecated, please use a user-land alternative.');
 
 function isNumber(arg) {
   return typeof arg === 'number';
 }
-exports.isNumber = isNumber;
+exports.isNumber = deprecate(isNumber,
+    'util.isNumber is deprecated, please use a user-land alternative.');
 
 function isString(arg) {
   return typeof arg === 'string';
 }
-exports.isString = isString;
+exports.isString = deprecate(isString,
+    'util.isSrting is deprecated, please use a user-land alternative.');
 
 function isSymbol(arg) {
   return typeof arg === 'symbol';
 }
-exports.isSymbol = isSymbol;
+exports.isSymbol = deprecate(isSymbol,
+    'util.isSymbol is deprecated, please use a user-land alternative.');
 
 function isUndefined(arg) {
   return arg === undefined;
 }
-exports.isUndefined = isUndefined;
+exports.isUndefined = deprecate(isUndefined,
+    'util.isUndefined is deprecated, please use a user-land alternative.');
 
+// note: the isRegExp function is still used here in util
 function isRegExp(re) {
   return re !== null && typeof re === 'object' &&
          objectToString(re) === '[object RegExp]';
 }
-exports.isRegExp = isRegExp;
+exports.isRegExp = deprecate(isRegExp,
+    'util.isRegExp is deprecated, please use a user-land alternative.');
 
 function isObject(arg) {
   return arg !== null && typeof arg === 'object';
 }
-exports.isObject = isObject;
+exports.isObject = deprecate(isObject,
+    'util.isObject is deprecated, please use a user-land alternative.');
 
+// still used in assert and fs
 function isDate(d) {
   return d !== null && typeof d === 'object' &&
          objectToString(d) === '[object Date]';
@@ -558,13 +569,16 @@ function isError(e) {
   return e !== null && typeof e === 'object' &&
       (objectToString(e) === '[object Error]' || e instanceof Error);
 }
-exports.isError = isError;
+exports.isError = deprecate(isError,
+    'util.isError is deprecated, please use a user-land alternative.');
 
 function isFunction(arg) {
   return typeof arg === 'function';
 }
-exports.isFunction = isFunction;
+exports.isFunction = deprecate(isFunction,
+    'util.isFunction is deprecated, please use a user-land alternative.');
 
+// still used in assert, domain, and smalloc
 function isPrimitive(arg) {
   return arg === null ||
          typeof arg !== 'object' && typeof arg !== 'function';
@@ -574,7 +588,8 @@ exports.isPrimitive = isPrimitive;
 function isBuffer(arg) {
   return arg instanceof Buffer;
 }
-exports.isBuffer = isBuffer;
+exports.isBuffer = deprecate(isBuffer,
+    'util.isBuffer is deprecated, please use a user-land alternative.');
 
 function objectToString(o) {
   return Object.prototype.toString.call(o);

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,11 +43,11 @@ exports.format = function(f) {
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
-exports.deprecate = function(fn, msg) {
+function deprecate(fn, msg) {
   // Allow for deprecating things in the process of starting up.
   if (global.process === undefined) {
     return function() {
-      return exports.deprecate(fn, msg).apply(this, arguments);
+      return deprecate(fn, msg).apply(this, arguments);
     };
   }
 
@@ -71,7 +71,8 @@ exports.deprecate = function(fn, msg) {
   }
 
   return deprecated;
-};
+}
+exports.deprecate = deprecate;
 
 
 var debugs = {};
@@ -663,45 +664,45 @@ function hasOwnProperty(obj, prop) {
 
 // Deprecated old stuff.
 
-exports.p = exports.deprecate(function() {
+exports.p = deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     console.error(exports.inspect(arguments[i]));
   }
 }, 'util.p: Use console.error() instead');
 
 
-exports.exec = exports.deprecate(function() {
+exports.exec = deprecate(function() {
   return require('child_process').exec.apply(this, arguments);
 }, 'util.exec is now called `child_process.exec`.');
 
 
-exports.print = exports.deprecate(function() {
+exports.print = deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(String(arguments[i]));
   }
 }, 'util.print: Use console.log instead');
 
 
-exports.puts = exports.deprecate(function() {
+exports.puts = deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(arguments[i] + '\n');
   }
 }, 'util.puts: Use console.log instead');
 
 
-exports.debug = exports.deprecate(function(x) {
+exports.debug = deprecate(function(x) {
   process.stderr.write('DEBUG: ' + x + '\n');
 }, 'util.debug: Use console.error instead');
 
 
-exports.error = exports.deprecate(function(x) {
+exports.error = deprecate(function(x) {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stderr.write(arguments[i] + '\n');
   }
 }, 'util.error: Use console.error instead');
 
 
-exports.pump = exports.deprecate(function(readStream, writeStream, callback) {
+exports.pump = deprecate(function(readStream, writeStream, callback) {
   var callbackCalled = false;
 
   function call(a, b, c) {


### PR DESCRIPTION
Extension of #743 / #822 / #1295

Deprecates any util.is* function that are not used in core.

Also adds some cleanup for in-util deprecations.

WIP and pending much discussion I'm sure. Might as well just add other util deprecations here also.


cc @iojs/tc - @iojs/collaborators - @ceejbot - (everyone really..)