### PR TITLE
lib,test: Use long paths when loading native addons

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -466,7 +466,9 @@ Module._extensions['.json'] = function(module, filename) {
 
 
 //Native extension for .node
-Module._extensions['.node'] = process.dlopen;
+Module._extensions['.node'] = function(module, filename) {
+  return process.dlopen(module, path._makeLong(filename));
+};
 
 
 // bootstrap main module.

--- a/test/addons/load-long-path/binding.cc
+++ b/test/addons/load-long-path/binding.cc
@@ -1,0 +1,14 @@
+#include <node.h>
+#include <v8.h>
+
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::HandleScope scope(isolate);
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+}
+
+void init(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "hello", Method);
+}
+
+NODE_MODULE(binding, init);

--- a/test/addons/load-long-path/binding.gyp
+++ b/test/addons/load-long-path/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../../common');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+// make a path that is more than 260 chars long.
+// Any given folder cannot have a name longer than 260 characters,
+// so create 10 nested folders each with 30 character long names.
+var addonDestinationDir = path.resolve(common.tmpDir);
+
+for (var i = 0; i < 10; i++) {
+  addonDestinationDir = path.join(addonDestinationDir, 'x'.repeat(30));
+  fs.mkdirSync(addonDestinationDir);
+}
+
+const addonPath = path.join(__dirname, 'build', 'Release', 'binding.node');
+const addonDestinationPath = path.join(addonDestinationDir, 'binding.node');
+
+// Copy binary to long path destination
+var contents = fs.readFileSync(addonPath);
+fs.writeFileSync(addonDestinationPath, contents);
+
+// Attempt to load at long path destination
+var addon = require(addonDestinationPath);
+assert(addon != null);
+assert(addon.hello() == 'world');


### PR DESCRIPTION
Currently, it's possible for a native addon on windows to throw an exception during module loading if it's path is too long.

This change resolves the issue by converting the path to the addon to a long path before calling `process.dlopen`.

Fixes #2964 