### PR TITLE
net: cleans up 4 instances of internal stream access

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -239,17 +239,21 @@ function afterShutdown(status, handle, req) {
 // up.
 function onSocketEnd() {
   debug('onSocketEnd', this._readableState);
-  if (this._readableState.endEmitted) {
+
+  // No 'end' event should have already been emitted, because it is emitted
+  // with process.nextTick instead of synchronously by Readable.
+  assert.ok(!this._readableState.endEmitted);
+
+  // After EOF, wait for the 'end' event from Readable before (possibly)
+  // destroying the socket. Then trigger a stream refresh with .read(0).
+  this.once('end', function() {
     this.readable = false;
     maybeDestroy(this);
-  } else {
-    this.once('end', function() {
-      this.readable = false;
-      maybeDestroy(this);
-    });
-    this.read(0);
-  }
+  });
+  this.read(0);
 
+  // For sockets that don't allow half open connections, replace the write
+  // function and destroy.
   if (!this.allowHalfOpen) {
     this.write = writeAfterFIN;
     this.destroySoon();

--- a/lib/net.js
+++ b/lib/net.js
@@ -167,7 +167,8 @@ function Socket(options) {
       // stop the handle from reading and pause the stream
       this._handle.reading = false;
       this._handle.readStop();
-      this._readableState.flowing = false;
+
+      this.pause();
     } else {
       this.read(0);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -238,11 +238,7 @@ function afterShutdown(status, handle, req) {
 // if the writable side has ended already, then clean everything
 // up.
 function onSocketEnd() {
-  // XXX Should not have to do as much crap in this function.
-  // ended should already be true, since this is called *after*
-  // the EOF errno and onread has eof'ed
   debug('onSocketEnd', this._readableState);
-  this._readableState.ended = true;
   if (this._readableState.endEmitted) {
     this.readable = false;
     maybeDestroy(this);

--- a/lib/net.js
+++ b/lib/net.js
@@ -119,6 +119,12 @@ function Socket(options) {
     options = { fd: options }; // Legacy interface.
   else if (options === undefined)
     options = {};
+  else
+    options = util._extend({}, options); // Create a copy.
+
+  // net handles strings directly for performance in C++, so do not convert
+  // written strings to Buffers before passing to the handle.
+  options.decodeStrings = false;
 
   stream.Duplex.call(this, options);
 
@@ -150,9 +156,6 @@ function Socket(options) {
 
   this._pendingData = null;
   this._pendingEncoding = '';
-
-  // handle strings directly
-  this._writableState.decodeStrings = false;
 
   // default to *not* allowing half open sockets
   this.allowHalfOpen = options && options.allowHalfOpen || false;

--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -15,6 +15,10 @@ var server1 = net.createServer({pauseOnConnect: true}, function(socket) {
     server1.close();
   });
 
+  // No 'pause' event should be emitted because the socket 'connection' event
+  // should be emitted after the 'pause' event is.
+  socket.on('pause', assert.fail);
+
   setTimeout(function() {
     // After 50(ish) ms, the other socket should have already read the data.
     assert.equal(read, true);
@@ -36,6 +40,9 @@ var server2 = net.createServer({pauseOnConnect: false}, function(socket) {
     socket.end();
     server2.close();
   });
+
+  // No 'pause' event anyways.
+  socket.on('pause', assert.fail);
 });
 
 server1.listen(common.PORT, function() {


### PR DESCRIPTION
This pull request contains 4 commits, each which clean up an individual instance of stream `_writableState` or `_readableState` access. Each commit contains a nice explanation on how each change works and why it should work the same.

If node can't use the public stream APIs, why should anyone else?

Ref to: https://github.com/nodejs/node/issues/445