### PR TITLE
src: honor --abort_on_uncaught_exception flag

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1067,7 +1067,7 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
     break;
   default:
     CHECK(0 && "bad address family");
-    abort();
+    ABORT();
   }
 
   GetAddrInfoReqWrap* req_wrap = new GetAddrInfoReqWrap(env, req_wrap_obj);
@@ -1193,7 +1193,7 @@ static void SetServers(const FunctionCallbackInfo<Value>& args) {
         break;
       default:
         CHECK(0 && "Bad address family.");
-        abort();
+        ABORT();
     }
 
     if (err)

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -146,7 +146,7 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
     event_string = env->change_string();
   } else {
     CHECK(0 && "bad fs events flag");
-    abort();
+    ABORT();
   }
 
   Local<Value> argv[] = {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2180,7 +2180,11 @@ void FatalException(Isolate* isolate,
 
   if (false == caught->BooleanValue()) {
     ReportException(env, error, message);
-    exit(1);
+    if (abort_on_uncaught_exception) {
+      ABORT();
+    } else {
+      exit(1);
+    }
   }
 }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -918,7 +918,7 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
 
   if (!tick_callback_function->IsFunction()) {
     fprintf(stderr, "process._tickDomainCallback assigned to non-function\n");
-    abort();
+    ABORT();
   }
 
   process_object->Set(env->tick_callback_string(), tick_callback_function);
@@ -1514,7 +1514,7 @@ void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
 
 
 static void Abort(const FunctionCallbackInfo<Value>& args) {
-  abort();
+  ABORT();
 }
 
 
@@ -2134,14 +2134,14 @@ static void OnFatalError(const char* location, const char* message) {
     fprintf(stderr, "FATAL ERROR: %s\n", message);
   }
   fflush(stderr);
-  abort();
+  ABORT();
 }
 
 
 NO_RETURN void FatalError(const char* location, const char* message) {
   OnFatalError(location, message);
   // to suppress compiler warning
-  abort();
+  ABORT();
 }
 
 
@@ -3543,9 +3543,9 @@ inline void PlatformInit() {
     // Anything but EBADF means something is seriously wrong.  We don't
     // have to special-case EINTR, fstat() is not interruptible.
     if (errno != EBADF)
-      abort();
+      ABORT();
     if (fd != open("/dev/null", O_RDWR))
-      abort();
+      ABORT();
   }
 
   CHECK_EQ(err, 0);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -182,7 +182,7 @@ static void crypto_lock_init(void) {
 
   for (i = 0; i < n; i++)
     if (uv_mutex_init(locks + i))
-      abort();
+      ABORT();
 }
 
 
