### PR TITLE
test: remove check for valid hostname in test-dns.js

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -436,15 +436,6 @@ exports.hasMultiLocalhost = function hasMultiLocalhost() {
   return ret === 0;
 };
 
-exports.isValidHostname = function(str) {
-  // See http://stackoverflow.com/a/3824105
-  var re = new RegExp(
-    '^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])' +
-    '(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$');
-
-  return !!str.match(re) && str.length <= 255;
-};
-
 exports.fileExists = function(pathname) {
   try {
     fs.accessSync(pathname);

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -575,7 +575,8 @@ TEST(function test_lookup_all_mixed(done) {
 TEST(function test_lookupservice_ip_ipv4(done) {
   var req = dns.lookupService('127.0.0.1', 80, function(err, host, service) {
     if (err) throw err;
-    assert.ok(common.isValidHostname(host));
+    assert.equal(typeof host, 'string');
+    assert(host);
 
     /*
      * Retrieve the actual HTTP service name as setup on the host currently
@@ -604,7 +605,8 @@ TEST(function test_lookupservice_ip_ipv4(done) {
 TEST(function test_lookupservice_ip_ipv6(done) {
   var req = dns.lookupService('::1', 80, function(err, host, service) {
     if (err) throw err;
-    assert.ok(common.isValidHostname(host));
+    assert.equal(typeof host, 'string');
+    assert(host);
 
     /*
      * Retrieve the actual HTTP service name as setup on the host currently


### PR DESCRIPTION
Operating systems can and do return invalid hostnames if that's
what they have (for example) in /etc/hosts. Test passes if no
error is thrown and the hostname string is not empty.

Fixes: https://github.com/nodejs/node/issues/2468