### PR TITLE
"Fix" repl race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ bench-idle:
 	./$(NODE_EXE) benchmark/idle_clients.js &
 
 jslint:
-	./$(NODE_EXE) tools/eslint/bin/eslint.js src/*.js lib/*.js --reset --quiet
+	./$(NODE_EXE) tools/eslint/bin/eslint.js src/*.js lib/*.js lib/internal/*.js --reset --quiet
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -3,6 +3,9 @@
 const Interface = require('readline').Interface;
 const REPL = require('repl');
 const path = require('path');
+const util = require('util');
+
+const debug = util.debuglog('repl');
 
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
@@ -17,15 +20,17 @@ function replStart() {
   return REPL.start.apply(REPL, arguments);
 }
 
-function createRepl(env, cb) {
+function createRepl(env, attemptPersistentHistory, cb) {
   const opts = {
     ignoreUndefined: false,
-    terminal: process.stdout.isTTY,
     useGlobal: true
   };
 
   if (parseInt(env.NODE_NO_READLINE)) {
     opts.terminal = false;
+  }
+  if (parseInt(env.NODE_FORCE_READLINE)) {
+    opts.terminal = true;
   }
   if (parseInt(env.NODE_DISABLE_COLORS)) {
     opts.useColors = false;
@@ -51,7 +56,7 @@ function createRepl(env, cb) {
   }
 
   const repl = REPL.start(opts);
-  if (opts.terminal && env.NODE_REPL_HISTORY_FILE) {
+  if (env.NODE_REPL_HISTORY_FILE && attemptPersistentHistory) {
     return setupHistory(repl, env.NODE_REPL_HISTORY_FILE, cb);
   }
   repl._historyPrev = _replHistoryMessage;
@@ -64,27 +69,14 @@ function setupHistory(repl, historyPath, ready) {
   var writing = false;
   var pending = false;
   repl.pause();
-  fs.open(historyPath, 'a+', oninit);
+  fs.readFile(historyPath, {encoding: 'utf8', flag: 'a+'}, ondata);
 
-  function oninit(err, hnd) {
-    if (err) {
-      return ready(err);
-    }
-    fs.close(hnd, onclose);
-  }
-
-  function onclose(err) {
-    if (err) {
-      return ready(err);
-    }
-    fs.readFile(historyPath, 'utf8', onread);
-  }
-
-  function onread(err, data) {
+  function ondata(err, data) {
     if (err) {
       return ready(err);
     }
 
+    debug('loaded %s', historyPath);
     if (data) {
       try {
         repl.history = JSON.parse(data);
@@ -98,17 +90,16 @@ function setupHistory(repl, historyPath, ready) {
       }
     }
 
-    fs.open(historyPath, 'w', onhandle);
+    getTMPFile(ontmpfile);
   }
 
-  function onhandle(err, hnd) {
+  function ontmpfile(err, tmpinfo) {
     if (err) {
       return ready(err);
     }
-    repl._historyHandle = hnd;
+    repl._historyTMPInfo = tmpinfo;
     repl.on('line', online);
 
-    // reading the file data out erases it
     repl.once('flushHistory', function() {
       repl.resume();
       ready(null, repl);
@@ -134,11 +125,11 @@ function setupHistory(repl, historyPath, ready) {
       return;
     }
     writing = true;
-    const historyData = JSON.stringify(repl.history, null, 2);
-    fs.write(repl._historyHandle, historyData, 0, 'utf8', onwritten);
+    const historyData = JSON.stringify(repl.history || [], null, 2);
+    writeAndSwapTMP(historyData, repl._historyTMPInfo, historyPath, onflushed);
   }
 
-  function onwritten(err, data) {
+  function onflushed(err, data) {
     writing = false;
     if (pending) {
       pending = false;
@@ -164,4 +155,61 @@ function _replHistoryMessage() {
   }
   this._historyPrev = Interface.prototype._historyPrev;
   return this._historyPrev();
+}
+
+
+function getTMPFile(ready) {
+  var tmpPath = os.tmpdir();
+  if (!tmpPath) {
+    return ready(new Error('no tmpdir available'));
+  }
+  tmpPath = path.join(tmpPath, process.pid + '-' + 'repl.tmp');
+  fs.open(tmpPath, 'w', 0o600, function(err, fd) {
+    if (err) {
+      return ready(err);
+    }
+    return ready(null, {
+      fd: fd,
+      path: tmpPath
+    });
+  });
+}
+
+// write data, sync the fd, close it, overwrite the target
+// with a rename, open a new tmpfile
+function writeAndSwapTMP(data, tmpInfo, target, ready) {
+  debug('writing tmp file... %s', tmpInfo.path, data);
+  return fs.write(tmpInfo.fd, data, 0, 'utf8', onwritten);
+
+  function onwritten(err) {
+    if (err) return ready(err);
+    debug('syncing... %s', tmpInfo.path);
+    fs.fsync(tmpInfo.fd, onsync);
+  }
+
+  function onsync(err) {
+    if (err) return ready(err);
+    debug('closing... %s', tmpInfo.path);
+    fs.close(tmpInfo.fd, onclose);
+  }
+
+  function onclose(err) {
+    if (err) return ready(err);
+    debug('rename... %s -> %s', tmpInfo.path, target);
+    fs.rename(tmpInfo.path, target, onrename);
+  }
+
+  function onrename(err) {
+    if (err) return ready(err);
+    debug('re-loading...');
+    getTMPFile(ontmpfile);
+  }
+
+  function ontmpfile(err, info) {
+    if (err) return ready(err);
+    tmpInfo.fd = info.fd;
+    tmpInfo.path = info.path;
+    debug('done!');
+    return ready(null);
+  }
 }

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -164,7 +164,7 @@ function getTMPFile(ready) {
     return ready(new Error('no tmpdir available'));
   }
   tmpPath = path.join(tmpPath, process.pid + '-' + 'repl.tmp');
-  fs.open(tmpPath, 'w', 0o600, function(err, fd) {
+  fs.open(tmpPath, 'wx', 0o600, function(err, fd) {
     if (err) {
       return ready(err);
     }

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -90,16 +90,16 @@ function setupHistory(repl, historyPath, ready) {
       }
     }
 
-    getTMPFile(ontmpfile);
+    getTempFile(ontmpfile);
   }
 
   function ontmpfile(err, tmpinfo) {
     if (err) {
       return ready(err);
     }
-    repl._historyTMPInfo = tmpinfo;
+    repl._historyTempInfo = tmpinfo;
     repl.on('line', online);
-
+    repl.on('exit', removeTempFile);
     repl.once('flushHistory', function() {
       repl.resume();
       ready(null, repl);
@@ -126,7 +126,7 @@ function setupHistory(repl, historyPath, ready) {
     }
     writing = true;
     const historyData = JSON.stringify(repl.history || [], null, 2);
-    writeAndSwapTMP(historyData, repl._historyTMPInfo, historyPath, onflushed);
+    writeAndSwapTemp(historyData, repl._historyTempInfo, historyPath, onflushed);
   }
 
   function onflushed(err, data) {
@@ -140,6 +140,17 @@ function setupHistory(repl, historyPath, ready) {
         repl.emit('flushHistory');
       }
     }
+  }
+
+  function removeTempFile() {
+    if (repl._flushing)
+      return repl.once('flushHistory', function() {
+        removeTempFile();
+      });
+    repl._flushing = true;
+    fs.unlink(repl._historyTempInfo.path, function() {
+      onflushed();
+    });
   }
 }
 
@@ -158,7 +169,7 @@ function _replHistoryMessage() {
 }
 
 
-function getTMPFile(ready) {
+function getTempFile(ready) {
   var tmpPath = os.tmpdir();
   if (!tmpPath) {
     return ready(new Error('no tmpdir available'));
@@ -177,7 +188,7 @@ function getTMPFile(ready) {
 
 // write data, sync the fd, close it, overwrite the target
 // with a rename, open a new tmpfile
-function writeAndSwapTMP(data, tmpInfo, target, ready) {
+function writeAndSwapTemp(data, tmpInfo, target, ready) {
   debug('writing tmp file... %s', tmpInfo.path, data);
   return fs.write(tmpInfo.fd, data, 0, 'utf8', onwritten);
 
@@ -202,7 +213,7 @@ function writeAndSwapTMP(data, tmpInfo, target, ready) {
   function onrename(err) {
     if (err) return ready(err);
     debug('re-loading...');
-    getTMPFile(ontmpfile);
+    getTempFile(ontmpfile);
   }
 
   function ontmpfile(err, info) {

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -186,8 +186,8 @@ function getTempFile(ready) {
   });
 }
 
-// write data, sync the fd, close it, overwrite the target
-// with a rename, open a new tmpfile
+// Write data, sync the fd, close it, overwrite the target
+// with a rename, and open a new tmpfile.
 function writeAndSwapTemp(data, tmpInfo, target, ready) {
   debug('writing tmp file... %s', tmpInfo.path, data);
   return fs.write(tmpInfo.fd, data, 0, 'utf8', onwritten);

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -193,6 +193,9 @@ function getTempFile(ready) {
 
 // Write data, sync the fd, close it, overwrite the target
 // with a rename, and open a new tmpfile.
+//
+// We use fs.write instead of writeFile because the latter
+// does not accept an fd at the time of writing.
 function writeAndSwapTemp(data, tmpInfo, target, ready) {
   debug('writing tmp file... %s', tmpInfo.path, data);
   return fs.write(tmpInfo.fd, data, 0, 'utf8', onwritten);

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -57,7 +57,12 @@ function createRepl(env, attemptPersistentHistory, cb) {
 
   const repl = REPL.start(opts);
   if (env.NODE_REPL_HISTORY_FILE && attemptPersistentHistory) {
-    return setupHistory(repl, env.NODE_REPL_HISTORY_FILE, cb);
+    return setupHistory(repl, env.NODE_REPL_HISTORY_FILE, function(err) {
+      if (err) {
+        repl.close();
+      }
+      cb(err);
+    });
   }
   repl._historyPrev = _replHistoryMessage;
   cb(null, repl);

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -61,7 +61,7 @@ function createRepl(env, attemptPersistentHistory, cb) {
       if (err) {
         repl.close();
       }
-      cb(err);
+      cb(err, repl);
     });
   }
   repl._historyPrev = _replHistoryMessage;
@@ -179,7 +179,7 @@ function getTempFile(ready) {
   if (!tmpPath) {
     return ready(new Error('no tmpdir available'));
   }
-  tmpPath = path.join(tmpPath, process.pid + '-' + 'repl.tmp');
+  tmpPath = path.join(tmpPath, `${process.pid}-node-repl.tmp`);
   fs.open(tmpPath, 'wx', 0o600, function(err, fd) {
     if (err) {
       return ready(err);

--- a/src/node.js
+++ b/src/node.js
@@ -131,9 +131,15 @@
         if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
           // REPL
           var cliRepl = Module.requireRepl();
-          cliRepl.createInternalRepl(process.env, function(err, repl) {
+          cliRepl.createInternalRepl(process.env, true, function(err, repl) {
             if (err) {
-              throw err;
+              console.log('Encountered error with persistent history support.');
+              return cliRepl.createInternalRepl(process.env, false, function (err, repl) {
+                if (err) {
+                  throw err;
+                }
+                repl.on('exit', process.exit);
+              })
             }
             repl.on('exit', function() {
               if (repl._flushing) {

--- a/src/node.js
+++ b/src/node.js
@@ -134,12 +134,13 @@
           cliRepl.createInternalRepl(process.env, true, function(err, repl) {
             if (err) {
               console.log('Encountered error with persistent history support.');
-              return cliRepl.createInternalRepl(process.env, false, function (err, repl) {
+              return cliRepl.createInternalRepl(
+                process.env, false, function(err, repl) {
                 if (err) {
                   throw err;
                 }
                 repl.on('exit', process.exit);
-              })
+              });
             }
             repl.on('exit', function() {
               if (repl._flushing) {

--- a/src/node.js
+++ b/src/node.js
@@ -133,7 +133,11 @@
           var cliRepl = Module.requireRepl();
           cliRepl.createInternalRepl(process.env, true, function(err, repl) {
             if (err) {
-              console.log('Encountered error with persistent history support.');
+              console.error('Encountered error with persistent history support.')
+              console.error('Run with NODE_DEBUG=repl for more information.');
+              if (/repl/.test(process.env.NODE_DEBUG || '')) {
+                console.error(err.stack);
+              }
               return cliRepl.createInternalRepl(
                 process.env, false, function(err, repl) {
                 if (err) {

--- a/test/parallel/test-internal-repl-race.js
+++ b/test/parallel/test-internal-repl-race.js
@@ -1,0 +1,60 @@
+var spawn = require('child_process').spawn;
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var os = require('os');
+var fs = require('fs');
+
+var filename = path.join(common.tmpDir, 'node-history.json');
+
+var config = {
+  env: {
+    NODE_REPL_HISTORY_FILE: filename,
+    NODE_FORCE_READLINE: 1
+  }
+}
+
+var lhs = spawn(process.execPath, ['-i'], config);
+var rhs = spawn(process.execPath, ['-i'], config);
+
+lhs.stdout.pipe(process.stdout);
+rhs.stdout.pipe(process.stdout);
+lhs.stderr.pipe(process.stderr);
+rhs.stderr.pipe(process.stderr);
+
+
+var i = 0;
+var tried = 0;
+var exitcount = 0;
+while (i++ < 100) {
+  lhs.stdin.write('hello = 0' + os.EOL);
+  rhs.stdin.write('OK = 0' + os.EOL);
+}
+lhs.stdin.write('\u0004')
+rhs.stdin.write('\u0004')
+
+lhs.once('exit', onexit)
+rhs.once('exit', onexit)
+
+function onexit() {
+  if (++exitcount !== 2) {
+    return;
+  }
+  check();
+}
+
+function check() {
+  fs.readFile(filename, 'utf8', function(err, data) {
+    if (err) {
+      console.log(err)
+      if (++tried > 100) {
+        throw err;
+      }
+      return setTimeout(check, 15);
+    }
+    assert.doesNotThrow(function() {
+      console.log(data)
+      JSON.parse(data);
+    })
+  })
+}


### PR DESCRIPTION
For some value of "fix."

Per #1634, having multiple CLI repls open could lead to inconsistencies in the JSON data being stored. This PR changes the internal repl so that it commits to a temporary file first, then renames it to the target file. @bnoordhuis noted that this will only work if the tmpdir and target dir are on the same mount, but I imagine the worst case is not any worse than conflicting, racing writes, and this should solve the 80% use case.

This PR also re-addresses the problem of non-terminal readline instances corrupting history. Now the internal repl always defaults the written history to `[]` (vs. trying to set the options in internal/repl [as before](https://github.com/iojs/io.js/pull/1575).)

Additionally, the PR makes it so that repls that fail to load history (for whatever reason) don't crash out – they simply continue without persistent history support.

Finally, this adds the internal modules to the list of files checked by eslint.

Will fix up the commit log once review is over, as I suspect reviewers will have thoughts about the strategy I've taken here!

R=@indutny, @bnoordhuis 