### PR TITLE
test: remove util from test-child-process-execsync

### DIFF
--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var util = require('util');
 var os = require('os');
 
 var execSync = require('child_process').execSync;
@@ -13,10 +12,10 @@ var SLEEP = 2000;
 var start = Date.now();
 var err;
 var caught = false;
+
 try
 {
-  var cmd = util.format('"%s" -e "setTimeout(function(){}, %d);"',
-                        process.execPath, SLEEP);
+  var cmd = `"${process.execPath}" -e "setTimeout(function(){}, ${SLEEP});"`;
   var ret = execSync(cmd, {timeout: TIMER});
 } catch (e) {
   caught = true;
@@ -38,7 +37,8 @@ var msg = 'foobar';
 var msgBuf = new Buffer(msg + '\n');
 
 // console.log ends every line with just '\n', even on Windows.
-cmd = util.format('"%s" -e "console.log(\'%s\');"', process.execPath, msg);
+
+cmd = `"${process.execPath}" -e "console.log(\'${msg}\');"`;
 
 var ret = execSync(cmd);
 
@@ -51,7 +51,7 @@ assert.strictEqual(ret, msg + '\n', 'execSync encoding result should match');
 
 var args = [
   '-e',
-  util.format('console.log("%s");', msg)
+  `console.log("${msg}");`
 ];
 ret = execFileSync(process.execPath, args);
 


### PR DESCRIPTION
Now that we have backticks we no longer need to use util.format to template strings! This commit was inspired by #3324, and it replaces all instances of util.format with backtick strings to simply all the things

/cc @jasnell @Trott 