### PR TITLE
test: skip test-dns-ipv6.js if ipv6 is unavailable

### DIFF
--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -12,6 +12,11 @@ var expected = 0,
     running = false,
     queue = [];
 
+if (!common.hasIPv6) {
+  console.log('1..0 # Skipped: this test, no IPv6 support');
+  return;
+}
+
 function TEST(f) {
   function next() {
     var f = queue.shift();


### PR DESCRIPTION
Test should be skipped if ipv6 is unavailable on the running system.