### PR TITLE
test: mark eval_messages as flaky

### DIFF
--- a/test/message/message.status
+++ b/test/message/message.status
@@ -9,6 +9,7 @@ prefix message
 [$system==win32]
 
 [$system==linux]
+eval_messages                      : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
This test has failed recently during a PR test in Jenkins, for
reasons seemingly not related to the change in the PR.