### PR TITLE
Revert "lib,src: add unix socket getsockname/getpeername"

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -255,9 +255,6 @@ Example:
 
 Don't call `server.address()` until the `'listening'` event has been emitted.
 
-This method used to return the file path as a string for UNIX sockets and
-Windows pipes.  As of Node.js v4.0.0, it returns the expected object.
-
 ### server.unref()
 
 Calling `unref` on a server will allow the program to exit if this is the only
@@ -511,18 +508,14 @@ Returns `socket`.
 The string representation of the remote IP address. For example,
 `'74.125.127.100'` or `'2001:4860:a005::68'`.
 
-For UNIX sockets and Windows pipes, the file path the socket is connected
-to.  The remote address for server sockets is always `''`, the empty string.
-
 ### socket.remoteFamily
 
-The string representation of the remote IP family. `'IPv4'` or `'IPv6'`
-for TCP sockets, `'pipe'` for UNIX sockets and Windows pipes.
+The string representation of the remote IP family. `'IPv4'` or `'IPv6'`.
 
 ### socket.remotePort
 
-The numeric representation of the remote port. For example, `80` or `21`.
-`undefined` for UNIX sockets and Windows pipes.
+The numeric representation of the remote port. For example,
+`80` or `21`.
 
 ### socket.localAddress
 
@@ -530,18 +523,10 @@ The string representation of the local IP address the remote client is
 connecting on. For example, if you are listening on `'0.0.0.0'` and the
 client connects on `'192.168.1.1'`, the value would be `'192.168.1.1'`.
 
-For UNIX sockets and Windows pipes, the file path the socket is listening
-on.  The local address for client sockets is always `''`, the empty string.
-
-### socket.localFamily
-
-The string representation of the local IP family. `'IPv4'` or `'IPv6'`
-for TCP sockets, `'pipe'` for UNIX sockets and Windows pipes.
-
 ### socket.localPort
 
-The numeric representation of the local port. For example, `80` or `21`.
-`undefined` for UNIX sockets and Windows pipes.
+The numeric representation of the local port. For example,
+`80` or `21`.
 
 ### socket.bytesRead
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -606,9 +606,6 @@ Socket.prototype.__defineGetter__('localAddress', function() {
   return this._getsockname().address;
 });
 
