### PR TITLE
deps: backport 6d32be2 from v8's upstream

### DIFF
--- a/deps/v8/src/v8natives.js
+++ b/deps/v8/src/v8natives.js
@@ -21,7 +21,6 @@ var GlobalFunction = global.Function;
 var GlobalNumber = global.Number;
 var GlobalObject = global.Object;
 var InternalArray = utils.InternalArray;
-var SetFunctionName = utils.SetFunctionName;
 
 var MathAbs;
 var ProxyDelegateCallAndConstruct;
@@ -1705,7 +1704,8 @@ function FunctionBind(this_arg) { // Length is 1.
 
   var name = this.name;
   var bound_name = IS_STRING(name) ? name : "";
-  SetFunctionName(result, bound_name, "bound");
+  %DefineDataPropertyUnchecked(result, "name", "bound " + bound_name,
+                               DONT_ENUM | READ_ONLY);
 
   // We already have caller and arguments properties on functions,
   // which are non-configurable. It therefore makes no sence to

--- a/deps/v8/test/mjsunit/function-bind-name.js
+++ b/deps/v8/test/mjsunit/function-bind-name.js
@@ -5,9 +5,12 @@
 function f() {}
 var fb = f.bind({});
 assertEquals('bound f', fb.name);
-assertEquals('function bound f() { [native code] }', fb.toString());
 
 Object.defineProperty(f, 'name', {value: 42});
 var fb2 = f.bind({});
 assertEquals('bound ', fb2.name);
-assertEquals('function bound () { [native code] }', fb2.toString());
+
+function g() {}
+var gb = g.bind({});
+assertEquals('bound g', gb.name);
+assertEquals('bound f', fb.name);


### PR DESCRIPTION
Original commit message:

    [es6] Bound function name

    Instead of updating the SharedFuntionInfo set the name property on
    the function directly.

    BUG=v8:4278
    LOG=N
    R=verwaest@chromium.org, littledan@chromium.org
    CQ_INCLUDE_TRYBOTS=tryserver.chromium.linux:linux_chromium_rel_ng;tryserver.blink:linux_blink_rel

    Review URL: https://codereview.chromium.org/1227523003

    Cr-Commit-Position: refs/heads/master@{#29558}

Fixes: https://github.com/nodejs/node/issues/2754

/cc @rvagg @nodejs/v8 