### PR TITLE
test: remove excessively poor performance

### DIFF
--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -40,8 +40,7 @@ var c_ucs = new Buffer(b_ucs, 'ucs2');
 assert.equal(c_bin.length, c_ucs.length);
 // make sure Buffers from externals are the same
 for (var i = 0; i < c_bin.length; i++) {
-  assert.equal(c_bin[i], c_ucs[i], c_bin[i] + ' == ' + c_ucs[i] +
-               ' : index ' + i);
+  assert.equal(c_bin[i], c_ucs[i]);
 }
 // check resultant strings
 assert.equal(c_bin.toString('ucs2'), c_ucs.toString('ucs2'));
@@ -63,19 +62,14 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
     var pumped_string2 = slice2.toString('hex');
     var decoded = new Buffer(pumped_string, 'hex');
 
-    var metadata = '\nEXTERN_APEX=1031913 - pumped_string.length=';
-    metadata += pumped_string.length + '\n';
-
     // the string are the same?
     for (var k = 0; k < pumped_string.length; ++k) {
-      assert.equal(pumped_string[k], pumped_string2[k],
-                   metadata + 'chars should be the same at ' + k);
+      assert.equal(pumped_string[k], pumped_string2[k]);
     }
 
     // the recoded buffer is the same?
     for (var i = 0; i < decoded.length; ++i) {
-      assert.equal(datum[i], decoded[i],
-                   metadata + 'bytes should be the same at ' + i);
+      assert.equal(datum[i], decoded[i]);
     }
   }
 })();
@@ -89,20 +83,14 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
     var pumped_string2 = slice2.toString('base64');
     var decoded = new Buffer(pumped_string, 'base64');
 
-    var metadata = '\nEXTERN_APEX=1031913 - data=" + slice.length';
-    metadata += ' pumped_string.length=' + pumped_string.length + '\n';
-
     // the string are the same?
     for (var k = 0; k < pumped_string.length - 3; ++k) {
-      assert.equal(pumped_string[k], pumped_string2[k],
-                   metadata + 'chars should be the same for two slices at '
-                   + k + ' ' + pumped_string[k] + ' ' + pumped_string2[k]);
+      assert.equal(pumped_string[k], pumped_string2[k]);
     }
 
     // the recoded buffer is the same?
     for (var i = 0; i < decoded.length; ++i) {
-      assert.equal(datum[i], decoded[i],
-                   metadata + 'bytes should be the same at ' + i);
+      assert.equal(datum[i], decoded[i]);
     }
   }
 })();


### PR DESCRIPTION
String concatenation in the assert messages has drastic impact on test
runtime. Removal of these messages is unlikely to affect debugging if
any breaking changes are made.

Previous time to run:

    $ time ./iojs test/parallel/test-stringbytes-external.js

    real    0m2.321s
    user    0m2.256s
    sys     0m0.092s

With fix:

    $ time ./iojs test/parallel/test-stringbytes-external.js

    real    0m0.518s
    user    0m0.508s
    sys     0m0.008s

R=@bnoordhuis 