### PR TITLE
Docs: use Calls over Executes for Consistency

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -132,7 +132,7 @@ Returns a copy of the array of listeners for the specified event.
 
 ### emitter.emit(event[, arg1][, arg2][, ...])
 
-Executes each of the listeners in order with the supplied arguments.
+Calls each of the listeners in order with the supplied arguments.
 
 Returns `true` if event had listeners, `false` otherwise.
 


### PR DESCRIPTION
Calls are used frequently through the doc except this line
use Calls over Executes to make it consistent