### PR TITLE
util: Remove exec, has been deprecated for years

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -760,11 +760,6 @@ exports.p = internalUtil.deprecate(function() {
 }, 'util.p is deprecated. Use console.error instead.');
 
 
-exports.exec = internalUtil.deprecate(function() {
-  return require('child_process').exec.apply(this, arguments);
-}, 'util.exec is deprecated. Use child_process.exec instead.');
-
-
 exports.print = internalUtil.deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(String(arguments[i]));


### PR DESCRIPTION
This has been deprecated for years: https://github.com/joyent/node/blob/v0.8.28-release/lib/util.js#L480-L482