### PR TITLE
debugger: use strict equality comparison

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -173,7 +173,7 @@ Client.prototype._addHandle = function(desc) {
 
   this.handles[desc.handle] = desc;
 
-  if (desc.type == 'script') {
+  if (desc.type === 'script') {
     this._addScript(desc);
   }
 };


### PR DESCRIPTION
There is no type-conversion to be done because both parameters are already the same type. 
Therefore, the === operator should be used for better performance.