### PR TITLE
src: fix linking when built as shared library

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3014,6 +3014,13 @@ void LoadEnvironment(Environment* env) {
   f->Call(global, 1, &arg);
 }
 
+
+void FreeEnvironment(Environment* env) {
+  CHECK_NE(env, nullptr);
+  env->Dispose();
+}
+
+
 static void PrintHelp();
 
 static bool ParseDebugOpt(const char* arg) {

--- a/src/node.h
+++ b/src/node.h
@@ -196,6 +196,7 @@ NODE_EXTERN Environment* CreateEnvironment(v8::Isolate* isolate,
                                            int exec_argc,
                                            const char* const* exec_argv);
 NODE_EXTERN void LoadEnvironment(Environment* env);
+NODE_EXTERN void FreeEnvironment(Environment* env);
 
 // NOTE: Calling this is the same as calling
 // CreateEnvironment() + LoadEnvironment() from above.


### PR DESCRIPTION
This is another solution to fix the problem in #3046 as suggested by @bnoordhuis.

Currently linking Node as shared library in third party embedders will result in undefined symbols problem because the constructor of `Environment` is inlined and is calling constructor of `debugger::Agent`, which is not exported. This fix moves the constructor and destructor of `Environment` to `src/env.cc` to avoid leaking implementation details to solve this problem.

Following changes are also made for the fix:

1. The types of `Environment`'s properties are changed from `v8::Persistent` to `v8::Global`, so we don't have to manually reset all of them, this is because the `ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES` macro is removed in `env-inl.h` and calling `Reset()` in `env.cc` would be very hard.
2. A new `IsolateData::Scope` class is introduced to manage `IsolateData` automatically instead of manually calling `Put()`, so we can rely the destructor to do clean up job.
3. The `*_buffer_` members are managed by `std::vector` so we don't have to manually delete them in destructor.
4. `PersistentToLocal` are extended to handle `v8::Global`.
5. The `Environment::New` and `Environment::Dispose` are now exported functions so embedders can still use them as APIs without knowing the definition of `Environment`'s constructor.