### PR TITLE
tools,makefile: fix file open mode and cleanup tap file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ clean:
 	-rm -rf out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE)
 	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' | xargs rm -rf; fi
 	-rm -rf node_modules
+	-rm -f test.tap
 
 distclean:
 	-rm -rf out

--- a/tools/test.py
+++ b/tools/test.py
@@ -1418,7 +1418,7 @@ def Main():
   logger.addHandler(ch)
   logger.setLevel(logging.INFO)
   if options.logfile:
-    fh = logging.FileHandler(options.logfile)
+    fh = logging.FileHandler(options.logfile, mode='wb')
     logger.addHandler(fh)
 
   workspace = abspath(join(dirname(sys.argv[0]), '..'))


### PR DESCRIPTION
**1st commit:**

By default the logfile is opened in append mode. This commit makes sure
that the file is opened in write-binary mode, so that the file will be
created if it doesn't exist or overwrite if it exists.

**2nd commit:**

Make `make clean` cleanup the generated tap file as well.

Fixes: #2834 

cc @nodejs/build 