### PR TITLE
test: marking recent test failures as flaky

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,53 +331,53 @@ information about the governance of the Node.js project, see
 
 ### TSC (Technical Steering Committee)
 
-* **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt; ([@bnoordhuis](https://github.com/bnoordhuis))
-* **Bert Belder** &lt;bertbelder@gmail.com&gt; ([@piscisaureus](https://github.com/piscisaureus))
-* **Fedor Indutny** &lt;fedor.indutny@gmail.com&gt; ([@indutny](https://github.com/indutny))
-* **Trevor Norris** &lt;trev.norris@gmail.com&gt; ([@trevnorris](https://github.com/trevnorris))
-* **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt; ([@chrisdickinson](https://github.com/chrisdickinson))
-* **Rod Vagg** &lt;rod@vagg.org&gt; ([@rvagg](https://github.com/rvagg))
-* **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt; ([@fishrock123](https://github.com/fishrock123))
-* **Colin Ihrig** &lt;cjihrig@gmail.com&gt; ([@cjihrig](https://github.com/cjihrig))
-* **Alexis Campailla** &lt;orangemocha@nodejs.org&gt; ([@orangemocha](https://github.com/orangemocha))
-* **Julien Gilli** &lt;jgilli@nodejs.org&gt; ([@misterdjules](https://github.com/misterdjules))
-* **James M Snell** &lt;jasnell@gmail.com&gt; ([@jasnell](https://github.com/jasnell))
-* **Steven R Loomis** &lt;srloomis@us.ibm.com&gt; ([@srl295](https://github.com/srl295))
-* **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt; ([@mhdawson](https://github.com/mhdawson))
-* **Shigeki Ohtsu** &lt;ohtsu@iij.ad.jp&gt; ([@shigeki](https://github.com/shigeki))
-* **Brian White** &lt;mscdex@mscdex.net&gt; ([@mscdex](https://github.com/mscdex))
+* [bnoordhuis](https://github.com/bnoordhuis) - **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
+* [chrisdickinson](https://github.com/chrisdickinson) - **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt;
+* [cjihrig](https://github.com/cjihrig) - **Colin Ihrig** &lt;cjihrig@gmail.com&gt;
+* [fishrock123](https://github.com/fishrock123) - **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
+* [indutny](https://github.com/indutny) - **Fedor Indutny** &lt;fedor.indutny@gmail.com&gt;
+* [jasnell](https://github.com/jasnell) - **James M Snell** &lt;jasnell@gmail.com&gt;
+* [mhdawson](https://github.com/mhdawson) - **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt;
+* [misterdjules](https://github.com/misterdjules) - **Julien Gilli** &lt;jgilli@nodejs.org&gt;
+* [mscdex](https://github.com/mscdex) - **Brian White** &lt;mscdex@mscdex.net&gt;
+* [orangemocha](https://github.com/orangemocha) - **Alexis Campailla** &lt;orangemocha@nodejs.org&gt;
+* [piscisaureus](https://github.com/piscisaureus) - **Bert Belder** &lt;bertbelder@gmail.com&gt;
+* [rvagg](https://github.com/rvagg) - **Rod Vagg** &lt;rod@vagg.org&gt;
+* [shigeki](https://github.com/shigeki) - **Shigeki Ohtsu** &lt;ohtsu@iij.ad.jp&gt;
+* [srl295](https://github.com/srl295) - **Steven R Loomis** &lt;srloomis@us.ibm.com&gt;
+* [trevnorris](https://github.com/trevnorris) - **Trevor Norris** &lt;trev.norris@gmail.com&gt;
 
 ### Collaborators
 
-* **Isaac Z. Schlueter** &lt;i@izs.me&gt; ([@isaacs](https://github.com/isaacs))
-* **Mikeal Rogers** &lt;mikeal.rogers@gmail.com&gt; ([@mikeal](https://github.com/mikeal))
-* **Thorsten Lorenz** &lt;thlorenz@gmx.de&gt; ([@thlorenz](https://github.com/thlorenz))
-* **Stephen Belanger** &lt;admin@stephenbelanger.com&gt; ([@qard](https://github.com/qard))
-* **Evan Lucas** &lt;evanlucas@me.com&gt; ([@evanlucas](https://github.com/evanlucas))
-* **Brendan Ashworth** &lt;brendan.ashworth@me.com&gt; ([@brendanashworth](https://github.com/brendanashworth))
-* **Vladimir Kurchatkin** &lt;vladimir.kurchatkin@gmail.com&gt; ([@vkurchatkin](https://github.com/vkurchatkin))
-* **Nikolai Vavilov** &lt;vvnicholas@gmail.com&gt; ([@seishun](https://github.com/seishun))
-* **Nicu Micleușanu** &lt;micnic90@gmail.com&gt; ([@micnic](https://github.com/micnic))
-* **Aleksey Smolenchuk** &lt;lxe@lxe.co&gt; ([@lxe](https://github.com/lxe))
-* **Sam Roberts** &lt;vieuxtech@gmail.com&gt; ([@sam-github](https://github.com/sam-github))
-* **Wyatt Preul** &lt;wpreul@gmail.com&gt; ([@geek](https://github.com/geek))
-* **Christian Tellnes** &lt;christian@tellnes.no&gt; ([@tellnes](https://github.com/tellnes))
-* **Robert Kowalski** &lt;rok@kowalski.gd&gt; ([@robertkowalski](https://github.com/robertkowalski))
-* **Julian Duque** &lt;julianduquej@gmail.com&gt; ([@julianduque](https://github.com/julianduque))
-* **Johan Bergström** &lt;bugs@bergstroem.nu&gt; ([@jbergstroem](https://github.com/jbergstroem))
-* **Roman Reiss** &lt;me@silverwind.io&gt; ([@silverwind](https://github.com/silverwind))
-* **Petka Antonov** &lt;petka_antonov@hotmail.com&gt; ([@petkaantonov](https://github.com/petkaantonov))
-* **Yosuke Furukawa** &lt;yosuke.furukawa@gmail.com&gt; ([@yosuke-furukawa](https://github.com/yosuke-furukawa))
-* **Alex Kocharin** &lt;alex@kocharin.ru&gt; ([@rlidwka](https://github.com/rlidwka))
-* **Christopher Monsanto** &lt;chris@monsan.to&gt; ([@monsanto](https://github.com/monsanto))
-* **Ali Ijaz Sheikh** &lt;ofrobots@google.com&gt; ([@ofrobots](https://github.com/ofrobots))
-* **Oleg Elifantiev** &lt;oleg@elifantiev.ru&gt; ([@Olegas](https://github.com/Olegas))
-* **Domenic Denicola** &lt;d@domenic.me&gt; ([@domenic](https://github.com/domenic))
-* **Rich Trott** &lt;rtrott@gmail.com&gt; ([@Trott](https://github.com/Trott))
-* **Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt; ([@ChALkeR](https://github.com/ChALkeR))
-* **Sakthipriyan Vairamani** &lt;thechargingvolcano@gmail.com&gt; ([@thefourtheye](https://github.com/thefourtheye))
-* **Michaël Zasso** &lt;mic.besace@gmail.com&gt; ([@targos](https://github.com/targos))
-* **João Reis** &lt;reis@janeasystems.com&gt; ([@joaocgreis](https://github.com/joaocgreis))
+* [brendanashworth](https://github.com/brendanashworth) - **Brendan Ashworth** &lt;brendan.ashworth@me.com&gt;
+* [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt;
+* [domenic](https://github.com/domenic) - **Domenic Denicola** &lt;d@domenic.me&gt;
+* [evanlucas](https://github.com/evanlucas) - **Evan Lucas** &lt;evanlucas@me.com&gt;
+* [geek](https://github.com/geek) - **Wyatt Preul** &lt;wpreul@gmail.com&gt;
+* [isaacs](https://github.com/isaacs) - **Isaac Z. Schlueter** &lt;i@izs.me&gt;
+* [jbergstroem](https://github.com/jbergstroem) - **Johan Bergström** &lt;bugs@bergstroem.nu&gt;
+* [joaocgreis](https://github.com/joaocgreis) - **João Reis** &lt;reis@janeasystems.com&gt;
+* [julianduque](https://github.com/julianduque) - **Julian Duque** &lt;julianduquej@gmail.com&gt;
+* [lxe](https://github.com/lxe) - **Aleksey Smolenchuk** &lt;lxe@lxe.co&gt;
+* [micnic](https://github.com/micnic) - **Nicu Micleușanu** &lt;micnic90@gmail.com&gt;
+* [mikeal](https://github.com/mikeal) - **Mikeal Rogers** &lt;mikeal.rogers@gmail.com&gt;
+* [monsanto](https://github.com/monsanto) - **Christopher Monsanto** &lt;chris@monsan.to&gt;
+* [ofrobots](https://github.com/ofrobots) - **Ali Ijaz Sheikh** &lt;ofrobots@google.com&gt;
+* [Olegas](https://github.com/Olegas) - **Oleg Elifantiev** &lt;oleg@elifantiev.ru&gt;
+* [petkaantonov](https://github.com/petkaantonov) - **Petka Antonov** &lt;petka_antonov@hotmail.com&gt;
+* [qard](https://github.com/qard) - **Stephen Belanger** &lt;admin@stephenbelanger.com&gt;
+* [rlidwka](https://github.com/rlidwka) - **Alex Kocharin** &lt;alex@kocharin.ru&gt;
+* [robertkowalski](https://github.com/robertkowalski) - **Robert Kowalski** &lt;rok@kowalski.gd&gt;
+* [sam-github](https://github.com/sam-github) - **Sam Roberts** &lt;vieuxtech@gmail.com&gt;
+* [seishun](https://github.com/seishun) - **Nikolai Vavilov** &lt;vvnicholas@gmail.com&gt;
+* [silverwind](https://github.com/silverwind) - **Roman Reiss** &lt;me@silverwind.io&gt;
+* [targos](https://github.com/targos) - **Michaël Zasso** &lt;mic.besace@gmail.com&gt;
+* [tellnes](https://github.com/tellnes) - **Christian Tellnes** &lt;christian@tellnes.no&gt;
+* [thefourtheye](https://github.com/thefourtheye) - **Sakthipriyan Vairamani** &lt;thechargingvolcano@gmail.com&gt;
+* [thlorenz](https://github.com/thlorenz) - **Thorsten Lorenz** &lt;thlorenz@gmx.de&gt;
+* [Trott](https://github.com/Trott) - **Rich Trott** &lt;rtrott@gmail.com&gt;
+* [vkurchatkin](https://github.com/vkurchatkin) - **Vladimir Kurchatkin** &lt;vladimir.kurchatkin@gmail.com&gt;
+* [yosuke-furukawa](https://github.com/yosuke-furukawa) - **Yosuke Furukawa** &lt;yosuke.furukawa@gmail.com&gt;
 
 Collaborators & TSC members follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -426,10 +426,12 @@ exit, the master may choose not to respawn a worker based on this value.
     // kill worker
     worker.kill();
 
-### worker.send(message[, sendHandle])
+### worker.send(message[, sendHandle][, callback])
 
 * `message` {Object}
 * `sendHandle` {Handle object}
+* `callback` {Function}
+* Return: Boolean
 
 Send a message to a worker or master, optionally with a handle.
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -350,10 +350,14 @@ function slowToString(encoding, start, end) {
 
 
 Buffer.prototype.toString = function() {
-  const length = this.length | 0;
-  if (arguments.length === 0)
-    return this.utf8Slice(0, length);
-  return slowToString.apply(this, arguments);
+  if (arguments.length === 0) {
+    var result = this.utf8Slice(0, this.length);
+  } else {
+    var result = slowToString.apply(this, arguments);
+  }
+  if (result === undefined)
+    throw new Error('toString failed');
+  return result;
 };
 
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -48,16 +48,12 @@ exports._forkChild = function(fd) {
   var p = new Pipe(true);
   p.open(fd);
   p.unref();
-  setupChannel(process, p);
-
-  var refs = 0;
+  const control = setupChannel(process, p);
   process.on('newListener', function(name) {
-    if (name !== 'message' && name !== 'disconnect') return;
-    if (++refs === 1) p.ref();
+    if (name === 'message' || name === 'disconnect') control.ref();
   });
   process.on('removeListener', function(name) {
-    if (name !== 'message' && name !== 'disconnect') return;
-    if (--refs === 0) p.unref();
+    if (name === 'message' || name === 'disconnect') control.unref();
   });
 };
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -397,6 +397,25 @@ function setupChannel(target, channel) {
   target._channel = channel;
   target._handleQueue = null;
 
+  const control = new class extends EventEmitter {
+    constructor() {
+      super();
+      this.channel = channel;
+      this.refs = 0;
+    }
+    ref() {
+      if (++this.refs === 1) {
+        this.channel.ref();
+      }
+    }
+    unref() {
+      if (--this.refs === 0) {
+        this.channel.unref();
+        this.emit('unref');
+      }
+    }
+  };
+
   var decoder = new StringDecoder('utf8');
   var jsonBuffer = '';
   channel.buffering = false;
@@ -446,7 +465,7 @@ function setupChannel(target, channel) {
       target._handleQueue = null;
 
       queue.forEach(function(args) {
-        target._send(args.message, args.handle, false);
+        target._send(args.message, args.handle, false, args.callback);
       });
 
       // Process a pending disconnect (if any).
@@ -478,14 +497,24 @@ function setupChannel(target, channel) {
     });
   });
 
-  target.send = function(message, handle) {
-    if (!this.connected)
-      this.emit('error', new Error('channel closed'));
-    else
-      this._send(message, handle, false);
+  target.send = function(message, handle, callback) {
+    if (typeof handle === 'function') {
+      callback = handle;
+      handle = undefined;
+    }
+    if (this.connected) {
+      this._send(message, handle, false, callback);
+      return;
+    }
+    const ex = new Error('channel closed');
+    if (typeof callback === 'function') {
+      process.nextTick(callback, ex);
+    } else {
+      this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+    }
   };
 
-  target._send = function(message, handle, swallowErrors) {
+  target._send = function(message, handle, swallowErrors, callback) {
     assert(this.connected || this._channel);
 
     if (message === undefined)
@@ -516,7 +545,11 @@ function setupChannel(target, channel) {
 
       // Queue-up message and handle if we haven't received ACK yet.
       if (this._handleQueue) {
-        this._handleQueue.push({ message: message.msg, handle: handle });
+        this._handleQueue.push({
+          callback: callback,
+          handle: handle,
+          message: message.msg,
+        });
         return;
       }
 
@@ -538,24 +571,43 @@ function setupChannel(target, channel) {
     } else if (this._handleQueue &&
                !(message && message.cmd === 'NODE_HANDLE_ACK')) {
       // Queue request anyway to avoid out-of-order messages.
-      this._handleQueue.push({ message: message, handle: null });
+      this._handleQueue.push({
+        callback: callback,
+        handle: null,
+        message: message,
+      });
       return;
     }
 
     var req = new WriteWrap();
-    req.oncomplete = nop;
+    req.async = false;
+
     var string = JSON.stringify(message) + '\n';
     var err = channel.writeUtf8String(req, string, handle);
 
-    if (err) {
-      if (!swallowErrors)
-        this.emit('error', errnoException(err, 'write'));
-    } else if (handle && !this._handleQueue) {
-      this._handleQueue = [];
-    }
-
-    if (obj && obj.postSend) {
-      req.oncomplete = obj.postSend.bind(null, handle);
+    if (err === 0) {
+      if (handle && !this._handleQueue)
+        this._handleQueue = [];
+      req.oncomplete = function() {
+        if (this.async === true)
+          control.unref();
+        if (obj && obj.postSend)
+          obj.postSend(handle);
+        if (typeof callback === 'function')
+          callback(null);
+      };
+      if (req.async === true) {
+        control.ref();
+      } else {
+        process.nextTick(function() { req.oncomplete(); });
+      }
+    } else if (!swallowErrors) {
+      const ex = errnoException(err, 'write');
+      if (typeof callback === 'function') {
+        process.nextTick(callback, ex);
+      } else {
+        this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+      }
     }
 
     /* If the master is > 2 read() calls behind, please stop sending. */
@@ -616,6 +668,7 @@ function setupChannel(target, channel) {
   };
 
   channel.readStart();
+  return control;
 }
 
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1024,6 +1024,10 @@ void Initialize(Handle<Object> target,
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxLength"),
               Integer::NewFromUnsigned(env->isolate(), kMaxLength)).FromJust();
+
+  target->Set(env->context(),
+              FIXED_ONE_BYTE_STRING(env->isolate(), "kStringMaxLength"),
+              Integer::New(env->isolate(), String::kMaxLength)).FromJust();
 }
 
 

--- a/test/message/message.status
+++ b/test/message/message.status
@@ -9,6 +9,7 @@ prefix message
 [$system==win32]
 
 [$system==linux]
+eval_messages                      : PASS,FLAKY
 
 [$system==macos]
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,17 +5,38 @@ prefix parallel
 # sample-test                       : PASS,FLAKY
 
 [true] # This section applies to all platforms
-
-[$system==win32]
+test-child-process-fork-net2      : PASS,FLAKY
+test-tick-processor               : PASS,FLAKY
 test-tls-ticket-cluster           : PASS,FLAKY
 
+[$system==win32]
+test-process-config               : PASS,FLAKY
+test-repl-tab-complete            : PASS,FLAKY
+
 [$system==linux]
-test-cluster-worker-forced-exit   : PASS,FLAKY
-test-http-client-timeout-event    : PASS,FLAKY
-test-tick-processor               : PASS,FLAKY
-test-tls-no-sslv3                 : PASS,FLAKY
 test-child-process-buffering      : PASS,FLAKY
 test-child-process-exit-code      : PASS,FLAKY
+test-child-process-fork-dgram     : PASS,FLAKY
+test-cluster-dgram-1              : PASS,FLAKY
+test-cluster-dgram-2              : PASS,FLAKY
+test-cluster-disconnect           : PASS,FLAKY
+test-cluster-worker-forced-exit   : PASS,FLAKY
+test-dgram-bind-default-address   : PASS,FLAKY
+test-dgram-bind-shared-ports      : PASS,FLAKY
+test-dgram-empty-packet           : PASS,FLAKY
+test-dgram-exclusive-implicit-bind : PASS,FLAKY
+test-dgram-implicit-bind          : PASS,FLAKY
+test-dgram-multicast-setTTL       : PASS,FLAKY
+test-dgram-pingpong               : PASS,FLAKY
+test-dgram-udp4                   : PASS,FLAKY
+test-http-client-timeout-event    : PASS,FLAKY
+test-http-end-throw-socket-handling : PASS,FLAKY
+test-http-set-timeout             : PASS,FLAKY
+test-net-listen-shared-ports      : PASS,FLAKY
+test-net-server-max-connections   : PASS,FLAKY
+test-stringbytes-external         : PASS,FLAKY
+test-tls-cipher-list              : PASS,FLAKY
+test-tls-no-sslv3                 : PASS,FLAKY
 
 [$system==macos]
 

--- a/test/parallel/test-child-process-send-cb.js
+++ b/test/parallel/test-child-process-send-cb.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fork = require('child_process').fork;
+
+if (process.argv[2] === 'child') {
+  process.send('ok', common.mustCall(function(err) {
+    assert.strictEqual(err, null);
+  }));
+} else {
+  const child = fork(process.argv[1], ['child']);
+  child.on('message', common.mustCall(function(message) {
+    assert.strictEqual(message, 'ok');
+  }));
+  child.on('exit', common.mustCall(function(exitCode, signalCode) {
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(signalCode, null);
+  }));
+}

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -107,3 +107,69 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
   assert.equal(a, b);
   assert.equal(b, c);
 })();
+
+// v8 fails silently if string length > v8::String::kMaxLength
+(function() {
+  // v8::String::kMaxLength defined in v8.h
+  const kStringMaxLength = process.binding('buffer').kStringMaxLength;
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString();
+  }, /toString failed|Buffer allocation failed/);
+
+  try {
+    new Buffer(kStringMaxLength * 4);
+  } catch(e) {
+    assert.equal(e.message, 'Buffer allocation failed - process out of memory');
+    console.log(
+        '1..0 # Skipped: intensive toString tests due to memory confinements');
+    return;
+  }
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('ascii');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('utf8');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength * 2 + 2).toString('utf16le');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('binary');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('base64');
+  }, /toString failed/);
+
+  assert.throws(function() {
+    new Buffer(kStringMaxLength + 1).toString('hex');
+  }, /toString failed/);
+
+  var maxString = new Buffer(kStringMaxLength).toString();
+  assert.equal(maxString.length, kStringMaxLength);
+  // Free the memory early instead of at the end of the next assignment
+  maxString = undefined;
+
+  maxString = new Buffer(kStringMaxLength).toString('binary');
+  assert.equal(maxString.length, kStringMaxLength);
+  maxString = undefined;
+
+  maxString =
+      new Buffer(kStringMaxLength + 1).toString('binary', 1);
+  assert.equal(maxString.length, kStringMaxLength);
+  maxString = undefined;
+
+  maxString =
+      new Buffer(kStringMaxLength + 1).toString('binary', 0, kStringMaxLength);
+  assert.equal(maxString.length, kStringMaxLength);
+  maxString = undefined;
+
+  maxString = new Buffer(kStringMaxLength + 2).toString('utf16le');
+  assert.equal(maxString.length, (kStringMaxLength + 2) / 2);
+  maxString = undefined;
+})();

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -12,10 +12,14 @@ test-repl-persistent-history                    : PASS,FLAKY
 
 [$system==linux]
 test-vm-syntax-error-stderr                     : PASS,FLAKY
+test-sigint-infinite-loop                       : PASS,FLAKY
+test-child-process-emfile                       : PASS,FLAKY
+test-stdout-stderr-reading                      : PASS,FLAKY
 
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS
+test-regress-GH-877                             : PASS,FLAKY
 
 [$system==freebsd]
 


### PR DESCRIPTION
These tests failed in either master builds, unrelated changes (like marking tests as flaky) or are properly discussed in the respective pull requests.

- `test-tick-processor`: https://github.com/nodejs/node/pull/2376#issuecomment-137402700
- `test-regress-GH-877`: https://ci.nodejs.org/job/node-test-commit-other/411/nodes=smartos14-32/tapTestReport/test.tap-894/
- `test-net-listen-shared-ports`: https://ci.nodejs.org/job/node-test-commit-arm/458/nodes=armv7-wheezy/tapTestReport/test.tap-501/
- `test-dgram-udp4`: https://ci.nodejs.org/job/node-test-commit-arm/459/nodes=pi1-raspbian-wheezy-1_of_2/tapTestReport/test.tap-83/
- `test-http-set-timeout`: https://ci.nodejs.org/job/node-test-commit-linux/431/nodes=centos7-64/tapTestReport/test.tap-395/
- `test-cluster-disconnect`: https://ci.nodejs.org/job/node-test-commit-arm/464/nodes=pi1-raspbian-wheezy-1_of_2/tapTestReport/test.tap-38/
- `test-sigint-infinite-loop`: https://ci.nodejs.org/job/node-test-commit-arm/469/nodes=armv7-wheezy/tapTestReport/test.tap-904/
- `test-child-process-fork-dgram`, `test-cluster-dgram-1.js`, `test-cluster-dgram-2`, `test-dgram-bind-default-address`, `test-dgram-bind-shared-ports`, `test-dgram-empty-packet`, `test-dgram-exclusive-implicit-bind`, `test-dgram-implicit-bind`, `test-dgram-multicast-setTTL`, `test-dgram-pingpong`: https://ci.nodejs.org/job/node-test-commit-linux/448/nodes=centos5-64/console
- `test-stringbytes-external`: https://ci.nodejs.org/job/node-test-commit-arm/474/nodes=pi1-raspbian-wheezy-2_of_2/tapTestReport/test.tap-336/
- `test-stdout-stderr-reading`: https://ci.nodejs.org/job/node-test-commit-arm/474/nodes=armv7-wheezy/tapTestReport/test.tap-907/
- `test-process-config`: https://ci.nodejs.org/job/node-test-commit-windows/469/nodes=win2012r2/tapTestReport/test.tap-551/
- `test-repl-tab-complete`: https://ci.nodejs.org/job/node-test-commit-windows/469/nodes=win2012r2/tapTestReport/test.tap-602/
- `test-child-process-fork-net2`: https://github.com/nodejs/node/pull/2670 also for Windows: https://ci.nodejs.org/job/node-test-commit-windows/460/nodes=win2012r2/tapTestReport/test.tap-36/
- `test-child-process-emfile`: https://github.com/nodejs/node/pull/2671
- `test-net-server-max-connections`: https://github.com/nodejs/node/pull/2664

Replaces https://github.com/nodejs/node/pull/2664 , https://github.com/nodejs/node/pull/2670 and https://github.com/nodejs/node/pull/2671 

cc @nodejs/build 