### PR TITLE
Workaround for crash in #2721 on 4.0.0-rc

### DIFF
--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -98,7 +98,7 @@ class ProcessWrap : public HandleWrap {
         options->stdio[i].data.stream = stream;
       } else {
         Local<String> fd_key = env->fd_string();
-        int fd = static_cast<int>(stdio->Get(fd_key)->IntegerValue());
+        int fd = static_cast<int>(stdio->Get(fd_key)->Int32Value());
         options->stdio[i].flags = UV_INHERIT_FD;
         options->stdio[i].data.fd = fd;
       }

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -18,3 +18,8 @@ assert.equal(child.stderr, null);
 options = {stdio: 'ignore'};
 child = common.spawnSyncCat(options);
 assert.deepEqual(options, {stdio: 'ignore'});
+
+// This should never cause segmentation faults
+// cf. https://github.com/nodejs/node/issues/2721
+options = {stdio: [process.stdin, process.stdout, process.stderr]};
+child = common.spawnPwd(options);


### PR DESCRIPTION
Here is the workaround solution for #2721 that was suggested by @evanlucas in https://github.com/nodejs/node/pull/2722#issuecomment-138294341. Includes the test scenario that @pmq20 contributed in #2722.