### PR TITLE
installer: install the tick processor

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -10,6 +10,7 @@ except ImportError:
 import os
 import re
 import shutil
+import stat
 import sys
 
 # set at init time
@@ -126,6 +127,46 @@ def subdir_files(path, dest, action):
   for subdir, files in ret.items():
     action(files, subdir + '/')
 
+def build_tick_processor(action):
+  tmp_script = 'out/Release/tick-processor'
+  if action == install:
+    # construct script
+    scripts = [
+        'tools/v8-prof/polyfill.js',
+        'deps/v8/tools/splaytree.js',
+        'deps/v8/tools/codemap.js',
+        'deps/v8/tools/csvparser.js',
+        'deps/v8/tools/consarray.js',
+        'deps/v8/tools/csvparser.js',
+        'deps/v8/tools/consarray.js',
+        'deps/v8/tools/profile.js',
+        'deps/v8/tools/profile_view.js',
+        'deps/v8/tools/logreader.js',
+        'deps/v8/tools/tickprocessor.js',
+        'deps/v8/tools/SourceMap.js',
+        'deps/v8/tools/tickprocessor-driver.js']
+    args = []
+    if sys.platform == 'darwin':
+      args.append('--nm=' + abspath(install_path, 'share/doc/node') + '/mac-nm')
+      args.append('--mac')
+    with open(tmp_script, 'w') as out_file:
+      # Add #! line to run with node
+      out_file.write('#! ' + abspath(install_path, 'bin/node') + '\n')
+      # inject arguments
+      for arg in args:
+        out_file.write('process.argv.splice(2, 0, \'' + arg + '\');\n')
+      # cat in source files
+      for script in scripts:
+        with open(script) as in_file:
+          shutil.copyfileobj(in_file, out_file)
+    # make executable
+    st = os.stat(tmp_script)
+    os.chmod(tmp_script, st.st_mode | stat.S_IEXEC)
+  # perform installations
+  action([tmp_script], 'share/doc/node/')
+  if sys.platform == 'darwin':
+    action(['deps/v8/tools/mac-nm'], 'share/doc/node/')
+
 def files(action):
   is_windows = sys.platform == 'win32'
 
@@ -139,6 +180,8 @@ def files(action):
   action(['src/node.stp'], 'share/systemtap/tapset/')
 
   action(['deps/v8/tools/gdbinit'], 'share/doc/node/')
+
+  build_tick_processor(action)
 
   if 'freebsd' in sys.platform or 'openbsd' in sys.platform:
     action(['doc/node.1'], 'man/man1/')

--- a/tools/rpm/node.spec
+++ b/tools/rpm/node.spec
@@ -94,6 +94,7 @@ done
 /usr/include/*
 /usr/lib/node_modules/
 /usr/share/doc/node/gdbinit
+/usr/share/doc/node/tick-processor
 /usr/share/man/man1/node.1.gz
 /usr/share/systemtap/tapset/node.stp
 %{_datadir}/%{name}/
@@ -101,6 +102,9 @@ done
 
 
 %changelog
+* Tue Sep 22 2015 Matt Loring <mattloring@google.com>
+- Added tick processor.
+
 * Tue Jul 7 2015 Ali Ijaz Sheikh <ofrobots@google.com>
 - Added gdbinit.
 


### PR DESCRIPTION
The tick processor is used to provide readable profiling information
from isolate tick logs (produced by a call to node -prof).

This patch installs the file at $PREFIX/share/doc/node/tick-processor.

/cc @bnoordhuis @ofrobots