### PR TITLE
Fix util extend issue

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -715,6 +715,9 @@ exports._extend = function(origin, add) {
   // Don't do anything if add isn't an object
   if (add === null || typeof add !== 'object') return origin;
 
+  // Return add if origin isn't an object
+  if (origin === null || typeof origin !== 'object') return add;
+
   var keys = Object.keys(add);
   var i = keys.length;
   while (i--) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -715,7 +715,7 @@ exports._extend = function(origin, add) {
   // Don't do anything if add isn't an object
   if (add === null || typeof add !== 'object') return origin;
 
-  // Return add if origin isn't an object
+  // Create new object for origin, if origin isn't an object
   if (origin === null || typeof origin !== 'object') origin = {};
 
   var keys = Object.keys(add);

--- a/lib/util.js
+++ b/lib/util.js
@@ -716,7 +716,7 @@ exports._extend = function(origin, add) {
   if (add === null || typeof add !== 'object') return origin;
 
   // Return add if origin isn't an object
-  if (origin === null || typeof origin !== 'object') return add;
+  if (origin === null || typeof origin !== 'object') origin = {};
 
   var keys = Object.keys(add);
   var i = keys.length;

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -83,6 +83,10 @@ assert.deepEqual(util._extend({a:1}, true),       {a:1});
 assert.deepEqual(util._extend({a:1}, false),      {a:1});
 assert.deepEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
 assert.deepEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});
+assert.deepEqual(util._extend(null, {a:1}),       {a:1});
+assert.deepEqual(util._extend(undefined, {a:1}),  {a:1});
+assert.deepEqual(util._extend(true, {a:1}),       {a:1});
+assert.deepEqual(util._extend(false, {a:1}),      {a:1});
 
 // inherits
 var ctor = function() {};


### PR DESCRIPTION
When the "origin" object argument is null or not defined, _extend
throws exception.
Fix _extend to allow undefined "origin" object argument and return
the "add" object argument.