### PR TITLE
assert: handle NaN properly in deep assertions

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -143,6 +143,10 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
 };
 
 function _deepEqual(actual, expected, strict) {
+  if (Number.isNaN(actual) && Number.isNaN(expected)) {
+    return true;
+  }
+
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
     return true;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -465,4 +465,16 @@ testBlockTypeError(assert.doesNotThrow, null);
 testBlockTypeError(assert.throws, undefined);
 testBlockTypeError(assert.doesNotThrow, undefined);
 
+// tests specific to `NaN` values in other container objects
+assert.deepEqual([NaN], [NaN]);
+assert.deepStrictEqual([NaN], [NaN]);
+
+assert.deepEqual({key: NaN}, {key: NaN});
+assert.deepStrictEqual({key: NaN}, {key: NaN});
+
+assert.throws(assert.notDeepEqual.bind(assert, [NaN], [NaN]));
+assert.throws(assert.notDeepStrictEqual.bind(assert, [NaN], [NaN]));
+assert.throws(assert.notDeepEqual.bind(assert, {key: NaN}, {key: NaN}));
+assert.throws(assert.notDeepStrictEqual.bind(assert, {key: NaN}, {key: NaN}));
+
 console.log('All OK');


### PR DESCRIPTION
As it is, when two container objects which have `NaN`s are asserted
to be equal, it will fail.

    > process.version
    'v3.0.0'
    > assert.deepEqual([NaN], [NaN])
    ...
    AssertionError: [ NaN ] deepEqual [ NaN ]
    > assert.deepEqual({key: NaN}, {key: NaN})
    ...

This patch explicitly compares the `NaN` values with `Number.isNaN`.

PR-URL: https://github.com/nodejs/node/pull/2440