### PR TITLE
dns: remove exports.ADNAME

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -330,7 +330,6 @@ exports.NOTFOUND = 'ENOTFOUND';
 exports.NOTIMP = 'ENOTIMP';
 exports.REFUSED = 'EREFUSED';
 exports.BADQUERY = 'EBADQUERY';
-exports.ADNAME = 'EADNAME';
 exports.BADNAME = 'EBADNAME';
 exports.BADFAMILY = 'EBADFAMILY';
 exports.BADRESP = 'EBADRESP';


### PR DESCRIPTION
This is the `semver-major` part of #3051 which removes the nonexistant errorcode `EADNAME`.