### PR TITLE
doc: clarify http.request language

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -463,10 +463,10 @@ automatically parsed with [url.parse()][].
 Options:
 
 - `protocol`: Protocol to use. Defaults to `'http'`.
-- `host`: A domain name or IP address of the server to issue the request to.
-  Defaults to `'localhost'`.
-- `hostname`: Alias for `host`. To support `url.parse()` `hostname` is
-  preferred over `host`.
+- `host`: A domain name or IP address of the server to issue the request to,
+  optionally including a colon-prefixed port number. Defaults to `'localhost'`.
+- `hostname`: A domain name or IP address. May not include colon-prefixed port
+  number. To support `url.parse()`, `hostname` is preferred over `host`.
 - `family`: IP address family to use when resolving `host` and `hostname`.
   Valid values are `4` or `6`. When unspecified, both IP v4 and v6 will be
   used.


### PR DESCRIPTION
Improve messaging for `http.request`'s `host` and `hostname` parameters, as per joyent/node#8990. I can't even count the number of times I've looked at the http docs to see whether `host` or `hostname` lets you include a port for `http.request`.

The current language in the docs says that the host parameter is "A domain name or IP address of the server to issue the request to. Defaults to 'localhost'," and described the hostname parameter with "To support url.parse() hostname is preferred over host." The host description actually fits the hostname parameter better, and it seems like the host description needs to say something about allowing a port.