### PR TITLE
doc: make types in API docs not blend visually with description

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -342,7 +342,7 @@ li code {
 }
 
 span.type {
-  color: #222;
+  color: #00b192;
 }
 
 #content {


### PR DESCRIPTION
Let's make types look differently from the rest of the text at least somehow (color, italic, whatever).

That's what it looks like without this change:
![image](https://cloud.githubusercontent.com/assets/94334/10349792/e88b3a3c-6d48-11e5-9bd6-b5f35c14ffe8.png)