### PR TITLE
https: throw error if required params missing

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -869,9 +869,25 @@ Server.prototype.setOptions = function(options) {
   }
 
   if (options.pfx) this.pfx = options.pfx;
-  if (options.key) this.key = options.key;
+  var defaultCiphers = options.ciphers === tls.DEFAULT_CIPHERS;
+  if (!options.key) {
+    if ((options.ciphers === undefined || defaultCiphers) && !options.pfx) {
+      throw new Error('key is a required parameter for Server.createServer');
+    }
+  } else {
+    this.key = options.key;
+  }
+
   if (options.passphrase) this.passphrase = options.passphrase;
-  if (options.cert) this.cert = options.cert;
+
+  if (!options.cert) {
+    if ((options.ciphers === undefined || defaultCiphers) && !options.pfx) {
+      throw new Error('cert is a required parameter for Server.createServer');
+    }
+  } else {
+    this.cert = options.cert;
+  }
+
   if (options.ca) this.ca = options.ca;
   if (options.secureProtocol) this.secureProtocol = options.secureProtocol;
   if (options.crl) this.crl = options.crl;

--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -21,12 +21,27 @@ var options = {
   rejectUnauthorized: false
 };
 
+var options1 = {
+  host: '127.0.0.1',
+  port: common.PORT,
+  path: '/',
+  pfx: pfx,
+  passphrase: 'sample',
+  requestCert: true
+};
+
 var server = https.createServer(options, function(req, res) {
   assert.equal(req.socket.authorized, false); // not a client cert
   assert.equal(req.socket.authorizationError, 'DEPTH_ZERO_SELF_SIGNED_CERT');
   res.writeHead(200);
   res.end('OK');
 });
+
+assert.doesNotThrow(() => https.createServer(options1, assert.fail),
+ 'cert is a required parameter for Server.createServer');
+
+assert.doesNotThrow(() => https.createServer(options1, assert.fail),
+  'key is a required parameter for Server.createServer');
 
 server.listen(options.port, options.host, function() {
   var data = '';

--- a/test/parallel/test-https-server-options.js
+++ b/test/parallel/test-https-server-options.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const https = require('https');
+const fs = require('fs');
+
+const options1 = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem', 'ascii'),
+  crt: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem', 'ascii')
+};
+
+const options2 = {
+  ky: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem', 'ascii'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem', 'ascii')
+};
+
+assert.throws(() => https.createServer(options1, assert.fail),
+'cert is a required parameter for Server.createServer');
+
+assert.throws(() => https.createServer(options2, assert.fail),
+'key is a required parameter for Server.createServer');


### PR DESCRIPTION
throw Error when required parameters for options in https.createServer are missing

The required parameters of https.createServer is key and cert. When these parameters are not provided by the user then a new Error is thrown for the missing parameter. 
A subsequent test is also added to verify the same. 

This was discussed in Issue: https://github.com/nodejs/node/issues/3024

cc: @jasnell @mhdawson 
