### PR TITLE
buffer: use strict equality comparison

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -116,7 +116,7 @@ function fromObject(obj) {
     return b;
   }
 
-  if (obj == null) {
+  if (obj === null) {
     throw new TypeError('must start with number, buffer, array or string');
   }
 


### PR DESCRIPTION
There is no type-conversion to be done because both parameters are already the same type. 
Therefore, the === operator should be used for better performance.