### PR TITLE
net: make stdout & stderr block on all platforms

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@ ecmaFeatures:
   generators: true
   forOf: true
   objectLiteralShorthandProperties: true
+  objectLiteralShorthandMethods: true
 
 rules:
   # Possible Errors

--- a/lib/net.js
+++ b/lib/net.js
@@ -126,10 +126,7 @@ function Socket(options) {
   } else if (options.fd !== undefined) {
     this._handle = createHandle(options.fd);
     this._handle.open(options.fd);
-    if ((options.fd == 1 || options.fd == 2) &&
-        (this._handle instanceof Pipe) &&
-        process.platform === 'win32') {
-      // Make stdout and stderr blocking on Windows
+    if ((options.fd == 1 || options.fd == 2) && this._handle instanceof Pipe) {
       var err = this._handle.setBlocking(true);
       if (err)
         throw errnoException(err, 'setBlocking');

--- a/test/fixtures/stdout-producer.js
+++ b/test/fixtures/stdout-producer.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Produce a very long string, so that stdout will have to break it into chunks.
+var str = 'test\n';
+for (var i = 0; i < 17; i++, str += str);
+
+// Add something so that we can identify the end.
+str += 'hey\n';
+
+process.stdout.write(str);
+
+// Close the process, attempting to close before
+// all chunked stdout writes are done.
+//
+// This is required to achieve the regression described in
+// https://github.com/nodejs/io.js/issues/784.
+process.exit();

--- a/test/parallel/test-child-process-chunked-stdout.js
+++ b/test/parallel/test-child-process-chunked-stdout.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fork = require('child_process').fork;
+const stream = require('stream');
+const path = require('path');
+
+const producer = fork(path.join(common.fixturesDir, 'stdout-producer.js'),
+                      { silent: true });
+
+var output = '';
+const writable = new stream.Writable({
+  write(chunk, _, next) {
+    output += chunk.toString();
+    next();
+  }
+});
+
+producer.stdout.pipe(writable);
+producer.stdout.on('close', function() {
+  assert(output.endsWith('hey\n'),
+      'Not all chunked writes were completed before process termination.');
+});
+
+producer.stderr.pipe(process.stderr);


### PR DESCRIPTION
Fixes https://github.com/nodejs/io.js/issues/784

@vkurchatkin suggested a test [here](https://github.com/nodejs/io.js/issues/784#issuecomment-73744582), but I'm not sure how to adapt to be only in javascript. Maybe with two child processes? I'm not sure how to pipe them without the unix `|`.

R=@bnoordhuis 