### PR TITLE
build,win: try next MSVS version on failure

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -97,7 +97,7 @@ if defined msi (
   )
 )
 call "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat"
-if not defined VCINSTALLDIR goto msbuild-not-found
+if not defined VCINSTALLDIR goto vc-set-2013
 set GYP_MSVS_VERSION=2015
 set PLATFORM_TOOLSET=v140
 goto msbuild-found
@@ -117,7 +117,7 @@ if defined msi (
   )
 )
 call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
-if not defined VCINSTALLDIR goto msbuild-not-found
+if not defined VCINSTALLDIR goto vc-set-2012
 set GYP_MSVS_VERSION=2013
 set PLATFORM_TOOLSET=v120
 goto msbuild-found
@@ -136,7 +136,7 @@ if defined msi (
   )
 )
 call "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat"
-if not defined VCINSTALLDIR goto msbuild-not-found
+if not defined VCINSTALLDIR goto vc-set-2010
 set GYP_MSVS_VERSION=2012
 set PLATFORM_TOOLSET=v110
 goto msbuild-found


### PR DESCRIPTION
As suggested by @bnoordhuis in https://github.com/nodejs/node/pull/2843#discussion_r39415007 , `vcbuild.bat` should try the next version of Visual Studio when `VCINSTALLDIR` is not defined, as VC++ might not be installed for the current version.

This has already landed in v0.12 in e07c86e24081bd35512f5fabdfe50e1f1c94b96d.

cc @nodejs/platform-windows 