### PR TITLE
fs: speed up fs.WriteStream#_write

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1840,22 +1840,36 @@ fs.FileWriteStream = fs.WriteStream; // support the legacy name
 
 
 WriteStream.prototype.open = function() {
+  const self = this;
+
   fs.open(this.path, this.flags, this.mode, function(er, fd) {
     if (er) {
-      this.destroy();
-      this.emit('error', er);
+      self.destroy();
+      self.emit('error', er);
       return;
     }
 
-    this.fd = fd;
-    this.emit('open', fd);
-  }.bind(this));
+    self.fd = fd;
+    self.emit('open', fd);
+  });
 };
+
+
+function write(fd, buffer, position, callback) {
+  function wrapper(err, written) {
+    // Retain a reference to buffer so that it can't be GC'ed too soon.
+    callback(err, written || 0, buffer);
+  }
+
+  var req = new FSReqWrap();
+  req.oncomplete = wrapper;
+  binding.writeBuffer(fd, buffer, 0, buffer.length, position, req);
+}
 
 
 WriteStream.prototype._write = function(data, encoding, cb) {
   if (!(data instanceof Buffer))
-    return this.emit('error', new Error('Invalid data'));
+    return this.emit('error', new TypeError('Invalid data'));
 
   if (typeof this.fd !== 'number')
     return this.once('open', function() {
@@ -1863,7 +1877,8 @@ WriteStream.prototype._write = function(data, encoding, cb) {
     });
 
   var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+
+  write(this.fd, data, this.pos, function(er, bytes) {
     if (er) {
       self.destroy();
       return cb(er);


### PR DESCRIPTION
This avoids a number of type checks and a maybeCallback call that was being done by fs.write before.

Benchmarking this is not an exact science. I tend to see some improvement, especially when dealing with the small and countless buffers (like in #2167, it's probably best to focus on size=2 and size=1024 for benchmark consistency). In any case, looking at the code change, it should be fairly obvious that it should be at least somewhat faster.

Previous benchmark:

```
fs/write-stream-throughput.js dur=5 type=buf size=2: 4.27074
fs/write-stream-throughput.js dur=5 type=buf size=1024: 231.85246
fs/write-stream-throughput.js dur=5 type=buf size=65535: 548.05857
fs/write-stream-throughput.js dur=5 type=buf size=1048576: 524.05158
fs/write-stream-throughput.js dur=5 type=asc size=2: 1.30060
fs/write-stream-throughput.js dur=5 type=asc size=1024: 182.64069
fs/write-stream-throughput.js dur=5 type=asc size=65535: 491.32727
fs/write-stream-throughput.js dur=5 type=asc size=1048576: 513.10271
fs/write-stream-throughput.js dur=5 type=utf size=2: 1.22798
fs/write-stream-throughput.js dur=5 type=utf size=1024: 132.25211
fs/write-stream-throughput.js dur=5 type=utf size=65535: 306.84604
fs/write-stream-throughput.js dur=5 type=utf size=1048576: 375.21379
```

With this PR:

```
fs/write-stream-throughput.js dur=5 type=buf size=2: 4.54269
fs/write-stream-throughput.js dur=5 type=buf size=1024: 274.99219
fs/write-stream-throughput.js dur=5 type=buf size=65535: 517.75836
fs/write-stream-throughput.js dur=5 type=buf size=1048576: 524.53301
fs/write-stream-throughput.js dur=5 type=asc size=2: 1.55818
fs/write-stream-throughput.js dur=5 type=asc size=1024: 198.47340
fs/write-stream-throughput.js dur=5 type=asc size=65535: 466.72804
fs/write-stream-throughput.js dur=5 type=asc size=1048576: 506.89006
fs/write-stream-throughput.js dur=5 type=utf size=2: 1.57304
fs/write-stream-throughput.js dur=5 type=utf size=1024: 183.35674
fs/write-stream-throughput.js dur=5 type=utf size=65535: 335.97045
fs/write-stream-throughput.js dur=5 type=utf size=1048576: 374.15673
```

After #2167, you may wonder why this would have any affect on this benchmark at all. But that's because pretty much each _writev is followed by a _write and vice versa. When tracking whether _writev or _write is called, you see both pop up almost equally. For that reason I thought it would be worthwhile to optimize fs.WriteStream#_write. Independently, it would be interesting to try and figure out if we can optimize Stream.Writable to chunk more through _writev when possible.