### PR TITLE
src,build: support g++ 4.7.x

### DIFF
--- a/configure
+++ b/configure
@@ -485,8 +485,8 @@ def check_compiler(o):
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CXX, 'c++')
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
-  elif clang_version < '3.4.0' if is_clang else gcc_version < '4.8.0':
-    warn('C++ compiler too old, need g++ 4.8 or clang++ 3.4 (CXX=%s)' % CXX)
+  elif clang_version < '3.4.0' if is_clang else gcc_version < '4.7.0':
+    warn('C++ compiler too old, need g++ 4.7 or clang++ 3.4 (CXX=%s)' % CXX)
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
   if not ok:

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -443,6 +443,7 @@ Local<Object> StreamBase::GetObject() {
   return GetAsyncWrap()->object();
 }
 
+StreamBase::~StreamBase() = default;
 
 int StreamResource::DoTryWrite(uv_buf_t** bufs, size_t* count) {
   // No TryWrite by default
@@ -458,5 +459,7 @@ const char* StreamResource::Error() const {
 void StreamResource::ClearError() {
   // No-op
 }
+
+StreamResource::~StreamResource() = default;
 
 }  // namespace node

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -131,7 +131,7 @@ class StreamResource {
 
   StreamResource() {
   }
-  virtual ~StreamResource() = default;
+  virtual ~StreamResource();
 
   virtual int DoShutdown(ShutdownWrap* req_wrap) = 0;
   virtual int DoTryWrite(uv_buf_t** bufs, size_t* count);
@@ -215,7 +215,7 @@ class StreamBase : public StreamResource {
   explicit StreamBase(Environment* env) : env_(env), consumed_(false) {
   }
 
-  virtual ~StreamBase() = default;
+  virtual ~StreamBase();
 
   // One of these must be implemented
   virtual AsyncWrap* GetAsyncWrap();


### PR DESCRIPTION
Requiring g++ 4.8.x and later to build node binaries means that users
who download node binaries from nodejs.org may not be able to use them
if the C++ runtime library installed on their system is older. This is
the case for instance by default for Solaris 11.2.

This change works around a g++ bug
(https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53613) whose fix is
present in g++ 4.8.x, but hasn't been backported to g++ 4.7.x and makes
node buildable with g++4.7.x. The resulting binary thus requires a less
recent C++ runtime and works on a broader set of systems.

Fixes #3349.