### PR TITLE
Fix v8_enable_handle_zapping for 4.5

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -56,7 +56,7 @@
     'configurations': {
       'Debug': {
         'variables': {
-          'v8_enable_handle_zapping%': 1,
+          'v8_enable_handle_zapping': 1,
         },
         'defines': [ 'DEBUG', '_DEBUG' ],
         'cflags': [ '-g', '-O0' ],
@@ -83,7 +83,7 @@
       },
       'Release': {
         'variables': {
-          'v8_enable_handle_zapping%': 0,
+          'v8_enable_handle_zapping': 0,
         },
         'cflags': [ '-O3', '-ffunction-sections', '-fdata-sections' ],
         'conditions': [


### PR DESCRIPTION
upstream disabled v8_enable_handle_zapping on the debug build
and not on the release which would be correct

Correct codereview for 4.6:
https://codereview.chromium.org/1302343002

Wrong codereview for 4.5:
https://codereview.chromium.org/1229243002

Found this via this issue https://github.com/nodejs/node/issues/2721 because it only crashed now. Handle zapping in IntegerValue was exposing a bug (thanks to @indutny) but it still should be disabled for performance reasons https://code.google.com/p/chromium/issues/detail?id=318206

Our variable did not overwrite the variable in v8:
https://github.com/nodejs/node/blob/master/common.gypi#L86