### PR TITLE
repl: better REPL commands detection

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -361,7 +361,7 @@ function REPLServer(prompt,
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (cmd && cmd.charAt(0) === '.' && isNaN(parseFloat(cmd))) {
+    if (cmd && isNaN(parseFloat(cmd)) && /^\.[a-z]+\s*[^(]*$/.test(cmd)) {
       var matches = cmd.match(/^\.([^\s]+)\s*(.*)$/);
       var keyword = matches && matches[1];
       var rest = matches && matches[2];

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -242,6 +242,24 @@ function error_test() {
             'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
       expect: ['\'1\'\n', '\'2\'\n', '\'3\'\n', '\'4\'\n', '\'5\'\n', '\'6\'\n',
                '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
+    // making sure that the function calls on objects will not be treated as
+    // REPL commands
+    { client: client_unix, send: 'function sum(arr) {\nreturn arr\n\t' +
+                                 '.reduce(function(a, x) { return a + x })\n}',
+      expect: prompt_multiline + prompt_multiline + prompt_multiline +
+              'undefined\n' + prompt_unix },
+    // ... even if the function calls have whitespaces between the function
+    // name and the parameters.
+    { client: client_unix, send: 'function sum(arr) {\nreturn arr\n\t' +
+                                 '.reduce  (\tfunction(a, x) { return a + x }' +
+                                 ')\n}',
+      expect: prompt_multiline + prompt_multiline + prompt_multiline +
+              'undefined\n' + prompt_unix },
+    // but the parsing will misinterpret `(` if it is used somewhere in a valid
+    // command, and it will NOT be considered as a REPL command.
+    { client: client_unix,
+      send: '.load file_name_with_opening_paren_().js\n.clear',
+      expect: prompt_multiline + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
Fixes the problem shown in https://github.com/nodejs/io.js/pull/2246

The REPL module, treats any line which starts with a dot character as
a REPL command and this limits the ability to use function calls in
the next lines to improve readability.

This patch checks if the current line starts with `.` and then a series
of lowercase letters and then any characters.

For example:

    > process.version
    'v2.4.0'
    > function sum(arr) {
    ... return arr
    ...     .reduce(function(c, x) { return x + c; });
    Invalid REPL keyword
    undefined

but then, this patches allows this:

    > process.version
    'v2.4.1-pre'
    > function sum(arr) {
    ... return arr
    ...     .reduce(function(c, x) { return x + c; });
    ... }
    undefined