### PR TITLE
child_process: `null` channel handle on close

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -449,6 +449,7 @@ function setupChannel(target, channel) {
       target.disconnect();
       channel.onread = nop;
       channel.close();
+      target._channel = null;
       maybeClose(target);
     }
   };

--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const assert = require('assert');
 const common = require('../common');
+const assert = require('assert');
 
 const cluster = require('cluster');
 const net = require('net');
@@ -25,8 +25,6 @@ var server = net.createServer(function(s) {
   function send(callback) {
     var s = net.connect(common.PORT, function() {
       worker.send({}, s, callback);
-    });
-    s.on('error', function() {
     });
   }
 

--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common');
+
+const cluster = require('cluster');
+const net = require('net');
+const util = require('util');
+
+if (!cluster.isMaster) {
+  // Exit on first received handle to leave the queue non-empty in master
+  process.on('message', function() {
+    process.exit(1);
+  });
+  return;
+}
+
+var server = net.createServer(function(s) {
+  setTimeout(function() {
+    s.destroy();
+  }, 100);
+}).listen(common.PORT, function() {
+  var worker = cluster.fork();
+
+  function send(callback) {
+    var s = net.connect(common.PORT, function() {
+      worker.send({}, s, callback);
+    });
+    s.on('error', function() {
+    });
+  }
+
+  worker.process.once('close', common.mustCall(function() {
+    // Otherwise the crash on `_channel.fd` access may happen
+    assert(worker.process._channel === null);
+    server.close();
+  }));
+
+  // Queue up several handles, to make `process.disconnect()` wait
+  for (var i = 0; i < 100; i++)
+    send();
+});


### PR DESCRIPTION
`HandleWrap::OnClose` destroys the underlying C++ object and null's the
internal field pointer to it. Therefore there should be no references to
the wrapping JavaScript object.

`null` the process' `_channel` field right after closing it, to ensure
no crashes will happen.

Fix: https://github.com/nodejs/node/issues/2847