### PR TITLE
src: fix v8::CpuProfiler idle sampling

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3587,10 +3587,6 @@ inline void PlatformInit() {
   RegisterSignalHandler(SIGINT, SignalExit, true);
   RegisterSignalHandler(SIGTERM, SignalExit, true);
 
-  // Block SIGPROF signals when sleeping in epoll_wait/kevent/etc.  Avoids the
-  // performance penalty of frequent EINTR wakeups when the profiler is running.
-  uv_loop_configure(uv_default_loop(), UV_LOOP_BLOCK_SIGNAL, SIGPROF);
-
   // Raise the open file descriptor limit.
   struct rlimit lim;
   if (getrlimit(RLIMIT_NOFILE, &lim) == 0 && lim.rlim_cur != lim.rlim_max) {
@@ -3673,6 +3669,15 @@ void Init(int* argc,
       break;
     }
   }
+
+#ifdef __POSIX__
+  // Block SIGPROF signals when sleeping in epoll_wait/kevent/etc.  Avoids the
+  // performance penalty of frequent EINTR wakeups when the profiler is running.
+  // Only do this for v8.log profiling, as it breaks v8::CpuProfiler users.
+  if (v8_is_profiling) {
+    uv_loop_configure(uv_default_loop(), UV_LOOP_BLOCK_SIGNAL, SIGPROF);
+  }
+#endif
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
   if (icu_data_dir == nullptr) {


### PR DESCRIPTION
Correctly mark idle wait as "(idle)" instead of "(program)", and take
samples during that time.

This makes profiling with node-inspector (via v8-profiler) actually useful.

---

Simple test program:
```
var http = require("http");

http.createServer(function(req, res) {
	res.end("Hello World\n");
}).listen(1337, "127.0.0.1");

console.log("node.js version: " + process.version);
console.log("Server running at http://127.0.0.1:1337/");
```

Testing was done by starting profiling, waiting few seconds, loading page once in the browser, waiting few more seconds and then stopping profiling.

What profiler showed before the fix (omg, several seconds of CPU time to handle one trivial request?):
<img width="1579" alt="io js-2 5 0" src="https://cloud.githubusercontent.com/assets/11211653/9137118/e365456e-3d1b-11e5-9e10-fc263cb8188e.png">

After the fix (now actually looks like reality):
<img width="1581" alt="io js-2 5 0-fixed" src="https://cloud.githubusercontent.com/assets/11211653/9137131/eaa024ca-3d1b-11e5-86af-94e155929574.png">

Please cherry-pick this fix to 2.x and 3.x - having working convenient profiling can be really useful.
The fix itself was in fact tested off 2.5.0, since v8-profiler package has not been updated yet for module ABI v45.
