### PR TITLE
Fix flaky test-child-process-emfile

### DIFF
--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -31,9 +31,6 @@ for (;;) {
   try {
     openFds.push(fs.openSync(__filename, 'r'));
   } catch (err) {
-    if (err.code === 'ENFILE') {
-      continue;
-    }
     assert(err.code === 'EMFILE');
     break;
   }

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -1,30 +1,49 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var spawn = require('child_process').spawn;
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const fs = require('fs');
 
 if (common.isWindows) {
   console.log('1..0 # Skipped: no RLIMIT_NOFILE on Windows');
   return;
 }
 
-var openFds = [];
+const ulimit = Number(child_process.execSync('ulimit -n'));
+if (ulimit > 64) {
+  // Sorry about this nonsense. It can be replaced if
+  // https://github.com/nodejs/node-v0.x-archive/pull/2143#issuecomment-2847886
+  // ever happens.
+  const result = child_process.spawnSync(
+    '/bin/sh',
+    ['-c', `ulimit -n 64 && ${process.execPath} ${__filename}`]
+  );
+  assert.strictEqual(result.stdout.toString(), '');
+  assert.strictEqual(result.stderr.toString(), '');
+  assert.strictEqual(result.status, 0);
+  assert.strictEqual(result.error, undefined);
+  return;
+}
+
+const openFds = [];
 
 for (;;) {
   try {
     openFds.push(fs.openSync(__filename, 'r'));
   } catch (err) {
-    assert(err.code === 'EMFILE' || err.code === 'ENFILE');
+    if (err.code === 'ENFILE') {
+      continue;
+    }
+    assert(err.code === 'EMFILE');
     break;
   }
 }
 
 // Should emit an error, not throw.
-var proc = spawn(process.execPath, ['-e', '0']);
+const proc = child_process.spawn(process.execPath, ['-e', '0']);
 
 proc.on('error', common.mustCall(function(err) {
-  assert(err.code === 'EMFILE' || err.code === 'ENFILE');
+  assert.strictEqual(err.code, 'EMFILE');
 }));
 
 proc.on('exit', function() {

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -9,7 +9,7 @@ if (common.isWindows) {
   return;
 }
 
-const ulimit = Number(child_process.execSync('ulimit -n'));
+const ulimit = Number(child_process.execSync('ulimit -Hn'));
 if (ulimit > 64 || Number.isNaN(ulimit)) {
   // Sorry about this nonsense. It can be replaced if
   // https://github.com/nodejs/node-v0.x-archive/pull/2143#issuecomment-2847886

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -16,7 +16,7 @@ if (ulimit > 64 || Number.isNaN(ulimit)) {
   // ever happens.
   const result = child_process.spawnSync(
     '/bin/sh',
-    ['-c', `ulimit -n 64 && ${process.execPath} ${__filename}`]
+    ['-c', `ulimit -n 64 && '${process.execPath}' '${__filename}'`]
   );
   assert.strictEqual(result.stdout.toString(), '');
   assert.strictEqual(result.stderr.toString(), '');

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -10,7 +10,7 @@ if (common.isWindows) {
 }
 
 const ulimit = Number(child_process.execSync('ulimit -n'));
-if (ulimit > 64) {
+if (ulimit > 64 || Number.isNaN(ulimit)) {
   // Sorry about this nonsense. It can be replaced if
   // https://github.com/nodejs/node-v0.x-archive/pull/2143#issuecomment-2847886
   // ever happens.


### PR DESCRIPTION
Require the test setup to obtain an EMFILE error and not ENFILE as
ENFILE means there is a race condition with other processes that may
close files before `spawn()` is called by the test.

This test as is had failed 6 out of 26 times that are in the Jenkins history for freebsd101-32 at https://ci.nodejs.org/job/node-test-commit-freebsd/. With the fix, it has run successfully 12 out of 12 times. (UPDATE: 14 out of 14 now.)

Fixes: https://github.com/nodejs/node/issues/2666