### PR TITLE
net: type check createServer options object

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1080,12 +1080,14 @@ function Server(options, connectionListener) {
     connectionListener = options;
     options = {};
     self.on('connection', connectionListener);
-  } else {
+  } else if(options == null || typeof options === 'object') {
     options = options || {};
 
     if (typeof connectionListener === 'function') {
       self.on('connection', connectionListener);
     }
+  } else {
+    throw new TypeError('options must be an object');
   }
 
   this._connections = 0;

--- a/test/parallel/test-net-server-options.js
+++ b/test/parallel/test-net-server-options.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
 assert.throws(function() { net.createServer('path'); }, TypeError);
 assert.throws(function() { net.createServer(common.PORT); }, TypeError);

--- a/test/parallel/test-net-server-options.js
+++ b/test/parallel/test-net-server-options.js
@@ -1,0 +1,7 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+assert.throws(function() { net.createServer('path'); }, TypeError);
+assert.throws(function() { net.createServer(common.PORT); }, TypeError);


### PR DESCRIPTION
net.createServer('aPipe') and net.createServer(8080) are mistakes, and
now throw a TypeError instead of silently being treated as an object.
