### PR TITLE
build: make icu download path customisable

### DIFF
--- a/configure
+++ b/configure
@@ -296,6 +296,12 @@ intl_optgroup.add_option('--download',
     dest='download_list',
     help=nodedownload.help())
 
+intl_optgroup.add_option('--download-path',
+    action='store',
+    dest='download_path',
+    default=os.path.join(root_dir, 'deps'),
+    help='Download directory [default: %default]')
+
 parser.add_option_group(intl_optgroup)
 
 parser.add_option('--with-perfctr',
@@ -844,11 +850,15 @@ def configure_intl(o):
   ]
   def icu_download(path):
     # download ICU, if needed
+    if not os.access(options.download_path, os.W_OK):
+      print 'Error: cannot write to desired download path. ' \
+            'Either create it or verify permissions.'
+      sys.exit(1)
     for icu in icus:
       url = icu['url']
       md5 = icu['md5']
       local = url.split('/')[-1]
-      targetfile = os.path.join(root_dir, 'deps', local)
+      targetfile = os.path.join(options.download_path, local)
       if not os.path.isfile(targetfile):
         if nodedownload.candownload(auto_downloads, "icu"):
           nodedownload.retrievefile(url, targetfile)


### PR DESCRIPTION
This makes it easier to store icu tarballs outside of the node.js directory which is useful in our CI where git directories are scrubbed between runs.

/R=@srl295, @rvagg 