### PR TITLE
Fix Memory Leaks

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -220,7 +220,14 @@ MaybeLocal<Object> New(Isolate* isolate,
   CHECK(actual <= length);
 
   if (actual < length) {
-    data = static_cast<char*>(realloc(data, actual));
+    char* new_data = static_cast<char*>(realloc(data, actual));
+    if ( new_data != nullptr )
+    {
+        data = new_data;
+    }else{
+        free(data);
+        data = nullptr;
+    }
     CHECK_NE(data, nullptr);
   }
 

--- a/src/node_counters.cc
+++ b/src/node_counters.cc
@@ -65,7 +65,8 @@ static void counter_gc_start(Isolate* isolate,
 static void counter_gc_done(Isolate* isolate,
                             GCType type,
                             GCCallbackFlags flags) {
-  uint64_t endgc = NODE_COUNT_GET_GC_RAWTIME();
+  uint64_t endgc = 0;
+  endgc = NODE_COUNT_GET_GC_RAWTIME();
   if (endgc != 0) {
     uint64_t totalperiod = endgc - counter_gc_end_time;
     uint64_t gcperiod = endgc - counter_gc_start_time;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3320,6 +3320,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
 
   bool r = hmac->HmacDigest(&md_value, &md_len);
   if (!r) {
+    delete[] md_value;
     md_value = nullptr;
     md_len = 0;
   }


### PR DESCRIPTION
Fixes various memory leaks :
[node_buffer.cc:222]: (error) Common realloc mistake: 'data' nulled but not freed upon failure
[node_counters.cc:69]: (error) Uninitialized variable: endgc
[node_crypto.cc:3323]: (error) Memory leak: md_value
