### PR TITLE
src: better error message on failed Buffer malloc

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -409,7 +409,7 @@ void Create(const FunctionCallbackInfo<Value>& args) {
   if (length > 0) {
     data = malloc(length);
     if (data == nullptr)
-      return env->ThrowRangeError("invalid Buffer length");
+      return env->ThrowRangeError("Buffer allocation failed - process out of memory");
   } else {
     data = nullptr;
   }


### PR DESCRIPTION
The original message confused me because I thought I was concatenating with too large buffers but I had simply no memory left.