### PR TITLE
doc: fix two doc errors

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -256,13 +256,7 @@ For example, a `console.log` equivalent could look like this:
 
 `process.stderr` and `process.stdout` are unlike other streams in Node.js in
 that they cannot be closed (`end()` will throw), they never emit the `finish`
-event and that writes are usually blocking.
-
-- They are blocking in the case that they refer to regular files or TTY file
-  descriptors.
-- In the case they refer to pipes:
-  - They are blocking in Linux/Unix.
-  - They are non-blocking like other streams in Windows.
+event and that writes are always blocking.
 
 To check if Node.js is being run in a TTY context, read the `isTTY` property
 on `process.stderr`, `process.stdout`, or `process.stdin`:

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1440,8 +1440,8 @@ var transform = new stream.Transform({
 <!--type=misc-->
 
 Both Writable and Readable streams will buffer data on an internal
-object called `_writableState.buffer` or `_readableState.buffer`,
-respectively.
+object which can be retrieved from `_writableState.getBuffer()` or 
+`_readableState.buffer`, respectively.
 
 The amount of data that will potentially be buffered depends on the
 `highWaterMark` option which is passed into the constructor.


### PR DESCRIPTION
Found these while digging around.

`process.stdout` always blocks as of
20176a98416353d4596900793f739d5ebf4f0ee1

`WritableState.buffer` is `getBuffer()` as of
91586661c983f45d650644451df73c8649a8d459

cc @orangemocha for the first one. I'm unaware of a case where it wouldn't block now.