### PR TITLE
Removing a readable listener now updates the readable state i.e.

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -3,7 +3,6 @@
 module.exports = Readable;
 Readable.ReadableState = ReadableState;
 
-const EE = require('events').EventEmitter;
 const Stream = require('stream');
 const Buffer = require('buffer').Buffer;
 const util = require('util');
@@ -97,7 +96,7 @@ function Readable(options) {
 // similar to how Writable.write() returns true if you should
 // write() some more.
 Readable.prototype.push = function(chunk, encoding) {
-  var state = this._readableState;
+  const state = this._readableState;
 
   if (!state.objectMode && typeof chunk === 'string') {
     encoding = encoding || state.defaultEncoding;
@@ -112,7 +111,7 @@ Readable.prototype.push = function(chunk, encoding) {
 
 // Unshift should *always* be something directly out of read()
 Readable.prototype.unshift = function(chunk) {
-  var state = this._readableState;
+  const state = this._readableState;
   return readableAddChunk(this, state, chunk, '', true);
 };
 
@@ -249,7 +248,7 @@ function howMuchToRead(n, state) {
 // you can override either this method, or the async _read(n) below.
 Readable.prototype.read = function(n) {
   debug('read', n);
-  var state = this._readableState;
+  const state = this._readableState;
   var nOrig = n;
 
   if (typeof n !== 'number' || n > 0)
@@ -394,7 +393,7 @@ function onEofChunk(stream, state) {
 // another read() call => stack overflow.  This way, it might trigger
 // a nextTick recursion warning, but that's not so bad.
 function emitReadable(stream) {
-  var state = stream._readableState;
+  const state = stream._readableState;
   state.needReadable = false;
   if (!state.emittedReadable) {
     debug('emitReadable', state.flowing);
@@ -451,7 +450,7 @@ Readable.prototype._read = function(n) {
 
 Readable.prototype.pipe = function(dest, pipeOpts) {
   var src = this;
-  var state = this._readableState;
+  const state = this._readableState;
 
   switch (state.pipesCount) {
     case 0:
@@ -582,7 +581,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
 
 function pipeOnDrain(src) {
   return function() {
-    var state = src._readableState;
+    const state = src._readableState;
     debug('pipeOnDrain', state.awaitDrain);
     if (state.awaitDrain)
       state.awaitDrain--;
@@ -595,7 +594,7 @@ function pipeOnDrain(src) {
 
 
 Readable.prototype.unpipe = function(dest) {
-  var state = this._readableState;
+  const state = this._readableState;
 
   // if we're not piping anywhere, then do nothing.
   if (state.pipesCount === 0)
@@ -661,7 +660,7 @@ Readable.prototype.on = function(ev, fn) {
   }
 
   if (ev === 'readable' && this.readable) {
-    var state = this._readableState;
+    const state = this._readableState;
     if (!state.readableListening) {
       state.readableListening = true;
       state.emittedReadable = false;
@@ -681,8 +680,8 @@ Readable.prototype.addListener = Readable.prototype.on;
 Readable.prototype.removeListener = function(type, listener) {
   Stream.prototype.removeListener.call(this, type, listener);
 
-  if (type === 'readable' && EE.listenerCount(this, type) === 0) {
-    var state = this._readableState;
+  if (type === 'readable' && this.listenerCount(type) === 0) {
+    const state = this._readableState;
     state.readableListening = false;
     state.emittedReadable = false;
     state.needReadable = false;
@@ -697,7 +696,7 @@ function nReadingNextTick(self) {
 // pause() and resume() are remnants of the legacy readable stream API
 // If the user uses them, then switch into old mode.
 Readable.prototype.resume = function() {
-  var state = this._readableState;
+  const state = this._readableState;
   if (!state.flowing) {
     debug('resume');
     state.flowing = true;
@@ -737,7 +736,7 @@ Readable.prototype.pause = function() {
 };
 
 function flow(stream) {
-  var state = stream._readableState;
+  const state = stream._readableState;
   debug('flow', state.flowing);
   if (state.flowing) {
     do {
@@ -750,7 +749,7 @@ function flow(stream) {
 // This is *not* part of the readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.wrap = function(stream) {
-  var state = this._readableState;
+  const state = this._readableState;
   var paused = false;
 
   var self = this;
@@ -883,7 +882,7 @@ function fromList(n, state) {
 }
 
 function endReadable(stream) {
-  var state = stream._readableState;
+  const state = stream._readableState;
 
   // If we get here before consuming all the bytes, then that is a
   // bug in node.  Should never happen.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -683,8 +683,6 @@ Readable.prototype.removeListener = function(type, listener) {
   if (type === 'readable' && this.listenerCount(type) === 0) {
     const state = this._readableState;
     state.readableListening = false;
-    state.emittedReadable = false;
-    state.needReadable = false;
   }
 };
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -669,7 +669,7 @@ Readable.prototype.on = function(ev, fn) {
       if (!state.reading) {
         process.nextTick(nReadingNextTick, this);
       } else if (state.length) {
-        emitReadable(this, state);
+        setImmediate(emitReadable.bind(null, this));
       }
     }
   }
@@ -677,6 +677,17 @@ Readable.prototype.on = function(ev, fn) {
   return res;
 };
 Readable.prototype.addListener = Readable.prototype.on;
+
+Readable.prototype.removeListener = function(type, listener) {
+  Stream.prototype.removeListener.call(this, type, listener);
+
+  if (type === 'readable' && EE.listenerCount(this, type) === 0) {
+    var state = this._readableState;
+    state.readableListening = false;
+    state.emittedReadable = false;
+    state.needReadable = false;
+  }
+};
 
 function nReadingNextTick(self) {
   debug('readable nexttick read 0');

--- a/test/parallel/test-stream-readable-removeListener.js
+++ b/test/parallel/test-stream-readable-removeListener.js
@@ -1,20 +1,19 @@
 'use strict';
-var assert = require('assert');
-var EE = require('events').EventEmitter;
-var Readable = require('stream').Readable;
+const assert = require('assert');
+const Readable = require('stream').Readable;
 
-var buf = new Buffer(65536);
+const buf = new Buffer(65536);
 buf.fill(0);
 
 var packetsToPush = 10;
-var toUnshift = 16 * 1024;
+const toUnshift = 16 * 1024;
 
 Readable.prototype._read = function() {
   var chunk = --packetsToPush > 0 ? buf.slice() : null;
   setImmediate(this.push.bind(this, chunk));
 };
 
-var rStream = new Readable();
+const rStream = new Readable();
 
 var first = true;
 rStream.on('readable', function onReadable() {
@@ -22,7 +21,7 @@ rStream.on('readable', function onReadable() {
   if (first) {
     first = false;
     rStream.removeListener('readable', onReadable);
-    assert.equal(EE.listenerCount(rStream, 'readable'), 0);
+    assert.equal(this.listenerCount('readable'), 0);
     rStream.unshift(buf.slice(0, toUnshift));
     rStream.on('readable', onReadable);
   }

--- a/test/parallel/test-stream-readable-removeListener.js
+++ b/test/parallel/test-stream-readable-removeListener.js
@@ -1,0 +1,35 @@
+'use strict';
+var assert = require('assert');
+var EE = require('events').EventEmitter;
+var Readable = require('stream').Readable;
+
+var buf = new Buffer(65536);
+buf.fill(0);
+
+var packetsToPush = 10;
+var toUnshift = 16 * 1024;
+
+Readable.prototype._read = function() {
+  var chunk = --packetsToPush > 0 ? buf.slice() : null;
+  setImmediate(this.push.bind(this, chunk));
+};
+
+var rStream = new Readable();
+
+var first = true;
+rStream.on('readable', function onReadable() {
+  var data = rStream.read();
+  if (first) {
+    first = false;
+    rStream.removeListener('readable', onReadable);
+    assert.equal(EE.listenerCount(rStream, 'readable'), 0);
+    rStream.unshift(buf.slice(0, toUnshift));
+    rStream.on('readable', onReadable);
+  }
+});
+
+process.on('exit', function() {
+  assert.equal(packetsToPush, 0);
+});
+
+rStream.read(0);


### PR DESCRIPTION
_Replicates changes made in joyent/node's PR: https://github.com/joyent/node/pull/25886_

readableListening, needReadable and emittedReadable are set to false.
Then, if a readable listener is added at a later time, the stream will
know none are attached and will take proper action to get the stream
going back again.

Fixes joyent/node#7678
