### PR TITLE
tools: remove leftover license boilerplate

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -1,5 +1,3 @@
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 var processIncludes = require('./preprocess.js');
 var marked = require('marked');
 var fs = require('fs');


### PR DESCRIPTION
This last line was missed in 3e1b1dd4a9ac048105a4dc4cd81578e26d39a1fc.