### PR TITLE
buffer: don't abort on prototype getters

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -304,6 +304,8 @@ Buffer.byteLength = byteLength;
 Object.defineProperty(Buffer.prototype, 'parent', {
   enumerable: true,
   get: function() {
+    if (!(this instanceof Buffer))
+      return undefined;
     if (this.byteLength === 0 ||
         this.byteLength === this.buffer.byteLength) {
       return undefined;
@@ -314,6 +316,8 @@ Object.defineProperty(Buffer.prototype, 'parent', {
 Object.defineProperty(Buffer.prototype, 'offset', {
   enumerable: true,
   get: function() {
+    if (!(this instanceof Buffer))
+      return undefined;
     return this.byteOffset;
   }
 });

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1224,3 +1224,10 @@ assert.throws(function() {
 assert.throws(function() {
   new Buffer(null);
 }, /must start with number, buffer, array or string/);
+
+
+// Test prototype getters don't throw
+assert.equal(Buffer.prototype.parent, undefined);
+assert.equal(Buffer.prototype.offset, undefined);
+assert.equal(SlowBuffer.prototype.parent, undefined);
+assert.equal(SlowBuffer.prototype.offset, undefined);


### PR DESCRIPTION
Accessing prototype properties directly on a typed array will throw. So
do an extra check in Buffer's own getters to verify it is being called
on an instance.

Fixes: https://github.com/nodejs/node/issues/3297

R=@Fishrock123 ?

CI: https://ci.nodejs.org/job/node-test-pull-request/468/