### PR TITLE
src: null env_ field from constructor

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -230,7 +230,7 @@ NODE_DEPRECATED("Use ThrowUVException(isolate)",
 
 class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  public:
-  ArrayBufferAllocator() { }
+  ArrayBufferAllocator() : env_(nullptr) { }
 
   inline void set_env(Environment* env) { env_ = env; }
 


### PR DESCRIPTION
The env_ field in ArrayBufferAllocator needs to be null'd out since it
is used during initialization and checked prior to properly being set by
set_env().

Fixes: 74178a5 "buffer: construct Uint8Array in JS"

R=@indutny 
R=@Fishrock123 