### PR TITLE
url: more closely comply with WHATWG spec and browsers

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -50,8 +50,10 @@ const autoEscape = ['\''].concat(unwise);
 const nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape);
 const hostEndingChars = ['/', '?', '#'];
 const hostnameMaxLen = 255;
-const hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/;
-const hostnamePartStart = /^([+a-z0-9A-Z_-]{0,63})(.*)$/;
+const hostnamePartPattern = /^[+\w-]{0,63}$/;
+const hostnamePartStart = /^([^:/?#\t\r\n]{0,63})(.*)$/;
+const hostnameTerminators = /[:/?#\t\r\n]/;
+const hostnameEncode = /[^+\w\-.]/g;
 // protocols that can allow "unsafe" and "unwise" chars.
 const unsafeProtocol = {
   'javascript': true,
@@ -83,6 +85,24 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
   var u = new Url();
   u.parse(url, parseQueryString, slashesDenoteHost);
   return u;
+}
+
+// Browsers encode these in hostnames. Let's encode them too.
+const hostEscapeSpecial = {
+  '!': '%21',
+  '*': '%2A',
+  '(': '%28',
+  ')': '%29'
+};
+
+const hostSpecial =
+  new RegExp('[' + Object.keys(hostEscapeSpecial).join('') + ']', 'g');
+
+function encodeHost(host) {
+  host = encodeURIComponent(host);
+  return host.replace(hostSpecial, function(char) {
+    return hostEscapeSpecial[char];
+  });
 }
 
 Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
@@ -141,7 +161,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // user@server is *always* interpreted as a hostname, and url
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
+  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@/]+@[^@/]+/)) {
     var slashes = rest.substr(0, 2) === '//';
     if (slashes && !(proto && hostlessProtocol[proto])) {
       rest = rest.substr(2);
@@ -164,8 +184,9 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // http://a@b@c/ => user:a@b host:c
     // http://a@b?@c => user:a host:b path:/?@c
 
-    // v0.12 TODO(isaacs): This is not quite how Chrome does things.
-    // Review our test case against browsers more comprehensively.
+    // Strive to emulate browsers and conform with https://url.spec.whatwg.org/
+    // Thus:
+    // http://a.com*foo => host:a.com%2Afoo path:/
 
     // find the first instance of any hostEndingChars
     var hostEnd = -1;
@@ -239,8 +260,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
               newpart += part[j];
             }
           }
-          // we test again with ASCII char only
-          if (!newpart.match(hostnamePartPattern)) {
+
+          if (newpart.match(hostnameTerminators)) {
             var validParts = hostparts.slice(0, i);
             var notHost = hostparts.slice(i + 1);
             var bit = part.match(hostnamePartStart);
@@ -271,6 +292,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       // have non-ASCII characters, i.e. it doesn't matter if
       // you call it with a domain that already is ASCII-only.
       this.hostname = punycode.toASCII(this.hostname);
+      this.hostname = this.hostname.replace(hostnameEncode, encodeHost);
     }
 
     var p = this.port ? ':' + this.port : '';

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -853,6 +853,21 @@ var parseTests = {
     pathname: '/:npm/npm',
     path: '/:npm/npm',
     href: 'git+ssh://git@github.com/:npm/npm'
+  },
+
+  'http://a.com*foo!(bar)': {
+    protocol: 'http:',
+    slashes: true,
+    auth: null,
+    host: 'a.com%2Afoo%21%28bar%29',
+    port: null,
+    hostname: 'a.com%2Afoo%21%28bar%29',
+    hash: null,
+    search: null,
+    query: null,
+    href: 'http://a.com%2Afoo%21%28bar%29/',
+    path: '/',
+    pathname: '/'
   }
 
 };


### PR DESCRIPTION
Although certainly only an incremental improvement, this
change does comply more closely with the host parsing
rules laid out at https://url.spec.whatwg.org/#concept-host-parser
and also those used by browsers.

As noted in https://github.com/nodejs/io.js/commit/5dc51d4e215b65,
browsers treat `http://a.com*foo` as `http://a.com%2Afoo/`. So
that is the test case used here.

Might be some code smells to remove here (Multiple Similar Regular Expressions, I am looking in your collective direction), but first I'd like to confirm that I'm doing something worthwhile. /cc @isaacs 