### PR TITLE
tools: enable arrow functions in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,15 +3,16 @@ env:
 
 # enable ECMAScript features
 ecmaFeatures:
-  blockBindings: true
-  templateStrings: true
-  octalLiterals: true
+  arrowFunctions: true
   binaryLiterals: true
-  generators: true
-  forOf: true
-  objectLiteralShorthandProperties: true
-  objectLiteralShorthandMethods: true
+  blockBindings: true
   classes: true
+  forOf: true
+  generators: true
+  objectLiteralShorthandMethods: true
+  objectLiteralShorthandProperties: true
+  octalLiterals: true
+  templateStrings: true
 
 rules:
   # Possible Errors


### PR DESCRIPTION
As of v8 4.5, arrow functions are rolled out. This patch allows eslint
to accept arrow functions as well.

Sorted the entries as per @silverwind's suggestion in https://github.com/nodejs/node/pull/2836#issuecomment-139818278