### PR TITLE
test: lint test-fs-non-number-arguments-throw

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,5 @@ lib/punycode.js
 test/addons/doc-*/
 test/fixtures
 test/**/node_modules
-test/parallel/test-fs-non-number-arguments-throw.js
 test/disabled
 test/tmp*/

--- a/test/parallel/test-fs-non-number-arguments-throw.js
+++ b/test/parallel/test-fs-non-number-arguments-throw.js
@@ -1,24 +1,31 @@
-var assert = require('assert'),
-    fs = require('fs'),
-    saneEmitter,
-    sanity = 'ire(\'assert\')';
+'use strict';
 
-saneEmitter = fs.createReadStream(__filename, { start: 17, end: 29 });
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const tempFile = path.join(common.tmpDir, 'fs-non-number-arguments-throw');
 
-assert.throws(function () {
-  fs.createReadStream(__filename, { start: "17", end: 29 });
+common.refreshTmpDir();
+fs.writeFileSync(tempFile, 'abc\ndef');
+
+// a sanity check when using numbers instead of strings
+const sanity = 'def';
+const saneEmitter = fs.createReadStream(tempFile, { start: 4, end: 6 });
+
+assert.throws(function() {
+  fs.createReadStream(tempFile, { start: '4', end: 6 });
 }, "start as string didn't throw an error for createReadStream");
 
-assert.throws(function () {
-  fs.createReadStream(__filename, { start: 17, end: "29" });
+assert.throws(function() {
+  fs.createReadStream(tempFile, { start: 4, end: '6' });
 }, "end as string didn't throw an error");
 
-assert.throws(function () {
-  fs.createWriteStream(__filename, { start: "17" });
+assert.throws(function() {
+  fs.createWriteStream(tempFile, { start: '4' });
 }, "start as string didn't throw an error for createWriteStream");
 
-saneEmitter.on('data', function (data) {
-  // a sanity check when using numbers instead of strings
+saneEmitter.on('data', function(data) {
   assert.strictEqual(sanity, data.toString('utf8'), 'read ' +
                      data.toString('utf8') + ' instead of ' + sanity);
 });


### PR DESCRIPTION
This test was excluded from linting changes because of a https://github.com/nodejs/node/issues/1737. 

I'm going to check if the issue is still present on the CI through this PR.