### PR TITLE
v8: let Object.defineProperty work with process.env

### DIFF
--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -50,6 +50,17 @@ if (process.argv[2] == 'you-are-the-child') {
   delete process.env.NODE_PROCESS_ENV_DELETED;
   assert.equal(false, 'NODE_PROCESS_ENV_DELETED' in process.env);
 
+  Object.defineProperty(process.env, 'NODE_PROCESS_ENV_DELETED', {
+    writable: true,
+    configurable: true,
+    enumerable: true,
+    value: 0
+  });
+  assert.equal(true, 'NODE_PROCESS_ENV_DELETED' in process.env);
+
+  delete process.env.NODE_PROCESS_ENV_DELETED;
+  assert.equal(false, 'NODE_PROCESS_ENV_DELETED' in process.env);
+
   var child = spawn(process.argv[0], [process.argv[1], 'you-are-the-child']);
   child.stdout.on('data', function(data) { console.log(data.toString()); });
   child.stderr.on('data', function(data) { console.log(data.toString()); });


### PR DESCRIPTION
This fixes #2998.

This is only a back port to v3.x since the bug will not emerge in v4.x. It turned out that the v8 team encountered a similar bug regarding `window.localStorage` in Chrome and landed a patch in Jun which is consequently applied into Node 4.x.

https://codereview.chromium.org/1180073002

However the patch is too big to back port to v3.x. I made a minimal version and therefore come this PR.
