### PR TITLE
build: Add build-with-asan + use leak-check before v8 teardown

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -173,15 +173,33 @@
     },
     'msvs_disabled_warnings': [4351, 4355, 4800],
     'conditions': [
-      ['asan != 0', {
+      ['asan == 1 and OS != "mac"', {
         'cflags+': [
           '-fno-omit-frame-pointer',
           '-fsanitize=address',
-          '-w',  # http://crbug.com/162783
+          '-DLEAK_SANITIZER'
         ],
         'cflags_cc+': [ '-gline-tables-only' ],
         'cflags!': [ '-fomit-frame-pointer' ],
         'ldflags': [ '-fsanitize=address' ],
+      }],
+      ['asan == 1 and OS == "mac"', {
+        'xcode_settings': {
+          'OTHER_CFLAGS+': [
+            '-fno-omit-frame-pointer',
+            '-gline-tables-only',
+            '-fsanitize=address',
+            '-DLEAK_SANITIZER'
+          ],
+          'OTHER_CFLAGS!': [
+            '-fomit-frame-pointer',
+          ],
+        },
+        'target_conditions': [
+          ['_type!="static_library"', {
+            'xcode_settings': {'OTHER_LDFLAGS': ['-fsanitize=address']},
+          }],
+        ],
       }],
       ['OS == "win"', {
         'msvs_cygwin_shell': 0, # prevent actions from trying to use cygwin

--- a/configure
+++ b/configure
@@ -335,6 +335,11 @@ parser.add_option('--xcode',
     dest='use_xcode',
     help='generate build files for use with xcode')
 
+parser.add_option('--enable-asan',
+    action='store_true',
+    dest='enable_asan',
+    help='build with asan')
+
 parser.add_option('--enable-static',
     action='store_true',
     dest='enable_static',
@@ -707,6 +712,7 @@ def configure_node(o):
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module
 
+  o['variables']['asan'] = int(options.enable_asan or 0)
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/src/node.cc
+++ b/src/node.cc
@@ -52,6 +52,10 @@
 #include <string.h>
 #include <sys/types.h>
 
+#if defined(LEAK_SANITIZER)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 #if defined(_MSC_VER)
 #include <direct.h>
 #include <io.h>
@@ -3966,6 +3970,10 @@ static void StartNodeInstance(void* arg) {
     if (instance_data->is_main())
       instance_data->set_exit_code(exit_code);
     RunAtExit(env);
+
+#if defined(LEAK_SANITIZER)
+    __lsan_do_leak_check();
+#endif
 
     env->Dispose();
     env = nullptr;

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -9,9 +9,11 @@ if (common.isWindows) {
   return;
 }
 
+var openFds = [];
+
 for (;;) {
   try {
-    fs.openSync(__filename, 'r');
+    openFds.push(fs.openSync(__filename, 'r'));
   } catch (err) {
     assert(err.code === 'EMFILE' || err.code === 'ENFILE');
     break;
@@ -27,3 +29,8 @@ proc.on('error', common.mustCall(function(err) {
 
 // 'exit' should not be emitted, the process was never spawned.
 proc.on('exit', assert.fail);
+
+// close one fd for LSan
+if (openFds.length >= 1) {
+  fs.closeSync(openFds.pop());
+}

--- a/tools/lsan_suppressions.txt
+++ b/tools/lsan_suppressions.txt
@@ -1,0 +1,4 @@
+# Usage: LSAN_OPTIONS=suppressions=`pwd`/tools/lsan_suppressions.txt make check
+
+# Suppress small (intentional) leaks in glibc
+leak:libc.so


### PR DESCRIPTION
Adds the flag --enable-asan to configure
Run __lsan_do_leak_check before v8 teardown and add -DLEAK_SANITIZER for v8 to make it possible for lsan to scan v8 heap

    CC=clang CXX=clang++ ./configure --enable-asan
    LSAN_OPTIONS=suppressions=`pwd`/tools/lsan_blacklist.txt make check

Command above runs fine with #2359 and #2375 except for test/sequential/test-child-process-emfile.js because RLIMIT_NOFILE prevents lsan from running