### PR TITLE
test: lint addon tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,8 +483,19 @@ CPPLINT_EXCLUDE += src/node_win32_perfctr_provider.cc
 CPPLINT_EXCLUDE += src/queue.h
 CPPLINT_EXCLUDE += src/tree.h
 CPPLINT_EXCLUDE += src/v8abbr.h
+CPPLINT_EXCLUDE += $(wildcard test/addons/doc-*/*.cc test/addons/doc-*/*.h)
 
-CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard src/*.cc src/*.h src/*.c tools/icu/*.h tools/icu/*.cc deps/debugger-agent/include/* deps/debugger-agent/src/*))
+CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard \
+	deps/debugger-agent/include/* \
+	deps/debugger-agent/src/* \
+	src/*.c \
+	src/*.cc \
+	src/*.h \
+	test/addons/*/*.cc \
+	test/addons/*/*.h \
+	tools/icu/*.cc \
+	tools/icu/*.h \
+	))
 
 cpplint:
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_FILES)

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -3,35 +3,33 @@
 #include <v8.h>
 #include <uv.h>
 
-using namespace v8;
-using namespace node;
-
 struct async_req {
   uv_work_t req;
   int input;
   int output;
-  Persistent<Function> callback;
+  v8::Persistent<v8::Function> callback;
 };
 
 void DoAsync(uv_work_t* r) {
   async_req* req = reinterpret_cast<async_req*>(r->data);
-  sleep(1); // simulate CPU intensive process...
+  sleep(1);  // Simulate CPU intensive process...
   req->output = req->input * 2;
 }
 
 void AfterAsync(uv_work_t* r) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(isolate);
   async_req* req = reinterpret_cast<async_req*>(r->data);
 
-  Handle<Value> argv[2] = {
-    Null(isolate),
-    Integer::New(isolate, req->output)
+  v8::Handle<v8::Value> argv[2] = {
+    v8::Null(isolate),
+    v8::Integer::New(isolate, req->output)
   };
 
-  TryCatch try_catch;
+  v8::TryCatch try_catch(isolate);
 
-  Local<Function> callback = Local<Function>::New(isolate, req->callback);
+  v8::Local<v8::Function> callback =
+      v8::Local<v8::Function>::New(isolate, req->callback);
   callback->Call(isolate->GetCurrentContext()->Global(), 2, argv);
 
   // cleanup
@@ -39,13 +37,13 @@ void AfterAsync(uv_work_t* r) {
   delete req;
 
   if (try_catch.HasCaught()) {
-    FatalException(isolate, try_catch);
+    node::FatalException(isolate, try_catch);
   }
 }
 
-void Method(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(isolate);
 
   async_req* req = new async_req;
   req->req.data = req;
@@ -53,7 +51,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   req->input = args[0]->IntegerValue();
   req->output = 0;
 
-  Local<Function> callback = Local<Function>::Cast(args[1]);
+  v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(args[1]);
   req->callback.Reset(isolate, callback);
 
   uv_queue_work(uv_default_loop(),
@@ -62,7 +60,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                 (uv_after_work_cb)AfterAsync);
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(v8::Handle<v8::Object> exports, v8::Handle<v8::Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -16,10 +16,8 @@ static int at_exit_cb1_called = 0;
 static int at_exit_cb2_called = 0;
 
 static void at_exit_cb1(void* arg) {
-  // FIXME(bnoordhuis) Isolate::GetCurrent() is on its way out.
-  Isolate* isolate = Isolate::GetCurrent();
+  Isolate* isolate = static_cast<Isolate*>(arg);
   HandleScope handle_scope(isolate);
-  assert(arg == 0);
   Local<Object> obj = Object::New(isolate);
   assert(!obj.IsEmpty());  // Assert VM is still alive.
   assert(obj->IsObject());
@@ -37,7 +35,7 @@ static void sanity_check(void) {
 }
 
 void init(Handle<Object> target) {
-  AtExit(at_exit_cb1);
+  AtExit(at_exit_cb1, target->CreationContext()->GetIsolate());
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);
   atexit(sanity_check);

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -21,7 +21,7 @@ static void at_exit_cb1(void* arg) {
   HandleScope handle_scope(isolate);
   assert(arg == 0);
   Local<Object> obj = Object::New(isolate);
-  assert(!obj.IsEmpty()); // assert VM is still alive
+  assert(!obj.IsEmpty());  // Assert VM is still alive.
   assert(obj->IsObject());
   at_exit_cb1_called++;
 }

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -1,15 +1,13 @@
 #include <node.h>
 #include <v8.h>
 
-using namespace v8;
-
-void Method(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(isolate);
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(v8::Handle<v8::Object> exports, v8::Handle<v8::Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -2,7 +2,7 @@
 #include <v8.h>
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Isolate* isolate = args.GetIsolate();
   v8::HandleScope scope(isolate);
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -2,7 +2,7 @@
 #include <v8.h>
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Isolate* isolate = args.GetIsolate();
   v8::HandleScope scope(isolate);
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -1,15 +1,13 @@
 #include <node.h>
 #include <v8.h>
 
-using namespace v8;
-
-void Method(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(isolate);
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> target) {
+void init(v8::Handle<v8::Object> target) {
   NODE_SET_METHOD(target, "hello", Method);
 }
 


### PR DESCRIPTION
Add files in test/addon to the `make cpplint` rule and fix up existing
style issues.  Tests scraped from doc/api/addon.md are filtered out
because those are predominantly for illustrative purposes.

R=@trevnorris?

Lint CI only because `make run-ci` doesn't run add-on tests at the moment: https://jenkins-iojs.nodesource.com/job/node-linter/188/