-Socket.prototype.__defineGetter__('localFamily', function() {
-  return this._getsockname().family;
-});
 
 Socket.prototype.__defineGetter__('localPort', function() {
   return this._getsockname().port;
@@ -1342,14 +1339,16 @@ Server.prototype.listen = function() {
         else
           listen(self, null, h.port | 0, 4, backlog, undefined, h.exclusive);
       } else if (h.path && isPipeName(h.path)) {
-        listen(self, h.path, -1, -1, backlog, undefined, h.exclusive);
+        var pipeName = self._pipeName = h.path;
+        listen(self, pipeName, -1, -1, backlog, undefined, h.exclusive);
       } else {
         throw new Error('Invalid listen argument: ' + h);
       }
     }
   } else if (isPipeName(arguments[0])) {
     // UNIX socket or Windows pipe.
-    listen(self, arguments[0], -1, -1, backlog);
+    var pipeName = self._pipeName = arguments[0];
+    listen(self, pipeName, -1, -1, backlog);
 
   } else if (arguments[1] === undefined ||
              typeof arguments[1] === 'function' ||
@@ -1382,6 +1381,8 @@ Server.prototype.address = function() {
     this._handle.getsockname(out);
     // TODO(bnoordhuis) Check err and throw?
     return out;
+  } else if (this._pipeName) {
+    return this._pipeName;
   } else {
     return null;
   }

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -89,10 +89,6 @@ void PipeWrap::Initialize(Handle<Object> target,
   env->SetProtoMethod(t, "listen", Listen);
   env->SetProtoMethod(t, "connect", Connect);
   env->SetProtoMethod(t, "open", Open);
-  env->SetProtoMethod(t, "getpeername",
-                      GetSockOrPeerName<uv_pipe_getpeername>);
-  env->SetProtoMethod(t, "getsockname",
-                      GetSockOrPeerName<uv_pipe_getsockname>);
 
 #ifdef _WIN32
   env->SetProtoMethod(t, "setPendingInstances", SetPendingInstances);
@@ -277,28 +273,6 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   req_wrap->Dispatched();
 
   args.GetReturnValue().Set(0);  // uv_pipe_connect() doesn't return errors.
-}
-
-
-template <int (*F)(const uv_pipe_t*, char*, size_t*)>
-void PipeWrap::GetSockOrPeerName(
-    const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args[0]->IsObject());
-  char buffer[1024];
-  size_t size = sizeof(buffer);
-  const PipeWrap* wrap = Unwrap<PipeWrap>(args.Holder());
-  const int err = F(&wrap->handle_, buffer, &size);
-  if (err == 0) {
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer);
-    const String::NewStringType type = String::kNormalString;
-    Local<String> path =
-        String::NewFromOneByte(args.GetIsolate(), data, type, size);
-    Environment* env = Environment::GetCurrent(args);
-    Local<Object> out = args[0].As<Object>();
-    out->Set(env->address_string(), path);
-    out->Set(env->family_string(), env->pipe_string());
-  }
-  args.GetReturnValue().Set(err);
 }
 
 

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -30,9 +30,6 @@ class PipeWrap : public StreamWrap {
   static void Connect(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  template <int (*F)(const uv_pipe_t*, char*, size_t*)>
-  static void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>&);
-
 #ifdef _WIN32
   static void SetPendingInstances(
       const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/common.js
+++ b/test/common.js
@@ -134,7 +134,7 @@ Object.defineProperty(exports, 'hasCrypto', {get: function() {
 }});
 
 if (exports.isWindows) {
-  exports.PIPE = '\\\\?\\pipe\\libuv-test';
+  exports.PIPE = '\\\\.\\pipe\\libuv-test';
 } else {
   exports.PIPE = exports.tmpDir + '/test.sock';
 }

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -29,12 +29,8 @@ if (cluster.isMaster) {
 }
 
 http.createServer(function(req, res) {
-  assert.equal(req.connection.remoteAddress, '');
-  assert.equal(req.connection.remoteFamily, 'pipe');
-  assert.equal(req.connection.remotePort, undefined);
-  assert.equal(req.connection.localAddress, common.PIPE);
-  assert.equal(req.connection.localFamily, 'pipe');
-  assert.equal(req.connection.localPort, undefined);
+  assert.equal(req.connection.remoteAddress, undefined);
+  assert.equal(req.connection.localAddress, undefined); // TODO common.PIPE?
   res.writeHead(200);
   res.end('OK');
 }).listen(common.PIPE, function() {

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -9,7 +9,6 @@ var headers_ok = false;
 var body_ok = false;
 
 var server = http.createServer(function(req, res) {
-  assert.equal(req.socket.address().address, common.PIPE);
   res.writeHead(200, {
     'Content-Type': 'text/plain',
     'Connection': 'close'
@@ -20,7 +19,6 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PIPE, function() {
-  assert.equal(server.address().address, common.PIPE);
 
   var options = {
     socketPath: common.PIPE,

--- a/test/sequential/test-pipe-address.js
+++ b/test/sequential/test-pipe-address.js
@@ -15,6 +15,5 @@ server.listen(common.PIPE, function() {
 });
 
 process.on('exit', function() {
-  assert.equal(address.address, common.PIPE);
-  assert.equal(address.family, 'pipe');
+  assert.equal(address, common.PIPE);
 });


### PR DESCRIPTION
This reverts commit 6cd0e2664b1ce944e5e461457d160be83f70d379.
This reverts commit 7a999a13766ac68049812fedbdfd15a0250f0f07.
This reverts commit f337595441641ad36f6ab8ae770e56c1673ef692.

It turns out that on Windows, uv_pipe_getsockname() is a no-op for
client sockets.  It slipped through testing because of a CI snafu.

R=@thefourtheye?

CI: https://jenkins-iojs.nodesource.com/job/node-test-pull-request/193/