### PR TITLE
buffer: consider deprecated raws as valid encoding

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -185,6 +185,7 @@ Buffer.isEncoding = function(encoding) {
       case 'utf16le':
       case 'utf-16le':
       case 'raw':
+      case 'raws':
         return true;
 
       default:


### PR DESCRIPTION
Even though `raws` is a deprecated encoding, it is still valid as per
`ParseEncoding` in `node.cc`.

Refer https://github.com/nodejs/node/blob/v4.0.0/src/node.cc#L1214-L1218

cc @trevnorris 