### PR TITLE
lib: avoid REPL exit on completion error

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -32,6 +32,8 @@ const Console = require('console').Console;
 const domain = require('domain');
 const debug = util.debuglog('repl');
 
+const replMap = new WeakMap();
+
 try {
   // hack for require.resolve("./relative") to work properly.
   module.filename = path.resolve('repl');
@@ -189,11 +191,12 @@ function REPLServer(prompt,
 
   self._domain.on('error', function(e) {
     debug('domain error');
-    self.outputStream.write((e.stack || e) + '\n');
-    self._currentStringLiteral = null;
-    self.bufferedCommand = '';
-    self.lines.level = [];
-    self.displayPrompt();
+    const top = replMap.get(self);
+    top.outputStream.write((e.stack || e) + '\n');
+    top._currentStringLiteral = null;
+    top.bufferedCommand = '';
+    top.lines.level = [];
+    top.displayPrompt();
   });
 
   if (!input && !output) {
@@ -472,6 +475,7 @@ exports.start = function(prompt,
                             ignoreUndefined,
                             replMode);
   if (!exports.repl) exports.repl = repl;
+  replMap.set(repl, repl);
   return repl;
 };
 
@@ -601,6 +605,7 @@ REPLServer.prototype.complete = function(line, callback) {
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand
     if (!magic.bufferedCommand) {
+      replMap.set(magic, replMap.get(this));
       return magic.complete(line, callback);
     }
   }

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+const repl = require('repl');
+
+var referenceErrorCount = 0;
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function(data) {
+    const self = this;
+    data.forEach(function(line) {
+      self.emit('data', line + '\n');
+    });
+  };
+}
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function() {};
+ArrayStream.prototype.write = function(msg) {
+  if (msg.startsWith('ReferenceError: ')) {
+    referenceErrorCount++;
+  }
+};
+
+const putIn = new ArrayStream();
+const testMe = repl.start('', putIn);
+
+// https://github.com/nodejs/node/issues/3346
+// Tab-completion for an undefined variable inside a function should report a
+// ReferenceError.
+putIn.run(['.clear']);
+putIn.run(['function () {']);
+testMe.complete('arguments.');
+
+process.on('exit', function() {
+  assert.strictEqual(referenceErrorCount, 1);
+});


### PR DESCRIPTION
If a tab completion is attempted on an undefined reference inside of a
function, the REPL was exiting without reporting an error or anything
else. This change results in the REPL reporting the ReferenceError and
continuing.

Fixes: #3346