### PR TITLE
test: mark test-repl-persistent-history as flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -6,6 +6,7 @@ prefix sequential
 
 [true] # This section applies to all platforms
 test-child-process-fork-getconnections          : PASS,FLAKY
+test-repl-persistent-history                    : PASS,FLAKY
 
 [$system==win32]
 


### PR DESCRIPTION
This test is already being investigated, but until a solution is found it should be marked flaky. One issue mentions failures in OSX, so marking flaky in all platforms.

Ref: https://github.com/nodejs/node/issues/2319
Ref: https://github.com/nodejs/node/pull/2356

Recent failure:
- [`centos6-64`](https://ci.nodejs.org/job/node-test-commit-linux/422/nodes=centos6-64/tapTestReport/test.tap-900/)

cc @nodejs/build 