### PR TITLE
test: some runtime speed improvements

### DIFF
--- a/test/parallel/test-net-keepalive.js
+++ b/test/parallel/test-net-keepalive.js
@@ -8,8 +8,8 @@ var echoServer = net.createServer(function(connection) {
   serverConnection = connection;
   connection.setTimeout(0);
   assert.notEqual(connection.setKeepAlive, undefined);
-  // send a keepalive packet after 1000 ms
-  connection.setKeepAlive(true, 1000);
+  // send a keepalive packet after 50 ms
+  connection.setKeepAlive(true, common.platformTimeout(50));
   connection.on('end', function() {
     connection.end();
   });
@@ -27,5 +27,5 @@ echoServer.on('listening', function() {
     serverConnection.end();
     clientConnection.end();
     echoServer.close();
-  }, 1200);
+  }, common.platformTimeout(100));
 });

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -27,20 +27,17 @@ function pingPongTest(port, host) {
       // than one message.
       assert.ok(0 <= socket.bufferSize && socket.bufferSize <= 4);
 
-      console.log('server got: ' + data);
       assert.equal(true, socket.writable);
       assert.equal(true, socket.readable);
       assert.equal(true, count <= N);
-      if (/PING/.exec(data)) {
-        socket.write('PONG', function() {
-          sentPongs++;
-          console.error('sent PONG');
-        });
-      }
+      assert.equal(data, 'PING');
+
+      socket.write('PONG', function() {
+        sentPongs++;
+      });
     });
 
     socket.on('end', function() {
-      console.error(socket);
       assert.equal(true, socket.allowHalfOpen);
       assert.equal(true, socket.writable); // because allowHalfOpen
       assert.equal(false, socket.readable);
@@ -73,8 +70,6 @@ function pingPongTest(port, host) {
     });
 
     client.on('data', function(data) {
-      console.log('client got: ' + data);
-
       assert.equal('PONG', data);
       count += 1;
 

--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -16,14 +16,22 @@ var server1 = net.createServer({pauseOnConnect: true}, function(socket) {
   });
 
   setTimeout(function() {
+    // After 50(ish) ms, the other socket should have already read the data.
+    assert.equal(read, true);
     assert.equal(socket.bytesRead, 0, 'no data should have been read yet');
+
     socket.resume();
     stopped = false;
-  }, 3000);
+  }, common.platformTimeout(50));
 });
 
+// read is a timing check, as server1's timer should fire after server2's
+// connection receives the data. Note that this could be race-y.
+var read = false;
 var server2 = net.createServer({pauseOnConnect: false}, function(socket) {
   socket.on('data', function(data) {
+    read = true;
+
     assert.equal(data.toString(), msg, 'invalid data received');
     socket.end();
     server2.close();
@@ -36,4 +44,9 @@ server1.listen(common.PORT, function() {
 
 server2.listen(common.PORT + 1, function() {
   net.createConnection({port: common.PORT + 1}).write(msg);
+});
+
+process.on('exit', function() {
+  assert.equal(stopped, false);
+  assert.equal(read, true);
 });


### PR DESCRIPTION
This PR consists of a few commits, each that address an individual test's runtime. I've done it this way so they're easy to revert in case they turn out to be flaky on a buildbot, but I can squash them if preferred.

Basically, these tests ran relatively long when they didn't need to, so their speed has been fixed:

- `parallel/test-net-pingpong.js`, 1.130s to 0.481s
- `parallel/test-net-keepalive.js`, 1.335s to 0.236s
- `parallel/test-net-server-pause-on-connect.js`, 3.141s to 0.356s

These commits improve each individual test by reducing timeouts and making the conditions / assertions stricter. Also, `test-net-pingpong.js` logged a bunch of annoying info (4k lines!?), which has been mostly removed.