### PR TITLE
buffer: FreeCallback should be tied to ArrayBuffer

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -356,7 +356,7 @@ MaybeLocal<Object> New(Environment* env,
   if (!mb.FromMaybe(false))
     return Local<Object>();
 
-  CallbackInfo::New(env->isolate(), ui, callback, hint);
+  CallbackInfo::New(env->isolate(), ab, callback, hint);
   return scope.Escape(ui);
 }
 

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -1,0 +1,36 @@
+#include <node.h>
+#include <node_buffer.h>
+#include <util.h>
+#include <v8.h>
+
+static int alive;
+static char buf[1024];
+
+static void FreeCallback(char* data, void* hint) {
+  alive--;
+}
+
+void Alloc(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  alive++;
+  args.GetReturnValue().Set(node::Buffer::New(
+        isolate,
+        buf,
+        sizeof(buf),
+        FreeCallback,
+        nullptr).ToLocalChecked());
+}
+
+void Check(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  isolate->RequestGarbageCollectionForTesting(
+      v8::Isolate::kFullGarbageCollection);
+  CHECK_GT(alive, 0);
+}
+
+void init(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "alloc", Alloc);
+  NODE_SET_METHOD(target, "check", Check);
+}
+
+NODE_MODULE(binding, init);

--- a/test/addons/buffer-free-callback/binding.gyp
+++ b/test/addons/buffer-free-callback/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -1,0 +1,9 @@
+'use strict';
+// Flags: --expose-gc
+
+var assert = require('assert');
+var binding = require('./build/Release/binding');
+var buf = binding.alloc();
+var slice = buf.slice(32);
+buf = null;
+binding.check(slice);


### PR DESCRIPTION
FreeCallback should be invoked on the storage disposal (`ArrayBuffer`),
not when the view (`Uint8Array` or `Buffer`) is disposed. This causes
bug and crashes in addons which create buffers and store only slices of
them.

cc @trevnorris @bnoordhuis @nodejs/collaborators 