### PR TITLE
Fix missing original env variable issue on multiple test cases.

### DIFF
--- a/test/parallel/test-child-process-spawnsync-env.js
+++ b/test/parallel/test-child-process-spawnsync-env.js
@@ -7,9 +7,12 @@ if (process.argv[2] === 'child') {
   console.log(process.env.foo);
 } else {
   var expected = 'bar';
-  var child = cp.spawnSync(process.execPath, [__filename, 'child'], {
-    env: {foo: expected}
-  });
+  var opt = {
+    env: process.env
+  };
+  opt.env.foo = expected;
+
+  var child = cp.spawnSync(process.execPath, [__filename, 'child'], opt);
 
   assert.equal(child.stdout.toString().trim(), expected);
 }

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -25,13 +25,15 @@ function test(env, cb) {
   });
 }
 
-test({ NODE_DEBUG: '' }, function(data) {
+process.env.NODE_DEBUG = '';
+test(process.env, function(data) {
   assert(/EISDIR/.test(data));
   assert(!/test-fs-readfile-error/.test(data));
   callbacks++;
 });
 
-test({ NODE_DEBUG: 'fs' }, function(data) {
+process.env.NODE_DEBUG = 'fs';
+test(process.env, function(data) {
   assert(/EISDIR/.test(data));
   assert(/test-fs-readfile-error/.test(data));
   callbacks++;

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -54,11 +54,9 @@ function parent() {
   var clientExited = false;
   var serverListened = false;
   var opt = {
-    env: {
-      NODE_DEBUG: 'net',
-      NODE_COMMON_PORT: process.env.NODE_COMMON_PORT,
-    }
+    env: process.env
   };
+  opt.env.NODE_DEBUG = 'net';
 
   process.on('exit', function() {
     assert(serverExited);

--- a/test/sequential/test-stdin-script-child.js
+++ b/test/sequential/test-stdin-script-child.js
@@ -3,11 +3,12 @@ var common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;
-var child = spawn(process.execPath, [], {
-  env: {
-    NODE_DEBUG: process.argv[2]
-  }
-});
+var opt = {
+  env: process.env
+};
+
+opt.env.NODE_DEBUG = process.argv[2];
+var child = spawn(process.execPath, [], opt);
 var wanted = child.pid + '\n';
 var found = '';
 

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -26,14 +26,17 @@ function test(environ, shouldWrite) {
   var didTest = false;
 
   var spawn = require('child_process').spawn;
-  var child = spawn(process.execPath, [__filename, 'child'], {
-    // Lttng requires the HOME env variable or it prints to stderr,
-    // This is not really ideal, as it breaks this test, so the HOME
-    // env variable is passed to the child to make the test pass.
-    // this is fixed in the next version of lttng (2.7+), so we can
-    // remove it at sometime in the future.
-    env: { NODE_DEBUG: environ, HOME: process.env.HOME }
-  });
+  var opt = {
+    env: process.env
+  };
+  opt.env.NODE_DEBUG = environ;
+  // Lttng requires the HOME env variable or it prints to stderr,
+  // This is not really ideal, as it breaks this test, so the HOME
+  // env variable is passed to the child to make the test pass.
+  // this is fixed in the next version of lttng (2.7+), so we can
+  // remove it at sometime in the future.
+  opt.env.HOME = process.env.HOME;
+  var child = spawn(process.execPath, [__filename, 'child'], opt);
 
   expectErr = expectErr.split('%PID%').join(child.pid);
 


### PR DESCRIPTION
When the parent spawn the child processes, the environment variables passing into the child processes are missing the original env variables passing into the parent. Some missing variables like LD_LIBRARY_PATH cause the child processes unable to run.

PR-URL: #3183