### PR TITLE
test: make temp path customizable

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -8,6 +8,8 @@ var child_process = require('child_process');
 const stream = require('stream');
 const util = require('util');
 
+const testRoot = path.resolve(process.env.NODE_TEST_DIR ||
+                              path.dirname(__filename));
 
 exports.testDir = path.dirname(__filename);
 exports.fixturesDir = path.join(exports.testDir, 'fixtures');
@@ -69,13 +71,10 @@ exports.refreshTmpDir = function() {
 };
 
 if (process.env.TEST_THREAD_ID) {
-  // Distribute ports in parallel tests
-  if (!process.env.NODE_COMMON_PORT)
-    exports.PORT += +process.env.TEST_THREAD_ID * 100;
-
+  exports.PORT += process.env.TEST_THREAD_ID * 100;
   exports.tmpDirName += '.' + process.env.TEST_THREAD_ID;
 }
-exports.tmpDir = path.join(exports.testDir, exports.tmpDirName);
+exports.tmpDir = path.join(testRoot, exports.tmpDirName);
 
 var opensslCli = null;
 var inFreeBSDJail = null;
@@ -168,19 +167,11 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 
 if (exports.isWindows) {
   exports.PIPE = '\\\\.\\pipe\\libuv-test';
+  if (process.env.TEST_THREAD_ID) {
+    exports.PIPE += '.' + process.env.TEST_THREAD_ID;
+  }
 } else {
   exports.PIPE = exports.tmpDir + '/test.sock';
-}
-
-if (process.env.NODE_COMMON_PIPE) {
-  exports.PIPE = process.env.NODE_COMMON_PIPE;
-  // Remove manually, the test runner won't do it
-  // for us like it does for files in test/tmp.
-  try {
-    fs.unlinkSync(exports.PIPE);
-  } catch (e) {
-    // Ignore.
-  }
 }
 
 if (exports.isWindows) {

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -273,14 +273,14 @@ function test_deep_symlink_mix(callback) {
   }
 
   /*
-  /tmp/node-test-realpath-f1 -> ../tmp/node-test-realpath-d1/foo
-  /tmp/node-test-realpath-d1 -> ../node-test-realpath-d2
-  /tmp/node-test-realpath-d2/foo -> ../node-test-realpath-f2
+  /tmp/node-test-realpath-f1 -> $tmpDir/node-test-realpath-d1/foo
+  /tmp/node-test-realpath-d1 -> $tmpDir/node-test-realpath-d2
+  /tmp/node-test-realpath-d2/foo -> $tmpDir/node-test-realpath-f2
   /tmp/node-test-realpath-f2
     -> /node/test/fixtures/nested-index/one/realpath-c
   /node/test/fixtures/nested-index/one/realpath-c
     -> /node/test/fixtures/nested-index/two/realpath-c
-  /node/test/fixtures/nested-index/two/realpath-c -> ../../cycles/root.js
+  /node/test/fixtures/nested-index/two/realpath-c -> $tmpDir/cycles/root.js
   /node/test/fixtures/cycles/root.js (hard)
   */
   var entry = tmp('node-test-realpath-f1');
@@ -289,16 +289,16 @@ function test_deep_symlink_mix(callback) {
   fs.mkdirSync(tmp('node-test-realpath-d2'), 0o700);
   try {
     [
-      [entry, '../' + common.tmpDirName + '/node-test-realpath-d1/foo'],
+      [entry, common.tmpDir + '/node-test-realpath-d1/foo'],
       [tmp('node-test-realpath-d1'),
-          '../' + common.tmpDirName + '/node-test-realpath-d2'],
+        common.tmpDir + '/node-test-realpath-d2'],
       [tmp('node-test-realpath-d2/foo'), '../node-test-realpath-f2'],
       [tmp('node-test-realpath-f2'), fixturesAbsDir +
-           '/nested-index/one/realpath-c'],
+        '/nested-index/one/realpath-c'],
       [fixturesAbsDir + '/nested-index/one/realpath-c', fixturesAbsDir +
-            '/nested-index/two/realpath-c'],
+        '/nested-index/two/realpath-c'],
       [fixturesAbsDir + '/nested-index/two/realpath-c',
-        '../../../' + common.tmpDirName + '/cycles/root.js']
+        common.tmpDir + '/cycles/root.js']
     ].forEach(function(t) {
       try { fs.unlinkSync(t[0]); } catch (e) {}
       fs.symlinkSync(t[1], t[0]);

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -11,7 +11,7 @@ var expected_tests = 2;
 var linkPath1 = path.join(common.tmpDir, 'junction1');
 var linkPath2 = path.join(common.tmpDir, 'junction2');
 var linkTarget = path.join(common.fixturesDir);
-var linkData = '../fixtures';
+var linkData = path.join(common.fixturesDir);
 
 common.refreshTmpDir();
 
@@ -42,4 +42,3 @@ function verifyLink(linkPath) {
 process.on('exit', function() {
   assert.equal(completed, expected_tests);
 });
-

--- a/tools/test.py
+++ b/tools/test.py
@@ -1310,6 +1310,8 @@ def BuildOptions():
   result.add_option("-r", "--run",
       help="Divide the tests in m groups (interleaved) and run tests from group n (--run=n,m with n < m)",
       default="")
+  result.add_option('--temp-dir',
+      help='Optional path to change directory used for tests', default=False)
   return result
 
 
@@ -1537,6 +1539,16 @@ def Main():
   if options.warn_unused:
     for rule in globally_unused_rules:
       print "Rule for '%s' was not used." % '/'.join([str(s) for s in rule.path])
+
+  tempdir = os.environ.get('NODE_TEST_DIR') or options.temp_dir
+  if tempdir:
+    try:
+      os.makedirs(tempdir)
+      os.environ['NODE_TEST_DIR'] = tempdir
+    except OSError as exception:
+      if exception.errno != errno.EEXIST:
+        print "Could not create the temporary directory", options.temp_dir
+        sys.exit(1)
 
   if options.report:
     PrintReport(all_cases)


### PR DESCRIPTION
In CI we previously passed `NODE_COMMON_PIPE` to the test runner to avoid long filenames on Windows. Avoid long paths by changing the temporary directory instead. This also allows us to run test suites in parallel since `NODE_COMMON_PIPE` otherwise would have been used from multiple tests.

/R=@nodejs/build, @Trott ?