### PR TITLE
child_process: make the maxBuffer correct with unicode

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -168,8 +168,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     _stderr = [];
     encoding = null;
   }
-  var stdoutLen = 0;
-  var stderrLen = 0;
+
   var killed = false;
   var exited = false;
   var timeoutId;
@@ -260,9 +259,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
       child.stdout.setEncoding(encoding);
 
     child.stdout.addListener('data', function(chunk) {
-      stdoutLen += chunk.length;
-
-      if (stdoutLen > options.maxBuffer) {
+      if (child.stdout.bytesRead > options.maxBuffer) {
         ex = new Error('stdout maxBuffer exceeded');
         kill();
       } else {
@@ -279,9 +276,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
       child.stderr.setEncoding(encoding);
 
     child.stderr.addListener('data', function(chunk) {
-      stderrLen += chunk.length;
-
-      if (stderrLen > options.maxBuffer) {
+      if (child.stderr.bytesRead > options.maxBuffer) {
         ex = new Error('stderr maxBuffer exceeded');
         kill();
       } else {

--- a/test/parallel/test-exec-max-buffer.js
+++ b/test/parallel/test-exec-max-buffer.js
@@ -1,11 +1,22 @@
 'use strict';
-require('../common');
-var exec = require('child_process').exec;
-var assert = require('assert');
 
-var cmd = 'echo "hello world"';
+const common = require('../common');
+const exec = require('child_process').exec;
+const assert = require('assert');
+
+const cmd = 'echo "hello world"';
 
 exec(cmd, { maxBuffer: 5 }, function(err, stdout, stderr) {
   assert.ok(err);
   assert.ok(/maxBuffer/.test(err.message));
 });
+
+if (!common.isWindows) {
+  const unicode = '中文测试'; // length: 12
+  exec('echo ' + unicode, {
+    encoding: 'utf8',
+    maxBuffer: 10
+  }, common.mustCall(function(err, stdout, stderr) {
+    assert.strictEqual(err.message, 'stdout maxBuffer exceeded');
+  }));
+}


### PR DESCRIPTION
The maxLen just caculate the string length, but to unicode string,
the string size is less than buffer size.