### PR TITLE
buffer: don't set zero fill for zero-length buffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -22,7 +22,8 @@ const kNoZeroFill = 0;
 
 function createPool() {
   poolSize = Buffer.poolSize;
-  flags[kNoZeroFill] = 1;
+  if (poolSize > 0)
+    flags[kNoZeroFill] = 1;
   allocPool = new Uint8Array(poolSize);
   Object.setPrototypeOf(allocPool, Buffer.prototype);
   poolOffset = 0;
@@ -64,7 +65,8 @@ Buffer.__proto__ = Uint8Array;
 function SlowBuffer(length) {
   if (+length != length)
     length = 0;
-  flags[kNoZeroFill] = 1;
+  if (length > 0)
+    flags[kNoZeroFill] = 1;
   const ui8 = new Uint8Array(+length);
   Object.setPrototypeOf(ui8, Buffer.prototype);
   return ui8;
@@ -75,8 +77,11 @@ SlowBuffer.__proto__ = Buffer;
 
 
 function allocate(size) {
-  if (size === 0)
-    return SlowBuffer(0);
+  if (size === 0) {
+    const ui8 = new Uint8Array(size);
+    Object.setPrototypeOf(ui8, Buffer.prototype);
+    return ui8;
+  }
   if (size < (Buffer.poolSize >>> 1)) {
     if (size > (poolSize - poolOffset))
       createPool();
@@ -85,7 +90,11 @@ function allocate(size) {
     alignPool();
     return b;
   } else {
-    flags[kNoZeroFill] = 1;
+    // Even though this is checked above, the conditional is a safety net and
+    // sanity check to prevent the arraybuffer from being allocated with
+    // garbage.
+    if (size > 0)
+      flags[kNoZeroFill] = 1;
     const ui8 = new Uint8Array(size);
     Object.setPrototypeOf(ui8, Buffer.prototype);
     return ui8;

--- a/test/parallel/test-buffer-zero-fill-reset.js
+++ b/test/parallel/test-buffer-zero-fill-reset.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+
+function testUint8Array(ui) {
+  const length = ui.length;
+  for (let i = 0; i < length; i++)
+    if (ui[i] !== 0) return false;
+  return true;
+}
+
+
+for (let i = 0; i < 100; i++) {
+  new Buffer(0);
+  let ui = new Uint8Array(65);
+  assert.ok(testUint8Array(ui), 'Uint8Array is not zero-filled');
+}


### PR DESCRIPTION
The Uint8Array constructor doesn't hit the ArrayBuffer::Allocator() when
length == 0. So in these cases don't set the kNoZeroFill flag, since it
won't be reset.

Add test to ensure Uint8Array's are zero-filled after creating a Buffer
of length zero. This test may falsely succeed, but will not falsely fail.

Fix: https://github.com/nodejs/node/issues/2930

R=@indutny 
R=@Fishrock123 
