### PR TITLE
punycode: use strict identity operator

### DIFF
--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -2,11 +2,11 @@
 ;(function(root) {
 
 	/** Detect free variables */
-	var freeExports = typeof exports == 'object' && exports &&
+	var freeExports = typeof exports === 'object' && exports &&
 		!exports.nodeType && exports;
-	var freeModule = typeof module == 'object' && module &&
+	var freeModule = typeof module === 'object' && module &&
 		!module.nodeType && module;
-	var freeGlobal = typeof global == 'object' && global;
+	var freeGlobal = typeof global === 'object' && global;
 	if (
 		freeGlobal.global === freeGlobal ||
 		freeGlobal.window === freeGlobal ||
@@ -134,7 +134,7 @@
 			if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
 				// high surrogate, and there is a next character
 				extra = string.charCodeAt(counter++);
-				if ((extra & 0xFC00) == 0xDC00) { // low surrogate
+				if ((extra & 0xFC00) === 0xDC00) { // low surrogate
 					output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
 				} else {
 					// unmatched surrogate; only append this code unit, in case the next
@@ -410,7 +410,7 @@
 					error('overflow');
 				}
 
-				if (currentValue == n) {
+				if (currentValue === n) {
 					// Represent delta as a generalized variable-length integer
 					for (q = delta, k = base; /* no condition */; k += base) {
 						t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
@@ -508,15 +508,15 @@
 	// Some AMD build optimizers, like r.js, check for specific condition patterns
 	// like the following:
 	if (
-		typeof define == 'function' &&
-		typeof define.amd == 'object' &&
+		typeof define === 'function' &&
+		typeof define.amd === 'object' &&
 		define.amd
 	) {
 		define('punycode', function() {
 			return punycode;
 		});
 	} else if (freeExports && freeModule) {
-		if (module.exports == freeExports) { // in Node.js or RingoJS v0.8.0+
+		if (module.exports === freeExports) { // in Node.js or RingoJS v0.8.0+
 			freeModule.exports = punycode;
 		} else { // in Narwhal or RingoJS v0.7.0-
 			for (key in punycode) {


### PR DESCRIPTION
There is no type-conversion to be done because both parameters are already the same type. 
Therefore, the === operator should be used for better performance.