### PR TITLE
querystring: add a break for missing switch case

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -30,6 +30,7 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
           case charCode('+'):
             if (decodeSpaces) c = charCode(' ');
             // falls through
+            break;
           default:
             out[outIndex++] = c;
             break;


### PR DESCRIPTION
a break is missing for a charCode case.
add a break code for missing break segment