### PR TITLE
Update the assert module summary to better describe the module

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -2,8 +2,7 @@
 
     Stability: 2 - Stable
 
-This module is used for testing actual values against expected values. You can
-access it with `require('assert')`.
+This module is used for writing assertion tests. You can access it with `require('assert')`.
 
 ## assert.fail(actual, expected, message, operator)
 

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -2,7 +2,7 @@
 
     Stability: 2 - Stable
 
-This module is used for testing actual values against expected values, you can
+This module is used for testing actual values against expected values. You can
 access it with `require('assert')`.
 
 ## assert.fail(actual, expected, message, operator)

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -2,7 +2,8 @@
 
     Stability: 2 - Stable
 
-This module is used for writing assertion tests. You can access it with `require('assert')`.
+This module is used for writing assertion tests. You can access it with
+`require('assert')`.
 
 ## assert.fail(actual, expected, message, operator)
 

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -2,7 +2,7 @@
 
     Stability: 2 - Stable
 
-This module is used for writing unit tests for your applications, you can
+This module is used for testing actual values against expected values, you can
 access it with `require('assert')`.
 
 ## assert.fail(actual, expected, message, operator)


### PR DESCRIPTION
The current wording "This module is used for writing unit tests for your applications, you can access it with require('assert')." implies that this module should only be used in development while unit testing.

The article "Error Handling in Node.js" by Joyent (https://www.joyent.com/developers/node/design/errors) uses the assert module in an efficient way to validate required function arguments.