### PR TITLE
doc: createServer's key option can be an array

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -162,10 +162,9 @@ automatically set as a listener for the [secureConnection][] event.  The
     the `key`, `cert` and `ca` options.)
 
   - `key`: A string or `Buffer` containing the private key of the server in
-    PEM format. It can also be an array of keys. The array can either be of
-    just keys or if you have different passphrases for the keys, then the
-    array elements can be of the form `{pem: key, passphrase: passphrase}` and
-    the keys should use different algorithms. (Required)
+    PEM format. To support multiple keys using different algorithms, an array
+    can be provided. It can either be a plain array of keys, or an array of
+    objects in the form of `{pem: key, passphrase: passphrase}`. (Required)
 
   - `passphrase`: A string of passphrase for the private key or pfx.
 
@@ -490,10 +489,9 @@ dictionary with keys:
 * `pfx` : A string or buffer holding the PFX or PKCS12 encoded private
   key, certificate and CA certificates
 * `key`: A string or `Buffer` containing the private key of the server in
-   PEM format. It can also be an array of keys. The array can either be of
-   just keys or if you have different passphrases for the keys, then the
-   array elements can be of the form `{pem: key, passphrase: passphrase}` and
-   the keys should use different algorithms. (Required)
+  PEM format. To support multiple keys using different algorithms, an array
+  can be provided. It can either be a plain array of keys, or an array of
+  objects in the form of `{pem: key, passphrase: passphrase}`. (Required)
 * `passphrase` : A string of passphrase for the private key or pfx
 * `cert` : A string holding the PEM encoded certificate
 * `ca` : Either a string or list of strings of PEM encoded CA

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -164,8 +164,8 @@ automatically set as a listener for the [secureConnection][] event.  The
   - `key`: A string or `Buffer` containing the private key of the server in
     PEM format. It can also be an array of keys. The array can either be of
     just keys or if you have different passphrases for the keys, then the
-    array elements can be of the form `{pem: key, passphrase: passphrase}`.
-    (Required)
+    array elements can be of the form `{pem: key, passphrase: passphrase}` and
+    the keys should use different algorithms. (Required)
 
   - `passphrase`: A string of passphrase for the private key or pfx.
 
@@ -490,10 +490,10 @@ dictionary with keys:
 * `pfx` : A string or buffer holding the PFX or PKCS12 encoded private
   key, certificate and CA certificates
 * `key`: A string or `Buffer` containing the private key of the server in
-    PEM format. It can also be an array of keys. The array can either be of
-    just keys or if you have different passphrases for the keys, then the
-    array elements can be of the form `{pem: key, passphrase: passphrase}`.
-    (Required)
+   PEM format. It can also be an array of keys. The array can either be of
+   just keys or if you have different passphrases for the keys, then the
+   array elements can be of the form `{pem: key, passphrase: passphrase}` and
+   the keys should use different algorithms. (Required)
 * `passphrase` : A string of passphrase for the private key or pfx
 * `cert` : A string holding the PEM encoded certificate
 * `ca` : Either a string or list of strings of PEM encoded CA

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -162,7 +162,10 @@ automatically set as a listener for the [secureConnection][] event.  The
     the `key`, `cert` and `ca` options.)
 
   - `key`: A string or `Buffer` containing the private key of the server in
-    PEM format. (Could be an array of keys). (Required)
+    PEM format. It can also be an array of keys. The array can either be of
+    just keys or if you have different passphrases for the keys, then the
+    array elements can be of the form `{pem: key, passphrase: passphrase}`.
+    (Required)
 
   - `passphrase`: A string of passphrase for the private key or pfx.
 
@@ -486,7 +489,11 @@ dictionary with keys:
 
 * `pfx` : A string or buffer holding the PFX or PKCS12 encoded private
   key, certificate and CA certificates
-* `key` : A string holding the PEM encoded private key
+* `key`: A string or `Buffer` containing the private key of the server in
+    PEM format. It can also be an array of keys. The array can either be of
+    just keys or if you have different passphrases for the keys, then the
+    array elements can be of the form `{pem: key, passphrase: passphrase}`.
+    (Required)
 * `passphrase` : A string of passphrase for the private key or pfx
 * `cert` : A string holding the PEM encoded certificate
 * `ca` : Either a string or list of strings of PEM encoded CA


### PR DESCRIPTION
The `tls` module's `createServer` and `createSecureContext` accept
`key` option and it can be an array of keys as well. This patch
explains the format of the entries in that array.

Corresponding code:
https://github.com/nodejs/node/blob/v4.1.1/lib/_tls_common.js#L73-L90

cc @nodejs/crypto 