### PR TITLE
test: remove common.inspect()

### DIFF
--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -94,14 +94,10 @@ function test_simple_relative_symlink(callback) {
   });
   var result = fs.realpathSync(entry);
   assert.equal(result, path.resolve(expected),
-      'got ' + common.inspect(result) + ' expected ' +
-      common.inspect(expected));
+      'got ' + result + ' expected ' + expected);
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(expected));
+        'got ' + result + ' expected ' + expected);
   });
 }
 
@@ -126,16 +122,10 @@ function test_simple_absolute_symlink(callback) {
   });
   var result = fs.realpathSync(entry);
   assert.equal(result, path.resolve(expected),
-      'got ' +
-      common.inspect(result) +
-      ' expected ' +
-      common.inspect(expected));
+      'got ' + result + ' expected ' + expected);
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(expected));
+        'got ' + result + ' expected ' + expected);
   });
 }
 
@@ -164,10 +154,7 @@ function test_deep_relative_file_symlink(callback) {
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(path.resolve(expected)));
+        'got ' + result + ' expected ' + path.resolve(expected));
   });
 }
 
@@ -196,10 +183,7 @@ function test_deep_relative_dir_symlink(callback) {
 
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(path.resolve(expected)));
+        'got ' + result + ' expected ' + path.resolve(expected));
   });
 }
 
@@ -281,10 +265,7 @@ function test_relative_input_cwd(callback) {
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     process.chdir(origcwd);
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(path.resolve(expected)));
+        'got ' + result + ' expected ' + path.resolve(expected));
     return true;
   });
 }
@@ -337,10 +318,7 @@ function test_deep_symlink_mix(callback) {
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(path.resolve(expected)));
+        'got ' + result + ' expected ' + path.resolve(expected));
     return true;
   });
 }
@@ -356,10 +334,7 @@ function test_non_symlinks(callback) {
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     process.chdir(origcwd);
     assert.equal(result, path.resolve(expected),
-        'got ' +
-        common.inspect(result) +
-        ' expected ' +
-        common.inspect(path.resolve(expected)));
+        'got ' + result + ' expected ' + path.resolve(expected));
     return true;
   });
 }

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -93,11 +93,9 @@ function test_simple_relative_symlink(callback) {
     unlink.push(t[0]);
   });
   var result = fs.realpathSync(entry);
-  assert.equal(result, path.resolve(expected),
-      'got ' + result + ' expected ' + expected);
+  assert.equal(result, path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + expected);
+    assert.equal(result, path.resolve(expected));
   });
 }
 
@@ -121,11 +119,9 @@ function test_simple_absolute_symlink(callback) {
     unlink.push(t[0]);
   });
   var result = fs.realpathSync(entry);
-  assert.equal(result, path.resolve(expected),
-      'got ' + result + ' expected ' + expected);
+  assert.equal(result, path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + expected);
+    assert.equal(result, path.resolve(expected));
   });
 }
 
@@ -153,8 +149,7 @@ function test_deep_relative_file_symlink(callback) {
 
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + path.resolve(expected));
+    assert.equal(result, path.resolve(expected));
   });
 }
 
@@ -182,8 +177,7 @@ function test_deep_relative_dir_symlink(callback) {
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
 
   asynctest(fs.realpath, [entry], callback, function(err, result) {
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + path.resolve(expected));
+    assert.equal(result, path.resolve(expected));
   });
 }
 
@@ -264,8 +258,7 @@ function test_relative_input_cwd(callback) {
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     process.chdir(origcwd);
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + path.resolve(expected));
+    assert.equal(result, path.resolve(expected));
     return true;
   });
 }
@@ -317,8 +310,7 @@ function test_deep_symlink_mix(callback) {
   var expected = tmpAbsDir + '/cycles/root.js';
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + path.resolve(expected));
+    assert.equal(result, path.resolve(expected));
     return true;
   });
 }
@@ -333,8 +325,7 @@ function test_non_symlinks(callback) {
   assert.equal(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     process.chdir(origcwd);
-    assert.equal(result, path.resolve(expected),
-        'got ' + result + ' expected ' + path.resolve(expected));
+    assert.equal(result, path.resolve(expected));
     return true;
   });
 }

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -3,5 +3,4 @@ var common = require('../common');
 var assert = require('assert');
 
 var r = process.memoryUsage();
-console.log(common.inspect(r));
 assert.equal(true, r['rss'] > 0);

--- a/test/sequential/test-memory-usage-emfile.js
+++ b/test/sequential/test-memory-usage-emfile.js
@@ -10,5 +10,4 @@ while (files.length < 256)
   files.push(fs.openSync(__filename, 'r'));
 
 var r = process.memoryUsage();
-console.log(common.inspect(r));
 assert.equal(true, r['rss'] > 0);


### PR DESCRIPTION
`common.inspect()` is just `util.inspect()`. `common` copies every property
from `util` but this is the only one that gets used and it only gets used
in three files. Well, four, but the fourth is removed in a pending #3256.

This commit removes it. Subsequently, the "copy util to common"
part of `common` can be removed altogether.