### PR TITLE
src: export Agent's constructor and destructor

### DIFF
--- a/src/debug-agent.h
+++ b/src/debug-agent.h
@@ -22,10 +22,10 @@
 #ifndef SRC_DEBUG_AGENT_H_
 #define SRC_DEBUG_AGENT_H_
 
+#include "node.h"
 #include "util.h"
 #include "util-inl.h"
 #include "uv.h"
-#include "v8.h"
 #include "v8-debug.h"
 
 #include <string.h>
@@ -66,8 +66,8 @@ class AgentMessage {
 
 class Agent {
  public:
-  explicit Agent(node::Environment* env);
-  ~Agent();
+  NODE_EXTERN explicit Agent(node::Environment* env);
+  NODE_EXTERN ~Agent();
 
   typedef void (*DispatchHandler)(node::Environment* env);
 


### PR DESCRIPTION
Since `node::Environment` includes `node::debugger::Agent` as a member data, and the constructor and destructor of `node::Environment` are inlined, we have to export `Agent`'s constructor and destructor, otherwise when Node is built as shared library we will get following error:

```
electron_lib.lib(electron_lib.node_main.obj) : error LNK2019: unresolved external symbol "public: __cdecl node::debugger::Agent::~Agent(void)" (??1Agent@debugger@node@@QEAA@XZ) referenced in function "private: __cdecl node::Environment::~Environment(void)" (??1Environment@node@@AEAA@XZ)
electron_lib.lib(electron_lib.atom_renderer_client.obj) : error LNK2001: unresolved external symbol "public: __cdecl node::debugger::Agent::~Agent(void)" (??1Agent@debugger@node@@QEAA@XZ)
electron_lib.lib(electron_lib.atom_renderer_client.obj) : error LNK2019: unresolved external symbol "public: __cdecl node::debugger::Agent::Agent(class node::Environment *)" (??0Agent@debugger@node@@QEAA@PEAVEnvironment@2@@Z) referenced in function "private: __cdecl node::Environment::Environment(class v8::Local<class v8::Context>,struct uv_loop_s *)" (??0Environment@node@@AEAA@V?$Local@VContext@v8@@@v8@@PEAUuv_loop_s@@@Z)
```