### PR TITLE
querystring: use `String.prototype.split`'s `limit`

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -209,18 +209,19 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
     return obj;
   }
 
-  qs = qs.split(sep);
-
   var maxKeys = 1000;
   if (options && typeof options.maxKeys === 'number') {
     maxKeys = options.maxKeys;
   }
 
-  var len = qs.length;
   // maxKeys <= 0 means that we should not limit keys count
-  if (maxKeys > 0 && len > maxKeys) {
-    len = maxKeys;
+  if (maxKeys > 0) {
+    qs = qs.split(sep, maxKeys);
+  } else {
+    qs = qs.split(sep);
   }
+
+  var len = qs.length;
 
   var decode = QueryString.unescape;
   if (options && typeof options.decodeURIComponent === 'function') {


### PR DESCRIPTION
There's no need to add extra logic for it, `String.prototype.split` already has a `limit` argument. By using this argument we avoid keeping the whole array in memory, and V8 doesn't have to process the entire string.