### PR TITLE
test: fix flaky test for symlinks

### DIFF
--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -3,75 +3,18 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const exec = require('child_process').exec;
-var completed = 0;
-var expected_async;
-var linkTime;
-var fileTime;
 
 common.refreshTmpDir();
 
-const runTest = function() {
-  if (!skip_symlinks) {
-    // test creating and reading symbolic link
-    const linkData = path.join(common.fixturesDir, '/cycles/root.js');
-    const linkPath = path.join(common.tmpDir, 'symlink1.js');
+// test creating and reading hard link
+const srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
+const dstPath = path.join(common.tmpDir, 'link1.js');
 
-    fs.symlink(linkData, linkPath, function(err) {
-      if (err) throw err;
-      console.log('symlink done');
-
-      fs.lstat(linkPath, function(err, stats) {
-        if (err) throw err;
-        linkTime = stats.mtime.getTime();
-        completed++;
-      });
-
-      fs.stat(linkPath, function(err, stats) {
-        if (err) throw err;
-        fileTime = stats.mtime.getTime();
-        completed++;
-      });
-
-      fs.readlink(linkPath, function(err, destination) {
-        if (err) throw err;
-        assert.equal(destination, linkData);
-        completed++;
-      });
-    });
-  }
-
-  // test creating and reading hard link
-  const srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
-  const dstPath = path.join(common.tmpDir, 'link1.js');
-
-  fs.link(srcPath, dstPath, function(err) {
-    if (err) throw err;
-    console.log('hard link done');
-    const srcContent = fs.readFileSync(srcPath, 'utf8');
-    const dstContent = fs.readFileSync(dstPath, 'utf8');
-    assert.equal(srcContent, dstContent);
-    completed++;
-  });
+const callback = function(err) {
+  if (err) throw err;
+  const srcContent = fs.readFileSync(srcPath, 'utf8');
+  const dstContent = fs.readFileSync(dstPath, 'utf8');
+  assert.strictEqual(srcContent, dstContent);
 };
 
-var skip_symlinks = false;
-var expected_async = 4;
-if (common.isWindows) {
-  // On Windows, creating symlinks requires admin privileges.
-  // We'll only try to run symlink test if we have enough privileges.
-  exec('whoami /priv', function(err, o) {
-    if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
-      expected_async = 1;
-      skip_symlinks = true;
-    }
-  });
-}
-runTest();
-
-process.on('exit', function() {
-  assert.equal(completed, expected_async);
-  if (! skip_symlinks) {
-    assert.notStrictEqual(linkTime, fileTime);
-  }
-});
+fs.link(srcPath, dstPath, common.mustCall(callback));

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -1,21 +1,21 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
-var exec = require('child_process').exec;
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const exec = require('child_process').exec;
 var completed = 0;
-var expected_async = 4;
+var expected_async;
 var linkTime;
 var fileTime;
 
 common.refreshTmpDir();
 
-var runtest = function(skip_symlinks) {
+const runTest = function() {
   if (!skip_symlinks) {
     // test creating and reading symbolic link
-    var linkData = path.join(common.fixturesDir, '/cycles/root.js');
-    var linkPath = path.join(common.tmpDir, 'symlink1.js');
+    const linkData = path.join(common.fixturesDir, '/cycles/root.js');
+    const linkPath = path.join(common.tmpDir, 'symlink1.js');
 
     fs.symlink(linkData, linkPath, function(err) {
       if (err) throw err;
@@ -42,36 +42,36 @@ var runtest = function(skip_symlinks) {
   }
 
   // test creating and reading hard link
-  var srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
-  var dstPath = path.join(common.tmpDir, 'link1.js');
+  const srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
+  const dstPath = path.join(common.tmpDir, 'link1.js');
 
   fs.link(srcPath, dstPath, function(err) {
     if (err) throw err;
     console.log('hard link done');
-    var srcContent = fs.readFileSync(srcPath, 'utf8');
-    var dstContent = fs.readFileSync(dstPath, 'utf8');
+    const srcContent = fs.readFileSync(srcPath, 'utf8');
+    const dstContent = fs.readFileSync(dstPath, 'utf8');
     assert.equal(srcContent, dstContent);
     completed++;
   });
 };
 
+var skip_symlinks = false;
+var expected_async = 4;
 if (common.isWindows) {
   // On Windows, creating symlinks requires admin privileges.
   // We'll only try to run symlink test if we have enough privileges.
   exec('whoami /priv', function(err, o) {
     if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
       expected_async = 1;
-      runtest(true);
-    } else {
-      runtest(false);
+      skip_symlinks = true;
     }
   });
-} else {
-  runtest(false);
 }
+runTest();
 
 process.on('exit', function() {
   assert.equal(completed, expected_async);
-  assert(linkTime !== fileTime);
+  if (! skip_symlinks) {
+    assert.notStrictEqual(linkTime, fileTime);
+  }
 });
-

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -1,0 +1,50 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const exec = require('child_process').exec;
+
+var linkTime;
+var fileTime;
+
+if (common.isWindows) {
+  // On Windows, creating symlinks requires admin privileges.
+  // We'll only try to run symlink test if we have enough privileges.
+  exec('whoami /priv', function(err, o) {
+    if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
+      console.log('1..0 # Skipped: insufficient privileges');
+      return;
+    }
+  });
+}
+
+common.refreshTmpDir();
+
+// test creating and reading symbolic link
+const linkData = path.join(common.fixturesDir, '/cycles/root.js');
+const linkPath = path.join(common.tmpDir, 'symlink1.js');
+
+fs.symlink(linkData, linkPath, function(err) {
+  if (err) throw err;
+
+  fs.lstat(linkPath, common.mustCall(function(err, stats) {
+    if (err) throw err;
+    linkTime = stats.mtime.getTime();
+  }));
+
+  fs.stat(linkPath, common.mustCall(function(err, stats) {
+    if (err) throw err;
+    fileTime = stats.mtime.getTime();
+  }));
+
+  fs.readlink(linkPath, common.mustCall(function(err, destination) {
+    if (err) throw err;
+    assert.equal(destination, linkData);
+  }));
+});
+
+
+process.on('exit', function() {
+  assert.notStrictEqual(linkTime, fileTime);
+});


### PR DESCRIPTION
    If the symlink portion of the test was being skipped due to a
    combination of OS support and user privileges, then an assertion would
    always fail. This fixes that problem, improves assertion error reporting
    and renames the test to make it clear that it is a test for links and
    not just symlinks.
    
Fixes: https://github.com/nodejs/node/issues/3311