### PR TITLE
http: DRY ClientRequest.prototype._deferToConnect

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -504,19 +504,17 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
   // in the future (when a socket gets assigned out of the pool and is
   // eventually writable).
   var self = this;
+  var callSocketMethod = function() {
+    if (method) {
+      self.socket[method].apply(self.socket, arguments_);
+    }
+    if (cb) { cb(); }
+  };
   var onSocket = function() {
     if (self.socket.writable) {
-      if (method) {
-        self.socket[method].apply(self.socket, arguments_);
-      }
-      if (cb) { cb(); }
+      callSocketMethod();
     } else {
-      self.socket.once('connect', function() {
-        if (method) {
-          self.socket[method].apply(self.socket, arguments_);
-        }
-        if (cb) { cb(); }
-      });
+      self.socket.once('connect', callSocketMethod);
     }
   };
   if (!self.socket) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -504,11 +504,11 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
   // in the future (when a socket gets assigned out of the pool and is
   // eventually writable).
   var self = this;
-  var callSocketMethod = function() {
-    if (method) {
+  function callSocketMethod() {
+    if (method)
       self.socket[method].apply(self.socket, arguments_);
-    }
-    if (cb) { cb(); }
+    if (typeof cb === 'function')
+      cb();
   };
   var onSocket = function() {
     if (self.socket.writable) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -509,7 +509,7 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
       self.socket[method].apply(self.socket, arguments_);
     if (typeof cb === 'function')
       cb();
-  };
+  }
   var onSocket = function() {
     if (self.socket.writable) {
       callSocketMethod();


### PR DESCRIPTION
Came across some repetitive lines when reviewing code.

Logic for calling the passed in socket `method` and/or `cb` was duplicated. Extracted these calls into a separate function, `callSocketMethod`, and invoked this new function in place of the replaced code.