### PR TITLE
src: internalize per-isolate string properties

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -478,7 +478,10 @@ inline void Environment::SetMethod(v8::Local<v8::Object> that,
                                    v8::FunctionCallback callback) {
   v8::Local<v8::Function> function =
       NewFunctionTemplate(callback)->GetFunction();
-  v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate(), name);
+  // kInternalized strings are created in the old space.
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  v8::Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
   that->Set(name_string, function);
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
@@ -489,7 +492,10 @@ inline void Environment::SetProtoMethod(v8::Local<v8::FunctionTemplate> that,
   v8::Local<v8::Signature> signature = v8::Signature::New(isolate(), that);
   v8::Local<v8::Function> function =
       NewFunctionTemplate(callback, signature)->GetFunction();
-  v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate(), name);
+  // kInternalized strings are created in the old space.
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  v8::Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
   that->PrototypeTemplate()->Set(name_string, function);
   function->SetName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
 }
@@ -499,7 +505,10 @@ inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
                                            v8::FunctionCallback callback) {
   v8::Local<v8::Function> function =
       NewFunctionTemplate(callback)->GetFunction();
-  v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate(), name);
+  // kInternalized strings are created in the old space.
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  v8::Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
   that->Set(name_string, function);
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }

--- a/src/env.h
+++ b/src/env.h
@@ -39,7 +39,7 @@ namespace node {
 #endif
 
 // Strings are per-isolate primitives but Environment proxies them
-// for the sake of convenience.
+// for the sake of convenience.  Strings should be ASCII-only.
 #define PER_ISOLATE_STRING_PROPERTIES(V)                                      \
   V(address_string, "address")                                                \
   V(args_string, "args")                                                      \


### PR DESCRIPTION
Speeds up property lookups a little and it creates the string in the
old space straight away.  It's a little easier on the garbage collector
because it doesn't have to track eternalized strings in the new space.

R=@trevnorris?

There are more places the comment above applies to.  I started with the most obvious ones.