### PR TITLE
deps: backport c281c15 from V8's upstream

### DIFF
--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -150,6 +150,7 @@ extras_accessors = [
     'HeapObject, map, Map, kMapOffset',
     'JSObject, elements, Object, kElementsOffset',
     'FixedArray, data, uintptr_t, kHeaderSize',
+    'JSTypedArray, length, Object, kLengthOffset',
     'Map, instance_attributes, int, kInstanceAttributesOffset',
     'Map, inobject_properties, int, kInObjectPropertiesOffset',
     'Map, instance_size, int, kInstanceSizeOffset',


### PR DESCRIPTION
Backport c281c15d6dab8370a7805f0717502d260e0ad433 from V8's upstream to
allow post-mortem debugging tools to inspect Buffer instances' length.

Original commit message:

  Add JSTypedArray's length in post-mortem metadata.

  BUG=
  R=bmeurer@chromium.org

  Review URL: https://codereview.chromium.org/1363683002

  Cr-Commit-Position: refs/heads/master@{#30873}

/cc @nodejs/post-mortem