### PR TITLE
doc: Amend capitalization of word JavaScript

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -171,7 +171,7 @@ refer to an entry in `\\?\pipe\` or `\\.\pipe\`. Any characters are permitted,
 but the latter may do some processing of pipe names, such as resolving `..`
 sequences. Despite appearances, the pipe name space is flat.  Pipes will *not
 persist*, they are removed when the last reference to them is closed. Do not
-forget javascript string escaping requires paths to be specified with
+forget JavaScript string escaping requires paths to be specified with
 double-backslashes, such as:
 
     net.createServer().listen(

--- a/doc/node.1
+++ b/doc/node.1
@@ -35,7 +35,7 @@ Execute without arguments to start the REPL.
 
 .SH DESCRIPTION
 
-Node.js is a set of libraries for javascript which allows
+Node.js is a set of libraries for JavaScript which allows
 it to be used outside of the browser. It is primarily
 focused on creating simple, easy to build network clients
 and servers.


### PR DESCRIPTION
Standardizes the capitalization of the word 'JavaScript' across
documentation.