### PR TITLE
test: update test-npm to work with npm 3

### DIFF
--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -29,10 +29,10 @@ export npm_config_prefix="npm-prefix"
 export npm_config_tmp="npm-tmp"
 
 # install npm devDependencies and run npm's tests
-
-../$NODE cli.js install --ignore-scripts
-../$NODE cli.js run-script test-legacy
-../$NODE cli.js run-script test
+NODEPATH="$(../$NODE -p 'require("path").resolve("..")')"
+PATH="$NODEPATH:$PATH" ../$NODE cli.js install --ignore-scripts
+PATH="$NODEPATH:$PATH" ../$NODE test/run.js
+PATH="$NODEPATH:$PATH" ../$NODE cli.js run-script tap -- "test/tap/*.js"
 
 # clean up everything one single shot
 cd .. && rm -rf test-npm


### PR DESCRIPTION
This is a prerequisite for bringing in npm 3. This will still work with npm 2.

The reason this is a problem is that in npm 3, `test-legacy` and `test` both run `standard` against the source tree. When `test-legacy` runs it installs things into its temp directory, which with node's `make test-npm`, is located in the npm folder itself. So when `npm run-script test` executes, it runs standard, which sees the things installed by `test-legacy` and refuses to continue.  Using `test-all` solves this problem by combining `test-legacy` with `test` all in a single command.

npm itself never puts the temp folder in npm's source folder and so had never encountered this on its own.

**r**: @Fishrock123
**r**: @chrisdickinson