### PR TITLE
deps: backport 357e6b9 from V8's upstream

### DIFF
--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -4086,7 +4086,6 @@ class ScopeInfo : public FixedArray {
   FOR_EACH_NUMERIC_FIELD(FIELD_ACCESSORS)
 #undef FIELD_ACCESSORS
 
- private:
   enum {
 #define DECL_INDEX(name) k##name,
   FOR_EACH_NUMERIC_FIELD(DECL_INDEX)
@@ -4095,6 +4094,7 @@ class ScopeInfo : public FixedArray {
     kVariablePartIndex
   };
 
+ private:
   // The layout of the variable part of a ScopeInfo is as follows:
   // 1. ParameterEntries:
   //    This part stores the names of the parameters for function scopes. One

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -132,6 +132,15 @@ consts_misc = [
         'value': 'JavaScriptFrameConstants::kFunctionOffset' },
     { 'name': 'off_fp_args',
         'value': 'JavaScriptFrameConstants::kLastParameterOffset' },
+
+    { 'name': 'scopeinfo_idx_nparams',
+        'value': 'ScopeInfo::kParameterCount' },
+    { 'name': 'scopeinfo_idx_nstacklocals',
+        'value': 'ScopeInfo::kStackLocalCount' },
+    { 'name': 'scopeinfo_idx_ncontextlocals',
+        'value': 'ScopeInfo::kContextLocalCount' },
+    { 'name': 'scopeinfo_idx_first_vars',
+        'value': 'ScopeInfo::kVariablePartIndex' },
 ];
 
 #


### PR DESCRIPTION
Backport 357e6b99ee3927cc075dd8d27c99b89d858f9dd5 from V8's upstream.

Original commit message:

  Add ScopeInfo constants to post-mortem metadata

  mdb_v8, a post-mortem debugging tool for Node.js, allows users to
  inspect ScopeInfo structures in order to get more information about
  closures.

  Currently, it hardcodes the metadata it uses to find this information.
  This change allows it to get this metadata from the node binary itself,
  and thus to adapt to future changes made to the layout of the ScopeInfo
  data structure.

  BUG=

  R=bmeurer@chromium.org