### PR TITLE
test: fix invalid variable name

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -30,7 +30,7 @@ function rimrafSync(p) {
     if (e.code === 'ENOENT')
       return;
     if (e.code === 'EPERM')
-      return rmdirSync(p, er);
+      return rmdirSync(p, e);
     if (e.code !== 'EISDIR')
       throw e;
     rmdirSync(p, e);


### PR DESCRIPTION
The variable `er` is not declared at all. So if EPERM error is ever
raised then the `er` will throw `ReferenceError` and the code will
break.

CI Run: https://ci.nodejs.org/job/node-test-pull-request/408/