### PR TITLE
src: Include "signal.h" in "util.h"

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,7 @@
 #include "v8.h"
 
 #include <assert.h>
+#include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
It is required for using the `SIGABRT` constant.

It doesn't cause compilation errors in Node because most files already have "signal.h" included, but it causes errors for third party embedder.