### PR TITLE
Prototype bleeding in events.js

### DIFF
--- a/test/parallel/test-event-emitter-prototype-bleeding.js
+++ b/test/parallel/test-event-emitter-prototype-bleeding.js
@@ -1,0 +1,19 @@
+'use strict';
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+
+var TestClass = function () {};
+TestClass.prototype = new EventEmitter;
+
+function listener_n1() {
+	// This one is okay to be called!
+}
+function listener_n2() {
+	throw new Error("This one should not be called!")
+}
+
+var ok = new TestClass();
+var broken = new TestClass();
+broken.on('end', listener_n2);
+ok.on('end', listener_n1);
+ok.emit('end');

--- a/test/parallel/test-event-emitter-prototype-bleeding.js
+++ b/test/parallel/test-event-emitter-prototype-bleeding.js
@@ -1,19 +1,23 @@
 'use strict';
 var util = require('util');
+var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
+var called = false;
 
-var TestClass = function () {};
-TestClass.prototype = new EventEmitter;
-
-function listener_n1() {
-	// This one is okay to be called!
+function TestClass() {
 }
-function listener_n2() {
-	throw new Error("This one should not be called!")
+TestClass.prototype = new EventEmitter();
+
+function okListener() {
+  called = true;
+}
+function brokenListener() {
+  throw new Error('This one should not be called!');
 }
 
 var ok = new TestClass();
 var broken = new TestClass();
-broken.on('end', listener_n2);
-ok.on('end', listener_n1);
+broken.on('end', okListener);
+ok.on('end', brokenListener);
 ok.emit('end');
+assert.ok(called, 'The ok listener should have been called');


### PR DESCRIPTION
Inheriting from EventEmitter using `.prototype`-old-school-notation like this:

```JavaScript
var MyClass = function() {};
MyClass.prototype = new EventEmitter();
```
 will result in the listeners added to one instance being executed by listeners of another instance.

```JavaScript
var ok = new MyClass();
var broken = new MyClass();
broken.on('x', function () { console.log('b'); });
ok.on('x', function () { console.log('a'); });
ok.emit('x'); // b a
```
This can be quite easily resolved by changing the inheritance to:

```JavaScript
util.inherits(MyClass, EventEmitter);
```

or 

```JavaScript
MyClass.prototype = Object.create(EventEmitter.prototype);
```

but it still is a problem because even developers like substack seem to not be aware of this: https://github.com/substack/node-charm/blob/c6646deed2dcee7f512bbbfac6d2ab58fb528a68/index.js#L67

This PR - at the time of writing this - still just contains just the test. I am not sure how to fix this. Any help welcome.

_Note: This fixes a problem that exists in older node versions as well, however: I found this bug/problem while investigating a different bug that started to appear in io.js after version 1.3.0 either due to https://github.com/nodejs/io.js/commit/7061669dba or https://github.com/nodejs/io.js/commit/630f636334 However my other bug was too hard to properly reproduce. Fixing this will fix the other bug as well._