### PR TITLE
timers: reuse timer in `setTimeout().unref()`

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -119,16 +119,27 @@ function listOnTimeoutNT(list) {
 }
 
 
-const unenroll = exports.unenroll = function(item) {
+function reuse(item) {
   L.remove(item);
 
   var list = lists[item._idleTimeout];
-  // if empty then stop the watcher
-  debug('unenroll');
+  // if empty - reuse the watcher
   if (list && L.isEmpty(list)) {
+    debug('reuse hit');
+    list.stop();
+    delete lists[item._idleTimeout];
+    return list;
+  }
+
+  return null;
+}
+
+
+const unenroll = exports.unenroll = function(item) {
+  var list = reuse(item);
+  if (list) {
     debug('unenroll: list empty');
     list.close();
-    delete lists[item._idleTimeout];
   }
   // if active is called later, then we want to make sure not to insert again
   item._idleTimeout = -1;
@@ -312,12 +323,16 @@ Timeout.prototype.unref = function() {
     if (!this._idleStart) this._idleStart = now;
     var delay = this._idleStart + this._idleTimeout - now;
     if (delay < 0) delay = 0;
-    exports.unenroll(this);
 
     // Prevent running cb again when unref() is called during the same cb
-    if (this._called && !this._repeat) return;
+    if (this._called && !this._repeat) {
+      exports.unenroll(this);
+      return;
+    }
 
-    this._handle = new Timer();
+    var handle = reuse(this);
+
+    this._handle = handle || new Timer();
     this._handle.owner = this;
     this._handle[kOnTimeout] = unrefdHandle;
     this._handle.start(delay, 0);

--- a/test/parallel/test-timers-unrefed-in-beforeexit.js
+++ b/test/parallel/test-timers-unrefed-in-beforeexit.js
@@ -1,0 +1,20 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+var once = 0;
+
+process.on('beforeExit', () => {
+  if (once > 1)
+    throw new RangeError('beforeExit should only have been called once!');
+
+  setTimeout(() => {}, 1).unref();
+  once++;
+});
+
+process.on('exit', (code) => {
+  if (code !== 0) return;
+
+  assert.strictEqual(once, 1);
+});


### PR DESCRIPTION
Instead of creating new timer - reuse the timer from the freelist. This
won't make the freelist timer active for the duration of `uv_close()`,
and will let the event-loop exit properly.

Fix: #1264 

R=@trevnorris @Fishrock123 