### PR TITLE
doc: binary encoding is not deprecated

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -30,10 +30,9 @@ encoding method.  Here are the different string encodings.
 
 * `'base64'` - Base64 string encoding.
 
-* `'binary'` - A way of encoding raw binary data into strings by using only
-  the first 8 bits of each character. This encoding method is deprecated and
-  should be avoided in favor of `Buffer` objects where possible. This encoding
-  will be removed in future versions of Node.js.
+* `'binary'` - A way of encoding the buffer into a one-byte (i.e. `latin-1`)
+  encoded string. The string `'latin-1'` is not supported. Instead simply pass
+  `'binary'` to use `'latin-1'` encoding.
 
 * `'hex'` - Encode each byte as two hexadecimal characters.
 


### PR DESCRIPTION
When v8 implemented proper one-byte string support Node's internal
"binary" encoding implementation was removed in favor of it. The result
was that "binary" encoding effectively became "latin-1" encoding.
Because of this and because one-byte strings are natively supported by
v8 the buffer encoding is not deprecated and will not be removed.

Ref: 83261e7 "deps: update v8 to 3.17.13"

R=@bnoordhuis 