### PR TITLE
util: correctly inspect Map/Set Iterators

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -292,7 +292,10 @@ function formatValue(ctx, value, recurseTimes) {
   var base = '', empty = false, braces, formatter;
 
   if (Array.isArray(value)) {
-    if (constructor === Array)
+    // We can't use `constructor === Array` because this could
+    // have come from a Debug context.
+    // Otherwise, an Array will print "Array [...]".
+    if (constructor && constructor.name === 'Array')
       constructor = null;
     braces = ['[', ']'];
     empty = value.length === 0;

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@
 const uv = process.binding('uv');
 const Buffer = require('buffer').Buffer;
 const internalUtil = require('internal/util');
+const binding = process.binding('util');
 
 var Debug;
 var ObjectIsPromise;
@@ -323,11 +324,23 @@ function formatValue(ctx, value, recurseTimes) {
       braces = ['{', '}'];
       formatter = formatPromise;
     } else {
-      if (constructor === Object)
-        constructor = null;
-      braces = ['{', '}'];
-      empty = true;  // No other data than keys.
-      formatter = formatObject;
+      if (binding.isMapIterator(value)) {
+        constructor = { name: 'MapIterator' };
+        braces = ['{', '}'];
+        empty = false;
+        formatter = formatCollectionIterator;
+      } else if (binding.isSetIterator(value)) {
+        constructor = { name: 'SetIterator' };
+        braces = ['{', '}'];
+        empty = false;
+        formatter = formatCollectionIterator;
+      } else {
+        if (constructor === Object)
+          constructor = null;
+        braces = ['{', '}'];
+        empty = true;  // No other data than keys.
+        formatter = formatObject;
+      }
     }
   }
 
@@ -498,6 +511,18 @@ function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                key, false));
   });
+  return output;
+}
+
+function formatCollectionIterator(ctx, value, recurseTimes, visibleKeys, keys) {
+  ensureDebugIsInitialized();
+  const mirror = Debug.MakeMirror(value, true);
+  var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
+  var vals = mirror.preview();
+  var output = [];
+  for (let o of vals) {
+    output.push(formatValue(ctx, o, nextRecurseTimes));
+  }
   return output;
 }
 

--- a/node.gyp
+++ b/node.gyp
@@ -115,6 +115,7 @@
         'src/node_javascript.cc',
         'src/node_main.cc',
         'src/node_os.cc',
+        'src/node_util.cc',
         'src/node_v8.cc',
         'src/node_stat_watcher.cc',
         'src/node_watchdog.cc',

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -1,0 +1,38 @@
+#include "node.h"
+#include "v8.h"
+#include "env.h"
+#include "env-inl.h"
+
+namespace node {
+namespace util {
+
+using v8::Context;
+using v8::FunctionCallbackInfo;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+static void IsMapIterator(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(args[0]->IsMapIterator());
+}
+
+
+static void IsSetIterator(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(args[0]->IsSetIterator());
+}
+
+
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+  env->SetMethod(target, "isMapIterator", IsMapIterator);
+  env->SetMethod(target, "isSetIterator", IsSetIterator);
+}
+
+}  // namespace util
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(util, node::util::Initialize)

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -23,6 +23,19 @@ assert.equal(util.inspect(a), '[ \'foo\', , \'baz\' ]');
 assert.equal(util.inspect(a, true), '[ \'foo\', , \'baz\', [length]: 3 ]');
 assert.equal(util.inspect(new Array(5)), '[ , , , ,  ]');
 
+// test for Array constructor in different context
+const Debug = require('vm').runInDebugContext('Debug');
+var map = new Map();
+map.set(1, 2);
+var mirror = Debug.MakeMirror(map.entries(), true);
+var vals = mirror.preview();
+var valsOutput = [];
+for (let o of vals) {
+  valsOutput.push(o);
+}
+
+assert.strictEqual(util.inspect(valsOutput), '[ [ 1, 2 ] ]');
+
 // test for property descriptors
 var getter = Object.create(null, {
   a: {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -287,6 +287,26 @@ global.Promise = function() { this.bar = 42; };
 assert.equal(util.inspect(new Promise()), '{ bar: 42 }');
 global.Promise = oldPromise;
 
+// Map/Set Iterators
+var m = new Map([['foo', 'bar']]);
+assert.strictEqual(util.inspect(m.keys()), 'MapIterator { \'foo\' }');
+assert.strictEqual(util.inspect(m.values()), 'MapIterator { \'bar\' }');
+assert.strictEqual(util.inspect(m.entries()),
+                   'MapIterator { [ \'foo\', \'bar\' ] }');
+// make sure the iterator doesn't get consumed
+var keys = m.keys();
+assert.strictEqual(util.inspect(keys), 'MapIterator { \'foo\' }');
+assert.strictEqual(util.inspect(keys), 'MapIterator { \'foo\' }');
+
+var s = new Set([1, 3]);
+assert.strictEqual(util.inspect(s.keys()), 'SetIterator { 1, 3 }');
+assert.strictEqual(util.inspect(s.values()), 'SetIterator { 1, 3 }');
+assert.strictEqual(util.inspect(s.entries()),
+                   'SetIterator { [ 1, 1 ], [ 3, 3 ] }');
+// make sure the iterator doesn't get consumed
+keys = s.keys();
+assert.strictEqual(util.inspect(keys), 'SetIterator { 1, 3 }');
+assert.strictEqual(util.inspect(keys), 'SetIterator { 1, 3 }');
 
 // Test alignment of items in container
 // Assumes that the first numeric character is the start of an item.


### PR DESCRIPTION
Currently, inspecting `new Map().keys()` or other iterators will return an empty object.

I am opening more for discussion of how we want (if at all) to address not being able to inspect map and set iterators. I first had first attempting using `Debug.MakeMirror` but the performance of doing it this way was about 10x better.

Related: https://github.com/nodejs/node/issues/3107