### PR TITLE
deps: v8 build on FreeBSD 10.2 (v8 4.5 upgrade)

### DIFF
--- a/deps/v8/test/cctest/test-heap.cc
+++ b/deps/v8/test/cctest/test-heap.cc
@@ -1855,7 +1855,7 @@ TEST(TestAlignmentCalculations) {
       Heap::GetMaximumFillToAlign(kSimd128Unaligned);
   CHECK_EQ(maximum_simd128_misalignment, max_simd128_unaligned_fill);
 
-  Address base = reinterpret_cast<Address>(NULL);
+  Address base = static_cast<Address>(NULL);
   int fill = 0;
 
   // Word alignment never requires fill.


### PR DESCRIPTION
When https://github.com/v8/v8-git-mirror/commit/75e43a6681e01de9422a0211f502723d23b51247 was cherry-picked for v8 v4.4 (landed in nodejs#2636), test-heap.cc:1989 chunk did not exist. It now exists in v8 v4.5.101.30. This PR completes the cherry pick of the whole commit from v8.
