### PR TITLE
http: interpret strings as utf8

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -136,7 +136,10 @@ struct StringPtr {
 
   Local<String> ToString(Environment* env) const {
     if (str_)
-      return OneByteString(env->isolate(), str_, size_);
+      return String::NewFromUtf8(env->isolate(),
+                                 str_,
+                                 String::kNormalString,
+                                 size_);
     else
       return String::Empty(env->isolate());
   }

--- a/test/parallel/test-http-utf-incoming.js
+++ b/test/parallel/test-http-utf-incoming.js
@@ -1,0 +1,28 @@
+
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+
+var http = require('http');
+
+var req;
+
+process.on('exit', function() {
+  assert.equal(req.url, '/?тест');
+  assert.equal(req.headers['x-test'], 'тест');
+});
+
+
+http.createServer(function(req_, res) {
+  req = req_;
+  res.end();
+  this.close();
+}).listen(common.PORT, function() {
+  http.request({
+    port: common.PORT,
+    path: new Buffer('/?тест').toString('binary'),
+    headers: {
+      'x-test': new Buffer('тест').toString('binary')
+    }
+   }).end();
+});


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/1693

At some point `http` began to interpret all strings as `binary`. This causes various incompatibilities in both incoming and outgoing messages. Incoming message seem more problematic, since both url and header values could be corrupted and there is no good way to tell whether they are.

It's probably right that clients should properly encode urls and headers, but some don't and this used to work, so a lot of code is broken by this change.

R=@bnoordhuis 