### PR TITLE
util: Remove p, has been deprecated for years

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -753,13 +753,6 @@ function hasOwnProperty(obj, prop) {
 
 // Deprecated old stuff.
 
-exports.p = internalUtil.deprecate(function() {
-  for (var i = 0, len = arguments.length; i < len; ++i) {
-    console.error(exports.inspect(arguments[i]));
-  }
-}, 'util.p is deprecated. Use console.error instead.');
-
-
 exports.exec = internalUtil.deprecate(function() {
   return require('child_process').exec.apply(this, arguments);
 }, 'util.exec is deprecated. Use child_process.exec instead.');


### PR DESCRIPTION
This function has been deprecated for years... it's not documented either, so should fall under the implicit API deprecation policy:

https://github.com/joyent/node/blob/v0.8.28-release/lib/util.js#L450-L454 