### PR TITLE
Fix flaky test test-http-pipeline-flood

### DIFF
--- a/test/sequential/test-http-pipeline-flood.js
+++ b/test/sequential/test-http-pipeline-flood.js
@@ -2,6 +2,15 @@
 var common = require('../common');
 var assert = require('assert');
 
+
+// Here we are testing the HTTP server module's flood prevention mechanism.
+// When writeable.write returns false (ie the underlying send() indicated the native buffer
+// is full), the HTTP server cork()s the readable part of the stream. This means that new requests
+// will not be read (however request which have already been read, but are awaiting processing 
+// will still be processed).
+// Normally when the writable stream emits a 'drain' event, the server then uncorks the readable
+// stream, although we arent testing that part here.
+
 switch (process.argv[2]) {
   case undefined:
     return parent();
@@ -18,22 +27,30 @@ function parent() {
   var childClosed = false;
   var requests = 0;
   var connections = 0;
+  var backloggedReqs = 0;
 
   var server = http.createServer(function(req, res) {
     requests++;
     res.setHeader('content-length', bigResponse.length);
-    res.end(bigResponse);
+    if(!res.write(bigResponse)){
+      if(backloggedReqs == 0){
+        // once the native buffer fills (ie write() returns false), the flood prevention should 
+        // kick in.
+        // This means the stream should emit no more 'data' events. However we may still be asked
+        // to process more requests if they were read before mechanism activated.
+        req.socket.on('data', function(){assert(false)})
+      }
+      backloggedReqs++;
+    }
+    res.end();
   });
 
   server.on('connection', function(conn) {
     connections++;
   });
 
-  // kill the connection after a bit, verifying that the
-  // flood of requests was eventually halted.
   server.setTimeout(200, function(conn) {
     gotTimeout = true;
-    conn.destroy();
   });
 
   server.listen(common.PORT, function() {
@@ -53,9 +70,9 @@ function parent() {
     assert.equal(connections, 1);
     // The number of requests we end up processing before the outgoing
     // connection backs up and requires a drain is implementation-dependent.
-    // We can safely assume is more than 250.
     console.log('server got %d requests', requests);
-    assert(requests >= 250);
+    console.log('server sent %d backlogged requests', backloggedReqs);
+
     console.log('ok');
   });
 }
@@ -63,7 +80,6 @@ function parent() {
 function child() {
   var net = require('net');
 
-  var gotEpipe = false;
   var conn = net.connect({ port: common.PORT });
 
   var req = 'GET / HTTP/1.1\r\nHost: localhost:' +
@@ -72,17 +88,14 @@ function child() {
   req = new Array(10241).join(req);
 
   conn.on('connect', function() {
+    //kill child after 1s of flooding
+    setTimeout(function(){conn.destroy()}, 1000)
     write();
   });
 
   conn.on('drain', write);
 
-  conn.on('error', function(er) {
-    gotEpipe = true;
-  });
-
   process.on('exit', function() {
-    assert(gotEpipe);
     console.log('ok - child');
   });
 


### PR DESCRIPTION
rebase of nodejs/node-v0.x-archive#25870
Fixes nodejs/node-v0.x-archive#25732 and  nodejs/node-v0.x-archive#25709

So, some background. This test looks to test a feature to prevent a DoS vulnerability. Essentially once native socket write buffers have filled up, the http parser should cork the read stream. (requests in data which has already been read will still be processed)

## Current test
* sets up a http server, with a timeout which destroys the connection after 200ms of inactivity.
* creates a child which continuously fires requests and does not read responses.
* On exit asserts that:
 * Inactivity timeout has fired
 * >250 requests have been processed
 * The child process terminated

### Issues:
* Flaky on windows because of very small socket buffers (write buffers fill after only a few responses), depending on timing this means that only ~40 requests will get processed
* Does not make much sense to assert number of requests greater than a threshold when testing a DoS prevention feature.
* If feature under test not working, the test case runs until program runs out of memory 

## New test
* Set up server without inactivity timer
* Create child process like before, but with timeout to kill itself after  specified amount of time
* When server sends response, check if native buffer filled (res.write() returns false). On first time:
  * Add listener for data events on the socket which asserts false (backlog logic should have corked the stream so it should never be called)