### PR TITLE
Do not unref debug handle to avoid debug process stuck

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3652,7 +3652,6 @@ void Init(int* argc,
   uv_async_init(uv_default_loop(),
                 &dispatch_debug_messages_async,
                 DispatchDebugMessagesAsyncCallback);
-  uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()
@@ -3959,8 +3958,11 @@ static void StartNodeInstance(void* arg) {
     env->set_trace_sync_io(trace_sync_io);
 
     // Enable debugger
-    if (instance_data->use_debug_agent())
+    if (instance_data->use_debug_agent()) {
       EnableDebug(env);
+    } else {
+      uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
+    }
 
     {
       SealHandleScope seal(isolate);


### PR DESCRIPTION
For a simple javascript file:

     console.log('debug');

Run `node debug a.js` to launch debug process. Press first `c` and the program outputs `> debug`. After that, press `c` again the process just gets stuck and has no response so we have to kill it.

This is because debug handle has been unrefed. Once the program is finished, the event loop will be exited and the debug process will be stuck when debug sends commend again. We shouldn't unref the debug handle because even the script is finished, we can still send more debug command such as `restart`.

Fixes #1788.