### PR TITLE
test: linting for buffer-free-callback test

### DIFF
--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -1,6 +1,7 @@
 'use strict';
 // Flags: --expose-gc
 
+require('../../common');
 var assert = require('assert');
 var binding = require('./build/Release/binding');
 var buf = binding.alloc();


### PR DESCRIPTION
Test added in d1f24044 does not pass linting rule added in 3de353b5.
Fixed in this commit. `common` module required in all tests except
those that intentionally leak variables.

Fixes: https://github.com/nodejs/node/issues/3229