### PR TITLE
test: better message for test-child-process-emfile failures

### DIFF
--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -27,8 +27,10 @@ proc.on('error', common.mustCall(function(err) {
   assert(err.code === 'EMFILE' || err.code === 'ENFILE');
 }));
 
-// 'exit' should not be emitted, the process was never spawned.
-proc.on('exit', assert.fail);
+proc.on('exit', function() {
+  const msg = '"exit" should not be emitted (the process never spawned!)';
+  assert.fail(null, null, msg);
+});
 
 // close one fd for LSan
 if (openFds.length >= 1) {


### PR DESCRIPTION
When the test fails (as it does frequently on FreeBSD unfortunately)
provide a non-cryptic error message that also provides a meaningful line
number (`test-child-process-emfile.js:33`).

Before:

````
#assert.js:87
#  throw new assert.AssertionError({
#  ^
#AssertionError: 0 undefined null
#    at emitTwo (events.js:87:13)
#    at ChildProcess.emit (events.js:172:7)
#    at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
````

After:

````
#assert.js:89
#  throw new assert.AssertionError({
#  ^
#AssertionError: "exit" should not be emitted (the process never spawned!)
#    at ChildProcess.<anonymous> (/usr/home/iojs/build/workspace/node-test-commit-other/nodes/freebsd101-64/test/sequential/test-child-process-emfile.js:33:10)
#    at emitTwo (events.js:87:13)
#    at ChildProcess.emit (events.js:172:7)
#    at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
````