### PR TITLE
buffer: add a break code for default switch segment

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -192,6 +192,7 @@ Buffer.isEncoding = function(encoding) {
           return false;
         encoding = ('' + encoding).toLowerCase();
         loweredCase = true;
+        break;
     }
   }
 };
@@ -278,6 +279,7 @@ function byteLength(string, encoding) {
 
         encoding = ('' + encoding).toLowerCase();
         loweredCase = true;
+        break;
     }
   }
 }
@@ -344,6 +346,7 @@ function slowToString(encoding, start, end) {
           throw new TypeError('Unknown encoding: ' + encoding);
         encoding = (encoding + '').toLowerCase();
         loweredCase = true;
+        break;
     }
   }
 }
@@ -532,6 +535,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
           throw new TypeError('Unknown encoding: ' + encoding);
         encoding = ('' + encoding).toLowerCase();
         loweredCase = true;
+        break;
     }
   }
 };


### PR DESCRIPTION
There are some missing break code segments in default cases.
If more cases are added below the default case, there might be a problem in the future.

To solve this problem, Add a break code for default switch segment