### PR TITLE
tls: TLSSocket options not initialized

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -454,18 +454,19 @@ Or
 Wrapper for instance of [net.Socket][], replaces internal socket read/write
 routines to perform transparent encryption/decryption of incoming/outgoing data.
 
-## new tls.TLSSocket(socket, options)
+## new tls.TLSSocket(socket[, options])
 
 Construct a new TLSSocket object from existing TCP socket.
 
 `socket` is an instance of [net.Socket][]
 
-`options` is an object that might contain following properties:
+`options` is an optional object that might contain following properties:
 
   - `secureContext`: An optional TLS context object from
      `tls.createSecureContext( ... )`
 
-  - `isServer`: If true - TLS socket will be instantiated in server-mode
+  - `isServer`: If `true` - TLS socket will be instantiated in server-mode.
+    Default: `false`
 
   - `server`: An optional [net.Server][] instance
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -228,7 +228,10 @@ function initRead(tls, wrapped) {
  */
 
 function TLSSocket(socket, options) {
-  this._tlsOptions = options;
+  if (options === undefined)
+    this._tlsOptions = {};
+  else
+    this._tlsOptions = options;
   this._secureEstablished = false;
   this._securePending = false;
   this._newSessionPending = false;
@@ -321,7 +324,7 @@ TLSSocket.prototype._wrapHandle = function(wrap) {
                 tls.createSecureContext();
   res = tls_wrap.wrap(handle._externalStream,
                       context.context,
-                      options.isServer);
+                      !!options.isServer);
   res._parent = handle;
   res._parentWrap = wrap;
   res._secureContext = context;

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -1,0 +1,57 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+const tls = require('tls');
+
+const fs = require('fs');
+const net = require('net');
+
+const sent = 'hello world';
+
+const serverOptions = {
+  isServer: true,
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+function testSocketOptions(socket, socketOptions) {
+  let received = '';
+  const server = tls.createServer(serverOptions, function(s) {
+    s.on('data', function(chunk) {
+      received += chunk;
+    });
+
+    s.on('end', function() {
+      server.close();
+      s.destroy();
+      assert.equal(received, sent);
+      setImmediate(runTests);
+    });
+  }).listen(common.PORT, function() {
+    let c = new tls.TLSSocket(socket, socketOptions);
+    c.connect(common.PORT, function() {
+      c.end(sent);
+    });
+  });
+
+}
+
+const testArgs = [
+  [],
+  [undefined, {}]
+];
+
+let n = 0;
+function runTests() {
+  if (n++ < testArgs.length) {
+    testSocketOptions.apply(null, testArgs[n]);
+  }
+}
+
+runTests();
+


### PR DESCRIPTION
Upon creating a TLSSocket object without options, default options will be used, which
set the socket as isServer: false
Updated tls docs and added test-tls-socket-default-options

See issue #2394 