### PR TITLE
Profile on start

### DIFF
--- a/doc/iojs.1
+++ b/doc/iojs.1
@@ -62,7 +62,7 @@ and servers.
 
   --track-heap-objects   track heap object allocations for heap snapshots
 
-  --profile-cpu          begin cpu profiler during start up
+  --profile-cpu          begin cpu profiling during start up
 
   --v8-options           print v8 command line options
 

--- a/doc/iojs.1
+++ b/doc/iojs.1
@@ -62,7 +62,7 @@ and servers.
 
   --track-heap-objects   track heap object allocations for heap snapshots
 
-  --profile-cpu          begin cpu profiling during start up
+  --profile-cpu          silently begin cpu profiler during start up
 
   --v8-options           print v8 command line options
 

--- a/doc/iojs.1
+++ b/doc/iojs.1
@@ -62,6 +62,8 @@ and servers.
 
   --track-heap-objects   track heap object allocations for heap snapshots
 
+  --profile-cpu          begin cpu profiler during start up
+
   --v8-options           print v8 command line options
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3107,7 +3107,7 @@ static void PrintHelp() {
          "                        is detected after the first tick\n"
          "  --track-heap-objects  track heap object allocations for heap "
          "snapshots\n"
-         "  --profile-cpu         being cpu profile during start up\n" 
+         "  --profile-cpu         being cpu profiling during start up\n"
          "  --v8-options          print v8 command line options\n"
 #if defined(NODE_HAVE_I18N_SUPPORT)
          "  --icu-data-dir=dir    set ICU data load path to dir\n"

--- a/src/node.cc
+++ b/src/node.cc
@@ -120,7 +120,6 @@ static bool abort_on_uncaught_exception = false;
 static bool trace_sync_io = false;
 static bool track_heap_objects = false;
 static bool profile_cpu = false;
-static const char* profile_title = "";
 static const char* eval_string = nullptr;
 static unsigned int preload_module_count = 0;
 static const char** preload_modules = nullptr;
@@ -3107,7 +3106,7 @@ static void PrintHelp() {
          "                        is detected after the first tick\n"
          "  --track-heap-objects  track heap object allocations for heap "
          "snapshots\n"
-         "  --profile-cpu         being cpu profiling during start up\n"
+         "  --profile-cpu         silently begin cpu profiler during start up\n"
          "  --v8-options          print v8 command line options\n"
 #if defined(NODE_HAVE_I18N_SUPPORT)
          "  --icu-data-dir=dir    set ICU data load path to dir\n"
@@ -3943,8 +3942,9 @@ static void StartNodeInstance(void* arg) {
     Local<Context> context = Context::New(isolate);
 
     // CpuProfiler requires HandleScope
+    // addons can pick up the results with StopProfiling(...) using same title
     if (profile_cpu) {
-      isolate->GetCpuProfiler()->StartProfiling(String::NewFromUtf8(isolate, profile_title), true);
+      isolate->GetCpuProfiler()->StartProfiling(String::Empty(isolate), true);
     }
 
     Environment* env = CreateEnvironment(isolate, context, instance_data);

--- a/src/node.cc
+++ b/src/node.cc
@@ -119,6 +119,8 @@ static bool throw_deprecation = false;
 static bool abort_on_uncaught_exception = false;
 static bool trace_sync_io = false;
 static bool track_heap_objects = false;
+static bool profile_cpu = false;
+static const char* profile_title = "";
 static const char* eval_string = nullptr;
 static unsigned int preload_module_count = 0;
 static const char** preload_modules = nullptr;
@@ -3105,6 +3107,7 @@ static void PrintHelp() {
          "                        is detected after the first tick\n"
          "  --track-heap-objects  track heap object allocations for heap "
          "snapshots\n"
+         "  --profile-cpu         being cpu profile during start up\n" 
          "  --v8-options          print v8 command line options\n"
 #if defined(NODE_HAVE_I18N_SUPPORT)
          "  --icu-data-dir=dir    set ICU data load path to dir\n"
@@ -3227,6 +3230,8 @@ static void ParseArgs(int* argc,
       trace_deprecation = true;
     } else if (strcmp(arg, "--trace-sync-io") == 0) {
       trace_sync_io = true;
+    } else if (strcmp(arg, "--profile-cpu") == 0) {
+      profile_cpu = true;
     } else if (strcmp(arg, "--track-heap-objects") == 0) {
       track_heap_objects = true;
     } else if (strcmp(arg, "--throw-deprecation") == 0) {
@@ -3925,6 +3930,10 @@ static void StartNodeInstance(void* arg) {
   Isolate* isolate = Isolate::New();
   if (track_heap_objects) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
+  }
+
+  if (profile_cpu) {
+    isolate->GetCpuProfiler()->StartProfiling(String::NewFromUtf8(isolate, profile_title), true);
   }
 
   // Fetch a reference to the main isolate, so we have a reference to it

--- a/src/node.cc
+++ b/src/node.cc
@@ -3932,10 +3932,6 @@ static void StartNodeInstance(void* arg) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
   }
 
-  if (profile_cpu) {
-    isolate->GetCpuProfiler()->StartProfiling(String::NewFromUtf8(isolate, profile_title), true);
-  }
-
   // Fetch a reference to the main isolate, so we have a reference to it
   // even when we need it to access it from another (debugger) thread.
   if (instance_data->is_main())
@@ -3945,6 +3941,12 @@ static void StartNodeInstance(void* arg) {
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     Local<Context> context = Context::New(isolate);
+
+    // CpuProfiler requires HandleScope
+    if (profile_cpu) {
+      isolate->GetCpuProfiler()->StartProfiling(String::NewFromUtf8(isolate, profile_title), true);
+    }
+
     Environment* env = CreateEnvironment(isolate, context, instance_data);
     Context::Scope context_scope(context);
     if (instance_data->is_main())


### PR DESCRIPTION
simple way to start the cpu profiler when you application starts up using `--profile-cpu`. useful for applications that need help profiling startup time.