### PR TITLE
tools: enable no-extra-semi rule in eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,8 @@ rules:
   no-dupe-keys: 2
   ## check duplicate switch-case
   no-duplicate-case: 2
+  ## disallow superfluous semicolons
+  no-extra-semi: 2
   ## disallow assignment of exceptional params
   no-ex-assign: 2
   ## disallow unreachable code

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -574,7 +574,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
           });
           cb(null, mirror);
         }
-      };
+      }
     });
     return;
   } else if (handle.type === 'function') {
@@ -800,7 +800,7 @@ function Interface(stdin, stdout, args) {
     } else {
       self.repl.context[key] = fn;
     }
-  };
+  }
 
   // Copy all prototype methods in repl context
   // Setup them as getters if possible

--- a/lib/events.js
+++ b/lib/events.js
@@ -434,7 +434,7 @@ function listenerCount(type) {
   }
 
   return 0;
-};
+}
 
 // About 1.5x faster than the two-arg version of Array#splice().
 function spliceOne(list, index) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1183,7 +1183,7 @@ function createServerHandle(address, port, addressType, fd) {
   }
 
   return handle;
-};
+}
 exports._createServerHandle = createServerHandle;
 
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -46,7 +46,7 @@ function convertProtocols(protocols) {
   }, 0);
 
   return buff;
-};
+}
 
 exports.convertNPNProtocols  = function(protocols, out) {
   // If protocols is Array - translate it into buffer

--- a/test/common.js
+++ b/test/common.js
@@ -337,7 +337,7 @@ function leakedGlobals() {
       leaked.push(val);
 
   return leaked;
-};
+}
 exports.leakedGlobals = leakedGlobals;
 
 // Turn this off if the test should not check for global leaks.

--- a/test/debugger/helper-debugger-repl.js
+++ b/test/debugger/helper-debugger-repl.js
@@ -103,7 +103,7 @@ function addTest(input, output) {
     } else {
       quit();
     }
-  };
+  }
   expected.push({input: input, lines: output, callback: next});
 }
 

--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -23,7 +23,7 @@ var ret;
 function checkSpawnSyncRet(ret) {
   assert.strictEqual(ret.status, 0);
   assert.strictEqual(ret.error, undefined);
-};
+}
 
 function verifyBufOutput(ret) {
   checkSpawnSyncRet(ret);

--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -122,7 +122,7 @@ function check(tests) {
         current++;
         if (ctx.expectClose) return;
         conn.removeListener('close', onclose);
-        conn.removeListener('data', ondata);;
+        conn.removeListener('data', ondata);
         connected();
       }
       conn.on('data', ondata);

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -8,7 +8,7 @@ var passed = false;
 
 function PassThrough() {
   stream.Transform.call(this);
-};
+}
 util.inherits(PassThrough, stream.Transform);
 PassThrough.prototype._transform = function(chunk, encoding, done) {
   this.push(chunk);
@@ -17,7 +17,7 @@ PassThrough.prototype._transform = function(chunk, encoding, done) {
 
 function TestStream() {
   stream.Transform.call(this);
-};
+}
 util.inherits(TestStream, stream.Transform);
 TestStream.prototype._transform = function(chunk, encoding, done) {
   if (!passed) {

--- a/test/parallel/test-stream-pipe-without-listenerCount.js
+++ b/test/parallel/test-stream-pipe-without-listenerCount.js
@@ -16,4 +16,4 @@ r.on('error', common.mustCall(noop));
 w.on('error', common.mustCall(noop));
 r.pipe(w);
 
-function noop() {};
+function noop() {}

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -8,7 +8,7 @@ var util = require('util');
 function MyWritable(fn, options) {
   stream.Writable.call(this, options);
   this.fn = fn;
-};
+}
 
 util.inherits(MyWritable, stream.Writable);
 

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -8,7 +8,7 @@ var util = require('util');
 function MyWritable(fn, options) {
   stream.Writable.call(this, options);
   this.fn = fn;
-};
+}
 
 util.inherits(MyWritable, stream.Writable);
 
@@ -17,7 +17,7 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
   callback();
 };
 
