### PR TITLE
src: bump NODE_MODULE_VERSION To 47

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -49,6 +49,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 46 /* Node.js v4.0.0 */
+#define NODE_MODULE_VERSION 47 /* Node.js v5.0.0 */
 
 #endif  /* SRC_NODE_VERSION_H_ */


### PR DESCRIPTION
For Node.js v5.0.0, due to upgrade to V8 4.6 which has an incompatible ABI.

I've said in the past (and documented it in docs/release.md) that this should be done in the release commit, i.e. left until the last minute. But I think I want to contradict that and suggest that we should do it early so as to make the nightlies and RCs for a new major version closer to the final release and make it easier on users.

/R=@nodejs/release 