### PR TITLE
fix absolute path preloads when cwd is ENOENT

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -515,9 +515,16 @@ Module._preloadModules = function(requests) {
   // in the current working directory. This seeds the search path for
   // preloaded modules.
   var parent = new Module('internal/preload', null);
-  parent.paths = Module._nodeModulePaths(process.cwd());
+  try {
+    parent.paths = Module._nodeModulePaths(process.cwd());
+  }
+  catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+  }
   requests.forEach(function(request) {
-    Module._load(request, parent, false);
+    parent.require(request);
   });
 };
 

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+
+// Fails with EINVAL on SmartOS, EBUSY on Windows.
+if (process.platform === 'sunos' || common.isWindows) {
+  console.log('1..0 # Skipped: cannot rmdir current working directory');
+  return;
+}
+
+const dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+const abspathFile = require('path').join(common.fixturesDir, 'a.js');
+common.refreshTmpDir();
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+
+const proc = spawn(process.execPath, ['-r', abspathFile, '-e', '0']);
+proc.stdout.pipe(process.stdout);
+proc.stderr.pipe(process.stderr);
+
+proc.once('exit', common.mustCall(function(exitCode, signalCode) {
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signalCode, null);
+}));


### PR DESCRIPTION
regression related to #1803 , using a try catch in this case since we use preload combined with native module. I cannot easily find out if we should bootstrap the module paths otherwise.