### PR TITLE
deps: v8 build on FreeBSD 10.2

### DIFF
--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -69,6 +69,7 @@ Kang-Hao (Kenny) Lu <kennyluck@csail.mit.edu>
 Luis Reis <luis.m.reis@gmail.com>
 Luke Zarko <lukezarko@gmail.com>
 Maciej Małecki <me@mmalecki.com>
+Marcin Cieślak <saper@marcincieslak.com>
 Mathias Bynens <mathias@qiwi.be>
 Matt Hanselman <mjhanselman@gmail.com>
 Matthew Sporleder <msporleder@gmail.com>

--- a/deps/v8/src/runtime/runtime-i18n.cc
+++ b/deps/v8/src/runtime/runtime-i18n.cc
@@ -627,7 +627,7 @@ RUNTIME_FUNCTION(Runtime_CreateBreakIterator) {
 
   local_object->SetInternalField(0, reinterpret_cast<Smi*>(break_iterator));
   // Make sure that the pointer to adopted text is NULL.
-  local_object->SetInternalField(1, reinterpret_cast<Smi*>(NULL));
+  local_object->SetInternalField(1, static_cast<Smi*>(nullptr));
 
   Factory* factory = isolate->factory();
   Handle<String> key = factory->NewStringFromStaticChars("breakIterator");

--- a/deps/v8/test/cctest/test-heap.cc
+++ b/deps/v8/test/cctest/test-heap.cc
@@ -126,7 +126,7 @@ TEST(HandleNull) {
   Isolate* isolate = CcTest::i_isolate();
   HandleScope outer_scope(isolate);
   LocalContext context;
-  Handle<Object> n(reinterpret_cast<Object*>(NULL), isolate);
+  Handle<Object> n(static_cast<Object*>(nullptr), isolate);
   CHECK(!n.is_null());
 }
 


### PR DESCRIPTION
Building v3.2.0 with clang 3.4.1 get `error: reinterpret_cast from 'nullptr_t' to 'v8::internal::Smi *' is not allowed`. Fix proposed matches approach by @indutny to fix issue #324 in commit https://github.com/indutny/io.js/commit/d9977e8f1ff6ac64bfc7e0c0907f27ec020eff80