### PR TITLE
crypto: Fix memory deallocator in Certificate::ExportChallenge

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5252,10 +5252,12 @@ const char* Certificate::ExportChallenge(const char* data, int len) {
   if (sp == nullptr)
     return nullptr;
 
-  const char* buf = nullptr;
-  buf = reinterpret_cast<const char*>(ASN1_STRING_data(sp->spkac->challenge));
+  unsigned char* buf = nullptr;
+  ASN1_STRING_to_UTF8(&buf, sp->spkac->challenge);
 
-  return buf;
+  NETSCAPE_SPKI_free(sp);
+
+  return reinterpret_cast<const char*>(buf);
 }
 
 
@@ -5282,7 +5284,7 @@ void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
 
   Local<Value> outString = Encode(env->isolate(), cert, strlen(cert), BUFFER);
 
-  delete[] cert;
+  OPENSSL_free(const_cast<char*>(cert));
 
   args.GetReturnValue().Set(outString);
 }


### PR DESCRIPTION
Three fixes:
* Use correct deallocator for returned buffer
* Don't free internal structure via ASN1_STRING_data
* Deallocate NETSCAPE_SPKI