### PR TITLE
deps: remove and gitignore .bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ deps/openssl/openssl.xml
 deps/openssl/openssl.target.mk
 deps/zlib/zlib.target.mk
 
+# not needed and causes issues for distro packagers
+deps/npm/node_modules/.bin/
+
 # build/release artifacts
 /*.tar.*
 /SHASUMS*.txt*

--- a/deps/npm/node_modules/.bin/node-gyp
+++ b/deps/npm/node_modules/.bin/node-gyp
@@ -1,1 +1,0 @@
-../node-gyp/bin/node-gyp.js


### PR DESCRIPTION
The .bin/ directory in deps/npm/node_modules seens to have been an
accidental check-in in commit e79ccee ("npm: upgrade to v2.1.18").
It causes trouble for distro packagers so delete it and blacklist it.

Fixes: https://github.com/nodejs/node/issues/2839

R=@rvagg? /cc @othiym23

CI: https://ci.nodejs.org/job/node-test-pull-request/359/