### PR TITLE
debugger: fix debugger blocked main thread

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -37,6 +37,9 @@ exports.start = function start() {
     });
 
     agent.close();
+    agent.clients.forEach(function(client) {
+      client.destroy();
+    });
   };
 
   // Not used now, but anyway

--- a/test/debugger/test-debugger-stop.js
+++ b/test/debugger/test-debugger-stop.js
@@ -1,0 +1,28 @@
+'use strict';
+var common = require('../common');
+var debug = require('_debugger');
+
+var fork = require('child_process').fork;
+
+var scriptToDebug = common.fixturesDir + '/debug-connect.js';
+
+var nodeProcess;
+
+var failed = true;
+try {
+  process._debugProcess(process.pid);
+  failed = false;
+} finally {
+  // At least TRY not to leave zombie procs if this fails.
+  if (failed)
+    process.kill();
+}
+console.log('>>> starting debugger session');
+
+nodeProcess = fork(scriptToDebug);
+nodeProcess.send({ pid: process.pid });
+
+nodeProcess.on('message', function(m) {
+  process._debugEnd();
+  process.exit();
+});

--- a/test/fixtures/debug-connect.js
+++ b/test/fixtures/debug-connect.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var assert = require('assert');
+var debug = require('_debugger');
+var pid;
+
+setTimeout(function() {
+  if (pid) process.kill(pid, 'SIGTERM');
+  throw new Error('timeout');
+}, 5000).unref();
+
+function connectToDebug() {
+  var c = new debug.Client();
+  console.log('>>> connecting...');
+  c.connect(5858);
+  c.on('break', function(brk) {
+    c.reqContinue(function() {});
+  });
+}
+
+process.on('message', function(m) {
+  pid = m.pid;
+  connectToDebug();
+  process.send({ exit: 'exit' });
+});


### PR DESCRIPTION
see #2110  include a testcase. 
when call `process._debugEnd()` before fixed , it would be blocked, then throw a timeout error.

@thefourtheye @indutny 

