### PR TITLE
src: s/ia32/x86 for process.release.libUrl for win

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2727,22 +2727,25 @@ void SetupProcessObject(Environment* env,
 #endif
 
 #if defined(NODE_RELEASE_URLBASE)
-#  define _RELEASE_URLPFX NODE_RELEASE_URLBASE "v" NODE_VERSION_STRING "/"
-#  define _RELEASE_URLFPFX _RELEASE_URLPFX "node-v" NODE_VERSION_STRING
+#  define NODE_RELEASE_URLPFX NODE_RELEASE_URLBASE "v" NODE_VERSION_STRING "/"
+#  define NODE_RELEASE_URLFPFX NODE_RELEASE_URLPFX "node-v" NODE_VERSION_STRING
 
   READONLY_PROPERTY(release,
                     "sourceUrl",
                     OneByteString(env->isolate(),
-                    _RELEASE_URLFPFX ".tar.gz"));
+                    NODE_RELEASE_URLFPFX ".tar.gz"));
   READONLY_PROPERTY(release,
                     "headersUrl",
                     OneByteString(env->isolate(),
-                    _RELEASE_URLFPFX "-headers.tar.gz"));
+                    NODE_RELEASE_URLFPFX "-headers.tar.gz"));
 #  ifdef _WIN32
   READONLY_PROPERTY(release,
                     "libUrl",
                     OneByteString(env->isolate(),
-                    _RELEASE_URLPFX "win-" NODE_ARCH "/node.lib"));
+                    strcmp(NODE_ARCH, "ia32") ? NODE_RELEASE_URLPFX "win-"
+                                                NODE_ARCH "/node.lib"
+                                              : NODE_RELEASE_URLPFX
+                                                "win-x86/node.lib"));
 #  endif
 #endif
 


### PR DESCRIPTION
as per https://github.com/nodejs/node-gyp/pull/711#issuecomment-137807097, fixes this:

```
$ node -pe process.release
{ name: 'io.js',
  sourceUrl: 'https://iojs.org/download/release/v3.3.0/iojs-v3.3.0.tar.gz',
  headersUrl: 'https://iojs.org/download/release/v3.3.0/iojs-v3.3.0-headers.tar.gz',
  libUrl: 'https://iojs.org/download/release/v3.3.0/win-ia32/iojs.lib' }
```

We don't use `ia32` anywhere in our downloads directories or files (any more), it's been banished and `https://iojs.org/download/release/v3.3.0/win-ia32/iojs.lib` should actually be `https://iojs.org/download/release/v3.3.0/win-x86/iojs.lib`. Unfortunately we're still shipping with `process.arch=='ia32'` which I would equally love to banish but alas, it's well and truly baked in to history.

I'm also going to put a special case in node-gyp to account for `^3.0.0` and do some rewriting, which is a bit yuk but we've let this go wild since v3.x.

/cc @nodejs/build and anyone else who feels like critiquing my C++ style