### PR TITLE
fs: consider NaN/Infinity in toUnixTimestamp

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -363,6 +363,13 @@ descriptor.
 
 Change file timestamps of the file referenced by the supplied path.
 
+Note: the arguments `atime` and `mtime` of the following related functions does follow the
+below rules:
+
+- If the value is a numberable string like "123456789", the value would get converted to
+  corresponding number.
+- If the value is `NaN` or `Infinity`, the value would get converted to `Date.now()`.
+
 ## fs.utimesSync(path, atime, mtime)
 
 Synchronous version of `fs.utimes()`. Returns `undefined`.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1045,7 +1045,13 @@ fs.chownSync = function(path, uid, gid) {
 
 // converts Date or number to a fractional UNIX timestamp
 function toUnixTimestamp(time) {
+  if (typeof time === 'string' && +time == time) {
+    return +time;
+  }
   if (typeof time === 'number') {
+    if (!Number.isFinite(time) || time < 0) {
+      return Date.now() / 1000;
+    }
     return time;
   }
   if (util.isDate(time)) {

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -122,15 +122,21 @@ function runTest(atime, mtime, callback) {
 
 var stats = fs.statSync(__filename);
 
+// run tests
 runTest(new Date('1982-09-10 13:37'), new Date('1982-09-10 13:37'), function() {
   runTest(new Date(), new Date(), function() {
     runTest(123456.789, 123456.789, function() {
       runTest(stats.mtime, stats.mtime, function() {
-        // done
+        runTest(NaN, Infinity, function() {
+          runTest('123456', -1, function() {
+            // done
+          });
+        });
       });
     });
   });
 });
+
 
 process.on('exit', function() {
   console.log('Tests run / ok:', tests_run, '/', tests_ok);


### PR DESCRIPTION
We might should follow the rule of linux:

> If times is NULL, then the access and modification times of the file are set to the current time.

ref: http://linux.die.net/man/2/utime