### PR TITLE
docs: fs - remove encoding list and link to buffer

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -809,7 +809,7 @@ default value of 64 kb for the same parameter.
 
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file.  Both `start` and `end` are inclusive and
-start at 0. The `encoding` can be any one of those accepted by [Buffer](buffer.html).
+start at 0. The `encoding` can be any one of those accepted by [Buffer][].
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `open` event will be emitted.
@@ -854,7 +854,7 @@ Returns a new WriteStream object (See `Writable Stream`).
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
-default mode `w`. The `defaultEncoding` can be any one of those accepted by [Buffer](buffer.html).
+default mode `w`. The `defaultEncoding` can be any one of those accepted by [Buffer][].
 
 Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the
 `path` argument and will use the specified file descriptor. This means that no
@@ -904,3 +904,4 @@ Emitted when an error occurs.
 [fs.access]: #fs_fs_access_path_mode_callback
 [fs.statSync]: #fs_fs_statsync_path
 [fs.accessSync]: #fs_fs_accesssync_path_mode
+[Buffer]: buffer.html#buffer_buffer

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -809,7 +809,7 @@ default value of 64 kb for the same parameter.
 
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file.  Both `start` and `end` are inclusive and
-start at 0. The `encoding` can be `'utf8'`, `'ascii'`, or `'base64'`.
+start at 0. The `encoding` can be any one of those accepted by [Buffer](buffer.html).
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `open` event will be emitted.
@@ -854,8 +854,7 @@ Returns a new WriteStream object (See `Writable Stream`).
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
-default mode `w`. The `defaultEncoding` can be `'utf8'`, `'ascii'`, `binary`,
-or `'base64'`.
+default mode `w`. The `defaultEncoding` can be any one of those accepted by [Buffer](buffer.html).
 
 Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the
 `path` argument and will use the specified file descriptor. This means that no


### PR DESCRIPTION
Removes the accepted encoding lists from fs.createReadStream and fs.createWriteStream, linking instead to Buffer which has a list of accepted encodings. Would solve #2787 