### PR TITLE
tls: fix throughput issues after incorrect merge

### DIFF
--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -53,7 +53,7 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
   size_t self_size() const override { return sizeof(*this); }
 
  protected:
-  static const int kClearOutChunkSize = 1024;
+  static const int kClearOutChunkSize = 16384;
 
   // Maximum number of bytes for hello parser
   static const int kMaxHelloLength = 16384;


### PR DESCRIPTION
1e066e4a was done incorrectly and has overwritten an important change
in: c17449df. Using bigger output buffer increases performance in 3-4
times.

Fix: https://github.com/joyent/node/issues/25803

cc @nodejs/crypto 

Probably should be backported to whatever branch we consider LTS at the moment.