### PR TITLE
test: remove deprecated error logging

### DIFF
--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -20,11 +20,9 @@ common.refreshTmpDir();
 // test that empty file will be created and have content added
 var filename = join(common.tmpDir, 'append-sync.txt');
 
-common.error('appending to ' + filename);
 fs.appendFileSync(filename, data);
 
 var fileData = fs.readFileSync(filename);
-console.error('filedata is a ' + typeof fileData);
 
 assert.equal(Buffer.byteLength(data), fileData.length);
 
@@ -32,7 +30,6 @@ assert.equal(Buffer.byteLength(data), fileData.length);
 var filename2 = join(common.tmpDir, 'append-sync2.txt');
 fs.writeFileSync(filename2, currentFileData);
 
-common.error('appending to ' + filename2);
 fs.appendFileSync(filename2, data);
 
 var fileData2 = fs.readFileSync(filename2);
@@ -43,8 +40,6 @@ assert.equal(Buffer.byteLength(data) + currentFileData.length,
 // test that appendFileSync accepts buffers
 var filename3 = join(common.tmpDir, 'append-sync3.txt');
 fs.writeFileSync(filename3, currentFileData);
-
-common.error('appending to ' + filename3);
 
 var buf = new Buffer(data, 'utf8');
 fs.appendFileSync(filename3, buf);
@@ -57,7 +52,6 @@ assert.equal(buf.length + currentFileData.length, fileData3.length);
 var filename4 = join(common.tmpDir, 'append-sync4.txt');
 fs.writeFileSync(filename4, currentFileData, { mode: m });
 
-common.error('appending to ' + filename4);
 var m = 0o600;
 fs.appendFileSync(filename4, num, { mode: m });
 
@@ -75,8 +69,6 @@ assert.equal(Buffer.byteLength('' + num) + currentFileData.length,
 //exit logic for cleanup
 
 process.on('exit', function() {
-  common.error('done');
-
   fs.unlinkSync(filename);
   fs.unlinkSync(filename2);
   fs.unlinkSync(filename3);

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -6,8 +6,6 @@ var join = require('path').join;
 
 var filename = join(common.tmpDir, 'append.txt');
 
-common.error('appending to ' + filename);
-
 var currentFileData = 'ABCD';
 
 var n = 220;
@@ -28,11 +26,9 @@ fs.appendFile(filename, s, function(e) {
   if (e) throw e;
 
   ncallbacks++;
-  common.error('appended to file');
 
   fs.readFile(filename, function(e, buffer) {
     if (e) throw e;
-    common.error('file read');
     ncallbacks++;
     assert.equal(Buffer.byteLength(s), buffer.length);
   });
@@ -46,11 +42,9 @@ fs.appendFile(filename2, s, function(e) {
   if (e) throw e;
 
   ncallbacks++;
-  common.error('appended to file2');
 
   fs.readFile(filename2, function(e, buffer) {
     if (e) throw e;
-    common.error('file2 read');
     ncallbacks++;
     assert.equal(Buffer.byteLength(s) + currentFileData.length, buffer.length);
   });
@@ -61,17 +55,14 @@ var filename3 = join(common.tmpDir, 'append3.txt');
 fs.writeFileSync(filename3, currentFileData);
 
 var buf = new Buffer(s, 'utf8');
-common.error('appending to ' + filename3);
 
 fs.appendFile(filename3, buf, function(e) {
   if (e) throw e;
 
   ncallbacks++;
-  common.error('appended to file3');
 
   fs.readFile(filename3, function(e, buffer) {
     if (e) throw e;
-    common.error('file3 read');
     ncallbacks++;
     assert.equal(buf.length + currentFileData.length, buffer.length);
   });
@@ -81,14 +72,11 @@ fs.appendFile(filename3, buf, function(e) {
 var filename4 = join(common.tmpDir, 'append4.txt');
 fs.writeFileSync(filename4, currentFileData);
 
-common.error('appending to ' + filename4);
-
 var m = 0o600;
 fs.appendFile(filename4, n, { mode: m }, function(e) {
   if (e) throw e;
 
   ncallbacks++;
-  common.error('appended to file4');
 
   // windows permissions aren't unix
   if (!common.isWindows) {
@@ -98,7 +86,6 @@ fs.appendFile(filename4, n, { mode: m }, function(e) {
 
   fs.readFile(filename4, function(e, buffer) {
     if (e) throw e;
-    common.error('file4 read');
     ncallbacks++;
     assert.equal(Buffer.byteLength('' + n) + currentFileData.length,
                  buffer.length);
@@ -106,7 +93,6 @@ fs.appendFile(filename4, n, { mode: m }, function(e) {
 });
 
 process.on('exit', function() {
-  common.error('done');
   assert.equal(8, ncallbacks);
 
   fs.unlinkSync(filename);

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -8,27 +8,20 @@ var successes = 0;
 
 var file = path.join(common.fixturesDir, 'a.js');
 
-common.error('open ' + file);
-
 fs.open(file, 'a', 0o777, function(err, fd) {
-  common.error('fd ' + fd);
   if (err) throw err;
 
   fs.fdatasyncSync(fd);
-  common.error('fdatasync SYNC: ok');
   successes++;
 
   fs.fsyncSync(fd);
-  common.error('fsync SYNC: ok');
   successes++;
 
   fs.fdatasync(fd, function(err) {
     if (err) throw err;
-    common.error('fdatasync ASYNC: ok');
     successes++;
     fs.fsync(fd, function(err) {
       if (err) throw err;
-      common.error('fsync ASYNC: ok');
       successes++;
     });
   });

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -8,8 +8,6 @@ common.refreshTmpDir();
 
 var filename = join(common.tmpDir, 'test.txt');
 
-common.error('writing to ' + filename);
-
 var n = 220;
 var s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
         '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +
@@ -25,11 +23,9 @@ fs.writeFile(filename, s, function(e) {
   if (e) throw e;
 
   ncallbacks++;
-  common.error('file written');
 
   fs.readFile(filename, function(e, buffer) {
     if (e) throw e;
-    common.error('file read');
     ncallbacks++;
     assert.equal(Buffer.byteLength(s), buffer.length);
   });
@@ -38,17 +34,14 @@ fs.writeFile(filename, s, function(e) {
 // test that writeFile accepts buffers
 var filename2 = join(common.tmpDir, 'test2.txt');
 var buf = new Buffer(s, 'utf8');
-common.error('writing to ' + filename2);
 
 fs.writeFile(filename2, buf, function(e) {
   if (e) throw e;
 
   ncallbacks++;
-  common.error('file2 written');
 
   fs.readFile(filename2, function(e, buffer) {
     if (e) throw e;
-    common.error('file2 read');
     ncallbacks++;
     assert.equal(buf.length, buffer.length);
   });
@@ -56,7 +49,6 @@ fs.writeFile(filename2, buf, function(e) {
 
 // test that writeFile accepts numbers.
 var filename3 = join(common.tmpDir, 'test3.txt');
-common.error('writing to ' + filename3);
 
 var m = 0o600;
 fs.writeFile(filename3, n, { mode: m }, function(e) {
@@ -69,11 +61,9 @@ fs.writeFile(filename3, n, { mode: m }, function(e) {
   }
 
   ncallbacks++;
-  common.error('file3 written');
 
   fs.readFile(filename3, function(e, buffer) {
     if (e) throw e;
-    common.error('file3 read');
     ncallbacks++;
     assert.equal(Buffer.byteLength('' + n), buffer.length);
   });
@@ -81,7 +71,6 @@ fs.writeFile(filename3, n, { mode: m }, function(e) {
 
 
 process.on('exit', function() {
-  common.error('done');
   assert.equal(6, ncallbacks);
 
   fs.unlinkSync(filename);

--- a/test/parallel/test-http-304.js
+++ b/test/parallel/test-http-304.js
@@ -15,9 +15,5 @@ s.listen(common.PORT, function() {
                     function(err, stdout, stderr) {
                       if (err) throw err;
                       s.close();
-                      common.error('curled response correctly');
-                      common.error(common.inspect(stdout));
                     });
 });
-
-console.log('Server running at http://127.0.0.1:' + common.PORT + '/');

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -7,7 +7,6 @@ var net = require('net');
 var gotReq = false;
 
 var server = http.createServer(function(req, res) {
-  common.error('got req');
   gotReq = true;
   assert.equal('GET', req.method);
   assert.equal('/blah', req.url);
@@ -23,7 +22,6 @@ server.listen(common.PORT, function() {
   var c = net.createConnection(common.PORT);
 
   c.on('connect', function() {
-    common.error('client wrote message');
     c.write('GET /blah HTTP/1.1\r\n' +
             'Host: mapdevel.trolologames.ru:443\r\n' +
             'Cookie:\r\n' +
@@ -37,7 +35,6 @@ server.listen(common.PORT, function() {
   });
 
   c.on('close', function() {
-    common.error('client close');
     server.close();
   });
 });

--- a/test/parallel/test-http-client-upload-buf.js
+++ b/test/parallel/test-http-client-upload-buf.js
@@ -43,8 +43,6 @@ server.on('listening', function() {
 
   req.write(new Buffer(N));
   req.end();
-
-  common.error('client finished sending request');
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-http-client-upload.js
+++ b/test/parallel/test-http-client-upload.js
@@ -46,8 +46,6 @@ server.on('listening', function() {
   req.write('2\n');
   req.write('3\n');
   req.end();
-
-  common.error('client finished sending request');
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-http-head-response-has-no-body-end.js
+++ b/test/parallel/test-http-head-response-has-no-body-end.js
@@ -22,15 +22,12 @@ server.on('listening', function() {
     method: 'HEAD',
     path: '/'
   }, function(res) {
-    common.error('response');
     res.on('end', function() {
-      common.error('response end');
       server.close();
       responseComplete = true;
     });
     res.resume();
   });
-  common.error('req');
   req.end();
 });
 

--- a/test/parallel/test-http-head-response-has-no-body.js
+++ b/test/parallel/test-http-head-response-has-no-body.js
@@ -22,15 +22,12 @@ server.on('listening', function() {
     method: 'HEAD',
     path: '/'
   }, function(res) {
-    common.error('response');
     res.on('end', function() {
-      common.error('response end');
       server.close();
       responseComplete = true;
     });
     res.resume();
   });
-  common.error('req');
   req.end();
 });
 

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -4,10 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
-function p(x) {
-  common.error(common.inspect(x));
-}
-
 var responses_sent = 0;
 var responses_recvd = 0;
 var body0 = '';
@@ -39,8 +35,6 @@ var server = http.createServer(function(req, res) {
     responses_sent += 1;
   });
   req.resume();
-
-  //assert.equal('127.0.0.1', res.connection.remoteAddress);
 });
 
 server.listen(common.PORT, function() {

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -23,21 +23,17 @@ var server = http.createServer(function(req, res) {
   }
 
   if (req.id == 1) {
-    common.error('req 1');
     assert.equal('POST', req.method);
     assert.equal('/quit', url.parse(req.url).pathname);
   }
 
   if (req.id == 2) {
-    common.error('req 2');
     assert.equal('foo', req.headers['x-x']);
   }
 
   if (req.id == 3) {
-    common.error('req 3');
     assert.equal('bar', req.headers['x-x']);
     this.close();
-    common.error('server closed');
   }
 
   setTimeout(function() {

--- a/test/parallel/test-http-upgrade-server2.js
+++ b/test/parallel/test-http-upgrade-server2.js
@@ -5,12 +5,10 @@ var http = require('http');
 var net = require('net');
 
 var server = http.createServer(function(req, res) {
-  common.error('got req');
   throw new Error('This shouldn\'t happen.');
 });
 
 server.on('upgrade', function(req, socket, upgradeHead) {
-  common.error('got upgrade event');
   // test that throwing an error from upgrade gets
   // is uncaught
   throw new Error('upgrade error');
@@ -19,7 +17,6 @@ server.on('upgrade', function(req, socket, upgradeHead) {
 var gotError = false;
 
 process.on('uncaughtException', function(e) {
-  common.error('got \'clientError\' event');
   assert.equal('upgrade error', e.message);
   gotError = true;
   process.exit(0);
@@ -30,7 +27,6 @@ server.listen(common.PORT, function() {
   var c = net.createConnection(common.PORT);
 
   c.on('connect', function() {
-    common.error('client wrote message');
     c.write('GET /blah HTTP/1.1\r\n' +
             'Upgrade: WebSocket\r\n' +
             'Connection: Upgrade\r\n' +
@@ -42,7 +38,6 @@ server.listen(common.PORT, function() {
   });
 
   c.on('close', function() {
-    common.error('client close');
     server.close();
   });
 });

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -31,7 +31,6 @@ server.listen(common.PORT, function() {
     res.on('data', function(chunk) {
       response += chunk;
     });
-    common.error('Got /hello response');
   });
 });
 

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -4,10 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
-function p(x) {
-  common.error(common.inspect(x));
-}
-
 var responses_sent = 0;
 var responses_recvd = 0;
 var body0 = '';

--- a/test/parallel/test-net-binary.js
+++ b/test/parallel/test-net-binary.js
@@ -7,13 +7,6 @@ var binaryString = '';
 for (var i = 255; i >= 0; i--) {
   var s = '\'\\' + i.toString(8) + '\'';
   var S = eval(s);
-  common.error(s +
-               ' ' +
-               JSON.stringify(S) +
-               ' ' +
-               JSON.stringify(String.fromCharCode(i)) +
-               ' ' +
-               S.charCodeAt(0));
   assert.ok(S.charCodeAt(0) == i);
   assert.ok(S == String.fromCharCode(i));
   binaryString += S;
@@ -21,14 +14,11 @@ for (var i = 255; i >= 0; i--) {
 
 // safe constructor
 var echoServer = net.Server(function(connection) {
-  console.error('SERVER got connection');
   connection.setEncoding('binary');
   connection.on('data', function(chunk) {
-    common.error('SERVER recved: ' + JSON.stringify(chunk));
     connection.write(chunk, 'binary');
   });
   connection.on('end', function() {
-    console.error('SERVER ending');
     connection.end();
   });
 });
@@ -37,7 +27,6 @@ echoServer.listen(common.PORT);
 var recv = '';
 
 echoServer.on('listening', function() {
-  console.error('SERVER listening');
   var j = 0;
   var c = net.createConnection({
     port: common.PORT
@@ -45,48 +34,34 @@ echoServer.on('listening', function() {
 
   c.setEncoding('binary');
   c.on('data', function(chunk) {
-    console.error('CLIENT data %j', chunk);
     var n = j + chunk.length;
     while (j < n && j < 256) {
-      common.error('CLIENT write ' + j);
       c.write(String.fromCharCode(j), 'binary');
       j++;
     }
     if (j === 256) {
-      console.error('CLIENT ending');
       c.end();
     }
     recv += chunk;
   });
 
   c.on('connect', function() {
-    console.error('CLIENT connected, writing');
     c.write(binaryString, 'binary');
   });
 
   c.on('close', function() {
-    console.error('CLIENT closed');
-    console.dir(recv);
     echoServer.close();
-  });
-
-  c.on('finish', function() {
-    console.error('CLIENT finished');
   });
 });
 
 process.on('exit', function() {
-  console.log('recv: ' + JSON.stringify(recv));
-
   assert.equal(2 * 256, recv.length);
 
   var a = recv.split('');
 
   var first = a.slice(0, 256).reverse().join('');
-  console.log('first: ' + JSON.stringify(first));
 
   var second = a.slice(256, 2 * 256).join('');
-  console.log('second: ' + JSON.stringify(second));
 
   assert.equal(first, second);
 });

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -13,19 +13,15 @@ var clientReqComplete = false;
 var count = 0;
 
 var server = http.createServer(function(req, res) {
-  console.error('SERVER request');
   var timeoutId;
   assert.equal('POST', req.method);
   req.pause();
-  common.error('request paused');
 
   setTimeout(function() {
     req.resume();
-    common.error('request resumed');
   }, 1000);
 
   req.on('data', function(chunk) {
-    common.error('recv data! nchars = ' + chunk.length);
     count += chunk.length;
   });
 
@@ -33,7 +29,6 @@ var server = http.createServer(function(req, res) {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
-    console.log('request complete from server');
     res.writeHead(200, {'Content-Type': 'text/plain'});
     res.end();
   });
@@ -42,12 +37,9 @@ server.listen(common.PORT);
 
 server.on('listening', function() {
   var cmd = common.ddCommand(filename, 10240);
-  console.log('dd command: ', cmd);
 
   cp.exec(cmd, function(err, stdout, stderr) {
     if (err) throw err;
-    console.error('EXEC returned successfully stdout=%d stderr=%d',
-                  stdout.length, stderr.length);
     makeRequest();
   });
 });
@@ -59,27 +51,16 @@ function makeRequest() {
     method: 'POST'
   });
 
-  common.error('pipe!');
-
   var s = fs.ReadStream(filename);
   s.pipe(req);
-  s.on('data', function(chunk) {
-    console.error('FS data chunk=%d', chunk.length);
-  });
-  s.on('end', function() {
-    console.error('FS end');
-  });
   s.on('close', function(err) {
     if (err) throw err;
     clientReqComplete = true;
-    common.error('client finished sending request');
   });
 
   req.on('response', function(res) {
-    console.error('RESPONSE', res.statusCode, res.headers);
     res.resume();
     res.on('end', function() {
-      console.error('RESPONSE end');
       server.close();
     });
   });

--- a/test/sequential/test-pump-file2tcp-noexist.js
+++ b/test/sequential/test-pump-file2tcp-noexist.js
@@ -11,14 +11,12 @@ var got_error = false;
 var conn_closed = false;
 
 var server = net.createServer(function(stream) {
-  common.error('pump!');
   util.pump(fs.createReadStream(fn), stream, function(err) {
-    common.error('util.pump\'s callback fired');
     if (err) {
       got_error = true;
     } else {
-      console.error('util.pump\'s callback fired with no error');
-      console.error('this shouldn\'t happen as the file doesn\'t exist...');
+      // util.pump's callback fired with no error
+      // this shouldn't happen as the file doesn't exist...
       assert.equal(true, false);
     }
     server.close();
@@ -29,7 +27,6 @@ server.listen(common.PORT, function() {
   var conn = net.createConnection(common.PORT);
   conn.setEncoding('utf8');
   conn.on('data', function(chunk) {
-    common.error('recv data! nchars = ' + chunk.length);
     buffer += chunk;
   });
 
@@ -38,7 +35,6 @@ server.listen(common.PORT, function() {
   });
 
   conn.on('close', function() {
-    common.error('client connection close');
     conn_closed = true;
   });
 });
@@ -48,5 +44,4 @@ var buffer = '';
 process.on('exit', function() {
   assert.equal(true, got_error);
   assert.equal(true, conn_closed);
-  console.log('exiting');
 });

--- a/test/sequential/test-pump-file2tcp.js
+++ b/test/sequential/test-pump-file2tcp.js
@@ -10,10 +10,7 @@ var fn = path.join(common.fixturesDir, 'elipses.txt');
 var expected = fs.readFileSync(fn, 'utf8');
 
 var server = net.createServer(function(stream) {
-  common.error('pump!');
   util.pump(fs.createReadStream(fn), stream, function() {
-    common.error('server stream close');
-    common.error('server close');
     server.close();
   });
 });
@@ -22,15 +19,11 @@ server.listen(common.PORT, function() {
   var conn = net.createConnection(common.PORT);
   conn.setEncoding('utf8');
   conn.on('data', function(chunk) {
-    common.error('recv data! nchars = ' + chunk.length);
     buffer += chunk;
   });
 
   conn.on('end', function() {
     conn.end();
-  });
-  conn.on('close', function() {
-    common.error('client connection close');
   });
 });
 


### PR DESCRIPTION
`common.error()` is just `util.error()` which is deprecated. Update instances to `console.error()`.