### PR TITLE
doc: Infinity for emitter.setMaxListeners

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -92,7 +92,7 @@ Returns emitter, so calls can be chained.
 By default EventEmitters will print a warning if more than 10 listeners are
 added for a particular event. This is a useful default which helps finding
 memory leaks. Obviously not all Emitters should be limited to 10. This function
-allows that to be increased. Set to `Infinity` for unlimited.
+allows that to be increased. Set to `Infinity` (or `0`) for unlimited.
 
 Returns emitter, so calls can be chained.
 

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -92,7 +92,7 @@ Returns emitter, so calls can be chained.
 By default EventEmitters will print a warning if more than 10 listeners are
 added for a particular event. This is a useful default which helps finding
 memory leaks. Obviously not all Emitters should be limited to 10. This function
-allows that to be increased. Set to zero for unlimited.
+allows that to be increased. Set to `Infinity` for unlimited.
 
 Returns emitter, so calls can be chained.
 


### PR DESCRIPTION
Instead of recommending `0` as the magic value to set max listeners to unlimited, recommend `Infinity`.

This paves the way for `0` as a magic value eventually being deprecated and finally removed

original discussion: https://github.com/joyent/node/issues/22987
original PR: https://github.com/joyent/node/pull/25269