### PR TITLE
doc: correct method signature for assert.doesNotThrow()

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -86,7 +86,7 @@ Custom error validation:
       "unexpected error"
     );
 
-## assert.doesNotThrow(block[, message])
+## assert.doesNotThrow(block[, error][, message])
 
 Expects `block` not to throw an error. See `assert.throws()` for details.
 


### PR DESCRIPTION
This fixes a documentation shortcoming described at https://github.com/nodejs/node/issues/2989#issuecomment-142166934

