### PR TITLE
doc: remove outdated try/catch statements and use const

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -650,19 +650,10 @@ Generates cryptographically strong pseudo-random data. Usage:
       console.log('Have %d bytes of random data: %s', buf.length, buf);
     });
 
-    // sync
-    try {
-      var buf = crypto.randomBytes(256);
-      console.log('Have %d bytes of random data: %s', buf.length, buf);
-    } catch (ex) {
-      // handle error
-      // most likely, entropy sources are drained
-    }
-
 NOTE: This will block if there is insufficient entropy, although it should
-normally never take longer than a few milliseconds. 
-Under normal circumstances, the only error thrown from this is from RAND_bytes(), which throws when it doesn't have enough entropy.
-However, with CheckEntropy, this will block until the system has enough entropy for the OpenSSL pool.
+normally never take longer than a few milliseconds. The only time when this
+may conceivably block is right after boot, when the whole system is still
+low on entropy.
 
 ## Class: Certificate
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -650,6 +650,10 @@ Generates cryptographically strong pseudo-random data. Usage:
       console.log('Have %d bytes of random data: %s', buf.length, buf);
     });
 
+    // sync
+    var buf = crypto.randomBytes(256);
+    console.log('Have %d bytes of random data: %s', buf.length, buf);
+
 NOTE: This will block if there is insufficient entropy, although it should
 normally never take longer than a few milliseconds. The only time when this
 may conceivably block is right after boot, when the whole system is still

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -660,9 +660,9 @@ Generates cryptographically strong pseudo-random data. Usage:
     }
 
 NOTE: This will block if there is insufficient entropy, although it should
-normally never take longer than a few milliseconds. The only time when this
-may conceivably block is right after boot, when the whole system is still
-low on entropy.
+normally never take longer than a few milliseconds. 
+Under normal circumstances, the only error thrown from this is from RAND_bytes(), which throws when it doesn't have enough entropy.
+However, with CheckEntropy, this will block until the system has enough entropy for the OpenSSL pool.
 
 ## Class: Certificate
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -651,6 +651,7 @@ Generates cryptographically strong pseudo-random data. Usage:
     });
 
     // sync
+    // Implementation of handling erros is required.
     var buf = crypto.randomBytes(256);
     console.log('Have %d bytes of random data: %s', buf.length, buf);
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -651,7 +651,7 @@ Generates cryptographically strong pseudo-random data. Usage:
     });
 
     // sync
-    // Implementation of handling erros is recommended.
+    // Implementation of handling errors is recommended.
     var buf = crypto.randomBytes(256);
     console.log('Have %d bytes of random data: %s', buf.length, buf);
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -651,7 +651,7 @@ Generates cryptographically strong pseudo-random data. Usage:
     });
 
     // sync
-    // Implementation of handling erros is required.
+    // Implementation of handling erros is recommended.
     var buf = crypto.randomBytes(256);
     console.log('Have %d bytes of random data: %s', buf.length, buf);
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -651,7 +651,6 @@ Generates cryptographically strong pseudo-random data. Usage:
     });
 
     // sync
-    // Implementation of handling errors is recommended.
     var buf = crypto.randomBytes(256);
     console.log('Have %d bytes of random data: %s', buf.length, buf);
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -651,7 +651,7 @@ Generates cryptographically strong pseudo-random data. Usage:
     });
 
     // sync
-    var buf = crypto.randomBytes(256);
+    const buf = crypto.randomBytes(256);
     console.log('Have %d bytes of random data: %s', buf.length, buf);
 
 NOTE: This will block if there is insufficient entropy, although it should


### PR DESCRIPTION
The code shows that it throws on a lack of entropy, but the note below says that it does not.
Remove outdated `try/catch`statements in sync examples about crypto.randomBytes to make it clear