### PR TITLE
test: unmark test-process-argv-0.js as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,7 +12,6 @@ test-tls-ticket-cluster           : PASS,FLAKY
 [$system==linux]
 test-cluster-worker-forced-exit   : PASS,FLAKY
 test-http-client-timeout-event    : PASS,FLAKY
-test-process-argv-0               : PASS,FLAKY
 test-tick-processor               : PASS,FLAKY
 test-tls-no-sslv3                 : PASS,FLAKY
 test-child-process-buffering      : PASS,FLAKY


### PR DESCRIPTION
https://github.com/nodejs/node/pull/2541 fixed flakiness
in test-process-argv-0.js. However, it was not removed
from the list of flaky tests. This removes it from the
list of flaky tests.