### PR TITLE
assert: respect assert.doesNotThrow message.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -330,9 +330,9 @@ function _throws(shouldThrow, block, expected, message) {
     fail(actual, expected, 'Missing expected exception' + message);
   }
 
-  var userProvidedMessage = typeof message === 'string';
-  var isUnwantedException = !shouldThrow && util.isError(actual);
-  var isUnexpectedException = !shouldThrow && actual && !expected;
+  const userProvidedMessage = typeof message === 'string';
+  const isUnwantedException = !shouldThrow && util.isError(actual);
+  const isUnexpectedException = !shouldThrow && actual && !expected;
 
   if ((isUnwantedException &&
       userProvidedMessage &&

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -330,7 +330,11 @@ function _throws(shouldThrow, block, expected, message) {
     fail(actual, expected, 'Missing expected exception' + message);
   }
 
-  if (!shouldThrow && expectedException(actual, expected)) {
+  if (!shouldThrow &&
+      actual instanceof Error &&
+      typeof message === 'string' &&
+      expectedException(actual, expected) ||
+      !shouldThrow && actual && !expected) {
     fail(actual, expected, 'Got unwanted exception' + message);
   }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -330,11 +330,14 @@ function _throws(shouldThrow, block, expected, message) {
     fail(actual, expected, 'Missing expected exception' + message);
   }
 
-  if (!shouldThrow &&
-      actual instanceof Error &&
-      typeof message === 'string' &&
-      expectedException(actual, expected) ||
-      !shouldThrow && actual && !expected) {
+  var userProvidedMessage = typeof message === 'string';
+  var isUnwantedException = !shouldThrow && util.isError(actual);
+  var isUnexpectedException = !shouldThrow && actual && !expected;
+
+  if ((isUnwantedException &&
+      userProvidedMessage &&
+      expectedException(actual, expected)) ||
+      isUnexpectedException) {
     fail(actual, expected, 'Got unwanted exception' + message);
   }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -321,6 +321,13 @@ assert.throws(function() {assert.ifError(new Error('test error'));});
 assert.doesNotThrow(function() {assert.ifError(null);});
 assert.doesNotThrow(function() {assert.ifError();});
 
+try {
+  assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
+} catch(e) {
+  assert.equal(e.message, 'Got unwanted exception. user message',
+               'a.doesNotThrow ignores user message');
+}
+
 // make sure that validating using constructor really works
 threw = false;
 try {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -321,9 +321,10 @@ assert.throws(function() {assert.ifError(new Error('test error'));});
 assert.doesNotThrow(function() {assert.ifError(null);});
 assert.doesNotThrow(function() {assert.ifError();});
 
-assert.throws(function() {
+assert.throws(() => {
   assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
-}, /Got unwanted exception. user message/, 'a.doesNotThrow ignores user message');
+}, /Got unwanted exception. user message/,
+   'a.doesNotThrow ignores user message');
 
 // make sure that validating using constructor really works
 threw = false;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -321,12 +321,9 @@ assert.throws(function() {assert.ifError(new Error('test error'));});
 assert.doesNotThrow(function() {assert.ifError(null);});
 assert.doesNotThrow(function() {assert.ifError();});
 
-try {
+assert.throws(function() {
   assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
-} catch(e) {
-  assert.equal(e.message, 'Got unwanted exception. user message',
-               'a.doesNotThrow ignores user message');
-}
+}, /Got unwanted exception. user message/, 'a.doesNotThrow ignores user message');
 
 // make sure that validating using constructor really works
 threw = false;


### PR DESCRIPTION
Addresses #2385.
Special handling to detect when user has supplied a custom message.
Added a test for user message.
When testing if `actual` value is an error use
`util.isError` instead of `instanceof`.