### PR TITLE
buffer: fix assertion error in WeakCallback

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -152,7 +152,8 @@ void CallbackInfo::WeakCallback(Isolate* isolate, Local<Object> object) {
   Local<ArrayBuffer> buf = object.As<ArrayBuffer>();
   ArrayBuffer::Contents obj_c = buf->GetContents();
   char* const obj_data = static_cast<char*>(obj_c.Data());
-  CHECK_NE(obj_data, nullptr);
+  if (buf->ByteLength() != 0)
+    CHECK_NE(obj_data, nullptr);
 
   buf->Neuter();
   callback_(obj_data, hint_);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -148,11 +148,13 @@ void CallbackInfo::WeakCallback(
 
 
 void CallbackInfo::WeakCallback(Isolate* isolate, Local<Object> object) {
-  SPREAD_ARG(object, obj);
-  CHECK_EQ(obj_offset, 0);
-  CHECK_EQ(obj_c.ByteLength(), obj_length);
+  CHECK(object->IsArrayBuffer());
+  Local<ArrayBuffer> buf = object.As<ArrayBuffer>();
+  ArrayBuffer::Contents obj_c = buf->GetContents();
+  char* const obj_data = static_cast<char*>(obj_c.Data());
+  CHECK_NE(obj_data, nullptr);
 
-  obj->Buffer()->Neuter();
+  buf->Neuter();
   callback_(obj_data, hint_);
   int64_t change_in_bytes = -static_cast<int64_t>(sizeof(*this));
   isolate->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -16,7 +16,7 @@ void Alloc(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(node::Buffer::New(
         isolate,
         buf,
-        sizeof(buf),
+        args[0]->IntegerValue(),
         FreeCallback,
         nullptr).ToLocalChecked());
 }

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -8,3 +8,7 @@ var buf = binding.alloc();
 var slice = buf.slice(32);
 buf = null;
 binding.check(slice);
+slice = null;
+gc();
+gc();
+gc();

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -4,11 +4,20 @@
 require('../../common');
 var assert = require('assert');
 var binding = require('./build/Release/binding');
-var buf = binding.alloc();
-var slice = buf.slice(32);
-buf = null;
-binding.check(slice);
-slice = null;
-gc();
-gc();
-gc();
+
+function check(size) {
+  var buf = binding.alloc(size);
+  var slice = buf.slice(size >>> 1);
+
+  buf = null;
+  binding.check(slice);
+  slice = null;
+  gc();
+  gc();
+  gc();
+}
+
+check(64);
+
+// Empty ArrayBuffer does not allocate data, worth checking
+check(0);


### PR DESCRIPTION
`CallbackInfo` is now bound to `ArrayBuffer` instance, not `Uint8Array`,
therefore `SPREAD_ARG` will abort with:

    Assertion failed: ((object)->IsUint8Array())

Make changes necessary to migrate it to `ArrayBuffer`.

See: https://github.com/nodejs/node/pull/3080#issuecomment-147502167

R=@trevnorris