### PR TITLE
test: bp fix for test-http-get-pipeline-problem.js

### DIFF
--- a/test/simple/test-http-get-pipeline-problem.js
+++ b/test/simple/test-http-get-pipeline-problem.js
@@ -68,12 +68,10 @@ server.listen(common.PORT, function() {
         var s = fs.createWriteStream(common.tmpDir + '/' + x + '.jpg');
         res.pipe(s);
 
-        // TODO there should be a callback to pipe() that will allow
-        // us to get a callback when the pipe is finished.
-        res.on('end', function() {
+        s.on('finish', function() {
           console.error('done ' + x);
           if (++responses == total) {
-            s.on('close', checkFiles);
+            checkFiles();
           }
         });
       }).on('error', function(e) {


### PR DESCRIPTION
backport fix for test-http-get-pipeline-problem.js from master
to 0.12.X.  We've been seeing an intermittent failure
in runs for zLinux with SLES 12.  We confirmed that this fix
resolves the issue so would like it in 0.12.X

The original commit does not apply cleanly as the paths were
changed, but the actual change is identical.  The original commit was:

https://github.com/nodejs/node/commit/3ba4f71fc4a1b3acdcaaa250bc5ba81442257e09