### PR TITLE
buffer: More useful error when .toString() fails

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -370,8 +370,10 @@ Buffer.prototype.toString = function() {
   } else {
     var result = slowToString.apply(this, arguments);
   }
-  if (result === undefined)
-    throw new Error('toString failed');
+  if (result === undefined) {
+    throw new RangeError('toString() failed: buffer larger than maximum ' +
+                         `string size of ${binding.kStringMaxLength} bytes`);
+  }
   return result;
 };
 

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -129,31 +129,31 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
 
   assert.throws(function() {
     buf1.toString();
-  }, /toString failed|Invalid array buffer length/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   assert.throws(function() {
     buf1.toString('ascii');
-  }, /toString failed/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   assert.throws(function() {
     buf1.toString('utf8');
-  }, /toString failed/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   assert.throws(function() {
     buf0.toString('utf16le');
-  }, /toString failed/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   assert.throws(function() {
     buf1.toString('binary');
-  }, /toString failed/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   assert.throws(function() {
     buf1.toString('base64');
-  }, /toString failed/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   assert.throws(function() {
     buf1.toString('hex');
-  }, /toString failed/);
+  }, RangeError, /toString\(\) failed: buffer larger than maximum/);
 
   var maxString = buf2.toString();
   assert.equal(maxString.length, kStringMaxLength);


### PR DESCRIPTION
Fixes: #3175

As brought up by @mhart in #3175 the current error message for buffer.toString() is not very helpful. The new message reports that the failure is due to the buffer being larger than the maximum string size, and reports that value.

This is able to be done without any changes to the code as the only code path that will return ```undefined``` is when length > kMaxLength.

https://github.com/nodejs/node/blob/64beab0fc55f750bae648e9b69e027f2dbf3b18a/deps/v8/include/v8.h#L2294-L2324

In a conversation on irc with @trevnorris a test was performed to verify that there does not appear to be a scenario where StringBytes::Encode() could throw that would allow slowToString() to also throw.

"since it should be impossible for it to throw otherwise, and explicitly returning an empty handle means String::kMaxLength was exceeded." ~ @trevnorris