### PR TITLE
crypto: Use OPENSSL_cleanse to shred the data.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4723,8 +4723,8 @@ void EIO_PBKDF2(PBKDF2Request* req) {
     req->digest(),
     req->keylen(),
     reinterpret_cast<unsigned char*>(req->key())));
-  memset(req->pass(), 0, req->passlen());
-  memset(req->salt(), 0, req->saltlen());
+  OPENSSL_cleanse(req->pass(), req->passlen());
+  OPENSSL_cleanse(req->salt(), req->saltlen());
 }
 
 
@@ -4738,7 +4738,7 @@ void EIO_PBKDF2After(PBKDF2Request* req, Local<Value> argv[2]) {
   if (req->error()) {
     argv[0] = Undefined(req->env()->isolate());
     argv[1] = Encode(req->env()->isolate(), req->key(), req->keylen(), BUFFER);
-    memset(req->key(), 0, req->keylen());
+    OPENSSL_cleanse(req->key(), req->keylen());
   } else {
     argv[0] = Exception::Error(req->env()->pbkdf2_error_string());
     argv[1] = Undefined(req->env()->isolate());


### PR DESCRIPTION
memset() is not useful here, it's efficiently a noop.

Notice: I am not sure if this actually improves anything (because the secrets are also stored on the v8 side and there isn't much we could do about that), but it at least makes the affected lines in `node_crypto.cc` do what they are meant to do.

/cc @indutny 