### PR TITLE
events: deprecate static listenerCount function

### DIFF
--- a/benchmark/events/ee-listener-count-on-prototype.js
+++ b/benchmark/events/ee-listener-count-on-prototype.js
@@ -7,14 +7,13 @@ function main(conf) {
   var n = conf.n | 0;
 
   var ee = new EventEmitter();
-  var listenerCount = EventEmitter.listenerCount;
 
   for (var k = 0; k < 10; k += 1)
     ee.on('dummy', function() {});
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var r = listenerCount(ee, 'dummy');
+    var r = ee.listenerCount('dummy');
   }
   bench.end(n);
 }

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -137,10 +137,17 @@ Execute each of the listeners in order with the supplied arguments.
 Returns `true` if event had listeners, `false` otherwise.
 
 
+### emitter.listenerCount(type)
+
+* `type` {Value} The type of event
+
+Returns the number of listeners listening to the `type` of event.
+
 ### Class Method: EventEmitter.listenerCount(emitter, event)
 
 Return the number of listeners for a given event.
 
+_Note: This is deprecated. Use `emitter.listenerCount` instead._
 
 ### Event: 'newListener'
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -322,7 +322,7 @@ function socketOnData(d) {
     var bodyHead = d.slice(bytesParsed, d.length);
 
     var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-    if (EventEmitter.listenerCount(req, eventName) > 0) {
+    if (req.listenerCount(eventName) > 0) {
       req.upgradeOrConnect = true;
 
       // detach the socket

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -343,7 +343,7 @@ function connectionListener(socket) {
       parser = null;
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-      if (EventEmitter.listenerCount(self, eventName) > 0) {
+      if (self.listenerCount(eventName) > 0) {
         debug('SERVER have listener for %s', eventName);
         var bodyHead = d.slice(bytesParsed, d.length);
 
@@ -467,7 +467,7 @@ function connectionListener(socket) {
         (req.httpVersionMajor == 1 && req.httpVersionMinor == 1) &&
         continueExpression.test(req.headers['expect'])) {
       res._expect_continue = true;
-      if (EventEmitter.listenerCount(self, 'checkContinue') > 0) {
+      if (self.listenerCount('checkContinue') > 0) {
         self.emit('checkContinue', req, res);
       } else {
         res.writeContinue();

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -533,7 +533,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     debug('onerror', er);
     unpipe();
     dest.removeListener('error', onerror);
-    if (EE.listenerCount(dest, 'error') === 0)
+    if (dest.listenerCount('error') === 0)
       dest.emit('error', er);
   }
   // This is a brutally ugly hack to make sure that our error handler
@@ -582,7 +582,7 @@ function pipeOnDrain(src) {
     debug('pipeOnDrain', state.awaitDrain);
     if (state.awaitDrain)
       state.awaitDrain--;
-    if (state.awaitDrain === 0 && EE.listenerCount(src, 'data')) {
+    if (state.awaitDrain === 0 && src.listenerCount('data')) {
       state.flowing = true;
       flow(src);
     }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -5,7 +5,6 @@ const crypto = require('crypto');
 const net = require('net');
 const tls = require('tls');
 const util = require('util');
-const listenerCount = require('events').listenerCount;
 const common = require('_tls_common');
 const StreamWrap = require('_stream_wrap').StreamWrap;
 const Buffer = require('buffer').Buffer;
@@ -116,7 +115,7 @@ function requestOCSP(self, hello, ctx, cb) {
   if (ctx.context)
     ctx = ctx.context;
 
-  if (listenerCount(self.server, 'OCSPRequest') === 0) {
+  if (self.server.listenerCount('OCSPRequest') === 0) {
     return cb(null);
   } else {
     self.server.emit('OCSPRequest',
@@ -396,11 +395,11 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.handshakes = 0;
 
     if (this.server) {
-      if (listenerCount(this.server, 'resumeSession') > 0 ||
-          listenerCount(this.server, 'newSession') > 0) {
+      if (this.server.listenerCount('resumeSession') > 0 ||
+          this.server.listenerCount('newSession') > 0) {
         ssl.enableSessionCallbacks();
       }
-      if (listenerCount(this.server, 'OCSPRequest') > 0)
+      if (this.server.listenerCount('OCSPRequest') > 0)
         ssl.enableCertCb();
     }
   } else {

--- a/lib/events.js
+++ b/lib/events.js
@@ -395,19 +395,23 @@ EventEmitter.prototype.listeners = function listeners(type) {
 };
 
 EventEmitter.listenerCount = function(emitter, type) {
-  var evlistener;
-  var ret = 0;
-  var events = emitter._events;
+  return emitter.listenerCount(type);
+};
+
+EventEmitter.prototype.listenerCount = function listenerCount(type) {
+  const events = this._events;
 
   if (events) {
-    evlistener = events[type];
-    if (typeof evlistener === 'function')
-      ret = 1;
-    else if (evlistener)
-      ret = evlistener.length;
+    const evlistener = events[type];
+
+    if (typeof evlistener === 'function') {
+      return 1;
+    } else if (evlistener) {
+      return evlistener.length;
+    }
   }
 
-  return ret;
+  return 0;
 };
 
 // About 1.5x faster than the two-arg version of Array#splice().

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1354,7 +1354,7 @@ fs.unwatchFile = function(filename, listener) {
     stat.removeAllListeners('change');
   }
 
-  if (EventEmitter.listenerCount(stat, 'change') === 0) {
+  if (stat.listenerCount('change') === 0) {
     stat.stop();
     statWatchers.delete(filename);
   }

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -683,7 +683,7 @@ Interface.prototype._ttyWrite = function(s, key) {
 
     switch (key.name) {
       case 'c':
-        if (EventEmitter.listenerCount(this, 'SIGINT') > 0) {
+        if (this.listenerCount('SIGINT') > 0) {
           this.emit('SIGINT');
         } else {
           // This readline instance is finished
@@ -746,7 +746,7 @@ Interface.prototype._ttyWrite = function(s, key) {
 
       case 'z':
         if (process.platform == 'win32') break;
-        if (EventEmitter.listenerCount(this, 'SIGTSTP') > 0) {
+        if (this.listenerCount('SIGTSTP') > 0) {
           this.emit('SIGTSTP');
         } else {
           process.once('SIGCONT', (function(self) {
@@ -907,7 +907,7 @@ function emitKeypressEvents(stream) {
   stream[ESCAPE_DECODER].next();
 
   function onData(b) {
-    if (EventEmitter.listenerCount(stream, 'keypress') > 0) {
+    if (stream.listenerCount('keypress') > 0) {
       var r = stream[KEYPRESS_DECODER].write(b);
       if (r) {
         for (var i = 0; i < r.length; i++) {
@@ -936,7 +936,7 @@ function emitKeypressEvents(stream) {
     }
   }
 
-  if (EventEmitter.listenerCount(stream, 'keypress') > 0) {
+  if (stream.listenerCount('keypress') > 0) {
     stream.on('data', onData);
   } else {
     stream.on('newListener', onNewListener);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -70,7 +70,7 @@ Stream.prototype.pipe = function(dest, options) {
   // don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (EE.listenerCount(this, 'error') === 0) {
+    if (this.listenerCount('error') === 0) {
       throw er; // Unhandled stream error in pipe.
     }
   }

--- a/src/node.js
+++ b/src/node.js
@@ -802,8 +802,7 @@
     });
 
     process.on('removeListener', function(type, listener) {
-      if (signalWraps.hasOwnProperty(type) &&
-          NativeModule.require('events').listenerCount(this, type) === 0) {
+      if (signalWraps.hasOwnProperty(type) && this.listenerCount(type) === 0) {
         signalWraps[type].close();
         delete signalWraps[type];
       }

--- a/test/parallel/test-event-emitter-listener-count.js
+++ b/test/parallel/test-event-emitter-listener-count.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const emitter = new EventEmitter();
+emitter.on('foo', function() {});
+emitter.on('foo', function() {});
+emitter.on('baz', function() {});
+// Allow any type
+emitter.on(123, function() {});
+
+assert.strictEqual(EventEmitter.listenerCount(emitter, 'foo'), 2);
+assert.strictEqual(emitter.listenerCount('foo'), 2);
+assert.strictEqual(emitter.listenerCount('bar'), 0);
+assert.strictEqual(emitter.listenerCount('baz'), 1);
+assert.strictEqual(emitter.listenerCount(123), 1);

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -46,4 +46,4 @@ var ee2 = new MyEE2();
 
 ee1.on('x', function() {});
 
-assert.equal(EventEmitter.listenerCount(ee2, 'x'), 0);
+assert.equal(ee2.listenerCount('x'), 0);


### PR DESCRIPTION
As per the discussion in #734, this patch deprecates the usage of
`EventEmitter.listenerCount` static function and introduces the `listenerCount`
function in the prototype of `EventEmitter` itself.