### PR TITLE
doc: Adding best practises for crypto.pbkdf2

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -625,9 +625,16 @@ Asynchronous PBKDF2 function.  Applies the selected HMAC digest function
 salt and number of iterations.  The callback gets two arguments:
 `(err, derivedKey)`.
 
+The number of iterations passed to pbkdf2 should be as high as possible, the
+higher the number, the more secure it will be, but will take a longer amount of
+time to complete.
+
+Chosen salts should also be unique. It is recommended that the salts are random
+and their length is greater than 16 bytes. See NIST 800-132 for details.
+
 Example:
 
-    crypto.pbkdf2('secret', 'salt', 4096, 64, 'sha256', function(err, key) {
+    crypto.pbkdf2('secret', 'salt', 100000, 512, 'sha512', function(err, key) {
       if (err)
         throw err;
       console.log(key.toString('hex'));  // 'c5e478d...1469e50'


### PR DESCRIPTION
Added some information around usages of how to use iterations, how to
choose decent salts and updating the example to have a significant work
factor and to use sha512.