### PR TITLE
node: add missing environment variables to --help and man page

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -72,9 +72,15 @@ and servers.
 
 .IP NODE_PATH
 \':\'\-separated list of directories prefixed to the module search path.
-
 .IP NODE_DISABLE_COLORS
 If set to 1 then colors will not be used in the REPL.
+.IP NODE_ICU_DATA
+Data path for ICU (Intl object) data. Will extend linked-in data when compiled
+with small-icu support.
+.IP NODE_REPL_HISTORY
+Path to the file used to store the persistent REPL history. The default path
+is ~/.node_repl_history, which can be overriden with this variable. Setting the
+value to an empty string "" disables persistent REPL history.
 
 .SH V8 OPTIONS
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -80,7 +80,7 @@ with small-icu support.
 .IP NODE_REPL_HISTORY
 Path to the file used to store the persistent REPL history. The default path
 is ~/.node_repl_history, which is overridden by this variable. Setting the
-value to an empty string "" disables persistent REPL history.
+value to an empty string ("") disables persistent REPL history.
 
 .SH V8 OPTIONS
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -79,7 +79,7 @@ Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small-icu support.
 .IP NODE_REPL_HISTORY
 Path to the file used to store the persistent REPL history. The default path
-is ~/.node_repl_history, which can be overriden with this variable. Setting the
+is ~/.node_repl_history, which is overridden by this variable. Setting the
 value to an empty string "" disables persistent REPL history.
 
 .SH V8 OPTIONS

--- a/src/node.cc
+++ b/src/node.cc
@@ -3083,7 +3083,7 @@ static void PrintHelp() {
          "                        (will extend linked-in data)\n"
 #endif
 #endif
-         "NODE_REPL_HISTORY       persistent history file location\n"
+         "NODE_REPL_HISTORY       path to the persistent REPL history file\n"
          "\n"
          "Documentation can be found at https://nodejs.org/\n");
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -3064,7 +3064,7 @@ static void PrintHelp() {
          "  --icu-data-dir=dir    set ICU data load path to dir\n"
          "                        (overrides NODE_ICU_DATA)\n"
 #if !defined(NODE_HAVE_SMALL_ICU)
-         "                        Note: linked-in ICU data is\n"
+         "                        note: linked-in ICU data is\n"
          "                        present.\n"
 #endif
 #endif
@@ -3076,13 +3076,14 @@ static void PrintHelp() {
          "NODE_PATH               ':'-separated list of directories\n"
 #endif
          "                        prefixed to the module search path.\n"
-         "NODE_DISABLE_COLORS     Set to 1 to disable colors in the REPL\n"
+         "NODE_DISABLE_COLORS     set to 1 to disable colors in the REPL\n"
 #if defined(NODE_HAVE_I18N_SUPPORT)
-         "NODE_ICU_DATA           Data path for ICU (Intl object) data\n"
+         "NODE_ICU_DATA           data path for ICU (Intl object) data\n"
 #if !defined(NODE_HAVE_SMALL_ICU)
          "                        (will extend linked-in data)\n"
 #endif
 #endif
+         "NODE_REPL_HISTORY       persistent history file location\n"
          "\n"
          "Documentation can be found at https://nodejs.org/\n");
 }


### PR DESCRIPTION
Added NODE_REPL_HISTORY to the environment variables in the `--help` print and made all descriptions start with lower case for consistency with the options descriptions above.

#### Before: 
```
Environment variables:
NODE_PATH               ':'-separated list of directories
                        prefixed to the module search path.
NODE_DISABLE_COLORS     Set to 1 to disable colors in the REPL
NODE_ICU_DATA           Data path for ICU (Intl object) data
```

#### After:
```
Environment variables:
NODE_PATH               ':'-separated list of directories
                        prefixed to the module search path.
NODE_DISABLE_COLORS     set to 1 to disable colors in the REPL
NODE_ICU_DATA           data path for ICU (Intl object) data
NODE_REPL_HISTORY       persistent history file location
```

cc: @Fishrock123 @chrisdickinson 