### PR TITLE
tools: enable space-after-keywords eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,6 +66,8 @@ rules:
   eol-last: 2
   ## no trailing spaces
   no-trailing-spaces: 2
+  # require space after keywords, eg 'for (..)'
+  space-after-keywords: 2
 
   # Strict Mode
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -54,7 +54,7 @@ function getall() {
   setImmediate(getall);
 }
 
-for(var i = 0; i < 10; i++)
+for (var i = 0; i < 10; i++)
   getall();
 
 function afterGC() {

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -18,7 +18,7 @@ var common = require('../common'),
 // take the first non-internal interface as the address for binding
 get_bindAddress: for (var name in networkInterfaces) {
   var interfaces = networkInterfaces[name];
-  for(var i = 0; i < interfaces.length; i++) {
+  for (var i = 0; i < interfaces.length; i++) {
     var localInterface = interfaces[i];
     if (!localInterface.internal && localInterface.family === 'IPv4') {
       var bindAddress = localInterface.address;

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -663,7 +663,7 @@ TEST(function test_resolve_failure(done) {
   var req = dns.resolve4('nosuchhostimsure', function(err) {
     assert(err instanceof Error);
 
-    switch(err.code) {
+    switch (err.code) {
       case 'ENOTFOUND':
       case 'ESERVFAIL':
         break;

--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -11,7 +11,7 @@ process.on('exit', function() {
 
 // this should fail with an async EINVAL error, not throw an exception
 net.createServer(assert.fail).listen({fd:0}).on('error', function(e) {
-  switch(e.code) {
+  switch (e.code) {
     case 'EINVAL':
     case 'ENOTSOCK':
       gotError = e;

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -11,7 +11,7 @@ var accum = [];
 var timeout;
 
 src._read = function(n) {
-  if(!hasRead) {
+  if (!hasRead) {
     hasRead = true;
     process.nextTick(function() {
       src.push(new Buffer('1'));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -106,7 +106,7 @@ assert.ok(util.inspect(y), '[ \'a\', \'b\', \'c\', \'\\\\\\\': \'d\' ]');
 function test_color_style(style, input, implicit) {
   var color_name = util.inspect.styles[style];
   var color = ['', ''];
-  if(util.inspect.colors[color_name])
+  if (util.inspect.colors[color_name])
     color = util.inspect.colors[color_name];
 
   var without_color = util.inspect(input, false, 0, false);


### PR DESCRIPTION
This adds a new eslint rule: [`space-after-keywords`](http://eslint.org/docs/rules/space-after-keywords).

Spaces after keywords makes this error (6 now fixed errors):
```javascript
if(x) { ... }
```
in favor of:
```javascript
if (x) { ... }
```