### PR TITLE
http: default Agent.getName to 'localhost'

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -94,19 +94,16 @@ Agent.prototype.createConnection = net.createConnection;
 
 // Get the key for a given set of request options
 Agent.prototype.getName = function(options) {
-  var name = '';
-
-  if (options.host)
-    name += options.host;
-  else
-    name += 'localhost';
+  var name = options.host || 'localhost';
 
   name += ':';
   if (options.port)
     name += options.port;
+
   name += ':';
   if (options.localAddress)
     name += options.localAddress;
+
   return name;
 };
 


### PR DESCRIPTION
This PR will: 

+ Refactor out the `if/else` conditional checking for `option.host`. If it exists, `name` will be initialized with it. If not, default to 'localhost'.
+ Add whitespace to make concatenation chunks more readable and consistent with the https version of [Agent.getName][0].

[0]: https://github.com/nodejs/node/blob/master/lib/https.js#L99-L127