### PR TITLE
DO NOT MERGE: Reproduce segmentation faults related to IntegerValue (#2721)

### DIFF
--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -18,3 +18,8 @@ assert.equal(child.stderr, null);
 options = {stdio: 'ignore'};
 child = common.spawnSyncCat(options);
 assert.deepEqual(options, {stdio: 'ignore'});
+
+// This should never cause segmentation faults
+// cf. https://github.com/nodejs/node/issues/2721
+options = {stdio: [process.stdin, process.stdout, process.stderr]};
+child = common.spawnPwd(options);


### PR DESCRIPTION
Here is the reproduction scenario by @pmq20 (#2722). It will be included in a workaround solution that I will issue next.

**NOTE:** This is on the `v4.0.0-rc` branch.