### PR TITLE
Add working group state per Project Lifecycle.

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -80,7 +80,7 @@ Its responsibilities are:
 
 ### [Tracing](https://github.com/nodejs/tracing-wg)
 
-**State** : Core
+**State** : Mature
 
 The tracing working group's purpose is to increase the
 transparency of software written in io.js.
@@ -198,7 +198,7 @@ Their responsibilities are:
 
 ### [Addon API](https://github.com/nodejs/nan)
 
-**State** : Mature
+**State** : Core
 
 The Addon API Working Group is responsible for maintaining the NAN project and
 corresponding _nan_ package in npm. The NAN project makes available an

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -32,6 +32,8 @@ back in to the TC.
 
 ### [Website](https://github.com/nodejs/website)
 
+**State** : Mature
+
 The website working group's purpose is to build and maintain a public
 website for the `io.js` project.
 
@@ -42,6 +44,8 @@ releases and features.
 * Foster and enable a community of translators.
 
 ### [Streams](https://github.com/nodejs/readable-stream)
+
+**State** : Core
 
 The Streams WG is dedicated to the support and improvement of the Streams API
 as used in io.js and the npm ecosystem. We seek to create a composable API that
@@ -62,6 +66,8 @@ responsibilities include:
 
 ### [Build](https://github.com/nodejs/build)
 
+**State** : Core
+
 The build working group's purpose is to create and maintain a
 distributed automation infrastructure.
 
@@ -74,6 +80,8 @@ Its responsibilities are:
 
 ### [Tracing](https://github.com/nodejs/tracing-wg)
 
+**State** : Core
+
 The tracing working group's purpose is to increase the
 transparency of software written in io.js.
 
@@ -85,6 +93,8 @@ Its responsibilities are:
 * Fostering a tracing and debugging ecosystem.
 
 ### i18n
+
+**State** : Mature
 
 The i18n working groups handle more than just translations. They
 are endpoints for community members to collaborate with each
@@ -143,6 +153,8 @@ Each language community maintains its own membership.
 
 ### [Evangelism](https://github.com/nodejs/evangelism)
 
+**State** : Mature
+
 The evangelism working group promotes the accomplishments
 of io.js and lets the community know how they can get involved.
 
@@ -156,6 +168,8 @@ content.
 
 
 ### [Roadmap](https://github.com/nodejs/roadmap)
+
+**State** : Mature
 
 The roadmap working group is responsible for user community outreach
 and the translation of their concerns into a plan of action for io.js.
@@ -171,6 +185,8 @@ Their responsibilities are:
 
 ### [Docker](https://github.com/nodejs/docker-iojs)
 
+**State** : Mature
+
 The Docker working group's purpose is to build, maintain, and improve official
 Docker images for the `io.js` project.
 
@@ -181,6 +197,8 @@ Their responsibilities are:
 
 
 ### [Addon API](https://github.com/nodejs/nan)
+
+**State** : Mature
 
 The Addon API Working Group is responsible for maintaining the NAN project and
 corresponding _nan_ package in npm. The NAN project makes available an


### PR DESCRIPTION
This adds the Working Group states I outlined in the [Project Lifecycle](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/TSC-Project-Lifecycle.md) and [WG-Merger](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/WG-Merger.md) documents for the project merger.

The biggest consequence of these states is that the "Core" WGs are entitled to elect a TSC seat.