### PR TITLE
cache  module with same version and same registry

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,7 @@ const path = require('path');
 const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 
-
+var moduleCache = {};
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
 // See: https://github.com/joyent/node/issues/1707
@@ -76,7 +76,7 @@ function readPackage(requestPath) {
   }
 
   try {
-    var pkg = packageMainCache[requestPath] = JSON.parse(json).main;
+    var pkg = packageMainCache[requestPath] = JSON.parse(json);
   } catch (e) {
     e.path = jsonPath;
     e.message = 'Error parsing ' + jsonPath + ': ' + e.message;
@@ -88,9 +88,18 @@ function readPackage(requestPath) {
 function tryPackage(requestPath, exts) {
   var pkg = readPackage(requestPath);
 
-  if (!pkg) return false;
+  if (!(pkg && pkg.main)) return false;
 
-  var filename = path.resolve(requestPath, pkg);
+  var resolved = pkg['_resolved'],
+      main = pkg.main;
+
+  var filename;
+  if(resolved) {
+    filename =  moduleCache[resolved] || (moduleCache[resolved] = path.resolve(requestPath, main));
+  }else{
+    filename = path.resolve(requestPath, main);
+  }
+
   return tryFile(filename) || tryExtensions(filename, exts) ||
          tryExtensions(path.resolve(filename, 'index'), exts);
 }


### PR DESCRIPTION
related pr https://github.com/nodejs/node-v0.x-archive/pull/8617

in my project, I start a single node process and here are the  memoryUsage.

 without cache
 { rss: 84873216, heapTotal: 63907840, heapUsed: 38901048 }

and with cache
 { rss: 72458240, heapTotal: 62887936, heapUsed: 33719160 }


rss  ```14.6%↓``` , heapTotal ```1.59%↓```,  heapUsed  ```13.3%↓```