### PR TITLE
test: use reserved IP in test-net-connect-timeout.js

### DIFF
--- a/test/internet/test-net-connect-timeout.js
+++ b/test/internet/test-net-connect-timeout.js
@@ -15,9 +15,11 @@ var gotConnect = false;
 
 var T = 100;
 
-
-// 240.*.*.*.* is "reserved for future use"
-var socket = net.createConnection(9999, '240.0.0.0');
+// 192.0.2.1 is part of subnet assigned as "TEST-NET" in RFC 5737.
+// For use solely in documentation and example source code.
+// In short, it should be unreachable.
+// In practice, it's a network black hole.
+var socket = net.createConnection(9999, '192.0.2.1');
 
 socket.setTimeout(T);
 


### PR DESCRIPTION
test-net-connect-timeout.js does not use internet anymore
so it can and should be moved to the parallel tests directory.

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/205/