### PR TITLE
child_process: use stdio.fd even if it is 0

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -766,7 +766,7 @@ function _validateStdio(stdio, sync) {
     } else if (typeof stdio === 'number' || typeof stdio.fd === 'number') {
       acc.push({
         type: 'fd',
-        fd: stdio.fd || stdio
+        fd: typeof stdio === 'number' ? stdio : stdio.fd
       });
     } else if (getHandleWrapType(stdio) || getHandleWrapType(stdio.handle) ||
                getHandleWrapType(stdio._handle)) {

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -28,3 +28,15 @@ var stdio2 = ['ipc', 'ipc', 'ipc'];
 assert.throws(function() {
   _validateStdio(stdio2, true);
 }, /You cannot use IPC with synchronous forks/);
+
+const stdio3 = [process.stdin, process.stdout, process.stderr];
+var result = _validateStdio(stdio3, false);
+assert.deepStrictEqual(result, {
+  stdio: [
+    { type: 'fd', fd: 0 },
+    { type: 'fd', fd: 1 },
+    { type: 'fd', fd: 2 }
+  ],
+  ipc: undefined,
+  ipcFd: undefined
+});


### PR DESCRIPTION
Previously, in _validateStdio we were using stdio.fd || stdio. If
stdio.fd was falsy (or 0 in the case of stdin), then the entire stdio
object would be passed which could cause a crash.

Fixes: https://github.com/nodejs/node/issues/2721