### PR TITLE
debugger: also exit when the repl emits 'exit'

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1546,8 +1546,7 @@ Interface.prototype.repl = function() {
   var listeners = this.repl.rli.listeners('SIGINT').slice(0);
   this.repl.rli.removeAllListeners('SIGINT');
 
-  // Exit debug repl on Ctrl + C
-  this.repl.rli.once('SIGINT', function() {
+  function exitDebugRepl() {
     // Restore all listeners
     process.nextTick(function() {
       listeners.forEach(function(listener) {
@@ -1557,7 +1556,16 @@ Interface.prototype.repl = function() {
 
     // Exit debug repl
     self.exitRepl();
-  });
+    
+    self.repl.rli.removeListener('SIGINT', exitDebugRepl);
+    self.repl.removeListener('exit', exitDebugRepl);
+  }
+  
+  // Exit debug repl on Ctrl + C
+  this.repl.rli.on('SIGINT', exitDebugRepl);
+  
+  // Exit debug repl on '.exit'
+  this.repl.on('exit', exitDebugRepl);
 
   // Set new
   this.repl.eval = this.debugEval.bind(this);


### PR DESCRIPTION
See joyent/node#5637, fixes joyent/node#5631