### PR TITLE
tls, crypto: add ALPN Support

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -177,7 +177,7 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
     if (this.pair.encrypted._internallyPendingBytes())
       this.pair.encrypted.read(0);
 
-    // Get NPN and Server name when ready
+    // Get ALPN, NPN and Server name when ready
     this.pair.maybeInitFinished();
 
     // Whole buffer was written
@@ -273,7 +273,7 @@ CryptoStream.prototype._read = function read(size) {
            bytesRead < size &&
            this.pair.ssl !== null);
 
-  // Get NPN and Server name when ready
+  // Get ALPN, NPN and Server name when ready
   this.pair.maybeInitFinished();
 
   // Create new buffer if previous was filled up
@@ -726,6 +726,13 @@ function SecurePair(context, isServer, requestCert, rejectUnauthorized,
     this.npnProtocol = null;
   }
 
+  if (process.features.tls_alpn && options.ALPNProtocols) {
+    // keep reference in secureContext not to be GC-ed
+    this.ssl._secureContext.alpnBuffer = options.ALPNProtocols;
+    this.ssl.setALPNrotocols(this.ssl._secureContext.alpnBuffer);
+    this.alpnProtocol = null;
+  }
+
   /* Acts as a r/w stream to the cleartext side of the stream. */
   this.cleartext = new CleartextStream(this, options.cleartext);
 
