### PR TITLE
repl: backslash bug fix

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -288,8 +288,9 @@ function REPLServer(prompt,
 
     for (var i = 0; i < line.length; i += 1) {
       if (previous === '\\') {
-        // if it is a valid escaping, then skip processing
-        previous = current;
+        // if it is a valid escaping, then skip processing and the previous
+        // character doesn't matter anymore.
+        previous = null;
         continue;
       }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -242,6 +242,13 @@ function error_test() {
             'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
       expect: ['\'1\'\n', '\'2\'\n', '\'3\'\n', '\'4\'\n', '\'5\'\n', '\'6\'\n',
                '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
+    // regression tests for https://github.com/nodejs/node/issues/2749
+    { client: client_unix, send: 'function x() {\nreturn \'\\n\';\n }',
+      expect: prompt_multiline + prompt_multiline +
+              'undefined\n' + prompt_unix },
+    { client: client_unix, send: 'function x() {\nreturn \'\\\\\';\n }',
+      expect: prompt_multiline + prompt_multiline +
+              'undefined\n' + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
The actual problem was with the line parsing logic for string literals.
When we use backslash in the string literals, it used to remember the
`\` as the previous character even after we parsed the character next
to it. This leads to REPL thinking that the end of string literals is
not reached.

This patch replaces the previous character with `null`, so that it will
properly skip the character next to it.

Previous Discussion: https://github.com/nodejs/node/pull/2952
Fixes: https://github.com/nodejs/node/issues/2749

cc @silverwind @Fishrock123 