### PR TITLE
buffer: introduce zero-fill option in constructor

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -58,9 +58,10 @@ arrays specification.  `ArrayBuffer#slice()` makes a copy of the slice while
 The Buffer class is a global type for dealing with binary data directly.
 It can be constructed in a variety of ways.
 
-### new Buffer(size)
+### new Buffer(size[, zeroFill])
 
-* `size` Number
+* `size` {Number}
+* `zeroFill` {Value}
 
 Allocates a new buffer of `size` bytes.  `size` must be less than
 1,073,741,824 bytes (1 GB) on 32 bits architectures or
@@ -69,7 +70,9 @@ otherwise a `RangeError` is thrown.
 
 Unlike `ArrayBuffers`, the underlying memory for buffers is not initialized. So
 the contents of a newly created `Buffer` are unknown and could contain
-sensitive data. Use `buf.fill(0)` to initialize a buffer to zeroes.
+sensitive data. Use `buf.fill(0)` to initialize a buffer to zeroes. If a truthy
+value is passed as the second argument, then the returned buffer will be zero-filled
+by default.
 
 ### new Buffer(array)
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -30,18 +30,22 @@ function alignPool() {
 }
 
 
-function Buffer(arg) {
+function Buffer(arg, zeroFill) {
   // Common case.
   if (typeof arg === 'number') {
     // If less than zero, or NaN.
     if (arg < 0 || arg !== arg)
       arg = 0;
-    return allocate(arg);
+    const buffer = allocate(arg);
+    if (zeroFill)
+      buffer.fill(0);
+    return buffer;
   }
 
   // Slightly less common case.
   if (typeof arg === 'string') {
-    return fromString(arg, arguments[1]);
+    // In this case, the second argument is encoding
+    return fromString(arg, zeroFill);
   }
 
   // Unusual.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -30,22 +30,21 @@ function alignPool() {
 }
 
 
-function Buffer(arg, zeroFill) {
+function Buffer(arg) {
   // Common case.
   if (typeof arg === 'number') {
     // If less than zero, or NaN.
     if (arg < 0 || arg !== arg)
       arg = 0;
     const buffer = allocate(arg);
-    if (zeroFill)
+    if (arguments[1])
       buffer.fill(0);
     return buffer;
   }
 
   // Slightly less common case.
   if (typeof arg === 'string') {
-    // In this case, the second argument is encoding
-    return fromString(arg, zeroFill);
+    return fromString(arg, arguments[1]);
   }
 
   // Unusual.

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1189,3 +1189,7 @@ assert.throws(function() {
 assert.throws(function() {
   new Buffer(null);
 }, /must start with number, buffer, array or string/);
+
+// Test the zero fill option
+const zeroFilledBuffer = Buffer(5, true);
+assert.equal(0, Buffer.compare(zeroFilledBuffer, Buffer([0, 0, 0, 0, 0])));


### PR DESCRIPTION
This patch enables the newly created buffers to be zero-filled, by
default, if the constructor is called with one additional truthy
argument.

cc @trevnorris @ChALkeR 