### PR TITLE
repl: don't throw ENOENT on NODE_REPL_HISTORY_FILE

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -122,8 +122,10 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
         }
         repl.history = repl.history.slice(-repl.historySize);
       } catch (err) {
-        return ready(
+        if (err.code !== 'ENOENT') {
+          return ready(
             new Error(`Could not parse history data in ${oldHistoryPath}.`));
+        }
       }
     }
 

--- a/test/sequential/test-repl-persistent-history.js
+++ b/test/sequential/test-repl-persistent-history.js
@@ -69,10 +69,17 @@ const fixtures = path.join(common.testDir, 'fixtures');
 const historyFixturePath = path.join(fixtures, '.node_repl_history');
 const historyPath = path.join(common.tmpDir, '.fixture_copy_repl_history');
 const oldHistoryPath = path.join(fixtures, 'old-repl-history-file.json');
+const enoentHistoryPath = path.join(fixtures, 'enoent-repl-history-file.json');
 
 
 const tests = [{
   env: { NODE_REPL_HISTORY: '' },
+  test: [UP],
+  expected: [prompt, replDisabled, prompt]
+},
+{
+  env: { NODE_REPL_HISTORY: '',
+         NODE_REPL_HISTORY_FILE: enoentHistoryPath },
   test: [UP],
   expected: [prompt, replDisabled, prompt]
 },


### PR DESCRIPTION
Fixes: #2449.

If you have no history file written to disk, but the environment
variable set, `fs.readFileSync` will throw an ENOENT error,
but there's nothing to convert. The converter should ignore
ENOENT on that `fs.readFileSync` call