### PR TITLE
src: use ZCtxt as a source for v8::Isolates

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -142,6 +142,7 @@ class ZCtx : public AsyncWrap {
     Bytef *in;
     Bytef *out;
     size_t in_off, in_len, out_off, out_len;
+    Environment* env = ctx->env();
 
     if (args[1]->IsNull()) {
       // just a flush
@@ -152,7 +153,7 @@ class ZCtx : public AsyncWrap {
     } else {
       CHECK(Buffer::HasInstance(args[1]));
       Local<Object> in_buf;
-      in_buf = args[1]->ToObject(args.GetIsolate());
+      in_buf = args[1]->ToObject(env->isolate());
       in_off = args[2]->Uint32Value();
       in_len = args[3]->Uint32Value();
 
@@ -161,7 +162,7 @@ class ZCtx : public AsyncWrap {
     }
 
     CHECK(Buffer::HasInstance(args[4]));
-    Local<Object> out_buf = args[4]->ToObject(args.GetIsolate());
+    Local<Object> out_buf = args[4]->ToObject(env->isolate());
     out_off = args[5]->Uint32Value();
     out_len = args[6]->Uint32Value();
     CHECK(Buffer::IsWithinBounds(out_off, out_len, Buffer::Length(out_buf)));
@@ -199,7 +200,7 @@ class ZCtx : public AsyncWrap {
 
 
   static void AfterSync(ZCtx* ctx, const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
+    Environment* env = ctx->env();
     Local<Integer> avail_out = Integer::New(env->isolate(),
                                             ctx->strm_.avail_out);
     Local<Integer> avail_in = Integer::New(env->isolate(),


### PR DESCRIPTION
Other methods like `After` already use ZCtxt as the source for Environment/ v8::Isolate objects, this commit applies the same style to the other missing methods (`After sync` and `Write`)