### PR TITLE
core: implement resourceUsage()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -803,6 +803,40 @@ a diff reading, useful for benchmarks and measuring intervals:
     }, 1000);
 
 
+## process.resourceUsage()
+
+Returns the resource usage measures.
+
+Note: Windows only provides the following resource usage measures - all others
+are filled with zero:
+
+- `userCpuTimeUsedSec`
+- `userCpuTimeUsedMs`
+- `systemCpuTimeUsedSec`
+- `systemCpuTimeUsedMs`
+
+An example output looks like this:
+
+    { userCpuTimeUsedSec: 0,
+      userCpuTimeUsedMs: 159729,
+      systemCpuTimeUsedSec: 0,
+      systemCpuTimeUsedMs: 30597,
+      maxResidentSetSize: 20426752,
+      sharedMemSize: 0,
+      integralUnsharedDataSize: 0,
+      integralUnsharedStackSize: 0,
+      pageReclaims: 3002,
+      pageFaults: 2250,
+      swaps: 0,
+      blockInputOperations: 0,
+      blockOutputOperations: 0,
+      ipcMessagesSent: 55,
+      ipcMessagesReceived: 54,
+      signalsReceived: 0,
+      voluntaryContextSwitches: 92,
+      involuntaryContextSwitches: 374 }
+
+
 ## process.mainModule
 
 Alternate way to retrieve

