### PR TITLE
src: only memcmp if length > 0 in Buffer::Compare

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -835,7 +835,8 @@ void Compare(const FunctionCallbackInfo<Value> &args) {
 
   size_t cmp_length = MIN(obj_a_length, obj_b_length);
 
-  int32_t val = memcmp(obj_a_data, obj_b_data, cmp_length);
+  int val = cmp_length > 0 ? memcmp(obj_a_data, obj_b_data, cmp_length)
+                           : 0;
 
   // Normalize val to be an integer in the range of [1, -1] since
   // implementations of memcmp() can vary by platform.

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1137,6 +1137,9 @@ assert.equal(Buffer.compare(d, b), 1);
 assert.equal(Buffer.compare(b, d), -1);
 assert.equal(Buffer.compare(c, c), 0);
 
+assert.equal(Buffer.compare(Buffer(0), Buffer(0)), 0);
+assert.equal(Buffer.compare(Buffer(0), Buffer(1)), -1);
+assert.equal(Buffer.compare(Buffer(1), Buffer(0)), 1);
 
 assert.throws(function() {
   var b = new Buffer(1);


### PR DESCRIPTION
UBsan was complaining about passing `nullptr` to memcmp