### PR TITLE
Bind Net api servers to localhost and ::1 by default

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -121,7 +121,7 @@ This class is used to create a TCP or local server.
 
 Begin accepting connections on the specified `port` and `hostname`. If the
 `hostname` is omitted, the server will accept connections on any IPv6 address
-(`::`) when IPv6 is available, or any IPv4 address (`0.0.0.0`) otherwise. A
+(`::1`) when IPv6 is available, or any IPv4 address (`localhost`) otherwise. A
 port value of zero will assign a random port.
 
 Backlog is the maximum length of the queue of pending connections.

--- a/lib/net.js
+++ b/lib/net.js
@@ -1163,11 +1163,11 @@ var createServerHandle = exports._createServerHandle =
     debug('bind to ' + (address || 'anycast'));
     if (!address) {
       // Try binding to ipv6 first
-      err = handle.bind6('::', port);
+      err = handle.bind6('::1', port);
       if (err) {
         handle.close();
         // Fallback to ipv4
-        return createServerHandle('0.0.0.0', port);
+        return createServerHandle('localhost', port);
       }
     } else if (addressType === 6) {
       err = handle.bind6(address, port);
@@ -1199,14 +1199,14 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
     var rval = null;
 
     if (!address && typeof fd !== 'number') {
-      rval = createServerHandle('::', port, 6, fd);
+      rval = createServerHandle('::1', port, 6, fd);
 
       if (typeof rval === 'number') {
         rval = null;
-        address = '0.0.0.0';
+        address = 'localhost';
         addressType = 4;
       } else {
-        address = '::';
+        address = '::1';
         addressType = 6;
       }
     }


### PR DESCRIPTION
This PR resolves issue #2849 where the HTTP server is bound to IPs on all configured interfaces by default. This can lead to unintentional data leaks.

Changed default binding address to be localhost and ::1 for IPv4 and IPv6, respectively.