### PR TITLE
test: introduce a broadcast helper

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -68,6 +68,7 @@ exports.tmpDir = path.join(exports.testDir, exports.tmpDirName);
 var opensslCli = null;
 var inFreeBSDJail = null;
 var localhostIPv4 = null;
+var broadcastIPv4 = null;
 
 Object.defineProperty(exports, 'inFreeBSDJail', {
   get: function() {
@@ -104,6 +105,27 @@ Object.defineProperty(exports, 'localhostIPv4', {
     if (localhostIPv4 === null) localhostIPv4 = '127.0.0.1';
 
     return localhostIPv4;
+  }
+});
+
+Object.defineProperty(exports, 'broadcastIPv4', {
+
+  get: function() {
+    if (broadcastIPv4 !== null) return broadcastIPv4;
+
+    if (exports.inFreeBSDJail) {
+      if (process.env.BROADCAST) {
+        broadcastIPv4 = process.env.BROADCAST;
+      } else {
+        // shorter error than above since you'd probably be seeing both
+        console.error('In a FreeBSD jail. Pass broadcast as \'BROADCAST=\' ' +
+                      'to avoid test failures.');
+      }
+    }
+
+    if (broadcastIPv4 === null) broadcastIPv4 = '255.255.255.255';
+
+    return broadcastIPv4;
   }
 });
 

--- a/test/common.js
+++ b/test/common.js
@@ -51,22 +51,6 @@ function rmdirSync(p, originalEr) {
   }
 }
 
-function getEnvironmentDefault(environ, defaultValue) {
-  let value = null;
-  if (exports.inFreeBSDJail) {
-    if (process.env[environ]) {
-      value = process.env[environ];
-    } else {
-      console.error('In a FreeBSD jail. You might have to override the value ' +
-                    'by passing %s=\'value\' to avoid any test ' +
-                    'failures', environ);
-    }
-  }
-
-  if (value === null) value = defaultValue;
-  return value;
-}
-
 exports.refreshTmpDir = function() {
   rimrafSync(exports.tmpDir);
   fs.mkdirSync(exports.tmpDir);
@@ -177,6 +161,22 @@ exports.hasIPv6 = Object.keys(ifaces).some(function(name) {
 var util = require('util');
 for (var i in util) exports[i] = util[i];
 //for (var i in exports) global[i] = exports[i];
+
+function getEnvironmentDefault(environ, defaultValue) {
+  let value = null;
+  if (exports.inFreeBSDJail) {
+    if (process.env[environ]) {
+      value = process.env[environ];
+    } else {
+      console.error('In a FreeBSD jail. You might have to override the value ' +
+                    'by passing %s=\'value\' to avoid any test ' +
+                    'failures', environ);
+    }
+  }
+
+  if (value === null) value = defaultValue;
+  return value;
+}
 
 function protoCtrChain(o) {
   var result = [];

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -6,7 +6,7 @@ var common = require('../common'),
     networkInterfaces = require('os').networkInterfaces(),
     Buffer = require('buffer').Buffer,
     fork = require('child_process').fork,
-    LOCAL_BROADCAST_HOST = '255.255.255.255',
+    LOCAL_BROADCAST_HOST = common.broadcastIPv4,
     TIMEOUT = common.platformTimeout(5000),
     messages = [
       new Buffer('First message to send'),


### PR DESCRIPTION
Introduce a helper - very similar to `common.localhostIPv4` that allows test  runner to override a broadcast address. This is required in certain scenarios - like FreeBSD jails - since networking acts a bit different.

Refs: https://github.com/nodejs/node/issues/2472

(I've enabled BROADCAST=$foo on both FreeBSD bots)

/R=@Trott, ?