### PR TITLE
test: mark test-net-server-max-connections as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,6 +21,7 @@ test-child-process-exit-code      : PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 test-debug-signal-cluster         : PASS,FLAKY
+test-net-server-max-connections   : PASS,FLAKY
 
 [$system==freebsd]
 test-net-socket-local-address     : PASS,FLAKY


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/2663

cc @nodejs/build 
cc @thefourtheye (failed on https://github.com/nodejs/node/pull/2649)