### PR TITLE
path: make format() consistent and more functional

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -95,6 +95,16 @@ Returns a path string from an object, the opposite of `path.parse` above.
     // returns
     '/home/user/dir/file.txt'
 
+    // `root` will be used if `dir` is not specified and `name` + `ext` will be used
+    // if `base` is not specified
+    path.format({
+        root : "/",
+        ext : ".txt",
+        name : "file"
+    })
+    // returns
+    '/file.txt'
+
 ## path.isAbsolute(path)
 
 Determines whether `path` is an absolute path. An absolute path will always

--- a/lib/path.js
+++ b/lib/path.js
@@ -361,21 +361,13 @@ win32.format = function(pathObject) {
     );
   }
 
-  var root = pathObject.root || '';
-
-  if (typeof root !== 'string') {
-    throw new TypeError(
-        '"pathObject.root" must be a string or undefined, not ' +
-        typeof pathObject.root
-    );
-  }
-
-  var dir = pathObject.dir;
-  var base = pathObject.base || '';
+  var dir = pathObject.dir || pathObject.root;
+  var base = pathObject.base ||
+    ((pathObject.name || '') + (pathObject.ext || ''));
   if (!dir) {
     return base;
   }
-  if (dir[dir.length - 1] === win32.sep) {
+  if (dir === pathObject.root) {
     return dir + base;
   }
   return dir + win32.sep + base;
@@ -570,18 +562,16 @@ posix.format = function(pathObject) {
     );
   }
 
-  var root = pathObject.root || '';
-
-  if (typeof root !== 'string') {
-    throw new TypeError(
-        '"pathObject.root" must be a string or undefined, not ' +
-        typeof pathObject.root
-    );
+  var dir = pathObject.dir || pathObject.root;
+  var base = pathObject.base ||
+    ((pathObject.name || '') + (pathObject.ext || ''));
+  if (!dir) {
+    return base;
   }
-
-  var dir = pathObject.dir ? pathObject.dir + posix.sep : '';
-  var base = pathObject.base || '';
-  return dir + base;
+  if (dir === pathObject.root) {
+    return dir + base;
+  }
+  return dir + posix.sep + base;
 };
 
 

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -1,15 +1,16 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var path = require('path');
+const assert = require('assert');
+const path = require('path');
 
-var winPaths = [
+const winPaths = [
   'C:\\path\\dir\\index.html',
-  'C:\\another_path\\DIR\\1\\2\\33\\index',
+  'C:\\another_path\\DIR\\1\\2\\33\\\\index',
   'another_path\\DIR with spaces\\1\\2\\33\\index',
   '\\foo\\C:',
   'file',
   '.\\file',
+  'C:\\',
   '',
 
   // unc
@@ -19,13 +20,17 @@ var winPaths = [
   '\\\\?\\UNC\\server\\share'
 ];
 
-var winSpecialCaseFormatTests = [
+const winSpecialCaseFormatTests = [
   [{dir: 'some\\dir'}, 'some\\dir\\'],
   [{base: 'index.html'}, 'index.html'],
+  [{root: 'C:\\'}, 'C:\\'],
+  [{name: 'index', ext: '.html'}, 'index.html'],
+  [{dir: 'some\\dir', name: 'index', ext: '.html'}, 'some\\dir\\index.html'],
+  [{root: 'C:\\', name: 'index', ext: '.html'}, 'C:\\index.html'],
   [{}, '']
 ];
 
-var unixPaths = [
+const unixPaths = [
   '/home/user/dir/file.txt',
   '/home/user/a dir/another File.zip',
   '/home/user/a dir//another&File.',
@@ -35,16 +40,21 @@ var unixPaths = [
   '.\\file',
   './file',
   'C:\\foo',
+  '/',
   ''
 ];
 
-var unixSpecialCaseFormatTests = [
+const unixSpecialCaseFormatTests = [
   [{dir: 'some/dir'}, 'some/dir/'],
   [{base: 'index.html'}, 'index.html'],
+  [{root: '/'}, '/'],
+  [{name: 'index', ext: '.html'}, 'index.html'],
+  [{dir: 'some/dir', name: 'index', ext: '.html'}, 'some/dir/index.html'],
+  [{root: '/', name: 'index', ext: '.html'}, '/index.html'],
   [{}, '']
 ];
 
-var errors = [
+const errors = [
   {method: 'parse', input: [null],
    message: /Path must be a string. Received null/},
   {method: 'parse', input: [{}],
@@ -63,10 +73,6 @@ var errors = [
    message: /Parameter "pathObject" must be an object, not boolean/},
   {method: 'format', input: [1],
    message: /Parameter "pathObject" must be an object, not number/},
-  {method: 'format', input: [{root: true}],
-   message: /"pathObject\.root" must be a string or undefined, not boolean/},
-  {method: 'format', input: [{root: 12}],
-   message: /"pathObject\.root" must be a string or undefined, not number/},
 ];
 
 checkParseFormat(path.win32, winPaths);


### PR DESCRIPTION
This PR makes the `win32` and `posix` versions of `path.format()` consistent in when they add a directory separator between the dir and base parts of the path (always add it unless the `dir` part is the same as the `root` part). This fixes the following inconsistencies:

| `path.`                                                | Before      | After          |
|:-----------------------------------------------|--------------|---------------|
| `win32.format({dir: 'folder\\', base: 'file.txt'})` | `'folder\\file.txt'` | `'folder\\\\file.txt'` |
| `posix.format({dir: 'folder/', base: 'file.txt'})`   | `'folder//file.txt'` | (no change)   |
| `win32.format({root: 'C:\\', dir: 'C:\\'})` | `'C:\\'`       | (no change)        |
| `win32.format({root: '\\\\unc\\path\\', dir: '\\\\unc\\path\\'})` | `'\\\\unc\\path\\'`       | (no change)        |
| `posix.format({root: '/', dir: '/'})` | `'//'`           | `'/'`             |

This fixes bugs in `path.format()` and `path.parse()` being mirrors of each other (now they truly are mirrors for both `win32` and `posix`).

Also, `path.format()` is now more functional in that it uses the `name` and `ext` parts of the path if the `base` part is left out, and it uses the `root` part if the `dir` part is left out. I added an example to the docs to show the new functionality.

I also removed the check for `pathObject.root` to be a string, partially because before this commit, `pathObject.root` wasn't being used for anything in the `path.format()` function, and also because if that part gets checked then all of the parts should get checked.

Alternatively, the code could check that all of the path parts in the `pathObject` are strings, in which case it could just go back to using only the `dir` and `base` parts (essentially expecting the input to only come from `path.parse()`).

The discussion for this originated [here](https://github.com/woollybogger/node-old/commit/6048b25e1f3336ec83fa94a5f2c977c448f2e48a#commitcomment-10379330).