### PR TITLE
Fix parse pkg_libpath error

### DIFF
--- a/configure
+++ b/configure
@@ -728,7 +728,7 @@ def configure_library(lib, output):
     # libpath needs to be provided ahead libraries
     if pkg_libpath:
       output['libraries'] += (
-          filter(None, map(str.strip, pkg_cflags.split('-L'))))
+          filter(None, map(str.strip, pkg_libpath.split('-L'))))
 
     default_libs = getattr(options, shared_lib + '_libname')
     default_libs = map('-l{0}'.format, default_libs.split(','))


### PR DESCRIPTION
Can't get pkg_libpath properly. It'll cause cross compile failed. (cannot find -lz -lssl -lcrypto, etc...)