### PR TITLE
test: skip test_lookup_ipv6_hint on FreeBSD

### DIFF
--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -390,6 +390,15 @@ TEST(function test_lookup_ipv6_explicit_object(done) {
 
 
 TEST(function test_lookup_ipv6_hint(done) {
+  // FreeBSD does not support V4MAPPED flag.
+  if (process.platform === 'freebsd') {
+    console.log(
+      '1..0 # Skipped: test_lookup_ipv6_hint is disabled on FreeBSD.'
+    );
+    done();
+    return;
+  }
+
   var req = dns.lookup('www.google.com', {
     family: 6,
     hints: dns.V4MAPPED


### PR DESCRIPTION
FreeBSD does not support the V4MAPPED flag so skip the test that uses it.

I hacked the Makefile to run this on CI to confirm that it had been failing and that this change would cause it to pass. There are other failures, but they are for other tests. https://ci.nodejs.org/job/node-test-commit-other/518/

