### PR TITLE
node: improve GetActiveRequests performance

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -227,6 +227,7 @@ namespace node {
   V(zero_return_string, "ZERO_RETURN")                                        \
 
 #define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
+  V(add_properties_by_index_function, v8::Function)                           \
   V(as_external, v8::External)                                                \
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_pre_function, v8::Function)                                   \

--- a/src/node.js
+++ b/src/node.js
@@ -22,6 +22,8 @@
 
     process.EventEmitter = EventEmitter; // process.EventEmitter is deprecated
 
+    startup.setupProcessObject();
+
     // do this good and early, since it handles errors.
     startup.processFatal();
 
@@ -172,6 +174,15 @@
       }
     }
   }
+
+  startup.setupProcessObject = function() {
+    process._setupProcessObject(setPropByIndex);
+
+    function setPropByIndex() {
+      for (var i = 0; i < arguments.length; i++)
+        this.push(arguments[i]);
+    }
+  };
 
   startup.globalVariables = function() {
     global.process = process;

--- a/test/parallel/test-process-getactiverequests.js
+++ b/test/parallel/test-process-getactiverequests.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+for (let i = 0; i < 12; i++)
+  fs.open(__filename, 'r', function() { });
+
+assert.equal(12, process._getActiveRequests().length);


### PR DESCRIPTION
v8 is faster at setting object properties in JS than C++. Even when it
requires calling into JS from native code. Make
process._getActiveRequests() faster by doing this when populating the
array containing request objects.

Simple benchmark:

    for (let i = 0; i < 22; i++)
      fs.open(__filename, 'r', function() { });
    let t = process.hrtime();
    for (let i = 0; i < 1e6; i++)
      process._getActiveRequests();
    t = process.hrtime(t);
    console.log((t[0] * 1e9 + t[1]) / 1e6);

Results between the two:

    Previous:  4406 ns/op
    Patched:    829 ns/op     4.3x faster

R=@bnoordhuis 

Have another addition of improving the same for active handles, but wanted to solicit feedback on the approach early.