### PR TITLE
build: make executable Large Address Aware

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -169,6 +169,7 @@
         'DataExecutionPrevention': 2, # enable DEP
         'AllowIsolation': 'true',
         'SuppressStartupBanner': 'true',
+        'LargeAddressAware': 2, # enable 4GB mem with 32-bit executable on 64-bit Windows
       },
     },
     'msvs_disabled_warnings': [4351, 4355, 4800],


### PR DESCRIPTION
This gives 32-bit binaries the opportunity to use up to 4GB of memory when executed on 64-bit Windows.