### PR TITLE
docs: Clarify assert.doesNotThrow behavior

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -85,9 +85,27 @@ Custom error validation:
       "unexpected error"
     );
 
-## assert.doesNotThrow(block[, message])
+## assert.doesNotThrow(block[, error][, message])
 
-Expects `block` not to throw an error, see `assert.throws` for details.
+Expects `block` not to throw an error. See [assert.throws()](#assert_assert_throws_block_error_message) for more details.
+
+If `block` throws an error and if it is of a different type from `error`, the thrown error will get propagated back to the caller. The following call will throw the `TypeError`, since we're not matching the error types in the assertion.
+
+    assert.doesNotThrow(
+      function() {
+        throw new TypeError("Wrong value");
+      },
+      SyntaxError
+    );
+
+In case `error` matches with the error thrown by `block`, an `AssertionError` is thrown instead.
+
+    assert.doesNotThrow(
+      function() {
+        throw new TypeError("Wrong value");
+      },
+      TypeError
+    );
 
 ## assert.ifError(value)
 


### PR DESCRIPTION
Relates to #2385

The documentation now seems to be up to date with the code and tests for the `assert` module