### PR TITLE
doc,test: enable recursive file watching in Windows

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -625,9 +625,9 @@ the event.
 The `fs.watch` API is not 100% consistent across platforms, and is
 unavailable in some situations.
 
-The recursive option is currently supported on OS X. Only FSEvents supports this
-type of file watching so it is unlikely any additional platforms will be added
-soon.
+The recursive option is currently supported on OS X and Windows. Only FSEvents
+ supports this type of file watching so it is unlikely any additional platforms
+ will be added soon.
 
 #### Availability
 

--- a/test/sequential/test-fs-watch-recursive.js
+++ b/test/sequential/test-fs-watch-recursive.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 
-if (process.platform === 'darwin') {
+if (process.platform === 'darwin' || common.isWindows) {
   var watchSeenOne = 0;
 
   var testDir = common.tmpDir;
@@ -46,4 +46,6 @@ if (process.platform === 'darwin') {
   setTimeout(function() {
     fs.writeFileSync(filepathOne, 'world');
   }, 10);
+} else {
+  console.log('1..0 # Skipped: recursive option is darwin/windows specific');
 }


### PR DESCRIPTION
Recursive file watching is supported by libuv since 1.7.0. Refer
https://github.com/nodejs/node/blob/master/deps/uv/ChangeLog#L126. This
patch notes that in the docs and enables testing this feature. It also
adds proper TAP plugin parsable message for other platforms.

CI Run: https://ci.nodejs.org/job/node-test-pull-request/233/