### PR TITLE
test: make test-process-argv-0 robust

### DIFF
--- a/test/parallel/test-process-argv-0.js
+++ b/test/parallel/test-process-argv-0.js
@@ -12,7 +12,7 @@ if (process.argv[2] !== 'child') {
   child.stdout.on('data', function(chunk) {
     childArgv0 += chunk;
   });
-  child.on('exit', function() {
+  process.on('exit', function() {
     assert.equal(childArgv0, process.execPath);
   });
 }

--- a/test/parallel/test-process-argv-0.js
+++ b/test/parallel/test-process-argv-0.js
@@ -1,12 +1,7 @@
 'use strict';
-var util = require('util');
 var path = require('path');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
-var common = require('../common');
-
-console.error('argv=%j', process.argv);
-console.error('exec=%j', process.execPath);
 
 if (process.argv[2] !== 'child') {
   var child = spawn(process.execPath, [__filename, 'child'], {
@@ -14,15 +9,10 @@ if (process.argv[2] !== 'child') {
   });
 
   var childArgv0 = '';
-  var childErr = '';
   child.stdout.on('data', function(chunk) {
     childArgv0 += chunk;
   });
-  child.stderr.on('data', function(chunk) {
-    childErr += chunk;
-  });
   child.on('exit', function() {
-    console.error('CHILD: %s', childErr.trim().split('\n').join('\nCHILD: '));
     assert.equal(childArgv0, process.execPath);
   });
 }


### PR DESCRIPTION
Remove use of STDERR to avoid test flakiness on CentOS.

Fixes: https://github.com/nodejs/node/issues/2477

Additional benefit: This makes the test a fair bit faster.

Before:

real	0m0.909s
user	0m0.216s
sys	0m0.083s

After:

real	0m0.223s
user	0m0.193s
sys	0m0.035s