### PR TITLE
deps: upgrade V8 to 4.5.103.33

### DIFF
--- a/deps/v8/build/features.gypi
+++ b/deps/v8/build/features.gypi
@@ -108,7 +108,7 @@
       'DebugBaseCommon': {
         'abstract': 1,
         'variables': {
-          'v8_enable_handle_zapping%': 0,
+          'v8_enable_handle_zapping%': 1,
         },
         'conditions': [
           ['v8_enable_handle_zapping==1', {
@@ -118,7 +118,7 @@
       },  # Debug
       'Release': {
         'variables': {
-          'v8_enable_handle_zapping%': 1,
+          'v8_enable_handle_zapping%': 0,
         },
         'conditions': [
           ['v8_enable_handle_zapping==1', {

--- a/deps/v8/codereview.settings
+++ b/deps/v8/codereview.settings
@@ -1,5 +1,5 @@
 CODE_REVIEW_SERVER: https://codereview.chromium.org
-CC_LIST: v8-dev@googlegroups.com
+CC_LIST: v8-reviews@googlegroups.com
 VIEW_VC: https://chromium.googlesource.com/v8/v8/+/
 STATUS: http://v8-status.appspot.com/status
 TRY_ON_UPLOAD: False

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 30
+#define V8_PATCH_LEVEL 33
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/ast.cc
+++ b/deps/v8/src/ast.cc
@@ -441,6 +441,7 @@ void ObjectLiteral::BuildConstantProperties(Isolate* isolate) {
 
     if (position == boilerplate_properties_ * 2) {
       DCHECK(property->is_computed_name());
+      is_simple = false;
       break;
     }
     DCHECK(!property->is_computed_name());

--- a/deps/v8/test/mjsunit/harmony/computed-property-names.js
+++ b/deps/v8/test/mjsunit/harmony/computed-property-names.js
@@ -300,3 +300,59 @@ function ID(x) {
     };
   }, MyError);
 })();
+
+
+(function TestNestedLiterals() {
+  var array = [
+    42,
+    { a: 'A',
+      ['b']: 'B',
+      c: 'C',
+      [ID('d')]: 'D',
+    },
+    43,
+  ];
+  assertEquals(42, array[0]);
+  assertEquals(43, array[2]);
+  assertEquals('A', array[1].a);
+  assertEquals('B', array[1].b);
+  assertEquals('C', array[1].c);
+  assertEquals('D', array[1].d);
+  var object = {
+    outer: 42,
+    inner: {
+      a: 'A',
+      ['b']: 'B',
+      c: 'C',
+      [ID('d')]: 'D',
+    },
+    outer2: 43,
+  };
+  assertEquals(42, object.outer);
+  assertEquals(43, object.outer2);
+  assertEquals('A', object.inner.a);
+  assertEquals('B', object.inner.b);
+  assertEquals('C', object.inner.c);
+  assertEquals('D', object.inner.d);
+  var object = {
+    outer: 42,
+    array: [
+      43,
+      { a: 'A',
+        ['b']: 'B',
+        c: 'C',
+        [ID('d')]: 'D',
+      },
+      44,
+    ],
+    outer2: 45
+  };
+  assertEquals(42, object.outer);
+  assertEquals(45, object.outer2);
+  assertEquals(43, object.array[0]);
+  assertEquals(44, object.array[2]);
+  assertEquals('A', object.array[1].a);
+  assertEquals('B', object.array[1].b);
+  assertEquals('C', object.array[1].c);
+  assertEquals('D', object.array[1].d);
+})();


### PR DESCRIPTION
This brings in the patches from 4.5.103.30...4.5.103.33 fixing the issue with
computed property names not working in nested literals.

Full V8 4.5 commit log at:
https://chromium.googlesource.com/v8/v8.git/+log/branch-heads/4.5

Fixes: https://github.com/nodejs/node/issues/2507

R=@bnoordhuis
/cc @nodejs/v8 