### PR TITLE
build: fix ARM vfp naming in configure script for older ARM processors

### DIFF
--- a/configure
+++ b/configure
@@ -604,7 +604,7 @@ def configure_arm(o):
     o['variables']['arm_fpu'] = 'vfpv3'
     o['variables']['arm_version'] = '7'
   else:
-    o['variables']['arm_fpu'] = 'vfpv2'
+    o['variables']['arm_fpu'] = 'vfp'
     o['variables']['arm_version'] = '6' if is_arch_armv6() else 'default'
 
   o['variables']['arm_thumb'] = 0      # -marm


### PR DESCRIPTION
This commit changes the default vfp name from 'vfpv2' to 'vfp', affecting
builds for ARM architectures older than ARMv7.

Valid options for 'arm_fpu' in gcc do NOT include 'vfpv2', causing gcc to
quit with `error: unrecognized argument in option ‘-mfpu=vfpv2’` when
using the configure script with `--dest-cpu=arm`.

Gyp also expects only `vfp, vfpv3-d16, vfpv3, neon`.

GCC reference for the `-mfpu=` option:
https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
Gyp makefile reference:
https://github.com/nodejs/node/blob/v4.0.0/Makefile.build#L173