### PR TITLE
js_stream: prevent abort if isalive doesn't exist

### DIFF
--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -44,7 +44,10 @@ AsyncWrap* JSStream::GetAsyncWrap() {
 
 
 bool JSStream::IsAlive() {
-  return MakeCallback(env()->isalive_string(), 0, nullptr)->IsTrue();
+  v8::Local<v8::Value> fn = object()->Get(env()->isalive_string());
+  if (!fn->IsFunction())
+    return false;
+  return MakeCallback(fn.As<v8::Function>(), 0, nullptr)->IsTrue();
 }
 
 

--- a/test/parallel/test-js-stream-call-properties.js
+++ b/test/parallel/test-js-stream-call-properties.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const common = require('../common');
+const util = require('util');
+const JSStream = process.binding('js_stream').JSStream;
+
+// Testing if will abort when properties are printed.
+util.inspect(new JSStream());


### PR DESCRIPTION
Attempting to check IsAlive() on a JSStream before the isAlive()
callback can be set in JS causes a CHECK to fail in MakeCallback.
Instead return false if the callback hasn't been set.

R=@indutny

CI: https://ci.nodejs.org/job/node-test-pull-request/455/