### PR TITLE
debugger: req-timeout emits close

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -254,9 +254,18 @@ Client.prototype._onResponse = function(res) {
 
 
 Client.prototype.req = function(req, cb) {
-  this.write(this.protocol.serialize(req));
-  cb.request_seq = req.seq;
-  this._reqCallbacks.push(cb);
+  var self = this;
+  self.write(this.protocol.serialize(req));
+  var timer = setTimeout(function() {
+    console.log('request timeout');
+    self.emit('close');
+  }, 3000);
+  var _cb = function(err, res) {
+    clearTimeout(timer);
+    cb(err, res);
+  };
+  _cb.request_seq = req.seq;
+  self._reqCallbacks.push(_cb);
 };
 
 
@@ -798,7 +807,7 @@ function Interface(stdin, stdout, args) {
     } else {
       self.repl.context[key] = fn;
     }
-  };
+  }
 
   // Copy all prototype methods in repl context
   // Setup them as getters if possible
@@ -845,7 +854,9 @@ Interface.prototype.pause = function() {
 };
 
 Interface.prototype.resume = function(silent) {
-  if (this.killed || this.paused === 0 || --this.paused !== 0) return this;
+  if (this.killed || this.paused === 0 || --this.paused !== 0) {
+    return this;
+  }
   this.repl.rli.resume();
   if (silent !== true) {
     this.repl.displayPrompt();

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1229,9 +1229,13 @@ Interface.stepGenerator = function(type, count) {
     if (!this.requireConnection()) return;
 
     var self = this;
+    var resumeTimer = setTimeout(function() {
+      self.resume();
+    }, 500);
 
     self.pause();
     self.client.step(type, count, function(err, res) {
+      clearTimeout(resumeTimer);
       if (err) self.error(err);
       self.resume();
     });

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -255,12 +255,12 @@ Client.prototype._onResponse = function(res) {
 
 Client.prototype.req = function(req, cb) {
   var self = this;
-  self.write(this.protocol.serialize(req));
-  var timer = setTimeout(function() {
+  this.write(this.protocol.serialize(req));
+  var timer = this.setTimeout(function() {
     console.log('request timeout');
     self.emit('close');
   }, 3000);
-  var _cb = function(err, res) {
+  function _cb(err, res) {
     clearTimeout(timer);
     cb(err, res);
   };
@@ -807,7 +807,7 @@ function Interface(stdin, stdout, args) {
     } else {
       self.repl.context[key] = fn;
     }
-  }
+  };
 
   // Copy all prototype methods in repl context
   // Setup them as getters if possible
@@ -854,9 +854,7 @@ Interface.prototype.pause = function() {
 };
 
 Interface.prototype.resume = function(silent) {
-  if (this.killed || this.paused === 0 || --this.paused !== 0) {
-    return this;
-  }
+  if (this.killed || this.paused === 0 || --this.paused !== 0) return this;
   this.repl.rli.resume();
   if (silent !== true) {
     this.repl.displayPrompt();

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -158,6 +158,9 @@ function Client() {
   socket.on('data', function(d) {
     protocol.execute(d);
   });
+  socket.setTimeout(3000, function () {
+    socket.emit('close');
+  });
 
   protocol.onResponse = this._onResponse.bind(this);
 }
@@ -254,18 +257,9 @@ Client.prototype._onResponse = function(res) {
 
 
 Client.prototype.req = function(req, cb) {
-  var self = this;
   this.write(this.protocol.serialize(req));
-  var timer = this.setTimeout(function() {
-    console.log('request timeout');
-    self.emit('close');
-  }, 3000);
-  function _cb(err, res) {
-    clearTimeout(timer);
-    cb(err, res);
-  };
-  _cb.request_seq = req.seq;
-  self._reqCallbacks.push(_cb);
+  cb.request_seq = req.seq;
+  this._reqCallbacks.push(cb);
 };
 
 


### PR DESCRIPTION
To reproduce this bug, run `node debug any.js` and type the n(next) until the debugger and terminal do not have any response. This might be an issue of v8's DebuggerProtocol, but do we should add a **request-timeout** to handle with the above error at Node.js?
