### PR TITLE
fs: don't fail with EBADF on double close

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1770,6 +1770,8 @@ ReadStream.prototype.close = function(cb) {
   close();
 
   function close(fd) {
+    if (fd === undefined && self.fd === null)
+      return;
     fs.close(fd || self.fd, function(er) {
       if (er)
         self.emit('error', er);

--- a/test/parallel/test-fs-read-stream-double-close.js
+++ b/test/parallel/test-fs-read-stream-double-close.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+common.refreshTmpDir();
+fs.writeFileSync(common.tmpDir + '/ro', '');
+
+const s = fs.createReadStream(common.tmpDir + '/ro');
+s.close(common.mustCall(function() {}));
+s.close(common.mustCall(function() {}));

--- a/test/parallel/test-fs-write-stream-double-close.js
+++ b/test/parallel/test-fs-write-stream-double-close.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+common.refreshTmpDir();
+
+const s = fs.createWriteStream(common.tmpDir + '/rw');
+s.close(common.mustCall(function() {}));
+s.close(common.mustCall(function() {}));


### PR DESCRIPTION
Calling fs.ReadStream#close() or fs.WriteStream#close() twice made it
try to close the file descriptor twice, with the second attempt using
the nulled out `.fd` property and failing with an EBADF error.

Fixes: https://github.com/nodejs/node/issues/2950

CI: https://ci.nodejs.org/job/node-test-pull-request/342/