### PR TITLE
stream: avoid unnecessary concat of a single buffer.

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -826,6 +826,8 @@ function fromList(n, state) {
     // read it all, truncate the array.
     if (stringMode)
       ret = list.join('');
+    else if (list.length === 1)
+      ret = list[0];
     else
       ret = Buffer.concat(list, length);
     list.length = 0;


### PR DESCRIPTION
Avoids doing a buffer.concat on the internal buffer when that array has only a single thing in it. As pointed out in nodejs/readable-stream#162 this causes an unnecessary copy.