### PR TITLE
repl: event ordering: delay 'close' until 'flushHistory'

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -27,7 +27,7 @@ const Stream = require('stream');
 const vm = require('vm');
 const path = require('path');
 const fs = require('fs');
-const rl = require('readline');
+const Interface = require('readline').Interface;
 const Console = require('console').Console;
 const domain = require('domain');
 const debug = util.debuglog('repl');
@@ -229,7 +229,7 @@ function REPLServer(prompt,
     self.complete(text, callback);
   }
 
-  rl.Interface.call(this, {
+  Interface.call(this, {
     input: self.inputStream,
     output: self.outputStream,
     completer: complete,
@@ -453,7 +453,7 @@ function REPLServer(prompt,
 
   self.displayPrompt();
 }
-inherits(REPLServer, rl.Interface);
+inherits(REPLServer, Interface);
 exports.REPLServer = REPLServer;
 
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
@@ -477,6 +477,20 @@ exports.start = function(prompt,
   if (!exports.repl) exports.repl = repl;
   replMap.set(repl, repl);
   return repl;
+};
+
+REPLServer.prototype.close = function replClose() {
+  if (this.terminal && this._flushing && !this._closingOnFlush) {
+    this._closingOnFlush = true;
+    this.once('flushHistory', () =>
+      Interface.prototype.close.call(this)
+    );
+
+    return;
+  }
+  process.nextTick(() =>
+    Interface.prototype.close.call(this)
+  );
 };
 
 REPLServer.prototype.createContext = function() {


### PR DESCRIPTION
Emitting close before the history has flushed is somewhat incorrect and
rather confusing.

Fixes an issue related to https://github.com/nodejs/node/pull/2356

Separate PR since I'm going to try to make https://github.com/nodejs/node/pull/2356 work without it, but would already like review here.

