### PR TITLE
repl: don't use tty control codes when $TERM is set to "dumb"

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -34,7 +34,10 @@ function createRepl(env, opts, cb) {
   if (parseInt(env.NODE_NO_READLINE)) {
     opts.terminal = false;
   }
-  if (parseInt(env.NODE_DISABLE_COLORS)) {
+  // the "dumb" special terminal, as defined by terminfo, doesn't support
+  // ANSI colour control codes.
+  // see http://invisible-island.net/ncurses/terminfo.ti.html#toc-_Specials
+  if (parseInt(env.NODE_DISABLE_COLORS) || env.TERM === 'dumb') {
     opts.useColors = false;
   }
 

--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Flags: --expose-internals
+
+const common = require('../common');
+const stream = require('stream');
+const REPL = require('internal/repl');
+const assert = require('assert');
+
+const tests = [{
+  env: {},
+  expected: { terminal: true, useColors: true }
+},
+{
+  env: { NODE_DISABLE_COLORS: "1" },
+  expected: { terminal: true, useColors: false }
+},
+{
+  env: { NODE_NO_READLINE: "1" },
+  expected: { terminal: false, useColors: false }
+},
+{
+  env: { TERM: "dumb" },
+  expected: { terminal: true, useColors: false }
+},
+{
+  env: { NODE_NO_READLINE: "1", NODE_DISABLE_COLORS: "1" },
+  expected: { terminal: false, useColors: false }
+},
+{
+  env: { NODE_NO_READLINE: "0" },
+  expected: { terminal: true, useColors: true }
+}];
+
+function run(test) {
+  const env = test.env;
+  const expected = test.expected;
+  const opts = {
+    terminal: true,
+    input: new stream.Readable({ read() {} }),
+    output: new stream.Writable({ write() {} })
+  }
+
+  REPL.createInternalRepl(env, opts, function(err, repl) {
+    if (err) throw err;
+    assert.equal(expected.terminal, repl.terminal);
+    assert.equal(expected.useColors, repl.useColors);
+    repl.close();
+  });
+}
+
+tests.forEach(run)


### PR DESCRIPTION
This stops the REPL from using ANSI control codes on terminals
which don't support them. (Fixes nodejs/node-v0.x-archive#5344)

For history see nodejs/node-v0.x-archive#25506