### PR TITLE
deps: backport 03ef3cd from V8 upstream

### DIFF
--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -147,7 +147,7 @@ class CodeEventLogger::NameBuffer {
 
  private:
   static const int kUtf8BufferSize = 512;
-  static const int kUtf16BufferSize = 128;
+  static const int kUtf16BufferSize = kUtf8BufferSize;
 
   int utf8_pos_;
   char utf8_buffer_[kUtf8BufferSize];


### PR DESCRIPTION
Reduces likelihood of the filename being truncated in /tmp/perf-*.map when
profiling with --perf_basic_prof.

R=@bnoordhuis

https://github.com/v8/v8/commit/03ef3cd004c2fd31ae7e48772f106df67b8c2feb

Original commit message:
  improve perf_basic_prof filename reporting

  The buffer used for appending filenames to the string printed to the
  perf_basic_prof log was unnecessarily too small. Bump it up to be at least
  kUtf8BufferSize.

  Truncation of filenames makes it really hard to work with profiles gathered on
  Node.js. Because of the way Node.js works, you can have node module dependencies
  in deeply nested directories. The last thing you want when investigating a
  performance problem is to have script names be truncated.

  This patch is a stop-gap. Ideally, I want no truncation of the filename at all
  and use a dynamically growing buffer. That would be a larger change, and I
  wanted to have a quick fix available that can be back-ported to Node.js LTS
  release.

  R=yangguo@chromium.org,yurys@chromium.org
  BUG=

  Review URL: https://codereview.chromium.org/1388543002

  Cr-Commit-Position: refs/heads/master@{#31092}