### PR TITLE
util: Remove p, has been deprecated for years

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -790,13 +790,6 @@ function hasOwnProperty(obj, prop) {
 
 // Deprecated old stuff.
 
-exports.p = internalUtil.deprecate(function() {
-  for (var i = 0, len = arguments.length; i < len; ++i) {
-    console.error(exports.inspect(arguments[i]));
-  }
-}, 'util.p is deprecated. Use console.error instead.');
-
-
 exports.exec = internalUtil.deprecate(function() {
   return require('child_process').exec.apply(this, arguments);
 }, 'util.exec is deprecated. Use child_process.exec instead.');

--- a/test/fixtures/deprecated.js
+++ b/test/fixtures/deprecated.js
@@ -1,1 +1,1 @@
-require('util').p('This is deprecated');
+require('util').debug('This is deprecated');

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -16,8 +16,8 @@ execFile(node, normal, function(er, stdout, stderr) {
   console.error('normal: show deprecation warning');
   assert.equal(er, null);
   assert.equal(stdout, '');
-  assert.equal(stderr, '(node) util.p is deprecated. Use console.error ' +
-                       'instead.\n\'This is deprecated\'\n');
+  assert.equal(stderr, '(node) util.debug is deprecated. Use console.error ' +
+                       'instead.\nDEBUG: This is deprecated\n');
   console.log('normal ok');
 });
 
@@ -25,7 +25,7 @@ execFile(node, noDep, function(er, stdout, stderr) {
   console.error('--no-deprecation: silence deprecations');
   assert.equal(er, null);
   assert.equal(stdout, '');
-  assert.equal(stderr, '\'This is deprecated\'\n');
+  assert.equal(stderr, 'DEBUG: This is deprecated\n');
   console.log('silent ok');
 });
 
@@ -36,8 +36,8 @@ execFile(node, traceDep, function(er, stdout, stderr) {
   var stack = stderr.trim().split('\n');
   // just check the top and bottom.
   assert.equal(stack[0],
-               'Trace: util.p is deprecated. Use console.error instead.');
-  assert.equal(stack.pop(), '\'This is deprecated\'');
+               'Trace: util.debug is deprecated. Use console.error instead.');
+  assert.equal(stack.pop(), 'DEBUG: This is deprecated');
   console.log('trace ok');
 });
 


### PR DESCRIPTION
Replaces https://github.com/nodejs/node/pull/2529

It is the same change, with an update to the deprecation test to use another method.