### PR TITLE
src: added big-endian check and support to UTF-16 encode

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -460,10 +460,11 @@ void StringSlice<UCS2>(const FunctionCallbackInfo<Value>& args) {
   // need to reorder on BE platforms.  See http://nodejs.org/api/buffer.html
   // regarding Node's "ucs2" encoding specification.
   const bool aligned = (reinterpret_cast<uintptr_t>(data) % sizeof(*buf) == 0);
-  if (IsLittleEndian() && aligned) {
-    buf = reinterpret_cast<const uint16_t*>(data);
-  } else {
+  if (IsLittleEndian() && !aligned) {
     // Make a copy to avoid unaligned accesses in v8::String::NewFromTwoByte().
+    // This applies ONLY to little endian platforms, as misalignment will be
+    // handled by a byte-swapping operation in StringBytes::Encode on
+    // big endian platforms.
     uint16_t* copy = new uint16_t[length];
     for (size_t i = 0, k = 0; i < length; i += 1, k += 2) {
       // Assumes that the input is little endian.
@@ -473,6 +474,8 @@ void StringSlice<UCS2>(const FunctionCallbackInfo<Value>& args) {
     }
     buf = copy;
     release = true;
+  } else {
+    buf = reinterpret_cast<const uint16_t*>(data);
   }
 
   args.GetReturnValue().Set(StringBytes::Encode(env->isolate(), buf, length));

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -198,6 +198,20 @@ TypeName* Unwrap(v8::Local<v8::Object> object) {
   return static_cast<TypeName*>(pointer);
 }
 
+void SwapBytes(uint16_t* dst, const uint16_t* src, size_t buflen) {
+  for (size_t i = 0; i < buflen; i++) {
+    // __builtin_bswap16 generates more efficient code with
+    // g++ 4.8 on PowerPC and other big-endian archs
+#ifdef __GNUC__
+    dst[i] = __builtin_bswap16(src[i]);
+#else
+    dst[i] = (src[i] << 8) | (src[i] >> 8);
+#endif
+  }
+}
+
+
+
 }  // namespace node
 
 #endif  // SRC_UTIL_INL_H_

--- a/src/util.h
+++ b/src/util.h
@@ -176,6 +176,8 @@ inline void ClearWrap(v8::Local<v8::Object> object);
 template <typename TypeName>
 inline TypeName* Unwrap(v8::Local<v8::Object> object);
 
+inline void SwapBytes(uint16_t* dst, const uint16_t* src, size_t buflen);
+
 class Utf8Value {
   public:
     explicit Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value);


### PR DESCRIPTION
Added for loop to Encode function to support big-endian machines.
Used stack allocation instead of heap allocation to improve speed of endianness correction.
Resolves https://github.com/nodejs/node/issues/3409