### PR TITLE
Fix missing original env variable issue on multiple test cases.

### DIFF
--- a/test/parallel/test-child-process-spawnsync-env.js
+++ b/test/parallel/test-child-process-spawnsync-env.js
@@ -8,7 +8,7 @@ if (process.argv[2] === 'child') {
 } else {
   var expected = 'bar';
   var child = cp.spawnSync(process.execPath, [__filename, 'child'], {
-    env: {foo: expected}
+    env: Object.assign(process.env, { foo: expected })
   });
 
   assert.equal(child.stdout.toString().trim(), expected);

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -16,7 +16,7 @@ var callbacks = 0;
 function test(env, cb) {
   var filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
   var execPath = '"' + process.execPath + '" "' + filename + '"';
-  var options = { env: env || {} };
+  var options = { env: Object.assign(process.env, env) };
   exec(execPath, options, function(err, stdout, stderr) {
     assert(err);
     assert.equal(stdout, '');

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -53,12 +53,6 @@ function parent() {
   var serverExited = false;
   var clientExited = false;
   var serverListened = false;
-  var opt = {
-    env: {
-      NODE_DEBUG: 'net',
-      NODE_COMMON_PORT: process.env.NODE_COMMON_PORT,
-    }
-  };
 
   process.on('exit', function() {
     assert(serverExited);
@@ -75,7 +69,11 @@ function parent() {
     });
   }, common.platformTimeout(2000)).unref();
 
-  var s = spawn(node, [__filename, 'server'], opt);
+  var s = spawn(node, [__filename, 'server'], {
+    env: Object.assign(process.env, {
+      NODE_DEBUG: 'net'
+    })
+  });
   var c;
 
   wrap(s.stderr, process.stderr, 'SERVER 2>');

--- a/test/sequential/test-stdin-script-child.js
+++ b/test/sequential/test-stdin-script-child.js
@@ -4,9 +4,9 @@ var assert = require('assert');
 
 var spawn = require('child_process').spawn;
 var child = spawn(process.execPath, [], {
-  env: {
+  env: Object.assign(process.env, {
     NODE_DEBUG: process.argv[2]
-  }
+  })
 });
 var wanted = child.pid + '\n';
 var found = '';

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -27,12 +27,7 @@ function test(environ, shouldWrite) {
 
   var spawn = require('child_process').spawn;
   var child = spawn(process.execPath, [__filename, 'child'], {
-    // Lttng requires the HOME env variable or it prints to stderr,
-    // This is not really ideal, as it breaks this test, so the HOME
-    // env variable is passed to the child to make the test pass.
-    // this is fixed in the next version of lttng (2.7+), so we can
-    // remove it at sometime in the future.
-    env: { NODE_DEBUG: environ, HOME: process.env.HOME }
+    env: Object.assign(process.env, { NODE_DEBUG: environ })
   });
 
   expectErr = expectErr.split('%PID%').join(child.pid);


### PR DESCRIPTION
When the parent spawn the child processes, the environment variables passing into the child processes are missing the original env variables passing into the parent. Some missing variables like LD_LIBRARY_PATH cause the child processes unable to run.

PR-URL: #3183 