### PR TITLE
test: remove arguments.callee usage

### DIFF
--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -30,7 +30,7 @@ function expect_errno(syscall, resource, err, errno) {
   if (err && (err.code === errno || err.code === 'ENOSYS')) {
     tests_ok++;
   } else {
-    console.log('FAILED:', arguments.callee.name, util.inspect(arguments));
+    console.log('FAILED:', 'expect_errno', util.inspect(arguments));
   }
 }
 
@@ -39,7 +39,7 @@ function expect_ok(syscall, resource, err, atime, mtime) {
       err && err.code === 'ENOSYS') {
     tests_ok++;
   } else {
-    console.log('FAILED:', arguments.callee.name, util.inspect(arguments));
+    console.log('FAILED:', 'expect_ok', util.inspect(arguments));
   }
 }
 


### PR DESCRIPTION
`arguments.callee` is forbidden in strict mode and the fact that it's being used masked a possible error in this test like in this case:

https://ci.nodejs.org/job/node-test-binary-arm/101/RUN_SUBSET=0,nodes=pi1-raspbian-wheezy/tapTestReport/test.tap-39/