### PR TITLE
--link-module for ./configure to specify 3rd party builtins

### DIFF
--- a/configure
+++ b/configure
@@ -84,6 +84,13 @@ parser.add_option("--fully-static",
     help="Generate an executable without external dynamic libraries. This "
          "will not work on OSX when using default compilation environment")
 
+parser.add_option("--link-module",
+    action="append",
+    dest="linked_module",
+    help="Path to a JS file to be bundled in the binary as a builtin."
+         "This module will be referenced by basename without extension."
+         "Can be used multiple times")
+
 parser.add_option("--openssl-no-asm",
     action="store_true",
     dest="openssl_no_asm",
@@ -696,6 +703,9 @@ def configure_node(o):
 
   if options.enable_static:
     o['variables']['node_target_type'] = 'static_library'
+
+  if options.linked_module:
+    o['variables']['library_files'] = options.linked_module
 
 
 def configure_library(lib, output):

--- a/configure
+++ b/configure
@@ -335,6 +335,9 @@ parser.add_option('--enable-static',
 
 (options, args) = parser.parse_args()
 
+# Expand ~ in the install prefix now, it gets written to multiple files.
+options.prefix = os.path.expanduser(options.prefix or '')
+
 # set up auto-download list
 auto_downloads = nodedownload.parse(options.download_list)
 
@@ -611,7 +614,7 @@ def configure_mips(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
-  o['variables']['node_prefix'] = os.path.expanduser(options.prefix or '')
+  o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
 


### PR DESCRIPTION
- Uses JS2C still, so basename collisions result in a compile error
- Allows specifying a _third_party_main outside of the node repository
- Allows embedders to create custom builtin modules outside of node's repository