### PR TITLE
timer: call list.start regardless new or not

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -40,7 +40,6 @@ exports.active = function(item) {
     list = lists[msecs];
   } else {
     list = new Timer();
-    list.start(msecs, 0);
 
     L.init(list);
 
@@ -48,6 +47,10 @@ exports.active = function(item) {
     list.msecs = msecs;
     list[kOnTimeout] = listOnTimeout;
   }
+  // Call start regardless whether list is new
+  // or not to prevent incorrect active_handles
+  // count. See https://github.com/nodejs/node-v0.x-archive/issues/25831.
+  list.start(msecs, 0);
 
   L.append(list, item);
   assert(!L.isEmpty(list)); // list is not empty

--- a/test/addons/timers-active-handles/binding.cc
+++ b/test/addons/timers-active-handles/binding.cc
@@ -1,0 +1,17 @@
+#include <node.h>
+#include <uv.h>
+
+using namespace v8;
+
+void Method(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  int hCnt = uv_default_loop()->active_handles;
+  uv_run(uv_default_loop(), UV_RUN_ONCE);
+  args.GetReturnValue().Set(Integer::New(isolate, hCnt));
+}
+
+void init(Handle<Object> exports) {
+  NODE_SET_METHOD(exports, "run", Method);
+}
+
+NODE_MODULE(deasync, init)

--- a/test/addons/timers-active-handles/binding.gyp
+++ b/test/addons/timers-active-handles/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/timers-active-handles/test.js
+++ b/test/addons/timers-active-handles/test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const assert = require('assert');
+var uvRunOnce = require('./build/Release/binding');
+setTimeout(function () {
+  var res;
+  setTimeout(function () {
+    res = true;
+  }, 2);
+  while (!res && uvRunOnce.run()) {
+  }
+  assert.equal(res, true);
+}, 2);


### PR DESCRIPTION
Call start regardless whether list is new
or not to prevent incorrect active_handles
count.

Fixes issue nodejs/node-v0.x-archive#25831.
Ported from pr nodejs/node-v0.x-archive#25832 and #2788.