### PR TITLE
net: add net.listen, symetrical with net.connect

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -57,6 +57,23 @@ Use `nc` to connect to a UNIX domain socket server:
 
     nc -U /tmp/echo.sock
 
+## net.listen(options[, callback])
+
+A factory function, which returns a new ['net.Server'](#net_class_net_server).
+
+The options are passed to the ['net.Server'](#net_class_net_server)
+constructor.
+
+Both the options and the callback, if present, are passed to the the
+['server.listen'](#net_server_listen_options_listenlistener) method.
+
+## net.listen(...)
+
+A factory function, which returns a new ['net.Server'](#net_class_net_server).
+
+All the arguments are passed to the`Server.listen()` that matches the provided
+argument types.
+
 ## net.connect(options[, connectListener])
 ## net.createConnection(options[, connectListener])
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -43,6 +43,13 @@ exports.createServer = function(options, connectionListener) {
   return new Server(options, connectionListener);
 };
 
+exports.listen = function() {
+  var server = arguments[0] !== null && typeof arguments[0] === 'object' ?
+    exports.createServer(arguments[0]) : exports.createServer();
+  server.listen.apply(server, arguments);
+  return server;
+}
+
 
 // Target API:
 //


### PR DESCRIPTION
This is a WIP, I didn't want to spend time to complete the unit tests in the absence of some support.

I think having a `net.connect()` convenience wrapper, but _not_ having the equivalent `net.listen()` wrapper is weird - I keep thinking it should be there and have to remind myself it is not.

Should it exist? @nodejs/collaborators 
