### PR TITLE
test: fix Buffer OOM error message

### DIFF
--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -30,7 +30,7 @@ assert.strictEqual(SlowBuffer(0).length, 0);
 try {
   assert.strictEqual(SlowBuffer(buffer.kMaxLength).length, buffer.kMaxLength);
 } catch (e) {
-  assert.equal(e.message, 'Buffer allocation failed - process out of memory');
+  assert.equal(e.message, 'Invalid array buffer length');
 }
 
 // should work with number-coercible values

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -115,12 +115,12 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
 
   assert.throws(function() {
     new Buffer(kStringMaxLength + 1).toString();
-  }, /toString failed|Buffer allocation failed/);
+  }, /toString failed|Invalid array buffer length/);
 
   try {
     new Buffer(kStringMaxLength * 4);
   } catch(e) {
-    assert.equal(e.message, 'Buffer allocation failed - process out of memory');
+    assert.equal(e.message, 'Invalid array buffer length');
     console.log(
         '1..0 # Skipped: intensive toString tests due to memory confinements');
     return;


### PR DESCRIPTION
Now that Buffers instantiate the Uint8Array in JS the error message has
changed in case the allocation fails due to OOM. Tests have been updated
to match.

R=@Fishrock123 