### PR TITLE
added before-flushing-head event to _http_server.ServerResponse.writeHead

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -640,6 +640,14 @@ passed as the second parameter to the `'request'` event.
 The response implements the [Writable Stream][] interface. This is an
 [`EventEmitter`][] with the following events:
 
+### Event: 'before-flushing-head'
+
+`function () {}`
+
+Indicates that the server is about to flush the HTTP headers to the underlying 
+socket. This event can be used for measuring time to first byte or customizing 
+the response headers.
+
 ### Event: 'close'
 
 `function () { }`

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -642,11 +642,18 @@ The response implements the [Writable Stream][] interface. This is an
 
 ### Event: 'before-flushing-head'
 
-`function () {}`
+`function (messageHead) {}`
 
 Indicates that the server is about to flush the HTTP headers to the underlying 
 socket. This event can be used for measuring time to first byte or customizing 
-the response headers.
+the response headers and status code.
+
+The `messageHead` parameter allows overriding the http response code, message and headers. 
+It includes
+
+* `responseCode` {Number}
+* `responseMessage` {String}
+* `headers` {Object}
 
 ### Event: 'close'
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -653,7 +653,12 @@ It includes
 
 * `responseCode` {Number}
 * `responseMessage` {String}
-* `headers` {Object}
+* `headers` {Object|Array}
+
+The headers member will be either an object of the form
+`{header-names: header value}`
+or an array of the form
+`[['header-name', 'header-value'] ...]`
 
 ### Event: 'close'
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -640,7 +640,7 @@ passed as the second parameter to the `'request'` event.
 The response implements the [Writable Stream][] interface. This is an
 [`EventEmitter`][] with the following events:
 
-### Event: 'before-flushing-head'
+### Event: 'beforeFlushingHead'
 
 `function (messageHead) {}`
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -185,7 +185,7 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
     args.headers = this._renderHeaders();
   } else {
     // only writeHead() called
-    args.headers = obj || {};
+
   }
 
   this.emit("beforeFlushingHead", args);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -183,12 +183,9 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
     }
     // only progressive api is used
     args.headers = this._renderHeaders();
-  } else {
-    // only writeHead() called
-
   }
 
-  this.emit("beforeFlushingHead", args);
+  this.emit('beforeFlushingHead', args);
 
   this.statusMessage = args.statusMessage;
   this.statusCode = args.statusCode;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -163,20 +163,22 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
   // writeHead(statusCode, reasonPhrase[, headers])
   var args = {statusCode: statusCode, statusMessage: reason, headers: obj};
 
