### PR TITLE
lib: remove redundant code from timers.js

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -23,13 +23,16 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // value = list
 var lists = {};
 
+
+// call this whenever the item is active (not idle)
+// it will reset its timeout.
 // the main function - creates lists on demand and the watchers associated
 // with them.
-function insert(item, msecs) {
-  item._idleStart = Timer.now();
-  item._idleTimeout = msecs;
-
+exports.active = function(item) {
+  const msecs = item._idleTimeout;
   if (msecs < 0) return;
+
+  item._idleStart = Timer.now();
 
   var list;
 
@@ -48,7 +51,7 @@ function insert(item, msecs) {
 
   L.append(list, item);
   assert(!L.isEmpty(list)); // list is not empty
-}
+};
 
 function listOnTimeout() {
   var msecs = this.msecs;
@@ -153,15 +156,6 @@ exports.enroll = function(item, msecs) {
 
   item._idleTimeout = msecs;
   L.init(item);
-};
-
-
-// call this whenever the item is active (not idle)
-// it will reset its timeout.
-exports.active = function(item) {
-  var msecs = item._idleTimeout;
-  if (msecs >= 0)
-    insert(item, msecs);
 };
 
 

--- a/test/parallel/test-timers-active.js
+++ b/test/parallel/test-timers-active.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const active = require('timers').active;
 
-// active() should not create a timer for these
+// active() should create timers for these
 var legitTimers = [
   { _idleTimeout: 0 },
   { _idleTimeout: 1 }

--- a/test/parallel/test-timers-active.js
+++ b/test/parallel/test-timers-active.js
@@ -10,9 +10,13 @@ var legitTimers = [
 ];
 
 legitTimers.forEach(function(legit) {
+  const savedTimeout = legit._idleTimeout;
   active(legit);
   // active() should mutate these objects
-  assert.notDeepEqual(Object.keys(legit), ['_idleTimeout']);
+  assert(legit._idleTimeout === savedTimeout);
+  assert(Number.isInteger(legit._idleStart));
+  assert(legit._idleNext);
+  assert(legit._idlePrev);
 });
 
 
@@ -22,7 +26,8 @@ var bogusTimers = [
 ];
 
 bogusTimers.forEach(function(bogus) {
+  const savedTimeout = bogus._idleTimeout;
   active(bogus);
   // active() should not mutate these objects
-  assert.deepEqual(Object.keys(bogus), ['_idleTimeout']);
+  assert.deepStrictEqual(bogus, {_idleTimeout: savedTimeout});
 });

--- a/test/parallel/test-timers-active.js
+++ b/test/parallel/test-timers-active.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const active = require('timers').active;
+
+// active() should not create a timer for these
+var legitTimers = [
+  { _idleTimeout: 0 },
+  { _idleTimeout: 1 }
+];
+
+legitTimers.forEach(function(legit) {
+  active(legit);
+  // active() should mutate these objects
+  assert.notDeepEqual(Object.keys(legit), ['_idleTimeout']);
+});
+
+
+// active() should not create a timer for these
+var bogusTimers = [
+  { _idleTimeout: -1 }
+];
+
+bogusTimers.forEach(function(bogus) {
+  active(bogus);
+  // active() should not mutate these objects
+  assert.deepEqual(Object.keys(bogus), ['_idleTimeout']);
+});


### PR DESCRIPTION
insert() is only [called from one place where there is already a check
that msecs is greater than or equal to zero](https://github.com/nodejs/node/blob/master/lib/timers.js#L163-L164), so do not repeat the check
inside insert().