### PR TITLE
assert: respect assert.doesNotThrow message.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -302,7 +302,11 @@ function _throws(shouldThrow, block, expected, message) {
     fail(actual, expected, 'Missing expected exception' + message);
   }
 
-  if (!shouldThrow && expectedException(actual, expected)) {
+  if (!shouldThrow &&
+      actual instanceof Error &&
+      typeof message === 'string' &&
+      expectedException(actual, expected) ||
+      !shouldThrow && actual && !expected) {
     fail(actual, expected, 'Got unwanted exception' + message);
   }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -322,6 +322,13 @@ assert.throws(function() {assert.ifError(new Error('test error'));});
 assert.doesNotThrow(function() {assert.ifError(null);});
 assert.doesNotThrow(function() {assert.ifError();});
 
+try {
+  assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
+} catch(e) {
+  assert.equal(e.message, 'Got unwanted exception. user message',
+               'a.doesNotThrow ignores user message');
+}
+
 // make sure that validating using constructor really works
 threw = false;
 try {


### PR DESCRIPTION
Addresses #2385.
Special handling to detect when user has supplied a custom message.
Added a test for user message.
When testing if `actual` value is an error use
`util.isError` instead of `instanceof`.

Replaces https://github.com/joyent/node/pull/6470.