### PR TITLE
util: treat all args identically in absence of a format

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -68,9 +68,8 @@ and then concatenated, delimited by a space.
 
     util.format('%s:%s', 'foo', 'bar', 'baz'); // 'foo:bar baz'
 
-If the first argument is not a format string then `util.format()` returns
-a string that is the concatenation of all its arguments separated by spaces.
-Each argument is converted to a string with `util.inspect()`.
+If the first argument is not a string then all arguments are treated as extra
+arguments.
 
     util.format(1, 2, 3); // '1 2 3'
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,9 +6,17 @@ const Debug = require('vm').runInDebugContext('Debug');
 const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (typeof f !== 'string') {
+    var i = 0;
+    var len = arguments.length;
     var objects = [];
-    for (var i = 0; i < arguments.length; i++) {
-      objects.push(inspect(arguments[i]));
+    for (var x = arguments[i]; i < len; x = arguments[++i]) {
+      // Keep this conditional synced with the one at the end of this function
+      // this is used for trailing args after a format string.
+      if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
+        objects.push(String(x));
+      } else {
+        objects.push(inspect(x));
+      }
     }
     return objects.join(' ');
   }

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -3,8 +3,10 @@ var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 var symbol = Symbol('foo');
+var fn = function() {};
 
 assert.equal(util.format(), '');
+assert.equal(util.format(fn), 'function () {}');
 assert.equal(util.format(''), '');
 assert.equal(util.format([]), '[]');
 assert.equal(util.format({}), '{}');
@@ -12,6 +14,17 @@ assert.equal(util.format(null), 'null');
 assert.equal(util.format(true), 'true');
 assert.equal(util.format(false), 'false');
 assert.equal(util.format('test'), 'test');
+
+// Args get formatted identically whether they are in args[0] (no format), or
+// used as trailing args (no format).
+assert.equal(util.format('foo', fn), 'foo function () {}');
+assert.equal(util.format('foo', ''), 'foo ');
+assert.equal(util.format('foo', []), 'foo []');
+assert.equal(util.format('foo', {}), 'foo {}');
+assert.equal(util.format('foo', null), 'foo null');
+assert.equal(util.format('foo', true), 'foo true');
+assert.equal(util.format('foo', false), 'foo false');
+assert.equal(util.format('foo', 'test'), 'foo test');
 
 // CHECKME this is for console.log() compatibility - but is it *right*?
 assert.equal(util.format('foo', 'bar', 'baz'), 'foo bar baz');

--- a/test/parallel/test-util-log.js
+++ b/test/parallel/test-util-log.js
@@ -18,7 +18,7 @@ var tests = [
   {input: null, output: 'null'},
   {input: false, output: 'false'},
   {input: 42, output: '42'},
-  {input: function() {}, output: '[Function]'},
+  {input: function() {}, output: 'function () {}'},
   {input: parseInt('not a number', 10), output: 'NaN'},
   {input: {answer: 42}, output: '{ answer: 42 }'},
   {input: [1,2,3], output: '[ 1, 2, 3 ]'}


### PR DESCRIPTION
Unformatted arguments to util.format() are those that trail a format
string and the arguments it consumes, and they are all arguments when
there is no format string.

This make util.format() behave more as it used to be documented in node
v0.10.

Note that since https://github.com/joyent/node/issues/6551, the "inspect everything if there wasn't a leading format string" behaviour was enshrined in the docs. That's the other way to fix things when they don't work as documented, but I don't think the current behaviour makes a lot of sense, see conversations below for more info, and unit tests for example output after this change.

Fixes https://github.com/joyent/node/issues/6551

Replaces https://github.com/joyent/node/pull/6393
