### PR TITLE
buffer: remove raw & raws encoding

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -184,7 +184,6 @@ Buffer.isEncoding = function(encoding) {
       case 'ucs-2':
       case 'utf16le':
       case 'utf-16le':
-      case 'raw':
         return true;
 
       default:
@@ -250,9 +249,6 @@ function byteLength(string, encoding) {
     switch (encoding) {
       case 'ascii':
       case 'binary':
-      // Deprecated
-      case 'raw':
-      case 'raws':
         return len;
 
       case 'utf8':

--- a/src/node.cc
+++ b/src/node.cc
@@ -1205,18 +1205,6 @@ enum encoding ParseEncoding(const char* encoding,
     return BUFFER;
   } else if (strcasecmp(encoding, "hex") == 0) {
     return HEX;
-  } else if (strcasecmp(encoding, "raw") == 0) {
-    if (!no_deprecation) {
-      fprintf(stderr, "'raw' (array of integers) has been removed. "
-                      "Use 'binary'.\n");
-    }
-    return BINARY;
-  } else if (strcasecmp(encoding, "raws") == 0) {
-    if (!no_deprecation) {
-      fprintf(stderr, "'raws' encoding has been renamed to 'binary'. "
-                      "Please update your code.\n");
-    }
-    return BINARY;
   } else {
     return default_encoding;
   }

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -5,9 +5,9 @@ var assert = require('assert');
 var Buffer = require('buffer').Buffer;
 
 // coerce values to string
-assert.equal(Buffer.byteLength(32, 'raw'), 2);
+assert.equal(Buffer.byteLength(32, 'binary'), 2);
 assert.equal(Buffer.byteLength(NaN, 'utf8'), 3);
-assert.equal(Buffer.byteLength({}, 'raws'), 15);
+assert.equal(Buffer.byteLength({}, 'binary'), 15);
 assert.equal(Buffer.byteLength(), 9);
 
 // special case: zero length string

--- a/test/parallel/test-file-read-noexist.js
+++ b/test/parallel/test-file-read-noexist.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var got_error = false;
 
 var filename = path.join(common.fixturesDir, 'does_not_exist.txt');
-fs.readFile(filename, 'raw', function(err, content) {
+fs.readFile(filename, 'binary', function(err, content) {
   if (err) {
     got_error = true;
   } else {


### PR DESCRIPTION
As `raw` and `raws` encodings are deprecated for such a long time, and
it is an undocumented feature. This patch removes the support for those
encoding completely.

Previous discussion: #2829

cc @trevnorris 

As this removes the existing functionality, tagging this as major.