### PR TITLE
test: repl-persistent-history is no longer flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -5,7 +5,6 @@ prefix sequential
 # sample-test                       : PASS,FLAKY
 
 [true] # This section applies to all platforms
-test-repl-persistent-history                    : PASS,FLAKY
 
 [$system==win32]
 


### PR DESCRIPTION
The race conditions were fixed in
286ef1daca1c1f3e3363ee162fb97fb823632352

R=@evanlucas?