### PR TITLE
Restore missing backtick in Buffer documentation

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -248,7 +248,7 @@ may be beyond the end of the buffer. Defaults to `false`.
 
 Decodes and returns a string from buffer data encoded using the specified
 character set encoding. If `encoding` is `undefined` or `null`, then `encoding`
-defaults to `'utf8'. The `start` and `end` parameters default to `0` and
+defaults to `'utf8'`. The `start` and `end` parameters default to `0` and
 `buffer.length` when `undefined`.
 
     buf = new Buffer(26);


### PR DESCRIPTION
Fixes the formatting.