### PR TITLE
src: fix memory leak in ExternString

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -350,10 +350,14 @@ function slowToString(encoding, start, end) {
 
 
 Buffer.prototype.toString = function() {
-  const length = this.length | 0;
-  if (arguments.length === 0)
-    return this.utf8Slice(0, length);
-  return slowToString.apply(this, arguments);
+  if (arguments.length === 0) {
+    var result = this.utf8Slice(0, this.length);
+  } else {
+    var result = slowToString.apply(this, arguments);
+  }
+  if (result === undefined)
+    throw new Error('toString failed');
+  return result;
 };
 
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1024,6 +1024,10 @@ void Initialize(Handle<Object> target,
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxLength"),
               Integer::NewFromUnsigned(env->isolate(), kMaxLength)).FromJust();
+
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "kStringMaxLength"),
+              Integer::New(env->isolate(), String::kMaxLength)).FromJust();
 }
 
 

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -107,3 +107,69 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
   assert.equal(a, b);
   assert.equal(b, c);
 })();
+
+// v8 fails silently if string length > v8::String::kMaxLength
+(function() {
+  // v8::String::kMaxLength defined in v8.h
+  const kStringMaxLength = process.binding('buffer').kStringMaxLength;
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString();
+  }, /toString failed|Buffer allocation failed/);
+
+  try {
+    new Buffer(kStringMaxLength * 4);
+  } catch(e) {
+    assert.equal(e.message, 'Buffer allocation failed - process out of memory');
+    console.log(
+        '1..0 # Skipped: intensive toString tests due to memory confinements');
+    return;
+  }
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('ascii');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('utf8');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength * 2 + 2).toString('utf16le');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('binary');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('base64');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('hex');
+  }, /toString failed/);
+
+  var maxString = new Buffer(kStringMaxLength).toString();
+  assert.equal(maxString.length, kStringMaxLength);
+  // Free the memory early instead of at the end of the next assignment
+  maxString = undefined;
+
+  maxString = new Buffer(kStringMaxLength).toString('binary');
+  assert.equal(maxString.length, kStringMaxLength);
+  maxString = undefined;
+
+  maxString =
+      new Buffer(kStringMaxLength + 1).toString('binary', 1);
+  assert.equal(maxString.length, kStringMaxLength);
+  maxString = undefined;
+
+  maxString =
+      new Buffer(kStringMaxLength + 1).toString('binary', 0, kStringMaxLength);
+  assert.equal(maxString.length, kStringMaxLength);
+  maxString = undefined;
+
+  maxString = new Buffer(kStringMaxLength + 2).toString('utf16le');
+  assert.equal(maxString.length, (kStringMaxLength + 2) / 2);
+  maxString = undefined;
+})();


### PR DESCRIPTION
v8 will silently return an empty handle
which doesn't delete node's allocated data if string length is
above String::kMaxLength.

````
==3556==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x717a0b in operator new(unsigned long) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:62:35
    #1 0x1a7d88e in node::ExternString<v8::String::ExternalOneByteStringResource, char>::New(v8::Isolate*, char const*, unsigned long) /home/skomski/Code/io.js/out/../src/string_bytes.cc:72:29
    #2 0x1a7d030 in node::StringBytes::Encode(v8::Isolate*, char const*, unsigned long, node::encoding) /home/skomski/Code/io.js/out/../src/string_bytes.cc:720:17
    #3 0x1a269c1 in void node::Buffer::StringSlice<(node::encoding)0>(v8::FunctionCallbackInfo<v8::Value> const&) /home/skomski/Code/io.js/out/../src/node_buffer.cc:495:7

Indirect leak of 268435441 byte(s) in 1 object(s) allocated from:
    #0 0x717b7b in operator new[](unsigned long) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:64:37
    #1 0x1a7b2a5 in node::StringBytes::Encode(v8::Isolate*, char const*, unsigned long, node::encoding) /home/skomski/Code/io.js/out/../src/string_bytes.cc:714:21
    #2 0x1a269c1 in void node::Buffer::StringSlice<(node::encoding)0>(v8::FunctionCallbackInfo<v8::Value> const&) /home/skomski/Code/io.js/out/../src/node_buffer.cc:495:7

SUMMARY: AddressSanitizer: 268435473 byte(s) leaked in 2 allocation(s).
````

v8 related commit: https://chromium.googlesource.com/v8/v8/+/85a0e8075f433fe92c9a4f2df3c86d14000580d9
Before v8 simply crashed: #1374