### PR TITLE
Revert "deps: backport 03ef3cd from V8 upstream"

### DIFF
--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -147,7 +147,7 @@ class CodeEventLogger::NameBuffer {
 
  private:
   static const int kUtf8BufferSize = 512;
-  static const int kUtf16BufferSize = kUtf8BufferSize;
+  static const int kUtf16BufferSize = 128;
 
   int utf8_pos_;
   char utf8_buffer_[kUtf8BufferSize];


### PR DESCRIPTION
This reverts commit 6fff47ffacfe663efeb0d31ebd700a65bf5521ba as it is causing
issues in upstream: https://codereview.chromium.org/1390923004/

Original PR: #3165.

R=@bnoordhuis, @targos 