### PR TITLE
eslintrc,lib,test: enable prefer-const rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,6 +70,11 @@ rules:
   # require space after keywords, eg 'for (..)'
   space-after-keywords: 2
 
+  # ECMAScript 6
+  # list: http://eslint.org/docs/rules/#ecmascript-6
+  ## Suggest using 'const' wherever possible
+  prefer-const: 2
+
   # Strict Mode
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
   ## 'use strict' on top

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -291,7 +291,7 @@ function masterInit() {
       var match = execArgv[i].match(/^(--debug|--debug-(brk|port))(=\d+)?$/);
 
       if (match) {
-        let debugPort = process.debugPort + debugPortOffset;
+        const debugPort = process.debugPort + debugPortOffset;
         ++debugPortOffset;
         execArgv[i] = match[1] + '=' + debugPort;
       }

--- a/lib/util.js
+++ b/lib/util.js
@@ -517,7 +517,7 @@ function formatCollectionIterator(ctx, value, recurseTimes, visibleKeys, keys) {
   var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
   var vals = mirror.preview();
   var output = [];
-  for (let o of vals) {
+  for (const o of vals) {
     output.push(formatValue(ctx, o, nextRecurseTimes));
   }
   return output;

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -73,16 +73,17 @@ process.on('SIGINT', () => process.exit());
 
 // Run from closed net server above.
 function checkTLS() {
-  let options = {
+  const options = {
     key: fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
     cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
   };
-  let server = tls.createServer(options, noop).listen(common.PORT, function() {
-    tls.connect(common.PORT, { rejectUnauthorized: false }, function() {
-      this.destroy();
-      server.close();
+  const server = tls.createServer(options, noop)
+    .listen(common.PORT, function() {
+      tls.connect(common.PORT, { rejectUnauthorized: false }, function() {
+        this.destroy();
+        server.close();
+      });
     });
-  });
 }
 
 zlib.createGzip();

--- a/test/parallel/test-buffer-zero-fill-reset.js
+++ b/test/parallel/test-buffer-zero-fill-reset.js
@@ -14,6 +14,6 @@ function testUint8Array(ui) {
 
 for (let i = 0; i < 100; i++) {
   new Buffer(0);
-  let ui = new Uint8Array(65);
+  const ui = new Uint8Array(65);
   assert.ok(testUint8Array(ui), 'Uint8Array is not zero-filled');
 }

--- a/test/parallel/test-http-flush-headers.js
+++ b/test/parallel/test-http-flush-headers.js
@@ -10,7 +10,7 @@ server.on('request', function(req, res) {
   server.close();
 });
 server.listen(common.PORT, '127.0.0.1', function() {
-  let req = http.request({
+  const req = http.request({
     method: 'GET',
     host: '127.0.0.1',
     port: common.PORT,

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -17,13 +17,13 @@ const norepeat = [
 const server = http.createServer(function(req, res) {
   var num = req.headers['x-num'];
   if (num == 1) {
-    for (let name of norepeat) {
+    for (const name of norepeat) {
       res.setHeader(name, ['A', 'B']);
     }
     res.setHeader('X-A', ['A', 'B']);
   } else if (num == 2) {
-    let headers = {};
-    for (let name of norepeat) {
+    const headers = {};
+    for (const name of norepeat) {
       headers[name] = ['A', 'B'];
     }
     headers['X-A'] = ['A', 'B'];
@@ -44,7 +44,7 @@ server.listen(common.PORT, common.mustCall(function() {
       {port:common.PORT, headers:{'x-num': n}},
       common.mustCall(function(res) {
         if (n == 2) server.close();
-        for (let name of norepeat) {
+        for (const name of norepeat) {
           assert.equal(res.headers[name], 'A');
         }
         assert.equal(res.headers['x-a'], 'A, B');

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -33,7 +33,7 @@ function testSocketOptions(socket, socketOptions) {
       setImmediate(runTests);
     });
   }).listen(common.PORT, function() {
-    let c = new tls.TLSSocket(socket, socketOptions);
+    const c = new tls.TLSSocket(socket, socketOptions);
     c.connect(common.PORT, function() {
       c.end(sent);
     });

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -135,7 +135,7 @@ map.set(1, 2);
 var mirror = Debug.MakeMirror(map.entries(), true);
 var vals = mirror.preview();
 var valsOutput = [];
-for (let o of vals) {
+for (const o of vals) {
   valsOutput.push(o);
 }
 

--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -22,11 +22,11 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing el' 
 ].forEach(function(methods) {
   zlib[methods.comp](inputString, function(err, compressed) {
     assert(!err);
-    let truncated = compressed.slice(0, compressed.length / 2);
+    const truncated = compressed.slice(0, compressed.length / 2);
 
     // sync sanity
     assert.doesNotThrow(function() {
-      let decompressed = zlib[methods.decompSync](compressed);
+      const decompressed = zlib[methods.decompSync](compressed);
       assert.equal(decompressed, inputString);
     });
 

--- a/test/sequential/test-child-process-fork-getconnections.js
+++ b/test/sequential/test-child-process-fork-getconnections.js
@@ -6,7 +6,7 @@ const net = require('net');
 const count = 12;
 
 if (process.argv[2] === 'child') {
-  let sockets = [];
+  const sockets = [];
 
   process.on('message', function(m, socket) {
     function sendClosed(id) {
@@ -42,7 +42,7 @@ if (process.argv[2] === 'child') {
   });
 
   const server = net.createServer();
-  let sockets = [];
+  const sockets = [];
   let sent = 0;
 
   server.on('connection', function(socket) {


### PR DESCRIPTION
Description from: http://eslint.org/docs/rules/prefer-const.html

If a variable is never modified, using the `const` declaration is
better. `const` declaration tells readers, "this variable is never
modified," reducing cognitive load and improving maintainability.

Refer: https://github.com/nodejs/node/issues/3118