### PR TITLE
assert: support arrow functions in .throws()

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -268,13 +268,17 @@ function expectedException(actual, expected) {
 
   if (Object.prototype.toString.call(expected) == '[object RegExp]') {
     return expected.test(actual);
-  } else if (actual instanceof expected) {
-    return true;
-  } else if (expected.call({}, actual) === true) {
-    return true;
   }
 
-  return false;
+  try {
+    if (actual instanceof expected) {
+      return true;
+    }
+  } catch (e) {
+    // Ignore.  The instanceof check doesn't work for arrow functions.
+  }
+
+  return expected.call({}, actual) === true;
 }
 
 function _throws(shouldThrow, block, expected, message) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -465,4 +465,8 @@ testBlockTypeError(assert.doesNotThrow, null);
 testBlockTypeError(assert.throws, undefined);
 testBlockTypeError(assert.doesNotThrow, undefined);
 
+// https://github.com/nodejs/node/issues/3275
+assert.throws(() => { throw 'error'; }, err => err === 'error');
+assert.throws(() => { throw Error(); }, err => err instanceof Error);
+
 console.log('All OK');


### PR DESCRIPTION
`x instanceof f` where f is an arrow function throws a (spec-conforming)
"Function has non-object prototype 'undefined' in instanceof check"
exception.

Add a workaround so that it's possible to pass arrow functions as the
second argument to assert.throws().  The try/catch block is a little
jarring but swapping around the clauses in the if statements changes
the semantics too much.

Fixes: https://github.com/nodejs/node/issues/3275

R=@thefourtheye

CI: https://ci.nodejs.org/job/node-test-pull-request/453/