### PR TITLE
[addons] Implement new init function argument dispatch

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -129,9 +129,7 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-static void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+static void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
@@ -270,4 +268,4 @@ Handle<Value> AsyncWrap::MakeCallback(const Handle<Function> cb,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(async_wrap, node::Initialize)
+NODE_MODULE_BUILTIN(async_wrap, node::Initialize)

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1240,9 +1240,7 @@ static void CaresTimerClose(Environment* env,
 }
 
 
-static void Initialize(Handle<Object> target,
-                       Handle<Value> unused,
-                       Handle<Context> context) {
+static void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   int r = ares_library_init(ARES_LIB_INIT_ALL);
@@ -1318,4 +1316,4 @@ static void Initialize(Handle<Object> target,
 }  // namespace cares_wrap
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(cares_wrap, node::cares_wrap::Initialize)
+NODE_MODULE_BUILTIN(cares_wrap, node::cares_wrap::Initialize)

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -24,9 +24,7 @@ using v8::Value;
 
 class FSEventWrap: public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context);
+  static void Initialize(Local<Object> target, Local<Context> context);
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Start(const FunctionCallbackInfo<Value>& args);
   static void Close(const FunctionCallbackInfo<Value>& args);
@@ -59,9 +57,7 @@ FSEventWrap::~FSEventWrap() {
 }
 
 
-void FSEventWrap::Initialize(Handle<Object> target,
-                             Handle<Value> unused,
-                             Handle<Context> context) {
+void FSEventWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -176,4 +172,4 @@ void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(fs_event_wrap, node::FSEventWrap::Initialize)
+NODE_MODULE_BUILTIN(fs_event_wrap, node::FSEventWrap::Initialize)

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -201,9 +201,7 @@ void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void JSStream::Initialize(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void JSStream::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -226,4 +224,4 @@ void JSStream::Initialize(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(js_stream, node::JSStream::Initialize)
+NODE_MODULE_BUILTIN(js_stream, node::JSStream::Initialize)

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -10,9 +10,8 @@ namespace node {
 
 class JSStream : public StreamBase, public AsyncWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   ~JSStream();
 

--- a/src/node.h
+++ b/src/node.h
@@ -363,11 +363,11 @@ const char *signo_string(int errorno);
 namespace detail {
 
 typedef void (*addon_register_func)(
-    void * init_function,
+    void* init_function,
     v8::Local<v8::Object> exports,
     v8::Local<v8::Object> module,
     v8::Local<v8::Context> context,
-    void * priv);
+    void* priv);
 
 // This template is used to select the optional arguments of the (addon) init
 // function. Each specialization returns the corresponding argument.
@@ -377,7 +377,7 @@ template <>
 struct OptionalInitArg<v8::Local<v8::Object> > {
   static inline
   v8::Local<v8::Object>
-  pick(v8::Local<v8::Object> module, v8::Local<v8::Context>, void *) {
+  pick(v8::Local<v8::Object> module, v8::Local<v8::Context>, void*) {
     return module;
   }
 };
@@ -386,7 +386,7 @@ template <>
 struct OptionalInitArg<v8::Local<v8::Context> > {
   static inline
   v8::Local<v8::Context>
-  pick(v8::Local<v8::Object>, v8::Local<v8::Context> context, void *) {
+  pick(v8::Local<v8::Object>, v8::Local<v8::Context> context, void*) {
     return context;
   }
 };
@@ -395,7 +395,7 @@ template <>
 struct OptionalInitArg<void*> {
   static inline
   void*
-  pick(v8::Local<v8::Object>, v8::Local<v8::Context>, void * private_) {
+  pick(v8::Local<v8::Object>, v8::Local<v8::Context>, void* private_) {
     return private_;
   }
 };
@@ -432,11 +432,11 @@ struct AddonInitAdapter<void (*)(v8::Local<v8::Object>, Args...)> {
 
   static
   void
-  registerAddon(void * f,
+  registerAddon(void* f,
                 v8::Local<v8::Object> exports,
                 v8::Local<v8::Object> module,
                 v8::Local<v8::Context> context,
-                void * priv) {
+                void* priv) {
     // restore function pointer type
     init_function init(reinterpret_cast<init_function>(f));
     // call it

--- a/src/node.h
+++ b/src/node.h
@@ -504,20 +504,20 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 
 #define NODE_MODULE_X(modname, initfunc, priv, flags)                 \
   extern "C" {                                                        \
-    static node::node_module _module_ ## modname =                    \
-    {                                                                 \
-      NODE_MODULE_VERSION,                                            \
-      flags,                                                          \
-      NULL,                                                           \
-      __FILE__,                                                       \
-      node::detail::selectAddonRegisterFunction(initfunc),            \
-      reinterpret_cast<void*>(initfunc),                              \
-      NODE_STRINGIFY(modname),                                        \
-      priv,                                                           \
-      NULL                                                            \
-    };                                                                \
     NODE_C_CTOR(_register_ ## modname) {                              \
-      node_module_register(&_module_ ## modname);                     \
+      static node::node_module _module =                              \
+      {                                                               \
+        NODE_MODULE_VERSION,                                          \
+        flags,                                                        \
+        NULL,                                                         \
+        __FILE__,                                                     \
+        node::detail::selectAddonRegisterFunction(initfunc),          \
+        reinterpret_cast<void*>(initfunc),                            \
+        NODE_STRINGIFY(modname),                                      \
+        priv,                                                         \
+        NULL                                                          \
+      };                                                              \
+      node_module_register(&_module);                                 \
     }                                                                 \
   }
 

--- a/src/node.h
+++ b/src/node.h
@@ -415,7 +415,7 @@ template <typename F> struct AddonInitAdapter;
 //   - takes zero or more additional arguments of arbitrary type
 //
 // To further narrow it down it uses a little bit of SFINAE. It only matches
-// if there is a suitable specialization of OptionalInitArg<> for each 
+// if there is a suitable specialization of OptionalInitArg<> for each
 // additional argument. See registerAddon(...) below. This limits the argument
 // types to:
 //   - Local<Object>   (the module)
@@ -444,7 +444,7 @@ struct AddonInitAdapter<void (*)(v8::Local<v8::Object>, Args...)> {
   }
 };
 
-// Main entry point into the init-fuction-argument-discomvobulator. It is 
+// Main entry point into the init-fuction-argument-discomvobulator. It is
 // called with an init function as argument and returns a suitable
 // addon_register_func. Note how a template function is used to capture
 // the type F. A user of this function (our NODE_MODULE_X(...) macro, below)

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -991,9 +991,7 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "setupBufferJS", SetupBufferJS);
@@ -1028,4 +1026,4 @@ void Initialize(Handle<Object> target,
 }  // namespace Buffer
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(buffer, node::Buffer::Initialize)
+NODE_MODULE_BUILTIN(buffer, node::Buffer::Initialize)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -704,9 +704,7 @@ class ContextifyScript : public BaseObject {
 };
 
 
-void InitContextify(Handle<Object> target,
-                    Handle<Value> unused,
-                    Handle<Context> context) {
+void InitContextify(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   ContextifyContext::Init(env, target);
   ContextifyScript::Init(env, target);
@@ -714,4 +712,4 @@ void InitContextify(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(contextify, node::InitContextify);
+NODE_MODULE_BUILTIN(contextify, node::InitContextify);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5262,10 +5262,7 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
 
 
 // FIXME(bnoordhuis) Handle global init correctly.
-void InitCrypto(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context,
-                void* priv) {
+void InitCrypto(Local<Object> target, Local<Context> context) {
   static uv_once_t init_once = UV_ONCE_INIT;
   uv_once(&init_once, InitCryptoOnce);
 
@@ -5311,4 +5308,4 @@ void InitCrypto(Handle<Object> target,
 }  // namespace crypto
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(crypto, node::crypto::InitCrypto)
+NODE_MODULE_BUILTIN(crypto, node::crypto::InitCrypto)

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -722,7 +722,7 @@ bool EntropySource(unsigned char* buffer, size_t length);
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif  // !OPENSSL_NO_ENGINE
-void InitCrypto(v8::Handle<v8::Object> target);
+void InitCrypto(v8::Local<v8::Object> target, v8::Local<v8::Context> context);
 
 }  // namespace crypto
 }  // namespace node

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1188,10 +1188,7 @@ void FSInitialize(const FunctionCallbackInfo<Value>& args) {
   env->set_fs_stats_constructor_function(stats_constructor);
 }
 
-void InitFs(Handle<Object> target,
-            Handle<Value> unused,
-            Handle<Context> context,
-            void* priv) {
+void InitFs(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   // Function which creates a new Stats object.
@@ -1245,4 +1242,4 @@ void InitFs(Handle<Object> target,
 
 }  // end namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(fs, node::InitFs)
+NODE_MODULE_BUILTIN(fs, node::InitFs)

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -6,7 +6,7 @@
 
 namespace node {
 
-void InitFs(v8::Handle<v8::Object> target);
+void InitFs(v8::Local<v8::Object> target, v8::Local<v8::Context> context);
 
 }  // namespace node
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -560,10 +560,7 @@ const struct http_parser_settings Parser::settings = {
 };
 
 
-void InitHttpParser(Handle<Object> target,
-                    Handle<Value> unused,
-                    Handle<Context> context,
-                    void* priv) {
+void InitHttpParser(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -602,4 +599,4 @@ void InitHttpParser(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(http_parser, node::InitHttpParser)
+NODE_MODULE_BUILTIN(http_parser, node::InitHttpParser)

--- a/src/node_http_parser.h
+++ b/src/node_http_parser.h
@@ -7,7 +7,8 @@
 
 namespace node {
 
-void InitHttpParser(v8::Handle<v8::Object> target);
+void InitHttpParser(v8::Local<v8::Object> target,
+                    v8::Local<v8::Context> context);
 
 }  // namespace node
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -291,9 +291,7 @@ static void GetHomeDirectory(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "getHostname", GetHostname);
   env->SetMethod(target, "getLoadAvg", GetLoadAvg);
@@ -312,4 +310,4 @@ void Initialize(Handle<Object> target,
 }  // namespace os
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(os, node::os::Initialize)
+NODE_MODULE_BUILTIN(os, node::os::Initialize)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -58,9 +58,7 @@ void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void InitializeV8Bindings(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void InitializeV8Bindings(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target,
                  "updateHeapStatisticsArrayBuffer",
@@ -88,4 +86,4 @@ void InitializeV8Bindings(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(v8, node::InitializeV8Bindings)
+NODE_MODULE_BUILTIN(v8, node::InitializeV8Bindings)

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -43,7 +43,7 @@ enum node_zlib_mode {
 };
 
 
-void InitZlib(v8::Handle<v8::Object> target);
+void InitZlib(Local<Object> target, Local<Context> context);
 
 
 /**
@@ -573,10 +573,7 @@ class ZCtx : public AsyncWrap {
 };
 
 
-void InitZlib(Handle<Object> target,
-              Handle<Value> unused,
-              Handle<Context> context,
-              void* priv) {
+void InitZlib(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> z = env->NewFunctionTemplate(ZCtx::New);
 
@@ -636,4 +633,4 @@ void InitZlib(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(zlib, node::InitZlib)
+NODE_MODULE_BUILTIN(zlib, node::InitZlib)

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -70,9 +70,7 @@ Local<Object> PipeWrap::Instantiate(Environment* env, AsyncWrap* parent) {
 }
 
 
-void PipeWrap::Initialize(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void PipeWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -278,4 +276,4 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(pipe_wrap, node::PipeWrap::Initialize)
+NODE_MODULE_BUILTIN(pipe_wrap, node::PipeWrap::Initialize)

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -12,9 +12,8 @@ class PipeWrap : public StreamWrap {
   uv_pipe_t* UVHandle();
 
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   size_t self_size() const override { return sizeof(*this); }
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -26,9 +26,7 @@ using v8::Value;
 
 class ProcessWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target, Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -262,4 +260,4 @@ class ProcessWrap : public HandleWrap {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(process_wrap, node::ProcessWrap::Initialize)
+NODE_MODULE_BUILTIN(process_wrap, node::ProcessWrap::Initialize)

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -22,9 +22,7 @@ using v8::Value;
 
 class SignalWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target, Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -91,4 +89,4 @@ class SignalWrap : public HandleWrap {
 }  // namespace node
 
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(signal_wrap, node::SignalWrap::Initialize)
+NODE_MODULE_BUILTIN(signal_wrap, node::SignalWrap::Initialize)

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -340,9 +340,8 @@ void SyncProcessStdioPipe::CloseCallback(uv_handle_t* handle) {
 }
 
 
-void SyncProcessRunner::Initialize(Handle<Object> target,
-                                   Handle<Value> unused,
-                                   Handle<Context> context) {
+void SyncProcessRunner::Initialize(Local<Object> target,
+                                   Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "spawn", Spawn);
 }
@@ -1041,5 +1040,4 @@ void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(spawn_sync,
-  node::SyncProcessRunner::Initialize)
+NODE_MODULE_BUILTIN(spawn_sync, node::SyncProcessRunner::Initialize)

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -129,9 +129,7 @@ class SyncProcessRunner {
   };
 
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context);
+  static void Initialize(Local<Object> target, Local<Context> context);
   static void Spawn(const FunctionCallbackInfo<Value>& args);
 
  private:

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -40,9 +40,7 @@ using v8::Undefined;
 using v8::Value;
 
 
-void StreamWrap::Initialize(Handle<Object> target,
-                            Handle<Value> unused,
-                            Handle<Context> context) {
+void StreamWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> sw =
@@ -379,4 +377,4 @@ void StreamWrap::OnAfterWriteImpl(WriteWrap* w, void* ctx) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(stream_wrap, node::StreamWrap::Initialize)
+NODE_MODULE_BUILTIN(stream_wrap, node::StreamWrap::Initialize)

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -15,9 +15,8 @@ class StreamWrap;
 
 class StreamWrap : public HandleWrap, public StreamBase {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   int GetFD() override;
   void* Cast() override;

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -64,9 +64,7 @@ Local<Object> TCPWrap::Instantiate(Environment* env, AsyncWrap* parent) {
 }
 
 
-void TCPWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TCPWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -448,4 +446,4 @@ Local<Object> AddressToJS(Environment* env,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tcp_wrap, node::TCPWrap::Initialize)
+NODE_MODULE_BUILTIN(tcp_wrap, node::TCPWrap::Initialize)

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -10,9 +10,8 @@ namespace node {
 class TCPWrap : public StreamWrap {
  public:
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   uv_tcp_t* UVHandle();
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -25,9 +25,7 @@ const uint32_t kOnTimeout = 0;
 
 class TimerWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target, Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -115,4 +113,4 @@ class TimerWrap : public HandleWrap {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(timer_wrap, node::TimerWrap::Initialize)
+NODE_MODULE_BUILTIN(timer_wrap, node::TimerWrap::Initialize)

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -869,9 +869,7 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
 
-void TLSWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TLSWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "wrap", TLSWrap::Wrap);
@@ -904,4 +902,4 @@ void TLSWrap::Initialize(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tls_wrap, node::TLSWrap::Initialize)
+NODE_MODULE_BUILTIN(tls_wrap, node::TLSWrap::Initialize)

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -27,9 +27,8 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
  public:
   ~TLSWrap() override;
 
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   void* Cast() override;
   int GetFD() override;

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -27,9 +27,7 @@ using v8::String;
 using v8::Value;
 
 
-void TTYWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TTYWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -140,4 +138,4 @@ TTYWrap::TTYWrap(Environment* env, Handle<Object> object, int fd, bool readable)
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tty_wrap, node::TTYWrap::Initialize)
+NODE_MODULE_BUILTIN(tty_wrap, node::TTYWrap::Initialize)

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -9,9 +9,8 @@ namespace node {
 
 class TTYWrap : public StreamWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   uv_tty_t* UVHandle();
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -71,9 +71,7 @@ UDPWrap::UDPWrap(Environment* env, Handle<Object> object, AsyncWrap* parent)
 }
 
 
-void UDPWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void UDPWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -430,4 +428,4 @@ uv_udp_t* UDPWrap::UVHandle() {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(udp_wrap, node::UDPWrap::Initialize)
+NODE_MODULE_BUILTIN(udp_wrap, node::UDPWrap::Initialize)

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -13,9 +13,8 @@ namespace node {
 
 class UDPWrap: public HandleWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
   static void GetFD(v8::Local<v8::String>,
                     const v8::PropertyCallbackInfo<v8::Value>&);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -9,7 +9,7 @@ namespace uv {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
+using v8::Local;
 using v8::Integer;
 using v8::Object;
 using v8::String;
@@ -26,9 +26,7 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "errname"),
               env->NewFunctionTemplate(ErrName)->GetFunction());
@@ -43,4 +41,4 @@ void Initialize(Handle<Object> target,
 }  // namespace uv
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(uv, node::uv::Initialize)
+NODE_MODULE_BUILTIN(uv, node::uv::Initialize)

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -62,7 +62,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                 (uv_after_work_cb)AfterAsync);
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -36,7 +36,7 @@ static void sanity_check(void) {
   assert(at_exit_cb2_called == 2);
 }
 
-void init(Handle<Object> target) {
+void init(Local<Object> exports) {
   AtExit(at_exit_cb1);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -9,7 +9,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -9,8 +9,8 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> target) {
-  NODE_SET_METHOD(target, "hello", Method);
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "hello", Method);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/init_signatures/binding.gyp
+++ b/test/addons/init_signatures/binding.gyp
@@ -1,0 +1,25 @@
+{ 'target_defaults': { 'defines': ['NODE_TEST_ADDON_NAME=>(_target_name)']}
+, 'targets':
+  [ { 'target_name': 'init_exports'
+    , 'sources'    : ['init_exports.cc']
+    }
+  , { 'target_name': 'init_exports_module'
+    , 'sources'    : ['init_exports_module.cc']
+    }
+  , { 'target_name': 'init_exports_context'
+    , 'sources'    : ['init_exports_context.cc']
+    }
+  , { 'target_name': 'init_exports_private'
+    , 'sources'    : ['init_exports_private.cc']
+    }
+  , { 'target_name': 'init_exports_module_private'
+    , 'sources'    : ['init_exports_module_private.cc']
+    }
+  , { 'target_name': 'init_exports_module_context'
+    , 'sources'    : ['init_exports_module_context.cc']
+    }
+  , { 'target_name': 'init_exports_module_context_private'
+    , 'sources'    : ['init_exports_module_context_private.cc']
+    }
+  ]
+}

--- a/test/addons/init_signatures/init_exports.cc
+++ b/test/addons/init_signatures/init_exports.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_context.cc
+++ b/test/addons/init_signatures/init_exports_context.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module.cc
+++ b/test/addons/init_signatures/init_exports_module.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_context.cc
+++ b/test/addons/init_signatures/init_exports_module_context.cc
@@ -1,0 +1,7 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Object> module,
+          v8::Local<v8::Context> context) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_context_private.cc
+++ b/test/addons/init_signatures/init_exports_module_context_private.cc
@@ -1,0 +1,8 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Object> module,
+          v8::Local<v8::Context> context,
+          void * priv) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_context_private.cc
+++ b/test/addons/init_signatures/init_exports_module_context_private.cc
@@ -2,7 +2,7 @@
 void init(v8::Local<v8::Object> exports,
           v8::Local<v8::Object> module,
           v8::Local<v8::Context> context,
-          void * priv) {
+          void* priv) {
   node::test::setInitTag(exports);
 }
 NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_private.cc
+++ b/test/addons/init_signatures/init_exports_module_private.cc
@@ -1,0 +1,7 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Object> module,
+          void * priv) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_private.cc
+++ b/test/addons/init_signatures/init_exports_module_private.cc
@@ -1,7 +1,7 @@
 #include "init_test.h"
 void init(v8::Local<v8::Object> exports,
           v8::Local<v8::Object> module,
-          void * priv) {
+          void* priv) {
   node::test::setInitTag(exports);
 }
 NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_private.cc
+++ b/test/addons/init_signatures/init_exports_private.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports, void * priv) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_private.cc
+++ b/test/addons/init_signatures/init_exports_private.cc
@@ -1,5 +1,5 @@
 #include "init_test.h"
-void init(v8::Local<v8::Object> exports, void * priv) {
+void init(v8::Local<v8::Object> exports, void* priv) {
   node::test::setInitTag(exports);
 }
 NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_test.h
+++ b/test/addons/init_signatures/init_test.h
@@ -1,0 +1,24 @@
+#ifndef NODE_TEST_ADDON_INIT_TEST_H
+# define NODE_TEST_ADDON_INIT_TEST_H
+
+#include <node.h>
+
+namespace node { namespace test {
+
+inline
+void
+set(v8::Handle<v8::Object> obj, char const* name, bool value) {
+    v8::Isolate * isolate = v8::Isolate::GetCurrent();
+    obj->Set(
+        v8::String::NewFromUtf8(isolate, name),
+        v8::Boolean::New(isolate, value));
+}
+
+inline
+void
+setInitTag(v8::Handle<v8::Object> obj) {
+  set(obj, "initialized", true);
+}
+
+}}  // end of namespace node::test
+#endif // NODE_TEST_ADDON_INIT_TEST_H

--- a/test/addons/init_signatures/init_test.h
+++ b/test/addons/init_signatures/init_test.h
@@ -1,14 +1,15 @@
 #ifndef NODE_TEST_ADDON_INIT_TEST_H
-# define NODE_TEST_ADDON_INIT_TEST_H
+#define NODE_TEST_ADDON_INIT_TEST_H
 
 #include <node.h>
 
-namespace node { namespace test {
+namespace node {
+namespace test {
 
 inline
 void
-set(v8::Handle<v8::Object> obj, char const* name, bool value) {
-    v8::Isolate * isolate = v8::Isolate::GetCurrent();
+set(v8::Handle<v8::Object> obj, const char* name, bool value) {
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
     obj->Set(
         v8::String::NewFromUtf8(isolate, name),
         v8::Boolean::New(isolate, value));
@@ -20,5 +21,6 @@ setInitTag(v8::Handle<v8::Object> obj) {
   set(obj, "initialized", true);
 }
 
-}}  // end of namespace node::test
+}  // end of namespace test
+}  // end of namespace node
 #endif // NODE_TEST_ADDON_INIT_TEST_H

--- a/test/addons/init_signatures/test.js
+++ b/test/addons/init_signatures/test.js
@@ -1,0 +1,17 @@
+'use strict';
+var assert = require('assert')
+  , path   = require('path')
+  , i, name, addon
+  , signatures = [ ['exports']
+                 , ['exports', 'module']
+                 , ['exports', 'context']
+                 , ['exports', 'private']
+                 , ['exports', 'module', 'private']
+                 , ['exports', 'module', 'context']
+                 , ['exports', 'module', 'context', 'private']
+                 ];
+for (i in signatures) {
+  name  = 'init_' + signatures[i].join('_');
+  addon = require('./build/Release/' + name);
+  assert.ok(addon.initialized);
+}

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -3,7 +3,7 @@
 
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
+using v8::Local;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Object;
@@ -19,8 +19,8 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                      NULL);
 }
 
-void init(Handle<Object> target) {
-  NODE_SET_METHOD(target, "method", Method);
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "method", Method);
 }
 
 NODE_MODULE(binding, init);


### PR DESCRIPTION
#### In Short:

Stop discarding the (addon) init function signature. Instead capture it at compile-time and provide a suitable adapter, thus restoring type safety.

Doing so uncovered a bug-to-happen: The old `addon_register_func` declared the module argument with type `Handle<Value>` instead of `Handle<Object>`. This only compiled because of the discarded type information. It only worked because it exploited numerous v8 implementation details.

It also exposed a few diverged prototypes of `Initialize(...)` functions. Both is fixed in this patch.

The new init function handling makes a few things easier:
- Builtin modules had an `unused` module argument which is no longer neccessary.
- We no longer have to deal with context aware modules seperatly. It's all the same.
#### The Issue:

This is not easy to spot and everything works just fine. So let me explain. The [addon register function](https://github.com/nodejs/io.js/blob/master/src/node.h#L361-L364) is currently declared as:

``` C++
typedef void (*addon_register_func)(
    v8::Handle<v8::Object> exports,
    v8::Handle<v8::Value> module,
    void* priv);
```

But the [documentation](https://github.com/nodejs/io.js/blob/master/doc/api/addons.markdown#object-factory) and thus _everybody_ uses:

``` C++
void Init(Local<Object> exports, Local<Object> module) {}
```

Ignore the `Handle<>` to `Local<>` thing for now and focus on the switch from `Value` to `Object` on the module argument. That looks like an attempted _upcast_. Now, how does this even compile? It compiles because of [this cast](https://github.com/nodejs/io.js/blob/master/src/node.h#L419) in the `NODE_MODULE_X(...)` macro:

``` C++
#define NODE_MODULE_X(modname, regfunc, priv, flags)                  \
  extern "C" {                                                        \
    static node::node_module _module =                                \
    {                                                                 \
      /* things */                                                    \
      (node::addon_register_func) (regfunc),    /* <=== EVIL */       \ 
      /* more things */                                               \
    };                                                                \
    NODE_C_CTOR(_register_ ## modname) {                              \
      node_module_register(&_module);                                 \
    }                                                                 \
  }
```

The intention here is to allow addons to only mention the first few arguments and ignore the rest. Kind of like default arguments but reverse. The _result_ is that we miss the type mismatch _and_ bypass any possible argument conversion that might help. (No such conversion exists, but we miss that too).

It also ignores that in fact `Handle<X>` and `Handle<Y>` are two _completely unrelated_ types. Since the handles are passed by value, we not only depend on `Handle<X>` and `Handle<Y>` having the same API (which is reasonable), but also on things like `sizeof()` being equal. We treat them like actual pointers while they are _objects_ passed on the stack. (Again, even if they where pointers such a cast `Value` to `Object` would be illegal... without RTTI blah blah). 

All of this only works because we know how the handles are implemented and how polymorphism works in v8. Although non of this is _likely_ to change I still think we are way to deep in v8 implementation details.

A minor nuisance is that `NODE_MODULE(...)` accepts any garbage as a function pointer. 

So, we are looking for a way to deal with different `init(...)` signatures without producing a gaping hole in the type system.
#### A Solution:

Instead of _discarding_ the type information we _use_ it to "generate" an adapter function at compile-time. This adapter function always takes the full set of arguments and calls the user provided init function with the "requested" subset. This is implemented using template techniques to introspect the `init(...)` functions at compile-time. This is implemented in the first commit. The lot of it is in `node.h` and is best read from bottom to top.

The second commit touches all builtin modules and uses the new infrastructure.

_All_ of this is pretty complex. I hope I caught the essence. If not, please ask.
