### PR TITLE
doc: add example for tls session resumption

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -603,6 +603,16 @@ perform lookup in external storage using given `sessionId`, and invoke
 NOTE: adding this event listener will have an effect only on connections
 established after addition of event listener.
 
+Here's an example for using TLS session resumption:
+
+  var tlsSessionStore = {};
+  server.on('newSession', function(id, data, cb) {
+    tlsSessionStore[id.toString('hex')] = data;
+    cb();
+  });
+  server.on('resumeSession', function(id, cb) {
+    cb(null, tlsSessionStore[id.toString('hex')] || null);
+  });
 
 ### Event: 'OCSPRequest'
 


### PR DESCRIPTION
This came up in https://github.com/nodejs/node/issues/3132. I was assuming this API was still synchronous while it was changed back in https://github.com/nodejs/node/commit/75ea11fc08019bb1ffac81583ed7d0da3241a5b5. Hopefully this example clears up on how to use TLS session resumption correctly.

cc: @bnoordhuis 