### PR TITLE
src: add missing Exception::Error in node_http_parser

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -443,7 +443,7 @@ class Parser : public BaseObject {
     if (rv != 0) {
       enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
 
-      Local<Value> e = env->parse_error_string();
+      Local<Value> e = Exception::Error(env->parse_error_string());
       Local<Object> obj = e->ToObject(env->isolate());
       obj->Set(env->bytes_parsed_string(), Integer::New(env->isolate(), 0));
       obj->Set(env->code_string(),


### PR DESCRIPTION
Origin commit line: https://github.com/nodejs/node/commit/75adde07f9a2de7f38a67bec72bd377d450bdb52#diff-1334479bba4bea496229d9e955ed2c58L445

Dug up from the hapi smoke tests at https://jenkins-iojs.nodesource.com/job/smoker/8/nodes=debian8-64/console

CI: https://jenkins-iojs.nodesource.com/job/node-test-pull-request/166/

R=@indutny?