### PR TITLE
Proposal: crypto: Make the digest parameter required for pbkdf2.

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -618,11 +618,11 @@ Example (obtaining a shared secret):
     /* alice_secret and bob_secret should be the same */
     console.log(alice_secret == bob_secret);
 
-## crypto.pbkdf2(password, salt, iterations, keylen[, digest], callback)
+## crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)
 
-Asynchronous PBKDF2 function.  Applies the selected HMAC digest function
-(default: SHA1) to derive a key of the requested length from the password,
-salt and number of iterations.  The callback gets two arguments:
+Asynchronous PBKDF2 function.  Applies the selected HMAC digest function to
+derive a key of the requested length from the password, salt and number of
+iterations.  The callback gets two arguments:
 `(err, derivedKey)`.
 
 Example:

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -537,9 +537,9 @@ exports.pbkdf2 = function(password,
                           keylen,
                           digest,
                           callback) {
-  if (typeof digest === 'function') {
-    callback = digest;
-    digest = undefined;
+
+  if (typeof digest !== 'string') {
+    throw new Error('No digest provided to pbkdf2');
   }
 
   if (typeof callback !== 'function')

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4831,7 +4831,8 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (digest == nullptr) {
-    digest = EVP_sha1();
+    type_error = "Bad digest name";
+    goto err;
   }
 
   obj = env->NewInternalFieldObject();

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -627,12 +627,14 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
-  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen);
+  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha1');
   assert.equal(actual, expected);
 
-  crypto.pbkdf2(password, salt, iterations, keylen, function(err, actual) {
+  function assertCb(err, actual) {
     assert.equal(actual, expected);
-  });
+  }
+
+  crypto.pbkdf2(password, salt, iterations, keylen, 'sha1', assertCb);
 }
 
 

--- a/test/parallel/test-crypto-domains.js
+++ b/test/parallel/test-crypto-domains.js
@@ -25,7 +25,7 @@ d.run(function() {
   one();
 
   function one() {
-    crypto.pbkdf2('a', 'b', 1, 8, function() {
+    crypto.pbkdf2('a', 'b', 1, 8, 'sha1', function() {
       two();
       throw new Error('pbkdf2');
     });

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -12,12 +12,14 @@ var crypto = require('crypto');
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
-  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen);
+  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha1');
   assert.equal(actual.toString('binary'), expected);
 
-  crypto.pbkdf2(password, salt, iterations, keylen, function(err, actual) {
+  function assertCb(err, actual) {
     assert.equal(actual.toString('binary'), expected);
-  });
+  }
+
+  crypto.pbkdf2(password, salt, iterations, keylen, 'sha1', assertCb);
 }
 
 
@@ -62,28 +64,28 @@ assert.throws(function() {
 
 // Should not work with Infinity key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, Infinity, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, Infinity, 'sha1', assert.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });
 
 // Should not work with negative Infinity key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, -Infinity, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, -Infinity, 'sha1', assert.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });
 
 // Should not work with NaN key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, NaN, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, NaN, 'sha1', assert.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });
 
 // Should not work with negative key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, -1, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, -1, 'sha1', assert.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -14,4 +14,4 @@ crypto.randomBytes(8);
 crypto.randomBytes(8, function() {});
 crypto.pseudoRandomBytes(8);
 crypto.pseudoRandomBytes(8, function() {});
-crypto.pbkdf2('password', 'salt', 8, 8, function() {});
+crypto.pbkdf2('password', 'salt', 8, 8, 'sha1', function() {});


### PR DESCRIPTION
This change will remove the default behaviour of defaulting to SHA1
as its digest function, instead this will break backwards compatibility
and force implementers to choose a secure digest that is suited for them
at that time.

At this moment of time SHA1 is fine to be used as an HMAC, but this statement
will eventually not be true, as is the nature of cryptography. Instead of changing the default
hash algorithm when we deem one to be not secure (and thus break backwards
compatibility at each change in the future), implementing this fix now (v5?) will remove any future
breakages as it pushes the choice onto the consumer of this api.

I would like to hear your thoughts on this, I understand that this sub-module is at the stability index of 2: stable, however I still think that this should be changed now, instead of waiting till it *has* to be changed.

Thanks.