### PR TITLE
ensure preload modules are always preloaded

### DIFF
--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -1,12 +1,17 @@
 'use strict';
+// Refs: https://github.com/nodejs/node/pull/2253
+if (process.platform === 'sunos') {
+  console.log('1..0 # Skipped: Running on SunOS');
+  return;
+}
 const common = require('../common');
 const assert = require('assert');
 const path = require('path');
-const child_process = require('child_process');
+const childProcess = require('child_process');
 
-var nodeBinary = process.argv[0];
+const nodeBinary = process.argv[0];
 
-var preloadOption = function(preloads) {
+const preloadOption = function(preloads) {
   var option = '';
   preloads.forEach(function(preload, index) {
     option += '-r ' + preload + ' ';
@@ -14,18 +19,18 @@ var preloadOption = function(preloads) {
   return option;
 };
 
-var fixture = function(name) {
+const fixture = function(name) {
   return path.join(__dirname, '../fixtures/' + name);
 };
 
-var fixtureA = fixture('printA.js');
-var fixtureB = fixture('printB.js');
-var fixtureC = fixture('printC.js');
+const fixtureA = fixture('printA.js');
+const fixtureB = fixture('printB.js');
+const fixtureC = fixture('printC.js');
 const fixtureD = fixture('define-global.js');
-var fixtureThrows = fixture('throws_error4.js');
+const fixtureThrows = fixture('throws_error4.js');
 
 // test preloading a single module works
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + preloadOption([fixtureA]) + ' '
   + fixtureB,
   function(err, stdout, stderr) {
@@ -34,7 +39,7 @@ child_process.exec(nodeBinary + ' '
   });
 
 // test preloading multiple modules works
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + preloadOption([fixtureA, fixtureB]) + ' '
   + fixtureC,
   function(err, stdout, stderr) {
@@ -43,7 +48,7 @@ child_process.exec(nodeBinary + ' '
   });
 
 // test that preloading a throwing module aborts
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + preloadOption([fixtureA, fixtureThrows]) + ' '
   + fixtureB,
   function(err, stdout, stderr) {
@@ -55,7 +60,7 @@ child_process.exec(nodeBinary + ' '
   });
 
 // test that preload can be used with --eval
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + preloadOption([fixtureA])
   + '-e "console.log(\'hello\');"',
   function(err, stdout, stderr) {
@@ -63,9 +68,45 @@ child_process.exec(nodeBinary + ' '
     assert.equal(stdout, 'A\nhello\n');
   });
 
+// test that preload can be used with stdin
+const stdinProc = childProcess.spawn(
+  nodeBinary,
+  ['--require', fixtureA],
+  {stdio: 'pipe'}
+);
+stdinProc.stdin.end('console.log(\'hello\');');
+var stdinStdout = '';
+stdinProc.stdout.on('data', function(d) {
+  stdinStdout += d;
+});
+stdinProc.on('exit', function(code) {
+  assert.equal(code, 0);
+  assert.equal(stdinStdout, 'A\nhello\n');
+});
+
+// test that preload can be used with repl
+const replProc = childProcess.spawn(
+  nodeBinary,
+  ['-i', '--require', fixtureA],
+  {stdio: 'pipe'}
+);
+replProc.stdin.end('.exit\n');
+var replStdout = '';
+replProc.stdout.on('data', function(d) {
+  replStdout += d;
+});
+replProc.on('exit', function(code) {
+  assert.equal(code, 0);
+  const output = [
+    'A',
+    '> '
+  ].join('\n');
+  assert.equal(replStdout, output);
+});
+
 // test that preload placement at other points in the cmdline
 // also test that duplicated preload only gets loaded once
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + preloadOption([fixtureA])
   + '-e "console.log(\'hello\');" '
   + preloadOption([fixtureA, fixtureB]),
@@ -75,7 +116,7 @@ child_process.exec(nodeBinary + ' '
   });
 
 // test that preload works with -i
-const interactive = child_process.exec(nodeBinary + ' '
+const interactive = childProcess.exec(nodeBinary + ' '
   + preloadOption([fixtureD])
   + '-i',
   common.mustCall(function(err, stdout, stderr) {
@@ -86,7 +127,7 @@ const interactive = child_process.exec(nodeBinary + ' '
 interactive.stdin.write('a\n');
 interactive.stdin.write('process.exit()\n');
 
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + '--require ' + fixture('cluster-preload.js') + ' '
   + fixture('cluster-preload-test.js'),
   function(err, stdout, stderr) {
@@ -96,7 +137,7 @@ child_process.exec(nodeBinary + ' '
 
 // https://github.com/nodejs/node/issues/1691
 process.chdir(path.join(__dirname, '../fixtures/'));
-child_process.exec(nodeBinary + ' '
+childProcess.exec(nodeBinary + ' '
   + '--expose_debug_as=v8debug '
   + '--require ' + fixture('cluster-preload.js') + ' '
   + 'cluster-preload-test.js',


### PR DESCRIPTION
For consistency `-r/--require` should *always* preload modules; right now it works with normal startup, cluster, and eval; having preloading work with stdin and interactive mode would make this more consistent.