### PR TITLE
doc: Clarify the use of `option.detached`

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -535,9 +535,10 @@ file:
      child.unref();
 
 When using the `detached` option to start a long-running process, the process
-will not stay running in the background unless it is provided with a `stdio`
-configuration that is not connected to the parent.  If the parent's `stdio` is
-inherited, the child will remain attached to the controlling terminal.
+will not stay running in the background after the parent exits unless it is
+provided with a `stdio` configuration that is not connected to the parent.
+If the parent's `stdio` is inherited, the child will remain attached to the
+controlling terminal.
 
 See also: `child_process.exec()` and `child_process.fork()`
 


### PR DESCRIPTION
This paragraph conveys that detached child processes do not stay
running in the background in general. Instead clarify that this refers
to the parent process exiting before the detached child process is
complete.