### PR TITLE
Make tests usable with debug release

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -246,21 +246,23 @@ exports.spawnPwd = function(options) {
 };
 
 exports.platformTimeout = function(ms) {
-  if (process.config.target_defaults.default_configuration === 'Debug')
-    ms = 2 * ms;
+  var newTimeout = ms;
 
-  if (process.arch !== 'arm')
-    return ms;
+  if (process.arch === 'arm') {
+    const armv = process.config.variables.arm_version;
 
-  const armv = process.config.variables.arm_version;
+    if (armv === '6') // ARMv6
+      newTimeout *= 7;  
 
-  if (armv === '6')
-    return 7 * ms;  // ARMv6
+    if (armv === '7') // ARMv7
+      newTimeout *= 2; 
+  }
 
-  if (armv === '7')
-    return 2 * ms;  // ARMv7
+  if (process.features.debug) {
+    newTimeout *= 5;
+  }
 
-  return ms; // ARMv8+
+  return newTimeout;
 };
 
 var knownGlobals = [setTimeout,

--- a/test/common.js
+++ b/test/common.js
@@ -262,6 +262,10 @@ exports.platformTimeout = function(ms) {
     newTimeout *= 5;
   }
 
+  if (process.env.TEST_TIMEOUT_MULTIPLIER !== undefined) {
+    newTimeout = ms * process.env.TEST_TIMEOUT_MULTIPLIER;
+  }
+
   return newTimeout;
 };
 

--- a/test/parallel/test-cluster-debug-port.js
+++ b/test/parallel/test-cluster-debug-port.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 
 if (cluster.isMaster) {
-  assert.strictEqual(process.execArgv.length, 0, 'run test with no args');
+  assert.strictEqual(process.argv.length, 2, 'run test with no args');
 
   function checkExitCode(code, signal) {
     assert.strictEqual(code, 0);
@@ -28,11 +28,11 @@ if (cluster.isMaster) {
     portSet: process.debugPort + 2
   }).on('exit', checkExitCode);
 } else {
-  const hasDebugArg = process.execArgv.some(function(arg) {
-    return /debug/.test(arg);
+  const hasDebugPortArg = process.execArgv.some(function(arg) {
+    return /debug-port/.test(arg);
   });
 
-  assert.strictEqual(hasDebugArg, process.env.portSet !== undefined);
+  assert.strictEqual(hasDebugPortArg, process.env.portSet !== undefined);
   assert.strictEqual(process.debugPort, +process.env.portSet || 5858);
   process.exit();
 }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -427,4 +427,4 @@ unix_test();
 
 timer = setTimeout(function() {
   assert.fail(null, null, 'Timeout');
-}, 5000);
+}, common.platformTimeout(5000));

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -61,6 +61,7 @@ class SimpleTestCase(test.TestCase):
 
   def GetCommand(self):
     result = [self.config.context.GetVm(self.arch, self.mode)]
+    result += self.config.context.GetVmFlags(self, self.mode)
     source = open(self.file).read()
     flags_match = FLAGS_PATTERN.search(source)
     if flags_match:


### PR DESCRIPTION
mode=debug multiply platformTimeout by 5
Add debug VmFlags to GetCommand (`--verify-heap --debug-code --enable-slow-asserts`)
Fixed tests that rely on zero arguments or hard coded timeouts
Possible to override platformTimeout with TEST_TIMEOUT_MULTIPLIER for longer timeouts for example with an asan debug release

Makes it possible to run `tools/test.py -J --mode=debug sequential message parallel`.
