### PR TITLE
path: make basename() on Windows case-insensitive

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -341,8 +341,7 @@ win32.basename = function(path, ext) {
     throw new TypeError('ext must be a string');
 
   var f = win32SplitPath(path)[2];
-  // TODO: make this comparison case-insensitive on windows?
-  if (ext && f.substr(-1 * ext.length) === ext) {
+  if (ext && f.toLowerCase().substr(-1 * ext.length) === ext.toLowerCase()) {
     f = f.substr(0, f.length - ext.length);
   }
   return f;

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -17,14 +17,20 @@ assert.equal(path.basename('basename.ext'), 'basename.ext');
 assert.equal(path.basename('basename.ext/'), 'basename.ext');
 assert.equal(path.basename('basename.ext//'), 'basename.ext');
 
-// On Windows a backslash acts as a path separator.
+// Windows: case insensitivie
+assert.equal(path.win32.basename('test.js', '.JS'), 'test');
+
+// POSIX: case sensitive
+assert.equal(path.posix.basename('test.js', '.JS'), 'test.js');
+
+// Windows: a backslash is the path separator.
 assert.equal(path.win32.basename('\\dir\\basename.ext'), 'basename.ext');
 assert.equal(path.win32.basename('\\basename.ext'), 'basename.ext');
 assert.equal(path.win32.basename('basename.ext'), 'basename.ext');
 assert.equal(path.win32.basename('basename.ext\\'), 'basename.ext');
 assert.equal(path.win32.basename('basename.ext\\\\'), 'basename.ext');
 
-// On unix a backslash is just treated as any other character.
+// POSIX: a backslash is treated as any other character.
 assert.equal(path.posix.basename('\\dir\\basename.ext'), '\\dir\\basename.ext');
 assert.equal(path.posix.basename('\\basename.ext'), '\\basename.ext');
 assert.equal(path.posix.basename('basename.ext'), 'basename.ext');


### PR DESCRIPTION
`path.relative()` correctly treats Windows as case-insensitive.

`path.basename()` should do the same when supplied with an extension.

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/117/

(Came around to this because I'm going through "TODO" comments in the code. This one seemed sensible to me. But if the consensus is that this is a bad idea, then I can go back and instead just remove the TODO comment and be done with it.)