### PR TITLE
net: don't throw on bytesWritten access

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -727,6 +727,9 @@ Socket.prototype.__defineGetter__('bytesWritten', function() {
       data = this._pendingData,
       encoding = this._pendingEncoding;
 
+  if (!state)
+    return undefined;
+
   state.getBuffer().forEach(function(el) {
     if (el.chunk instanceof Buffer)
       bytes += el.chunk.length;

--- a/test/parallel/test-net-access-byteswritten.js
+++ b/test/parallel/test-net-access-byteswritten.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+const tty = require('tty');
+
+// Check that the bytesWritten getter doesn't crash if object isn't
+// constructed.
+assert.strictEqual(net.Socket.prototype.bytesWritten, undefined);
+assert.strictEqual(tls.TLSSocket.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(tls.TLSSocket.prototype.bytesWritten, undefined);
+assert.strictEqual(tty.ReadStream.super_.prototype.bytesWritten, undefined);
+assert.strictEqual(tty.ReadStream.prototype.bytesWritten, undefined);
+assert.strictEqual(tty.WriteStream.prototype.bytesWritten, undefined);


### PR DESCRIPTION
If bytesWritten is accessed before the object has been properly
constructed then return undefined.

Fixes: https://github.com/nodejs/node/issues/3298

R=@bnoordhuis 

CI: https://ci.nodejs.org/job/node-test-pull-request/470/