### PR TITLE
string_bytes: fix unaligned write in UCS2

### DIFF
--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -151,6 +151,15 @@ class StringBytes {
       enum encoding encoding) {
     return Encode(v8::Isolate::GetCurrent(), buf, buflen, encoding);
   })
+
+ private:
+  static size_t WriteUCS2(char* buf,
+                          size_t buflen,
+                          size_t nbytes,
+                          const char* data,
+                          v8::Local<v8::String> str,
+                          int flags,
+                          size_t* chars_written);
 };
 
 }  // namespace node


### PR DESCRIPTION
Support unaligned output buffer when writing out UCS2 in
`StringBytes::Write`.

Fix: https://github.com/nodejs/node/issues/2457

cc @bnoordhuis 

I wasn't able to find a way to re-unify it with your code in `node_buffer.cc`. No test is included, as I believe there are already different unaligned stores in `parallel/test-buffer`.