### PR TITLE
build,win: fix node.exe resource version

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -18,12 +18,21 @@
 # else
 #  define NODE_TAG "-pre"
 # endif
+#else
+// NODE_TAG is passed without quotes when rc.exe is run from msbuild
+# define NODE_EXE_VERSION NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
+                          NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
+                          NODE_STRINGIFY(NODE_PATCH_VERSION)     \
+                          NODE_STRINGIFY(NODE_TAG)
 #endif
 
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_PATCH_VERSION)     \
                               NODE_TAG
+#ifndef NODE_EXE_VERSION
+# define NODE_EXE_VERSION NODE_VERSION_STRING
+#endif
 
 #define NODE_VERSION "v" NODE_VERSION_STRING
 

--- a/src/res/node.rc
+++ b/src/res/node.rc
@@ -32,8 +32,8 @@ BEGIN
             VALUE "CompanyName", "Node.js"
             VALUE "ProductName", "Node.js"
             VALUE "FileDescription", "Node.js: Server-side JavaScript"
-            VALUE "FileVersion", "NODE_VERSION_STRING"
-            VALUE "ProductVersion", "NODE_VERSION_STRING"
+            VALUE "FileVersion", NODE_EXE_VERSION
+            VALUE "ProductVersion", NODE_EXE_VERSION
             VALUE "OriginalFilename", "node.exe"
             VALUE "InternalName", "node"
             VALUE "LegalCopyright", "Copyright Node.js contributors. MIT license."


### PR DESCRIPTION
As was described in https://github.com/nodejs/node/issues/2963 , the resource file was not being compiled correctly and the version information in the details of `node.exe` was wrong.

Simply removing the quotes from `node.rc` solves this for releases and `-pre` builds, but does not work for nightlies and rcs, that require `rc.exe` to receive the `NODE_TAG` as a preprocessor definition.

When MSBuild invokes `rc.exe`, it passes `NODE_TAG` unstringified, but passes it correctly to `cl.exe`. Hence, this workaround was made to apply only to the resource file.

cc @nodejs/platform-windows 