### PR TITLE
added CSI (\x9b) as additionally allowable escape

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -973,8 +973,9 @@ exports.emitKeypressEvents = emitKeypressEvents;
 */
 
 // Regexes used for ansi escape code splitting
-const metaKeyCodeReAnywhere = /(?:\x1b)([a-zA-Z0-9])/;
-const functionKeyCodeReAnywhere = new RegExp('(?:\x1b+)(O|N|\\[|\\[\\[)(?:' + [
+const metaKeyCodeReAnywhere = /(?:(?:\x1b|\x9b))([a-zA-Z0-9])/;
+const functionKeyCodeReAnywhere = new RegExp('(?:(?:\x1b|\x9b)+)' +
+    '(O|N|\\[|\\[\\[)(?:' + [
   '(\\d+)(?:;(\\d+))?([~^$])',
   '(?:M([@ #!a`])(.)(.))', // mouse
   '(?:1;)?(\\d+)?([a-zA-Z])'
@@ -994,11 +995,11 @@ function* emitKeys(stream) {
       shift: false
     };
 
-    if (ch === '\x1b') {
+    if (ch === '\x1b' || ch === '\x9b') {
       escaped = true;
       s += (ch = yield);
 
-      if (ch === '\x1b') {
+      if (ch === '\x1b' || ch === '\x9b') {
         s += (ch = yield);
       }
     }
@@ -1219,7 +1220,7 @@ function* emitKeys(stream) {
       key.name = 'backspace';
       key.meta = escaped;
 
-    } else if (ch === '\x1b') {
+    } else if (ch === '\x1b' || ch === '\x9b') {
       // escape key
       key.name = 'escape';
       key.meta = escaped;


### PR DESCRIPTION
Added `\x9b` as an additionally allowable ANSI escape code. It's pretty phased out, but can still be used.

The difference between the two is that `\x1b` requires a following `[`. Together, both of those characters combined form the CSI. There is the single character alternative, `\x9b`, that doesn't require the `[`. It is less common, I speculate, because faulty ANSI implementations will output `[37;1m` which is more distinct than just `37;1m` - don't quote me on that though. All I know is that it has to do with [C0 and C1 control codes](https://en.wikipedia.org/wiki/C0_and_C1_control_codes) and a bunch of unicode voodoo.

I doubt many terminal emulators even support it nowadays but it _is_ something you should probably be checking for and should be innocuous to those not using it.

Brought to my attention from chalk/ansi-regex#5 cc @sindresorhus
