### PR TITLE
timers: fixing API refs to use safe internal refs

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -158,7 +158,7 @@ exports.enroll = function(item, msecs) {
 
 // call this whenever the item is active (not idle)
 // it will reset its timeout.
-exports.active = function(item) {
+const active = exports.active = function(item) {
   var msecs = item._idleTimeout;
   if (msecs >= 0)
     insert(item, msecs);
@@ -208,19 +208,19 @@ exports.setTimeout = function(callback, after) {
 
   if (process.domain) timer.domain = process.domain;
 
-  exports.active(timer);
+  active(timer);
 
   return timer;
 };
 
 
-exports.clearTimeout = function(timer) {
+const clearTimeout = exports.clearTimeout = function(timer) {
   if (timer && (timer[kOnTimeout] || timer._onTimeout)) {
     timer[kOnTimeout] = timer._onTimeout = null;
     if (timer instanceof Timeout) {
       timer.close(); // for after === 0
     } else {
-      exports.unenroll(timer);
+      unenroll(timer);
     }
   }
 };
@@ -262,7 +262,7 @@ exports.setInterval = function(callback, repeat) {
   timer._repeat = ontimeout;
 
   if (process.domain) timer.domain = process.domain;
-  exports.active(timer);
+  active(timer);
 
   return timer;
 
@@ -278,7 +278,7 @@ exports.setInterval = function(callback, repeat) {
       this._handle.start(repeat, 0);
     } else {
       timer._idleTimeout = repeat;
-      exports.active(timer);
+      active(timer);
     }
   }
 };
@@ -318,7 +318,7 @@ Timeout.prototype.unref = function() {
     if (!this._idleStart) this._idleStart = now;
     var delay = this._idleStart + this._idleTimeout - now;
     if (delay < 0) delay = 0;
-    exports.unenroll(this);
+    unenroll(this);
 
     // Prevent running cb again when unref() is called during the same cb
     if (this._called && !this._repeat) return;
@@ -343,7 +343,7 @@ Timeout.prototype.close = function() {
     this._handle[kOnTimeout] = null;
     this._handle.close();
   } else {
-    exports.unenroll(this);
+    unenroll(this);
   }
 };
 

--- a/test/parallel/test-timers-api-refs.js
+++ b/test/parallel/test-timers-api-refs.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+// don't verify the globals for this test
+common.globalCheck = false;
+
+// try overriding global APIs to make sure
+// they're not relied on by the timers
+global.clearTimeout = assert.fail;
+
+// run timeouts/intervals through the paces
+const intv = setInterval(function() {}, 1);
+
+setTimeout(function() {
+  clearInterval(intv);
+}, 100);
+
+setTimeout(function() {}, 2);
+


### PR DESCRIPTION
Added safe internal references for 'clearTimeout(..)', 'active(..)', and
'unenroll(..)'. Changed various API refs from 'export.*' to use these
safe internal references.

Now, overwriting the global API identifiers does not create potential
breakage and/or race conditions. See Issue #2493.