### PR TITLE
build: Intl: deps: bump ICU to 56.1 (GA)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,9 @@ uninstall:
 
 clean:
 	-rm -rf out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE)
-	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' | xargs rm -rf; fi
+	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' -o -name '*.d' | xargs rm -rf; fi
 	-rm -rf node_modules
+	@if [ -d deps/icu ]; then echo deleting deps/icu; rm -rf deps/icu; fi
 	-rm -f test.tap
 
 distclean:

--- a/configure
+++ b/configure
@@ -843,9 +843,8 @@ def glob_to_var(dir_base, dir_sub, patch_dir):
 def configure_intl(o):
   icus = [
     {
-      'url': 'http://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.zip',
-      # from https://ssl.icu-project.org/files/icu4c/55.1/icu4c-src-55_1.md5:
-      'md5': '4cddf1e1d47622fdd9de2cd7bb5001fd',
+      'url': 'https://ssl.icu-project.org/files/icu4c/56.1/icu4c-56_1-src.zip',
+      'md5': '61d71888f14bf00cc3e8a6f2c087d367',
     },
   ]
   def icu_download(path):

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -99,6 +99,11 @@ if "%i18n_arg%"=="full-icu" set i18n_arg=--with-intl=full-icu
 if "%i18n_arg%"=="small-icu" set i18n_arg=--with-intl=small-icu
 if "%i18n_arg%"=="intl-none" set i18n_arg=--with-intl=none
 
+if not exist "%~dp0deps\icu" goto no-depsicu
+if "%target%"=="Clean" echo deleting %~dp0deps\icu
+if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
+:no-depsicu
+
 call :getnodeversion || exit /b 1
 
 @rem Set environment for msbuild


### PR DESCRIPTION
* ICU 56 was just released yesterday. Update to it.
* Notable changes: Unicode 8, CLDR 28, 2-3x number format perf,
  20% improvement in Collator startup
  * more at http://site.icu-project.org/download/56 or in #2917

Fixes: https://github.com/nodejs/node/issues/2917

@jasnell if you can land this in master also it would be great otherwise I will do later