--- a/src/env.h
+++ b/src/env.h
@@ -222,6 +222,24 @@ namespace node {
   V(write_queue_size_string, "writeQueueSize")                                \
   V(x_forwarded_string, "x-forwarded-for")                                    \
   V(zero_return_string, "ZERO_RETURN")                                        \
+  V(user_cpu_time_used_sec, "userCpuTimeUsedSec")                             \
+  V(user_cpu_time_used_ms, "userCpuTimeUsedMs")                               \
+  V(system_cpu_time_used_sec, "systemCpuTimeUsedSec")                         \
+  V(system_cpu_time_used_ms, "systemCpuTimeUsedMs")                           \
+  V(max_resident_set_size, "maxResidentSetSize")                              \
+  V(integral_shared_mem_size, "sharedMemSize")                                \
+  V(integral_unshared_data_size, "integralUnsharedDataSize")                  \
+  V(integral_unshared_stack_size, "integralUnsharedStackSize")                \
+  V(page_reclaims, "pageReclaims")                                            \
+  V(page_faults, "pageFaults")                                                \
+  V(swaps, "swaps")                                                           \
+  V(block_input_operations, "blockInputOperations")                           \
+  V(block_output_operations, "blockOutputOperations")                         \
+  V(ipc_messages_sent, "ipcMessagesSent")                                     \
+  V(ipc_messages_received, "ipcMessagesReceived")                             \
+  V(signals_received, "signalsReceived")                                      \
+  V(voluntary_context_switches, "voluntaryContextSwitches")                   \
+  V(involuntary_context_switches, "involuntaryContextSwitches")               \
 
 #define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
   V(as_external, v8::External)                                                \

--- a/src/node.cc
+++ b/src/node.cc
@@ -1923,6 +1923,56 @@ static void Uptime(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+static void GetResourceUsage(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  uv_rusage_t rusage;
+  int err = uv_getrusage(&rusage);
+  if (err)
+    return env->ThrowUVException(err, "uv_getrusage");
+
+  Local<Object> resource_usage = Object::New(env->isolate());
+  resource_usage->Set(env->user_cpu_time_used_sec(),
+                      Number::New(env->isolate(), rusage.ru_utime.tv_sec));
+  resource_usage->Set(env->user_cpu_time_used_ms(),
+                      Number::New(env->isolate(), rusage.ru_utime.tv_usec));
+  resource_usage->Set(env->system_cpu_time_used_sec(),
+                      Number::New(env->isolate(), rusage.ru_stime.tv_sec));
+  resource_usage->Set(env->system_cpu_time_used_ms(),
+                      Number::New(env->isolate(), rusage.ru_stime.tv_usec));
+  resource_usage->Set(env->max_resident_set_size(),
+                      Number::New(env->isolate(), rusage.ru_maxrss));
+  resource_usage->Set(env->integral_shared_mem_size(),
+                      Number::New(env->isolate(), rusage.ru_ixrss));
+  resource_usage->Set(env->integral_unshared_data_size(),
+                      Number::New(env->isolate(), rusage.ru_idrss));
+  resource_usage->Set(env->integral_unshared_stack_size(),
+                      Number::New(env->isolate(), rusage.ru_isrss));
+  resource_usage->Set(env->page_reclaims(),
+                      Number::New(env->isolate(), rusage.ru_minflt));
+  resource_usage->Set(env->page_faults(),
+                      Number::New(env->isolate(), rusage.ru_majflt));
+  resource_usage->Set(env->swaps(),
+                      Number::New(env->isolate(), rusage.ru_nswap));
+  resource_usage->Set(env->block_input_operations(),
+                      Number::New(env->isolate(), rusage.ru_inblock));
+  resource_usage->Set(env->block_output_operations(),
+                      Number::New(env->isolate(), rusage.ru_oublock));
+  resource_usage->Set(env->ipc_messages_sent(),
+                      Number::New(env->isolate(), rusage.ru_msgsnd));
+  resource_usage->Set(env->ipc_messages_received(),
+                      Number::New(env->isolate(), rusage.ru_msgrcv));
+  resource_usage->Set(env->signals_received(),
+                      Number::New(env->isolate(), rusage.ru_nsignals));
+  resource_usage->Set(env->voluntary_context_switches(),
+                      Number::New(env->isolate(), rusage.ru_nvcsw));
+  resource_usage->Set(env->involuntary_context_switches(),
+                      Number::New(env->isolate(), rusage.ru_nivcsw));
+
+  args.GetReturnValue().Set(resource_usage);
+}
+
+
 void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -2838,6 +2888,8 @@ void SetupProcessObject(Environment* env,
   env->SetMethod(process, "_debugEnd", DebugEnd);
 
   env->SetMethod(process, "hrtime", Hrtime);
+
+  env->SetMethod(process, "resourceUsage", GetResourceUsage);
 
   env->SetMethod(process, "dlopen", DLOpen);
 

--- a/test/sequential/test-resource-usage.js
+++ b/test/sequential/test-resource-usage.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+var common = require('../common');
+
+
+const usage = process.resourceUsage();
+
+assert(usage.userCpuTimeUsedSec >= 0);
+assert(usage.userCpuTimeUsedMs >= 0);
+assert(usage.systemCpuTimeUsedSec >= 0);
+assert(usage.systemCpuTimeUsedMs >= 0);
+assert(usage.maxResidentSetSize >= 0);
+assert(usage.sharedMemSize >= 0);
+assert(usage.integralUnsharedDataSize >= 0);
+assert(usage.integralUnsharedStackSize >= 0);
+assert(usage.pageReclaims >= 0);
+assert(usage.pageFaults >= 0);
+assert(usage.swaps >= 0);
+assert(usage.blockInputOperations >= 0);
+assert(usage.blockOutputOperations >= 0);
+assert(usage.ipcMessagesSent >= 0);
+assert(usage.ipcMessagesReceived >= 0);
+assert(usage.voluntaryContextSwitches >= 0);
+assert(usage.involuntaryContextSwitches >= 0);


### PR DESCRIPTION
libuv already provides the `uv_getrusage` function to get the
resource mesaures for the current process.
This changes implements the new `process.resourceUsage()` function
to make use of it.

An example output looks like:

```
{ userCpuTimeUsedSec: 0,
  userCpuTimeUsedMs: 159729,
  systemCpuTimeUsedSec: 0,
  systemCpuTimeUsedMs: 30597,
  maxResidentSetSize: 20426752,
  sharedMemSize: 0,
  integralUnsharedDataSize: 0,
  integralUnsharedStackSize: 0,
  pageReclaims: 3002,
  pageFaults: 2250,
  swaps: 0,
  blockInputOperations: 0,
  blockOutputOperations: 0,
  ipcMessagesSent: 55,
  ipcMessagesReceived: 54,
  signalsReceived: 0,
  voluntaryContextSwitches: 92,
  involuntaryContextSwitches: 374 }
```

Not supported fields on windows are zero.
