### PR TITLE
test: replace util with backtick strings

### DIFF
--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var os = require('os');
-var util = require('util');
 
 var spawnSync = require('child_process').spawnSync;
 
@@ -15,7 +14,7 @@ var msgErrBuf = new Buffer(msgErr + '\n');
 
 var args = [
   '-e',
-  util.format('console.log("%s"); console.error("%s");', msgOut, msgErr)
+  `console.log("${msgOut}"); console.error("${msgErr}");`
 ];
 
 var ret;

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -1,16 +1,16 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var spawnSync = require('child_process').spawnSync;
+const spawnSync = require('child_process').spawnSync;
 
 // Echo does different things on Windows and Unix, but in both cases, it does
 // more-or-less nothing if there are no parameters
-var ret = spawnSync('sleep', ['0']);
+const ret = spawnSync('sleep', ['0']);
 assert.strictEqual(ret.status, 0, 'exit status should be zero');
 
 // Error test when command does not exist
-var ret_err = spawnSync('command_does_not_exist', ['bar']).error;
+const ret_err = spawnSync('command_does_not_exist', ['bar']).error;
 
 assert.strictEqual(ret_err.code, 'ENOENT');
 assert.strictEqual(ret_err.errno, 'ENOENT');

--- a/test/parallel/test-repl-setprompt.js
+++ b/test/parallel/test-repl-setprompt.js
@@ -1,9 +1,8 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
-    spawn = require('child_process').spawn,
-    os = require('os'),
-    util = require('util');
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const os = require('os');
 
 var args = [
   '-e',
@@ -19,7 +18,7 @@ child.stdout.setEncoding('utf8');
 var data = '';
 child.stdout.on('data', function(d) { data += d; });
 
-child.stdin.end(util.format("e.setPrompt('%s');%s", p, os.EOL));
+child.stdin.end(`e.setPrompt("${p}");${os.EOL}`);
 
 child.on('close', function(code, signal) {
   assert.strictEqual(code, 0);

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var util = require('util');
 var os = require('os');
 
 var execSync = require('child_process').execSync;
@@ -13,10 +12,10 @@ var SLEEP = 2000;
 var start = Date.now();
 var err;
 var caught = false;
+
 try
 {
-  var cmd = util.format('"%s" -e "setTimeout(function(){}, %d);"',
-                        process.execPath, SLEEP);
+  var cmd = `"${process.execPath}" -e "setTimeout(function(){}, ${SLEEP});"`;
   var ret = execSync(cmd, {timeout: TIMER});
 } catch (e) {
   caught = true;
@@ -38,7 +37,8 @@ var msg = 'foobar';
 var msgBuf = new Buffer(msg + '\n');
 
 // console.log ends every line with just '\n', even on Windows.
-cmd = util.format('"%s" -e "console.log(\'%s\');"', process.execPath, msg);
+
+cmd = `"${process.execPath}" -e "console.log(\'${msg}\');"`;
 
 var ret = execSync(cmd);
 
@@ -51,7 +51,7 @@ assert.strictEqual(ret, msg + '\n', 'execSync encoding result should match');
 
 var args = [
   '-e',
-  util.format('console.log("%s");', msg)
+  `console.log("${msg}");`
 ];
 ret = execFileSync(process.execPath, args);
 


### PR DESCRIPTION
Now that we have backticks we no longer need to use util.format to template strings!

This commit was inspired by #3324, and it replaces instances of util.format with backtick strings in a number of tests

closes #3340 #3338 #3336