### PR TITLE
src: improve startup time

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3706,7 +3706,8 @@ void Init(int* argc,
 #endif
   // The const_cast doesn't violate conceptual const-ness.  V8 doesn't modify
   // the argv array or the elements it points to.
-  V8::SetFlagsFromCommandLine(&v8_argc, const_cast<char**>(v8_argv), true);
+  if (v8_argc != 0)
+    V8::SetFlagsFromCommandLine(&v8_argc, const_cast<char**>(v8_argv), true);
 
   // Anything that's still in v8_argv is not a V8 or a node option.
   for (int i = 1; i < v8_argc; i++) {


### PR DESCRIPTION
Previously, V8:SetFlagsFromCommandLine was being called even if v8_argc
was 0. This change prevents that from being called unless v8 arguments
are actually passed.

Improves startup time by about 5% on average.

![screen shot 2015-08-21 at 4 10 14 am](https://cloud.githubusercontent.com/assets/677994/9405216/96c474a0-47bb-11e5-9300-6d8588a7d684.png)