@@ -776,6 +783,10 @@ SecurePair.prototype.maybeInitFinished = function() {
   if (this.ssl && !this._secureEstablished && this.ssl.isInitFinished()) {
     if (process.features.tls_npn) {
       this.npnProtocol = this.ssl.getNegotiatedProtocol();
+    }
+
+    if (process.features.tls_alpn) {
+      this.alpnProtocol = this.ssl.getALPNNegotiatedProtocol();
     }
 
     if (process.features.tls_sni) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -239,6 +239,7 @@ function TLSSocket(socket, options) {
   this._SNICallback = null;
   this.servername = null;
   this.npnProtocol = null;
+  this.alpnProtocol = null;
   this.authorized = false;
   this.authorizationError = null;
 
@@ -453,6 +454,12 @@ TLSSocket.prototype._init = function(socket, wrap) {
   if (process.features.tls_npn && options.NPNProtocols)
     ssl.setNPNProtocols(options.NPNProtocols);
 
+  if (process.features.tls_alpn && options.ALPNProtocols) {
+    // keep reference in secureContext not to be GC-ed
+    ssl._secureContext.alpnBuffer = options.ALPNProtocols;
+    ssl.setALPNProtocols(ssl._secureContext.alpnBuffer);
+  }
+
   if (options.handshakeTimeout > 0)
     this.setTimeout(options.handshakeTimeout, this._handleTimeout);
 
@@ -557,6 +564,10 @@ TLSSocket.prototype._finishInit = function() {
 
   if (process.features.tls_npn) {
     this.npnProtocol = this._handle.getNegotiatedProtocol();
+  }
+
+  if (process.features.tls_alpn) {
+    this.alpnProtocol = this.ssl.getALPNNegotiatedProtocol();
   }
 
   if (process.features.tls_sni && this._tlsOptions.isServer) {
@@ -766,6 +777,7 @@ function Server(/* [options], listener */) {
       rejectUnauthorized: self.rejectUnauthorized,
       handshakeTimeout: timeout,
       NPNProtocols: self.NPNProtocols,
+      ALPNProtocols: self.ALPNProtocols,
       SNICallback: options.SNICallback || SNICallback
     });
 
@@ -876,6 +888,8 @@ Server.prototype.setOptions = function(options) {
     this.honorCipherOrder = true;
   if (secureOptions) this.secureOptions = secureOptions;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
+  if (options.ALPNProtocols)
+    tls.convertALPNProtocols(options.ALPNProtocols, this);
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
@@ -968,8 +982,10 @@ exports.connect = function(/* [port, host], options, cb */) {
                  (options.socket && options.socket._host) ||
                  'localhost',
       NPN = {},
+      ALPN = {},
       context = tls.createSecureContext(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);
+  tls.convertALPNProtocols(options.ALPNProtocols, ALPN);
 
   var socket = new TLSSocket(options.socket, {
     pipe: options.path && !options.port,
@@ -979,6 +995,7 @@ exports.connect = function(/* [port, host], options, cb */) {
     rejectUnauthorized: options.rejectUnauthorized,
     session: options.session,
     NPNProtocols: NPN.NPNProtocols,
+    ALPNProtocols: ALPN.ALPNProtocols,
     requestOCSP: options.requestOCSP
   });
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -14,6 +14,13 @@ function Server(opts, requestListener) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 
+  if (process.features.tls_alpn && !opts.ALPNProtocols) {
+    // http/1.0 is not defined as Protocol IDs in IANA
+    // http://www.iana.org/assignments/tls-extensiontype-values
+    //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
+    opts.ALPNProtocols = ['http/1.1'];
+  }
+
   tls.Server.call(this, opts, http._connectionListener);
 
   this.httpAllowHalfOpen = false;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -33,27 +33,42 @@ exports.getCiphers = function() {
 
 // Convert protocols array into valid OpenSSL protocols list
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")
-exports.convertNPNProtocols = function convertNPNProtocols(NPNProtocols, out) {
-  // If NPNProtocols is Array - translate it into buffer
-  if (Array.isArray(NPNProtocols)) {
-    var buff = new Buffer(NPNProtocols.reduce(function(p, c) {
-      return p + 1 + Buffer.byteLength(c);
-    }, 0));
+function convertProtocols(protocols) {
+  var buff = new Buffer(protocols.reduce(function(p, c) {
+    return p + 1 + Buffer.byteLength(c);
+  }, 0));
 
-    NPNProtocols.reduce(function(offset, c) {
-      var clen = Buffer.byteLength(c);
-      buff[offset] = clen;
-      buff.write(c, offset + 1);
+  protocols.reduce(function(offset, c) {
+    var clen = Buffer.byteLength(c);
+    buff[offset] = clen;
+    buff.write(c, offset + 1);
 
-      return offset + 1 + clen;
-    }, 0);
+    return offset + 1 + clen;
+  }, 0);
 
-    NPNProtocols = buff;
+  return buff;
+};
+
+exports.convertNPNProtocols  = function(protocols, out) {
+  // If protocols is Array - translate it into buffer
+  if (Array.isArray(protocols)) {
+    protocols = convertProtocols(protocols);
   }
-
   // If it's already a Buffer - store it
-  if (NPNProtocols instanceof Buffer) {
-    out.NPNProtocols = NPNProtocols;
+  if (protocols instanceof Buffer) {
+    out.NPNProtocols = protocols;
+  }
+};
+
+exports.convertALPNProtocols = function(protocols, out) {
+  // If protocols is Array - translate it into buffer
+  if (Array.isArray(protocols)) {
+    protocols = convertProtocols(protocols);
+  }
+  // If it's already a Buffer - store it
+  if (protocols instanceof Buffer) {
+    // copy new buffer not to be modified by user
+    out.ALPNProtocols = new Buffer(protocols);
   }
 };
 

--- a/src/env.h
+++ b/src/env.h
@@ -42,6 +42,7 @@ namespace node {
 // for the sake of convenience.  Strings should be ASCII-only.
 #define PER_ISOLATE_STRING_PROPERTIES(V)                                      \
   V(address_string, "address")                                                \
+  V(alpn_buffer_string, "alpnBuffer")                                         \
   V(args_string, "args")                                                      \
   V(argv_string, "argv")                                                      \
   V(arrow_message_string, "arrowMessage")                                     \
@@ -205,6 +206,7 @@ namespace node {
   V(timestamp_string, "timestamp")                                            \
   V(title_string, "title")                                                    \
   V(tls_npn_string, "tls_npn")                                                \
+  V(tls_alpn_string, "tls_alpn")                                              \
   V(tls_ocsp_string, "tls_ocsp")                                              \
   V(tls_sni_string, "tls_sni")                                                \
   V(tls_string, "tls")                                                        \

--- a/src/env.h
+++ b/src/env.h
@@ -131,6 +131,7 @@ namespace node {
   V(netmask_string, "netmask")                                                \
   V(nice_string, "nice")                                                      \
   V(nlink_string, "nlink")                                                    \
+  V(npn_buffer_string, "npnBuffer")                                           \
   V(nsname_string, "nsname")                                                  \
   V(ocsp_request_string, "OCSPRequest")                                       \
   V(offset_string, "offset")                                                  \
@@ -181,6 +182,7 @@ namespace node {
   V(serial_string, "serial")                                                  \
   V(scavenge_string, "scavenge")                                              \
   V(scopeid_string, "scopeid")                                                \
+  V(selected_npn_buffer_string, "selectedNpnBuffer")                          \
   V(sent_shutdown_string, "sentShutdown")                                     \
   V(serial_number_string, "serialNumber")                                     \
   V(service_string, "service")                                                \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2582,6 +2582,13 @@ static Local<Object> GetFeatures(Environment* env) {
 #endif
   obj->Set(env->tls_npn_string(), tls_npn);
 
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+  Local<Boolean> tls_alpn = True(env->isolate());
+#else
+  Local<Boolean> tls_alpn = False(env->isolate());
+#endif
+  obj->Set(env->tls_alpn_string(), tls_alpn);
+
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   Local<Boolean> tls_sni = True(env->isolate());
 #else

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -935,6 +935,11 @@ void DefineOpenSSLConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, NPN_ENABLED);
 #endif
 
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+#define ALPN_ENABLED 1
+    NODE_DEFINE_CONSTANT(target, ALPN_ENABLED);
+#endif
+
 #ifdef RSA_PKCS1_PADDING
     NODE_DEFINE_CONSTANT(target, RSA_PKCS1_PADDING);
 #endif

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -167,6 +167,15 @@ template void SSLWrap<TLSWrap>::DestroySSL();
 template int SSLWrap<TLSWrap>::SSLCertCallback(SSL* s, void* arg);
 template void SSLWrap<TLSWrap>::WaitForCertCb(CertCb cb, void* arg);
 
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+template int SSLWrap<TLSWrap>::SelectALPNCallback(
+    SSL* s,
+    const unsigned char** out,
+    unsigned char* outlen,
+    const unsigned char* in,
+    unsigned int inlen,
+    void* arg);
+#endif  // TLSEXT_TYPE_application_layer_protocol_negotiation
 
 static void crypto_threadid_cb(CRYPTO_THREADID* tid) {
   static_assert(sizeof(uv_thread_t) <= sizeof(void*),  // NOLINT(runtime/sizeof)
@@ -1148,6 +1157,9 @@ void SSLWrap<Base>::AddMethods(Environment* env, Local<FunctionTemplate> t) {
   env->SetProtoMethod(t, "setNPNProtocols", SetNPNProtocols);
 #endif
 
+  env->SetProtoMethod(t, "getALPNNegotiatedProtocol", GetALPNNegotiatedProto);
+  env->SetProtoMethod(t, "setALPNProtocols", SetALPNProtocols);
+
   t->PrototypeTemplate()->SetAccessor(
       FIXED_ONE_BYTE_STRING(env->isolate(), "_external"),
       SSLGetter,
@@ -2009,6 +2021,98 @@ void SSLWrap<Base>::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
   w->npn_protos_.Reset(args.GetIsolate(), args[0].As<Object>());
 }
 #endif  // OPENSSL_NPN_NEGOTIATED
+
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+typedef struct tlsextalpnctx_st {
+  unsigned char* data;
+  unsigned short len;
+} tlsextalpnctx;
+
+template <class Base>
+int SSLWrap<Base>::SelectALPNCallback(SSL* s,
+                                      const unsigned char** out,
+                                      unsigned char* outlen,
+                                      const unsigned char* in,
+                                      unsigned int inlen,
+                                      void* arg) {
+  Base* w = static_cast<Base*>(SSL_get_app_data(s));
+  Environment* env = w->env();
+  HandleScope handle_scope(env->isolate());
+  Context::Scope context_scope(env->context());
+
+  Local<Value> alpn_buffer =
+      w->object()->GetHiddenValue(env->alpn_buffer_string());
+  CHECK(Buffer::HasInstance(alpn_buffer));
+  const unsigned char* alpn_protos =
+      reinterpret_cast<const unsigned char*>(Buffer::Data(alpn_buffer));
+  unsigned alpn_protos_len = Buffer::Length(alpn_buffer);
+  int status = SSL_select_next_proto(const_cast<unsigned char**>(out), outlen,
+                                     alpn_protos, alpn_protos_len, in, inlen);
+
+  switch (status) {
+    case OPENSSL_NPN_NO_OVERLAP:
+      // According to 3.2. Protocol Selection of RFC7301,
+      // fatal no_application_protocol alert shall be sent
+      // but current openssl does not support it yet. See
+      // https://rt.openssl.org/Ticket/Display.html?id=3463&user=guest&pass=guest
+      // Instead, we send a warning alert for now.
+      return SSL_TLSEXT_ERR_ALERT_WARNING;
+    case OPENSSL_NPN_NEGOTIATED:
+      return SSL_TLSEXT_ERR_OK;
+    default:
+      return SSL_TLSEXT_ERR_ALERT_FATAL;
+  }
+}
+#endif  // TLSEXT_TYPE_application_layer_protocol_negotiation
+
+
+template <class Base>
+void SSLWrap<Base>::GetALPNNegotiatedProto(
+    const FunctionCallbackInfo<v8::Value>& args) {
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+  HandleScope scope(args.GetIsolate());
+  Base* w = Unwrap<Base>(args.Holder());
+
+  const unsigned char* alpn_proto;
+  unsigned int alpn_proto_len;
+
+  SSL_get0_alpn_selected(w->ssl_, &alpn_proto, &alpn_proto_len);
+
+  if (!alpn_proto)
+    return args.GetReturnValue().Set(false);
+
+  args.GetReturnValue().Set(
+      OneByteString(args.GetIsolate(), alpn_proto, alpn_proto_len));
+#endif  // TLSEXT_TYPE_application_layer_protocol_negotiation
+}
+
+
+template <class Base>
+void SSLWrap<Base>::SetALPNProtocols(
+    const FunctionCallbackInfo<v8::Value>& args) {
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+  HandleScope scope(args.GetIsolate());
+  Base* w = Unwrap<Base>(args.Holder());
+  Environment* env = w->env();
+  if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
+    return env->ThrowTypeError("Must give a Buffer as first argument");
+
+  if (w->is_client()) {
+    const unsigned char* alpn_protos =
+        reinterpret_cast<const unsigned char*>(Buffer::Data(args[0]));
+    unsigned alpn_protos_len = Buffer::Length(args[0]);
+    int r = SSL_set_alpn_protos(w->ssl_, alpn_protos, alpn_protos_len);
+    CHECK_EQ(r, 0);
+  } else {
+    Local<Value> alpn_buffer =  Local<Value>::New(env->isolate(), args[0]);
+    bool ret = w->object()->SetHiddenValue(env->alpn_buffer_string(),
+                                           alpn_buffer);
+    CHECK(ret);
+    // Server should select ALPN protocol from list of advertised by client
+    SSL_CTX_set_alpn_select_cb(w->ssl_->ctx, SelectALPNCallback, nullptr);
+  }
+#endif  // TLSEXT_TYPE_application_layer_protocol_negotiation
+}
 
 
 #ifdef NODE__HAVE_TLSEXT_STATUS_CB

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -5,9 +5,7 @@
 #include "node_crypto_clienthello.h"  // ClientHelloParser
 #include "node_crypto_clienthello-inl.h"
 
-#ifdef OPENSSL_NPN_NEGOTIATED
 #include "node_buffer.h"
-#endif
 
 #include "env.h"
 #include "async-wrap.h"
@@ -187,6 +185,7 @@ class SSLWrap {
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
     sni_context_.Reset();
 #endif
+
 #ifdef NODE__HAVE_TLSEXT_STATUS_CB
     ocsp_response_.Reset();
 #endif  // NODE__HAVE_TLSEXT_STATUS_CB
@@ -259,6 +258,16 @@ class SSLWrap {
                                      unsigned int inlen,
                                      void* arg);
 #endif  // OPENSSL_NPN_NEGOTIATED
+
+  static void GetALPNNegotiatedProto(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetALPNProtocols(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static int SelectALPNCallback(SSL* s,
+                                const unsigned char** out,
+                                unsigned char* outlen,
+                                const unsigned char* in,
+                                unsigned int inlen,
+                                void* arg);
   static int TLSExtStatusCallback(SSL* s, void* arg);
   static int SSLCertCallback(SSL* s, void* arg);
   static void SSLGetter(v8::Local<v8::String> property,

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -178,10 +178,6 @@ class SSLWrap {
       next_sess_ = nullptr;
     }
 
-#ifdef OPENSSL_NPN_NEGOTIATED
-    npn_protos_.Reset();
-    selected_npn_proto_.Reset();
-#endif
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
     sni_context_.Reset();
 #endif
@@ -297,11 +293,6 @@ class SSLWrap {
 #ifdef NODE__HAVE_TLSEXT_STATUS_CB
   v8::Persistent<v8::Object> ocsp_response_;
 #endif  // NODE__HAVE_TLSEXT_STATUS_CB
-
-#ifdef OPENSSL_NPN_NEGOTIATED
-  v8::Persistent<v8::Object> npn_protos_;
-  v8::Persistent<v8::Value> selected_npn_proto_;
-#endif  // OPENSSL_NPN_NEGOTIATED
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   v8::Persistent<v8::Value> sni_context_;

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -1,0 +1,540 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+
+if (!process.features.tls_alpn) {
+  console.error('Skipping because node compiled without OpenSSL or ' +
+                'with old OpenSSL version.');
+  process.exit(0);
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const tls = require('tls');
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverPort = common.PORT;
+var serverIP = common.localhostIPv4;
+
+function checkResults(result, expected) {
+  assert.strictEqual(result.server.ALPN, expected.server.ALPN);
+  assert.strictEqual(result.server.NPN, expected.server.NPN);
+  assert.strictEqual(result.client.ALPN, expected.client.ALPN);
+  assert.strictEqual(result.client.NPN, expected.client.NPN);
+}
+
+function runTest(clientsOptions, serverOptions, cb) {
+  serverOptions.key = loadPEM('agent2-key');
+  serverOptions.cert = loadPEM('agent2-cert');
+  var results = [];
+  var index = 0;
+  var server = tls.createServer(serverOptions, function(c) {
+    results[index].server = {ALPN: c.alpnProtocol, NPN: c.npnProtocol};
+  });
+
+  server.listen(serverPort, serverIP, function() {
+    connectClient(clientsOptions);
+  });
+
+  function connectClient(options) {
+    var opt = options.shift();
+    opt.port = serverPort;
+    opt.host = serverIP;
+    opt.rejectUnauthorized = false;
+
+    results[index] = {};
+    var client = tls.connect(opt, function() {
+      results[index].client = {ALPN: client.alpnProtocol,
+                               NPN: client.npnProtocol};
+      client.destroy();
+      if (options.length) {
+        index++;
+        connectClient(options);
+      } else {
+        server.close();
+        cb(results);
+      }
+    });
+  };
+
+}
+
+// Server: ALPN/NPN, Client: ALPN/NPN
+function Test1() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0],
+                 {server: {ALPN: 'a', NPN: false},
+                  client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: 'b', NPN: false},
+                  client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: false},
+                  client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test2();
+  });
+}
+
+// Server: ALPN/NPN, Client: ALPN
+function Test2() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0],
+                 {server: {ALPN: 'a', NPN: false},
+                  client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: 'b', NPN: false},
+                  client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: false},
+                  client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test3();
+  });
+}
+
+// Server: ALPN/NPN, Client: NPN
+function Test3() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by NPN
+    checkResults(results[0],
+                 {server: {ALPN: false, NPN: 'a'},
+                  client: {ALPN: false, NPN: 'a'}});
+    // nothing is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test4();
+  });
+}
+
+// Server: ALPN/NPN, Client: Nothing
+function Test4() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected by ALPN
+    checkResults(results[0],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test5();
+  });
+}
+
+// Server: ALPN, Client: ALPN/NPN
+function Test5() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0], {server: {ALPN: 'a', NPN: false},
+                              client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1], {server: {ALPN: 'b', NPN: false},
+                              client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2], {server: {ALPN: false, NPN: false},
+                              client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test6();
+  });
+}
+
+// Server: ALPN, Client: ALPN
+function Test6() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0], {server: {ALPN: 'a', NPN: false},
+                              client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1], {server: {ALPN: 'b', NPN: false},
+                              client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2], {server: {ALPN: false, NPN: false},
+                              client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test7();
+  });
+}
+
+// Server: ALPN, Client: NPN
+function Test7() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected by ALPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN:  'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test8();
+  });
+}
+
+// Server: ALPN, Client: Nothing
+function Test8() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected by ALPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN:  'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test9();
+  });
+}
+
+// Server: NPN, Client: ALPN/NPN
+function Test9() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNrotocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by NPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: 'a'}});
+    // 'b' is selected by NPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'b'},
+                              client: {ALPN: false, NPN: 'b'}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test10();
+  });
+}
+
+// Server: NPN, Client: ALPN
+function Test10() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test11();
+  });
+}
+
+// Server: NPN, Client: NPN
+function Test11() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by NPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: 'a'}});
+    // 'b' is selected by NPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'b'},
+                              client: {ALPN: false, NPN: 'b'}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test12();
+  });
+}
+
+// Server: NPN, Client: Nothing
+function Test12() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test13();
+  });
+}
+
+// Server: Nothing, Client: ALPN/NPN
+function Test13() {
+  var serverOptions = {};
+
+  var clientsOptions = [{
+    ALPNrotocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test14();
+  });
+}
+
+// Server: Nothing, Client: ALPN
+function Test14() {
+  var serverOptions = {};
+
+  var clientsOptions = [{
+    ALPNrotocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test15();
+  });
+}
+
+// Server: Nothing, Client: NPN
+function Test15() {
+  var serverOptions = {};
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test16();
+  });
+}
+
+// Server: Nothing, Client: Nothing
+function Test16() {
+  var serverOptions = {};
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+  });
+}
+
+Test1();


### PR DESCRIPTION
ALPN is added to tls according to RFC7301, which supersedes NPN. 
When the server receives both NPN and ALPN extensions from the client, ALPN takes precedence over NPN and the server does not send NPN extension to the client. alpnProtocol in TLSSocket always returns false when no selected protocol exists by ALPN.
In https server, http/1.1 token is always set when no options.ALPNProtocols exists.

Here exist all 16x3 test cases of combination of  ALPN and NPN in a server and a client. Tests shows that there are some inconsistent returns in NPN between the server and the client but they are not changed for compatibility.

NPN in Chrome will be deprecated in early 2016 as in http://blog.chromium.org/2015/02/hello-http2-goodbye-spdy-http-is_9.html so it is better to include ALPN support in Node 4.0.

R= @nodejs/crypto 