### PR TITLE
test: port domains regression test from v0.10

### DIFF
--- a/test/parallel/test-domain-top-level-error-handler-clears-stack.js
+++ b/test/parallel/test-domain-top-level-error-handler-clears-stack.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+const domain = require('domain');
+
+/*
+ * Make sure that the domains stack is cleared after a top-level domain
+ * error handler exited gracefully.
+ */
+const d = domain.create();
+
+d.on('error', common.mustCall(function() {
+  process.nextTick(function() {
+    // Scheduling a callback with process.nextTick will enter a _new_ domain,
+    // and the callback will be called after the domain that handled the error
+    // was exited. So there should be only one domain on the domains stack if
+    // the domains stack was cleared properly when the domain error handler
+    // returned.
+    if (domain._stack.length !== 1) {
+      // Do not use assert to perform this test: this callback runs in a
+      // different callstack as the original process._fatalException that
+      // handled the original error, thus throwing here would trigger another
+      // call to process._fatalException, and so on recursively and
+      // indefinitely.
+      console.error('domains stack length should be 1, but instead is:',
+        domain._stack.length);
+      process.exit(1);
+    }
+  });
+}));
+
+d.run(function() {
+  throw new Error('Error from domain');
+});


### PR DESCRIPTION
f2a45caf2e1b73fea01fa9a941bc61096a999664 contained a test for a
regression that had been introduced by the original change that
77a10ed05f1e413818d29f07cbb268108b1f08fa ported. While
77a10ed05f1e413818d29f07cbb268108b1f08fa did not contain that
regression, the test that f2a45caf2e1b73fea01fa9a941bc61096a999664
contained should still be in the code base to prevent any regression
from happening in the future.

Original message for the commit that contained the test:

  domains: fix stack clearing after error handled

  caeb67735baa8e069902e23f21d01033907c4f33 introduced a regression where
  the domains stack would not be cleared after an error had been handled
  by the top-level domain.

  This change clears the domains stack regardless of the position of the
  active domain in the stack.

  PR: #9364
  PR-URL: https://github.com/joyent/node/pull/9364
  Reviewed-By: Trevor Norris <trev.norris@gmail.com>
  Reviewed-By: Julien Gilli <julien.gilli@joyent.com>