### PR TITLE
src: re-enable fast math on arm

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3599,20 +3599,6 @@ void Init(int* argc,
                 DispatchDebugMessagesAsyncCallback);
   uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
-#if defined(__ARM_ARCH_6__) || \
-    defined(__ARM_ARCH_6J__) || \
-    defined(__ARM_ARCH_6K__) || \
-    defined(__ARM_ARCH_6M__) || \
-    defined(__ARM_ARCH_6T2__) || \
-    defined(__ARM_ARCH_6ZK__) || \
-    defined(__ARM_ARCH_6Z__)
-  // See https://github.com/nodejs/node/issues/1376
-  // and https://code.google.com/p/v8/issues/detail?id=4019
-  // TODO(bnoordhuis): Remove test/parallel/test-arm-math-exp-regress-1376.js
-  // and this workaround when v8:4019 has been fixed and the patch back-ported.
-  V8::SetFlagsFromString("--nofast_math", sizeof("--nofast_math") - 1);
-#endif
-
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()
   // so the user can disable a flag --foo at run-time by passing


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/1376 and https://github.com/nodejs/node/pull/1398
V8 fixed the issue in https://chromium.googlesource.com/v8/v8/+/81703350bbb9923d211fe5b79e90bd458b0916e2
V8-Bug: https://code.google.com/p/v8/issues/detail?id=4019

This PR is against the `vee-eight-4.5` branch, which I rebased on master