### PR TITLE
timer: ref/unref return self

### DIFF
--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -41,11 +41,15 @@ In the case of `setTimeout` when you `unref` you create a separate timer that
 will wakeup the event loop, creating too many of these may adversely effect
 event loop performance -- use wisely.
 
+Returns the timer.
+
 ## ref()
 
 If you had previously `unref()`d a timer you can call `ref()` to explicitly
 request the timer hold the program open. If the timer is already `ref`d calling
 `ref` again will have no effect.
+
+Returns the timer.
 
 ## setImmediate(callback[, arg][, ...])
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -330,11 +330,13 @@ Timeout.prototype.unref = function() {
     this._handle.domain = this.domain;
     this._handle.unref();
   }
+  return this;
 };
 
 Timeout.prototype.ref = function() {
   if (this._handle)
     this._handle.ref();
+  return this;
 };
 
 Timeout.prototype.close = function() {
@@ -345,6 +347,7 @@ Timeout.prototype.close = function() {
   } else {
     exports.unenroll(this);
   }
+  return this;
 };
 
 

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -12,6 +12,14 @@ var interval_fired = false,
 var LONG_TIME = 10 * 1000;
 var SHORT_TIME = 100;
 
+assert.doesNotThrow(function() {
+  setTimeout(function() {}, 10).unref().ref().unref();
+}, 'ref and unref are chainable');
+
+assert.doesNotThrow(function() {
+  setInterval(function() {}, 10).unref().ref().unref();
+}, 'ref and unref are chainable');
+
 setInterval(function() {
   interval_fired = true;
 }, LONG_TIME).unref();


### PR DESCRIPTION
Most calls to ref() and unref() are chainable, timers should be
chainable, too.

Typical use:

    var to = setTimeout(ontimeout, 123).unref();

/to @trevnorris This doesn't appear to me to have performance implications, look OK to you?