### PR TITLE
cluster,dgram: pass UDP bind flags from cluster worker

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -57,7 +57,7 @@ Worker.prototype.isConnected = function isConnected() {
 
 // Master/worker specific methods are defined in the *Init() functions.
 
-function SharedHandle(key, address, port, addressType, backlog, fd) {
+function SharedHandle(key, address, port, addressType, backlog, fd, flags) {
   this.key = key;
   this.workers = [];
   this.handle = null;
@@ -66,9 +66,9 @@ function SharedHandle(key, address, port, addressType, backlog, fd) {
   // FIXME(bnoordhuis) Polymorphic return type for lack of a better solution.
   var rval;
   if (addressType === 'udp4' || addressType === 'udp6')
-    rval = dgram._createSocketHandle(address, port, addressType, fd);
+    rval = dgram._createSocketHandle(address, port, addressType, fd, flags);
   else
-    rval = net._createServerHandle(address, port, addressType, fd);
+    rval = net._createServerHandle(address, port, addressType, fd, flags);
 
   if (typeof rval === 'number')
     this.errno = rval;
@@ -456,7 +456,8 @@ function masterInit() {
                                               message.port,
                                               message.addressType,
                                               message.backlog,
-                                              message.fd);
+                                              message.fd,
+                                              message.flags);
     }
     if (!handle.data) handle.data = message.data;
 
@@ -528,13 +529,14 @@ function workerInit() {
   };
 
   // obj is a net#Server or a dgram#Socket object.
-  cluster._getServer = function(obj, address, port, addressType, fd, cb) {
+  function getServer(obj, address, port, addressType, fd, flags, cb) {
     var message = {
       addressType: addressType,
       address: address,
       port: port,
       act: 'queryServer',
       fd: fd,
+      flags: flags,
       data: null
     };
     // Set custom data on handle (i.e. tls tickets key)
@@ -554,7 +556,8 @@ function workerInit() {
       message.port = address && address.port || port;
       send(message);
     });
-  };
+  }
+  cluster._getServer = getServer;
 
   // Shared listen socket.
   function shared(message, handle, cb) {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -60,14 +60,14 @@ function newHandle(type) {
 }
 
 
-exports._createSocketHandle = function(address, port, addressType, fd) {
+exports._createSocketHandle = function(address, port, addressType, fd, flags) {
   // Opening an existing fd is not supported for UDP handles.
   assert(typeof fd !== 'number' || fd < 0);
 
   var handle = newHandle(addressType);
 
   if (port || address) {
-    var err = handle.bind(address, port || 0, 0);
+    let err = handle.bind(address, port || 0, flags);
     if (err) {
       handle.close();
       return err;
@@ -173,11 +173,16 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
       return;
     }
 
+    let flags = 0;
+    if (self._reuseAddr)
+      flags |= constants.UV_UDP_REUSEADDR;
+
     if (!cluster)
       cluster = require('cluster');
 
     if (cluster.isWorker && !exclusive) {
-      cluster._getServer(self, ip, port, self.type, -1, function(err, handle) {
+      cluster._getServer(self, ip, port, self.type, -1, flags,
+                         function(err, handle) {
         if (err) {
           var ex = exceptionWithHostPort(err, 'bind', ip, port);
           self.emit('error', ex);
@@ -196,10 +201,6 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
     } else {
       if (!self._handle)
         return; // handle has been closed in the mean time
-
-      var flags = 0;
-      if (self._reuseAddr)
-        flags |= constants.UV_UDP_REUSEADDR;
 
       var err = self._handle.bind(ip, port || 0, flags);
       if (err) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1268,7 +1268,7 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
     return;
   }
 
-  cluster._getServer(self, address, port, addressType, fd, cb);
+  cluster._getServer(self, address, port, addressType, fd, 0, cb);
 
   function cb(err, handle) {
     // EADDRINUSE may not be reported until we call listen(). To complicate

--- a/test/parallel/test-cluster-shared-handle-bind-reuseaddr.js
+++ b/test/parallel/test-cluster-shared-handle-bind-reuseaddr.js
@@ -1,0 +1,57 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var dgram = require('dgram');
+var spawn = require('child_process').spawn;
+var cluster = require('cluster');
+
+if (common.isWindows) {
+  console.log("1..0 # Skipped: passing UDP handles isn't supported on Windows");
+  return;
+}
+
+var isDuplicateMaster = (process.argv[3] === 'dupmaster');
+var isDuplicateFork = (process.argv[3] === 'dupfork');
+var port = (isDuplicateMaster || isDuplicateFork ? +process.argv[2] : 0);
+
+if (cluster.isMaster) {
+  if (isDuplicateMaster)
+    cluster.setupMaster({ args: [port, 'dupfork'] });
+  var worker = cluster.fork();
+  if (isDuplicateMaster) {
+    worker.once('message', common.mustCall(function(msg) {
+      assert.strictEqual(msg.portno, port);
+    }));
+  }
+  worker.on('exit', common.mustCall(function(exitCode) {
+    assert.strictEqual(exitCode, 0);
+    if (isDuplicateMaster)
+      process.stdout.write(''+port);
+  }));
+} else {
+  var socket = dgram.createSocket({type: 'udp4'/*, reuseAddr: true*/});
+  socket.bind(port, common.localhostIPv4, common.mustCall(function() {
+    port = socket.address().port;
+
+    if (isDuplicateFork) {
+      process.send({ portno: port });
+      return setImmediate(cluster.worker.disconnect.bind(cluster.worker));
+    }
+
+    // Start duplicate cluster that listens on the same port ...
+    var child = spawn(process.execPath,
+                      [__filename, port, 'dupmaster'],
+                      {env: {}});
+    var stdoutBuf = '';
+    child.stdout.on('data', function(data) {
+      stdoutBuf += data;
+    });
+    child.stderr.pipe(process.stderr);
+    child.on('close', common.mustCall(function(code, signal) {
+      assert.strictEqual(stdoutBuf, ''+port);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+      cluster.worker.disconnect();
+    }));
+  }));
+}


### PR DESCRIPTION
Previously, `reuseAddr: true` was being ignored when set inside a cluster worker. This commit passes the bind flags to the master so that the socket is bound appropriately.

Fixes: https://github.com/nodejs/node/issues/2604