### PR TITLE
test: replace deprecated util.debug() calls

### DIFF
--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -52,7 +52,7 @@ var logChild = function(d) {
 
   d.split('\n').forEach(function(l) {
     if (l.length > 0) {
-      common.debug('CHILD: ' + l);
+      console.error('CHILD: ' + l);
     }
   });
 };

--- a/test/parallel/test-file-read-noexist.js
+++ b/test/parallel/test-file-read-noexist.js
@@ -10,8 +10,8 @@ fs.readFile(filename, 'binary', function(err, content) {
   if (err) {
     got_error = true;
   } else {
-    common.debug('cat returned some content: ' + content);
-    common.debug('this shouldn\'t happen as the file doesn\'t exist...');
+    console.error('cat returned some content: ' + content);
+    console.error('this shouldn\'t happen as the file doesn\'t exist...');
     assert.equal(true, false);
   }
 });

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -326,7 +326,6 @@ function test_deep_symlink_mix(callback) {
       [fixturesAbsDir + '/nested-index/two/realpath-c',
         '../../../' + common.tmpDirName + '/cycles/root.js']
     ].forEach(function(t) {
-      //common.debug('setting up '+t[0]+' -> '+t[1]);
       try { fs.unlinkSync(t[0]); } catch (e) {}
       fs.symlinkSync(t[1], t[0]);
       unlink.push(t[0]);

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -8,7 +8,7 @@ var serverRequests = 0;
 var clientResponses = 0;
 
 var server = http.createServer(function(req, res) {
-  common.debug('Server got GET request');
+  console.error('Server got GET request');
   req.resume();
   ++serverRequests;
   res.writeHead(200);
@@ -18,7 +18,7 @@ var server = http.createServer(function(req, res) {
   }, 50);
 });
 server.on('connect', function(req, socket, firstBodyChunk) {
-  common.debug('Server got CONNECT request');
+  console.error('Server got CONNECT request');
   serverConnected = true;
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
   socket.resume();
@@ -33,7 +33,7 @@ server.listen(common.PORT, function() {
     path: 'google.com:80'
   });
   req.on('connect', function(res, socket, firstBodyChunk) {
-    common.debug('Client got CONNECT response');
+    console.error('Client got CONNECT response');
     socket.end();
     socket.on('end', function() {
       doRequest(0);
@@ -49,7 +49,7 @@ function doRequest(i) {
     port: common.PORT,
     path: '/request' + i
   }, function(res) {
-    common.debug('Client got GET response');
+    console.error('Client got GET response');
     var data = '';
     res.setEncoding('utf8');
     res.on('data', function(chunk) {

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -12,7 +12,7 @@ var server = http.createServer(function(req, res) {
 server.on('connect', function(req, socket, firstBodyChunk) {
   assert.equal(req.method, 'CONNECT');
   assert.equal(req.url, 'google.com:443');
-  common.debug('Server got CONNECT request');
+  console.error('Server got CONNECT request');
   serverGotConnect = true;
 
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
@@ -40,7 +40,7 @@ server.listen(common.PORT, function() {
   });
 
   req.on('connect', function(res, socket, firstBodyChunk) {
-    common.debug('Client got CONNECT request');
+    console.error('Client got CONNECT request');
     clientGotConnect = true;
 
     // Make sure this request got removed from the pool.

--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -11,7 +11,7 @@ var got_continue = false;
 
 function handler(req, res) {
   assert.equal(sent_continue, true, 'Full response sent before 100 Continue');
-  common.debug('Server sending full response...');
+  console.error('Server sending full response...');
   res.writeHead(200, {
     'Content-Type' : 'text/plain',
     'ABCD' : '1'
@@ -21,7 +21,7 @@ function handler(req, res) {
 
 var server = http.createServer(handler);
 server.on('checkContinue', function(req, res) {
-  common.debug('Server got Expect: 100-continue...');
+  console.error('Server got Expect: 100-continue...');
   res.writeContinue();
   sent_continue = true;
   setTimeout(function() {
@@ -38,11 +38,11 @@ server.on('listening', function() {
     path: '/world',
     headers: { 'Expect': '100-continue' }
   });
-  common.debug('Client sending request...');
+  console.error('Client sending request...');
   outstanding_reqs++;
   var body = '';
   req.on('continue', function() {
-    common.debug('Client got 100 Continue...');
+    console.error('Client got 100 Continue...');
     got_continue = true;
     req.end(test_req_body);
   });
@@ -54,7 +54,7 @@ server.on('listening', function() {
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });
     res.on('end', function() {
-      common.debug('Got full response.');
+      console.error('Got full response.');
       assert.equal(body, test_res_body, 'Response body doesn\'t match.');
       assert.ok('abcd' in res.headers, 'Response headers missing.');
       outstanding_reqs--;

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -54,7 +54,7 @@ server.listen(common.PORT, function() {
     responses_recvd += 1;
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body0 += chunk; });
-    common.debug('Got /hello response');
+    console.error('Got /hello response');
   });
 
   setTimeout(function() {
@@ -65,16 +65,16 @@ server.listen(common.PORT, function() {
       responses_recvd += 1;
       res.setEncoding('utf8');
       res.on('data', function(chunk) { body1 += chunk; });
-      common.debug('Got /world response');
+      console.error('Got /world response');
     });
   }, 1);
 });
 
 process.on('exit', function() {
-  common.debug('responses_recvd: ' + responses_recvd);
+  console.error('responses_recvd: ' + responses_recvd);
   assert.equal(2, responses_recvd);
 
-  common.debug('responses_sent: ' + responses_sent);
+  console.error('responses_sent: ' + responses_sent);
   assert.equal(2, responses_sent);
 
   assert.equal('The path was /hello', body0);

--- a/test/parallel/test-http-pause.js
+++ b/test/parallel/test-http-pause.js
@@ -9,17 +9,17 @@ var expectedClient = 'Response Body from Server';
 var resultClient = '';
 
 var server = http.createServer(function(req, res) {
-  common.debug('pause server request');
+  console.error('pause server request');
   req.pause();
   setTimeout(function() {
-    common.debug('resume server request');
+    console.error('resume server request');
     req.resume();
     req.setEncoding('utf8');
     req.on('data', function(chunk) {
       resultServer += chunk;
     });
     req.on('end', function() {
-      common.debug(resultServer);
+      console.error(resultServer);
       res.writeHead(200);
       res.end(expectedClient);
     });
@@ -32,16 +32,16 @@ server.listen(common.PORT, function() {
     path: '/',
     method: 'POST'
   }, function(res) {
-    common.debug('pause client response');
+    console.error('pause client response');
     res.pause();
     setTimeout(function() {
-      common.debug('resume client response');
+      console.error('resume client response');
       res.resume();
       res.on('data', function(chunk) {
         resultClient += chunk;
       });
       res.on('end', function() {
-        common.debug(resultClient);
+        console.error(resultClient);
         server.close();
       });
     }, 100);

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -31,7 +31,7 @@ var server = http.createServer(function(req, res) {
         }
       }, function(res) {
         res.on('end', function() {
-          common.debug('res' + i + ' end');
+          console.error('res' + i + ' end');
           if (i === 2) {
             server.close();
           }
@@ -39,7 +39,7 @@ var server = http.createServer(function(req, res) {
         res.resume();
       });
       req.on('socket', function(s) {
-        common.debug('req' + i + ' start');
+        console.error('req' + i + ' start');
       });
       req.end('12345');
     }(i + 1));

--- a/test/parallel/test-http-set-timeout.js
+++ b/test/parallel/test-http-set-timeout.js
@@ -10,7 +10,7 @@ var server = http.createServer(function(req, res) {
   assert.ok(s instanceof net.Socket);
   req.connection.on('timeout', function() {
     req.connection.destroy();
-    common.debug('TIMEOUT');
+    console.error('TIMEOUT');
     server.close();
   });
 });

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -56,7 +56,7 @@ server.on('listening', function() {
     responses_recvd += 1;
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body0 += chunk; });
-    common.debug('Got /hello response');
+    console.error('Got /hello response');
   });
 
   setTimeout(function() {
@@ -70,17 +70,17 @@ server.on('listening', function() {
       responses_recvd += 1;
       res.setEncoding('utf8');
       res.on('data', function(chunk) { body1 += chunk; });
-      common.debug('Got /world response');
+      console.error('Got /world response');
     });
     req.end();
   }, 1);
 });
 
 process.on('exit', function() {
-  common.debug('responses_recvd: ' + responses_recvd);
+  console.error('responses_recvd: ' + responses_recvd);
   assert.equal(2, responses_recvd);
 
-  common.debug('responses_sent: ' + responses_sent);
+  console.error('responses_sent: ' + responses_sent);
   assert.equal(2, responses_sent);
 
   assert.equal('The path was /hello', body0);

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -34,7 +34,7 @@ server.listen(common.PORT, function() {
   }, function(res) {
     var timer;
     res.pause();
-    common.debug('paused');
+    console.error('paused');
     send();
     function send() {
       if (req.write(new Buffer(bufSize))) {
@@ -43,10 +43,10 @@ server.listen(common.PORT, function() {
         return process.nextTick(send);
       }
       sent += bufSize;
-      common.debug('sent: ' + sent);
+      console.error('sent: ' + sent);
       resumed = true;
       res.resume();
-      common.debug('resumed');
+      console.error('resumed');
       timer = setTimeout(function() {
         process.exit(1);
       }, 1000);
@@ -60,7 +60,7 @@ server.listen(common.PORT, function() {
       }
       received += data.length;
       if (received >= sent) {
-        common.debug('received: ' + received);
+        console.error('received: ' + received);
         req.end();
         server.close();
       }

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-common.debug('load test-module-loading-error.js');
+console.error('load test-module-loading-error.js');
 
 var error_desc = {
   win32: '%1 is not a valid Win32 application',

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -10,7 +10,7 @@ server.listen(common.PORT, function() {
   assert(false);
 });
 server.on('error', function(error) {
-  common.debug(error);
+  console.error(error);
   assert(false);
 });
 server.close();

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -10,7 +10,7 @@ server.listen(1, '1.1.1.1', function() { // EACCESS or EADDRNOTAVAIL
   assert(false);
 });
 server.on('error', function(error) {
-  common.debug(error);
+  console.error(error);
   gotError = true;
 });
 

--- a/test/parallel/test-tls-client-reject.js
+++ b/test/parallel/test-tls-client-reject.js
@@ -21,7 +21,7 @@ var connectCount = 0;
 var server = tls.createServer(options, function(socket) {
   ++connectCount;
   socket.on('data', function(data) {
-    common.debug(data.toString());
+    console.error(data.toString());
     assert.equal(data, 'ok');
   });
 }).listen(common.PORT, function() {
@@ -51,7 +51,7 @@ function rejectUnauthorized() {
     assert(false);
   });
   socket.on('error', function(err) {
-    common.debug(err);
+    console.error(err);
     authorized();
   });
   socket.write('ng');

--- a/test/parallel/test-tls-pause.js
+++ b/test/parallel/test-tls-pause.js
@@ -35,7 +35,7 @@ server.listen(common.PORT, function() {
   }, function() {
     console.error('connected');
     client.pause();
-    common.debug('paused');
+    console.error('paused');
     send();
     function send() {
       console.error('sending');
@@ -48,7 +48,7 @@ server.listen(common.PORT, function() {
         return process.nextTick(send);
       }
       sent += bufSize;
-      common.debug('sent: ' + sent);
+      console.error('sent: ' + sent);
       resumed = true;
       client.resume();
       console.error('resumed', client);
@@ -61,7 +61,7 @@ server.listen(common.PORT, function() {
     console.error('received', received);
     console.error('sent', sent);
     if (received >= sent) {
-      common.debug('received: ' + received);
+      console.error('received: ' + received);
       client.end();
       server.close();
     }

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -30,7 +30,7 @@ server.listen(common.PORT, function() {
   }, function() {
     var peerCert = socket.getPeerCertificate();
 
-    common.debug(util.inspect(peerCert));
+    console.error(util.inspect(peerCert));
     assert.equal(peerCert.subject.CN, 'Ádám Lippai');
     verified = true;
     server.close();

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -28,7 +28,7 @@ server.listen(common.PORT, function() {
     rejectUnauthorized: false
   }, function() {
     var peerCert = socket.getPeerCertificate();
-    common.debug(util.inspect(peerCert));
+    console.error(util.inspect(peerCert));
     assert.deepEqual(peerCert.subject.OU,
                      ['Information Technology', 'Engineering', 'Marketing']);
     verified = true;

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -35,7 +35,7 @@ server.listen(common.PORT, function() {
     peerCert = socket.getPeerCertificate(true);
     assert.ok(peerCert.issuerCertificate);
 
-    common.debug(util.inspect(peerCert));
+    console.error(util.inspect(peerCert));
     assert.equal(peerCert.subject.emailAddress, 'ry@tinyclouds.org');
     assert.equal(peerCert.serialNumber, '9A84ABCFB8A72AC0');
     assert.equal(peerCert.exponent, '0x10001');

--- a/test/pummel/test-net-pause.js
+++ b/test/pummel/test-net-pause.js
@@ -65,5 +65,5 @@ server.listen(common.PORT);
 
 process.on('exit', function() {
   assert.equal(N, recv.length);
-  common.debug('Exit');
+  console.error('Exit');
 });

--- a/test/pummel/test-net-pingpong-delay.js
+++ b/test/pummel/test-net-pingpong-delay.js
@@ -27,7 +27,7 @@ function pingPongTest(port, host, on_complete) {
     });
 
     socket.on('timeout', function() {
-      common.debug('server-side timeout!!');
+      console.error('server-side timeout!!');
       assert.equal(false, true);
     });
 
@@ -73,7 +73,7 @@ function pingPongTest(port, host, on_complete) {
     });
 
     client.on('timeout', function() {
-      common.debug('client-side timeout!!');
+      console.error('client-side timeout!!');
       assert.equal(false, true);
     });
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 
-common.debug('load test-module-loading.js');
+console.error('load test-module-loading.js');
 
 // assert that this is the main module.
 assert.equal(require.main.id, '.', 'main module should have id of \'.\'');
@@ -56,36 +56,36 @@ assert.equal('D', d4.D());
 
 assert.ok((new a.SomeClass()) instanceof c.SomeClass);
 
-common.debug('test index.js modules ids and relative loading');
+console.error('test index.js modules ids and relative loading');
 var one = require('../fixtures/nested-index/one'),
     two = require('../fixtures/nested-index/two');
 assert.notEqual(one.hello, two.hello);
 
-common.debug('test index.js in a folder with a trailing slash');
+console.error('test index.js in a folder with a trailing slash');
 var three = require('../fixtures/nested-index/three'),
     threeFolder = require('../fixtures/nested-index/three/'),
     threeIndex = require('../fixtures/nested-index/three/index.js');
 assert.equal(threeFolder, threeIndex);
 assert.notEqual(threeFolder, three);
 
-common.debug('test package.json require() loading');
+console.error('test package.json require() loading');
 assert.equal(require('../fixtures/packages/main').ok, 'ok',
              'Failed loading package');
 assert.equal(require('../fixtures/packages/main-index').ok, 'ok',
              'Failed loading package with index.js in main subdir');
 
-common.debug('test cycles containing a .. path');
+console.error('test cycles containing a .. path');
 var root = require('../fixtures/cycles/root'),
     foo = require('../fixtures/cycles/folder/foo');
 assert.equal(root.foo, foo);
 assert.equal(root.sayHello(), root.hello);
 
-common.debug('test node_modules folders');
+console.error('test node_modules folders');
 // asserts are in the fixtures files themselves,
 // since they depend on the folder structure.
 require('../fixtures/node_modules/foo');
 
-common.debug('test name clashes');
+console.error('test name clashes');
 // this one exists and should import the local module
 var my_path = require('../fixtures/path');
 assert.ok(common.indirectInstanceOf(my_path.path_func, Function));
@@ -102,7 +102,7 @@ try {
 
 assert.equal(require('path').dirname(__filename), __dirname);
 
-common.debug('load custom file types with extensions');
+console.error('load custom file types with extensions');
 require.extensions['.test'] = function(module, filename) {
   var content = fs.readFileSync(filename).toString();
   assert.equal('this is custom source\n', content);
@@ -115,7 +115,7 @@ assert.equal(require('../fixtures/registerExt').test, 'passed');
 // unknown extension, load as .js
 assert.equal(require('../fixtures/registerExt.hello.world').test, 'passed');
 
-common.debug('load custom file types that return non-strings');
+console.error('load custom file types that return non-strings');
 require.extensions['.test'] = function(module, filename) {
   module.exports = {
     custom: 'passed'
@@ -139,7 +139,7 @@ try {
 }
 
 // Check load order is as expected
-common.debug('load order');
+console.error('load order');
 
 var loadOrder = '../fixtures/module-load-order/',
     msg = 'Load order incorrect.';

--- a/test/sequential/test-pump-file2tcp-noexist.js
+++ b/test/sequential/test-pump-file2tcp-noexist.js
@@ -17,8 +17,8 @@ var server = net.createServer(function(stream) {
     if (err) {
       got_error = true;
     } else {
-      common.debug('util.pump\'s callback fired with no error');
-      common.debug('this shouldn\'t happen as the file doesn\'t exist...');
+      console.error('util.pump\'s callback fired with no error');
+      console.error('this shouldn\'t happen as the file doesn\'t exist...');
       assert.equal(true, false);
     }
     server.close();


### PR DESCRIPTION
`common.debug()` is just `util.debug()` and emits a deprecation notice. Per docs, use `console.error()` instead.