### PR TITLE
Add the CESU-8 encoding support

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2046,6 +2046,12 @@ class V8_EXPORT String : public Name {
   int Utf8Length() const;
 
   /**
+  * Returns the number of bytes in the CESU-8 encoded
+  * representation of this string.
+  */
+  int Cesu8Length() const;
+
+  /**
    * Returns whether this string is known to contain only one byte data.
    * Does not read the string.
    * False negatives are possible.
@@ -2091,7 +2097,10 @@ class V8_EXPORT String : public Name {
     // Used by WriteUtf8 to replace orphan surrogate code units with the
     // unicode replacement character. Needs to be set to guarantee valid UTF-8
     // output.
-    REPLACE_INVALID_UTF8 = 8
+    REPLACE_INVALID_UTF8 = 8,
+    // Compatibility Encoding Scheme for UTF-16: 8-Bit
+    // a variant of UTF-8 that is described in Unicode Technical Report #26
+    ENCODE_AS_CESU_8 = 16
   };
 
   // 16-bit character codes.

--- a/deps/v8/src/unicode-inl.h
+++ b/deps/v8/src/unicode-inl.h
@@ -75,7 +75,8 @@ unsigned Utf8::EncodeOneByte(char* str, uint8_t c) {
 unsigned Utf8::Encode(char* str,
                       uchar c,
                       int previous,
-                      bool replace_invalid) {
+                      bool replace_invalid,
+                      bool encode_as_cesu_8) {
   static const int kMask = ~(1 << 6);
   if (c <= kMaxOneByteChar) {
     str[0] = c;
@@ -85,16 +86,18 @@ unsigned Utf8::Encode(char* str,
     str[1] = 0x80 | (c & kMask);
     return 2;
   } else if (c <= kMaxThreeByteChar) {
-    if (Utf16::IsSurrogatePair(previous, c)) {
-      const int kUnmatchedSize = kSizeOfUnmatchedSurrogate;
-      return Encode(str - kUnmatchedSize,
-                    Utf16::CombineSurrogatePair(previous, c),
-                    Utf16::kNoPreviousCharacter,
-                    replace_invalid) - kUnmatchedSize;
-    } else if (replace_invalid &&
-               (Utf16::IsLeadSurrogate(c) ||
-               Utf16::IsTrailSurrogate(c))) {
-      c = kBadChar;
+    if (!encode_as_cesu_8) {
+      if (Utf16::IsSurrogatePair(previous, c)) {
+        const int kUnmatchedSize = kSizeOfUnmatchedSurrogate;
+        return Encode(str - kUnmatchedSize,
+                      Utf16::CombineSurrogatePair(previous, c),
+                      Utf16::kNoPreviousCharacter,
+                      replace_invalid) - kUnmatchedSize;
+      } else if (replace_invalid &&
+                 (Utf16::IsLeadSurrogate(c) ||
+                 Utf16::IsTrailSurrogate(c))) {
+        c = kBadChar;
+      }
     }
     str[0] = 0xE0 | (c >> 12);
     str[1] = 0x80 | ((c >> 6) & kMask);
@@ -134,6 +137,18 @@ unsigned Utf8::Length(uchar c, int previous) {
     return 3;
   } else {
     return 4;
+  }
+}
+
+unsigned Utf8::CesuLength(uchar c, int previous) {
+  if (c <= kMaxOneByteChar) {
+    return 1;
+  } else if (c <= kMaxTwoByteChar) {
+    return 2;
+  } else if (c <= kMaxThreeByteChar) {
+    return 3;
+  } else {
+    return 6;
   }
 }
 

--- a/deps/v8/src/unicode.h
+++ b/deps/v8/src/unicode.h
@@ -131,11 +131,13 @@ class Utf16 {
 class Utf8 {
  public:
   static inline uchar Length(uchar chr, int previous);
+  static inline uchar CesuLength(uchar chr, int previous);
   static inline unsigned EncodeOneByte(char* out, uint8_t c);
   static inline unsigned Encode(char* out,
                                 uchar c,
                                 int previous,
-                                bool replace_invalid = false);
+                                bool replace_invalid = false,
+                                bool encode_as_cesu_8 = false);
   static uchar CalculateValue(const byte* str, size_t length, size_t* cursor);
 
   // The unicode replacement character, used to signal invalid unicode

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -166,6 +166,8 @@ Buffer.isEncoding = function(encoding) {
       case 'hex':
       case 'utf8':
       case 'utf-8':
+      case 'cesu8':
+      case 'cesu-8':
       case 'ascii':
       case 'binary':
       case 'base64':
@@ -247,6 +249,10 @@ function byteLength(string, encoding) {
       case 'utf8':
       case 'utf-8':
         return binding.byteLengthUtf8(string);
+
+      case 'cesu8':
+      case 'cesu-8':
+        return binding.byteLengthCesu8(string);
 
       case 'ucs2':
       case 'ucs-2':
@@ -499,6 +505,10 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       case 'utf8':
       case 'utf-8':
         return this.utf8Write(string, offset, length);
+
+      case 'cesu8':
+      case 'cesu-8':
+        return this.cesu8Write(string, offset, length);
 
       case 'ascii':
         return this.asciiWrite(string, offset, length);

--- a/src/node.cc
+++ b/src/node.cc
@@ -1241,6 +1241,10 @@ enum encoding ParseEncoding(const char* encoding,
     return UTF8;
   } else if (strcasecmp(encoding, "utf-8") == 0) {
     return UTF8;
+  } else if (strcasecmp(encoding, "cesu8") == 0) {
+    return CESU8;
+  } else if (strcasecmp(encoding, "cesu-8") == 0) {
+    return CESU8;
   } else if (strcasecmp(encoding, "ascii") == 0) {
     return ASCII;
   } else if (strcasecmp(encoding, "base64") == 0) {

--- a/src/node.h
+++ b/src/node.h
@@ -264,7 +264,7 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
 }
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 
-enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
+enum encoding {ASCII, UTF8, CESU8, BASE64, UCS2, BINARY, HEX, BUFFER};
 NODE_EXTERN enum encoding ParseEncoding(
     v8::Isolate* isolate,
     v8::Handle<v8::Value> encoding_v,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -700,6 +700,9 @@ void Utf8Write(const FunctionCallbackInfo<Value>& args) {
   StringWrite<UTF8>(args);
 }
 
+void Cesu8Write(const FunctionCallbackInfo<Value>& args) {
+  StringWrite<CESU8>(args);
+}
 
 void Ucs2Write(const FunctionCallbackInfo<Value>& args) {
   StringWrite<UCS2>(args);
@@ -822,6 +825,12 @@ void ByteLengthUtf8(const FunctionCallbackInfo<Value> &args) {
   args.GetReturnValue().Set(args[0].As<String>()->Utf8Length());
 }
 
+void ByteLengthCesu8(const FunctionCallbackInfo<Value> &args) {
+  CHECK(args[0]->IsString());
+
+  // Fast case: avoid StringBytes on CESU8 string. Jump to v8.
+  args.GetReturnValue().Set(args[0].As<String>()->Cesu8Length());
+}
 
 void Compare(const FunctionCallbackInfo<Value> &args) {
   Environment* env = Environment::GetCurrent(args);
@@ -986,6 +995,7 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
   env->SetMethod(proto, "hexWrite", HexWrite);
   env->SetMethod(proto, "ucs2Write", Ucs2Write);
   env->SetMethod(proto, "utf8Write", Utf8Write);
+  env->SetMethod(proto, "cesu8Write", Cesu8Write);
 
   env->SetMethod(proto, "copy", Copy);
 }
@@ -1003,6 +1013,7 @@ void Initialize(Handle<Object> target,
 
   env->SetMethod(target, "slice", Slice);
   env->SetMethod(target, "byteLengthUtf8", ByteLengthUtf8);
+  env->SetMethod(target, "byteLengthCesu8", ByteLengthCesu8);
   env->SetMethod(target, "compare", Compare);
   env->SetMethod(target, "fill", Fill);
   env->SetMethod(target, "indexOfBuffer", IndexOfBuffer);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -333,6 +333,11 @@ size_t StringBytes::Write(Isolate* isolate,
       nbytes = str->WriteUtf8(buf, buflen, chars_written, flags);
       break;
 
+    case CESU8:
+      nbytes = str->WriteUtf8(buf, buflen, chars_written,
+                              (flags | String::ENCODE_AS_CESU_8));
+      break;
+
     case UCS2: {
       uint16_t* const dst = reinterpret_cast<uint16_t*>(buf);
       size_t nchars;
@@ -477,6 +482,10 @@ size_t StringBytes::Size(Isolate* isolate,
 
     case UTF8:
       data_size = str->Utf8Length();
+      break;
+
+    case CESU8:
+      data_size = str->Cesu8Length();
       break;
 
     case UCS2:

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1189,3 +1189,9 @@ assert.throws(function() {
 assert.throws(function() {
   new Buffer(null);
 }, /must start with number, buffer, array or string/);
+
+// String encoded as CESU-8
+var grinning_face = new Buffer('f09f9880', 'hex').toString();
+var grinning_face_buf = new Buffer(grinning_face, 'cesu-8');
+var grinning_face_hex = grinning_face_buf.toString('hex').toLowerCase();
+assert.equal(grinning_face_hex, 'eda0bdedb880');


### PR DESCRIPTION
In our daily work it frequently occurs that we need to let io.js apps communicate in binary with Java apps, which necessitates the CESU-8 encoding. Details about this encoding is observed in [1]. This pull request is a quick implementation of it. One test case has been added and passed.

Since it modifies the upstream v8 code, I am not sure about how to handle such kind of patches. It seems problematic to make changes naively onto the node repository. Please guide me on how to merge this code. Thank you very much!

* CESU-8 stands for Compatibility Encoding Scheme for UTF-16: 8-Bit
* Function VisitTwoByteString() was made virtual to call in CESU-8 mode
* Added a new class CesuVisitor inheriting from Visitor
* Added Smiling Face symbol as a test case
* New API - String::Cesu8Length()
* New String::WriteOptions - ENCODE_AS_CESU_8

[1] https://en.wikipedia.org/wiki/CESU-8
