### PR TITLE
doc: make the deprecation messages consistent

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -67,7 +67,7 @@ Example:
 
 ## crypto.createCredentials(details)
 
-    Stability: 0 - Deprecated. Use [tls.createSecureContext][] instead.
+    Stability: 0 - Deprecated: Use [tls.createSecureContext][] instead.
 
 Creates a credentials object, with the optional details being a
 dictionary with keys:

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -145,9 +145,9 @@ Returns the number of listeners listening to the `type` of event.
 
 ### Class Method: EventEmitter.listenerCount(emitter, event)
 
-Return the number of listeners for a given event.
+    Stability: 0 - Deprecated: Use [emitter.listenerCount][] instead.
 
-_Note: This is deprecated. Use `emitter.listenerCount` instead._
+Returns the number of listeners for a given event.
 
 ### Event: 'newListener'
 
@@ -186,3 +186,6 @@ constructor function. For example:
 
     // Inherit functions from `EventEmitter`'s prototype
     util.inherits(MyEventEmitter, EventEmitter);
+
+
+[emitter.listenerCount]: #events_emitter_listenercount_type

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -671,9 +671,7 @@ callback, and have some fallback logic if it is null.
 
 ## fs.exists(path, callback)
 
-`fs.exists()` is **deprecated**. For supported alternatives please check out
-[`fs.stat`](fs.html#fs_fs_stat_path_callback) or
-[`fs.access`](fs.html#fs_fs_access_path_mode_callback).
+    Stability: 0 - Deprecated: Use [fs.stat][] or [fs.access][] instead.
 
 Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
@@ -697,9 +695,7 @@ and handle the error when it's not there.
 Synchronous version of [`fs.exists`](fs.html#fs_fs_exists_path_callback).
 Returns `true` if the file exists, `false` otherwise.
 
-`fs.existsSync()` is **deprecated**. For supported alternatives please check
-out [`fs.statSync`](fs.html#fs_fs_statsync_path) or
-[`fs.accessSync`](fs.html#fs_fs_accesssync_path_mode).
+    Stability: 0 - Deprecated: Use [fs.statSync][] or [fs.accessSync][] instead.
 
 ## fs.access(path[, mode], callback)
 
@@ -907,3 +903,9 @@ See more details in [fs.watch](#fs_fs_watch_filename_options_listener).
 * `error` {Error object}
 
 Emitted when an error occurs.
+
+
+[fs.stat]: #fs_fs_stat_path_callback
+[fs.access]: #fs_fs_access_path_mode_callback
+[fs.statSync]: #fs_fs_statsync_path
+[fs.accessSync]: #fs_fs_accesssync_path_mode

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -66,7 +66,8 @@ added to the `'request'` event.
 
 ## http.createClient([port][, host])
 
-This function is **deprecated**; please use [http.request()][] instead.
+    Stability: 0 - Deprecated: Use [http.request][] instead.
+
 Constructs a new HTTP client. `port` and `host` refer to the server to be
 connected to.
 
@@ -1092,8 +1093,7 @@ client's authentication details.
 [http.IncomingMessage]: #http_http_incomingmessage
 [http.ServerResponse]: #http_class_http_serverresponse
 [http.Server]: #http_class_http_server
-[http.request()]: #http_http_request_options_callback
-[http.request()]: #http_http_request_options_callback
+[http.request]: #http_http_request_options_callback
 [net.Server.close()]: net.html#net_server_close_callback
 [net.Server.listen(path)]: net.html#net_server_listen_path_callback
 [net.Server.listen(port)]: net.html#net_server_listen_port_hostname_backlog_callback

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -281,7 +281,8 @@ with `child_process.fork()`.
 
 ### server.connections
 
-This function is **deprecated**; please use [server.getConnections()][] instead.
+    Stability: 0 - Deprecated: Use [server.getConnections][] instead.
+
 The number of concurrent connections on the server.
 
 This becomes `null` when sending a socket to a child with
@@ -623,7 +624,7 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 ['end']: #net_event_end
 [EventEmitter]: events.html#events_class_events_eventemitter
 ['listening']: #net_event_listening
-[server.getConnections()]: #net_server_getconnections_callback
+[server.getConnections]: #net_server_getconnections_callback
 [Readable Stream]: stream.html#stream_class_stream_readable
 [stream.setEncoding()]: stream.html#stream_readable_setencoding_encoding
 [dns.lookup()]: dns.html#dns_dns_lookup_hostname_options_callback

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -35,6 +35,10 @@ By default, the REPL will persist history between `node` REPL sessions by saving
 to a `.node_repl_history` file in the user's home directory. This can be
 disabled by setting the environment variable `NODE_REPL_HISTORY=""`.
 
+### NODE_REPL_HISTORY_FILE
+
+    Stability: 0 - Deprecated: Use `NODE_REPL_HISTORY` instead.
+
 Previously in Node.js/io.js v2.x, REPL history was controlled by using a
 `NODE_REPL_HISTORY_FILE` environment variable, and the history was saved in JSON
 format. This variable has now been deprecated, and your REPL history will

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -702,7 +702,7 @@ The number of concurrent connections on the server.
 
 ## Class: CryptoStream
 
-    Stability: 0 - Deprecated. Use tls.TLSSocket instead.
+    Stability: 0 - Deprecated: Use [tls.TLSSocket][] instead.
 
 This is an encrypted stream.
 

--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -24,8 +24,7 @@ terminal.
 
 ## tty.setRawMode(mode)
 
-Deprecated. Use `tty.ReadStream#setRawMode()`
-(i.e. `process.stdin.setRawMode()`) instead.
+    Stability: 0 - Deprecated: Use [tty.ReadStream#setRawMode][] (i.e. process.stdin.setRawMode) instead.
 
 
 ## Class: ReadStream
@@ -73,3 +72,6 @@ has changed.
       console.log('screen size has changed!');
       console.log(process.stdout.columns + 'x' + process.stdout.rows);
     });
+
+
+[tty.ReadStream#setRawMode]: #tty_rs_setrawmode_mode


### PR DESCRIPTION
The deprecation messages in the documentations should be in the format

    Stability: 0 - Deprecated: Use [alternate] instead.

so that they will be consistent.