### PR TITLE
smalloc: remove module

### DIFF
--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const util = require('internal/util');
-
-module.exports = require('internal/smalloc');
-util.printDeprecationMessage('smalloc is deprecated. ' +
-                             'Use typed arrays instead.');


### PR DESCRIPTION
Bye bye, smalloc. I'm not sure why this was still here; it was removed
a little while ago and hasn't worked since. It wasn't packaged in the
binary, either.

```sh
$ node
> process.version
'v4.1.1'
> require('smalloc')
Error: Cannot find module 'smalloc'
    ...
```