### PR TITLE
test: make spawnSync() test robust

### DIFF
--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -7,12 +7,8 @@ var spawnSync = require('child_process').spawnSync;
 var TIMER = 100;
 var SLEEP = 1000;
 
-var timeout = 0;
-
 setTimeout(function() {
-  timeout = process.hrtime(start);
   assert.ok(stop, 'timer should not fire before process exits');
-  assert.strictEqual(timeout[0], 1, 'timer should take as long as sleep');
 }, TIMER);
 
 console.log('sleep started');


### PR DESCRIPTION
The test had checked that a timer fired within a period after
spawnSync() returns. The result was a test that sometimes was
flaky.

Because there's no guarantee of how long a timer will take
before running, remove the check. There is a check that the
timer runs after spawnSync() so that is sufficient.

Fixes: https://github.com/nodejs/node/issues/2470