### PR TITLE
http_server: fix resume after socket close

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -512,11 +512,13 @@ function connectionListener(socket) {
 exports._connectionListener = connectionListener;
 
 function onSocketResume() {
-  this._handle.readStart();
+  if (this._handle)
+    this._handle.readStart();
 }
 
 function onSocketPause() {
-  this._handle.readStop();
+  if (this._handle)
+    this._handle.readStop();
 }
 
 function socketOnWrap(ev, fn) {
@@ -526,7 +528,7 @@ function socketOnWrap(ev, fn) {
     return res;
   }
 
-  if (ev === 'data' || ev === 'readable')
+  if (this._handle && (ev === 'data' || ev === 'readable'))
     this.parser.unconsume(this._handle._externalStream);
 
   return res;

--- a/test/parallel/test-http-regr-gh-2821.js
+++ b/test/parallel/test-http-regr-gh-2821.js
@@ -17,7 +17,7 @@ server.listen(common.PORT, function() {
     port: common.PORT
   });
 
-  const payload = new Array(1640).join('0123456789');
+  const payload = new Buffer(16390);
   req.write(payload);
   req.end();
 });

--- a/test/parallel/test-http-regr-gh-2821.js
+++ b/test/parallel/test-http-regr-gh-2821.js
@@ -18,6 +18,7 @@ server.listen(common.PORT, function() {
   });
 
   const payload = new Buffer(16390);
+  payload.fill('Й');
   req.write(payload);
   req.end();
 });

--- a/test/parallel/test-http-regr-gh-2821.js
+++ b/test/parallel/test-http-regr-gh-2821.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200);
+  res.end();
+
+  server.close();
+});
+
+server.listen(common.PORT, function() {
+
+  const req = http.request({
+    method: 'POST',
+    port: common.PORT
+  });
+
+  const payload = new Array(1640).join('0123456789');
+  req.write(payload);
+  req.end();
+});


### PR DESCRIPTION
Socket resume may happen on a next tick, and in following scenario:

1. `socket.resume()`
2. `socket._handle.close()`
3. `socket._handle = null;`

The `_resume` will be invoked with empty `._handle` property. There is
nothing bad about it, and we should just ignore the `resume`/`pause`
events in this case.

Same applies to the unconsuming of socket on adding `data` and/or
`readable` event listeners.

Fix: https://github.com/nodejs/node/issues/2821