### PR TITLE
assert: handle NaN properly

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -115,6 +115,9 @@ assert.ok = ok;
 // assert.equal(actual, expected, message_opt);
 
 assert.equal = function equal(actual, expected, message) {
+  if (Number.isNaN(actual) && Number.isNaN(expected)) {
+    return;
+  }
   if (actual != expected) fail(actual, expected, message, '==', assert.equal);
 };
 
@@ -122,7 +125,7 @@ assert.equal = function equal(actual, expected, message) {
 // with != assert.notEqual(actual, expected, message_opt);
 
 assert.notEqual = function notEqual(actual, expected, message) {
-  if (actual == expected) {
+  if (actual == expected || (Number.isNaN(actual) && Number.isNaN(expected))) {
     fail(actual, expected, message, '!=', assert.notEqual);
   }
 };
@@ -163,6 +166,9 @@ function _deepEqual(actual, expected, strict) {
            actual.multiline === expected.multiline &&
            actual.lastIndex === expected.lastIndex &&
            actual.ignoreCase === expected.ignoreCase;
+
+  } else if (Number.isNaN(actual) && Number.isNaN(expected)) {
+    return true;
 
   // 7.4. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
@@ -247,6 +253,9 @@ function notDeepStrictEqual(actual, expected, message) {
 // assert.strictEqual(actual, expected, message_opt);
 
 assert.strictEqual = function strictEqual(actual, expected, message) {
+  if (Number.isNaN(actual) && Number.isNaN(expected)) {
+    return;
+  }
   if (actual !== expected) {
     fail(actual, expected, message, '===', assert.strictEqual);
   }
@@ -256,7 +265,7 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
 // determined by !==.  assert.notStrictEqual(actual, expected, message_opt);
 
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
-  if (actual === expected) {
+  if (actual === expected || (Number.isNaN(actual) && Number.isNaN(expected))) {
     fail(actual, expected, message, '!==', assert.notStrictEqual);
   }
 };

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -465,4 +465,25 @@ testBlockTypeError(assert.doesNotThrow, null);
 testBlockTypeError(assert.throws, undefined);
 testBlockTypeError(assert.doesNotThrow, undefined);
 
+// tests specific to NaN comparison
+assert.equal(NaN, NaN);
+assert.strictEqual(NaN, NaN);
+
+assert.throws(function() {
+  assert.notEqual(NaN, NaN);
+});
+assert.throws(function() {
+  assert.notStrictEqual(NaN, NaN);
+});
+
+assert.deepEqual(NaN, NaN);
+assert.deepStrictEqual(NaN, NaN);
+
+assert.throws(function() {
+  assert.notDeepEqual(NaN, NaN);
+});
+assert.throws(function() {
+  assert.notDeepStrictEqual(NaN, NaN);
+});
+
 console.log('All OK');


### PR DESCRIPTION
As it is, when two NaNs are compared with assert module, they fail.

    > process.version
    'v3.0.0'
    > assert.equal(NaN, NaN)
    AssertionError: NaN == NaN
        at repl:1:8
        at REPLServer.defaultEval (repl.js:164:27)

this patch makes sure that NaNs are properly asserted, with the help of
Number.isNaN function.

    > process.version
    'v4.0.0-pre'
    > assert.equal(NaN, NaN);
    undefined
    > assert.strictEqual(NaN, NaN);
    undefined
    > assert.deepEqual(NaN, NaN);
    undefined
    > assert.deepStrictEqual(NaN, NaN);
    undefined