### PR TITLE
timer: call list.start regardless new or not

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -59,7 +59,6 @@ function insert(item, msecs) {
     list = lists[msecs];
   } else {
     list = new Timer();
-    list.start(msecs, 0);
 
     L.init(list);
 
@@ -67,6 +66,10 @@ function insert(item, msecs) {
     list.msecs = msecs;
     list[kOnTimeout] = listOnTimeout;
   }
+  // Call start regardless whether list is new
+  // or not to prevent incorrect active_handles
+  // count. See nodejs/node-v0.x-archive issue #25831.
+  list.start(msecs, 0);
 
   L.append(list, item);
   assert(!L.isEmpty(list)); // list is not empty

--- a/test/simple/test-timers-active-handles.js
+++ b/test/simple/test-timers-active-handles.js
@@ -1,0 +1,36 @@
+var cp = require('child_process');
+var assert = require('assert');
+
+// build deasync
+cp.spawn(
+    process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp', ['rebuild'], {
+      stdio: 'inherit',
+      cwd: __dirname + '/test-timers-active-handles'
+    })
+  .on('exit', function (err) {
+    if (err) {
+      if (err === 127) {
+        console.error(
+          'node-gyp not found! Please upgrade your install of npm!'
+        );
+      } else {
+        console.error('Build failed');
+      }
+      return process.exit(err);
+    }
+    test();
+  });
+
+function test() {
+  var uvRunOnce = require('./test-timers-active-handles/build/Release/deasync');
+  setTimeout(function () {
+    var res;
+    setTimeout(function () {
+      res = true;
+    }, 2);
+    while (!res) {
+      uvRunOnce.run();
+    }
+    assert.equal(res, true);
+  }, 2);
+}

--- a/test/simple/test-timers-active-handles/binding.gyp
+++ b/test/simple/test-timers-active-handles/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [{
+    "target_name": "deasync",
+    "sources": [
+      "deasync.cc"
+    ]
+  }]
+}

--- a/test/simple/test-timers-active-handles/deasync.cc
+++ b/test/simple/test-timers-active-handles/deasync.cc
@@ -1,0 +1,17 @@
+#include <node.h>
+#include <uv.h>
+
+using namespace v8;
+
+void Method(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
+  uv_run(uv_default_loop(), UV_RUN_ONCE);
+  args.GetReturnValue().Set(Undefined(isolate));
+}
+
+void init(Handle<Object> exports) {
+  NODE_SET_METHOD(exports, "run", Method);
+}
+
+NODE_MODULE(deasync, init)


### PR DESCRIPTION
Call start regardless whether list is new
or not to prevent incorrect active_handles
count.

Fixes https://github.com/nodejs/node-v0.x-archive/issues/25831.
Ported from pr https://github.com/nodejs/node-v0.x-archive/pull/25832.
