### PR TITLE
lib: Prevent leaking arguments in several places.

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const assert = require('assert');
 
 function Console(stdout, stderr) {
   if (!(this instanceof Console)) {
@@ -83,8 +84,11 @@ Console.prototype.trace = function trace() {
 
 Console.prototype.assert = function(expression) {
   if (!expression) {
-    var arr = Array.prototype.slice.call(arguments, 1);
-    require('assert').ok(false, util.format.apply(this, arr));
+    var argsleft = arguments.length - 1;
+    const arr = new Array(argsleft > 0 ? argsleft : 0);
+    while (argsleft-- > 0) arr[argsleft] = arguments[argsleft + 1];
+
+    assert.ok(false, util.format.apply(this, arr));
   }
 };
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -185,14 +185,13 @@ win32.isAbsolute = function(path) {
 };
 
 win32.join = function() {
-  function f(p) {
-    if (typeof p !== 'string') {
-      throw new TypeError('Arguments to path.join must be strings');
-    }
-    return p;
+  const paths = new Array(arguments.length);
+  for (var i = 0; i < arguments.length; i++) {
+     if (typeof arguments[i] !== 'string') {
+       throw new TypeError('Arguments to path.join must be strings');
+     }
+     paths[i] = arguments[i];
   }
-
-  var paths = Array.prototype.filter.call(arguments, f);
   var joined = paths.join('\\');
 
   // Make sure that the joined path doesn't start with two slashes, because

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,8 +15,11 @@ exports.format = function(f) {
 
   if (arguments.length === 1) return f;
 
+  var argsleft = arguments.length;
+  const args = new Array(argsleft);
+  while (argsleft--) args[argsleft] = arguments[argsleft];
+
   var i = 1;
-  var args = arguments;
   var len = args.length;
   var str = String(f).replace(formatRegExp, function(x) {
     if (x === '%%') return '%';


### PR DESCRIPTION
This prevents leaking arguments in several places.

**Not yet final, I will probably update this with more patches, waiting for comments.**

Currently the three fixed places are `util.format` (called for example by `console.log`), `console.assert`, and `path.win32.join`.

In `path.win32.join` this PR changes the stack of the `TypeError('Arguments to path.join must be strings')`, removing the top `at f (path.js:190:13)` and `at Object.filter (native)` so now it is similar to the stack in `path.posix.join`.

`util.format` results:
* ~50% speedup on `util.format('abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc1234567890')` (16700000 ⇒ 32900000 ops/second).
* ~8% speedup on `util.format({a:2,b:10,c:10},20,'d')` (50000 ⇒ 54000 ops/second).
* ~28% speedup on `util.format('Hello %s %s',20,'d')` (580000 ⇒ 800000 ops/second).

`console.assert` results:
* ~27% speedup on common `console.assert(true, 'text')` (2550000 ⇒ 3230000 ops/second).
* ~23% speedup on `console.assert(true)` ( 3000000 ⇒ 3700000 ops/second).

`path.win32.join` results:
* ~33% speedup on `path.join('a','b','c')` (400000 ⇒ 598000 ops/second).

See https://github.com/nodejs/io.js/pull/1749#discussion_r30743809, https://gist.github.com/Fishrock123/98c35a0c745cb59d7496 and https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments