### PR TITLE
fs: fix confusing flags TypeError msg

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -465,10 +465,11 @@ fs.readFileSync = function(path, options) {
 
 // Used by binding.open and friends
 function stringToFlags(flag) {
-  // Only mess with strings
-  if (typeof flag !== 'string') {
+  if (typeof flag === 'number')
     return flag;
-  }
+
+  if (typeof flag !== 'string')
+    throw new TypeError('flag must be a string');
 
   switch (flag) {
     case 'r' : return O_RDONLY;

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -38,3 +38,17 @@ assert.equal(fs._stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
  'x +x x+ rx rx+ wxx wax xwx xxx').split(' ').forEach(function(flags) {
   assert.throws(function() { fs._stringToFlags(flags); });
 });
+
+// Use of numeric flags is permitted.
+assert.equal(fs._stringToFlags(O_RDONLY), O_RDONLY);
+
+// Non-numeric/string flags are a type error.
+assert.throws(function() { fs._stringToFlags(undefined); }, TypeError);
+assert.throws(function() { fs._stringToFlags(null); }, TypeError);
+assert.throws(function() { fs._stringToFlags(assert); }, TypeError);
+assert.throws(function() { fs._stringToFlags([]); }, TypeError);
+assert.throws(function() { fs._stringToFlags({}); }, TypeError);
+
+// Numeric flags that are not int will be passed to the binding, which
+// will throw a TypeError
+assert.throws(function() { fs.openSync('_', O_RDONLY + 0.1); }, TypeError);


### PR DESCRIPTION
Fix #2871, replace #2873. I did this on the plane back from NodeConf, it is basically the same change as #2873, but with more tests.

File open flags must be an int when passed to the binding layer, but
they must be a string when passed to the fs module (numbers are
permitted, though undocumented). The module used to do no type checking,
so the binding layer error would be thrown, and it was wrong:

    > fs.openSync('_')
    TypeError: flags must be an int
        at TypeError (native)
        at Object.fs.openSync (fs.js:549:18)

It is now:

    > fs.openSync('_')
    TypeError: flag must be a string