### PR TITLE
Fix build break with icutrim on Big-Endian platforms

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -29,9 +29,17 @@
       'type': 'none',
       'toolsets': [ 'host', 'target' ],
       'direct_dependent_settings': {
+        'conditions': [
+          [ 'icu_endianness == "l"', {
+             'defines': [
+                # ICU cannot swap the initial data without this. 
+                # http://bugs.icu-project.org/trac/ticket/11046 
+                'UCONFIG_NO_LEGACY_CONVERSION=1',
+                'UCONFIG_NO_IDNA=1',
+             ],
+          }],
+        ], 
         'defines': [
-          'UCONFIG_NO_LEGACY_CONVERSION=1',
-          'UCONFIG_NO_IDNA=1',
           'UCONFIG_NO_TRANSLITERATION=1',
           'UCONFIG_NO_SERVICE=1',
           'UCONFIG_NO_REGULAR_EXPRESSIONS=1',


### PR DESCRIPTION
Since this failure causes "make binary" to fail on BE platforms I'm submitting this request to put it into the 4.0 stream as well as master.