### PR TITLE
http: correct fencepost error when freeing socket

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -65,7 +65,7 @@ function Agent(options) {
         if (self.sockets[name])
           count += self.sockets[name].length;
 
-        if (count > self.maxSockets || freeLen >= self.maxFreeSockets) {
+        if (count >= self.maxSockets || freeLen >= self.maxFreeSockets) {
           socket.destroy();
         } else {
           freeSockets = freeSockets || [];


### PR DESCRIPTION
Per: https://github.com/joyent/node/pull/7260 /cc @othiym23 

Original commit message:
This only becomes apparent when using a small maxSockets for pipelining
requests on keep-alive connection. Bug introduced in https://github.com/othiym23/node/commit/65f6f06a61c36630ee405a697b1d876208212874

This was originally submitted by @othiym23 back in March 2014 but never landed. 
It was reviewed by @indutny who requested that a test be included. This PR does
*not* yet include that requested test