### PR TITLE
test: TapReporter fixes

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -263,6 +263,10 @@ class TapProgressIndicator(SimpleProgressIndicator):
       if FLAKY in output.test.outcomes and self.flaky_tests_mode == DONTCARE:
         status_line = status_line + ' # TODO : Fix flaky test'
       logger.info(status_line)
+
+      if output.HasTimedOut():
+        logger.info('# TIMEOUT')
+
       for l in output.output.stderr.splitlines():
         logger.info('#' + l)
       for l in output.output.stdout.splitlines():


### PR DESCRIPTION
test: report timeout in TapReporter

Before: https://ci.nodejs.org/job/node-test-commit-arm/433/nodes=pi1-raspbian-wheezy-2_of_2/tapTestReport/test.tap-336/