### PR TITLE
repl: fix/improve persistent repl history

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -110,7 +110,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     }
 
     if (data) {
-      repl.history = data.split(/[\n\r]+/).slice(-repl.historySize);
+      repl.history = data.split(/[\n\r]+/, repl.historySize);
     } else if (oldHistoryPath) {
       // Grab data from the older pre-v3.0 JSON NODE_REPL_HISTORY_FILE format.
       repl._writeToOutput(
@@ -123,7 +123,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
         if (!Array.isArray(repl.history)) {
           throw new Error('Expected array, got ' + typeof repl.history);
         }
-        repl.history = repl.history.slice(-repl.historySize);
+        repl.history = repl.history.slice(0, repl.historySize);
       } catch (err) {
         if (err.code !== 'ENOENT') {
           return ready(

--- a/test/sequential/test-repl-persistent-history.js
+++ b/test/sequential/test-repl-persistent-history.js
@@ -135,6 +135,18 @@ const tests = [{
   expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\n',
              prompt]
 },
+{
+  env: { NODE_REPL_HISTORY: historyPath,
+         NODE_REPL_HISTORY_SIZE: 1 },
+  test: [UP, UP, CLEAR],
+  expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+},
+{
+  env: { NODE_REPL_HISTORY_FILE: oldHistoryPath,
+         NODE_REPL_HISTORY_SIZE: 1 },
+  test: [UP, UP, UP, CLEAR],
+  expected: [prompt, convertMsg, prompt, prompt + '\'=^.^=\'', prompt]
+},
 { // Make sure this is always the last test, since we change os.homedir()
   before: function mockHomedirFailure() {
     // Mock os.homedir() failure


### PR DESCRIPTION
Fix the history limiting to take the most recent. History additions are unshifted in readline.

Now tests the saved repl history size limiting.

Cleans up the test a bunch in the process, and also adds some debug so you can figure out which test case failed if it fails. Let me know if there is a better way to do that.