### PR TITLE
tools: fix flakiness in test-tick-processor

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,7 +12,6 @@ test-tls-ticket-cluster           : PASS,FLAKY
 [$system==linux]
 test-cluster-worker-forced-exit   : PASS,FLAKY
 test-http-client-timeout-event    : PASS,FLAKY
-test-tick-processor               : PASS,FLAKY
 test-tls-no-sslv3                 : PASS,FLAKY
 test-child-process-buffering      : PASS,FLAKY
 test-child-process-exit-code      : PASS,FLAKY

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -6,32 +6,48 @@ var cp = require('child_process');
 var common = require('../common');
 
 common.refreshTmpDir();
-
 process.chdir(common.tmpDir);
-cp.execFileSync(process.execPath, ['-prof', '-pe',
-    'function foo(n) {' +
-    'require(\'vm\').runInDebugContext(\'Debug\');' +
-    'return n < 2 ? n : setImmediate(function() { foo(n-1) + foo(n-2);}); };' +
-    'setTimeout(function() { process.exit(0); }, 2000);' +
-    'foo(40);']);
-var matches = fs.readdirSync(common.tmpDir).filter(function(file) {
-  return /^isolate-/.test(file);
-});
-if (matches.length != 1) {
-  assert.fail('There should be a single log file.');
-}
-var log = matches[0];
 var processor =
     path.join(common.testDir, '..', 'tools', 'v8-prof', getScriptName());
-var out = cp.execSync(processor + ' ' + log, {encoding: 'utf8'});
-assert(out.match(/LazyCompile.*foo/));
+// Unknown checked for to prevent flakiness, if pattern is not found,
+// then a large number of unknown ticks should be present
+runTest(/LazyCompile.*\[eval\]:1|.*%  UNKNOWN/,
+  `function f() {
+     for (var i = 0; i < 1000000; i++) {
+       i++;
+     }
+     setImmediate(function() { f(); });
+   };
+   setTimeout(function() { process.exit(0); }, 2000);
+   f();`);
 if (process.platform === 'win32' ||
     process.platform === 'sunos' ||
     process.platform === 'freebsd') {
   console.log('1..0 # Skipped: C++ symbols are not mapped for this os.');
   return;
 }
-assert(out.match(/RunInDebugContext/));
+runTest(/RunInDebugContext/,
+  `function f() {
+     require(\'vm\').runInDebugContext(\'Debug\');
+     setImmediate(function() { f(); });
+   };
+   setTimeout(function() { process.exit(0); }, 2000);
+   f();`);
+
+function runTest(pattern, code) {
+  cp.execFileSync(process.execPath, ['-prof', '-pe', code]);
+  var matches = fs.readdirSync(common.tmpDir).filter(function(file) {
+    return /^isolate-/.test(file);
+  });
+  if (matches.length != 1) {
+    assert.fail('There should be a single log file.');
+  }
+  var log = matches[0];
+  var out = cp.execSync(processor + ' --call-graph-size=10 ' + log,
+                        {encoding: 'utf8'});
+  assert(out.match(pattern));
+  fs.unlinkSync(log);
+}
 
 function getScriptName() {
   switch (process.platform) {

--- a/tools/v8-prof/polyfill.js
+++ b/tools/v8-prof/polyfill.js
@@ -47,6 +47,7 @@ function read(fileName) {
   return fs.readFileSync(fileName, 'utf8');
 }
 arguments = process.argv.slice(2);
+var quit = process.exit;
 
 // Polyfill "readline()".
 var fd = fs.openSync(arguments[arguments.length - 1], 'r');


### PR DESCRIPTION
Per the discussion on #2471, the JS symbols checked for by this test
were occasionally too deep in the stack and were being ignored by the
tick processor.

I have addressed this by increasing the stack depth inspected by the
tick processor and looking for the eval symbol which is more likely
to be present.

I also sneaked in a polyfill that was missing from the original PR.
It is only a problem if incorrect command line arguments are passed
to the script so it was missed in initial testing. 

/cc @ofrobots @bnoordhuis @Fishrock123 @joaocgreis @Trott 