@@ -3466,7 +3466,7 @@ void SignBase::CheckThrow(SignBase::Error error) {
           case kSignPublicKey:
             return env()->ThrowError("PEM_read_bio_PUBKEY failed");
           default:
-            abort();
+            ABORT();
         }
       }
 

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -172,7 +172,7 @@ long NodeBIO::Ctrl(BIO* bio, int cmd, long num, void* ptr) {
       break;
     case BIO_C_SET_BUF_MEM:
       CHECK(0 && "Can't use SET_BUF_MEM_PTR with NodeBIO");
-      abort();
+      ABORT();
       break;
     case BIO_C_GET_BUF_MEM_PTR:
       CHECK(0 && "Can't use GET_BUF_MEM_PTR with NodeBIO");

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -485,7 +485,7 @@ void SyncProcessRunner::TryInitializeAndRunLoop(Local<Value> options) {
   r = uv_run(uv_loop_, UV_RUN_DEFAULT);
   if (r < 0)
     // We can't handle uv_run failure.
-    abort();
+    ABORT();
 
   // If we get here the process should have exited.
   CHECK_GE(exit_status_, 0);
@@ -508,7 +508,7 @@ void SyncProcessRunner::CloseHandlesAndDeleteLoop() {
     // callbacks called.
     int r = uv_run(uv_loop_, UV_RUN_DEFAULT);
     if (r < 0)
-      abort();
+      ABORT();
 
     CHECK_EQ(uv_loop_close(uv_loop_), 0);
     delete uv_loop_;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -179,7 +179,7 @@ static Local<Object> AcceptHandle(Environment* env, StreamWrap* parent) {
   handle = wrap->UVHandle();
 
   if (uv_accept(parent->stream(), reinterpret_cast<uv_stream_t*>(handle)))
-    abort();
+    ABORT();
 
   return scope.Escape(wrap_obj);
 }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -152,7 +152,7 @@ void TLSWrap::InitSSL() {
     SSL_set_connect_state(ssl_);
   } else {
     // Unexpected
-    abort();
+    ABORT();
   }
 
   // Initialize ring for queud clear data

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -72,7 +72,7 @@ void TTYWrap::GuessHandleType(const FunctionCallbackInfo<Value>& args) {
   case UV_NAMED_PIPE: type = "PIPE"; break;
   case UV_UNKNOWN_HANDLE: type = "UNKNOWN"; break;
   default:
-    abort();
+    ABORT();
   }
 
   args.GetReturnValue().Set(OneByteString(env->isolate(), type));

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -166,7 +166,7 @@ void UDPWrap::DoBind(const FunctionCallbackInfo<Value>& args, int family) {
     break;
   default:
     CHECK(0 && "unexpected address family");
-    abort();
+    ABORT();
   }
 
   if (err == 0) {
@@ -278,7 +278,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
     break;
   default:
     CHECK(0 && "unexpected address family");
-    abort();
+    ABORT();
   }
 
   if (err == 0) {

--- a/src/util.h
+++ b/src/util.h
@@ -18,11 +18,18 @@ namespace node {
   TypeName(const TypeName&) = delete;                                         \
   TypeName(TypeName&&) = delete
 
+// Windows 8+ does not like abort() in Release mode
+#ifdef _WIN32
+#define ABORT() raise(SIGABRT)
+#else
+#define ABORT() abort()
+#endif
+
 #if defined(NDEBUG)
 # define ASSERT(expression)
 # define CHECK(expression)                                                    \
   do {                                                                        \
-    if (!(expression)) abort();                                               \
+    if (!(expression)) ABORT();                                               \
   } while (0)
 #else
 # define ASSERT(expression)  assert(expression)
@@ -43,7 +50,7 @@ namespace node {
 #define CHECK_LT(a, b) CHECK((a) < (b))
 #define CHECK_NE(a, b) CHECK((a) != (b))
 
-#define UNREACHABLE() abort()
+#define UNREACHABLE() ABORT()
 
 // TAILQ-style intrusive list node.
 template <typename T>

--- a/test/abort/test-abort-uncaught-exception.js
+++ b/test/abort/test-abort-uncaught-exception.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const node = process.execPath;
+
+if (process.argv[2] === 'child') {
+  throw new Error('child error');
+} else {
+  run('', null);
+  run('--abort-on-uncaught-exception', 'SIGABRT');
+}
+
+function run(flags, signal) {
+  const args = [__filename, 'child'];
+  if (flags)
+    args.unshift(flags);
+
+  const child = spawn(node, args);
+  child.on('exit', common.mustCall(function(code, sig) {
+    if (!common.isWindows) {
+      assert.strictEqual(sig, signal);
+    } else {
+      if (signal)
+        assert.strictEqual(code, 3);
+      else
+        assert.strictEqual(code, 1);
+    }
+  }));
+}


### PR DESCRIPTION
Fix regression introduced in 0af4c9ea7434e4f505dbe071357e4bc3b4ab2a8a
that ignores the --abort-on-uncaught-exception flag. Prior to that
commit, the flag was passed through to v8. After that commit, the
process just calls exit(1).

The tests added in https://github.com/nodejs/node/commit/0af4c9ea7434e4f505dbe071357e4bc3b4ab2a8a all are still passing. 

There probably is a better way of doing this, but this is working for me, so...