### PR TITLE
buffer: reapply 07c0667

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -21,6 +21,15 @@ function createPool() {
 }
 
 
+function alignPool() {
+  // Ensure aligned slices
+  if (poolOffset & 0x7) {
+    poolOffset |= 0x7;
+    poolOffset++;
+  }
+}
+
+
 function Buffer(arg) {
   // Common case.
   if (typeof arg === 'number') {
@@ -66,6 +75,7 @@ function allocate(size) {
       createPool();
     var b = binding.slice(allocPool, poolOffset, poolOffset + size);
     poolOffset += size;
+    alignPool();
     return b;
   } else {
     return binding.create(size);
@@ -86,6 +96,7 @@ function fromString(string, encoding) {
   var actual = allocPool.write(string, poolOffset, encoding);
   var b = binding.slice(allocPool, poolOffset, poolOffset + actual);
   poolOffset += actual;
+  alignPool();
   return b;
 }
 


### PR DESCRIPTION
Original commit message:

    buffer: align chunks on 8-byte boundary

    When slicing global pool - ensure that the underlying buffer's data
    ptr is 8-byte alignment to do not ruin expectations of 3rd party C++
    addons.

    NOTE: 0.10 node.js always returned aligned pointers and io.js should
    do this too for compatibility.

R=@trevnorris