### PR TITLE
module: remove require('.') with NODE_PATH compat

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -201,7 +201,7 @@ code.
 <a id="DEP0019"></a>
 ### DEP0019: require('.') resolved outside directory
 
-Type: Runtime
+Type: End-of-Life
 
 In certain cases, `require('.')` may resolve outside the package directory.
 This behavior is deprecated and will be removed in a future major Node.js

--- a/lib/module.js
+++ b/lib/module.js
@@ -159,7 +159,6 @@ function tryExtensions(p, exts, isMain) {
   return false;
 }
 
-var warned = false;
 Module._findPath = function(request, paths, isMain) {
   if (path.isAbsolute(request)) {
     paths = [''];
@@ -221,18 +220,6 @@ Module._findPath = function(request, paths, isMain) {
     }
 
     if (filename) {
-      // Warn once if '.' resolved outside the module dir
-      if (request === '.' && i > 0) {
-        if (!warned) {
-          warned = true;
-          process.emitWarning(
-            'warning: require(\'.\') resolved outside the package ' +
-            'directory. This functionality is deprecated and will be removed ' +
-            'soon.',
-            'DeprecationWarning', 'DEP0019');
-        }
-      }
-
       Module._pathCache[cacheKey] = filename;
       return filename;
     }
@@ -335,8 +322,7 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
   }
 
   // Check for relative path
-  if (request.length < 2 ||
-      request.charCodeAt(0) !== 46/*.*/ ||
+  if (request.charCodeAt(0) !== 46/*.*/ &&
       (request.charCodeAt(1) !== 46/*.*/ &&
        request.charCodeAt(1) !== 47/*/*/)) {
     var paths = modulePaths;
@@ -345,16 +331,6 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
         paths = parent.paths = [];
       else
         paths = parent.paths.concat(paths);
-    }
-
-    // Maintain backwards compat with certain broken uses of require('.')
-    // by putting the module's directory in front of the lookup paths.
-    if (request === '.') {
-      if (parent && parent.filename) {
-        paths.unshift(path.dirname(parent.filename));
-      } else {
-        paths.unshift(path.resolve(request));
-      }
     }
 
     debug('looking for %j in %j', request, paths);

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -10,9 +10,7 @@ const b = require(fixtures.path('module-require', 'relative', 'dot-slash.js'));
 assert.strictEqual(a.value, 42);
 assert.strictEqual(a, b, 'require(".") should resolve like require("./")');
 
+// require('.') should not lookup in NODE_PATH
 process.env.NODE_PATH = fixtures.path('module-require', 'relative');
 m._initPaths();
-
-const c = require('.');
-
-assert.strictEqual(c.value, 42, 'require(".") should honor NODE_PATH');
+assert.throws(() => { require('.'); }, Error, "Cannot find module '.'");


### PR DESCRIPTION
This PR replaces #1452. It's updated and targets `master` now. Adding 6.0.0 milestone as discussed.
