### PR TITLE
freelist: Performance, replace shift() with pop()

### DIFF
--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var common = require('../common.js');
+var FreeList = require('internal/freelist').FreeList;
+
+var bench = common.createBenchmark(main, {
+  n: [100000]
+});
+
+function main(conf) {
+  var n = conf.n;
+  var poolSize = 1000;
+  var list = new FreeList('test', poolSize, Object);
+  var i;
+  var j;
+  var used = [];
+
+  // First, alloc `poolSize` items
+  for (j = 0; j < poolSize; j++) {
+    used.push(list.alloc());
+  }
+
+  bench.start();
+
+  for (i = 0; i < n; i++){
+    // Return all the items to the pool
+    for (j = 0; j < poolSize; j++) {
+      list.free(used[j]);
+    }
+
+    // Re-alloc from pool
+    for (j = 0; j < poolSize; j++) {
+      list.alloc();
+    }
+  }
+
+  bench.end(n);
+}

--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -10,7 +10,7 @@ exports.FreeList = function(name, max, constructor) {
 
 
 exports.FreeList.prototype.alloc = function() {
-  return this.list.length ? this.list.shift() :
+  return this.list.length ? this.list.pop() :
                             this.constructor.apply(this, arguments);
 };
 

--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -27,6 +27,6 @@ assert.strictEqual(flist1.free('test4'), false);
 assert.strictEqual(flist1.free('test5'), false);
 
 // At this point 'alloc' should just return the stored values
-assert.strictEqual(flist1.alloc(), 'test1');
-assert.strictEqual(flist1.alloc(), 'test2');
 assert.strictEqual(flist1.alloc(), 'test3');
+assert.strictEqual(flist1.alloc(), 'test2');
+assert.strictEqual(flist1.alloc(), 'test1');


### PR DESCRIPTION
Array#pop() is known to be faster than Array#shift().
In this case there's no difference from which side of the "pool" array
the object is retrieved.