### PR TITLE
child_process: handle zero fd in process.stdin

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -766,7 +766,7 @@ function _validateStdio(stdio, sync) {
     } else if (typeof stdio === 'number' || typeof stdio.fd === 'number') {
       acc.push({
         type: 'fd',
-        fd: stdio.fd || stdio
+        fd: typeof stdio === 'number' ? stdio : stdio.fd
       });
     } else if (getHandleWrapType(stdio) || getHandleWrapType(stdio.handle) ||
                getHandleWrapType(stdio._handle)) {


### PR DESCRIPTION
When passing `process.stdin` in `stdio` options to
`child_process.spawn`, make sure that its `fd` is getting passed
properly to the C++ internals. It is `0`, so the `stdio.fd || stdio`
check will return `process.stdin`, instead of the number.

Fix: https://github.com/nodejs/node/issues/2721