### PR TITLE
test: increase dgram timeout for armv6

### DIFF
--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -7,7 +7,7 @@ var common = require('../common'),
     Buffer = require('buffer').Buffer,
     fork = require('child_process').fork,
     LOCAL_BROADCAST_HOST = '255.255.255.255',
-    TIMEOUT = 5000,
+    TIMEOUT = common.platformTimeout(5000),
     messages = [
       new Buffer('First message to send'),
       new Buffer('Second message to send'),

--- a/test/internet/test-dgram-multicast-multi-process.js
+++ b/test/internet/test-dgram-multicast-multi-process.js
@@ -6,7 +6,7 @@ var common = require('../common'),
     Buffer = require('buffer').Buffer,
     fork = require('child_process').fork,
     LOCAL_BROADCAST_HOST = '224.0.0.114',
-    TIMEOUT = 5000,
+    TIMEOUT = common.platformTimeout(5000),
     messages = [
       new Buffer('First message to send'),
       new Buffer('Second message to send'),


### PR DESCRIPTION
test-dgram-broadcast-multi-process.js and
test-dgram-multicast-multi-process.js were failing on Pi 1 because the
test was timing out. Changed static 5000ms timeout to a dynamically
determined timeout based on the processor using
common.platformTimeout().

These tests aren't (yet) currently run on CI because they are in `test/internet`. But I altered the Makefile and had them run at https://ci.nodejs.org/job/node-test-commit-arm/593/

