### PR TITLE
i18n: add caller to removal list for bidi in ICU55

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -396,6 +396,7 @@
           '../../deps/icu/source/common/ushape.cpp',
           '../../deps/icu/source/common/usprep.cpp',
           '../../deps/icu/source/common/uts46.cpp',
+          '../../deps/icu/source/common/uidna.cpp',
         ]}],
         [ 'OS == "solaris"', { 'defines': [
           '_XOPEN_SOURCE_EXTENDED=0',


### PR DESCRIPTION
For ICU 55 we are currently stripping out bidi and
the callers.  AIX is more pedantic and identified
an additional caller than needed to be stripped out.
This PR adds that caller to those stripped out.