### PR TITLE
http{s}: fix connecting to localhost if URL is invalid

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -22,6 +22,9 @@ function ClientRequest(options, cb) {
 
   if (typeof options === 'string') {
     options = url.parse(options);
+    if (!options.hostname) {
+      throw new Error('Unable to determine the domain name');
+    }
   } else {
     options = util._extend({}, options);
   }

--- a/lib/https.js
+++ b/lib/https.js
@@ -156,6 +156,9 @@ exports.Agent = Agent;
 exports.request = function(options, cb) {
   if (typeof options === 'string') {
     options = url.parse(options);
+    if (!options.hostname) {
+      throw new Error('Unable to determine the domain name');
+    }
   } else {
     options = util._extend({}, options);
   }

--- a/test/parallel/test-http-invalid-urls.js
+++ b/test/parallel/test-http-invalid-urls.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const http = require('http');
+const https = require('https');
+const error = 'Unable to determine the domain name';
+
+function test(host) {
+  ['get', 'request'].forEach((method) => {
+    [http, https].forEach((module) => {
+      assert.throws(() => module[method](host, () => {
+        throw new Error(`${module}.${method} should not connect to ${host}`);
+      }), error);
+    });
+  });
+}
+
+['www.nodejs.org', 'localhost', '127.0.0.1', 'http://:80/'].forEach(test);


### PR DESCRIPTION
If the URL passed to `http.request` is not properly parsable by `url.parse`, we
fall back to use `localhost` and port 80. This creates confusing error messages
like in this question http://stackoverflow.com/q/32675907/1903116.

This patch throws an error message, if `url.parse` fails to parse the URL.

Previous Discussion: https://github.com/nodejs/node/pull/2966