### PR TITLE
Enable block scoped var eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,6 +83,9 @@ rules:
   # Custom rules in tools/eslint-rules
   require-buffer: 2
 
+  # treat `var` as Block Scoped
+  block-scoped-var: 2
+
 # Global scoped method and vars
 globals:
   DTRACE_HTTP_CLIENT_REQUEST           : false

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1325,7 +1325,8 @@ Interface.prototype.setBreakpoint = function(script, line,
 
   var self = this,
       scriptId,
-      ambiguous;
+      ambiguous,
+      req;
 
   // setBreakpoint() should insert breakpoint on current line
   if (script === undefined) {
@@ -1347,7 +1348,7 @@ Interface.prototype.setBreakpoint = function(script, line,
 
   if (/\(\)$/.test(script)) {
     // setBreakpoint('functionname()');
-    var req = {
+    req = {
       type: 'function',
       target: script.replace(/\(\)$/, ''),
       condition: condition
@@ -1373,7 +1374,6 @@ Interface.prototype.setBreakpoint = function(script, line,
     if (ambiguous) return this.error('Script name is ambiguous');
     if (line <= 0) return this.error('Line should be a positive value');
 
-    var req;
     if (scriptId) {
       req = {
         type: 'scriptId',

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -59,9 +59,10 @@ function ClientRequest(options, cb) {
 
   var port = options.port = options.port || defaultPort || 80;
   var host = options.host = options.hostname || options.host || 'localhost';
+  var setHost;
 
   if (options.setHost === undefined) {
-    var setHost = true;
+    setHost = true;
   }
 
   self.socketPath = options.socketPath;
@@ -138,11 +139,12 @@ function ClientRequest(options, cb) {
     // No agent, default to Connection:close.
     self._last = true;
     self.shouldKeepAlive = false;
+    var conn;
     if (options.createConnection) {
-      var conn = options.createConnection(options);
+      conn = options.createConnection(options);
     } else {
       debug('CLIENT use net.createConnection', options);
-      var conn = net.createConnection(options);
+      conn = net.createConnection(options);
     }
     self.onSocket(conn);
   }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -727,10 +727,11 @@ Readable.prototype.pause = function() {
 
 function flow(stream) {
   var state = stream._readableState;
+  var chunk;
   debug('flow', state.flowing);
   if (state.flowing) {
     do {
-      var chunk = stream.read();
+      chunk = stream.read();
     } while (null !== chunk && state.flowing);
   }
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -365,10 +365,12 @@ function slowToString(encoding, start, end) {
 
 
 Buffer.prototype.toString = function() {
+  var result;
+
   if (arguments.length === 0) {
-    var result = this.utf8Slice(0, this.length);
+    result = this.utf8Slice(0, this.length);
   } else {
-    var result = slowToString.apply(this, arguments);
+    result = slowToString.apply(this, arguments);
   }
   if (result === undefined)
     throw new Error('toString failed');

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -79,10 +79,11 @@ exports._createSocketHandle = function(address, port, addressType, fd, flags) {
 
 
 function Socket(type, listener) {
+  var options;
   EventEmitter.call(this);
 
   if (typeof type === 'object') {
-    var options = type;
+    options = type;
     type = options.type;
   }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1454,9 +1454,9 @@ fs.realpathSync = function realpathSync(p, cache) {
 
       // read the link if it wasn't read before
       // dev/ino always return 0 on windows, so skip the check.
-      var linkTarget = null;
+      var linkTarget = null, id;
       if (!isWindows) {
-        var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+        id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
         if (seenLinks.hasOwnProperty(id)) {
           linkTarget = seenLinks[id];
         }
@@ -1561,6 +1561,7 @@ fs.realpath = function realpath(p, cache, cb) {
   }
 
   function gotStat(err, stat) {
+    var id;
     if (err) return cb(err);
 
     // if not a symlink, skip to the next path part
@@ -1574,7 +1575,7 @@ fs.realpath = function realpath(p, cache, cb) {
     // call gotTarget as soon as the link target is known
     // dev/ino always return 0 on windows, so skip the check.
     if (!isWindows) {
-      var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+      id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
       if (seenLinks.hasOwnProperty(id)) {
         return gotTarget(null, seenLinks[id], base);
       }

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -517,6 +517,7 @@ function setupChannel(target, channel) {
 
   target._send = function(message, handle, swallowErrors, callback) {
     assert(this.connected || this._channel);
+    var obj;
 
     if (message === undefined)
       throw new TypeError('message cannot be undefined');
@@ -554,7 +555,7 @@ function setupChannel(target, channel) {
         return;
       }
 
-      var obj = handleConversion[message.type];
+      obj = handleConversion[message.type];
 
       // convert TCP object to native handle object
       handle =

--- a/lib/module.js
+++ b/lib/module.js
@@ -64,6 +64,8 @@ const debug = Module._debug;
 const packageMainCache = {};
 
 function readPackage(requestPath) {
+  var pkg;
+
   if (hasOwnProperty(packageMainCache, requestPath)) {
     return packageMainCache[requestPath];
   }
@@ -76,7 +78,7 @@ function readPackage(requestPath) {
   }
 
   try {
-    var pkg = packageMainCache[requestPath] = JSON.parse(json).main;
+    pkg = packageMainCache[requestPath] = JSON.parse(json).main;
   } catch (e) {
     e.path = jsonPath;
     e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
@@ -469,11 +471,12 @@ Module.runMain = function() {
 
 Module._initPaths = function() {
   const isWindows = process.platform === 'win32';
+  var homeDir;
 
   if (isWindows) {
-    var homeDir = process.env.USERPROFILE;
+    homeDir = process.env.USERPROFILE;
   } else {
-    var homeDir = process.env.HOME;
+    homeDir = process.env.HOME;
   }
 
   var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];

--- a/lib/net.js
+++ b/lib/net.js
@@ -1458,6 +1458,9 @@ Server.prototype.getConnections = function(cb) {
 
 
 Server.prototype.close = function(cb) {
+  var left;
+  var self = this;
+
   function onSlaveClose() {
     if (--left !== 0) return;
 
@@ -1481,8 +1484,7 @@ Server.prototype.close = function(cb) {
   }
 
   if (this._usingSlaves) {
-    var self = this,
-        left = this._slaves.length;
+    left = this._slaves.length;
 
     // Increment connections to be sure that, even if all sockets will be closed
     // during polling of slaves, `close` event will be emitted only once.

--- a/lib/path.js
+++ b/lib/path.js
@@ -105,7 +105,8 @@ function normalizeUNCRoot(device) {
 win32.resolve = function() {
   var resolvedDevice = '',
       resolvedTail = '',
-      resolvedAbsolute = false;
+      resolvedAbsolute = false,
+      isUnc;
 
   for (var i = arguments.length - 1; i >= -1; i--) {
     var path;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -15,9 +15,9 @@ function charCode(c) {
 QueryString.unescapeBuffer = function(s, decodeSpaces) {
   var out = new Buffer(s.length);
   var state = 'CHAR'; // states: CHAR, HEX0, HEX1
-  var n, m, hexchar;
+  var n, m, hexchar, outIndex = 0;
 
-  for (var inIndex = 0, outIndex = 0; inIndex <= s.length; inIndex++) {
+  for (var inIndex = 0; inIndex <= s.length; inIndex++) {
     var c = s.charCodeAt(inIndex);
     switch (state) {
       case 'CHAR':

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -124,7 +124,7 @@ function REPLServer(prompt,
   eval_ = eval_ || defaultEval;
 
   function defaultEval(code, context, file, cb) {
-    var err, result, retry = false;
+    var err, result, retry = false, script;
     // first, create the Script object to check the syntax
     while (true) {
       try {
@@ -134,7 +134,7 @@ function REPLServer(prompt,
           // result value for let/const statements.
           code = `'use strict'; void 0; ${code}`;
         }
-        var script = vm.createScript(code, {
+        script = vm.createScript(code, {
           filename: file,
           displayErrors: false
         });

--- a/lib/url.js
+++ b/lib/url.js
@@ -130,9 +130,11 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   }
 
   var proto = protocolPattern.exec(rest);
+  var slashes;
+  var lowerProto;
   if (proto) {
     proto = proto[0];
-    var lowerProto = proto.toLowerCase();
+    lowerProto = proto.toLowerCase();
     this.protocol = lowerProto;
     rest = rest.substr(proto.length);
   }
@@ -142,7 +144,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
   if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
-    var slashes = rest.substr(0, 2) === '//';
+    slashes = rest.substr(0, 2) === '//';
     if (slashes && !(proto && hostlessProtocol[proto])) {
       rest = rest.substr(2);
       this.slashes = true;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -510,10 +510,11 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
   var self = this;
 
   var async = typeof cb === 'function';
+  var buffers = [];
+  var nread = 0;
 
   if (!async) {
-    var buffers = [];
-    var nread = 0;
+    var res;
 
     var error;
     this.on('error', function(er) {
@@ -522,13 +523,13 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
 
     assert(!this._closed, 'zlib binding closed');
     do {
-      var res = this._handle.writeSync(flushFlag,
-                                       chunk, // in
-                                       inOff, // in_off
-                                       availInBefore, // in_len
-                                       this._buffer, // out
-                                       this._offset, //out_off
-                                       availOutBefore); // out_len
+      res = this._handle.writeSync(flushFlag,
+                                   chunk, // in
+                                   inOff, // in_off
+                                   availInBefore, // in_len
+                                   this._buffer, // out
+                                   this._offset, //out_off
+                                   availOutBefore); // out_len
     } while (!this._hadError && callback(res[0], res[1]));
 
     if (this._hadError) {

--- a/src/node.js
+++ b/src/node.js
@@ -553,14 +553,15 @@
   function evalScript(name) {
     var Module = NativeModule.require('module');
     var path = NativeModule.require('path');
+    var cwd;
 
     try {
-      var cwd = process.cwd();
+      cwd = process.cwd();
     } catch (e) {
       // getcwd(3) can fail if the current working directory has been deleted.
       // Fall back to the directory name of the (absolute) executable path.
       // It's not really correct but what are the alternatives?
-      var cwd = path.dirname(process.execPath);
+      cwd = path.dirname(process.execPath);
     }
 
     var module = new Module(name);

--- a/test/common.js
+++ b/test/common.js
@@ -14,8 +14,9 @@ exports.isWindows = process.platform === 'win32';
 exports.isAix = process.platform === 'aix';
 
 function rimrafSync(p) {
+  var st;
   try {
-    var st = fs.lstatSync(p);
+    st = fs.lstatSync(p);
   } catch (e) {
     if (e.code === 'ENOENT')
       return;

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common'),
     assert = require('assert'),

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -18,6 +18,7 @@ function parent() {
   var sent = 0;
 
   var n = '';
+  var buf;
   child.stdout.setEncoding('ascii');
   child.stdout.on('data', function(c) {
     n += c;
@@ -29,7 +30,7 @@ function parent() {
 
   // Write until the buffer fills up.
   do {
-    var buf = new Buffer(BUFSIZE);
+    buf = new Buffer(BUFSIZE);
     buf.fill('.');
     sent += BUFSIZE;
   } while (child.stdin.write(buf));

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -37,7 +37,7 @@ function parent() {
 
   // then write a bunch more times.
   for (var i = 0; i < 100; i++) {
-    var buf = new Buffer(BUFSIZE);
+    buf = new Buffer(BUFSIZE);
     buf.fill('.');
     sent += BUFSIZE;
     child.stdin.write(buf);

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, block-scoped-var */
 try {
   var crypto = require('crypto');
 } catch (e) {

--- a/test/parallel/test-domain-exit-dispose-again.js
+++ b/test/parallel/test-domain-exit-dispose-again.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-domain-exit-dispose.js
+++ b/test/parallel/test-domain-exit-dispose.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-exception-handler2.js
+++ b/test/parallel/test-exception-handler2.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, block-scoped-var */
 var common = require('../common');
 var assert = require('assert');
 

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-https-resume-after-renew.js
+++ b/test/parallel/test-https-resume-after-renew.js
@@ -21,9 +21,10 @@ hmac.fill('H');
 
 server._sharedCreds.context.enableTicketKeyCallback();
 server._sharedCreds.context.onticketkeycallback = function(name, iv, enc) {
+  var newName, newIV;
   if (enc) {
-    var newName = new Buffer(16);
-    var newIV = crypto.randomBytes(16);
+    newName = new Buffer(16);
+    newIV = crypto.randomBytes(16);
     newName.fill('A');
   } else {
     // Renew

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-repl-syntax-error-handling.js
+++ b/test/parallel/test-repl-syntax-error-handling.js
@@ -39,11 +39,7 @@ function parent() {
 
 function child() {
   var vm = require('vm');
-  try {
-    vm.runInThisContext('haf!@##&$!@$*!@', { displayErrors: false });
-  } catch (er) {
-    var caught = true;
-  }
-  assert(caught);
+  assert.throws(() =>
+      vm.runInThisContext('haf!@##&$!@$*!@', { displayErrors: false }), Error);
   vm.runInThisContext('console.log(10)', { displayErrors: false });
 }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-len, strict */
+/* eslint-disable max-len, strict, block-scoped-var */
 var common = require('../common');
 var assert = require('assert');
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -117,8 +117,9 @@ test('write backpressure', function(t) {
 
   var i = 0;
   (function W() {
+    var ret;
     do {
-      var ret = tw.write(chunks[i++]);
+      ret = tw.write(chunks[i++]);
     } while (ret !== false && i < chunks.length);
 
     if (i < chunks.length) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1,3 +1,4 @@
+/* eslint-disable block-scoped-var */
 'use strict';
 var common = require('../common');
 var assert = require('assert');

--- a/test/parallel/test-vm-new-script-new-context.js
+++ b/test/parallel/test-vm-new-script-new-context.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, block-scoped-var */
 var common = require('../common');
 var assert = require('assert');
 var Script = require('vm').Script;

--- a/test/parallel/test-vm-new-script-this-context.js
+++ b/test/parallel/test-vm-new-script-this-context.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, block-scoped-var */
 var common = require('../common');
 var assert = require('assert');
 var Script = require('vm').Script;

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, block-scoped-var */
 // Flags: --expose-gc
 
 var common = require('../common');

--- a/test/parallel/test-vm-static-this.js
+++ b/test/parallel/test-vm-static-this.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, block-scoped-var */
 var common = require('../common');
 var assert = require('assert');
 var vm = require('vm');

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -171,7 +171,8 @@ Object.keys(tests).forEach(function(file) {
                       Def.name + ' -> ' + Inf.name;
                   var ok = true;
                   var testNum = ++done;
-                  for (var i = 0; i < Math.max(c.length, test.length); i++) {
+                  var i;
+                  for (i = 0; i < Math.max(c.length, test.length); i++) {
                     if (c[i] !== test[i]) {
                       ok = false;
                       failures++;

--- a/test/pummel/test-net-connect-memleak.js
+++ b/test/pummel/test-net-connect-memleak.js
@@ -11,6 +11,7 @@ net.createServer(function() {}).listen(common.PORT);
 var before = 0;
 (function() {
   // 2**26 == 64M entries
+  var junk;
   gc();
   for (var i = 0, junk = [0]; i < 26; ++i) junk = junk.concat(junk);
   before = process.memoryUsage().rss;

--- a/test/pummel/test-net-connect-memleak.js
+++ b/test/pummel/test-net-connect-memleak.js
@@ -11,9 +11,9 @@ net.createServer(function() {}).listen(common.PORT);
 var before = 0;
 (function() {
   // 2**26 == 64M entries
-  var junk;
+  var junk = [0];
   gc();
-  for (var i = 0, junk = [0]; i < 26; ++i) junk = junk.concat(junk);
+  for (var i = 0; i < 26; ++i) junk = junk.concat(junk);
   before = process.memoryUsage().rss;
 
   net.createConnection(common.PORT, '127.0.0.1', function() {

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -21,8 +21,8 @@ tls.createServer({
 
 (function() {
   // 2**26 == 64M entries
-  var junk;
-  for (var i = 0, junk = [0]; i < 26; ++i) junk = junk.concat(junk);
+  var junk = [0];
+  for (var i = 0; i < 26; ++i) junk = junk.concat(junk);
 
   var options = { rejectUnauthorized: false };
   tls.connect(common.PORT, '127.0.0.1', options, function() {

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -21,6 +21,7 @@ tls.createServer({
 
 (function() {
   // 2**26 == 64M entries
+  var junk;
   for (var i = 0, junk = [0]; i < 26; ++i) junk = junk.concat(junk);
 
   var options = { rejectUnauthorized: false };


### PR DESCRIPTION
Description from: http://eslint.org/docs/rules/block-scoped-var.html

The block-scoped-var rule generates warnings when variables are used
outside of the block in which they were defined. This emulates C-style
block scope.

Refer: #3118