### PR TITLE
test: apply correct assert.fail() arguments

### DIFF
--- a/test/internet/test-dgram-send-cb-quelches-error.js
+++ b/test/internet/test-dgram-send-cb-quelches-error.js
@@ -28,7 +28,7 @@ function callbackOnly(err) {
 }
 
 function onEvent(err) {
-  assert.fail('Error should not be emitted if there is callback');
+  assert.fail(null, null, 'Error should not be emitted if there is callback');
 }
 
 function onError(err) {

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -24,7 +24,7 @@ common.refreshTmpDir();
   var stream = fs.createWriteStream(file);
 
   stream.on('drain', function() {
-    assert.fail('\'drain\' event must not be emitted before ' +
+    assert.fail(null, null, '\'drain\' event must not be emitted before ' +
                 'stream.write() has been called at least once.');
   });
   stream.destroy();

--- a/test/parallel/test-http-header-response-splitting.js
+++ b/test/parallel/test-http-header-response-splitting.js
@@ -27,7 +27,7 @@ var server = http.createServer(function(req, res) {
       res.writeHead(200, { b: header });
       break;
     default:
-      assert.fail('unreachable');
+      assert.fail(null, null, 'unreachable');
     }
     res.write(responseBody);
     if (testIndex % 8 < 4) {

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -24,7 +24,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
     method: 'GET',
     localAddress: invalidLocalAddress
   }, function(res) {
-    assert.fail('unexpectedly got response from server');
+    assert.fail(null, null, 'unexpectedly got response from server');
   }).on('error', function(e) {
     console.log('client got error: ' + e.message);
     gotError = true;

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -35,7 +35,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
     method: 'GET',
     localAddress: invalidLocalAddress
   }, function(res) {
-    assert.fail('unexpectedly got response from server');
+    assert.fail(null, null, 'unexpectedly got response from server');
   }).on('error', function(e) {
     console.log('client got error: ' + e.message);
     gotError = true;

--- a/test/parallel/test-net-connect-paused-connection.js
+++ b/test/parallel/test-net-connect-paused-connection.js
@@ -11,5 +11,5 @@ net.createServer(function(conn) {
 net.connect(common.PORT, 'localhost').pause();
 
 setTimeout(function() {
-  assert.fail('expected to exit');
+  assert.fail(null, null, 'expected to exit');
 }, 1000).unref();

--- a/test/parallel/test-net-write-slow.js
+++ b/test/parallel/test-net-write-slow.js
@@ -14,7 +14,7 @@ var server = net.createServer(function(socket) {
   socket.setNoDelay();
   socket.setTimeout(1000);
   socket.on('timeout', function() {
-    assert.fail('flushed: ' + flushed +
+    assert.fail(null, null, 'flushed: ' + flushed +
                 ', received: ' + received + '/' + SIZE * N);
   });
 

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -89,7 +89,7 @@ function checkErrors(path) {
       return;
     }
 
-    assert.fail('should have thrown');
+    assert.fail(null, null, 'should have thrown');
   });
 }
 

--- a/test/parallel/test-repl-reset-event.js
+++ b/test/parallel/test-repl-reset-event.js
@@ -45,7 +45,7 @@ function testResetGlobal(cb) {
 }
 
 var timeout = setTimeout(function() {
-  assert.fail('Timeout, REPL did not emit reset events');
+  assert.fail(null, null, 'Timeout, REPL did not emit reset events');
 }, 5000);
 
 testReset(function() {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -389,5 +389,5 @@ function unix_test() {
 unix_test();
 
 timer = setTimeout(function() {
-  assert.fail('Timeout');
+  assert.fail(null, null, 'Timeout');
 }, 5000);

--- a/test/parallel/test-spawn-cmd-named-pipe.js
+++ b/test/parallel/test-spawn-cmd-named-pipe.js
@@ -39,7 +39,7 @@ if (!process.argv[2]) {
 
   const comspec = process.env['comspec'];
   if (!comspec || comspec.length === 0) {
-    assert.fail('Failed to get COMSPEC');
+    assert.fail(null, null, 'Failed to get COMSPEC');
   }
 
   const args = ['/c', process.execPath, __filename, 'child',

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -33,5 +33,5 @@ src.on('end', function() {
 src.pipe(dst);
 
 timeout = setTimeout(function() {
-  assert.fail('timed out waiting for _write');
+  assert.fail(null, null, 'timed out waiting for _write');
 }, 100);

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -40,7 +40,7 @@ function runTest(pattern, code) {
     return /^isolate-/.test(file);
   });
   if (matches.length != 1) {
-    assert.fail('There should be a single log file.');
+    assert.fail(null, null, 'There should be a single log file.');
   }
   var log = matches[0];
   var out = cp.execSync(process.execPath + ' ' + processor +


### PR DESCRIPTION
The assert.fail function signature has the message as the third argument
but, understandably, it is often assumed that it is the first argument
(or at least the first argument if no other arguments are passed).

This corrects the assert.fail() invocations in the Node.js tests.

Before:
assert.fail('message');
// result: AssertionError: 'message' undefined undefined

After:
assert.fail(null, null, 'message');
// result: AssertionError: message