### PR TITLE
gitignore: only ignore root Debug directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,8 @@ icu_config.gypi
 /out
 
 # various stuff that VC++ produces/uses
-Debug/
-!node_modules/debug/
-Release/
+/Debug/
+/Release/
 !doc/blog/**
 *.sln
 !nodemsi.sln


### PR DESCRIPTION
On case insensitive platforms, the rule catches the debug module under
npm and eslint and a source directory in next versions of V8.

Ref: https://github.com/nodejs/node/pull/2286#issuecomment-139808871
Ref: https://github.com/nodejs/node/issues/2688#issuecomment-143401691