### PR TITLE
tls: use parent handle's close callback

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -296,7 +296,7 @@ proxiedMethods.forEach(function(name) {
 
 tls_wrap.TLSWrap.prototype.close = function closeProxy(cb) {
   if (this._parentWrap && this._parentWrap._handle === this._parent) {
-    setImmediate(cb);
+    this._parentWrap.once('close', cb);
     return this._parentWrap.destroy();
   }
   return this._parent.close(cb);


### PR DESCRIPTION
When closing the child TLSWrap handle - wait for the proper parent's
handle close callback invocation. `uv_close_cb` may be invoked much
later than the next libuv tick, depending on the platform.

Fix: https://github.com/nodejs/node/issues/2979