### PR TITLE
tools: remove hyphen in TAP result

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -259,7 +259,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
     self._done += 1
     command = basename(output.command[-1])
     if output.UnexpectedOutput():
-      status_line = 'not ok %i - %s' % (self._done, command)
+      status_line = 'not ok %i %s' % (self._done, command)
       if FLAKY in output.test.outcomes and self.flaky_tests_mode == DONTCARE:
         status_line = status_line + ' # TODO : Fix flaky test'
       logger.info(status_line)
@@ -271,9 +271,9 @@ class TapProgressIndicator(SimpleProgressIndicator):
       skip = skip_regex.search(output.output.stdout)
       if skip:
         logger.info(
-          'ok %i - %s # skip %s' % (self._done, command, skip.group(1)))
+          'ok %i %s # skip %s' % (self._done, command, skip.group(1)))
       else:
-        status_line = 'ok %i - %s' % (self._done, command)
+        status_line = 'ok %i %s' % (self._done, command)
         if FLAKY in output.test.outcomes:
           status_line = status_line + ' # TODO : Fix flaky test'
         logger.info(status_line)


### PR DESCRIPTION
As it is, the TAP result shows an extra hyphen in front of test names.
Sample:
ci.nodejs.org/job/node-test-commit-osx/nodes=osx1010/454/tapResults/
This patch removes the extra hyphen.

R = @jbergstroem ?