### PR TITLE
tty: Remove deprecated setRawMode wrapper

### DIFF
--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -22,11 +22,6 @@ Returns `true` or `false` depending on if the `fd` is associated with a
 terminal.
 
 
-## tty.setRawMode(mode)
-
-    Stability: 0 - Deprecated: Use [tty.ReadStream#setRawMode][] (i.e. process.stdin.setRawMode) instead.
-
-
 ## Class: ReadStream
 
 A `net.Socket` subclass that represents the readable portion of a tty. In normal

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -14,16 +14,6 @@ exports.isatty = function(fd) {
 };
 
 
-// backwards-compat
-exports.setRawMode = internalUtil.deprecate(function(flag) {
-  if (!process.stdin.isTTY) {
-    throw new Error('can\'t set raw mode on non-tty');
-  }
-  process.stdin.setRawMode(flag);
-}, 'tty.setRawMode is deprecated. ' +
-   'Use process.stdin.setRawMode instead.');
-
-
 function ReadStream(fd, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(fd, options);


### PR DESCRIPTION
This function should be removed, it was deprecated many years ago.  The documentation says its deprecated (https://nodejs.org/api/tty.html) as well as the code https://github.com/joyent/node/blob/v0.10.40-release/lib/tty.js#L35-L40

https://github.com/joyent/node/blob/v0.8.19-release/lib/tty.js#L34-L40