### PR TITLE
tls: handle empty cert in checkServerIndentity

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -151,7 +151,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
                            host,
                            ips.join(', '));
     }
-  } else {
+  } else if (cert.subject) {
     // Transform hostname to canonical form
     if (!/\.$/.test(host)) host += '.';
 
@@ -204,6 +204,8 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
                              cert.subject.CN);
       }
     }
+  } else {
+    reason = 'Cert is empty';
   }
 
   if (!valid) {

--- a/test/parallel/test-tls-check-server-identity.js
+++ b/test/parallel/test-tls-check-server-identity.js
@@ -30,6 +30,13 @@ var tests = [
            'DNS:omg.com'
   },
 
+  // Empty Cert
+  {
+    host: 'a.com',
+    cert: { },
+    error: 'Cert is empty'
+  },
+
   // Multiple CN fields
   {
     host: 'foo.com', cert: {


### PR DESCRIPTION
This resolves joyent/node#9272. `tlsSocket.getPeerCertificate` will
return an empty object when the peer does not provide a certificate,
but, prior to this, when the certificate is empty, `checkServerIdentity`
would throw because the `subject` wasn't present on the cert.
`checkServerIdentity` must return an error, not throw one, so this
returns an error when the cert is empty instead of throwing
a `TypeError`.