### PR TITLE
test: add Symbol test for assert.deepEqual()

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -140,9 +140,7 @@ assert.throws(makeBlock(a.deepEqual, 'a', ['a']), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, 'a', {0: 'a'}), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, 1, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, true, {}), a.AssertionError);
-if (typeof Symbol === 'symbol') {
-  assert.throws(makeBlock(assert.deepEqual, Symbol(), {}), a.AssertionError);
-}
+assert.throws(makeBlock(a.deepEqual, Symbol(), {}), a.AssertionError);
 
 // primitive wrappers and object
 assert.doesNotThrow(makeBlock(a.deepEqual, new String('a'), ['a']),


### PR DESCRIPTION
The existing test never ran because typeof Symbol === 'function' and not
'symbol'. Update to Symbol() which will be a symbol and not a function.