### PR TITLE
v8: fix segmentation faults caused by IntegerValue

### DIFF
--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -3262,14 +3262,16 @@ Maybe<int64_t> Value::IntegerValue(Local<Context> context) const {
   i::Handle<i::Object> num;
   if (obj->IsNumber()) {
     num = obj;
+    return Just(num->IsSmi() ? static_cast<int64_t>(i::Smi::cast(*num)->value())
+                             : static_cast<int64_t>(num->Number()));
   } else {
     PREPARE_FOR_EXECUTION_PRIMITIVE(context, "IntegerValue", int64_t);
     has_pending_exception =
         !i::Execution::ToInteger(isolate, obj).ToHandle(&num);
     RETURN_ON_FAILED_EXECUTION_PRIMITIVE(int64_t);
+    return Just(num->IsSmi() ? static_cast<int64_t>(i::Smi::cast(*num)->value())
+                             : static_cast<int64_t>(num->Number()));
   }
-  return Just(num->IsSmi() ? static_cast<int64_t>(i::Smi::cast(*num)->value())
-                           : static_cast<int64_t>(num->Number()));
 }
 
 

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -18,3 +18,8 @@ assert.equal(child.stderr, null);
 options = {stdio: 'ignore'};
 child = common.spawnSyncCat(options);
 assert.deepEqual(options, {stdio: 'ignore'});
+
+// This should never cause segmentation faults
+// cf. https://github.com/nodejs/node/issues/2721
+options = {stdio: [process.stdin, process.stdout, process.stderr]};
+child = common.spawnPwd(options);


### PR DESCRIPTION
This PR fixes #2721 and adds a test to guard it.

Investigations show that the problem was caused by -O3 optimisations of the compiler. When building a debug version the segmentation fault won't be triggered. Moving the return statement inside the inner scope somehow fixes the malicious optimisation.
