### PR TITLE
util: Remove pump

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -260,7 +260,7 @@ Returns `true` if the given "object" is a `Boolean`. `false` otherwise.
       // false
     util.isBoolean(false)
       // true
-      
+
 ## util.isBuffer(object)
 
     Stability: 0 - Deprecated
@@ -492,12 +492,6 @@ Output with timestamp on `stdout`.
     Stability: 0 - Deprecated: Use `console.log` instead.
 
 Deprecated predecessor of `console.log`.
-
-## util.pump(readableStream, writableStream[, callback])
-
-    Stability: 0 - Deprecated: Use readableStream.pipe(writableStream)
-
-Deprecated predecessor of `stream.pipe()`.
 
 ## util.puts([...])
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -611,7 +611,7 @@ function filteredOwnPropertyNames(obj) {
 //
 // Example:
 //  complete('var foo = util.')
-//    -> [['util.print', 'util.debug', 'util.log', 'util.inspect', 'util.pump'],
+//    -> [['util.print', 'util.debug', 'util.log', 'util.inspect'],
 //        'util.' ]
 //
 // Warning: This eval's code like "foo.bar.baz", so it will run property

--- a/lib/util.js
+++ b/lib/util.js
@@ -864,44 +864,6 @@ exports.error = internalUtil.deprecate(function(x) {
 }, 'util.error is deprecated. Use console.error instead.');
 
 
-exports.pump = internalUtil.deprecate(function(readStream, writeStream, cb) {
-  var callbackCalled = false;
-
-  function call(a, b, c) {
-    if (cb && !callbackCalled) {
-      cb(a, b, c);
-      callbackCalled = true;
-    }
-  }
-
-  readStream.addListener('data', function(chunk) {
-    if (writeStream.write(chunk) === false) readStream.pause();
-  });
-
-  writeStream.addListener('drain', function() {
-    readStream.resume();
-  });
-
-  readStream.addListener('end', function() {
-    writeStream.end();
-  });
-
-  readStream.addListener('close', function() {
-    call();
-  });
-
-  readStream.addListener('error', function(err) {
-    writeStream.end();
-    call(err);
-  });
-
-  writeStream.addListener('error', function(err) {
-    readStream.destroy();
-    call(err);
-  });
-}, 'util.pump is deprecated. Use readableStream.pipe instead.');
-
-
 exports._errnoException = function(err, syscall, original) {
   var errname = uv.errname(err);
   var message = syscall + ' ' + errname;


### PR DESCRIPTION
This has been deprecated since v0.10, it was also documented as being deprecated. https://github.com/joyent/node/blob/v0.10.40-release/lib/util.js#L537-L538