### PR TITLE
tools: enable no-unused-vars linter rule and fix issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -78,6 +78,8 @@ rules:
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#variables
   ## disallow use of undefined variables (globals)
   no-undef: 2
+  ## disallow unused variables
+  no-unused-vars: [2, {vars: "all", args: "none"}]
 
   # Custom rules in tools/eslint-rules
   require-buffer: 2

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -3,7 +3,6 @@
 const util = require('util');
 const net = require('net');
 const url = require('url');
-const EventEmitter = require('events').EventEmitter;
 const HTTPParser = process.binding('http_parser').HTTPParser;
 const assert = require('assert').ok;
 const common = require('_http_common');

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -14,12 +14,6 @@ module.exports.createInternalRepl = createRepl;
 // The debounce is to guard against code pasted into the REPL.
 const kDebounceHistoryMS = 15;
 
-// XXX(chrisdickinson): hack to make sure that the internal debugger
-// uses the original repl.
-function replStart() {
-  return REPL.start.apply(REPL, arguments);
-}
-
 function createRepl(env, opts, cb) {
   if (typeof opts === 'function') {
     cb = opts;

--- a/lib/os.js
+++ b/lib/os.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const binding = process.binding('os');
-const util = require('util');
 const internalUtil = require('internal/util');
 const isWindows = process.platform === 'win32';
 

--- a/test/addons/at-exit/test.js
+++ b/test/addons/at-exit/test.js
@@ -1,2 +1,2 @@
 'use strict';
-var binding = require('./build/Release/binding');
+require('./build/Release/binding');

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -41,4 +41,4 @@ var options = {
 };
 
 // Run commands from fake REPL.
-var dummy = repl.start(options);
+repl.start(options);

--- a/test/debugger/test-debugger-pid.js
+++ b/test/debugger/test-debugger-pid.js
@@ -1,16 +1,8 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 1337;
 var buffer = '';
-var expected = [];
-var scriptToDebug = common.fixturesDir + '/empty.js';
-
-function fail() {
-  assert(0); // `--debug-brk script.js` should not quit
-}
 
 // connect to debug agent
 var interfacer = spawn(process.execPath, ['debug', '-p', '655555']);

--- a/test/debugger/test-debugger-remote.js
+++ b/test/debugger/test-debugger-remote.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 1337;
 var buffer = '';
-var expected = [];
 var scriptToDebug = common.fixturesDir + '/empty.js';
 
 function fail() {

--- a/test/internet/test-dns-txt-sigsegv.js
+++ b/test/internet/test-dns-txt-sigsegv.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dns = require('dns');
 

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv4 = net.isIPv4,
     isIPv6 = net.isIPv6;
 var util = require('util');
@@ -117,7 +116,7 @@ TEST(function test_reverse_bogus(done) {
   var error;
 
   try {
-    var req = dns.reverse('bogus ip', function() {
+    dns.reverse('bogus ip', function() {
       assert.ok(false);
     });
   } catch (e) {
@@ -716,7 +715,7 @@ console.log('looking up nodejs.org...');
 
 var cares = process.binding('cares_wrap');
 var req = new cares.GetAddrInfoReqWrap();
-var err = cares.getaddrinfo(req, 'nodejs.org', 4);
+cares.getaddrinfo(req, 'nodejs.org', 4);
 
 req.oncomplete = function(err, domains) {
   assert.strictEqual(err, 0);

--- a/test/internet/test-http-dns-fail.js
+++ b/test/internet/test-http-dns-fail.js
@@ -4,7 +4,6 @@
  * should trigger the error event after each attempt.
  */
 
-var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/internet/test-net-connect-timeout.js
+++ b/test/internet/test-net-connect-timeout.js
@@ -3,7 +3,6 @@
 // https://groups.google.com/forum/#!topic/nodejs/UE0ZbfLt6t8
 // https://groups.google.com/forum/#!topic/nodejs-dev/jR7-5UDqXkw
 
-var common = require('../common');
 var net = require('net');
 var assert = require('assert');
 

--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/message/2100bytes.js
+++ b/test/message/2100bytes.js
@@ -1,7 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var util = require('util');
 
 console.log([
   '_______________________________________________50',

--- a/test/message/error_exit.js
+++ b/test/message/error_exit.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 process.on('exit', function(code) {

--- a/test/message/eval_messages.js
+++ b/test/message/eval_messages.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var common = require('../common');
-var assert = require('assert');
-
 var spawn = require('child_process').spawn;
 
 function run(cmd, strict, cb) {

--- a/test/message/hello_world.js
+++ b/test/message/hello_world.js
@@ -1,5 +1,3 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 console.log('hello world');

--- a/test/message/max_tick_depth.js
+++ b/test/message/max_tick_depth.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 
 process.maxTickDepth = 10;
 var i = 20;

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 process.nextTick(function() {
   process.nextTick(function() {

--- a/test/message/stack_overflow.js
+++ b/test/message/stack_overflow.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 Error.stackTraceLimit = 0;
 

--- a/test/message/stdin_messages.js
+++ b/test/message/stdin_messages.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var common = require('../common');
-var assert = require('assert');
-
 var spawn = require('child_process').spawn;
 
 function run(cmd, strict, cb) {

--- a/test/message/throw_custom_error.js
+++ b/test/message/throw_custom_error.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 // custom error throwing
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });

--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,4 +1,4 @@
-*test*message*throw_custom_error.js:6
+*test*message*throw_custom_error.js:4
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });
 ^
 MyCustomError: This is a custom message

--- a/test/message/throw_in_line_with_tabs.js
+++ b/test/message/throw_in_line_with_tabs.js
@@ -1,7 +1,5 @@
 /* eslint-disable indent */
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 console.error('before');
 

--- a/test/message/throw_in_line_with_tabs.out
+++ b/test/message/throw_in_line_with_tabs.out
@@ -1,5 +1,5 @@
 before
-*test*message*throw_in_line_with_tabs.js:10
+*test*message*throw_in_line_with_tabs.js:8
 	throw ({ foo: 'bar' });
 	^
 [object Object]

--- a/test/message/throw_non_error.js
+++ b/test/message/throw_non_error.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 // custom error throwing
 throw ({ foo: 'bar' });

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,4 +1,4 @@
-*test*message*throw_non_error.js:6
+*test*message*throw_non_error.js:4
 throw ({ foo: 'bar' });
 ^
 [object Object]

--- a/test/message/throw_null.js
+++ b/test/message/throw_null.js
@@ -1,5 +1,3 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 throw null;

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_null.js:5
+*test*message*throw_null.js:3
 throw null;
 ^
 null

--- a/test/message/throw_undefined.js
+++ b/test/message/throw_undefined.js
@@ -1,5 +1,3 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 throw undefined;

--- a/test/message/throw_undefined.out
+++ b/test/message/throw_undefined.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_undefined.js:5
+*test*message*throw_undefined.js:3
 throw undefined;
 ^
 undefined

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 setTimeout(function() {
   undefined_reference_error_maker;

--- a/test/message/undefined_reference_in_new_context.js
+++ b/test/message/undefined_reference_in_new_context.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('before');

--- a/test/message/vm_display_runtime_error.js
+++ b/test/message/vm_display_runtime_error.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/message/vm_display_syntax_error.js
+++ b/test/message/vm_display_syntax_error.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/message/vm_dont_display_runtime_error.js
+++ b/test/message/vm_dont_display_runtime_error.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/message/vm_dont_display_syntax_error.js
+++ b/test/message/vm_dont_display_syntax_error.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -273,8 +273,6 @@ assert.throws(makeBlock(a.deepStrictEqual, new Boolean(true), {}),
 function thrower(errorConstructor) {
   throw new errorConstructor('test');
 }
-var aethrow = makeBlock(thrower, a.AssertionError);
-aethrow = makeBlock(thrower, a.AssertionError);
 
 // the basic calls work
 assert.throws(makeBlock(thrower, a.AssertionError),

--- a/test/parallel/test-beforeexit-event.js
+++ b/test/parallel/test-beforeexit-event.js
@@ -1,7 +1,6 @@
 'use strict';
 var assert = require('assert');
 var net = require('net');
-var util = require('util');
 var common = require('../common');
 var revivals = 0;
 var deaths = 0;

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
-
 const Buffer = require('buffer').Buffer;
 const LENGTH = 16;
 

--- a/test/parallel/test-buffer-ascii.js
+++ b/test/parallel/test-buffer-ascii.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // ASCII conversion in node.js simply masks off the high bits,

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var common = require('../common');
 var assert = require('assert');
 var Buffer = require('buffer').Buffer;
 

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var zero = [];

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -1,9 +1,7 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const Buffer = require('buffer').Buffer;
-const Bp = Buffer.prototype;
 
 function FakeBuffer() { }
 FakeBuffer.__proto__ = Buffer;

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Buffer = require('buffer').Buffer;

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var util = require('util');

--- a/test/parallel/test-buffer-iterator.js
+++ b/test/parallel/test-buffer-iterator.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var buffer = new Buffer([1, 2, 3, 4, 5]);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const buffer = require('buffer');
 const Buffer = buffer.Buffer;

--- a/test/parallel/test-child-process-buffering.js
+++ b/test/parallel/test-child-process-buffering.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-var spawn = require('child_process').spawn;
-
 var pwd_called = false;
 var childClosed = false;
 var childExited = false;

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assert = require('assert');
-var common = require('../common');
 var child_process = require('child_process');
 var ChildProcess = child_process.ChildProcess;
 assert.equal(typeof ChildProcess, 'function');

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -1,8 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
-var path = require('path');
 
 var returns = 0;
 

--- a/test/parallel/test-child-process-detached.js
+++ b/test/parallel/test-child-process-detached.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 

--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -9,7 +9,7 @@ var success_count = 0;
 var str = 'hello';
 
 // default encoding
-var child = exec('echo ' + str, function(err, stdout, stderr) {
+exec('echo ' + str, function(err, stdout, stderr) {
   assert.ok('string', typeof(stdout), 'Expected stdout to be a string');
   assert.ok('string', typeof(stderr), 'Expected stderr to be a string');
   assert.equal(str + os.EOL, stdout);
@@ -18,7 +18,7 @@ var child = exec('echo ' + str, function(err, stdout, stderr) {
 });
 
 // no encoding (Buffers expected)
-var child = exec('echo ' + str, {
+exec('echo ' + str, {
   encoding: null
 }, function(err, stdout, stderr) {
   assert.ok(stdout instanceof Buffer, 'Expected stdout to be a Buffer');

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -16,7 +16,7 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-var child = exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
+exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
   if (err) {
     error_count++;
     console.log('error!: ' + err.code);

--- a/test/parallel/test-child-process-fork-and-spawn.js
+++ b/test/parallel/test-child-process-fork-and-spawn.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var fork = require('child_process').fork;

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -25,7 +25,6 @@ if (common.isWindows) {
 }
 
 if (process.argv[2] === 'child') {
-  var childCollected = 0;
   var server;
 
   process.on('message', function removeMe(msg, clusterServer) {

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var cp = require('child_process');
 var fs = require('fs');
 var path = require('path');
 var common = require('../common');

--- a/test/parallel/test-child-process-fork-ref.js
+++ b/test/parallel/test-child-process-fork-ref.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fork = require('child_process').fork;
 

--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 var fork = require('child_process').fork;
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 //messages

--- a/test/parallel/test-child-process-set-blocking.js
+++ b/test/parallel/test-child-process-set-blocking.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var ch = require('child_process');
 

--- a/test/parallel/test-child-process-silent.js
+++ b/test/parallel/test-child-process-silent.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var childProcess = require('child_process');
 

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var fs = require('fs');
 var spawn = require('child_process').spawn;
 var assert = require('assert');
 

--- a/test/parallel/test-child-process-spawnsync-env.js
+++ b/test/parallel/test-child-process-spawnsync-env.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cp = require('child_process');
 

--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var os = require('os');
 var util = require('util');
 
 var spawnSync = require('child_process').spawnSync;

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var spawnSync = require('child_process').spawnSync;

--- a/test/parallel/test-child-process-stdin-ipc.js
+++ b/test/parallel/test-child-process-stdin-ipc.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -59,6 +59,8 @@ cat.on('close', function() {
 
 process.on('exit', function() {
   assert.equal(0, exitStatus);
+  assert.equal(gotStdoutEOF, true);
+  assert.equal(gotStderrEOF, true);
   assert(closed);
   if (common.isWindows) {
     assert.equal('hello world\r\n', response);

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var BUFSIZE = 1024;
 

--- a/test/parallel/test-child-process-stdio-inherit.js
+++ b/test/parallel/test-child-process-stdio-inherit.js
@@ -31,5 +31,5 @@ function grandparent() {
 
 function parent() {
   // should not immediately exit.
-  var child = common.spawnCat({ stdio: 'inherit' });
+  common.spawnCat({ stdio: 'inherit' });
 }

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
 
 var options = {stdio: ['pipe']};
 var child = common.spawnPwd(options);

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var path = require('path');
 
 // if child process output to console and exit
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -2,7 +2,6 @@
 // Flags: --expose_internals
 
 var assert = require('assert');
-var common = require('../common');
 var _validateStdio = require('internal/child_process')._validateStdio;
 
 // should throw if string and not ignore, pipe, or inherit

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -5,11 +5,9 @@ if (module.parent) {
   process.exit(42);
 }
 
-var common = require('../common'),
-    assert = require('assert'),
-    child = require('child_process'),
-    nodejs = '"' + process.execPath + '"';
-
+var assert = require('assert');
+var child = require('child_process');
+var nodejs = '"' + process.execPath + '"';
 
 // replace \ by / because windows uses backslashes in paths, but they're still
 // interpreted as the escape character when put between quotes.

--- a/test/parallel/test-cluster-debug-port.js
+++ b/test/parallel/test-cluster-debug-port.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -2,7 +2,6 @@
 var NUM_WORKERS = 4;
 var PACKETS_PER_WORKER = 10;
 
-var assert = require('assert');
 var cluster = require('cluster');
 var common = require('../common');
 var dgram = require('dgram');

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -5,7 +5,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var cluster = require('cluster');
 var fork = require('child_process').fork;
 var net = require('net');
 

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -34,7 +34,6 @@ http.createServer(function(req, res) {
   res.writeHead(200);
   res.end('OK');
 }).listen(common.PIPE, function() {
-  var self = this;
   http.get({ socketPath: common.PIPE, path: '/' }, function(res) {
     res.resume();
     res.on('end', function(err) {

--- a/test/parallel/test-cluster-net-listen.js
+++ b/test/parallel/test-cluster-net-listen.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var net = require('net');

--- a/test/parallel/test-cluster-setup-master-argv.js
+++ b/test/parallel/test-cluster-setup-master-argv.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master-cumulative.js
+++ b/test/parallel/test-cluster-setup-master-cumulative.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master-emit.js
+++ b/test/parallel/test-cluster-setup-master-emit.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master-multiple.js
+++ b/test/parallel/test-cluster-setup-master-multiple.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -3,7 +3,6 @@
 // one that the cluster module installs.
 // https://github.com/joyent/node/issues/2556
 
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var fork = require('child_process').fork;

--- a/test/parallel/test-cluster-worker-constructor.js
+++ b/test/parallel/test-cluster-worker-constructor.js
@@ -2,7 +2,6 @@
 // test-cluster-worker-constructor.js
 // validates correct behavior of the cluster.Worker constructor
 
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var worker;

--- a/test/parallel/test-cluster-worker-death.js
+++ b/test/parallel/test-cluster-worker-death.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -1,7 +1,6 @@
 'use strict';
 var assert = require('assert');
 var cluster = require('cluster');
-var net = require('net');
 
 var SENTINEL = 42;
 

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -3,7 +3,6 @@
 // verifies that, when a child process is forked, the cluster.worker
 // object can receive messages as expected
 
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var msg = 'foo';

--- a/test/parallel/test-cluster-worker-isconnected.js
+++ b/test/parallel/test-cluster-worker-isconnected.js
@@ -1,7 +1,6 @@
 'use strict';
 var cluster = require('cluster');
 var assert = require('assert');
-var util = require('util');
 
 if (cluster.isMaster) {
   var worker = cluster.fork();

--- a/test/parallel/test-cluster-worker-isdead.js
+++ b/test/parallel/test-cluster-worker-isdead.js
@@ -1,7 +1,6 @@
 'use strict';
 var cluster = require('cluster');
 var assert = require('assert');
-var net = require('net');
 
 if (cluster.isMaster) {
   var worker = cluster.fork();

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var Stream = require('stream');
 var Console = require('console').Console;

--- a/test/parallel/test-console-not-call-toString.js
+++ b/test/parallel/test-console-not-call-toString.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var func = function() {};

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 assert.ok(process.stdout.writable);

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -20,7 +20,6 @@ var fs = require('fs');
 var path = require('path');
 
 // Test Certificates
-var caPem = fs.readFileSync(common.fixturesDir + '/test_ca.pem', 'ascii');
 var certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
 var certPfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
 var keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -11,7 +11,6 @@ var crypto = require('crypto');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 var fs = require('fs');
-var path = require('path');
 
 // Test Certificates
 var spkacValid = fs.readFileSync(common.fixturesDir + '/spkac.valid');

--- a/test/parallel/test-crypto-dh-odd-key.js
+++ b/test/parallel/test-crypto-dh-odd-key.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -166,7 +166,7 @@ var ecdh3 = crypto.createECDH('secp256k1');
 var key3 = ecdh3.generateKeys();
 
 assert.throws(function() {
-  var secret3 = ecdh2.computeSecret(key3, 'binary', 'buffer');
+  ecdh2.computeSecret(key3, 'binary', 'buffer');
 });
 
 // ECDH should allow .setPrivateKey()/.setPublicKey()

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
@@ -20,8 +19,6 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var canSend = true;
-
 var server = tls.Server(options, function(socket) {
   setImmediate(function() {
     console.log('sending');
@@ -32,17 +29,14 @@ var server = tls.Server(options, function(socket) {
   });
 });
 
-var client;
-
 function verify() {
   console.log('verify');
-  var verified = crypto.createVerify('RSA-SHA1')
-                     .update('Test')
-                     .verify(certPem, 'asdfasdfas', 'base64');
+  crypto.createVerify('RSA-SHA1').update('Test')
+        .verify(certPem, 'asdfasdfas', 'base64');
 }
 
 server.listen(common.PORT, function() {
-  client = tls.connect({
+  tls.connect({
     port: common.PORT,
     rejectUnauthorized: false
   }, function() {

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -10,7 +10,6 @@ var options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };
 var child = spawn(process.execPath, args, options);
 
 var outputLines = [];
-var outputTimerId;
 var waitingForDebuggers = false;
 
 var pids = null;

--- a/test/parallel/test-delayed-require.js
+++ b/test/parallel/test-delayed-require.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var a;

--- a/test/parallel/test-dgram-bind.js
+++ b/test/parallel/test-dgram-bind.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-bytes-length.js
+++ b/test/parallel/test-dgram-bytes-length.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-empty-packet.js
+++ b/test/parallel/test-dgram-empty-packet.js
@@ -1,8 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
-
-var fs = require('fs');
 var dgram = require('dgram');
 var callbacks = 0;
 var client;

--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -20,7 +20,6 @@ socket_ipv4.bind(common.PORT, '1.1.1.1');
 
 // IPv6 Test
 var socket_ipv6 = dgram.createSocket('udp6');
-var family_ipv6 = 'IPv6';
 
 socket_ipv6.on('listening', assert.fail);
 

--- a/test/parallel/test-dgram-listen-after-bind.js
+++ b/test/parallel/test-dgram-listen-after-bind.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-pingpong.js
+++ b/test/parallel/test-dgram-pingpong.js
@@ -57,6 +57,7 @@ function pingPongTest(port, host) {
 
     client.on('close', function() {
       console.log('client has closed, closing server');
+      assert.equal(sent_final_ping, true);
       assert.equal(N, count);
       tests_run += 1;
       server.close();

--- a/test/parallel/test-dgram-ref.js
+++ b/test/parallel/test-dgram-ref.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var dgram = require('dgram');
 
 // should not hang, see #1282

--- a/test/parallel/test-dgram-regress-4496.js
+++ b/test/parallel/test-dgram-regress-4496.js
@@ -1,7 +1,6 @@
 'use strict';
 // Remove this test once we support sending strings.
 
-var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/parallel/test-dgram-send-bad-arguments.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -2,9 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs');
 var dgram = require('dgram');
-var callbacks = 0;
 var client, timer, buf, len, offset;
 
 

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -1,10 +1,6 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
-
-var fs = require('fs');
 var dgram = require('dgram');
-var callbacks = 0;
 var client, timer, buf;
 
 if (process.platform === 'darwin') {

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -2,8 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs'),
-    dgram = require('dgram'), server, client,
+var dgram = require('dgram'), server, client,
     server_port = common.PORT,
     message_to_send = 'A message to send',
     timer;

--- a/test/parallel/test-dgram-unref.js
+++ b/test/parallel/test-dgram-unref.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var dgram = require('dgram');

--- a/test/parallel/test-dh-padding.js
+++ b/test/parallel/test-dh-padding.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 try {
@@ -13,7 +12,6 @@ var prime = 'c51f7bf8f0e1cf899243cdf408b1bc7c09c010e33ef7f3fbe5bd5feaf906113b';
 var apub = '6fe9f37037d8d017f908378c1ee04fe60e1cd3668bfc5075fac55c2f7153dd84';
 var bpub = '31d83e167fdf956c9dae6b980140577a9f8868acbfcbdc19113e58bfb9223abc';
 var apriv = '4fbfd4661f9181bbf574537b1a78adf473e8e771eef13c605e963c0f3094b697';
-var secret = '25616eed33f1af7975bbd0a8071d98a014f538b243bef90d76c08e81a0b3c500';
 
 var p = crypto.createDiffieHellman(prime, 'hex');
 

--- a/test/parallel/test-dns-cares-domains.js
+++ b/test/parallel/test-dns-cares-domains.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dns = require('dns');
 var domain = require('domain');

--- a/test/parallel/test-dns-lookup-cb-error.js
+++ b/test/parallel/test-dns-lookup-cb-error.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cares = process.binding('cares_wrap');
 

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var dns = require('dns');
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var dns = require('dns');

--- a/test/parallel/test-domain-exit-dispose-again.js
+++ b/test/parallel/test-domain-exit-dispose-again.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var disposalFailed = false;

--- a/test/parallel/test-domain-exit-dispose.js
+++ b/test/parallel/test-domain-exit-dispose.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var disposalFailed = false;

--- a/test/parallel/test-domain-from-timer.js
+++ b/test/parallel/test-domain-from-timer.js
@@ -1,7 +1,6 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-var common = require('../common');
 var assert = require('assert');
 
 // timeouts call the callback directly from cc, so need to make sure the

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -9,7 +9,6 @@ objects.baz.asdf = objects;
 
 var serverCaught = 0;
 var clientCaught = 0;
-var disposeEmit = 0;
 
 var server = http.createServer(function(req, res) {
   var dom = domain.create();

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -1,15 +1,12 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 var caught = 0;
 var expectCaught = 1;
 
 var d = new domain.Domain();
-var e = new events.EventEmitter();
 
 d.on('error', function(er) {
   console.error('caught', er);

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -4,7 +4,6 @@
 var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 
 var caughtA = false;
 var caughtB = false;

--- a/test/parallel/test-domain-nested-throw.js
+++ b/test/parallel/test-domain-nested-throw.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var domain = require('domain');

--- a/test/parallel/test-domain-stack.js
+++ b/test/parallel/test-domain-stack.js
@@ -1,10 +1,7 @@
 'use strict';
 // Make sure that the domain stack doesn't get out of hand.
 
-var common = require('../common');
-var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 
 var a = domain.create();
 a.name = 'a';

--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -1,7 +1,6 @@
 'use strict';
 var domain = require('domain');
 var assert = require('assert');
-var common = require('../common');
 
 var timeout_err, timeout, immediate_err;
 

--- a/test/parallel/test-domain.js
+++ b/test/parallel/test-domain.js
@@ -1,7 +1,6 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var events = require('events');

--- a/test/parallel/test-eval-require.js
+++ b/test/parallel/test-eval-require.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
-var path = require('path');
-var fs = require('fs');
 
 var options = {
   cwd: common.fixturesDir

--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -10,7 +10,7 @@ var error_count = 0;
 var cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
            'foo', 'bar'].join(' ');
 var expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
-var child = exec(cmd, function(err, stdout, stderr) {
+exec(cmd, function(err, stdout, stderr) {
   if (err) {
     console.log(err.toString());
     ++error_count;

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var EventEmitter = require('events');
 

--- a/test/parallel/test-event-emitter-listener-count.js
+++ b/test/parallel/test-event-emitter-listener-count.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var common = require('../common');
-var assert = require('assert');
-var events = require('events');
-
 var EventEmitter = require('events').EventEmitter;
 var assert = require('assert');
 

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-method-names.js
+++ b/test/parallel/test-event-emitter-method-names.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-modify-in-emit.js
+++ b/test/parallel/test-event-emitter-modify-in-emit.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
+++ b/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 var domain = require('domain');

--- a/test/parallel/test-event-emitter-num-args.js
+++ b/test/parallel/test-event-emitter-num-args.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -15,11 +15,6 @@ function listener2() {
   count++;
 }
 
-function listener3() {
-  console.log('listener3');
-  count++;
-}
-
 function remove1() {
   assert(0);
 }

--- a/test/parallel/test-event-emitter-set-max-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-set-max-listeners-side-effects.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');

--- a/test/parallel/test-exception-handler.js
+++ b/test/parallel/test-exception-handler.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var MESSAGE = 'catch me if you can';

--- a/test/parallel/test-exception-handler2.js
+++ b/test/parallel/test-exception-handler2.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 process.on('uncaughtException', function(err) {

--- a/test/parallel/test-exec-max-buffer.js
+++ b/test/parallel/test-exec-max-buffer.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var exec = require('child_process').exec;
 var assert = require('assert');
 

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -1,11 +1,8 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-
 var path = require('path');
 var fs = require('fs');
-var util = require('util');
-
 
 var filepath = path.join(common.tmpDir, 'write.txt');
 var file;

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -1,11 +1,8 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-
-var path = require('path'),
-    fs = require('fs'),
-    util = require('util');
-
+var path = require('path');
+var fs = require('fs');
 
 var filepath = path.join(common.tmpDir, 'write_pos.txt');
 
@@ -125,7 +122,7 @@ function run_test_2() {
 
 
 function run_test_3() {
-  var file, buffer, options;
+  var file, options;
 
   var data = '\u2026\u2026',    // 3 bytes * 2 = 6 bytes in UTF-8
       fileData;
@@ -168,10 +165,7 @@ function run_test_3() {
 
 
 function run_test_4() {
-  var file, options;
-
-  options = { start: -5,
-              flags: 'r+' };
+  var options = { start: -5, flags: 'r+' };
 
   //  Error: start must be >= zero
   assert.throws(

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var f = __filename;

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var constants = require('constants');
@@ -7,14 +6,9 @@ var fs = require('fs');
 
 var O_APPEND = constants.O_APPEND || 0;
 var O_CREAT = constants.O_CREAT || 0;
-var O_DIRECTORY = constants.O_DIRECTORY || 0;
 var O_EXCL = constants.O_EXCL || 0;
-var O_NOCTTY = constants.O_NOCTTY || 0;
-var O_NOFOLLOW = constants.O_NOFOLLOW || 0;
 var O_RDONLY = constants.O_RDONLY || 0;
 var O_RDWR = constants.O_RDWR || 0;
-var O_SYMLINK = constants.O_SYMLINK || 0;
-var O_SYNC = constants.O_SYNC || 0;
 var O_TRUNC = constants.O_TRUNC || 0;
 var O_WRONLY = constants.O_WRONLY || 0;
 

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -1,6 +1,4 @@
 'use strict';
-var constants = require('constants');
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-read-file-sync-hostname.js
+++ b/test/parallel/test-fs-read-file-sync-hostname.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-readfile-zero-byte-liar.js
+++ b/test/parallel/test-fs-readfile-zero-byte-liar.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -1,5 +1,4 @@
 /* eslint-disable strict */
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var got_error = false;

--- a/test/parallel/test-fs-sync-fd-leak.js
+++ b/test/parallel/test-fs-sync-fd-leak.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -48,7 +48,7 @@ function expect_ok(syscall, resource, err, atime, mtime) {
 // would be even better though (node doesn't have such functionality yet)
 function runTest(atime, mtime, callback) {
 
-  var fd, err;
+  var fd;
   //
   // test synchronized code paths, these functions throw on failure
   //

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -14,9 +14,6 @@ fs.openSync = openSync;
 fs._closeSync = fs.closeSync;
 fs.closeSync = closeSync;
 
-// Reset the umask for testing
-var mask = process.umask(0o000);
-
 // On Windows chmod is only able to manipulate read-only bit. Test if creating
 // the file in read-only mode works.
 if (common.isWindows) {

--- a/test/parallel/test-fs-write-no-fd.js
+++ b/test/parallel/test-fs-write-no-fd.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
 

--- a/test/parallel/test-handle-wrap-close-abort.js
+++ b/test/parallel/test-handle-wrap-close-abort.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-
 process.on('uncaughtException', function() { });
 
 setTimeout(function() {

--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var net = require('net');
 

--- a/test/parallel/test-http-304.js
+++ b/test/parallel/test-http-304.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 var childProcess = require('child_process');

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -14,7 +14,7 @@ var server = http.Server(function(req, res) {
 var responseClose = false;
 
 server.listen(common.PORT, function() {
-  var client = http.get({
+  http.get({
     port: common.PORT,
     headers: { connection: 'keep-alive' }
 

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -45,7 +45,7 @@ server.listen(common.PORT, function() {
 });
 
 function doRequest(i) {
-  var req = http.get({
+  http.get({
     port: common.PORT,
     path: '/request' + i
   }, function(res) {

--- a/test/parallel/test-http-agent-false.js
+++ b/test/parallel/test-http-agent-false.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert');
 var http = require('http');
-var common = require('../common');
 
 var agent = new http.Agent();
 

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var Agent = require('_http_agent').Agent;
-var EventEmitter = require('events').EventEmitter;
 
 var agent = new Agent({
   keepAlive: true,

--- a/test/parallel/test-http-agent-null.js
+++ b/test/parallel/test-http-agent-null.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var net = require('net');
 
 var request = 0;
 var response = 0;

--- a/test/parallel/test-http-buffer-sanity.js
+++ b/test/parallel/test-http-buffer-sanity.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
 
 var bufferSize = 5 * 1024 * 1024;
 var measuredSize = 0;

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
 var http = require('http');
 
 var body = 'hello world\n';

--- a/test/parallel/test-http-client-abort2.js
+++ b/test/parallel/test-http-client-abort2.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-client-encoding.js
+++ b/test/parallel/test-http-client-encoding.js
@@ -1,7 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
-
 var http = require('http');
 
 http.createServer(function(req, res) {

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -2,7 +2,6 @@
 // see https://github.com/joyent/node/issues/3257
 
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var util = require('util');

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -57,7 +57,7 @@ if (common.hasCrypto) {
     res.end('ok');
     this.close();
   }).listen(SSLPORT, function() {
-    var req = https.get({
+    https.get({
       host: 'localhost',
       rejectUnauthorized: false,
       headers: {

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -6,7 +6,6 @@ var assert = require('assert');
 // where the server has ended the socket.
 
 var http = require('http');
-var net = require('net');
 var server = http.createServer(function(req, res) {
   setImmediate(function() {
     res.destroy();

--- a/test/parallel/test-http-eof-on-connect.js
+++ b/test/parallel/test-http-eof-on-connect.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var net = require('net');
 var http = require('http');
 

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
@@ -11,9 +10,8 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req;
   for (var i = 0; i < 4; i += 1) {
-    req = http.get({ port: common.PORT, path: '/busy/' + i });
+    http.get({ port: common.PORT, path: '/busy/' + i });
   }
 });
 

--- a/test/parallel/test-http-flush.js
+++ b/test/parallel/test-http-flush.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 http.createServer(function(req, res) {

--- a/test/parallel/test-http-head-request.js
+++ b/test/parallel/test-http-head-request.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
-
 
 var body = 'hello world\n';
 var id = 0;

--- a/test/parallel/test-http-header-response-splitting.js
+++ b/test/parallel/test-http-header-response-splitting.js
@@ -32,7 +32,7 @@ var server = http.createServer(function(req, res) {
 
 server.listen(common.PORT, function() {
   for (var i = 0; i < 5; i++) {
-    var req = http.get({ port: common.PORT, path: '/' }, function(res) {
+    http.get({ port: common.PORT, path: '/' }, function(res) {
       assert.strictEqual(res.headers.test, 'foo invalid: bar');
       assert.strictEqual(res.headers.invalid, undefined);
       responses++;

--- a/test/parallel/test-http-incoming-pipelined-socket-destroy.js
+++ b/test/parallel/test-http-incoming-pipelined-socket-destroy.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 var net = require('net');

--- a/test/parallel/test-http-keep-alive-close-on-header.js
+++ b/test/parallel/test-http-keep-alive-close-on-header.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
 
 var body = 'hello world\n';
 var headers = {'connection': 'keep-alive'};

--- a/test/parallel/test-http-keep-alive.js
+++ b/test/parallel/test-http-keep-alive.js
@@ -11,7 +11,6 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
-var connectCount = 0;
 var agent = new http.Agent({maxSockets: 1});
 var headers = {'connection': 'keep-alive'};
 var name = agent.getName({ port: common.PORT });

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -4,10 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
-function p(x) {
-  common.error(common.inspect(x));
-}
-
 var responses_sent = 0;
 var responses_recvd = 0;
 var body0 = '';

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -17,7 +17,7 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var req = http.request({
+  http.request({
     host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // no warnings should happen!
 var trace = console.trace;

--- a/test/parallel/test-http-methods.js
+++ b/test/parallel/test-http-methods.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var util = require('util');

--- a/test/parallel/test-http-no-content-length.js
+++ b/test/parallel/test-http-no-content-length.js
@@ -10,7 +10,7 @@ var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
 }).listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  http.get({port: common.PORT}, function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       body += chunk;

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -4,7 +4,6 @@
 
 // Flags: --expose_gc
 
-var common = require('../common');
 var assert = require('assert');
 var HTTPParser = process.binding('http_parser').HTTPParser;
 

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var HTTPParser = process.binding('http_parser').HTTPParser;

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -25,7 +25,7 @@ var backend = http.createServer(function(req, res) {
 
 var proxy = http.createServer(function(req, res) {
   console.error('proxy req headers: ' + JSON.stringify(req.headers));
-  var proxy_req = http.get({
+  http.get({
     port: BACKEND_PORT,
     path: url.parse(req.url).pathname
   }, function(proxy_res) {
@@ -56,7 +56,7 @@ function startReq() {
   nlistening++;
   if (nlistening < 2) return;
 
-  var client = http.get({
+  http.get({
     port: PROXY_PORT,
     path: '/test'
   }, function(res) {

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -54,14 +54,6 @@ http.createServer(function(req, res) {
   ]);
   res.end('x f o o');
 }).listen(common.PORT, function() {
-  var expectRawHeaders = [
-    'Date',
-    'Tue, 06 Aug 2013 01:31:54 GMT',
-    'Connection',
-    'close',
-    'Transfer-Encoding',
-    'chunked'
-  ];
   var req = http.request({ port: common.PORT, path: '/' });
   req.addTrailers([
     ['x-bAr', 'yOyOyOy'],

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -18,7 +18,7 @@ var server = http.Server(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  http.get({port: common.PORT}, function(res) {
     server.close();
   });
 });

--- a/test/parallel/test-http-server-stale-close.js
+++ b/test/parallel/test-http-server-stale-close.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var util = require('util');
 var fork = require('child_process').fork;

--- a/test/parallel/test-http-timeout.js
+++ b/test/parallel/test-http-timeout.js
@@ -1,7 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
-
 var http = require('http');
 
 var port = common.PORT;

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
 var http = require('http');
 
 var status_ok = false; // status code == 200?

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -10,7 +10,6 @@ var https = require('https');
 
 var url = require('url');
 var fs = require('fs');
-var clientRequest;
 
 // https options
 var httpsOptions = {

--- a/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
+++ b/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -4,10 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
-function p(x) {
-  common.error(common.inspect(x));
-}
-
 var responses_sent = 0;
 var responses_recvd = 0;
 var body0 = '';

--- a/test/parallel/test-https-agent-servername.js
+++ b/test/parallel/test-https-agent-servername.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
-var http = require('http');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -53,7 +53,7 @@ var bodyBuffer = '';
 
 server.listen(common.PORT, function() {
   console.log('1) Making Request');
-  var req = https.get({
+  https.get({
     port: common.PORT,
     rejectUnauthorized: false
   }, function(res) {

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -28,7 +28,7 @@ var server = https.createServer(options, function(req, res) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var req = https.request({
+  https.request({
     host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -1,16 +1,12 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
   return;
 }
 var https = require('https');
-
 var fs = require('fs');
-var exec = require('child_process').exec;
-
 var http = require('http');
 
 var options = {

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -110,7 +110,6 @@ function makeReq(path, port, error, host, ca) {
     path: path,
     ca: ca
   };
-  var whichCa = 0;
   if (!ca) {
     options.agent = agent0;
   } else {

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 }
 var https = require('https');
 
-var net = require('net');
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var net = require('net');
-var tls = require('tls');
 var fs = require('fs');
 
 var clientErrors = 0;

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
@@ -9,7 +8,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var fs = require('fs');
-var exec = require('child_process').exec;
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var fs = require('fs');
-var path = require('path');
 
 var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');

--- a/test/parallel/test-internal-modules-expose.js
+++ b/test/parallel/test-internal-modules-expose.js
@@ -1,7 +1,6 @@
 'use strict';
 // Flags: --expose_internals
 
-var common = require('../common');
 var assert = require('assert');
 
 assert.equal(typeof require('internal/freelist').FreeList, 'function');

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 assert.throws(function() {

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // does node think that i18n was enabled?

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 var cluster = require('cluster');
 
 console.error('Cluster listen fd test', process.argv[2] || 'runner');

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 
 if (common.isWindows) {
   console.log('1..0 # Skipped: This test is disabled on windows.');

--- a/test/parallel/test-microtask-queue-integration-domain.js
+++ b/test/parallel/test-microtask-queue-integration-domain.js
@@ -1,7 +1,5 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
-var domain = require('domain');
 
 var implementations = [
   function(fn) {

--- a/test/parallel/test-microtask-queue-integration.js
+++ b/test/parallel/test-microtask-queue-integration.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var implementations = [

--- a/test/parallel/test-microtask-queue-run-domain.js
+++ b/test/parallel/test-microtask-queue-run-domain.js
@@ -1,7 +1,5 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
-var domain = require('domain');
 
 function enqueueMicrotask(fn) {
   Promise.resolve().then(fn);

--- a/test/parallel/test-microtask-queue-run-immediate-domain.js
+++ b/test/parallel/test-microtask-queue-run-immediate-domain.js
@@ -1,7 +1,5 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
-var domain = require('domain');
 
 function enqueueMicrotask(fn) {
   Promise.resolve().then(fn);

--- a/test/parallel/test-microtask-queue-run-immediate.js
+++ b/test/parallel/test-microtask-queue-run-immediate.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 function enqueueMicrotask(fn) {

--- a/test/parallel/test-microtask-queue-run.js
+++ b/test/parallel/test-microtask-queue-run.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 function enqueueMicrotask(fn) {

--- a/test/parallel/test-net-create-connection.js
+++ b/test/parallel/test-net-create-connection.js
@@ -22,7 +22,7 @@ server.listen(tcpPort, 'localhost', function() {
 
   function fail(opts, errtype, msg) {
     assert.throws(function() {
-      var client = net.createConnection(opts, cb);
+      net.createConnection(opts, cb);
     }, function(err) {
       return err instanceof errtype && msg === err.message;
     });

--- a/test/parallel/test-net-dns-custom-lookup.js
+++ b/test/parallel/test-net-dns-custom-lookup.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var dns = require('dns');
 var ok = false;
 
 function check(addressType, cb) {

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var net = require('net');

--- a/test/parallel/test-net-end-without-connect.js
+++ b/test/parallel/test-net-end-without-connect.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var net = require('net');
 
 var sock = new net.Socket();

--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var gotError = false;
 
 var server = net.createServer(function(socket) {
 });

--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var conns = 0, conns_closed = 0;
+var conns = 0;
 
 var server = net.createServer(function(socket) {
   conns++;

--- a/test/parallel/test-net-localerror.js
+++ b/test/parallel/test-net-localerror.js
@@ -17,6 +17,6 @@ connect({
 
 function connect(opts, msg) {
   assert.throws(function() {
-    var client = net.connect(opts);
+    net.connect(opts);
   }, msg);
 }

--- a/test/parallel/test-net-reconnect.js
+++ b/test/parallel/test-net-reconnect.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 var net = require('net');
 
 var N = 50;
-var c = 0;
 var client_recv_count = 0;
 var client_end_count = 0;
 var disconnect_count = 0;

--- a/test/parallel/test-net-server-connections.js
+++ b/test/parallel/test-net-server-connections.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var net = require('net');

--- a/test/parallel/test-net-server-unref-persistent.js
+++ b/test/parallel/test-net-server-unref-persistent.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 var closed = false;

--- a/test/parallel/test-next-tick-domain.js
+++ b/test/parallel/test-next-tick-domain.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var origNextTick = process.nextTick;

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var order = [],

--- a/test/parallel/test-next-tick-intentional-starvation.js
+++ b/test/parallel/test-next-tick-intentional-starvation.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // this is the inverse of test-next-tick-starvation.

--- a/test/parallel/test-next-tick-ordering.js
+++ b/test/parallel/test-next-tick-ordering.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var i;
 

--- a/test/parallel/test-next-tick-ordering2.js
+++ b/test/parallel/test-next-tick-ordering2.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var order = [];

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var complete = 0;

--- a/test/parallel/test-path-zero-length-strings.js
+++ b/test/parallel/test-path-zero-length-strings.js
@@ -5,7 +5,6 @@
 // directory. This test makes sure that the behaviour is intact between commits.
 // See: https://github.com/nodejs/node/pull/2106
 
-const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const pwd = process.cwd();

--- a/test/parallel/test-pipe-return-val.js
+++ b/test/parallel/test-pipe-return-val.js
@@ -1,10 +1,8 @@
 'use strict';
 // This test ensures SourceStream.pipe(DestStream) returns DestStream
 
-var common = require('../common');
 var Stream = require('stream').Stream;
 var assert = require('assert');
-var util = require('util');
 
 var sourceStream = new Stream();
 var destStream = new Stream();

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -1,8 +1,7 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    path = require('path'),
-    child_process = require('child_process');
+var assert = require('assert');
+var path = require('path');
+var child_process = require('child_process');
 
 var nodeBinary = process.argv[0];
 
@@ -82,7 +81,6 @@ child_process.exec(nodeBinary + ' '
   });
 
 // https://github.com/nodejs/node/issues/1691
-var originalCwd = process.cwd();
 process.chdir(path.join(__dirname, '../fixtures/'));
 child_process.exec(nodeBinary + ' '
   + '--expose_debug_as=v8debug '

--- a/test/parallel/test-process-before-exit.js
+++ b/test/parallel/test-process-before-exit.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var common = require('../common');
 
 var N = 5;
 var n = 0;

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -4,7 +4,6 @@
 // first things first, set the timezone; see tzset(3)
 process.env.TZ = 'Europe/Amsterdam';
 
-var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 switch (process.argv[2]) {

--- a/test/parallel/test-process-exit.js
+++ b/test/parallel/test-process-exit.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // calling .exit() from within "exit" should not overflow the call stack

--- a/test/parallel/test-process-getgroups.js
+++ b/test/parallel/test-process-getgroups.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // the default behavior, return an Array "tuple" of numbers

--- a/test/parallel/test-process-kill-null.js
+++ b/test/parallel/test-process-kill-null.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // test variants of pid

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var N = 2;
 var tickCount = 0;

--- a/test/parallel/test-process-raw-debug.js
+++ b/test/parallel/test-process-raw-debug.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var os = require('os');
 

--- a/test/parallel/test-process-wrap.js
+++ b/test/parallel/test-process-wrap.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var Process = process.binding('process_wrap').Process;
 var Pipe = process.binding('pipe_wrap').Pipe;

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 
@@ -185,12 +184,11 @@ asyncTest('When re-throwing new errors in a promise catch, only the' +
 asyncTest('Test params of unhandledRejection for a synchronously-rejected' +
           'promise', function(done) {
   var e = new Error();
-  var e2 = new Error();
   onUnhandledSucceed(done, function(reason, promise) {
     assert.strictEqual(e, reason);
     assert.strictEqual(promise, promise);
   });
-  var promise = Promise.reject(e);
+  Promise.reject(e);
 });
 
 asyncTest('When re-throwing new errors in a promise catch, only the ' +
@@ -629,7 +627,7 @@ asyncTest('Promise unhandledRejection handler does not interfere with domain' +
       assert.strictEqual(domainReceivedError, domainError);
       d.dispose();
     });
-    var a = Promise.reject(e);
+    Promise.reject(e);
     process.nextTick(function() {
       throw domainError;
     });

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var punycode = require('punycode');
 var assert = require('assert');
 

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // test using assert

--- a/test/parallel/test-readdouble.js
+++ b/test/parallel/test-readdouble.js
@@ -2,7 +2,6 @@
 /*
  * Tests to verify we're reading in doubles correctly
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-readfloat.js
+++ b/test/parallel/test-readfloat.js
@@ -2,7 +2,6 @@
 /*
  * Tests to verify we're reading in floats correctly
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-readint.js
+++ b/test/parallel/test-readint.js
@@ -2,7 +2,6 @@
 /*
  * Tests to verify we're reading in signed integers correctly
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -1,5 +1,4 @@
 'use strict';
-var EventEmitter = require('events').EventEmitter;
 var PassThrough = require('stream').PassThrough;
 var assert = require('assert');
 var inherits = require('util').inherits;
@@ -15,7 +14,7 @@ inherits(FakeInput, PassThrough);
 
 var fi = new FakeInput();
 var fo = new FakeInput();
-var rli = new Interface({ input: fi, output: fo, terminal: true });
+new Interface({ input: fi, output: fo, terminal: true });
 
 var keys = [];
 fi.on('keypress', function(s, k) {

--- a/test/parallel/test-readuint.js
+++ b/test/parallel/test-readuint.js
@@ -3,7 +3,6 @@
  * A battery of tests to help us read a series of uints
  */
 
-var common = require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-ref-unref-return.js
+++ b/test/parallel/test-ref-unref-return.js
@@ -2,7 +2,6 @@
 var assert = require('assert');
 var net = require('net');
 var dgram = require('dgram');
-var common = require('../common');
 
 assert.ok((new net.Server()).ref() instanceof net.Server);
 assert.ok((new net.Server()).unref() instanceof net.Server);

--- a/test/parallel/test-regress-GH-4256.js
+++ b/test/parallel/test-regress-GH-4256.js
@@ -1,5 +1,5 @@
 'use strict';
 process.domain = null;
-var timer = setTimeout(function() {
+setTimeout(function() {
   console.log('this console.log statement should not make node crash');
 }, 1);

--- a/test/parallel/test-regress-GH-6235.js
+++ b/test/parallel/test-regress-GH-6235.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 assert.doesNotThrow(function() {

--- a/test/parallel/test-regress-GH-7511.js
+++ b/test/parallel/test-regress-GH-7511.js
@@ -1,7 +1,6 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    vm     = require('vm');
+var assert = require('assert');
+var vm     = require('vm');
 
 assert.doesNotThrow(function() {
   var context = vm.createContext({ process: process });

--- a/test/parallel/test-regress-GH-897.js
+++ b/test/parallel/test-regress-GH-897.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var t = Date.now();

--- a/test/parallel/test-repl-autolibs.js
+++ b/test/parallel/test-repl-autolibs.js
@@ -19,7 +19,7 @@ ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
 var putIn = new ArrayStream();
-var testMe = repl.start('', putIn, null, true);
+repl.start('', putIn, null, true);
 
 test1();
 

--- a/test/parallel/test-repl-console.js
+++ b/test/parallel/test-repl-console.js
@@ -1,8 +1,7 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    Stream = require('stream'),
-    repl = require('repl');
+var assert = require('assert');
+var Stream = require('stream');
+var repl = require('repl');
 
 // create a dummy stream that does nothing
 var stream = new Stream();

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -1,6 +1,4 @@
 'use strict';
-var assert = require('assert');
-var common = require('../common');
 
 var util   = require('util');
 var repl   = require('repl');
@@ -21,7 +19,7 @@ ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
 var putIn = new ArrayStream();
-var testMe = repl.start('', putIn);
+repl.start('', putIn);
 
 putIn.write = function(data) {
   // Don't use assert for this because the domain might catch it, and

--- a/test/parallel/test-repl-end-emits-exit.js
+++ b/test/parallel/test-repl-end-emits-exit.js
@@ -1,10 +1,9 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    Stream = require('stream'),
-    repl = require('repl'),
-    terminalExit = 0,
-    regularExit = 0;
+var assert = require('assert');
+var Stream = require('stream');
+var repl = require('repl');
+var terminalExit = 0;
+var regularExit = 0;
 
 // create a dummy stream that does nothing
 var stream = new Stream();

--- a/test/parallel/test-repl-harmony.js
+++ b/test/parallel/test-repl-harmony.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/parallel/test-repl-require-cache.js
+++ b/test/parallel/test-repl-require-cache.js
@@ -1,7 +1,6 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    repl = require('repl');
+var assert = require('assert');
+var repl = require('repl');
 
 // https://github.com/joyent/node/issues/3226
 

--- a/test/parallel/test-repl-setprompt.js
+++ b/test/parallel/test-repl-setprompt.js
@@ -1,9 +1,8 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    spawn = require('child_process').spawn,
-    os = require('os'),
-    util = require('util');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var os = require('os');
+var util = require('util');
 
 var args = [
   '-e',

--- a/test/parallel/test-repl-syntax-error-handling.js
+++ b/test/parallel/test-repl-syntax-error-handling.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 switch (process.argv[2]) {

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var util = require('util');
 var repl = require('repl');
 var zlib = require('zlib');
 

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -2,7 +2,6 @@
 /*
  * This is a regression test for https://github.com/joyent/node/issues/8874.
  */
-var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/parallel/test-require-cache.js
+++ b/test/parallel/test-require-cache.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 (function testInjectFakeModule() {

--- a/test/parallel/test-require-extensions-main.js
+++ b/test/parallel/test-require-extensions-main.js
@@ -1,5 +1,4 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 require(common.fixturesDir + '/require-bin/bin/req.js');

--- a/test/parallel/test-signal-safety.js
+++ b/test/parallel/test-signal-safety.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var Signal = process.binding('signal_wrap').Signal;
 

--- a/test/parallel/test-stdin-hang.js
+++ b/test/parallel/test-stdin-hang.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 
 // This test *only* verifies that invoking the stdin getter does not
 // cause node to hang indefinitely.

--- a/test/parallel/test-stdio-readable-writable.js
+++ b/test/parallel/test-stdio-readable-writable.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 assert(process.stdout.writable);

--- a/test/parallel/test-stdout-close-unref.js
+++ b/test/parallel/test-stdout-close-unref.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var common = require('../common');
 
 var errs = 0;
 

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 var stream = require('stream');

--- a/test/parallel/test-stream-big-push.js
+++ b/test/parallel/test-stream-big-push.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
 var str = 'asdfasdfasdfasdfasdf';

--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Duplex = require('stream').Transform;

--- a/test/parallel/test-stream-end-paused.js
+++ b/test/parallel/test-stream-end-paused.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var gotEnd = false;
 

--- a/test/parallel/test-stream-ispaused.js
+++ b/test/parallel/test-stream-ispaused.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var common = require('../common');
 
 var stream = require('stream');
 

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('_stream_readable');

--- a/test/parallel/test-stream-pipe-cleanup.js
+++ b/test/parallel/test-stream-pipe-cleanup.js
@@ -2,7 +2,6 @@
 // This test asserts that Stream.prototype.pipe does not leave listeners
 // hanging on the source or dest.
 
-var common = require('../common');
 var stream = require('stream');
 var assert = require('assert');
 var util = require('util');

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var Stream = require('stream').Stream;
 
@@ -38,7 +37,6 @@ var Stream = require('stream').Stream;
 })();
 
 (function testErrorWithRemovedListenerThrows() {
-  var EE = require('events').EventEmitter;
   var R = Stream.Readable;
   var W = Stream.Writable;
 
@@ -73,7 +71,6 @@ var Stream = require('stream').Stream;
 })();
 
 (function testErrorWithRemovedListenerThrows() {
-  var EE = require('events').EventEmitter;
   var R = Stream.Readable;
   var W = Stream.Writable;
 

--- a/test/parallel/test-stream-pipe-event.js
+++ b/test/parallel/test-stream-pipe-event.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var stream = require('stream');
 var assert = require('assert');
 var util = require('util');

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var Readable = require('stream').Readable;
 var assert = require('assert');
 
@@ -21,7 +20,7 @@ s._read = function(n) {
   }
 };
 
-var v = s.read(0);
+s.read(0);
 
 // ACTUALLY [1, 3, 5, 6, 4, 2]
 

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream-readable-constructor-set-methods.js
+++ b/test/parallel/test-stream-readable-constructor-set-methods.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream-readable-flow-recursion.js
+++ b/test/parallel/test-stream-readable-flow-recursion.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // this test verifies that passing a huge number to read(size)

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Transform = require('stream').Transform;

--- a/test/parallel/test-stream-transform-objectmode-falsey-value.js
+++ b/test/parallel/test-stream-transform-objectmode-falsey-value.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream-transform-split-objectmode.js
+++ b/test/parallel/test-stream-transform-split-objectmode.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Transform = require('stream').Transform;

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // This test verifies that stream.unshift(Buffer(0)) or

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // This test verifies that:
@@ -13,7 +12,6 @@ var stream = require('stream');
 var hwm = 10;
 var r = stream.Readable({ highWaterMark: hwm });
 var chunks = 10;
-var t = (chunks * 5);
 
 var data = new Buffer(chunks * hwm + Math.ceil(hwm / 2));
 for (var i = 0; i < data.length; i++) {

--- a/test/parallel/test-stream-wrap.js
+++ b/test/parallel/test-stream-wrap.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 
 const StreamWrap = require('_stream_wrap');

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Writable = require('stream').Writable;

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var stream = require('stream');
@@ -30,11 +29,9 @@ function test(decode, uncork, multi, next) {
   function cnt(msg) {
     expectCount++;
     var expect = expectCount;
-    var called = false;
     return function(er) {
       if (er)
         throw er;
-      called = true;
       counter++;
       assert.equal(counter, expect);
     };

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var R = require('_stream_readable');
 var W = require('_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -1,10 +1,7 @@
 'use strict';
-var common = require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
-
 var util = require('util');
-var EE = require('events').EventEmitter;
 
 var ondataCalled = 0;
 
@@ -25,7 +22,7 @@ TestReader.prototype._read = function(n) {
   this._buffer = new Buffer(0);
 };
 
-var reader = new TestReader();
+new TestReader();
 setImmediate(function() {
   assert.equal(ondataCalled, 1);
   console.log('ok');

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var stream = require('stream');
 var Buffer = require('buffer').Buffer;
 

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // If everything aligns so that you do a read(n) of exactly the
@@ -54,7 +53,7 @@ function push() {
 }
 
 // start the flow
-var ret = r.read(0);
+r.read(0);
 
 process.on('exit', function() {
   assert.equal(pushes, PUSHCOUNT + 1);

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var Readable = require('_stream_readable');
 var Writable = require('_stream_writable');
 var assert = require('assert');
@@ -167,7 +166,7 @@ test('read(0) for object streams', function(t) {
   r.push('foobar');
   r.push(null);
 
-  var v = r.read(0);
+  r.read(0);
 
   r.pipe(toArray(function(array) {
     assert.deepEqual(array, ['foobar']);

--- a/test/parallel/test-stream2-pipe-error-handling.js
+++ b/test/parallel/test-stream2-pipe-error-handling.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
 

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 var util = require('util');
 var stream = require('stream');

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -1,11 +1,9 @@
 'use strict';
-var common = require('../common');
 var stream = require('stream');
 var Readable = stream.Readable;
 var Writable = stream.Writable;
 var assert = require('assert');
 
-var util = require('util');
 var EE = require('events').EventEmitter;
 
 

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var Readable = require('stream').Readable;
 var r = new Readable();

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var common = require('../common');
 var fromList = require('_stream_readable')._fromList;
 
 // tiny node-tap lookalike.
@@ -39,8 +38,6 @@ process.nextTick(run);
 
 
 test('buffers', function(t) {
-  // have a length
-  var len = 16;
   var list = [ new Buffer('foog'),
                new Buffer('bark'),
                new Buffer('bazy'),
@@ -69,8 +66,6 @@ test('buffers', function(t) {
 });
 
 test('strings', function(t) {
-  // have a length
-  var len = 16;
   var list = [ 'foog',
                'bark',
                'bazy',

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Stream = require('stream');

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var common = require('../common');
 var Readable = require('_stream_readable');
 
 var len = 0;

--- a/test/parallel/test-stream2-readable-wrap-empty.js
+++ b/test/parallel/test-stream2-readable-wrap-empty.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('_stream_readable');

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var Readable = require('_stream_readable');

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var R = require('_stream_readable');
 var util = require('util');

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var common = require('../common');
 var PassThrough = require('_stream_passthrough');
 var Transform = require('_stream_transform');
 
@@ -303,12 +302,9 @@ test('passthrough event emission', function(t) {
   var pt = new PassThrough();
   var emits = 0;
   pt.on('readable', function() {
-    var state = pt._readableState;
     console.error('>>> emit readable %d', emits);
     emits++;
   });
-
-  var i = 0;
 
   pt.write(new Buffer('foog'));
 

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var W = require('_stream_writable');
 var D = require('_stream_duplex');
 var assert = require('assert');

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var StringDecoder = require('string_decoder').StringDecoder;
 

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 // minimum string size to overflow into external string space
 var EXTERN_APEX = 0xFBEE9;

--- a/test/parallel/test-timers-args.js
+++ b/test/parallel/test-timers-args.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 function range(n) {

--- a/test/parallel/test-timers-immediate-queue.js
+++ b/test/parallel/test-timers-immediate-queue.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // setImmediate should run clear its queued cbs once per event loop turn

--- a/test/parallel/test-timers-immediate.js
+++ b/test/parallel/test-timers-immediate.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var immediateA = false,

--- a/test/parallel/test-timers-linked-list.js
+++ b/test/parallel/test-timers-linked-list.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var L = require('_linklist');
 

--- a/test/parallel/test-timers-non-integer-delay.js
+++ b/test/parallel/test-timers-non-integer-delay.js
@@ -15,8 +15,6 @@
  * it 100%.
  */
 
-var assert = require('assert');
-
 var TIMEOUT_DELAY = 1.1;
 var NB_TIMEOUTS_FIRED = 50;
 

--- a/test/parallel/test-timers-now.js
+++ b/test/parallel/test-timers-now.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 
 // Return value of Timer.now() should easily fit in a SMI right after start-up.

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -1,15 +1,12 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var Timer = process.binding('timer_wrap').Timer;
-
-var i;
 
 var N = 30;
 
 var last_i = 0;
 var last_ts = 0;
-var start = Timer.now();
+Timer.now();
 
 var f = function(i) {
   if (i <= N) {

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -5,7 +5,6 @@
  */
 
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 const clients = [];

--- a/test/parallel/test-timers-uncaught-exception.js
+++ b/test/parallel/test-timers-uncaught-exception.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var exceptions = 0;

--- a/test/parallel/test-timers-unref-active.js
+++ b/test/parallel/test-timers-unref-active.js
@@ -15,7 +15,6 @@
  * all 10 timeouts had the time to expire.
  */
 
-const common = require('../common');
 const timers = require('timers');
 const assert = require('assert');
 

--- a/test/parallel/test-timers-unref-call.js
+++ b/test/parallel/test-timers-unref-call.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-
 var Timer = process.binding('timer_wrap').Timer;
 Timer.now = function() { return ++Timer.now.ticks; };
 Timer.now.ticks = 0;

--- a/test/parallel/test-timers-unref-remove-other-unref-timers-only-one-fires.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers-only-one-fires.js
@@ -10,7 +10,6 @@
  * This behavior is a private implementation detail and should not be
  * considered public interface.
  */
-const common = require('../common');
 const timers = require('timers');
 const assert = require('assert');
 

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var interval_fired = false,

--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // https://github.com/joyent/node/issues/2079 - zero timeout drops extra args
@@ -7,7 +6,7 @@ var assert = require('assert');
   var ncalled = 0;
 
   setTimeout(f, 0, 'foo', 'bar', 'baz');
-  var timer = setTimeout(function() {}, 0);
+  setTimeout(function() {}, 0);
 
   function f(a, b, c) {
     assert.equal(a, 'foo');

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var inputs = [

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -7,10 +7,7 @@ if (!common.hasCrypto) {
   return;
 }
 var tls = require('tls');
-
 var fs = require('fs');
-var net = require('net');
-
 var common = require('../common');
 
 var requests = 0;

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -2,7 +2,6 @@
 
 var common = require('../common');
 
-var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 var constants = require('constants');

--- a/test/parallel/test-tls-client-default-ciphers.js
+++ b/test/parallel/test-tls-client-default-ciphers.js
@@ -19,7 +19,7 @@ function test1() {
   };
 
   try {
-    var s = tls.connect(common.PORT);
+    tls.connect(common.PORT);
   } catch (e) {
     assert(e instanceof Done);
   }

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -10,7 +10,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 var errorCount = 0;
 var closeCount = 0;

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -7,9 +7,7 @@ if (!common.hasCrypto) {
   return;
 }
 var tls = require('tls');
-
 var fs = require('fs');
-var net = require('net');
 
 var ended = 0;
 

--- a/test/parallel/test-tls-destroy-whilst-write.js
+++ b/test/parallel/test-tls-destroy-whilst-write.js
@@ -1,5 +1,4 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 
 if (!common.hasCrypto) {

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -20,7 +20,7 @@ var server = tls.createServer(options, onconnection);
 var gotChunk = false;
 var gotDrain = false;
 
-var timer = setTimeout(function() {
+setTimeout(function() {
   console.log('not ok - timed out');
   process.exit(1);
 }, common.platformTimeout(500));

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -8,9 +8,7 @@ if (!common.hasCrypto) {
   return;
 }
 var tls = require('tls');
-
 var fs = require('fs');
-var net = require('net');
 
 var errorCount = 0;
 var closeCount = 0;

--- a/test/parallel/test-tls-handshake-nohang.js
+++ b/test/parallel/test-tls-handshake-nohang.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -12,7 +12,7 @@ var fs = require('fs');
 var path = require('path');
 var net = require('net');
 
-var options, a, b, portA, portB;
+var options, a, b;
 var gotHello = false;
 
 options = {

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -7,10 +7,7 @@ if (!common.hasCrypto) {
   return;
 }
 var tls = require('tls');
-
 var fs = require('fs');
-var net = require('net');
-
 
 var received = '';
 var ended = 0;

--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -14,8 +14,6 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-var cert = null;
-
 assert.throws(function() {
   tls.createSecureContext(options);
 });

--- a/test/parallel/test-tls-legacy-onselect.js
+++ b/test/parallel/test-tls-legacy-onselect.js
@@ -9,17 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 var net = require('net');
 
-var fs = require('fs');
-
 var success = false;
-
-function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
-}
-
-function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
-}
 
 var server = net.Server(function(raw) {
   var pair = tls.createSecurePair(null, true, false, false);

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -7,10 +7,7 @@ if (!common.hasCrypto) {
   return;
 }
 var tls = require('tls');
-
 var fs = require('fs');
-var net = require('net');
-
 var common = require('../common');
 
 var buf = new Buffer(10000);

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -45,7 +45,6 @@ function test(testOptions, cb) {
   var clientSecure = 0;
   var ocspCount = 0;
   var ocspResponse;
-  var session;
 
   var server = tls.createServer(options, function(cleartext) {
     cleartext.on('error', function(er) {

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -11,7 +11,6 @@ var tls = require('tls');
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;
-var spawn = require('child_process').spawn;
 
 var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent5-key.pem')),

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -11,7 +11,6 @@ var tls = require('tls');
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;
-var spawn = require('child_process').spawn;
 
 var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'agent.key')),

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -11,7 +11,6 @@ var tls = require('tls');
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;
-var spawn = require('child_process').spawn;
 
 var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent1-key.pem')),

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -29,7 +29,7 @@ var server = tls.Server(options, function(socket) {
 });
 
 server.listen(common.PORT, function() {
-  var socket = tls.connect({
+  tls.connect({
     port: common.PORT,
     rejectUnauthorized: false
   });

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -42,7 +42,6 @@ if (cluster.isMaster) {
 
   function fork() {
     var worker = cluster.fork();
-    var workerReqCount = 0;
     worker.on('message', function(msg) {
       console.error('[master] got %j', msg);
       if (msg === 'reused') {

--- a/test/parallel/test-tty-wrap.js
+++ b/test/parallel/test-tty-wrap.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var TTY = process.binding('tty_wrap').TTY;

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1,10 +1,7 @@
 /* eslint-disable max-len */
 'use strict';
-var common = require('../common');
 var assert = require('assert');
-
-var url = require('url'),
-    util = require('util');
+var url = require('url');
 
 // URLs to parse, and expected data
 // { url : parsed }
@@ -1514,9 +1511,6 @@ relativeTests2.forEach(function(relativeTest) {
 
 //if format and parse are inverse operations then
 //resolveObject(parse(x), y) == parse(resolve(x, y))
-
-//host and hostname are special, in this case a '' value is important
-var emptyIsImportant = {'host': true, 'hostname': ''};
 
 //format: [from, path, expected]
 relativeTests.forEach(function(relativeTest) {

--- a/test/parallel/test-utf8-scripts.js
+++ b/test/parallel/test-utf8-scripts.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // üäö

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 var symbol = Symbol('foo');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 var context = require('vm').runInNewContext;

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 

--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 var vm = require('vm');

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-context-async-script.js
+++ b/test/parallel/test-vm-context-async-script.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-context-property-forwarding.js
+++ b/test/parallel/test-vm-context-property-forwarding.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-create-context-accessors.js
+++ b/test/parallel/test-vm-create-context-accessors.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -1,15 +1,14 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 
 assert.throws(function() {
-  var ctx = vm.createContext('string is not supported');
+  vm.createContext('string is not supported');
 }, TypeError);
 
 assert.doesNotThrow(function() {
-  var ctx = vm.createContext({ a: 1 });
-  ctx = vm.createContext([0, 1, 2, 3]);
+  vm.createContext({ a: 1 });
+  vm.createContext([0, 1, 2, 3]);
 });
 
 assert.doesNotThrow(function() {

--- a/test/parallel/test-vm-create-context-circular-reference.js
+++ b/test/parallel/test-vm-create-context-circular-reference.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-cross-context.js
+++ b/test/parallel/test-vm-cross-context.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-function-declaration.js
+++ b/test/parallel/test-vm-function-declaration.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-global-define-property.js
+++ b/test/parallel/test-vm-global-define-property.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-global-identity.js
+++ b/test/parallel/test-vm-global-identity.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-harmony-proxies.js
+++ b/test/parallel/test-vm-harmony-proxies.js
@@ -1,19 +1,18 @@
 'use strict';
 // Flags: --harmony_proxies
 
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 
 // src/node_contextify.cc filters out the Proxy object from the parent
 // context.  Make sure that the new context has a Proxy object of its own.
 var sandbox = {};
-var result = vm.runInNewContext('this.Proxy = Proxy', sandbox);
+vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert(typeof sandbox.Proxy === 'object');
 assert(sandbox.Proxy !== Proxy);
 
 // Unless we copy the Proxy object explicitly, of course.
 var sandbox = { Proxy: Proxy };
-var result = vm.runInNewContext('this.Proxy = Proxy', sandbox);
+vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert(typeof sandbox.Proxy === 'object');
 assert(sandbox.Proxy === Proxy);

--- a/test/parallel/test-vm-harmony-symbols.js
+++ b/test/parallel/test-vm-harmony-symbols.js
@@ -1,16 +1,15 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 
 // The sandbox should have its own Symbol constructor.
 var sandbox = {};
-var result = vm.runInNewContext('this.Symbol = Symbol', sandbox);
+vm.runInNewContext('this.Symbol = Symbol', sandbox);
 assert(typeof sandbox.Symbol === 'function');
 assert(sandbox.Symbol !== Symbol);
 
 // Unless we copy the Symbol constructor explicitly, of course.
 var sandbox = { Symbol: Symbol };
-var result = vm.runInNewContext('this.Symbol = Symbol', sandbox);
+vm.runInNewContext('this.Symbol = Symbol', sandbox);
 assert(typeof sandbox.Symbol === 'function');
 assert(sandbox.Symbol === Symbol);

--- a/test/parallel/test-vm-is-context.js
+++ b/test/parallel/test-vm-is-context.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-new-script-new-context.js
+++ b/test/parallel/test-vm-new-script-new-context.js
@@ -21,7 +21,6 @@ assert.throws(function() {
 
 
 console.error('undefined reference');
-var error;
 script = new Script('foo.bar = 5;');
 assert.throws(function() {
   script.runInNewContext();
@@ -41,7 +40,7 @@ code = 'foo = 1;' +
 foo = 2;
 obj = { foo: 0, baz: 3 };
 script = new Script(code);
-var baz = script.runInNewContext(obj);
+script.runInNewContext(obj);
 assert.equal(1, obj.foo);
 assert.equal(2, obj.bar);
 assert.equal(2, foo);

--- a/test/parallel/test-vm-preserves-property.js
+++ b/test/parallel/test-vm-preserves-property.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -29,7 +29,7 @@ code = 'foo = 1;' +
        'if (baz !== 3) throw new Error(\'test fail\');';
 foo = 2;
 obj = { foo: 0, baz: 3 };
-var baz = vm.runInNewContext(code, obj);
+vm.runInNewContext(code, obj);
 assert.equal(1, obj.foo);
 assert.equal(2, obj.bar);
 assert.equal(2, foo);

--- a/test/parallel/test-vm-static-this.js
+++ b/test/parallel/test-vm-static-this.js
@@ -25,7 +25,7 @@ code = 'foo = 1;' +
        'if (typeof baz !== \'undefined\') throw new Error(\'test fail\');';
 foo = 2;
 obj = { foo: 0, baz: 3 };
-var baz = vm.runInThisContext(code);
+vm.runInThisContext(code);
 assert.equal(0, obj.foo);
 assert.equal(2, bar);
 assert.equal(1, foo);

--- a/test/parallel/test-vm-symbols.js
+++ b/test/parallel/test-vm-symbols.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var common = require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-syntax-error-message.js
+++ b/test/parallel/test-vm-syntax-error-message.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var child_process = require('child_process');
 

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-writedouble.js
+++ b/test/parallel/test-writedouble.js
@@ -2,7 +2,6 @@
 /*
  * Tests to verify we're writing doubles correctly
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 function test(clazz) {

--- a/test/parallel/test-writefloat.js
+++ b/test/parallel/test-writefloat.js
@@ -2,7 +2,6 @@
 /*
  * Tests to verify we're writing floats correctly
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 function test(clazz) {

--- a/test/parallel/test-writeint.js
+++ b/test/parallel/test-writeint.js
@@ -2,7 +2,6 @@
 /*
  * Tests to verify we're writing signed integers correctly
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 function test8(clazz) {

--- a/test/parallel/test-writeuint.js
+++ b/test/parallel/test-writeuint.js
@@ -2,7 +2,6 @@
 /*
  * A battery of tests to help us read a series of uints
  */
-var common = require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-zlib-close-after-write.js
+++ b/test/parallel/test-zlib-close-after-write.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -1,5 +1,4 @@
 /* eslint-disable strict */
-var common = require('../common');
 var assert = require('assert');
 
 var zlib = require('zlib');

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -1,7 +1,6 @@
 'use strict';
 // test convenience methods with and without options supplied
 
-var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -1,10 +1,8 @@
 'use strict';
 // test compression/decompression with dictionary
 
-var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
-var path = require('path');
 
 var spdyDict = new Buffer([
   'optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-',

--- a/test/parallel/test-zlib-from-string.js
+++ b/test/parallel/test-zlib-from-string.js
@@ -1,7 +1,6 @@
 'use strict';
 // test compressing and uncompressing a string with zlib
 
-var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -1,9 +1,8 @@
 'use strict';
 // test uncompressing invalid input
 
-var common = require('../common'),
-    assert = require('assert'),
-    zlib = require('zlib');
+var assert = require('assert');
+var zlib = require('zlib');
 
 var nonStringInputs = [1, true, {a: 1}, ['a']];
 

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -1,8 +1,6 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
-var fs = require('fs');
 
 var gzip = zlib.createGzip();
 var gunz = zlib.createUnzip();

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var zlib = require('zlib');

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 try {

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -1,8 +1,6 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var os = require('os');
-var util = require('util');
 
 if (os.type() != 'SunOS') {
   console.log('1..0 # Skipped: no DTRACE support');
@@ -13,7 +11,6 @@ if (os.type() != 'SunOS') {
  * Some functions to create a recognizable stack.
  */
 var frames = [ 'stalloogle', 'bagnoogle', 'doogle' ];
-var expected;
 
 var stalloogle = function(str) {
   expected = str;
@@ -34,8 +31,6 @@ var doogle = function() {
 };
 
 var spawn = require('child_process').spawn;
-var prefix = '/var/tmp/node';
-var corefile = prefix + '.' + process.pid;
 
 /*
  * We're going to use DTrace to stop us, gcore us, and set us running again

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -9,7 +9,6 @@ var watchSeenTwo = 0;
 var watchSeenThree = 0;
 var watchSeenFour = 0;
 
-var startDir = process.cwd();
 var testDir = common.tmpDir;
 
 var filenameOne = 'watch.txt';

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -2,9 +2,8 @@
 var common = require('../common');
 var assert = require('assert');
 
-var net = require('net'),
-    util = require('util'),
-    http = require('http');
+var net = require('net');
+var http = require('http');
 
 var errorCount = 0;
 var eofCount = 0;

--- a/test/pummel/test-http-upload-timeout.js
+++ b/test/pummel/test-http-upload-timeout.js
@@ -2,11 +2,10 @@
 // This tests setTimeout() by having multiple clients connecting and sending
 // data in random intervals. Clients are also randomly disconnecting until there
 // are no more clients left. If no false timeout occurs, this test has passed.
-var common = require('../common'),
-    assert = require('assert'),
-    http = require('http'),
-    server = http.createServer(),
-    connections = 0;
+var common = require('../common');
+var http = require('http');
+var server = http.createServer();
+var connections = 0;
 
 server.on('request', function(req, res) {
   req.socket.setTimeout(1000);

--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -18,8 +18,6 @@ var options = {
 };
 
 var buf = new Buffer(1024 * 1024);
-var sent = 0;
-var received = 0;
 
 var server = https.createServer(options, function(req, res) {
   res.writeHead(200);
@@ -30,7 +28,6 @@ var server = https.createServer(options, function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var resumed = false;
   var req = https.request({
     method: 'POST',
     port: common.PORT,

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -5,7 +5,6 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var http = require('http');
-var path = require('path');
 var url = require('url');
 
 if (common.isWindows) {

--- a/test/pummel/test-next-tick-infinite-calls.js
+++ b/test/pummel/test-next-tick-infinite-calls.js
@@ -1,6 +1,4 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 var complete = 0;
 

--- a/test/pummel/test-process-hrtime.js
+++ b/test/pummel/test-process-hrtime.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var start = process.hrtime();

--- a/test/pummel/test-process-uptime.js
+++ b/test/pummel/test-process-uptime.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 console.error(process.uptime());

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -17,12 +17,7 @@ var https = require('https');
 
 var fs = require('fs');
 
-var PORT = 8000;
-
-
 var bytesExpected = 1024 * 1024 * 32;
-var gotResponse = false;
-
 var started = false;
 
 var childScript = require('path').join(common.fixturesDir, 'GH-892-request.js');

--- a/test/pummel/test-stream-pipe-multi.js
+++ b/test/pummel/test-stream-pipe-multi.js
@@ -2,7 +2,6 @@
 // Test that having a bunch of streams piping in parallel
 // doesn't break anything.
 
-var common = require('../common');
 var assert = require('assert');
 var Stream = require('stream').Stream;
 var rr = [];

--- a/test/pummel/test-stream2-basic.js
+++ b/test/pummel/test-stream2-basic.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 
@@ -157,7 +156,6 @@ test('pipe', function(t) {
                  'xxxxx' ];
 
   var w = new TestWriter();
-  var flush = true;
 
   w.on('end', function(received) {
     t.same(received, expect);
@@ -439,7 +437,6 @@ test('adding readable triggers data flow', function(t) {
       r.push(new Buffer('asdf'));
   };
 
-  var called = false;
   r.on('readable', function() {
     onReadable = true;
     r.read();

--- a/test/pummel/test-timer-wrap.js
+++ b/test/pummel/test-timer-wrap.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var timeouts = 0;

--- a/test/pummel/test-timer-wrap2.js
+++ b/test/pummel/test-timer-wrap2.js
@@ -1,9 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
 // Test that allocating a timer does not increase the loop's reference
 // count.
 
 var Timer = process.binding('timer_wrap').Timer;
-var t = new Timer();
+new Timer();

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var WINDOW = 200; // why is does this need to be so big?
@@ -91,12 +90,12 @@ function t() {
   expectedTimeouts--;
 }
 
-var w = setTimeout(t, 200);
-var x = setTimeout(t, 200);
+setTimeout(t, 200);
+setTimeout(t, 200);
 var y = setTimeout(t, 200);
 
 clearTimeout(y);
-var z = setTimeout(t, 200);
+setTimeout(t, 200);
 clearTimeout(y);
 
 

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -17,9 +17,7 @@ var join = require('path').join;
 var net = require('net');
 var assert = require('assert');
 var fs = require('fs');
-var crypto = require('crypto');
 var tls = require('tls');
-var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 
 test1();
@@ -46,8 +44,6 @@ function test(keyfn, certfn, check, next) {
   // the openssl s_server thus causing many tests to fail with
   // EADDRINUSE.
   var PORT = common.PORT + 5;
-
-  var connections = 0;
 
   keyfn = join(common.fixturesDir, keyfn);
   var key = fs.readFileSync(keyfn).toString();

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -2,7 +2,6 @@
 // Flags: --max_old_space_size=32
 
 var assert = require('assert');
-var common = require('../common');
 
 var start = Date.now();
 var maxMem = 0;

--- a/test/pummel/test-watch-file.js
+++ b/test/pummel/test-watch-file.js
@@ -6,7 +6,6 @@ var fs = require('fs');
 var path = require('path');
 
 var f = path.join(common.fixturesDir, 'x.txt');
-var f2 = path.join(common.fixturesDir, 'x2.txt');
 
 console.log('watching for changes of ' + f);
 

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var util = require('util');
-var os = require('os');
 
 var execSync = require('child_process').execSync;
 var execFileSync = require('child_process').execFileSync;

--- a/test/sequential/test-debug-args.js
+++ b/test/sequential/test-debug-args.js
@@ -1,7 +1,6 @@
 'use strict';
 // Flags: --debugger
 
-var common = require('../common');
 var assert = require('assert');
 
 assert.notEqual(process.execArgv.indexOf('--debugger'), -1);

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var execFile = require('child_process').execFile;
 var depmod = require.resolve('../fixtures/deprecated.js');

--- a/test/sequential/test-mkdir-rmdir.js
+++ b/test/sequential/test-mkdir-rmdir.js
@@ -6,7 +6,6 @@ var fs = require('fs');
 
 common.refreshTmpDir();
 
-var dirname = path.dirname(__filename);
 var d = path.join(common.tmpDir, 'dir');
 
 var mkdir_error = false;

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // this test only fails with CentOS 6.3 using kernel version 2.6.32
 // On other linuxes and darwin, the `read` call gets an ECONNRESET in

--- a/test/sequential/test-net-listen-exclusive-random-ports.js
+++ b/test/sequential/test-net-listen-exclusive-random-ports.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var net = require('net');

--- a/test/sequential/test-pump-file2tcp.js
+++ b/test/sequential/test-pump-file2tcp.js
@@ -35,7 +35,6 @@ server.listen(common.PORT, function() {
 });
 
 var buffer = '';
-var count = 0;
 
 server.on('listening', function() {
 });

--- a/test/sequential/test-regress-GH-1697.js
+++ b/test/sequential/test-regress-GH-1697.js
@@ -1,8 +1,7 @@
 'use strict';
 var common = require('../common');
-var net = require('net'),
-    cp = require('child_process'),
-    util = require('util');
+var net = require('net');
+var cp = require('child_process');
 
 if (process.argv[2] === 'server') {
   // Server

--- a/test/sequential/test-regress-GH-1726.js
+++ b/test/sequential/test-regress-GH-1726.js
@@ -4,7 +4,6 @@
 // exit when its child exits.
 // https://github.com/joyent/node/issues/1726
 
-var common = require('../common');
 var assert = require('assert');
 var ch = require('child_process');
 

--- a/test/sequential/test-regress-GH-819.js
+++ b/test/sequential/test-regress-GH-819.js
@@ -1,7 +1,5 @@
 'use strict';
-var common = require('../common');
 var net = require('net');
-var assert = require('assert');
 
 // Connect to something that we need to DNS resolve
 var c = net.createConnection(80, 'google.com');

--- a/test/sequential/test-repl-persistent-history.js
+++ b/test/sequential/test-repl-persistent-history.js
@@ -7,7 +7,6 @@ const stream = require('stream');
 const REPL = require('internal/repl');
 const assert = require('assert');
 const fs = require('fs');
-const util = require('util');
 const path = require('path');
 const os = require('os');
 

--- a/test/sequential/test-setproctitle.js
+++ b/test/sequential/test-setproctitle.js
@@ -7,7 +7,6 @@ if ('linux freebsd darwin'.indexOf(process.platform) === -1) {
   return;
 }
 
-var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 var path = require('path');

--- a/test/sequential/test-sigint-infinite-loop.js
+++ b/test/sequential/test-sigint-infinite-loop.js
@@ -2,7 +2,6 @@
 // This test is to assert that we can SIGINT a script which loops forever.
 // Ref(http):
 // groups.google.com/group/nodejs-dev/browse_thread/thread/e20f2f8df0296d3f
-var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 

--- a/test/sequential/test-stdin-child-proc.js
+++ b/test/sequential/test-stdin-child-proc.js
@@ -1,7 +1,6 @@
 'use strict';
 // This tests that pausing and resuming stdin does not hang and timeout
 // when done in a child process.  See test/simple/test-stdin-pause-resume.js
-var common = require('../common');
 var child_process = require('child_process');
 var path = require('path');
 child_process.spawn(process.execPath,

--- a/test/sequential/test-stdin-pipe-resume.js
+++ b/test/sequential/test-stdin-pipe-resume.js
@@ -1,6 +1,5 @@
 'use strict';
 // This tests that piping stdin will cause it to resume() as well.
-var common = require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child') {

--- a/test/sequential/test-stdin-script-child.js
+++ b/test/sequential/test-stdin-script-child.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/sequential/test-stdout-cannot-be-closed-child-process-pipe.js
+++ b/test/sequential/test-stdout-cannot-be-closed-child-process-pipe.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child')

--- a/test/sequential/test-stdout-close-catch.js
+++ b/test/sequential/test-stdout-close-catch.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var child_process = require('child_process');
-var fs = require('fs');
 
 var testScript = path.join(common.fixturesDir, 'catch-stdout-error.js');
 

--- a/test/sequential/test-stdout-stderr-reading.js
+++ b/test/sequential/test-stdout-stderr-reading.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 // verify that stdout is never read from.

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var R = require('_stream_readable');
 var assert = require('assert');
 
 var fs = require('fs');
@@ -41,7 +40,6 @@ var w = new TestWriter();
 w.on('results', function(res) {
   console.error(res, w.length);
   assert.equal(w.length, size);
-  var l = 0;
   assert.deepEqual(res.map(function(c) {
     return c.length;
   }), expectLengths);

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -1,12 +1,6 @@
 'use strict';
 // Make sure that sync writes to stderr get processed before exiting.
 
-var common = require('../common');
-var assert = require('assert');
-var util = require('util');
-
-var errnoException = util._errnoException;
-
 function parent() {
   var spawn = require('child_process').spawn;
   var assert = require('assert');

--- a/test/sequential/test-sync-fileread.js
+++ b/test/sequential/test-sync-fileread.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');

--- a/test/sequential/test-tcp-wrap-listen.js
+++ b/test/sequential/test-tcp-wrap-listen.js
@@ -12,7 +12,7 @@ assert.equal(0, r);
 
 server.listen(128);
 
-var slice, sliceCount = 0, eofCount = 0;
+var sliceCount = 0, eofCount = 0;
 
 var writeCount = 0;
 var recvCount = 0;

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -1,5 +1,4 @@
 'use strict';
-var common = require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child')

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -1,8 +1,6 @@
 'use strict';
 // FaketimeFlags: --exclude-monotonic -f '2014-07-21 09:00:00'
 
-var common = require('../common');
-
 var Timer  = process.binding('timer_wrap').Timer;
 var assert = require('assert');
 
@@ -44,7 +42,7 @@ monoTimer.ontimeout = function() {
 
 monoTimer.start(300, 0);
 
-var timer = setTimeout(function() {
+setTimeout(function() {
   timerFired = true;
 }, 200);
 


### PR DESCRIPTION
This enables the [`no-unused-vars`](http://eslint.org/docs/rules/no-unused-vars) rule. Issues that came up were mostly the variables on top of tests and there were a few cases where there was leftover dead code.

I intentionally didn't enable the feature for unused function arguments yet. I think the best to go about these is to comment out the arguments in `lib` while removing them in `test`, does that sound good?

Note that this is somewhat WIP, as there were a few cases where the intention seemed to be to use some of these variables, but I'm submitting this now as-is for some feedback.