### PR TITLE
win,msi: Upgrade from old upgrade code

### DIFF
--- a/tools/msvs/msi/i18n/de-de.wxl
+++ b/tools/msvs/msi/i18n/de-de.wxl
@@ -3,7 +3,7 @@
     <!-- See https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx -->
     <String Id="LocaleId">1031</String>
 
-    <String Id="WelcomeDlgDescription">Dieser Installationsassistent wird [ProductName] auf Ihrem Computer installieren.&#xD;&#xA;&#xD;&#xA;WARNUNG: Wenn Sie von io.js v1.0.0 oder v1.0.1 aus updaten wollen, müssen Sie diese Versionen zuerst manuell deinstallieren.</String>
+    <String Id="WelcomeDlgDescription">Dieser Installationsassistent wird [ProductName] auf Ihrem Computer installieren.</String>
     <String Id="InstallDirDlgDescription">Wählen Sie einen anderen Installationsort oder klicken Sie auf Weiter zum installieren.</String>
 
     <String Id="MajorUpgrade_DowngradeErrorMessage">Eine neuere Version von [ProductName] ist bereits installiert. Der Installationsassistent wird jetzt geschlossen.</String>

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -3,7 +3,7 @@
     <!-- See https://msdn.microsoft.com/en-us/goglobal/bb964664.aspx -->
     <String Id="LocaleId">1033</String>
 
-    <String Id="WelcomeDlgDescription">The Setup Wizard will install [ProductName] on your computer.&#xD;&#xA;&#xD;&#xA;WARNING: if you're upgrading from io.js v1.0.0 or v1.0.1, you must first uninstall these versions manually.</String>
+    <String Id="WelcomeDlgDescription">The Setup Wizard will install [ProductName] on your computer.</String>
     <String Id="InstallDirDlgDescription">Choose a custom location or click Next to install.</String>
 
     <String Id="MajorUpgrade_DowngradeErrorMessage">A later version of [ProductName] is already installed. Setup will now exit.</String>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -25,6 +25,15 @@
     <MajorUpgrade AllowSameVersionUpgrades="yes"
                   DowngradeErrorMessage="!(loc.MajorUpgrade_DowngradeErrorMessage)"/>
 
+    <Upgrade Id="1d60944c-b9ce-4a71-a7c0-0384eb884baa">
+      <UpgradeVersion Maximum="1.0.0"
+                      IncludeMaximum="no"
+                      Property="NODE_0X_DETECTED" />
+      <UpgradeVersion Minimum="1.0.0"
+                      IncludeMinimum="yes"
+                      Property="EARLY_IO_DETECTED" />
+    </Upgrade>
+
     <Icon Id="NodeIcon" SourceFile="$(var.RepoDir)\src\res\node.ico"/>
     <Property Id="ARPPRODUCTICON" Value="NodeIcon"/>
     <Property Id="ApplicationFolderName" Value="node"/>


### PR DESCRIPTION
As part of the convergence changes, this change allows new MSI installers to upgrade versions 0.x of Node.js and 1.0.0 and 1.0.1 of io.js. This addresses the issue raised by @rvagg in https://github.com/nodejs/node/pull/2367#issuecomment-132049399 .

@piscisaureus this was not done before because it could not have been done before convergence, but let me know if there's any other reason.

cc @nodejs/platform-windows 