### PR TITLE
add missing assert from 0.12 merge

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2013,6 +2013,9 @@ extern "C" void node_module_register(void* m) {
     mp->nm_link = modlist_linked;
     modlist_linked = mp;
   } else {
+    // Once node::Init was called we can only register dynamic modules.
+    // See DLOpen.
+    assert(modpending == NULL);
     modpending = mp;
   }
 }


### PR DESCRIPTION
An assert check is missing from 0.12 merge, adding it back

Reference: #2780 