### PR TITLE
Adding an extra check for cert.subject before assuming it is there.

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -177,10 +177,12 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
         reason = util.format('Host: %s is not in the cert\'s altnames: %s',
                              host,
                              cert.subjectaltname);
-      } else {
+      } else if (cert.subject) {
         reason = util.format('Host: %s is not cert\'s CN: %s',
                              host,
                              cert.subject.CN);
+      } else {
+        reason = util.format('Host: %s cert\'s subject is missing', host);
       }
     }
   } else {


### PR DESCRIPTION
One of my long running node services started giving out a TLS error without very much detail overnight: 
```
 TypeError: Cannot read property 'CN' of undefined
     at Object.checkServerIdentity (tls.js:182:37)
     at TLSSocket.<anonymous> (_tls_wrap.js:1016:29)
     at emitNone (events.js:67:13)
     at TLSSocket.emit (events.js:166:7)
     at TLSSocket._finishInit (_tls_wrap.js:566:8)
```
I tracked it down to the line: 
```
        reason = util.format('Host: %s is not cert\'s CN: %s',
                             host,
                             cert.subject.CN);
``` 
which assumes cert.subject is available. 

I don't really know what is causing this and I can't tell which domain is causing this so I probably won't be able to recreate this locally to verify it's still working but I think it is at least sensible to use defensive programming in this instance. 

I would ideally like to back port this to the 2.5.x branch but I couldn't find the head of that branch, can someone tell me which branch is currently the 2.5.x head? 