### PR TITLE
deps: upgrade V8 to 4.5.103.35

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 33
+#define V8_PATCH_LEVEL 35
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/messages.h
+++ b/deps/v8/src/messages.h
@@ -173,6 +173,7 @@ class CallSite {
   T(ObserveCallbackFrozen,                                                     \
     "Object.observe cannot deliver to a frozen function object")               \
   T(ObserveGlobalProxy, "% cannot be called on the global proxy object")       \
+  T(ObserveAccessChecked, "% cannot be called on access-checked objects")      \
   T(ObserveInvalidAccept,                                                      \
     "Third argument to Object.observe must be an array of strings.")           \
   T(ObserveNonFunction, "Object.% cannot deliver to non-function")             \

--- a/deps/v8/src/object-observe.js
+++ b/deps/v8/src/object-observe.js
@@ -389,6 +389,8 @@ function ObjectObserve(object, callback, acceptList) {
     throw MakeTypeError(kObserveNonObject, "observe", "observe");
   if (%IsJSGlobalProxy(object))
     throw MakeTypeError(kObserveGlobalProxy, "observe");
+  if (%IsAccessCheckNeeded(object))
+    throw MakeTypeError(kObserveAccessChecked, "observe");
   if (!IS_SPEC_FUNCTION(callback))
     throw MakeTypeError(kObserveNonFunction, "observe");
   if (ObjectIsFrozen(callback))
@@ -617,6 +619,8 @@ function ObjectGetNotifier(object) {
     throw MakeTypeError(kObserveNonObject, "getNotifier", "getNotifier");
   if (%IsJSGlobalProxy(object))
     throw MakeTypeError(kObserveGlobalProxy, "getNotifier");
+  if (%IsAccessCheckNeeded(object))
+    throw MakeTypeError(kObserveAccessChecked, "getNotifier");
 
   if (ObjectIsFrozen(object)) return null;
 

--- a/deps/v8/src/runtime/runtime-object.cc
+++ b/deps/v8/src/runtime/runtime-object.cc
@@ -1435,5 +1435,13 @@ RUNTIME_FUNCTION(Runtime_DefineSetterPropertyUnchecked) {
                                setter, attrs));
   return isolate->heap()->undefined_value();
 }
+
+
+RUNTIME_FUNCTION(Runtime_IsAccessCheckNeeded) {
+  SealHandleScope shs(isolate);
+  DCHECK_EQ(1, args.length());
+  CONVERT_ARG_CHECKED(Object, object, 0);
+  return isolate->heap()->ToBoolean(object->IsAccessCheckNeeded());
+}
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/src/runtime/runtime.h
+++ b/deps/v8/src/runtime/runtime.h
@@ -483,7 +483,8 @@ namespace internal {
   F(IsStrong, 1, 1)                                  \
   F(ClassOf, 1, 1)                                   \
   F(DefineGetterPropertyUnchecked, 4, 1)             \
-  F(DefineSetterPropertyUnchecked, 4, 1)
+  F(DefineSetterPropertyUnchecked, 4, 1)             \
+  F(IsAccessCheckNeeded, 1, 1)
 
 
 #define FOR_EACH_INTRINSIC_OBSERVE(F)            \

--- a/deps/v8/src/scanner-character-streams.h
+++ b/deps/v8/src/scanner-character-streams.h
@@ -94,6 +94,8 @@ class ExternalStreamingStream : public BufferedUtf16CharacterStream {
         current_data_length_(0),
         utf8_split_char_buffer_length_(0),
         bookmark_(0),
+        bookmark_data_is_from_current_data_(false),
+        bookmark_data_offset_(0),
         bookmark_utf8_split_char_buffer_length_(0) {}
 
   virtual ~ExternalStreamingStream() {
@@ -134,6 +136,8 @@ class ExternalStreamingStream : public BufferedUtf16CharacterStream {
   size_t bookmark_;
   Vector<uint16_t> bookmark_buffer_;
   Vector<uint8_t> bookmark_data_;
+  bool bookmark_data_is_from_current_data_;
+  size_t bookmark_data_offset_;
   uint8_t bookmark_utf8_split_char_buffer_[4];
   size_t bookmark_utf8_split_char_buffer_length_;
 };

--- a/deps/v8/test/cctest/test-object-observe.cc
+++ b/deps/v8/test/cctest/test-object-observe.cc
@@ -885,3 +885,39 @@ TEST(UseCountObjectGetNotifier) {
   CompileRun("Object.getNotifier(obj)");
   CHECK_EQ(1, use_counts[v8::Isolate::kObjectObserve]);
 }
+
+
+static bool NamedAccessCheckAlwaysAllow(Local<v8::Object> global,
+                                        Local<v8::Value> name,
+                                        v8::AccessType type,
+                                        Local<Value> data) {
+  return true;
+}
+
+
+TEST(DisallowObserveAccessCheckedObject) {
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope scope(isolate);
+  LocalContext env;
+  v8::Local<v8::ObjectTemplate> object_template =
+      v8::ObjectTemplate::New(isolate);
+  object_template->SetAccessCheckCallbacks(NamedAccessCheckAlwaysAllow, NULL);
+  env->Global()->Set(v8_str("obj"), object_template->NewInstance());
+  v8::TryCatch try_catch(isolate);
+  CompileRun("Object.observe(obj, function(){})");
+  CHECK(try_catch.HasCaught());
+}
+
+
+TEST(DisallowGetNotifierAccessCheckedObject) {
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope scope(isolate);
+  LocalContext env;
+  v8::Local<v8::ObjectTemplate> object_template =
+      v8::ObjectTemplate::New(isolate);
+  object_template->SetAccessCheckCallbacks(NamedAccessCheckAlwaysAllow, NULL);
+  env->Global()->Set(v8_str("obj"), object_template->NewInstance());
+  v8::TryCatch try_catch(isolate);
+  CompileRun("Object.getNotifier(obj)");
+  CHECK(try_catch.HasCaught());
+}


### PR DESCRIPTION
Pick up the latest fixes from V8 4.5 branch & bring us up to 4.5.103.35:
* Disallow Object.observe calls on access checked objects.
https://github.com/v8/v8/commit/134e541ad149b9732bc4fee6fe6952cf669703a7
* Avoid excessive data copying for ExternalStreamingStream::SetBookmark.
https://github.com/v8/v8/commit/96dddb455daff3d8626bc4e5d7b2898fbab55991

R=@targos, @bnoordhuis 
/cc @nodejs/v8 
