### PR TITLE
test: remove race in test-debug-signal-cluster.js

### DIFF
--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -16,7 +16,7 @@ var waitingForDebuggers = false;
 var pids = null;
 
 child.stderr.on('data', function(data) {
-  var lines = data.toString().replace(/\r/g, '').trim().split('\n');
+  var lines = data.toString().trim().split('\n');
 
   lines.forEach(function(line) {
     console.log('> ' + line);


### PR DESCRIPTION
If two lines of data are received, do not squash them into one.

They may legitimately be two lines arriving on the same tick.

This race appears to be a source of flakiness in the test. See https://jenkins-iojs.nodesource.com/job/node-test-commit-other/173/nodes=smartos14-32/console for this:

````
not ok 139 - test-debug-signal-cluster.js
#got pids [14030,14047,14050]
#
#assert.js:89
#  throw new assert.AssertionError({
#  ^
#AssertionError: test timed out.
#    at testTimedOut [as _onTimeout] (/home/iojs/build/workspace/node-test-commit-other/nodes/smartos14-32/test/parallel/test-debug-signal-cluster.js:54:3)
#    at Timer.unrefdHandle (timers.js:307:14)
#> all workers are running
#> Starting debugger agent.
#> Debugger listening on port 12388
#> Starting debugger agent.
#> Starting debugger agent.
#> Debugger listening on port 12389Debugger listening on port 12390
  ---
  duration_ms: 4.524
  ...
````

Note in particular this line which appears to be the cause of the failure:

> #> Debugger listening on port 12389Debugger listening on port 12390

That's two lines squashed into one. If not squashed, the test passes.