### PR TITLE
stream_base: expose and use External pointer

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -319,7 +319,9 @@ TLSSocket.prototype._wrapHandle = function(wrap) {
   var context = options.secureContext ||
                 options.credentials ||
                 tls.createSecureContext();
-  res = tls_wrap.wrap(handle, context.context, options.isServer);
+  res = tls_wrap.wrap(handle._externalStream,
+                      context.context,
+                      options.isServer);
   res._parent = handle;
   res._parentWrap = wrap;
   res._secureContext = context;

--- a/src/env.h
+++ b/src/env.h
@@ -88,6 +88,7 @@ namespace node {
   V(exponent_string, "exponent")                                              \
   V(exports_string, "exports")                                                \
   V(ext_key_usage_string, "ext_key_usage")                                    \
+  V(external_stream_string, "_externalStream")                                \
   V(family_string, "family")                                                  \
   V(fatal_exception_string, "_fatalException")                                \
   V(fd_string, "fd")                                                          \

--- a/src/node_wrap.h
+++ b/src/node_wrap.h
@@ -34,21 +34,6 @@ namespace node {
       }                                                                       \
     } while (0)
 
-#define WITH_GENERIC_STREAM(env, obj, BODY)                                   \
-    do {                                                                      \
-      WITH_GENERIC_UV_STREAM(env, obj, BODY, {                                \
-        if (env->tls_wrap_constructor_template().IsEmpty() == false &&        \
-            env->tls_wrap_constructor_template()->HasInstance(obj)) {         \
-          TLSWrap* const wrap = Unwrap<TLSWrap>(obj);                         \
-          BODY                                                                \
-        } else if (env->jsstream_constructor_template().IsEmpty() == false && \
-                   env->jsstream_constructor_template()->HasInstance(obj)) {  \
-          JSStream* const wrap = Unwrap<JSStream>(obj);                       \
-          BODY                                                                \
-        }                                                                     \
-      });                                                                     \
-    } while (0)
-
 inline uv_stream_t* HandleToStream(Environment* env,
                                    v8::Local<v8::Object> obj) {
   v8::HandleScope scope(env->isolate());

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -10,6 +10,7 @@
 
 namespace node {
 
+using v8::External;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Handle;
@@ -31,6 +32,13 @@ void StreamBase::AddMethods(Environment* env,
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
   t->InstanceTemplate()->SetAccessor(env->fd_string(),
                                      GetFD<Base>,
+                                     nullptr,
+                                     env->as_external(),
+                                     v8::DEFAULT,
+                                     attributes);
+
+  t->InstanceTemplate()->SetAccessor(env->external_stream_string(),
+                                     GetExternal<Base>,
                                      nullptr,
                                      env->as_external(),
                                      v8::DEFAULT,
@@ -69,6 +77,16 @@ void StreamBase::GetFD(Local<String> key,
     return args.GetReturnValue().Set(UV_EINVAL);
 
   args.GetReturnValue().Set(wrap->GetFD());
+}
+
+
+template <class Base>
+void StreamBase::GetExternal(Local<String> key,
+                             const PropertyCallbackInfo<Value>& args) {
+  StreamBase* wrap = Unwrap<Base>(args.Holder());
+
+  Local<External> ext = External::New(args.GetIsolate(), wrap);
+  args.GetReturnValue().Set(ext);
 }
 
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -74,9 +74,9 @@ StreamWrap::StreamWrap(Environment* env,
                  parent),
       StreamBase(env),
       stream_(stream) {
-  set_after_write_cb(OnAfterWriteImpl, this);
-  set_alloc_cb(OnAllocImpl, this);
-  set_read_cb(OnReadImpl, this);
+  set_after_write_cb({ OnAfterWriteImpl, this });
+  set_alloc_cb({ OnAllocImpl, this });
+  set_read_cb({ OnReadImpl, this });
 }
 
 


### PR DESCRIPTION
Expose and use in TLSWrap an `v8::External` wrap of the
`StreamBase*` pointer instead of guessing the ancestor C++ class in
`node_wrap.h`.

cc @trevnorris @bnoordhuis @nodejs/crypto 