### PR TITLE
standardizes references to 'userland' issue #3189

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2975,7 +2975,7 @@ https://iojs.org/api/tls.html
 - Added async session storage events.
 - Added async SNI callback.
 - Added multi-key server support (for example, ECDSA+RSA server).
-- Added optional callback to `checkServerIdentity` for manual certificate validation in user-land.
+- Added optional callback to `checkServerIdentity` for manual certificate validation in userland.
 - Added support for ECDSA/ECDHE cipher.
 - Implemented TLS streams in C++, boosting their performance.
 - Moved `createCredentials` to `tls` and renamed it to `createSecureContext`.

--- a/doc/tsc-meetings/io.js/2015-03-04.md
+++ b/doc/tsc-meetings/io.js/2015-03-04.md
@@ -117,7 +117,7 @@ Discussion of how we should probably just add more Buffer methods to core.
 
 Bert: there’s another aspect of this. At some point Node was really modern, but we’ve fallen behind. We can’t even get HTTP/2 or web sockets, we’re in trouble.
 
-Domenic: we’ve learned a lot over the last few years that pushes us to user-land code instead of in core. But we need to have some things be “official.”
+Domenic: we’ve learned a lot over the last few years that pushes us to userland code instead of in core. But we need to have some things be “official.”
 
 Trevor: I would like the infrastructure for HTTP/2 to be similar to HTTP/1, with http-parser etc.
 
@@ -125,9 +125,9 @@ Ben: is there any reason HTTP/2 couldn’t be done in pure JS?
 
 Discussion of http-parser and current HTTP/1 implementation strategy and speed.
 
-Bert: I think as a TC what we should say is “we would like to support HTTP/2, but want to see some user-land ideas first.” We don’t need to actually start implementation progress right now.
+Bert: I think as a TC what we should say is “we would like to support HTTP/2, but want to see some userland ideas first.” We don’t need to actually start implementation progress right now.
 
-Ben: does anyone on the TC want to write a user-land HTTP/2 module?
+Ben: does anyone on the TC want to write a userland HTTP/2 module?
 
 Discussion of how Fedor already has a SPDY implementation.
 


### PR DESCRIPTION
Decided to standardize from "user-land" to "userland" as the latter appears more frequently in the docs.