### PR TITLE
benchmark: use a bitwise right shift for faster division

### DIFF
--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -80,7 +80,7 @@ function client() {
       chunk.fill('x');
       break;
     case 'utf':
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = new Array(len >> 1 + 1).join('ü');
       break;
     case 'asc':
       chunk = new Array(len + 1).join('x');


### PR DESCRIPTION
Division in Javascript is known to be very slow
use a Bitwise right shift for faster division for better performance