### PR TITLE
fs: fix incorrect error message in fs.open family when flags are not string or int

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -465,9 +465,14 @@ fs.readFileSync = function(path, options) {
 
 // Used by binding.open and friends
 function stringToFlags(flag) {
-  // Only mess with strings
-  if (typeof flag !== 'string') {
+  // Integers are already good to go
+  if (Number.isInteger(flag)) {
     return flag;
+  }
+
+  // We only allow strings from here on
+  if (typeof flag !== 'string') {
+    throw new TypeError('File open flags may only be string or integer');
   }
 
   switch (flag) {

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -32,8 +32,15 @@ fs.open(__filename, 'rs', function(err, fd) {
   openFd2 = fd;
 });
 
+assert.throws(function() {
+  fs.open('/path/to/file/that/does/not/exist', { bad: 'flags' }, assert.fail);
+}, function(err) {
+  if (err instanceof TypeError) {
+    return err.message === 'File open flags may only be string or integer';
+  }
+});
+
 process.on('exit', function() {
   assert.ok(openFd);
   assert.ok(openFd2);
 });
-


### PR DESCRIPTION
This fixes #2871