### PR TITLE
module: remove unnecessary property and method

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -388,20 +388,10 @@ Module.prototype._compile = function(content, filename) {
     return Module._resolveFilename(request, self);
   };
 
-  Object.defineProperty(require, 'paths', { get: function() {
-    throw new Error('require.paths is removed. Use ' +
-                    'node_modules folders, or the NODE_PATH ' +
-                    'environment variable instead.');
-  }});
-
   require.main = process.mainModule;
 
   // Enable support to add extra extension types
   require.extensions = Module._extensions;
-  require.registerExtension = function() {
-    throw new Error('require.registerExtension() removed. Use ' +
-                    'require.extensions instead.');
-  };
 
   require.cache = Module._cache;
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -127,10 +127,6 @@ assert.equal(require('../fixtures/registerExt2').custom, 'passed');
 assert.equal(require('../fixtures/foo').foo, 'ok',
              'require module with no extension');
 
-assert.throws(function() {
-  require.paths;
-}, /removed/, 'Accessing require.paths should throw.');
-
 // Should not attempt to load a directory
 try {
   require('../fixtures/empty');


### PR DESCRIPTION
`require.paths` property and `require.registerExtension` function have
been throwing errors when used. They both are like this for years now.
This patch removes them from the system.

`require.paths`: https://github.com/nodejs/node/commit/7f0047c2d52eb39c30ee49a6e5a9a3167ec6f54d#diff-d1234a869b3d648ebfcdce5a76747d71R359

`require.registerExtension` was removed even before that.