### PR TITLE
build: rectify --link-module usage

### DIFF
--- a/configure
+++ b/configure
@@ -90,7 +90,8 @@ parser.add_option("--link-module",
     action="append",
     dest="linked_module",
     help="Path to a JS file to be bundled in the binary as a builtin."
-         "This module will be referenced by basename without extension."
+         "This module will be referenced by path without extension."
+         "e.g. /root/x/y.js will be referenced via require('root/x/y')."
          "Can be used multiple times")
 
 parser.add_option("--openssl-no-asm",


### PR DESCRIPTION
Modules imported by `--link-module` are not referenced by name but actually by path.