### PR TITLE
readline: fix tab completion bug

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -390,7 +390,10 @@ Interface.prototype._tabComplete = function() {
         var width = completions.reduce(function(a, b) {
           return a.length > b.length ? a : b;
         }).length + 2;  // 2 space padding
-        var maxColumns = Math.floor(self.columns / width) || 1;
+        var maxColumns = Math.floor(self.columns / width);
+        if (!maxColumns || maxColumns === Infinity) {
+          maxColumns = 1;
+        }
         var group = [], c;
         for (var i = 0, compLen = completions.length; i < compLen; i++) {
           c = completions[i];

--- a/test/parallel/test-readline-undefined-columns.js
+++ b/test/parallel/test-readline-undefined-columns.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('assert');
+const PassThrough = require('stream').PassThrough;
+const readline = require('readline');
+
+// Checks that tab completion still works
+// when output column size is undefined
+
+const iStream = new PassThrough();
+const oStream = new PassThrough();
+
+const rli = readline.createInterface({
+  terminal: true,
+  input: iStream,
+  output: oStream,
+  completer: function(line, cb) {
+    cb(null, [['process.stdout', 'process.stdin', 'process.stderr'], line]);
+  }
+});
+
+var output = '';
+
+oStream.on('data', function(data) {
+  output += data;
+});
+
+oStream.on('end', function() {
+  const expect = 'process.stdout\r\n' +
+    'process.stdin\r\n' +
+    'process.stderr';
+  assert(new RegExp(expect).test(output));
+});
+
+iStream.write('process.std\t');
+oStream.end();


### PR DESCRIPTION
This fixes a problem where tab completion is empty when the input
stream column size is `undefined`. As a solution we can force `maxColumns`
to 1 in this scenario.

Fixes: #2396
Related PR: #2612