### PR TITLE
tools: apply linting to custom rules code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,7 +505,8 @@ bench-idle:
 	$(NODE) benchmark/idle_clients.js &
 
 jslint:
-	$(NODE) tools/eslint/bin/eslint.js src lib test tools/eslint-rules --rulesdir tools/eslint-rules --reset --quiet
+	$(NODE) tools/eslint/bin/eslint.js src lib test tools/eslint-rules \
+		--rulesdir tools/eslint-rules --reset --quiet
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc

--- a/Makefile
+++ b/Makefile
@@ -505,7 +505,7 @@ bench-idle:
 	$(NODE) benchmark/idle_clients.js &
 
 jslint:
-	$(NODE) tools/eslint/bin/eslint.js src lib test --rulesdir tools/eslint-rules --reset --quiet
+	$(NODE) tools/eslint/bin/eslint.js src lib test tools/eslint-rules --rulesdir tools/eslint-rules --reset --quiet
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc

--- a/tools/eslint-rules/require-buffer.js
+++ b/tools/eslint-rules/require-buffer.js
@@ -8,9 +8,9 @@ module.exports = function(context) {
     'Program:exit': function() {
       context.getScope().through.forEach(function(ref) {
         if (ref.identifier.name === 'Buffer') {
-            context.report(ref.identifier, msg);
+          context.report(ref.identifier, msg);
         }
       });
     }
-  }
-}
+  };
+};

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -246,7 +246,7 @@ goto jslint
 :jslint
 if not defined jslint goto exit
 echo running jslint
-%config%\node tools\eslint\bin\eslint.js src lib test --rulesdir tools\eslint-rules --reset --quiet
+%config%\node tools\eslint\bin\eslint.js src lib test tools\eslint-rules --rulesdir tools\eslint-rules --reset --quiet
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION
Node.js project-specific estlint rules should maintain the style of the rest of the project JS code base.

Ref: #3157 