### PR TITLE
async_wrap: correctly pass parent to init callback

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -123,8 +123,6 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   env->set_async_hooks_init_function(args[0].As<Function>());
   env->set_async_hooks_pre_function(args[1].As<Function>());
   env->set_async_hooks_post_function(args[2].As<Function>());
-
-  env->set_using_asyncwrap(true);
 }
 
 
@@ -146,6 +144,10 @@ static void Initialize(Local<Object> target,
   NODE_ASYNC_PROVIDER_TYPES(V)
 #undef V
   target->Set(FIXED_ONE_BYTE_STRING(isolate, "Providers"), async_providers);
+
+  env->set_async_hooks_init_function(Local<Function>());
+  env->set_async_hooks_pre_function(Local<Function>());
+  env->set_async_hooks_post_function(Local<Function>());
 }
 
 
@@ -164,6 +166,8 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
                                       Local<Value>* argv) {
   CHECK(env()->context() == env()->isolate()->GetCurrentContext());
 
+  Local<Function> pre_fn = env()->async_hooks_pre_function();
+  Local<Function> post_fn = env()->async_hooks_post_function();
   Local<Object> context = object();
   Local<Object> process = env()->process_object();
   Local<Object> domain;
@@ -179,7 +183,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
     }
   }
 
-  TryCatch try_catch;
+  TryCatch try_catch(env()->isolate());
   try_catch.SetVerbose(true);
 
   if (has_domain) {
@@ -191,9 +195,9 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
     }
   }
 
-  if (has_async_queue()) {
+  if (ran_init_callback() && !pre_fn.IsEmpty()) {
     try_catch.SetVerbose(false);
-    env()->async_hooks_pre_function()->Call(context, 0, nullptr);
+    pre_fn->Call(context, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::AsyncWrap::MakeCallback", "pre hook threw");
     try_catch.SetVerbose(true);
@@ -205,9 +209,9 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
     return Undefined(env()->isolate());
   }
 
-  if (has_async_queue()) {
+  if (ran_init_callback() && !post_fn.IsEmpty()) {
     try_catch.SetVerbose(false);
-    env()->async_hooks_post_function()->Call(context, 0, nullptr);
+    post_fn->Call(context, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::AsyncWrap::MakeCallback", "post hook threw");
     try_catch.SetVerbose(true);

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -70,7 +70,7 @@ class AsyncWrap : public BaseObject {
 
  private:
   inline AsyncWrap();
-  inline bool has_async_queue() const;
+  inline bool ran_init_callback() const;
 
   // When the async hooks init JS function is called from the constructor it is
   // expected the context object will receive a _asyncQueue object property

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -208,7 +208,6 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate(), loop)),
       timer_base_(uv_now(loop)),
       using_domains_(false),
-      using_asyncwrap_(false),
       printed_error_(false),
       trace_sync_io_(false),
       debugger_agent_(this),
@@ -346,14 +345,6 @@ inline bool Environment::using_domains() const {
 
 inline void Environment::set_using_domains(bool value) {
   using_domains_ = value;
-}
-
-inline bool Environment::using_asyncwrap() const {
-  return using_asyncwrap_;
-}
-
-inline void Environment::set_using_asyncwrap(bool value) {
-  using_asyncwrap_ = value;
 }
 
 inline bool Environment::printed_error() const {

--- a/src/env.h
+++ b/src/env.h
@@ -435,9 +435,6 @@ class Environment {
   inline bool using_domains() const;
   inline void set_using_domains(bool value);
 
-  inline bool using_asyncwrap() const;
-  inline void set_using_asyncwrap(bool value);
-
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
 
@@ -537,7 +534,6 @@ class Environment {
   ares_channel cares_channel_;
   ares_task_list cares_task_list_;
   bool using_domains_;
-  bool using_asyncwrap_;
   bool printed_error_;
   bool trace_sync_io_;
   debugger::Agent debugger_agent_;

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const async_wrap = process.binding('async_wrap');
+const providers = Object.keys(async_wrap.Providers);
+
+let cntr = 0;
+let server;
+let client;
+
+function init(type, parent) {
+  if (parent) {
+    cntr++;
+    // Cannot assert in init callback or will abort.
+    process.nextTick(() => {
+      assert.equal(providers[type], 'TCPWRAP');
+      assert.equal(parent, server._handle, 'server doesn\'t match parent');
+      assert.equal(this, client._handle, 'client doesn\'t match context');
+    });
+  }
+}
+
+function noop() { }
+
+async_wrap.setupHooks(init, noop, noop);
+async_wrap.enable();
+
+server = net.createServer(function(c) {
+  client = c;
+  // Allow init callback to run before closing.
+  setImmediate(() => {
+    c.end();
+    this.close();
+  });
+}).listen(common.PORT, function() {
+  net.connect(common.PORT, noop);
+});
+
+async_wrap.disable();
+
+process.on('exit', function() {
+  // init should have only been called once with a parent.
+  assert.equal(cntr, 1);
+});

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const async_wrap = process.binding('async_wrap');
+
+let cntr = 0;
+let server;
+let client;
+
+function init(type, parent) {
+  if (parent) {
+    cntr++;
+    // Cannot assert in init callback or will abort.
+    process.nextTick(() => {
+      assert.equal(parent, server._handle, 'server doesn\'t match parent');
+      assert.equal(this, client._handle, 'client doesn\'t match context');
+    });
+  }
+}
+
+function noop() { }
+
+async_wrap.setupHooks(init, noop, noop);
+async_wrap.enable();
+
+server = net.createServer(function(c) {
+  client = c;
+  // Allow init callback to run before closing.
+  setImmediate(() => {
+    c.end();
+    this.close();
+  });
+}).listen(common.PORT, function() {
+  net.connect(common.PORT, noop);
+});
+
+
+process.on('exit', function() {
+  // init should have only been called once with a parent.
+  assert.equal(cntr, 1);
+});


### PR DESCRIPTION
Previous logic didn't allow parent to propagate to the init callback
properly. The fix now allows the init callback to be called and passed
the parent if:

- async wrap callbacks are enabled and parent exists
- the init callback has been called on the parent and an init callback
  exists then it will be called regardless of whether async wrap
  callbacks are disabled.

Change the init/pre/post callback checks to see if it has been properly
set. This allows removal of the Environment "using_asyncwrap" variable.

Pass Isolate to TryCatch instance.

R=@bnoordhuis 

CI: https://ci.nodejs.org/job/node-test-pull-request/428/