### PR TITLE
crypto: enable FIPS only when configured with it

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -228,6 +228,9 @@
             'src/tls_wrap.h'
           ],
           'conditions': [
+            ['openssl_fips != ""', {
+              'defines': [ 'NODE_FIPS_MODE' ],
+            }],
             [ 'node_shared_openssl=="false"', {
               'dependencies': [
                 './deps/openssl/openssl.gyp:openssl',

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5321,13 +5321,13 @@ void InitCryptoOnce() {
   CRYPTO_set_locking_callback(crypto_lock_cb);
   CRYPTO_THREADID_set_callback(crypto_threadid_cb);
 
-#ifdef OPENSSL_FIPS
+#ifdef NODE_FIPS_MODE
   if (!FIPS_mode_set(1)) {
     int err = ERR_get_error();
     fprintf(stderr, "openssl fips failed: %s\n", ERR_error_string(err, NULL));
     UNREACHABLE();
   }
-#endif  // OPENSSL_FIPS
+#endif  // NODE_FIPS_MODE
 
 
   // Turn off compression. Saves memory and protects against CRIME attacks.


### PR DESCRIPTION
Do not rely on `OPENSSL_FIPS` in `node_crypto.cc` when building with
shared FIPS-enabled OpenSSL library. Enable FIPS in core only when
configured with `--openssl-fips`.

Fix: https://github.com/nodejs/node/issues/3077

cc @nodejs/crypto 