### PR TITLE
src: throw when uv returns an error

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -166,10 +166,13 @@ static void GetTotalMemory(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetUptime(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   double uptime;
   int err = uv_uptime(&uptime);
   if (err == 0)
     args.GetReturnValue().Set(uptime);
+  else
+    return env->ThrowUVException(err, "uv_uptime");
 }
 
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -116,7 +116,7 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
 
   int err = uv_cpu_info(&cpu_infos, &count);
   if (err)
-    return;
+    return env->ThrowUVException(err, "uv_cpu_info");
 
   Local<Array> cpus = Array::New(env->isolate());
   for (i = 0; i < count; i++) {


### PR DESCRIPTION
When uv returns an error, throw that instead of ignoring it.