### PR TITLE
repl: backslash bug fix

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -288,7 +288,7 @@ function REPLServer(prompt,
     if (self._inTemplateLiteral) {
       self._inTemplateLiteral = false;
     } else {
-      cmd = trimWhitespace(cmd);
+      cmd = cmd.trim();
     }
 
     // Check to see if a REPL keyword was used. If it returns true,
@@ -972,17 +972,6 @@ function defineDefaultCommands(repl) {
       this.displayPrompt();
     }
   });
-}
-
-
-function trimWhitespace(cmd) {
-  const trimmer = /^\s*(.+)\s*$/m;
-  var matches = trimmer.exec(cmd);
-
-  if (matches && matches.length === 2) {
-    return matches[1];
-  }
-  return '';
 }
 
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -190,7 +190,6 @@ function REPLServer(prompt,
   self._domain.on('error', function(e) {
     debug('domain error');
     self.outputStream.write((e.stack || e) + '\n');
-    self._currentStringLiteral = null;
     self.bufferedCommand = '';
     self.lines.level = [];
     self.displayPrompt();
@@ -217,8 +216,6 @@ function REPLServer(prompt,
   self.outputStream = output;
 
   self.resetContext();
-  // Initialize the current string literal found, to be null
-  self._currentStringLiteral = null;
   self.bufferedCommand = '';
   self.lines.level = [];
 
@@ -277,86 +274,21 @@ function REPLServer(prompt,
       sawSIGINT = false;
     }
 
-    self._currentStringLiteral = null;
     self.bufferedCommand = '';
     self.lines.level = [];
     self.displayPrompt();
   });
 
-  function parseLine(line, currentStringLiteral) {
-    var previous = null, current = null;
-
-    for (var i = 0; i < line.length; i += 1) {
-      if (previous === '\\') {
-        // if it is a valid escaping, then skip processing
-        previous = current;
-        continue;
-      }
-
-      current = line.charAt(i);
-      if (current === currentStringLiteral) {
-        currentStringLiteral = null;
-      } else if (current === '\'' ||
-                 current === '"' &&
-                 currentStringLiteral === null) {
-        currentStringLiteral = current;
-      }
-      previous = current;
-    }
-
-    return currentStringLiteral;
-  }
-
-  function getFinisherFunction(cmd, defaultFn) {
-    if ((self._currentStringLiteral === null &&
-         cmd.charAt(cmd.length - 1) === '\\') ||
-        (self._currentStringLiteral !== null &&
-         cmd.charAt(cmd.length - 1) !== '\\')) {
-
-      // If the line continuation is used outside string literal or if the
-      // string continuation happens with out line continuation, then fail hard.
-      // Even if the error is recoverable, get the underlying error and use it.
-      return function(e, ret) {
-        var error = e instanceof Recoverable ? e.err : e;
-
-        if (arguments.length === 2) {
-          // using second argument only if it is actually passed. Otherwise
-          // `undefined` will be printed when invalid REPL commands are used.
-          return defaultFn(error, ret);
-        }
-
-        return defaultFn(error);
-      };
-    }
-    return defaultFn;
-  }
-
   self.on('line', function(cmd) {
     debug('line %j', cmd);
     sawSIGINT = false;
     var skipCatchall = false;
-    var finisherFn = finish;
 
     // leading whitespaces in template literals should not be trimmed.
     if (self._inTemplateLiteral) {
       self._inTemplateLiteral = false;
     } else {
-      const wasWithinStrLiteral = self._currentStringLiteral !== null;
-      self._currentStringLiteral = parseLine(cmd, self._currentStringLiteral);
-      const isWithinStrLiteral = self._currentStringLiteral !== null;
-
-      if (!wasWithinStrLiteral && !isWithinStrLiteral) {
-        // Current line has nothing to do with String literals, trim both ends
-        cmd = cmd.trim();
-      } else if (wasWithinStrLiteral && !isWithinStrLiteral) {
-        // was part of a string literal, but it is over now, trim only the end
-        cmd = cmd.trimRight();
-      } else if (isWithinStrLiteral && !wasWithinStrLiteral) {
-        // was not part of a string literal, but it is now, trim only the start
-        cmd = cmd.trimLeft();
-      }
-
-      finisherFn = getFinisherFunction(cmd, finish);
+      cmd = trimWhitespace(cmd);
     }
 
     // Check to see if a REPL keyword was used. If it returns true,
@@ -389,9 +321,9 @@ function REPLServer(prompt,
       }
 
       debug('eval %j', evalCmd);
-      self.eval(evalCmd, self.context, 'repl', finisherFn);
+      self.eval(evalCmd, self.context, 'repl', finish);
     } else {
-      finisherFn(null);
+      finish(null);
     }
 
     function finish(e, ret) {
@@ -402,7 +334,6 @@ function REPLServer(prompt,
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
-        self._currentStringLiteral = null;
         self.bufferedCommand = '';
         self.displayPrompt();
         return;
@@ -424,7 +355,6 @@ function REPLServer(prompt,
       }
 
       // Clear buffer if no SyntaxErrors
-      self._currentStringLiteral = null;
       self.bufferedCommand = '';
 
       // If we got any output - print it (if no error)
@@ -965,7 +895,6 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
     action: function() {
-      this._currentStringLiteral = null;
       this.bufferedCommand = '';
       this.displayPrompt();
     }
@@ -980,7 +909,6 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('clear', {
     help: clearMessage,
     action: function() {
-      this._currentStringLiteral = null;
       this.bufferedCommand = '';
       if (!this.useGlobal) {
         this.outputStream.write('Clearing context...\n');
@@ -1045,6 +973,18 @@ function defineDefaultCommands(repl) {
     }
   });
 }
+
+
+function trimWhitespace(cmd) {
+  const trimmer = /^\s*(.+)\s*$/m;
+  var matches = trimmer.exec(cmd);
+
+  if (matches && matches.length === 2) {
+    return matches[1];
+  }
+  return '';
+}
+
 
 function regexpEscape(s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');

--- a/test/fixtures/repl-load.js
+++ b/test/fixtures/repl-load.js
@@ -1,0 +1,1 @@
+module.exports = 'repl';

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -215,6 +215,12 @@ function error_test() {
             'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
       expect: ['\'1\'\n', '\'2\'\n', '\'3\'\n', '\'4\'\n', '\'5\'\n', '\'6\'\n',
                '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
+    // making sure that the lines entered are trimmed properly
+    { client: client_unix, send: '    \t  .break \t \t  ',
+      expect: prompt_unix },
+    { client: client_unix, send: '.load ' +
+              require('path').join(common.fixturesDir, 'repl-load.js    \t  '),
+      expect: prompt_unix + '\'repl\'\n' + prompt_unix },
   ]);
 }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -198,33 +198,6 @@ function error_test() {
     // a REPL command
     { client: client_unix, send: '.toString',
       expect: 'Invalid REPL keyword\n' + prompt_unix },
-    // fail when we are not inside a String and a line continuation is used
-    { client: client_unix, send: '[] \\',
-      expect: /^SyntaxError: Unexpected token ILLEGAL/ },
-    // do not fail when a String is created with line continuation
-    { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
-      expect: prompt_multiline + prompt_multiline +
-              '\'thefourtheye\'\n' + prompt_unix },
-    // Don't fail when a partial String is created and line continuation is used
-    // with whitespace characters at the end of the string. We are to ignore it.
-    // This test is to make sure that we properly remove the whitespace
-    // characters at the end of line, unlike the buggy `trimWhitespace` function
-    { client: client_unix, send: '  \t    .break  \t  ',
-      expect: prompt_unix },
-    // multiline strings preserve whitespace characters in them
-    { client: client_unix, send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
-      expect: prompt_multiline + prompt_multiline +
-              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix },
-    // more than one multiline strings also should preserve whitespace chars
-    { client: client_unix, send: '\'the \\\n   fourth\' +  \'\t\t\\\n  eye  \'',
-      expect: prompt_multiline + prompt_multiline +
-              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix },
-    // using REPL commands within a string literal should still work
-    { client: client_unix, send: '\'\\\n.break',
-      expect: prompt_unix },
-    // using REPL command "help" within a string literal should still work
-    { client: client_unix, send: '\'thefourth\\\n.help\neye\'',
-      expect: /'thefourtheye'/ },
     // empty lines in the REPL should be allowed
     { client: client_unix, send: '\n\r\n\r\n',
       expect: prompt_unix + prompt_unix + prompt_unix },


### PR DESCRIPTION
**1st commit:**

When some string is copied and pasted in REPL, if it has a newline (\n)
in it, then it is considered as end of line and REPL throws a
SyntaxError, because a line cannot end with a unclosed string literal.
This behavior is because of the fact that `readline` module breaks at
all the `\n`s in the input string and treats them as a seperate line.
So whenever it encounters a new line character it will emit a `line`
event.

This commit basically reverts 81ea52a, which was an attempt to improve
the way string literals were handled by REPL.

Fixes: #2749

**2nd commit**

As it is, the trimWhitespace function will not remove the white sapce
characters at the end of the string, as the greedy capturing group .+
captures everything till end of the string, leaving \s* with nothing.

This patch replaces the buggy function with the built-in, String
prototype's trim function.

**Note:** The second commit is necessary because, the revert brings back the old buggy trimming function. So, I though we could fix it now itself.

cc @silverwind @Fishrock123 