### PR TITLE
Make http.request correctly parse {host: "hostname:port"}

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -57,8 +57,19 @@ function ClientRequest(options, cb) {
   const defaultPort = options.defaultPort ||
                       self.agent && self.agent.defaultPort;
 
-  var port = options.port = options.port || defaultPort || 80;
-  var host = options.host = options.hostname || options.host || 'localhost';
+  const parsedHost = {host: options.host};
+  if (options.host) {
+    url.Url.prototype.parseHost.call(parsedHost);
+
+    // unwrap brackets from ipv6 ip addresses
+    const hostname = parsedHost.hostname;
+    if (hostname[0] === '[' && hostname[hostname.length - 1] === ']') {
+      parsedHost.hostname = hostname.substr(1, hostname.length - 2);
+    }
+  }
+
+  const port = options.port = options.port || parsedHost.port || defaultPort || 80;
+  const host = options.host = options.hostname || parsedHost.hostname || 'localhost';
 
   if (options.setHost === undefined) {
     var setHost = true;

--- a/test/parallel/test-http-request-host-port-ipv6.js
+++ b/test/parallel/test-http-request-host-port-ipv6.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+if (!common.hasIPv6) {
+    console.log('1..0 # Skipped: no IPv6 support');
+    return;
+}
+
+var connected = false;
+
+const server = http.createServer(function(req, res) {
+  connected = true;
+  res.writeHead(204);
+  res.end();
+});
+
+server.listen(common.PORT, '::1', function() {
+ http.get({
+    host: '[::1]:' + common.PORT
+  }, function(res) {
+    res.resume();
+    server.close();
+  }).on('error', function(e) {
+    throw e;
+  });
+});
+
+process.on('exit', function() {
+  assert(connected, 'http.request should correctly parse ' +
+      '{host: "hostname:port"} and connect to the specified host');
+});

--- a/test/parallel/test-http-request-host-port.js
+++ b/test/parallel/test-http-request-host-port.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+var connected = false;
+
+const server = http.createServer(function(req, res) {
+  connected = true;
+  res.writeHead(204);
+  res.end();
+});
+
+server.listen(common.PORT, function() {
+ http.get({
+    host: 'localhost:' + common.PORT
+  }, function(res) {
+    res.resume();
+    server.close();
+  }).on('error', function(e) {
+    throw e;
+  });
+});
+
+process.on('exit', function() {
+  assert(connected, 'http.request should correctly parse ' +
+      '{host: "hostname:port"} and connect to the specified host');
+});


### PR DESCRIPTION
The issue:
`http.request()` treats `host` as an alternate form of `hostname`, which it sort of is, except that `host` is (normally) allowed to contain a port number.

Before this change, if `host` contains a port number and there isn't a `hostname` field to override it, `http.request()` attempts a DNS lookup on the entire host field, including the port number. This always fails.

The fix:
If a host field is present, split it around `':'` and use the first portion as a fallback `hostname` and the second (if present) as a fallback `port`. ("Fallback" meaning that the values from the `host` field are only used when the `hostname` and `port` fields aren't set.)

Includes a test to verify the correct behavior.

I originally filed an [issue](https://github.com/joyent/node/issues/25751) on joyent/node and submitted a [patch](https://github.com/joyent/node/pull/25752) there, but @jasnell said that this might be a better fit for nodejs/io.js or nodejs/node, so I'm sending the same patch to each. (The node patch is at https://github.com/nodejs/node/pull/72) Please merge into whichever repo is appropriate and close the other one.
