### PR TITLE
test: pipe requires tmpdir

### DIFF
--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -47,9 +47,7 @@ new (process.binding('tty_wrap').TTY)();
 
 crypto.randomBytes(1, noop);
 
-try {
-  fs.unlinkSync(common.PIPE);
-} catch(e) { }
+common.refreshTmpDir();
 
 net.createServer(function(c) {
   c.end();

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -36,6 +36,7 @@ if (cluster.isMaster) {
   });
 
 } else {
+  common.refreshTmpDir();
   var cp = fork(common.fixturesDir + '/listen-on-socket-and-exit.js',
                 { stdio: 'inherit' });
 

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -14,6 +14,8 @@ var server = http.createServer(function(req, res) {
   });
 });
 
+common.refreshTmpDir();
+
 server.listen(common.PIPE, function() {
   var req = http.request({
     socketPath: common.PIPE,

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -11,6 +11,8 @@ process.on('exit', function() {
   assert(gotDomainError);
 });
 
+common.refreshTmpDir();
+
 // first fire up a simple HTTP server
 var server = http.createServer(function(req, res) {
   res.writeHead(200);

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -18,6 +18,8 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
+common.refreshTmpDir();
+
 server.listen(common.PIPE, function() {
 
   var options = {

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -106,7 +106,7 @@ function pingPongTest(port, host) {
 }
 
 /* All are run at once, so run on different ports */
-console.log(common.PIPE);
+common.refreshTmpDir();
 pingPongTest(common.PIPE);
 pingPongTest(common.PORT);
 pingPongTest(common.PORT + 1, 'localhost');

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -21,6 +21,7 @@ if (common.isWindows) {
 } else {
   // use common.PIPE to ensure we stay within POSIX socket path length
   // restrictions, even on CI
+  common.refreshTmpDir();
   emptyTxt = common.PIPE + '.txt';
 
   function cleanup() {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -3,6 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 
 common.globalCheck = false;
+common.refreshTmpDir();
 
 var net = require('net'),
     repl = require('repl'),

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -18,6 +18,8 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
+common.refreshTmpDir();
+
 var server = tls.Server(options, function(socket) {
   ++serverConnected;
   server.close();

--- a/test/sequential/test-pipe-address.js
+++ b/test/sequential/test-pipe-address.js
@@ -9,6 +9,8 @@ var server = net.createServer(function() {
   assert(false); // should not be called
 });
 
+common.refreshTmpDir();
+
 server.listen(common.PIPE, function() {
   address = server.address();
   server.close();

--- a/test/sequential/test-pipe-stream.js
+++ b/test/sequential/test-pipe-stream.js
@@ -3,6 +3,8 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
+common.refreshTmpDir();
+
 function test(clazz, cb) {
   var have_ping = false;
   var have_pong = false;

--- a/test/sequential/test-pipe-unref.js
+++ b/test/sequential/test-pipe-unref.js
@@ -5,6 +5,8 @@ var assert = require('assert');
 var net = require('net');
 var closed = false;
 
+common.refreshTmpDir();
+
 var s = net.Server();
 s.listen(common.PIPE);
 s.unref();


### PR DESCRIPTION
Fixes #3227 

Except on Windows, `common.PIPE` is in the temp directory. So tests that use `common.PIPE` need to call `common.refreshTmpDir()`. I dislike the non-obvious coupling of those two things, and maybe there's a better solution, but for the moment at least, this fixes it.