### PR TITLE
doc: document response.finished in http.markdown

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -452,6 +452,11 @@ If `data` is specified, it is equivalent to calling
 If `callback` is specified, it will be called when the response stream
 is finished.
 
+### response.finished
+
+Boolean value that indicates whether the response has completed. Starts
+as `false`. After `response.end()` executes, the value will be `true`.
+
 ## http.request(options[, callback])
 
 io.js maintains several connections per server to make HTTP requests.


### PR DESCRIPTION
Adds mention of response.finished to http.markdown
Originally submitted by @hackerjs. The original
commit needed a bit of cleanup on grammar.

Original PR: https://github.com/joyent/node/pull/6670