### PR TITLE
test: remove flaky status from eval_messages test

### DIFF
--- a/test/message/message.status
+++ b/test/message/message.status
@@ -9,7 +9,6 @@ prefix message
 [$system==win32]
 
 [$system==linux]
-eval_messages                      : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
This test has not failed on armv7-wheezy in over 6 weeks. Let's remove its
"flaky" status.

Fixes: https://github.com/nodejs/node/issues/2672