### PR TITLE
buffer: always allocate typed arrays outside heap

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3685,6 +3685,12 @@ void Init(int* argc,
     V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
   }
 
+  // Unconditionally force typed arrays to allocate outside the v8 heap. This
+  // is to prevent memory pointers from being moved around that are returned by
+  // Buffer::Data().
+  const char no_typed_array_heap[] = "--typed_array_max_size_in_heap=0";
+  V8::SetFlagsFromString(no_typed_array_heap, sizeof(no_typed_array_heap) - 1);
+
   if (!use_debug_agent) {
     RegisterDebugSignalHandler();
   }


### PR DESCRIPTION
By default v8 allocates typed arrays <= 64 bytes inside the v8 heap. In
these cases the memory pointer returned by Buffer::Data() can change
while the memory is being operated on. Resolve by passing a flag that
forces all typed arrays outside the v8 heap.

Fixes: 74178a5 "buffer: construct Uint8Array in JS"

R=@indutny 
R=@bnoordhuis 
