### PR TITLE
doc: show keylen in pbkdf2 as a byte length

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -621,13 +621,13 @@ Example (obtaining a shared secret):
 ## crypto.pbkdf2(password, salt, iterations, keylen[, digest], callback)
 
 Asynchronous PBKDF2 function.  Applies the selected HMAC digest function
-(default: SHA1) to derive a key of the requested length from the password,
+(default: SHA1) to derive a key of the requested byte length from the password,
 salt and number of iterations.  The callback gets two arguments:
 `(err, derivedKey)`.
 
 Example:
 
-    crypto.pbkdf2('secret', 'salt', 4096, 512, 'sha256', function(err, key) {
+    crypto.pbkdf2('secret', 'salt', 4096, 64, 'sha256', function(err, key) {
       if (err)
         throw err;
       console.log(key.toString('hex'));  // 'c5e478d...1469e50'


### PR DESCRIPTION
Ensure that keylen for pbkdf2 is documented as a length of bytes and not bits

This might be wrong if it's supposed to accept a bit length. In that case I'd need to change it around.