### PR TITLE
lib: improve spliceOne() for large arrays

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -410,11 +410,18 @@ EventEmitter.listenerCount = function(emitter, type) {
   return ret;
 };
 
-// About 1.5x faster than the two-arg version of Array#splice().
 function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
-  list.pop();
+  var len = list.length;
+  if (index === len - 1)
+    list.pop();
+  // This threshold value was determined empirically with v8 4.2
+  else if (len > 125)
+    list.splice(index, 1);
+  else {
+    for (var k = index + 1; k < len; index += 1, k += 1)
+      list[index] = list[k];
+    list.pop();
+  }
 }
 
 function arrayClone(arr, i) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -716,9 +716,16 @@ Url.prototype.parseHost = function() {
   if (host) this.hostname = host;
 };
 
-// About 1.5x faster than the two-arg version of Array#splice().
 function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
-  list.pop();
+  var len = list.length;
+  if (index === len - 1)
+    list.pop();
+  // This threshold value was determined empirically with v8 4.2
+  else if (len >= 125)
+    list.splice(index, 1);
+  else {
+    for (var k = index + 1; k < len; index += 1, k += 1)
+      list[index] = list[k];
+    list.pop();
+  }
 }


### PR DESCRIPTION
`array.splice()` works faster for arrays of size ~125 or larger, independent of the index (except for `array.length - 1` evidently).

Usually event listener arrays aren't that large, but I figured why not, especially since the changes do not negatively impact the (typical) < 125 element case at all.