### PR TITLE
build: bump ICU from 54 to 55

### DIFF
--- a/configure
+++ b/configure
@@ -796,9 +796,9 @@ def glob_to_var(dir_base, dir_sub):
 def configure_intl(o):
   icus = [
     {
-      'url': 'http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.zip',
-      # from https://ssl.icu-project.org/files/icu4c/54.1/icu4c-src-54_1.md5:
-      'md5': '6b89d60e2f0e140898ae4d7f72323bca',
+      'url': 'http://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.zip',
+      # from https://ssl.icu-project.org/files/icu4c/55.1/icu4c-src-55_1.md5:
+      'md5': '4cddf1e1d47622fdd9de2cd7bb5001fd',
     },
   ]
   def icu_download(path):

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -111,8 +111,8 @@
             '<@(icu_src_i18n)'
           ],
           'conditions': [
-            [ 'icu_ver_major == 54', { 'sources!': [
-              ## Strip out the following for ICU 54 only.
+            [ 'icu_ver_major == 55', { 'sources!': [
+              ## Strip out the following for ICU 55 only.
               ## add more conditions in the future?
               ## if your compiler can dead-strip, this will
               ## make ZERO difference to binary size.
@@ -369,8 +369,8 @@
         '<@(icu_src_common)',
       ],
       'conditions': [
-        [ 'icu_ver_major == 54', { 'sources!': [
-          ## Strip out the following for ICU 54 only.
+        [ 'icu_ver_major == 55', { 'sources!': [
+          ## Strip out the following for ICU 55 only.
           ## add more conditions in the future?
           ## if your compiler can dead-strip, this will
           ## make ZERO difference to binary size.


### PR DESCRIPTION
port of joyent/node/0c70451854e22d8441096bc869cda5bca1d86bae

node is using ICU 54 ( 2014-oct-06 ). Bump to 55 ( 2015-apr-08)

fixes #2292  

Also, retarget the file exclusions from ICU 54 to ICU 55
(improves on-disk footprint on some platforms)