### PR TITLE
wip,src: add utf8 consumer/validator

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -12,7 +12,7 @@
 
 #ifdef WIN32
 #include <intrin.h>
-static uint32_t __inline clz(uint32_t xs) {
+inline uint32_t __inline clz(uint32_t xs) {
   unsigned long result = 0;
   _BitScanReverse(&result, xs);
   return (31 - result);
@@ -20,7 +20,7 @@ static uint32_t __inline clz(uint32_t xs) {
 #elif defined(HAS_GCC_BUILTIN_CLZ)
 #define clz(xs) __builtin_clz(xs)
 #else
-static inline uint32_t clz(uint32_t xs) {
+inline uint32_t clz(uint32_t xs) {
   uint32_t out = 0;
   while (xs >> (31 - out)) {
     ++out;
@@ -119,7 +119,7 @@ static const uint32_t offsets_from_utf8[6] = {
 
 
 template <ErrorStrategy OnError, typename GlyphStrategy>
-static size_t Utf8Consume(
+inline size_t Utf8Consume(
     const uint8_t* const input,
     const size_t length,
     const GlyphStrategy OnGlyph) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -6,21 +6,6 @@
 #define UNI_REPLACEMENT_CHAR  0x0000FFFDUL
 #define UNI_MAX_LEGAL_UTF32   0x0010FFFFUL
 
-#if __GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
-#define HAS_GCC_BUILTIN_CLZ
-#endif
-
-#ifdef WIN32
-#include <intrin.h>
-inline uint32_t clz(uint8_t xs) {
-  unsigned long result = 0;
-  uint32_t input = static_cast<uint32_t>(xs) << 24;
-  _BitScanReverse(&result, xs);
-  return (31 - result);
-}
-#elif defined(HAS_GCC_BUILTIN_CLZ)
-#define clz(xs) __builtin_clz(static_cast<uint32_t>(xs) << 24)
-#else
 inline uint32_t log2(uint8_t v) {
   const uint32_t r = (v > 15) << 2;
   v >>= r;
@@ -31,10 +16,8 @@ inline uint32_t log2(uint8_t v) {
 }
 
 inline uint32_t clz(uint8_t v) {
-  // clz(0) == 7.  Add a zero check if that's an issue.
   return 7 - log2(v);
 }
-#endif
 
 namespace node {
 
@@ -190,8 +173,7 @@ size_t Utf8Value::StripInvalidUtf8Glyphs(uint8_t* const input, const size_t size
     memmove(input + old_idx, data, size);
   };
 
-  size_t copied = Utf8Consume<Skip>(input, size, on_glyph);
-  return idx;
+  return Utf8Consume<Skip>(input, size, on_glyph);
 }
 
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,10 +1,10 @@
 #include "util.h"
 #include "string_bytes.h"
 
-#define UNI_SUR_HIGH_START    (uint32_t) 0xD800
-#define UNI_SUR_LOW_END       (uint32_t) 0xDFFF
-#define UNI_REPLACEMENT_CHAR  (uint32_t) 0x0000FFFD
-#define UNI_MAX_LEGAL_UTF32   (uint32_t) 0x0010FFFF
+#define UNI_SUR_HIGH_START    0xD800UL
+#define UNI_SUR_LOW_END       0xDFFFUL
+#define UNI_REPLACEMENT_CHAR  0x0000FFFDUL
+#define UNI_MAX_LEGAL_UTF32   0x0010FFFFUL
 
 #if __GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
 #define HAS_GCC_BUILTIN_CLZ
@@ -122,7 +122,8 @@ static size_t Utf8Consume(
   while (idx < length) {
     size_t advance = 0;
     uint32_t glyph = 0;
-    uint8_t extrabytes = (uint8_t)clz(~(static_cast<int>(input[idx])<<24));
+    uint8_t extrabytes = static_cast<uint8_t>(
+        clz(~(static_cast<uint32_t>(input[idx])<<24)));
     size_t i = idx;
 
     if (extrabytes + idx > length) {
@@ -133,22 +134,22 @@ static size_t Utf8Consume(
     } else {
       switch (extrabytes) {
         case 5:
-          glyph += (uint8_t) input[i++];
+          glyph += static_cast<uint8_t>(input[i++]);
           glyph <<= 6;
         case 4:
-          glyph += (uint8_t) input[i++];
+          glyph += static_cast<uint8_t>(input[i++]);
           glyph <<= 6;
         case 3:
-          glyph += (uint8_t) input[i++];
+          glyph += static_cast<uint8_t>(input[i++]);
           glyph <<= 6;
         case 2:
-          glyph += (uint8_t) input[i++];
+          glyph += static_cast<uint8_t>(input[i++]);
           glyph <<= 6;
         case 1:
-          glyph += (uint8_t) input[i++];
+          glyph += static_cast<uint8_t>(input[i++]);
           glyph <<= 6;
         case 0:
-          glyph += (uint8_t) input[i];
+          glyph += static_cast<uint8_t>(input[i]);
       }
 
       glyph -= offsets_from_utf8[extrabytes];

--- a/src/util.h
+++ b/src/util.h
@@ -189,7 +189,7 @@ class Utf8Value {
       return length_;
     };
 
-    static bool IsValidUTF8(char * const, const size_t);
+    static bool IsValidUtf8(const uint8_t* const, const size_t);
   private:
     size_t length_;
     char* str_;

--- a/src/util.h
+++ b/src/util.h
@@ -190,6 +190,7 @@ class Utf8Value {
     };
 
     static bool IsValidUtf8(const uint8_t* const, const size_t);
+    static size_t StripInvalidUtf8Glyphs(uint8_t* const, const size_t);
   private:
     size_t length_;
     char* str_;

--- a/src/util.h
+++ b/src/util.h
@@ -189,6 +189,7 @@ class Utf8Value {
       return length_;
     };
 
+    static bool IsValidUTF8(char * const, const size_t);
   private:
     size_t length_;
     char* str_;


### PR DESCRIPTION
WIP. Opening this now to double check that this is headed in the right direction.

This is based on [utf-8-validate](https://github.com/websockets/utf-8-validate/blob/master/src/validation.cc). The primary differences are the use of `clz` (vs. a lookup table) to compute the number of extra bytes and the introduction of the error/glyph callbacks.

The Utf8Consume function will iterate over valid glyphs, calling a provided `OnGlyph` callback and an `OnError` callback as necessary. Provided error strategies are "Halt" and "Skip" – which either halts the consumer at the first error, or skips past them as appropriate. 

The strategies were added to accommodate the desire to build a [utf8-to-utf16 translator](http://logs.libuv.org/io.js/2015-03-26#21:27:52.314) as part of this work.
