### PR TITLE
build: Intl: avoid 'duplicate main()' on ICU 56

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -7,7 +7,10 @@
 
 {
   'variables': {
-    'icu_src_derb': [ '../../deps/icu/source/tools/genrb/derb.c' ],
+    'icu_src_derb': [
+      '../../deps/icu/source/tools/genrb/derb.c',
+      '../../deps/icu/source/tools/genrb/derb.cpp'
+    ],
   },
   'includes': [ '../../icu_config.gypi' ],
   'targets': [


### PR DESCRIPTION
ICU 56 renamed derb.c to derb.cpp because of C++ yay.
This broke the exclusion of "derb.c" when building tools.

Solution is to add derb.c AND derb.cpp to exclusion.
We don't build the 'derb' tool, so it's fine to list the
excluded source twice.

Reviewed-By:
PR-URL:
Fixes: https://github.com/nodejs/node/issues/3065