### PR TITLE
configure: iojs -> nodejs

### DIFF
--- a/configure
+++ b/configure
@@ -205,7 +205,7 @@ parser.add_option('--release-urlbase',
     dest='release_urlbase',
     help='Provide a custom URL prefix for the `process.release` properties '
          '`sourceUrl` and `headersUrl`. When compiling a release build, this '
-         'will default to https://iojs.org/download/release/')
+         'will default to https://nodejs.org/download/release/')
 
 parser.add_option('--v8-options',
     action='store',


### PR DESCRIPTION
Inconsistency between `configure` and `node.cc`.

![image](https://cloud.githubusercontent.com/assets/13315/10037330/343f6a1a-61e7-11e5-9ca4-6c67e2c0fbe2.png)

![image](https://cloud.githubusercontent.com/assets/13315/10037337/4fa324a4-61e7-11e5-8644-c3f6634144c4.png)

