### PR TITLE
doc: minor clarification in buffer.markdown

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -68,8 +68,8 @@ Allocates a new buffer of `size` bytes.  `size` must be less than
 otherwise a `RangeError` is thrown.
 
 Unlike `ArrayBuffers`, the underlying memory for buffers is not initialized. So
-the contents of a newly created `Buffer` is unknown. Use `buf.fill(0)`to
-initialize a buffer to zeroes.
+the contents of a newly created `Buffer` are unknown and could contain
+sensitive data. Use `buf.fill(0)` to initialize a buffer to zeroes.
 
 ### new Buffer(array)
 


### PR DESCRIPTION
Replaced "contents is" with "contents are".
Added a note that initial Buffer contents could contain sensitive data.

I am not sure if there has to be an additional paragraph on that, warning against sending data from unitialized `Buffer` objects.