### PR TITLE
test: change calls to deprecated util.print()

### DIFF
--- a/test/fixtures/net-fd-passing-receiver.js
+++ b/test/fixtures/net-fd-passing-receiver.js
@@ -26,7 +26,7 @@ receiver = net.createServer(function(socket) {
 
 /* To signal the test runne we're up and listening */
 receiver.on('listening', function() {
-  common.print('ready');
+  console.log('ready');
 });
 
 receiver.listen(path);

--- a/test/pummel/test-net-many-clients.js
+++ b/test/pummel/test-net-many-clients.js
@@ -19,7 +19,7 @@ for (var i = 0; i < bytes; i++) {
 var server = net.createServer(function(c) {
   console.log('connected');
   total_connections++;
-  common.print('#');
+  console.log('#');
   c.write(body);
   c.end();
 });
@@ -32,7 +32,7 @@ function runClient(callback) {
   client.setEncoding('utf8');
 
   client.on('connect', function() {
-    common.print('c');
+    console.log('c');
     client.recved = '';
     client.connections += 1;
   });
@@ -51,7 +51,7 @@ function runClient(callback) {
   });
 
   client.on('close', function(had_error) {
-    common.print('.');
+    console.log('.');
     assert.equal(false, had_error);
     assert.equal(bytes, client.recved.length);
 

--- a/test/pummel/test-net-pause.js
+++ b/test/pummel/test-net-pause.js
@@ -24,7 +24,7 @@ server.on('listening', function() {
   var client = net.createConnection(common.PORT);
   client.setEncoding('ascii');
   client.on('data', function(d) {
-    common.print(d);
+    console.log(d);
     recv += d;
   });
 

--- a/test/sequential/test-stdout-to-file.js
+++ b/test/sequential/test-stdout-to-file.js
@@ -24,7 +24,7 @@ function test(size, useBuffer, cb) {
     fs.unlinkSync(tmpFile);
   } catch (e) {}
 
-  common.print(size + ' chars to ' + tmpFile + '...');
+  console.log(size + ' chars to ' + tmpFile + '...');
 
   childProcess.exec(cmd, function(err) {
     if (err) throw err;


### PR DESCRIPTION
`common.print()` is just `util.print()` and as such prints a deprecation warning. Per docs, update to `console.log()`.