### PR TITLE
deps: backport ff7d70b from V8's upstream

### DIFF
--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -146,7 +146,7 @@ extras_accessors = [
     'Map, instance_size, int, kInstanceSizeOffset',
     'Map, bit_field, char, kBitFieldOffset',
     'Map, bit_field2, char, kBitField2Offset',
-    'Map, bit_field3, SMI, kBitField3Offset',
+    'Map, bit_field3, int, kBitField3Offset',
     'Map, prototype, Object, kPrototypeOffset',
     'NameDictionaryShape, prefix_size, int, kPrefixSize',
     'NameDictionaryShape, entry_size, int, kEntrySize',


### PR DESCRIPTION
Original commit message:

  Update BitField3 type in gen-postmortem-metadata.py

  Since https://codereview.chromium.org/272163002, BitField3 is a raw
  uint32 field, and not a SMI anymore.

  Update tools/gen-postmortem-metadata.py so that post-mortem tools can
  work with versions of V8 that shipped after that change.

  This change was merged in github.com/joyent/node right before node
  v0.12.0 was released.

  R=danno@chromium.org

  TEST=mdb_v8, a post-mortem debugging tool running on SmartOS,  has been
  using this change since Node.js v0.12.0 was released

  BUG=

  Review URL: https://codereview.chromium.org/1296743003

  Cr-Commit-Position: refs/heads/master@{#30839}

This is necessary to allow mdb_v8 to work properly with node v4.x, so this would need to be backported to the v4.x branch.

/cc @nodejs/post-mortem