### PR TITLE
debugger: introduce exec method for debugger

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -143,6 +143,7 @@ after)
 * `watchers` - List all watchers and their values (automatically listed on each
 breakpoint)
 * `repl` - Open debugger's repl for evaluation in debugging script's context
+* `exec expr` - Execute an expression in debugging script's context
 
 ### Execution control
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -142,7 +142,7 @@ Protocol.prototype.serialize = function(req) {
 const NO_FRAME = -1;
 
 function Client() {
-  net.Stream.call(this);
+  net.Socket.call(this);
   var protocol = this.protocol = new Protocol(this);
   this._reqCallbacks = [];
   var socket = this;
@@ -161,7 +161,7 @@ function Client() {
 
   protocol.onResponse = this._onResponse.bind(this);
 }
-inherits(Client, net.Stream);
+inherits(Client, net.Socket);
 exports.Client = Client;
 
 
@@ -657,6 +657,7 @@ const commands = [
     'unwatch',
     'watchers',
     'repl',
+    'exec',
     'restart',
     'kill',
     'list',
@@ -947,6 +948,12 @@ Interface.prototype.controlEval = function(code, context, filename, callback) {
       if (code === '\n') {
         code = this.repl.rli.history[0] + '\n';
       }
+    }
+
+    // exec process.title => exec("process.title");
+    var match = code.match(/^\s*exec\s+([^\n]*)/);
+    if (match) {
+      code = 'exec(' + JSON.stringify(match[1]) + ')';
     }
 
     var result = vm.runInContext(code, context, filename);
@@ -1527,6 +1534,18 @@ Interface.prototype.pause_ = function() {
 };
 
 
+// execute expression
+Interface.prototype.exec = function(code) {
+  this.debugEval(code, null, null, (err, result) => {
+    if (err) {
+      this.error(err);
+    } else {
+      this.print(util.inspect(result, {colors: true}));
+    }
+  });
+};
+
+
 // Kill child process
 Interface.prototype.kill = function() {
   if (!this.child) return;
@@ -1730,11 +1749,12 @@ Interface.prototype.trySpawn = function(cb) {
     client.connect(port, host);
   }
 
-  self.print('connecting to ' + host + ':' + port + ' ..', true);
   if (isRemote) {
+    self.print('connecting to ' + host + ':' + port + ' ..', true);
     attemptConnect();
   } else {
     this.child.stderr.once('data', function() {
+      self.print('connecting to ' + host + ':' + port + ' ..', true);
       setImmediate(attemptConnect);
     });
   }

--- a/test/debugger/test-debugger-repl.js
+++ b/test/debugger/test-debugger-repl.js
@@ -51,8 +51,18 @@ addTest('sb("setInterval()", "!(setInterval.flag++)")', [
 
 // Continue
 addTest('c', [
-  /break in node.js:\d+/,
+  /break in timers.js:\d+/,
   /\d/, /\d/, /\d/, /\d/, /\d/
+]);
+
+// Execute
+addTest('exec process.title', [
+  /node/
+]);
+
+// Execute
+addTest('exec exec process.title', [
+  /SyntaxError: Unexpected identifier/
 ]);
 
 // REPL and process.env regression


### PR DESCRIPTION
In debugger, the usage of `repl` very ugly. I'd like there is a `p`
like gdb. So the `exec` is coming.

Usage:

```
$ ./iojs debug ~/git/node_research/server.js
< Debugger listening on port 5858
connecting to 127.0.0.1:5858 ... ok
break in /Users/jacksontian/git/node_research/server.js:1
> 1 var http = require('http');
  2
  3 http.createServer(function (req, res) {
debug> exec('process.title')
/Users/jacksontian/git/io.js/out/Release/iojs
debug>
```

And the `repl`:

```
debug> repl
Press Ctrl + C to leave debug repl
> process.title
'/Users/jacksontian/git/io.js/out/Release/iojs'
debug>
(^C again to quit)
```

The enter and leave debug repl is superfluous.