### PR TITLE
doc: fix indent in tls resumption example

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -605,14 +605,14 @@ established after addition of event listener.
 
 Here's an example for using TLS session resumption:
 
-  var tlsSessionStore = {};
-  server.on('newSession', function(id, data, cb) {
-    tlsSessionStore[id.toString('hex')] = data;
-    cb();
-  });
-  server.on('resumeSession', function(id, cb) {
-    cb(null, tlsSessionStore[id.toString('hex')] || null);
-  });
+    var tlsSessionStore = {};
+    server.on('newSession', function(id, data, cb) {
+      tlsSessionStore[id.toString('hex')] = data;
+      cb();
+    });
+    server.on('resumeSession', function(id, cb) {
+      cb(null, tlsSessionStore[id.toString('hex')] || null);
+    });
 
 ### Event: 'OCSPRequest'
 


### PR DESCRIPTION
The example added in https://github.com/nodejs/node/pull/3147 was wrongly using a 2-space indent, but markdown requires 4-space for code blocks. This fixes it so this code example is now correctly formatted as a code block.