### PR TITLE
doc: fix broken link in REPL API documentation

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -277,5 +277,6 @@ and try to print `obj` in REPL, it will invoke the custom `inspect()` function:
     > obj
     { bar: 'baz' }
 
+[Readline Interface]: readline.html#readline_class_interface
 [util.inspect()]: util.html#util_util_inspect_object_options
 [here]: util.html#util_custom_inspect_function_on_objects


### PR DESCRIPTION
This patch fixes a link without a destination in the markdown file for the REPL API documentation.