### PR TITLE
doc: label v4.2.1 as LTS in changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Node.js ChangeLog
 
-## 2015-10-13, Version 4.2.1 'Argon' (Stable), @jasnell
+## 2015-10-13, Version 4.2.1 'Argon' (LTS), @jasnell
 
 ### Notable changes
 


### PR DESCRIPTION
Just as with [#3343](https://github.com/nodejs/node/pull/3343), v4.2.1 should probably also be marked as `LTS` rather than `Stable`.

Also what @jasnell decided when creating release blog post on [new.nodejs.org/59411](https://github.com/nodejs/new.nodejs.org/commit/594111907d8f945fddb62e06d162fdd778c58cac).

Needs to land on `master` and `v4.x` if it looks good