### PR TITLE
doc: add method links in dns.markdown

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -8,9 +8,9 @@ This module contains functions that belong to two different categories:
 
 1) Functions that use the underlying operating system facilities to perform
 name resolution, and that do not necessarily do any network communication.
-This category contains only one function: `dns.lookup`. __Developers looking
+This category contains only one function: `dns.lookup()`. __Developers looking
 to perform name resolution in the same way that other applications on the same
-operating system behave should use `dns.lookup`.__
+operating system behave should use [`dns.lookup()`][dns.lookup].__
 
 Here is an example that does a lookup of `www.google.com`.
 
@@ -22,8 +22,8 @@ Here is an example that does a lookup of `www.google.com`.
 
 2) Functions that connect to an actual DNS server to perform name resolution,
 and that _always_ use the network to perform DNS queries. This category
-contains all functions in the `dns` module but `dns.lookup`. These functions
-do not use the same set of configuration files than what `dns.lookup` uses.
+contains all functions in the `dns` module but [`dns.lookup()`][dns.lookup]. These functions
+do not use the same set of configuration files than what [`dns.lookup()`][dns.lookup] uses.
 For instance, _they do not use the configuration from `/etc/hosts`_. These
 functions should be used by developers who do not want to use the underlying
 operating system's facilities for name resolution, and instead want to
@@ -98,7 +98,7 @@ Keep in mind that `err.code` will be set to `'ENOENT'` not only when
 the hostname does not exist but also when the lookup fails in other ways
 such as no available file descriptors.
 
-`dns.lookup` doesn't necessarily have anything to do with the DNS protocol.
+`dns.lookup()` doesn't necessarily have anything to do with the DNS protocol.
 It's only an operating system facility that can associate name with addresses,
 and vice versa.
 
@@ -144,25 +144,25 @@ one of the error codes listed below.
 
 ## dns.resolve4(hostname, callback)
 
-The same as `dns.resolve()`, but only for IPv4 queries (`A` records).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for IPv4 queries (`A` records).
 `addresses` is an array of IPv4 addresses (e.g.
 `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
 
 ## dns.resolve6(hostname, callback)
 
-The same as `dns.resolve4()` except for IPv6 queries (an `AAAA` query).
+The same as [`dns.resolve4()`](#dns_dns_resolve4_hostname_callback) except for IPv6 queries (an `AAAA` query).
 
 
 ## dns.resolveMx(hostname, callback)
 
-The same as `dns.resolve()`, but only for mail exchange queries (`MX` records).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for mail exchange queries (`MX` records).
 
 `addresses` is an array of MX records, each with a priority and an exchange
 attribute (e.g. `[{'priority': 10, 'exchange': 'mx.example.com'},...]`).
 
 ## dns.resolveTxt(hostname, callback)
 
-The same as `dns.resolve()`, but only for text queries (`TXT` records).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for text queries (`TXT` records).
 `addresses` is a 2-d array of the text records available for `hostname` (e.g.,
 `[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`). Each sub-array contains TXT chunks of
 one record. Depending on the use case, the could be either joined together or
@@ -170,14 +170,14 @@ treated separately.
 
 ## dns.resolveSrv(hostname, callback)
 
-The same as `dns.resolve()`, but only for service records (`SRV` records).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for service records (`SRV` records).
 `addresses` is an array of the SRV records available for `hostname`. Properties
 of SRV records are priority, weight, port, and name (e.g.,
 `[{'priority': 10, 'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]`).
 
 ## dns.resolveSoa(hostname, callback)
 
-The same as `dns.resolve()`, but only for start of authority record queries
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for start of authority record queries
 (`SOA` record).
 
 `addresses` is an object with the following structure:
@@ -196,13 +196,13 @@ The same as `dns.resolve()`, but only for start of authority record queries
 
 ## dns.resolveNs(hostname, callback)
 
-The same as `dns.resolve()`, but only for name server records (`NS` records).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for name server records (`NS` records).
 `addresses` is an array of the name server records available for `hostname`
 (e.g., `['ns1.example.com', 'ns2.example.com']`).
 
 ## dns.resolveCname(hostname, callback)
 
-The same as `dns.resolve()`, but only for canonical name records (`CNAME`
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for canonical name records (`CNAME`
 records). `addresses` is an array of the canonical name records available for
 `hostname` (e.g., `['bar.example.com']`).
 
@@ -261,7 +261,7 @@ Each DNS query can return one of the following error codes:
 
 ## Supported getaddrinfo flags
 
-The following flags can be passed as hints to `dns.lookup`.
+The following flags can be passed as hints to `dns.lookup()`.
 
 - `dns.ADDRCONFIG`: Returned address types are determined by the types
 of addresses supported by the current system. For example, IPv4 addresses
@@ -273,17 +273,17 @@ on some operating systems (e.g FreeBSD 10.1).
 
 ## Implementation considerations
 
-Although `dns.lookup` and `dns.resolve*/dns.reverse` functions have the same
+Although `dns.lookup()` and `dns.resolve*()/dns.reverse()` functions have the same
 goal of associating a network name with a network address (or vice versa),
 their behavior is quite different. These differences can have subtle but
 significant consequences on the behavior of Node.js programs.
 
 ### dns.lookup
 
-Under the hood, `dns.lookup` uses the same operating system facilities as most
-other programs. For instance, `dns.lookup` will almost always resolve a given
+Under the hood, `dns.lookup()` uses the same operating system facilities as most
+other programs. For instance, `dns.lookup()` will almost always resolve a given
 name the same way as the `ping` command. On most POSIX-like operating systems,
-the behavior of the `dns.lookup` function can be tweaked by changing settings
+the behavior of the `dns.lookup()` function can be tweaked by changing settings
 in `nsswitch.conf(5)` and/or `resolv.conf(5)`, but be careful that changing
 these files will change the behavior of all other programs running on the same
 operating system.
@@ -302,13 +302,16 @@ documentation](http://docs.libuv.org/en/latest/threadpool.html).
 
 ### dns.resolve, functions starting with dns.resolve and dns.reverse
 
-These functions are implemented quite differently than `dns.lookup`. They do
+These functions are implemented quite differently than `dns.lookup()`. They do
 not use `getaddrinfo(3)` and they _always_ perform a DNS query on the network.
 This network communication is always done asynchronously, and does not use
 libuv's threadpool.
 
 As a result, these functions cannot have the same negative impact on other
-processing that happens on libuv's threadpool that `dns.lookup` can have.
+processing that happens on libuv's threadpool that `dns.lookup()` can have.
 
-They do not use the same set of configuration files than what `dns.lookup`
+They do not use the same set of configuration files than what `dns.lookup()`
 uses. For instance, _they do not use the configuration from `/etc/hosts`_.
+
+
+[dns.lookup]: #dns_dns_lookup_hostname_options_callback


### PR DESCRIPTION
Added links to referenced methods and added parenthesis to follow consistency.