### PR TITLE
fix a few wrong comments in Readable stream

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -56,10 +56,6 @@ function ReadableState(options, stream) {
   // Everything else in the universe uses 'utf8', though.
   this.defaultEncoding = options.defaultEncoding || 'utf8';
 
-  // when piping, we only care about 'readable' events that happen
-  // after read()ing all the bytes and not getting any pushback.
-  this.ranOut = false;
-
   // the number of writers that are awaiting a drain event in .pipe()s
   this.awaitDrain = 0;
 
@@ -680,8 +676,7 @@ function nReadingNextTick(self) {
   self.read(0);
 }
 
-// pause() and resume() are remnants of the legacy readable stream API
-// If the user uses them, then switch into old mode.
+// pause() and resume() disable and enable flowing mode repsectively.
 Readable.prototype.resume = function() {
   var state = this._readableState;
   if (!state.flowing) {
@@ -732,9 +727,10 @@ function flow(stream) {
   }
 }
 
-// wrap an old-style stream as the async data source.
+// wrap an old-style stream that implements advisory backpressure
+// with a new style stream that respects strict back pressure.
 // This is *not* part of the readable stream interface.
-// It is an ugly unfortunate mess of history.
+
 Readable.prototype.wrap = function(stream) {
   var state = this._readableState;
   var paused = false;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -676,7 +676,7 @@ function nReadingNextTick(self) {
   self.read(0);
 }
 
-// pause() and resume() disable and enable flowing mode repsectively.
+// pause() and resume() disable and enable flowing mode respectively.
 Readable.prototype.resume = function() {
   var state = this._readableState;
   if (!state.flowing) {


### PR DESCRIPTION
I was reading the code and noticed that some of the comments where clearly wrong.
The pipe function now resembles the classic 0.8 era pipe function (lib/stream.js) with data, end, pause and resume. The readable event and read() are not used in pipe at all, so the comments that say pause/resume is legacy are misleading.

Also I removed `stream.ranOut`, because it was never mentioned (anywhere in iojs or in the documentation) it's just always false, so mostly surely no dependant code ever checks it, and if it does it will still be falsey, this can probably be considered a patch, but it wasn't prefixed with _ so it _may_ be considered a public api by some.

There where some other comments which seemed dubious, but not as obviously so,
for example https://github.com/nodejs/io.js/blob/master/lib/_stream_readable.js#L412-L417 describes the user listening on `'readable'` and calling `read()` but they generally they should just use `pipe()` instead - however, it doesn't seem as clear cut as the above so I didn't make that commit.