### PR TITLE
test: update test-npm to use absolute paths for tmp/cache/prefix

### DIFF
--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -24,9 +24,9 @@ rm -rf npm-cache npm-tmp npm-prefix
 mkdir npm-cache npm-tmp npm-prefix
 
 # set some npm env varibles to point to our new temporary folders
-export npm_config_cache="npm-cache"
-export npm_config_prefix="npm-prefix"
-export npm_config_tmp="npm-tmp"
+export npm_config_cache="$(pwd)/npm-cache"
+export npm_config_prefix="$(pwd)/npm-prefix"
+export npm_config_tmp="$(pwd)/npm-tmp"
 
 # install npm devDependencies and run npm's tests
 


### PR DESCRIPTION
This gives npm absolute paths to use for its cache, prefix and tmp folders. Using relative paths seems to work, but makes me feel veeery edgy, as we do sometimes run subshells with copies of npm and we do sometimes change the working directory in tests. It seems to me that using relative paths here is just asking for really hard to track down trouble.

**r**: @Fishrock123
**r**: @chrisdickinson