### PR TITLE
Fix icutrim build failure when building small-icu on Big-Endian platforms

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -29,9 +29,17 @@
       'type': 'none',
       'toolsets': [ 'host', 'target' ],
       'direct_dependent_settings': {
+        'conditions': [
+          [ 'icu_endianness == "l"', {
+             'defines': [
+                # ICU cannot swap the initial data without this. 
+                # http://bugs.icu-project.org/trac/ticket/11046 
+                'UCONFIG_NO_LEGACY_CONVERSION=1',
+                'UCONFIG_NO_IDNA=1',
+             ],
+          }],
+        ], 
         'defines': [
-          'UCONFIG_NO_LEGACY_CONVERSION=1',
-          'UCONFIG_NO_IDNA=1',
           'UCONFIG_NO_TRANSLITERATION=1',
           'UCONFIG_NO_SERVICE=1',
           'UCONFIG_NO_REGULAR_EXPRESSIONS=1',


### PR DESCRIPTION
Fix a build error that occurs when icutrim is run to cut down the ICU locale set on Big-Endian platforms when building with --with-intl=small-icu (which is done by the "make binary" target). This fixes the binary build on POWER platforms. See https://github.com/nodejs/node/issues/2601 for details of the specific error that shows.

Cc @srl295 