### PR TITLE
test: remove TODO

### DIFF
--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -30,7 +30,7 @@ if (cluster.isMaster) {
 
 http.createServer(function(req, res) {
   assert.equal(req.connection.remoteAddress, undefined);
-  assert.equal(req.connection.localAddress, undefined); // TODO common.PIPE?
+  assert.equal(req.connection.localAddress, undefined);
   res.writeHead(200);
   res.end('OK');
 }).listen(common.PIPE, function() {


### PR DESCRIPTION
All instances of the socket path in `req`, `res`, and the return
value from `http.createServer()` are properties starting with `_`
indicating that they should be treated as internal.

Testing those values would tie the test to the implementation.
So, do not check the socket path. If it *should* be  checked,
perhaps a feature issue is in order to expose the value.

/cc @bnoordhuis who put the comment there, in case what's
going on here is that I Just Don't Get It. (Should it ideally be
exposed in `localAddress` and it's just not?)