### PR TITLE
doc: add information about Assert behavior and maintenance

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -2,9 +2,9 @@
 
     Stability: 3 - Locked
 
-This module is used so that Node.js can test itself. You can access it with
-`require('assert')`. However, it is recommended that you use a userland
-assertion library instead.
+This module is used so that Node.js can test itself. It can be accessed with
+`require('assert')`. However, it is recommended that a userland assertion
+library be used instead.
 
 ## assert.fail(actual, expected, message, operator)
 
@@ -36,7 +36,7 @@ potentially surprising results. For example, this does not throw an
 `AssertionError` because the properties on the `Error` object are
 non-enumerable:
 
-    // WARNING: This probably does not do what you expect!
+    // WARNING: This does not throw an AssertionError!
     assert.deepEqual(Error('a'), Error('b'));
 
 ## assert.notDeepEqual(actual, expected[, message])

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -2,8 +2,9 @@
 
     Stability: 2 - Stable
 
-This module is used for writing assertion tests. You can access it with
-`require('assert')`.
+This module is used so that Node.js can test itself. You can access it with
+`require('assert')`. However, it is recommended that you use a userland
+assertion library instead.
 
 ## assert.fail(actual, expected, message, operator)
 
@@ -26,8 +27,16 @@ Tests shallow, coercive inequality with the not equal comparison operator
 
 ## assert.deepEqual(actual, expected[, message])
 
-Tests for deep equality. Primitive values are compared with the equal comparison
-operator ( `==` ). Doesn't take object prototypes into account.
+Tests for deep equality. Primitive values are compared with the equal
+comparison operator ( `==` ).
+
+This only considers enumerable properties. It does not test object prototypes,
+attached symbols, or non-enumerable properties. This can lead to some
+potentially surprising results. For this does not throw an `AssertionError`
+because the properties on the `Error` object are non-enumerable:
+
+    // WARNING: This probably does not do what you expect!
+    assert.deepEqual(Error('a'), Error('b'));
 
 ## assert.notDeepEqual(actual, expected[, message])
 

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -32,8 +32,9 @@ comparison operator ( `==` ).
 
 This only considers enumerable properties. It does not test object prototypes,
 attached symbols, or non-enumerable properties. This can lead to some
-potentially surprising results. For this does not throw an `AssertionError`
-because the properties on the `Error` object are non-enumerable:
+potentially surprising results. For example, this does not throw an
+`AssertionError` because the properties on the `Error` object are
+non-enumerable:
 
     // WARNING: This probably does not do what you expect!
     assert.deepEqual(Error('a'), Error('b'));

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -1,6 +1,6 @@
 # Assert
 
-    Stability: 2 - Stable
+    Stability: 3 - Locked
 
 This module is used so that Node.js can test itself. You can access it with
 `require('assert')`. However, it is recommended that you use a userland


### PR DESCRIPTION
Doc that:

* `assert` is for Node.js testing itself and not intended for general use
* `deepEqual()` only considers enumerable properties

Ref: https://github.com/nodejs/node/pull/3124
Ref: https://github.com/nodejs/node/issues/3122