### PR TITLE
test: speed up test-child-process-spawnsync.js

### DIFF
--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -6,7 +6,7 @@ var spawnSync = require('child_process').spawnSync;
 
 // Echo does different things on Windows and Unix, but in both cases, it does
 // more-or-less nothing if there are no parameters
-var ret = spawnSync('echo');
+var ret = spawnSync('echo', ['test_message']);
 assert.strictEqual(ret.status, 0, 'exit status should be zero');
 
 // Error test when command does not exist

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -6,7 +6,7 @@ var spawnSync = require('child_process').spawnSync;
 
 // Echo does different things on Windows and Unix, but in both cases, it does
 // more-or-less nothing if there are no parameters
-var ret = spawnSync('echo', ['test_message']);
+var ret = spawnSync('sleep', ['0']);
 assert.strictEqual(ret.status, 0, 'exit status should be zero');
 
 // Error test when command does not exist

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -4,21 +4,10 @@ var assert = require('assert');
 
 var spawnSync = require('child_process').spawnSync;
 
-var TIMER = 100;
-var SLEEP = 1000;
-
-setTimeout(function() {
-  assert.ok(stop, 'timer should not fire before process exits');
-}, TIMER);
-
-console.log('sleep started');
-var start = process.hrtime();
-var ret = spawnSync('sleep', ['1']);
-var stop = process.hrtime(start);
+// Echo does different things on Windows and Unix, but in both cases, it does
+// more-or-less nothing if there are no parameters
+var ret = spawnSync('echo');
 assert.strictEqual(ret.status, 0, 'exit status should be zero');
-console.log('sleep exited', stop);
-assert.strictEqual(stop[0], 1,
-                   'sleep should not take longer or less than 1 second');
 
 // Error test when command does not exist
 var ret_err = spawnSync('command_does_not_exist', ['bar']).error;


### PR DESCRIPTION
There's a bunch of stuff in `test-child-process-spawnsync.js` that seems designed to test that it is in fact blocking/synchronous. However, that code really just tests the OS `sleep` command. This change shaves about a second off the test run time by replacing the `sleep` with `echo`. We check the return status to confirm the command is successful. The tests in this file in general would not work if `spawnSync()` were asynchronous. That includes this one, as a return status would not be available if the command where asynchronous.