### PR TITLE
lib: fix expensive isNaN call in readable streams

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -211,7 +211,7 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return n === 0 ? 0 : 1;
 
-  if (n === null || isNaN(n)) {
+  if (n === null || n !== n) {
     // only flow one buffer at a time
     if (state.flowing && state.buffer.length)
       return state.buffer[0].length;


### PR DESCRIPTION
Replace a call to `isNaN(n)` with `n !== n`.  Removes most of the
overhead from the following hotspot:

    13.59%  iojs             perf-603.map         [.] LazyCompile:*isNaN
    native v8natives.js:67

R=@chrisdickinson, /cc @trevnorris

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/784/