### PR TITLE
Return stdout, stderr and errors as an object if no callback is specified in exec()

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -175,8 +175,6 @@ exports.execFile = function(file /*, args, options, callback*/) {
       timeoutId = null;
     }
 
-    if (!callback) return;
-
     // merge chunks
     var stdout;
     var stderr;
@@ -207,6 +205,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     }
 
     ex.cmd = cmd;
+    if (!callback) return {stdout: stdout, stderr: stderr};
     callback(ex, stdout, stderr);
   }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -205,8 +205,11 @@ exports.execFile = function(file /*, args, options, callback*/) {
     }
 
     ex.cmd = cmd;
-    if (!callback) return {stdout: stdout, stderr: stderr};
-    callback(ex, stdout, stderr);
+    if (!callback){
+      return {stdout: stdout, stderr: stderr, errors: ex};
+    } else {
+      callback(ex, stdout, stderr);
+    }
   }
 
   function errorhandler(e) {


### PR DESCRIPTION
Usage:
```
var cmd = exec('ls -l / ');
if cmd.error; throw new Error;
console.log(cmd.stdout)
console.log(cmd.stderr)
console.log(cmd);
```
Should return:

```
drwxr-xr-x  1 User 197609       0 Oct 18 10:17 bin/
drwxr-xr-x  1 User 197609       0 Oct 18 10:16 cmd/
drwxr-xr-x  1 User 197609       0 Oct 18 10:17 dev/
drwxr-xr-x  1 User 197609       0 Oct 18 10:17 etc/
-rwxr-xr-x  1 User 197609  140800 Oct  5 20:00 git-bash.exe*
-rwxr-xr-x  1 User 197609  140288 Oct  5 20:00 git-cmd.exe*
drwxr-xr-x  1 User 197609       0 Oct 18 10:16 mingw64/
dr-xr-xr-x 22 User 197609       0 Oct 18 20:08 proc/
-rw-r--r--  1 User 197609   56930 Oct  5 20:41 ReleaseNotes.html
drwxr-xr-x  1 User 197609       0 Oct 18 20:05 tmp/
-rw-r--r--  1 User 197609  968959 Oct 18 10:17 unins001.dat
-rwxr-xr-x  1 User 197609 1300777 Oct 18 10:14 unins001.exe*
drwxr-xr-x  1 User 197609       0 Oct 18 10:16 usr/

{stdout: drwxr-xr-x  1 User 197609       0 Oct 18 10:17 bin/
drwxr-xr-x  1 User 197609       0 Oct 18 10:16 cmd/
drwxr-xr-x  1 User 197609       0 Oct 18 10:17 dev/
drwxr-xr-x  1 User 197609       0 Oct 18 10:17 etc/
-rwxr-xr-x  1 User 197609  140800 Oct  5 20:00 git-bash.exe*
-rwxr-xr-x  1 User 197609  140288 Oct  5 20:00 git-cmd.exe*
drwxr-xr-x  1 User 197609       0 Oct 18 10:16 mingw64/
dr-xr-xr-x 22 User 197609       0 Oct 18 20:08 proc/
-rw-r--r--  1 User 197609   56930 Oct  5 20:41 ReleaseNotes.html
drwxr-xr-x  1 User 197609       0 Oct 18 20:05 tmp/
-rw-r--r--  1 User 197609  968959 Oct 18 10:17 unins001.dat
-rwxr-xr-x  1 User 197609 1300777 Oct 18 10:14 unins001.exe*
drwxr-xr-x  1 User 197609       0 Oct 18 10:16 usr/
, stderr: null, errors: null}

```

This could be used like so, in an express app:
```
app.get('/', function (req, res) {
  // body...
  var cmd = exec('command');
  if(cmd.errors){
    throw new Error;
  }
  res.send('Output:'+cmd.stdout);
});
```

