### PR TITLE
build: only define NODE_V8_OPTIONS if not empty

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -179,7 +179,6 @@
       'defines': [
         'NODE_ARCH="<(target_arch)"',
         'NODE_PLATFORM="<(OS)"',
-        'NODE_V8_OPTIONS="<(node_v8_options)"',
         'NODE_WANT_INTERNALS=1',
       ],
 
@@ -187,6 +186,9 @@
       'conditions': [
         [ 'node_tag!=""', {
           'defines': [ 'NODE_TAG="<(node_tag)"' ],
+        }],
+        [ 'node_v8_options!=""', {
+          'defines': [ 'NODE_V8_OPTIONS="<(node_v8_options)"'],
         }],
         # No node_main.cc for anything except executable
         [ 'node_target_type!="executable"', {


### PR DESCRIPTION
Previously, `V8::SetFlagsFromString` was called on every launch even if
`NODE_V8_OPTIONS` was an empty string. This patch only defines
`NODE_V8_OPTIONS` if node_v8_options is not an empty string.

The speedup provided is not very noticeable on my machine (~0.5%) but could help on slower hardware like the Raspberry Pis.