### PR TITLE
deps: remove useless bz2 module import

### DIFF
--- a/deps/v8/tools/js2c.py
+++ b/deps/v8/tools/js2c.py
@@ -34,7 +34,6 @@
 import os, re, sys, string
 import optparse
 import jsmin
-import bz2
 import textwrap
 
 


### PR DESCRIPTION
The bz2 module is not required anymore.