### PR TITLE
src: increment NODE_MODULE_VERSION to 46

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -40,6 +40,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 45  /* io.js v3.0.0 */
+#define NODE_MODULE_VERSION 46  /* v4.0.0 */
 
 #endif  /* SRC_NODE_VERSION_H_ */


### PR DESCRIPTION
Trying to get this into `vee-eight-4.5` before the PR to master.

[V8 4.5 C++ API changes](https://docs.google.com/document/d/1g8JFi8T_oAE_7uAri7Njtig7fKaPDfotU6huOa1alds/edit?hl=en&forcehl=1) that warrant this:
* Remove deprecated v8::Object::TurnOnAccessCheck API
* Remove obsolete options in ScriptCompiler::CompileOptions
* Remove v8::Private

R=@rvagg, @nodejs/v8 