### PR TITLE
test: change call to deprecated util.isError()

### DIFF
--- a/test/parallel/test-tty-stdout-end.js
+++ b/test/parallel/test-tty-stdout-end.js
@@ -9,7 +9,7 @@ try {
   process.stdout.end();
 } catch (e) {
   exceptionCaught = true;
-  assert.ok(common.isError(e));
+  assert.ok(e instanceof Error);
   assert.equal('process.stdout cannot be closed.', e.message);
 }
 

--- a/test/parallel/test-tty-stdout-end.js
+++ b/test/parallel/test-tty-stdout-end.js
@@ -3,14 +3,13 @@
 var common = require('../common');
 var assert = require('assert');
 
-var exceptionCaught = false;
-
-try {
+var shouldThrow = function() {
   process.stdout.end();
-} catch (e) {
-  exceptionCaught = true;
-  assert.ok(e instanceof Error);
-  assert.equal('process.stdout cannot be closed.', e.message);
-}
+};
 
-assert.ok(exceptionCaught);
+var validateError = function(e) {
+  return e instanceof Error &&
+    e.message === 'process.stdout cannot be closed.';
+};
+
+assert.throws(shouldThrow, validateError);

--- a/test/parallel/test-tty-stdout-end.js
+++ b/test/parallel/test-tty-stdout-end.js
@@ -1,13 +1,13 @@
 'use strict';
 // Can't test this when 'make test' doesn't assign a tty to the stdout.
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var shouldThrow = function() {
+const shouldThrow = function() {
   process.stdout.end();
 };
 
-var validateError = function(e) {
+const validateError = function(e) {
   return e instanceof Error &&
     e.message === 'process.stdout cannot be closed.';
 };


### PR DESCRIPTION
`common.isError()` is just the deprecated `util.isError()`. Replace with `instanceof Error` check.