### PR TITLE
repl: fix freeze if util.inspect throws & clean up error handling a bit

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -344,7 +344,13 @@ function REPLServer(prompt,
       // If we got any output - print it (if no error)
       if (!e && (!self.ignoreUndefined || ret !== undefined)) {
         self.context._ = ret;
-        self.outputStream.write(self.writer(ret) + '\n');
+        try {
+          var s = self.writer(ret);
+        } catch(e) {
+          process.domain.emit('error', e);
+          return;
+        }
+        self.outputStream.write(s + '\n');
       }
 
       // Display prompt again

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -157,12 +157,6 @@ function REPLServer(prompt,
         }
       } catch (e) {
         err = e;
-        if (err && process.domain) {
-          debug('not recoverable, send to domain');
-          process.domain.emit('error', err);
-          process.domain.exit();
-          return;
-        }
       }
     }
 
@@ -314,35 +308,30 @@ function REPLServer(prompt,
       debug('finish', e, ret);
       self.memory(cmd);
 
-      if (e && !self.bufferedCommand && cmd.trim().match(/^npm /)) {
-        self.outputStream.write('npm should be run outside of the ' +
-                                'node repl, in your normal shell.\n' +
-                                '(Press Control-D to exit.)\n');
-        self.bufferedCommand = '';
-        self.displayPrompt();
-        return;
-      }
-
       // If error was SyntaxError and not JSON.parse error
       if (e) {
-        if (e instanceof Recoverable) {
+        if (!self.bufferedCommand && cmd.trim().match(/^npm /)) {
+          self.outputStream.write('npm should be run outside of the ' +
+                                  'node repl, in your normal shell.\n' +
+                                  '(Press Control-D to exit.)\n');
+          self.bufferedCommand = '';
+          self.displayPrompt();
+        } else if (e instanceof Recoverable) {
           // Start buffering data like that:
           // {
           // ...  x: 1
           // ... }
           self.bufferedCommand += cmd + '\n';
           self.displayPrompt();
-          return;
         } else {
-          self._domain.emit('error', e);
+          debug('not recoverable, send to domain');
+          process.domain.emit('error', e);
         }
+        return;
       }
 
-      // Clear buffer if no SyntaxErrors
-      self.bufferedCommand = '';
-
-      // If we got any output - print it (if no error)
-      if (!e && (!self.ignoreUndefined || ret !== undefined)) {
+      // If we got any output - print it
+      if (!self.ignoreUndefined || ret !== undefined) {
         self.context._ = ret;
         try {
           var s = self.writer(ret);
@@ -354,6 +343,7 @@ function REPLServer(prompt,
       }
 
       // Display prompt again
+      self.bufferedCommand = '';
       self.displayPrompt();
     }
   });

--- a/test/parallel/test-repl-inspect-throw.js
+++ b/test/parallel/test-repl-inspect-throw.js
@@ -1,0 +1,51 @@
+'use strict';
+var assert = require('assert');
+var common = require('../common');
+var util   = require('util');
+var repl   = require('repl');
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function(data) {
+    var self = this;
+    data.forEach(function(line) {
+      self.emit('data', line + '\n');
+    });
+  };
+}
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function() {};
+ArrayStream.prototype.write = function() {};
+
+var putIn = new ArrayStream();
+var testMe = repl.start({
+  input: putIn,
+  output: putIn,
+  terminal: true
+});
+
+// Regression test: an exception raised during the 'keypress' event in readline
+// would corrupt the state of the escape sequence decoder, rendering the REPL
+// (and possibly your terminal) completely unusable.
+//
+// We can trigger this by triggering a throw inside util.inspect, which is used
+// to print a string representation of what you evaluate in the REPL.
+testMe.context.throwObj = {
+  inspect: function() {
+    throw new Error('inspect error');
+  }
+};
+testMe.context.reached = false;
+
+// Exceptions for whatever reason do not reach the normal error handler after
+// the inspect throw, but will work if run in another tick.
+process.nextTick(function() {
+  assert(testMe.context.reached);
+});
+
+putIn.run([
+  'throwObj',
+  'reached = true'
+]);


### PR DESCRIPTION
If an error is thrown during the readline `keypress` event, the state of the streaming escape sequence decoder (added in https://github.com/nodejs/io.js/pull/1601) will become corrupted. This will render the REPL (and possibly your whole terminal) completely unusable. This can be triggered by an object with a custom `inspect` method that throws.

Originally I modified the escape sequence decoder to avoid corruption but it proved difficult to test because the synchronous throw in `keypress` would end up corrupting the state of the mock streams I was using to test (although for whatever reason it would work with the real TTY streams). Felt too fragile to commit.

Instead, I decided that none of the eval machinery should ever throw. This PR adds an extra try/catch around `self.writer` (which is `util.inspect` by default) and makes some minor cleanups to make error handling more consistent.

Note: our test suite currently forbids running any of the REPL machinery in a different tick, which would sidestep most, if not all, of these problems.

cc @rlidwka