### PR TITLE
test: Update cwd-enoent tests for AIX

### DIFF
--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -4,8 +4,8 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 
-// Fails with EINVAL on SmartOS, EBUSY on Windows.
-if (process.platform === 'sunos' || common.isWindows) {
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (process.platform === 'sunos' || common.isWindows || common.isAix) {
   console.log('1..0 # Skipped: cannot rmdir current working directory');
   return;
 }

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -4,8 +4,8 @@ var assert = require('assert');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 
-// Fails with EINVAL on SmartOS, EBUSY on Windows.
-if (process.platform === 'sunos' || common.isWindows) {
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (process.platform === 'sunos' || common.isWindows || common.isAix) {
   console.log('1..0 # Skipped: cannot rmdir current working directory');
   return;
 }

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -4,8 +4,8 @@ var assert = require('assert');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 
-// Fails with EINVAL on SmartOS, EBUSY on Windows.
-if (process.platform === 'sunos' || common.isWindows) {
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (process.platform === 'sunos' || common.isWindows || common.isAix) {
   console.log('1..0 # Skipped: cannot rmdir current working directory');
   return;
 }


### PR DESCRIPTION
On AIX you can not remove a directory that you are currently inside of
as it results in an EBUSY error "EBUSY: resource busy or locked".
Updated the tests accordingly so that they are skipped on AIX.