### PR TITLE
doc: add the smoke test working group

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -205,6 +205,24 @@ Their responsibilities are:
 The current members can be found in their
 [README](https://github.com/nodejs/nan#collaborators).
 
+### [Smoke Test](https://github.com/nodejs/smoke-test)
+
+The Smoke Test Working Group is repsonsible for making sure releases of Node.js
+and io.js do not break community modules. Smoke test will build the tooling and
+maintaining the infrastructure to achieve this.
+
+Their responsibilities are:
+
+* Building and maintaining [CITGM](https://github.com/nodejs/citgm) GitHub
+  repository, including code, issues and documentation.
+* Building and maintaining the infrastructure to run the tests. This is still
+  being defined.
+* Generating a list of negatively impacted modules by a given release or pull
+  request.
+
+The current members can be found in their
+[README](https://github.com/nodejs/smoke-test#collaborators).
+
 ## Starting a WG
 
 A Working Group is established by first defining a charter  that can be

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -207,7 +207,7 @@ The current members can be found in their
 
 ### [Smoke Test](https://github.com/nodejs/smoke-test)
 
-The Smoke Test Working Group is repsonsible for making sure releases of Node.js
+The Smoke Test Working Group is responsible for making sure releases of Node.js
 and io.js do not break community modules. Smoke test will build the tooling and
 maintaining the infrastructure to achieve this.
 


### PR DESCRIPTION
**This should not be merged yet**

@nodejs/smoke-test needs to review this to make sure I've represented us (I guess I'm part of it now as well) accurately. I put this together as a rough draft to kick off the process.

Also, discussing whether we should be an independent working group or if this should be folded into one of the other working groups.

In my opinion, because this will be very critical to @nodejs/lts but also critical to @nodejs/build and this will be shared infrastructure, it should be ran independently with stakeholders from both keeping involved. I think this is already the case from the seed list of members.

**Note:** Some of the links, like the collaborator one are not active as I need to put together the readme and the initial governance stuff in the https://github.com/nodejs/smoke-test repo.