### PR TITLE
http: certain response headers do not allow multiple instances

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -152,6 +152,12 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
     case 'from':
     case 'location':
     case 'max-forwards':
+    case 'retry-after':
+    case 'etag':
+    case 'last-modified':
+    case 'server':
+    case 'age':
+    case 'expires':
       // drop duplicates
       if (dest[field] === undefined)
         dest[field] = value;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -89,7 +89,7 @@ exports.OutgoingMessage = OutgoingMessage;
 
 
 OutgoingMessage.prototype.setTimeout = function(msecs, callback) {
-  if (callback)
+  if (typeof callback === 'function')
     this.on('timeout', callback);
 
   if (!this.socket) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -89,8 +89,12 @@ exports.OutgoingMessage = OutgoingMessage;
 
 
 OutgoingMessage.prototype.setTimeout = function(msecs, callback) {
-  if (typeof callback === 'function')
+
+  if (callback) {
+    if (typeof callback !== 'function')
+      throw new TypeError('callback must be a function');
     this.on('timeout', callback);
+  }
 
   if (!this.socket) {
     this.once('socket', function(socket) {

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -15,19 +15,40 @@ const norepeat = [
 ];
 
 const server = http.createServer(function(req, res) {
-  for (let name of norepeat) {
-    res.setHeader(name, ['A', 'B']);
+  var num = req.headers['x-num'];
+  if (num == 1) {
+    for (let name of norepeat) {
+      res.setHeader(name, ['A', 'B']);
+    }
+    res.setHeader('X-A', ['A', 'B']);
+  } else if (num == 2) {
+    let headers = {};
+    for (let name of norepeat) {
+      headers[name] = ['A', 'B'];
+    }
+    headers['X-A'] = ['A', 'B'];
+    res.writeHead(200, headers);
   }
-  res.setHeader('X-A', ['A', 'B']);
   res.end('ok');
 });
 
 server.listen(common.PORT, common.mustCall(function() {
-  http.get({port:common.PORT}, common.mustCall(function(res) {
-    server.close();
-    for (let name of norepeat) {
-      assert.equal(res.headers[name], 'A');
-    }
-    assert.equal(res.headers['x-a'], 'A, B');
-  }));
+  for (let n = 1; n <= 2 ; n++) {
+    // this runs twice, the first time, the server will use
+    // setHeader, the second time it uses writeHead. The
+    // result on the client side should be the same in
+    // either case -- only the first instance of the header
+    // value should be reported for the header fields listed
+    // in the norepeat array.
+    http.get(
+      {port:common.PORT, headers:{'x-num': n}},
+      common.mustCall(function(res) {
+        if (n == 2) server.close();
+        for (let name of norepeat) {
+          assert.equal(res.headers[name], 'A');
+        }
+        assert.equal(res.headers['x-a'], 'A, B');
+      })
+    );
+  }
 }));

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const http = require('http');
 const common = require('../common');
+const http = require('http');
 const assert = require('assert');
 
 // Test that certain response header fields do not repeat
@@ -22,12 +22,12 @@ const server = http.createServer(function(req, res) {
   res.end('ok');
 });
 
-server.listen(common.PORT, function() {
-  http.get({port:common.PORT}, function(res) {
+server.listen(common.PORT, common.mustCall(function() {
+  http.get({port:common.PORT}, common.mustCall(function(res) {
+    server.close();
     for (let name of norepeat) {
       assert.equal(res.headers[name], 'A');
     }
     assert.equal(res.headers['x-a'], 'A, B');
-    server.close();
-  });
-});
+  }));
+}));

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const http = require('http');
+const common = require('../common');
+const assert = require('assert');
+
+// Test that certain response header fields do not repeat
+const norepeat = [
+  'retry-after',
+  'etag',
+  'last-modified',
+  'server',
+  'age',
+  'expires'
+];
+
+const server = http.createServer(function(req, res) {
+  for (let name of norepeat) {
+    res.setHeader(name, ['A', 'B']);
+  }
+  res.setHeader('X-A', ['A', 'B']);
+  res.end('ok');
+});
+
+server.listen(common.PORT, function() {
+  http.get({port:common.PORT}, function(res) {
+    for (let name of norepeat) {
+      assert.equal(res.headers[name], 'A');
+    }
+    assert.equal(res.headers['x-a'], 'A, B');
+    server.close();
+  });
+});


### PR DESCRIPTION
This PR does two things:

1. Adds a quick callback check 
2. Limits certain response headers from having multiple instances

For instance, `ETag` does not allow for multiple instances, but the current code will concat multiple instances into a comma separated list. Likewise for Last-Updated.