### PR TITLE
contextify: use assert instead of `if`

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -217,7 +217,7 @@ class ContextifyContext {
 
     Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
     
-    assert(!ctx.IsEmpty());
+    CHECK(!ctx.IsEmpty());
     ctx->SetSecurityToken(env->context()->GetSecurityToken());
 
     env->AssignToContext(ctx);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -216,8 +216,9 @@ class ContextifyContext {
     object_template->SetHandler(config);
 
     Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
-    if (!ctx.IsEmpty())
-      ctx->SetSecurityToken(env->context()->GetSecurityToken());
+    
+    assert(!ctx.IsEmpty());
+    ctx->SetSecurityToken(env->context()->GetSecurityToken());
 
     env->AssignToContext(ctx);
 


### PR DESCRIPTION
I was walking through the vm changes and saw this particular `if` check is interesting. In case `ctx` is empty it's going to fail later anyways. 

So, instead of putting an `if` check there;

option a - use assert 
option b - do nothing

Considering the developer wanted to make sure `ctx` is not empty, `assert` option looked more convenient.