### PR TITLE
path: improve posixSplitPath performance

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -408,7 +408,9 @@ var posix = {};
 
 
 function posixSplitPath(filename) {
-  return splitPathRe.exec(filename).slice(1);
+  const out = splitPathRe.exec(filename);
+  out.shift();
+  return out;
 }
 
 


### PR DESCRIPTION
Instead of slicing the first element off of the matches, manually build
the array. This improves performance of the following path.posix functions:

- basename
  - path/basename.js type=win32 n=1000000: ./node: 847760 /usr/local/bin/node: 829710 .. 2.18%
  - path/basename.js type=posix n=1000000: ./node: 989290 /usr/local/bin/node: 847820 . 21.55%
- extname
  - path/extname.js type=win32 n=1000000: ./node: 2385400 /usr/local/bin/node: 2451800 . -2.71%
  - path/extname.js type=posix n=1000000: ./node: 3379700 /usr/local/bin/node: 2113500 . 70.64%
- dirname
  - path/dirname.js type=win32 n=1000000: ./node: 1699600 /usr/local/bin/node: 1706700 . -0.42%
  - path/dirname.js type=posix n=1000000: ./node: 2038700 /usr/local/bin/node: 1704300 . 21.99%
- parse
  - path/parse.js type=win32 n=1000000: ./node: 1907900 /usr/local/bin/node: 1886300 .. 1.15%
  - path/parse.js type=posix n=1000000: ./node: 1923400 /usr/local/bin/node: 1616800 . 22.79%
