### PR TITLE
doc: label v4.2.0 as LTS in changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Node.js ChangeLog
 
-## 2015-10-07, Version 4.2.0 'Argon' (Stable), @jasnell
+## 2015-10-07, Version 4.2.0 'Argon' (LTS), @jasnell
 
 ### Notable changes
 


### PR DESCRIPTION
R=@jasnell

I'm proposing that we use `(Stable)`, `(LTS)` and `(Maintenance)` in the headings of the CHANGELOG.

Pre v4 these labels were: `(Stable)` (even minor), `(Unstable)` (odd minor), `(Maintenance)` (previous even minor). `grep ^##\  CHANGELOG.md` to see the usage trend.

If agreed, this change needs to go on `master`, `v4` and also on the release blog post on the website.