### PR TITLE
src: only set v8 flags if argc > 1

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3688,7 +3688,7 @@ void Init(int* argc,
 #endif
   // The const_cast doesn't violate conceptual const-ness.  V8 doesn't modify
   // the argv array or the elements it points to.
-  if (v8_argc != 0)
+  if (v8_argc > 1)
     V8::SetFlagsFromCommandLine(&v8_argc, const_cast<char**>(v8_argv), true);
 
   // Anything that's still in v8_argv is not a V8 or a node option.


### PR DESCRIPTION
ParseArgs sets the first element of v8_args to argv[0], so v8_argc will
always be at least 1. This change only calls
V8::SetFlagsFromCommandLine if v8_argc > 1, leading to an additional
startup improvement of ~5% if no v8 flags are passed.

![screen shot 2015-09-02 at 2 56 13 am](https://cloud.githubusercontent.com/assets/677994/9625931/601b6338-511f-11e5-83c6-751a6f609109.png)