-;(function decodeStringsTrue() {
+(function decodeStringsTrue() {
   var m = new MyWritable(function(isBuffer, type, enc) {
     assert(isBuffer);
     assert.equal(type, 'object');
@@ -28,7 +28,7 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
   m.end();
 })();
 
-;(function decodeStringsFalse() {
+(function decodeStringsFalse() {
   var m = new MyWritable(function(isBuffer, type, enc) {
     assert(!isBuffer);
     assert.equal(type, 'string');

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -17,7 +17,7 @@ src._read = function(n) {
       src.push(new Buffer('1'));
       src.push(null);
     });
-  };
+  }
 };
 
 dst._write = function(chunk, enc, cb) {

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -42,7 +42,7 @@ function read100() {
 function readn(n, then) {
   console.error('read %d', n);
   expectEndingData -= n;
-  ;(function read() {
+  (function read() {
     var c = r.read(n);
     if (!c)
       r.once('readable', read);

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -39,7 +39,7 @@ server.listen(common.PORT, common.localhostIPv4, function() {
     if (nbClientsEnded === 2) {
       server.close();
     }
-  };
+  }
 
   const client1 = net.connect({ port: common.PORT });
   client1.on('end', addEndedClient);

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -66,7 +66,7 @@ function runTest(clientsOptions, serverOptions, cb) {
         cb(results);
       }
     });
-  };
+  }
 
 }
 

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -85,7 +85,7 @@ function startTest() {
 
       callback();
     });
-  };
+  }
 
   connectClient(clientsOptions[0], function() {
     connectClient(clientsOptions[1], function() {

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -146,7 +146,7 @@ function startTest() {
       else
         connectClient(i + 1, callback);
     }
-  };
+  }
 
   connectClient(0, function() {
     server.close();

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -103,7 +103,7 @@ function startTest() {
       // Continue
       start();
     });
-  };
+  }
 
   start();
 }

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1569,6 +1569,6 @@ var throws = [
 ];
 for (var i = 0; i < throws.length; i++) {
   assert.throws(function() { url.format(throws[i]); }, TypeError);
-};
+}
 assert(url.format('') === '');
 assert(url.format({}) === '');

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -33,7 +33,7 @@ deflater.flush(function(err) {
 });
 
 deflater.on('drain', function() {
-  drainCount++;;
+  drainCount++;
 });
 
 process.once('exit', function() {

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -24,7 +24,7 @@ var options = {
 function Mediator() {
   stream.Writable.call(this);
   this.buf = '';
-};
+}
 util.inherits(Mediator, stream.Writable);
 
 Mediator.prototype._write = function write(data, enc, cb) {

--- a/test/sequential/test-child-process-fork-getconnections.js
+++ b/test/sequential/test-child-process-fork-getconnections.js
@@ -11,7 +11,7 @@ if (process.argv[2] === 'child') {
   process.on('message', function(m, socket) {
     function sendClosed(id) {
       process.send({ id: id, status: 'closed'});
-    };
+    }
 
     if (m.cmd === 'new') {
       assert(socket);
@@ -82,7 +82,7 @@ if (process.argv[2] === 'child') {
     });
     sent++;
     child.send({ id: i, cmd: 'close' });
-  };
+  }
 
   let closeEmitted = false;
   server.on('close', function() {

--- a/test/sequential/test-tcp-wrap-listen.js
+++ b/test/sequential/test-tcp-wrap-listen.js
@@ -65,7 +65,7 @@ server.onconnection = function(err, client) {
         writeCount++;
         console.log('write ' + writeCount);
         maybeCloseClient();
-      };
+      }
 
       sliceCount++;
     } else {


### PR DESCRIPTION
This CL adds two rules:

### no-extra-semi

* Removed obvious extra semicolons
* Had to change some loops to add an empty body

### semi-spacing (removed)

This one is up for discussion because the changes I had to make feel wrong to me. 
For instance in `try {fs.rmdirSync(tmp(folder)); } catch (ex) {}` the space isn't really improving readability. Maybe it would better if we added a space as well at the beginning of the `try` block, but I can't find a rule for that.
Because of that I would prefer to explicitly disable this rule in `.eslintrc` but it is the one that enforces spaces in code like `for(let i = 0; i < x; i++)` so we'd lose that check.