### PR TITLE
src: add process.versions.icu

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -648,6 +648,7 @@ Will print something like:
       zlib: '1.2.8',
       ares: '1.10.0-DEV',
       modules: '43',
+      icu: '55.1',
       openssl: '1.0.1k' }
 
 ## process.config

--- a/src/node.cc
+++ b/src/node.cc
@@ -52,6 +52,10 @@
 #include <string.h>
 #include <sys/types.h>
 
+#if defined(NODE_HAVE_I18N_SUPPORT)
+#include <unicode/uvernum.h>
+#endif
+
 #if defined(LEAK_SANITIZER)
 #include <sanitizer/lsan_interface.h>
 #endif
@@ -2668,6 +2672,12 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(versions,
                     "ares",
                     FIXED_ONE_BYTE_STRING(env->isolate(), ARES_VERSION_STR));
+
+#if defined(NODE_HAVE_I18N_SUPPORT) && defined(U_ICU_VERSION)
+  READONLY_PROPERTY(versions,
+                    "icu",
+                    OneByteString(env->isolate(), U_ICU_VERSION));
+#endif
 
   const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);
   READONLY_PROPERTY(

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -9,4 +9,8 @@ if (common.hasCrypto) {
   expected_keys.push('openssl');
 }
 
+if (typeof Intl !== 'undefined') {
+  expected_keys.push('icu');
+}
+
 assert.deepEqual(Object.keys(process.versions).sort(), expected_keys.sort());


### PR DESCRIPTION
If i18n support is present, add the icu version
to process.versions

Fixes: https://github.com/nodejs/node/issues/3089

R= @silverwind / @srl295 ?