### PR TITLE
expose a global _require for usage in tools like node-inspector

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -888,6 +888,7 @@
 
     return nativeModule.exports;
   };
+  process._require = NativeModule.require.bind(NativeModule);
 
   NativeModule.getCached = function(id) {
     return NativeModule._cache[id];


### PR DESCRIPTION
right now we have no global way for tools to safely get access to builtins, we can use this to alleviate odd ways to get access to *a* require and define what is available safely globally by adding `process._require` rather than [how node-inspector currently does it](https://github.com/node-inspector/node-inspector/blob/8a8bf6e07c641ce64d066f010a3e8f1d23134bbf/lib/InjectorClient.js#L132-L150). This is also useful for other agent tools in similar boats that want to instrument code but only after node has managed to start up.

People can use `process._require("module")` if they need direct access to the node module system not purely for builtins.

I did not include the user land require because I think it could cause confusion about what the directory the `process.cwd()` and the fact that node's require uses static pathing.