### PR TITLE
util: fix for inspecting promises

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -6,7 +6,6 @@ const internalUtil = require('internal/util');
 const binding = process.binding('util');
 
 var Debug;
-var ObjectIsPromise;
 
 const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
@@ -189,16 +188,14 @@ function getConstructorOf(obj) {
 function ensureDebugIsInitialized() {
   if (Debug === undefined) {
     const runInDebugContext = require('vm').runInDebugContext;
-    const result = runInDebugContext('[Debug, ObjectIsPromise]');
-    Debug = result[0];
-    ObjectIsPromise = result[1];
+    Debug = runInDebugContext('Debug');
   }
 }
 
 
 function inspectPromise(p) {
   ensureDebugIsInitialized();
-  if (!ObjectIsPromise(p))
+  if (!binding.isPromise(p))
     return null;
   const mirror = Debug.MakeMirror(p, true);
   return {status: mirror.status(), value: mirror.promiseValue().value_};

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -23,6 +23,10 @@ static void IsSetIterator(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(args[0]->IsSetIterator());
 }
 
+static void IsPromise(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(args[0]->IsPromise());
+}
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -30,6 +34,7 @@ void Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "isMapIterator", IsMapIterator);
   env->SetMethod(target, "isSetIterator", IsSetIterator);
+  env->SetMethod(target, "isPromise", IsPromise);
 }
 
 }  // namespace util


### PR DESCRIPTION
The upgrade to v8 4.6 removed ObjectIsPromise. This change utilizes
v8::Value::IsPromise to verify that the argument is indeed a promise.

Ref: https://github.com/nodejs/node/pull/3197#issuecomment-145995043