### PR TITLE
build: update android-configure to required platform

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -6,7 +6,7 @@ $1/build/tools/make-standalone-toolchain.sh \
     --toolchain=arm-linux-androideabi-4.9 \
     --arch=arm \
     --install-dir=$TOOLCHAIN \
-    --platform=android-9
+    --platform=android-21
 export PATH=$TOOLCHAIN/bin:$PATH
 export AR=$TOOLCHAIN/bin/arm-linux-androideabi-ar
 export CC=$TOOLCHAIN/bin/arm-linux-androideabi-gcc


### PR DESCRIPTION
The introduction of libuv 1.6.0 broke the android-configure script by
not specifying the correct platform. uv_os_homedir uses getpwuid_r
which was not made public until API level 21 on android.

The regression was introduced in a804026...b5cd2f0

R= @nodejs/build 