### PR TITLE
bindings: close after reading module struct

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2087,12 +2087,12 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
     return;
   }
   if (mp->nm_version != NODE_MODULE_VERSION) {
-    uv_dlclose(&lib);
     char errmsg[1024];
     snprintf(errmsg,
              sizeof(errmsg),
              "Module version mismatch. Expected %d, got %d.",
              NODE_MODULE_VERSION, mp->nm_version);
+    uv_dlclose(&lib);
     env->ThrowError(errmsg);
     return;
   }


### PR DESCRIPTION
Do not let the module struct to be deallocated by `uv_dclose` before
reading data from it.

Found it while investigating: https://github.com/nodejs/node/issues/2791#issuecomment-139196668

cc @nodejs/collaborators 