### PR TITLE
tools: fix anchors in generated documents

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -79,12 +79,12 @@ code a:hover {
   color: white !important;
 }
 
-pre.api_stability_0 a,
-pre.api_stability_1 a,
-pre.api_stability_2 a,
-pre.api_stability_3 a,
-pre.api_stability_4 a,
-pre.api_stability_5 a {
+.api_stability_0 a,
+.api_stability_1 a,
+.api_stability_2 a,
+.api_stability_3 a,
+.api_stability_4 a,
+.api_stability_5 a {
   text-decoration: underline;
 }
 

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -79,6 +79,15 @@ code a:hover {
   color: white !important;
 }
 
+pre.api_stability_0 a,
+pre.api_stability_1 a,
+pre.api_stability_2 a,
+pre.api_stability_3 a,
+pre.api_stability_4 a,
+pre.api_stability_5 a {
+  text-decoration: underline;
+}
+
 .api_stability_0 {
   background-color: #D60027;
 }


### PR DESCRIPTION
When an anchor tag is used within a pre tag, the link is not
distinguishable. This patch makes sure that the links are highlighted
by underlining them.

cc @nodejs/documentation 

In Live: http://imgur.com/0ybPBNI

After the Fix: http://imgur.com/B0CtupD