### PR TITLE
Don't strip spaces for regular REPL input

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -329,10 +329,7 @@ function REPLServer(prompt,
       self._currentStringLiteral = parseLine(cmd, self._currentStringLiteral);
       const isWithinStrLiteral = self._currentStringLiteral !== null;
 
-      if (!wasWithinStrLiteral && !isWithinStrLiteral) {
-        // Current line has nothing to do with String literals, trim both ends
-        cmd = cmd.trim();
-      } else if (wasWithinStrLiteral && !isWithinStrLiteral) {
+      if (wasWithinStrLiteral && !isWithinStrLiteral) {
         // was part of a string literal, but it is over now, trim only the end
         cmd = cmd.trimRight();
       } else if (isWithinStrLiteral && !wasWithinStrLiteral) {


### PR DESCRIPTION
This means `  .method()` isn't misparsed as a REPL keyword, and significantly improves the usability of `.load`.