### PR TITLE
module: remove require('.') with NODE_PATH compatibilty

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -125,11 +125,6 @@ function tryExtensions(p, exts) {
 }
 
 
-const noopDeprecateRequireDot = util.deprecate(function() {},
-  "warning: require('.') resolved outside the package directory. " +
-  "This functionality is deprecated and will be removed soon.");
-
-
 Module._findPath = function(request, paths) {
   var exts = Object.keys(Module._extensions);
 
@@ -174,8 +169,6 @@ Module._findPath = function(request, paths) {
     }
 
     if (filename) {
-      // Warn once if '.' resolved outside the module dir
-      if (request === '.' && i > 0) noopDeprecateRequireDot();
       Module._pathCache[cacheKey] = filename;
       return filename;
     }
@@ -212,21 +205,11 @@ Module._resolveLookupPaths = function(request, parent) {
   }
 
   var start = request.substring(0, 2);
-  if (start !== './' && start !== '..') {
+  if (start !== '.' && start !== './' && start !== '..') {
     var paths = modulePaths;
     if (parent) {
       if (!parent.paths) parent.paths = [];
       paths = parent.paths.concat(paths);
-    }
-
-    // Maintain backwards compat with certain broken uses of require('.')
-    // by putting the module's directory in front of the lookup paths.
-    if (request === '.') {
-      if (parent && parent.filename) {
-        paths.splice(0, 0, path.dirname(parent.filename));
-      } else {
-        paths.splice(0, 0, path.resolve(request));
-      }
     }
 
     return [request, paths];

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -1,16 +1,8 @@
 var common = require('../common');
 var assert = require('assert');
-var module = require('module');
 
 var a = require(common.fixturesDir + '/module-require/relative/dot.js');
 var b = require(common.fixturesDir + '/module-require/relative/dot-slash.js');
 
 assert.equal(a.value, 42);
 assert.equal(a, b, 'require(".") should resolve like require("./")');
-
-process.env.NODE_PATH = common.fixturesDir + '/module-require/relative';
-module._initPaths();
-
-var c = require('.');
-
-assert.equal(c.value, 42, 'require(".") should honor NODE_PATH');


### PR DESCRIPTION
This basically reverts #1363 and removes the hack in place for the unintended use case of `require('.')` used in conjunction with `NODE_PATH`.

I'd like to give users a few months to accustom to the deprecation, so it might not be a candidate for 2.0.0, but rather 3.0.0.