-  if (!(typeof args.statusMessage === 'string')) {
+  if (typeof args.statusMessage !== 'string') {
     // writeHead(statusCode[, headers])
     args.statusMessage =
         this.statusMessage || STATUS_CODES[statusCode] || 'unknown';
     args.headers = reason;
   }
 
+  args.headers = args.headers || {};
+
   if (this._headers) {
     // Slow-case: when progressive API and header fields are passed.
-    if (obj) {
-      var keys = Object.keys(obj);
+    if (args.headers) {
+      var keys = Object.keys(args.headers);
       for (var i = 0; i < keys.length; i++) {
         var k = keys[i];
-        if (k) this.setHeader(k, obj[k]);
+        if (k) this.setHeader(k, args.headers[k]);
       }
     }
     // only progressive api is used

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -160,6 +160,8 @@ ServerResponse.prototype._implicitHeader = function() {
 ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
   var headers;
 
+  this.emit("before-flushing-head");
+
   if (typeof reason === 'string') {
     // writeHead(statusCode, reasonPhrase[, headers])
     this.statusMessage = reason;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -186,7 +186,7 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
     args.headers = obj || {};
   }
 
-  this.emit("before-flushing-head", args);
+  this.emit("beforeFlushingHead", args);
 
   this.statusMessage = args.statusMessage;
   this.statusCode = args.statusCode;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -160,18 +160,15 @@ ServerResponse.prototype._implicitHeader = function() {
 ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
   var headers;
 
-  this.emit("before-flushing-head");
+  // writeHead(statusCode, reasonPhrase[, headers])
+  var args = {statusCode: statusCode, statusMessage: reason, headers: obj};
 
-  if (typeof reason === 'string') {
-    // writeHead(statusCode, reasonPhrase[, headers])
-    this.statusMessage = reason;
-  } else {
+  if (!(typeof args.statusMessage === 'string')) {
     // writeHead(statusCode[, headers])
-    this.statusMessage =
+    args.statusMessage =
         this.statusMessage || STATUS_CODES[statusCode] || 'unknown';
-    obj = reason;
+    args.headers = reason;
   }
-  this.statusCode = statusCode;
 
   if (this._headers) {
     // Slow-case: when progressive API and header fields are passed.
@@ -183,13 +180,19 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
       }
     }
     // only progressive api is used
-    headers = this._renderHeaders();
+    args.headers = this._renderHeaders();
   } else {
     // only writeHead() called
-    headers = obj;
+    args.headers = obj || {};
   }
 
-  var statusLine = 'HTTP/1.1 ' + statusCode.toString() + ' ' +
+  this.emit("before-flushing-head", args);
+
+  this.statusMessage = args.statusMessage;
+  this.statusCode = args.statusCode;
+  headers = args.headers;
+
+  var statusLine = 'HTTP/1.1 ' + this.statusCode.toString() + ' ' +
                    this.statusMessage + CRLF;
 
   if (statusCode === 204 || statusCode === 304 ||

--- a/test/parallel/test-http-before-flush-head-event.js
+++ b/test/parallel/test-http-before-flush-head-event.js
@@ -6,7 +6,7 @@ var http = require('http');
 var testResBody = 'other stuff!\n';
 
 var server = http.createServer(function(req, res) {
-  res.on('before-flushing-head', function(args) {
+  res.on('beforeFlushingHead', function(args) {
     args.statusCode = 201;
     args.statusMessage = "changed to show we can";
     args.headers["Flush-Head"] = 'event-was-called'; 
@@ -31,9 +31,9 @@ server.addListener('listening', function() {
     assert.ok(res.statusMessage === 'changed to show we can', 
               'Response status message was not overridden.');
     assert.ok('flush-head' in res.headers,
-              'Response headers didn\'t contain the flush-head header, indicating the before-flush-head event was not called or did not allow adding headers.');
+              'Response headers didn\'t contain the flush-head header, indicating the beforeFlushingHead event was not called or did not allow adding headers.');
     assert.ok(res.headers['flush-head'] === 'event-was-called',
-              'Response headers didn\'t contain the flush-head header with value event-was-called, indicating the before-flush-head event was not called or did not allow adding headers.');
+              'Response headers didn\'t contain the flush-head header with value event-was-called, indicating the beforeFlushingHead event was not called or did not allow adding headers.');
     res.addListener('end', function() {
       server.close();
       process.exit();

--- a/test/parallel/test-http-before-flush-head-event.js
+++ b/test/parallel/test-http-before-flush-head-event.js
@@ -1,0 +1,40 @@
+'use strict';
+//var common = require('../common');
+var common = {};
+common.PORT = 1234;
+var assert = require('assert');
+var http = require('http');
+
+var testResBody = 'other stuff!\n';
+
+var server = http.createServer(function(req, res) {
+  res.on('before-flush-head', function() {
+    res.setHeader('Flush-Head', 'event-was-called');
+  })
+  res.writeHead(200, {
+    'Content-Type': 'text/plain'
+  });
+  res.end(testResBody);
+});
+server.listen(common.PORT);
+
+
+server.addListener('listening', function() {
+  var options = {
+    port: common.PORT,
+    path: '/',
+    method: 'GET'
+  };
+  var req = http.request(options, function(res) {
+    assert.ok('flush-head' in res.headers,
+              'Response headers didn\'t contain the flush-head header, indicating the before-flush-head event was not called or did not allow adding headers.');
+    assert.ok(res.headers['flush-head'] === 'event-was-called',
+              'Response headers didn\'t contain the flush-head header with value event-was-called, indicating the before-flush-head event was not called or did not allow adding headers.');
+    res.addListener('end', function() {
+      server.close();
+      process.exit();
+    });
+    res.resume();
+  });
+  req.end();
+});

--- a/test/parallel/test-http-before-flush-head-event.js
+++ b/test/parallel/test-http-before-flush-head-event.js
@@ -10,7 +10,7 @@ var server = http.createServer(function(req, res) {
     args.statusCode = 201;
     args.statusMessage = 'changed to show we can';
     args.headers['Flush-Head'] = 'event-was-called';
-  })
+  });
   res.writeHead(200, {
     'Content-Type': 'text/plain'
   });
@@ -28,7 +28,7 @@ server.addListener('listening', function() {
   var req = http.request(options, function(res) {
     assert.ok(res.statusCode === 201,
               'Response status code was not overridden from 200 to 201.');
-    assert.ok(res.statusMessage === 'changed to show we can', 
+    assert.ok(res.statusMessage === 'changed to show we can',
               'Response status message was not overridden.');
     assert.ok('flush-head' in res.headers,
               'Response headers didn\'t contain the flush-head header, ' +

--- a/test/parallel/test-http-before-flush-head-event.js
+++ b/test/parallel/test-http-before-flush-head-event.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
+const common = require('../common'),
+  assert = require('assert'),
+  http = require('http');
 
 var testResBody = 'other stuff!\n';
 
 var server = http.createServer(function(req, res) {
   res.on('beforeFlushingHead', function(args) {
     args.statusCode = 201;
-    args.statusMessage = "changed to show we can";
-    args.headers["Flush-Head"] = 'event-was-called'; 
+    args.statusMessage = 'changed to show we can';
+    args.headers['Flush-Head'] = 'event-was-called';
   })
   res.writeHead(200, {
     'Content-Type': 'text/plain'
@@ -31,9 +31,14 @@ server.addListener('listening', function() {
     assert.ok(res.statusMessage === 'changed to show we can', 
               'Response status message was not overridden.');
     assert.ok('flush-head' in res.headers,
-              'Response headers didn\'t contain the flush-head header, indicating the beforeFlushingHead event was not called or did not allow adding headers.');
+              'Response headers didn\'t contain the flush-head header, ' +
+                'indicating the beforeFlushingHead event was not called or ' +
+                'did not allow adding headers.');
     assert.ok(res.headers['flush-head'] === 'event-was-called',
-              'Response headers didn\'t contain the flush-head header with value event-was-called, indicating the beforeFlushingHead event was not called or did not allow adding headers.');
+              'Response headers didn\'t contain the flush-head header ' +
+                'with value event-was-called, indicating the ' +
+                'beforeFlushingHead event was not called or did not allow ' +
+                'adding headers.');
     res.addListener('end', function() {
       server.close();
       process.exit();


### PR DESCRIPTION
The before-flushing-head event is needed for monitoring of HTTP requests and capturing the time to first byte as well as for enabling middleware to write headers to responses. TTFB (time to first byte) is important measurement as it measures the server performance regardless of sending data down the stream and it actually what most monitoring tools measure on the client side, including google with their page speed and SEO engines.

Today we have to resort to using a wrapper for this method, but I think it is a great functionality to have in node.js
