### PR TITLE
lib: fix undefined timeout regression

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -30,7 +30,7 @@ var lists = {};
 // with them.
 exports.active = function(item) {
   const msecs = item._idleTimeout;
-  if (msecs < 0) return;
+  if (msecs < 0 || msecs === undefined) return;
 
   item._idleStart = Timer.now();
 

--- a/test/parallel/test-timers-active.js
+++ b/test/parallel/test-timers-active.js
@@ -22,7 +22,8 @@ legitTimers.forEach(function(legit) {
 
 // active() should not create a timer for these
 var bogusTimers = [
-  { _idleTimeout: -1 }
+  { _idleTimeout: -1 },
+  { _idleTimeout: undefined }
 ];
 
 bogusTimers.forEach(function(bogus) {


### PR DESCRIPTION
63644dd1cd6e introduced a regression caused by everyone's favourite
JavaScript feature: `undefined < 0 === undefined >= 0`.

Add a case to the existing tests to cover this scenario and then add
the check for undefined that makes the test pass.

@indutny @jasnell this should fix at least one of the v4.2.0 regressions.