### PR TITLE
test: wrap assert.fail when passed to callback

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -437,3 +437,7 @@ exports.fileExists = function(pathname) {
     return false;
   }
 };
+
+exports.fail = function(msg) {
+  assert.fail(null, null, msg);
+};

--- a/test/parallel/test-child-process-recv-handle.js
+++ b/test/parallel/test-child-process-recv-handle.js
@@ -24,7 +24,7 @@ function master() {
   });
   proc.stdout.on('data', function(data) {
     assert.equal(data, 'ok\r\n');
-    net.createServer(assert.fail).listen(common.PORT, function() {
+    net.createServer(common.fail).listen(common.PORT, function() {
       handle = this._handle;
       proc.send('one');
       proc.send('two', handle);

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -13,7 +13,7 @@ const empty = common.fixturesDir + '/empty.js';
 
 assert.throws(function() {
   var child = spawn(invalidcmd, 'this is not an array');
-  child.on('error', assert.fail);
+  child.on('error', common.fail);
 }, TypeError);
 
 // verify that valid argument combinations do not throw

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -20,8 +20,8 @@ if (cluster.isMaster) {
   }));
 }
 else {
-  var s = net.createServer(assert.fail);
-  s.listen(42, assert.fail.bind(null, 'listen should have failed'));
+  var s = net.createServer(common.fail);
+  s.listen(42, common.fail.bind(null, 'listen should have failed'));
   s.on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'EACCES');
     process.disconnect();

--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -68,7 +68,7 @@ if (!id) {
 else if (id === 'one') {
   if (cluster.isMaster) return startWorker();
 
-  var server = http.createServer(assert.fail).listen(common.PORT, function() {
+  var server = http.createServer(common.fail).listen(common.PORT, function() {
     process.send('READY');
   });
 
@@ -84,12 +84,12 @@ else if (id === 'two') {
     assert(ok);
   });
 
-  var server = http.createServer(assert.fail);
+  var server = http.createServer(common.fail);
   process.on('message', function(m) {
     if (typeof m === 'object') return; // ignore system messages
     if (m === 'QUIT') process.exit();
     assert.equal(m, 'START');
-    server.listen(common.PORT, assert.fail);
+    server.listen(common.PORT, common.fail);
     server.on('error', function(e) {
       assert.equal(e.code, 'EADDRINUSE');
       process.send(e.code);

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -12,7 +12,7 @@ var net = require('net');
 var id = '' + process.argv[2];
 
 if (id === 'undefined') {
-  var server = net.createServer(assert.fail);
+  var server = net.createServer(common.fail);
   server.listen(common.PORT, function() {
     var worker = fork(__filename, ['worker']);
     worker.on('message', function(msg) {
@@ -24,14 +24,14 @@ if (id === 'undefined') {
   });
 }
 else if (id === 'worker') {
-  var server = net.createServer(assert.fail);
-  server.listen(common.PORT, assert.fail);
+  var server = net.createServer(common.fail);
+  server.listen(common.PORT, common.fail);
   server.on('error', common.mustCall(function(e) {
     assert(e.code, 'EADDRINUSE');
     process.send('stop-listening');
     process.once('message', function(msg) {
       if (msg !== 'stopped-listening') return;
-      server = net.createServer(assert.fail);
+      server = net.createServer(common.fail);
       server.listen(common.PORT, common.mustCall(function() {
         server.close();
       }));

--- a/test/parallel/test-cluster-net-listen.js
+++ b/test/parallel/test-cluster-net-listen.js
@@ -17,5 +17,5 @@ if (cluster.isMaster) {
 }
 else {
   // listen() without port should not trigger a libuv assert
-  net.createServer(assert.fail).listen(process.exit);
+  net.createServer(common.fail).listen(process.exit);
 }

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -10,7 +10,7 @@ if (cluster.isMaster) {
     if (msg === 'done') this.kill();
   });
 } else {
-  const server = net.createServer(assert.fail);
+  const server = net.createServer(common.fail);
   server.listen(common.PORT, function() {
     server.unref();
     server.ref();

--- a/test/parallel/test-cluster-setup-master-argv.js
+++ b/test/parallel/test-cluster-setup-master-argv.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 
-setTimeout(assert.fail.bind(assert, 'setup not emitted'), 1000).unref();
+setTimeout(common.fail.bind(assert, 'setup not emitted'), 1000).unref();
 
 cluster.on('setup', function() {
   var clusterArgs = cluster.settings.args;

--- a/test/parallel/test-cluster-shared-handle-bind-error.js
+++ b/test/parallel/test-cluster-shared-handle-bind-error.js
@@ -8,7 +8,7 @@ if (cluster.isMaster) {
   // Master opens and binds the socket and shares it with the worker.
   cluster.schedulingPolicy = cluster.SCHED_NONE;
   // Hog the TCP port so that when the worker tries to bind, it'll fail.
-  net.createServer(assert.fail).listen(common.PORT, function() {
+  net.createServer(common.fail).listen(common.PORT, function() {
     var server = this;
     var worker = cluster.fork();
     worker.on('exit', common.mustCall(function(exitCode) {
@@ -18,8 +18,8 @@ if (cluster.isMaster) {
   });
 }
 else {
-  var s = net.createServer(assert.fail);
-  s.listen(common.PORT, assert.fail.bind(null, 'listen should have failed'));
+  var s = net.createServer(common.fail);
+  s.listen(common.PORT, common.fail.bind(null, 'listen should have failed'));
   s.on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'EADDRINUSE');
     process.disconnect();

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -22,8 +22,8 @@ if (cluster.isMaster) {
   }));
 }
 else {
-  var s = net.createServer(assert.fail);
-  s.listen(42, assert.fail.bind(null, 'listen should have failed'));
+  var s = net.createServer(common.fail);
+  s.listen(42, common.fail.bind(null, 'listen should have failed'));
   s.on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'EACCES');
     process.disconnect();

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -62,28 +62,28 @@ assert.throws(function() {
 
 // Should not work with Infinity key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, Infinity, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, Infinity, common.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });
 
 // Should not work with negative Infinity key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, -Infinity, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, -Infinity, common.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });
 
 // Should not work with NaN key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, NaN, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, NaN, common.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });
 
 // Should not work with negative key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, -1, assert.fail);
+  crypto.pbkdf2('password', 'salt', 1, -1, common.fail);
 }, function(err) {
   return err instanceof Error && err.message === 'Bad key length';
 });

--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -6,7 +6,7 @@ var dgram = require('dgram');
 // IPv4 Test
 var socket_ipv4 = dgram.createSocket('udp4');
 
-socket_ipv4.on('listening', assert.fail);
+socket_ipv4.on('listening', common.fail);
 
 socket_ipv4.on('error', common.mustCall(function(e) {
   assert.equal(e.message, 'bind EADDRNOTAVAIL 1.1.1.1:' + common.PORT);
@@ -22,7 +22,7 @@ socket_ipv4.bind(common.PORT, '1.1.1.1');
 var socket_ipv6 = dgram.createSocket('udp6');
 var family_ipv6 = 'IPv6';
 
-socket_ipv6.on('listening', assert.fail);
+socket_ipv6.on('listening', common.fail);
 
 socket_ipv6.on('error', common.mustCall(function(e) {
   // EAFNOSUPPORT or EPROTONOSUPPORT means IPv6 is disabled on this system.

--- a/test/parallel/test-dgram-oob-buffer.js
+++ b/test/parallel/test-dgram-oob-buffer.js
@@ -19,22 +19,22 @@ socket.send(buf, 3, 1, common.PORT, '127.0.0.1', ok);
 socket.send(buf, 4, 0, common.PORT, '127.0.0.1', ok);
 
 assert.throws(function() {
-  socket.send(buf, 0, 5, common.PORT, '127.0.0.1', assert.fail);
+  socket.send(buf, 0, 5, common.PORT, '127.0.0.1', common.fail);
 });
 assert.throws(function() {
-  socket.send(buf, 2, 3, common.PORT, '127.0.0.1', assert.fail);
+  socket.send(buf, 2, 3, common.PORT, '127.0.0.1', common.fail);
 });
 assert.throws(function() {
-  socket.send(buf, 4, 4, common.PORT, '127.0.0.1', assert.fail);
+  socket.send(buf, 4, 4, common.PORT, '127.0.0.1', common.fail);
 });
 assert.throws(function() {
-  socket.send('abc', 4, 1, common.PORT, '127.0.0.1', assert.fail);
+  socket.send('abc', 4, 1, common.PORT, '127.0.0.1', common.fail);
 });
 assert.throws(function() {
-  socket.send('abc', 0, 4, common.PORT, '127.0.0.1', assert.fail);
+  socket.send('abc', 0, 4, common.PORT, '127.0.0.1', common.fail);
 });
 assert.throws(function() {
-  socket.send('abc', -1, 2, common.PORT, '127.0.0.1', assert.fail);
+  socket.send('abc', -1, 2, common.PORT, '127.0.0.1', common.fail);
 });
 
 socket.close(); // FIXME should not be necessary

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -39,7 +39,7 @@ assert.deepEqual([], e1.listeners('hello'));
 
 var e2 = new events.EventEmitter();
 e2.on('hello', listener1);
-e2.on('removeListener', assert.fail);
+e2.on('removeListener', common.fail);
 e2.removeListener('hello', listener2);
 assert.deepEqual([listener1], e2.listeners('hello'));
 

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -43,10 +43,10 @@ check(fs.symlink,     fs.symlinkSync,     'foo\u0000bar', 'foobar');
 check(fs.symlink,     fs.symlinkSync,     'foobar', 'foo\u0000bar');
 check(fs.truncate,    fs.truncateSync,    'foo\u0000bar');
 check(fs.unlink,      fs.unlinkSync,      'foo\u0000bar');
-check(null,           fs.unwatchFile,     'foo\u0000bar', assert.fail);
+check(null,           fs.unwatchFile,     'foo\u0000bar', common.fail);
 check(fs.utimes,      fs.utimesSync,      'foo\u0000bar', 0, 0);
-check(null,           fs.watch,           'foo\u0000bar', assert.fail);
-check(null,           fs.watchFile,       'foo\u0000bar', assert.fail);
+check(null,           fs.watch,           'foo\u0000bar', common.fail);
+check(null,           fs.watchFile,       'foo\u0000bar', common.fail);
 check(fs.writeFile,   fs.writeFileSync,   'foo\u0000bar');
 
 // an 'error' for exists means that it doesn't exist.

--- a/test/parallel/test-fs-read-stream-err.js
+++ b/test/parallel/test-fs-read-stream-err.js
@@ -39,5 +39,5 @@ fs.read = function() {
 };
 
 stream.on('data', function(buf) {
-  stream.on('data', assert.fail);  // no more 'data' events should follow
+  stream.on('data', common.fail);  // no more 'data' events should follow
 });

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -5,5 +5,5 @@ var http = require('http');
 
 assert.throws(function() {
   // Path with spaces in it should throw.
-  http.get({ path: 'bad path' }, assert.fail);
+  http.get({ path: 'bad path' }, common.fail);
 }, /contains unescaped characters/);

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -53,7 +53,7 @@ server.on('listening', function() {
   c.on('connect', function() {
     outstanding_reqs++;
     c.write('GET / HTTP/1.1\r\n\r\n');
-    tid = setTimeout(assert.fail, 2000, 'Couldn\'t find last chunk.');
+    tid = setTimeout(common.fail, 2000, 'Couldn\'t find last chunk.');
   });
 
   c.on('data', function(chunk) {

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -18,7 +18,7 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var server = https.createServer(options, assert.fail);
+var server = https.createServer(options, common.fail);
 
 server.on('secureConnection', function(cleartext) {
   var s = cleartext.setTimeout(50, function() {

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -24,7 +24,7 @@ var options = {
   handshakeTimeout: 50
 };
 
-var server = https.createServer(options, assert.fail);
+var server = https.createServer(options, common.fail);
 
 server.on('clientError', function(err, conn) {
   // Don't hesitate to update the asserts if the internal structure of

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -9,8 +9,8 @@ process.on('exit', function() {
   assert.equal(gotError, 2);
 });
 
-net.createServer(assert.fail).listen({fd:2}).on('error', onError);
-net.createServer(assert.fail).listen({fd:42}).on('error', onError);
+net.createServer(common.fail).listen({fd:2}).on('error', onError);
+net.createServer(common.fail).listen({fd:42}).on('error', onError);
 
 function onError(ex) {
   assert.equal(ex.code, 'EINVAL');

--- a/test/parallel/test-net-better-error-messages-listen-path.js
+++ b/test/parallel/test-net-better-error-messages-listen-path.js
@@ -3,8 +3,8 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 var fp = '/blah/fadfa';
-var server = net.createServer(assert.fail);
-server.listen(fp, assert.fail);
+var server = net.createServer(common.fail);
+server.listen(fp, common.fail);
 server.on('error', common.mustCall(function(e) {
   assert.equal(e.address, fp);
 }));

--- a/test/parallel/test-net-better-error-messages-listen.js
+++ b/test/parallel/test-net-better-error-messages-listen.js
@@ -3,8 +3,8 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var server = net.createServer(assert.fail);
-server.listen(1, '1.1.1.1', assert.fail);
+var server = net.createServer(common.fail);
+server.listen(1, '1.1.1.1', common.fail);
 server.on('error', common.mustCall(function(e) {
   assert.equal(e.address, '1.1.1.1');
   assert.equal(e.port, 1);

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var fp = '/tmp/fadagagsdfgsdf';
 var c = net.connect(fp);
 
-c.on('connect', assert.fail);
+c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
   assert.equal(e.code, 'ENOENT');

--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 
 var c = net.createConnection(common.PORT, '...');
 
-c.on('connect', assert.fail);
+c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
   assert.equal(e.code, 'ENOTFOUND');

--- a/test/parallel/test-net-better-error-messages-port.js
+++ b/test/parallel/test-net-better-error-messages-port.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 
 var c = net.createConnection(common.PORT);
 
-c.on('connect', assert.fail);
+c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
   assert.equal(e.code, 'ECONNREFUSED');

--- a/test/parallel/test-net-dns-lookup-skip.js
+++ b/test/parallel/test-net-dns-lookup-skip.js
@@ -11,7 +11,7 @@ function check(addressType) {
 
   var address = addressType === 4 ? '127.0.0.1' : '::1';
   server.listen(common.PORT, address, function() {
-    net.connect(common.PORT, address).on('lookup', assert.fail);
+    net.connect(common.PORT, address).on('lookup', common.fail);
   });
 }
 

--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -10,7 +10,7 @@ process.on('exit', function() {
 });
 
 // this should fail with an async EINVAL error, not throw an exception
-net.createServer(assert.fail).listen({fd:0}).on('error', function(e) {
+net.createServer(common.fail).listen({fd:0}).on('error', function(e) {
   switch (e.code) {
     case 'EINVAL':
     case 'ENOTSOCK':

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -164,7 +164,7 @@ asyncTest('Catching a promise rejection after setImmediate is not' +
   });
   _reject(e);
   setImmediate(function() {
-    promise.then(assert.fail, function() {});
+    promise.then(common.fail, function() {});
   });
 });
 
@@ -176,7 +176,7 @@ asyncTest('When re-throwing new errors in a promise catch, only the' +
     assert.strictEqual(e2, reason);
     assert.strictEqual(promise2, promise);
   });
-  var promise2 = Promise.reject(e).then(assert.fail, function(reason) {
+  var promise2 = Promise.reject(e).then(common.fail, function(reason) {
     assert.strictEqual(e, reason);
     throw e2;
   });
@@ -206,7 +206,7 @@ asyncTest('When re-throwing new errors in a promise catch, only the ' +
     setTimeout(function() {
       reject(e);
     }, 1);
-  }).then(assert.fail, function(reason) {
+  }).then(common.fail, function(reason) {
     assert.strictEqual(e, reason);
     throw e2;
   });
@@ -225,7 +225,7 @@ asyncTest('When re-throwing new errors in a promise catch, only the re-thrown' +
     setTimeout(function() {
       reject(e);
       process.nextTick(function() {
-        promise2 = promise.then(assert.fail, function(reason) {
+        promise2 = promise.then(common.fail, function(reason) {
           assert.strictEqual(e, reason);
           throw e2;
         });
@@ -240,7 +240,7 @@ asyncTest('unhandledRejection should not be triggered if a promise catch is' +
           function(done) {
   var e = new Error();
   onUnhandledFail(done);
-  Promise.reject(e).then(assert.fail, function() {});
+  Promise.reject(e).then(common.fail, function() {});
 });
 
 asyncTest('unhandledRejection should not be triggered if a promise catch is' +
@@ -250,7 +250,7 @@ asyncTest('unhandledRejection should not be triggered if a promise catch is' +
   onUnhandledFail(done);
   new Promise(function(_, reject) {
     reject(e);
-  }).then(assert.fail, function() {});
+  }).then(common.fail, function() {});
 });
 
 asyncTest('Attaching a promise catch in a process.nextTick is soon enough to' +
@@ -259,7 +259,7 @@ asyncTest('Attaching a promise catch in a process.nextTick is soon enough to' +
   onUnhandledFail(done);
   var promise = Promise.reject(e);
   process.nextTick(function() {
-    promise.then(assert.fail, function() {});
+    promise.then(common.fail, function() {});
   });
 });
 
@@ -271,7 +271,7 @@ asyncTest('Attaching a promise catch in a process.nextTick is soon enough to' +
     reject(e);
   });
   process.nextTick(function() {
-    promise.then(assert.fail, function() {});
+    promise.then(common.fail, function() {});
   });
 });
 
@@ -302,7 +302,7 @@ asyncTest('catching a promise which is asynchronously rejected (via' +
         reject(e);
       }, 1);
     });
-  }).then(assert.fail, function(reason) {
+  }).then(common.fail, function(reason) {
     assert.strictEqual(e, reason);
   });
 });
@@ -313,7 +313,7 @@ asyncTest('Catching a rejected promise derived from throwing in a' +
   onUnhandledFail(done);
   Promise.resolve().then(function() {
     throw e;
-  }).then(assert.fail, function(reason) {
+  }).then(common.fail, function(reason) {
     assert.strictEqual(e, reason);
   });
 });
@@ -325,7 +325,7 @@ asyncTest('Catching a rejected promise derived from returning a' +
   onUnhandledFail(done);
   Promise.resolve().then(function() {
     return Promise.reject(e);
-  }).then(assert.fail, function(reason) {
+  }).then(common.fail, function(reason) {
     assert.strictEqual(e, reason);
   });
 });
@@ -380,7 +380,7 @@ asyncTest('Catching the Promise.all() of a collection that includes a' +
           'rejected promise prevents unhandledRejection', function(done) {
   var e = new Error();
   onUnhandledFail(done);
-  Promise.all([Promise.reject(e)]).then(assert.fail, function() {});
+  Promise.all([Promise.reject(e)]).then(common.fail, function() {});
 });
 
 asyncTest('Catching the Promise.all() of a collection that includes a ' +
@@ -395,7 +395,7 @@ asyncTest('Catching the Promise.all() of a collection that includes a ' +
   });
   p = Promise.all([p]);
   process.nextTick(function() {
-    p.then(assert.fail, function() {});
+    p.then(common.fail, function() {});
   });
 });
 
@@ -430,7 +430,7 @@ asyncTest('Waiting setTimeout(, 10) to catch a promise causes an' +
     throw e;
   });
   setTimeout(function() {
-    thePromise.then(assert.fail, function(reason) {
+    thePromise.then(common.fail, function(reason) {
       assert.strictEqual(e, reason);
     });
   }, 10);

--- a/test/parallel/test-timers-unref-remove-other-unref-timers.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 const timers = require('timers');
 
 const foo = {
-  _onTimeout: assert.fail
+  _onTimeout: common.fail
 };
 
 const bar = {

--- a/test/parallel/test-tls-cipher-list.js
+++ b/test/parallel/test-tls-cipher-list.js
@@ -17,12 +17,12 @@ function doCheck(arg, check) {
     'require("constants").defaultCipherList'
   ]);
   spawn(process.execPath, arg, {}).
-    on('error', assert.fail).
+    on('error', common.fail).
     stdout.on('data', function(chunk) {
       out += chunk;
     }).on('end', function() {
       assert.equal(out.trim(), check);
-    }).on('error', assert.fail);
+    }).on('error', common.fail);
 }
 
 // test the default unmodified version

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -18,7 +18,7 @@ if (common.opensslCli === false) {
 
 var cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem');
 var key = fs.readFileSync(common.fixturesDir + '/test_key.pem');
-var server = tls.createServer({ cert: cert, key: key }, assert.fail);
+var server = tls.createServer({ cert: cert, key: key }, common.fail);
 
 server.listen(common.PORT, '127.0.0.1', function() {
   var address = this.address().address + ':' + this.address().port;

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -23,7 +23,7 @@ var options = {
   handshakeTimeout: 50
 };
 
-var server = tls.createServer(options, assert.fail);
+var server = tls.createServer(options, common.fail);
 
 server.on('clientError', function(err, conn) {
   conn.destroy();

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -10,7 +10,7 @@ assert.throws(function() {
 }, /SyntaxError/);
 
 assert.throws(function() {
-  vm.runInDebugContext({ toString: assert.fail });
+  vm.runInDebugContext({ toString: common.fail });
 }, /AssertionError/);
 
 assert.throws(function() {
@@ -58,7 +58,7 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
 var script = common.fixturesDir + '/vm-run-in-debug-context.js';
 var proc = spawn(process.execPath, [script]);
 var data = [];
-proc.stdout.on('data', assert.fail);
+proc.stdout.on('data', common.fail);
 proc.stderr.on('data', data.push.bind(data));
 proc.stderr.once('end', common.mustCall(function() {
   var haystack = Buffer.concat(data).toString('utf8');
@@ -70,8 +70,8 @@ proc.once('exit', common.mustCall(function(exitCode, signalCode) {
 }));
 
 var proc = spawn(process.execPath, [script, 'handle-fatal-exception']);
-proc.stdout.on('data', assert.fail);
-proc.stderr.on('data', assert.fail);
+proc.stdout.on('data', common.fail);
+proc.stderr.on('data', common.fail);
 proc.once('exit', common.mustCall(function(exitCode, signalCode) {
   assert.equal(exitCode, 42);
   assert.equal(signalCode, null);

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -19,7 +19,7 @@ try { fs.mkdirSync(testsubdir, 0o700); } catch (e) {}
 
 // Need a grace period, else the mkdirSync() above fires off an event.
 setTimeout(function() {
-  var watcher = fs.watch(testDir, { persistent: true }, assert.fail);
+  var watcher = fs.watch(testDir, { persistent: true }, common.fail);
   setTimeout(function() {
     fs.writeFileSync(filepath, 'test');
   }, 100);

--- a/test/sequential/test-cluster-listening-port.js
+++ b/test/sequential/test-cluster-listening-port.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var net = require('net');
@@ -21,5 +21,5 @@ if (cluster.isMaster) {
   });
 }
 else {
-  net.createServer(assert.fail).listen(0);
+  net.createServer(common.fail).listen(0);
 }


### PR DESCRIPTION
Currently there are many instances where assert.fail is directly passed
to a callback for error handling. Unfortunately this will swallow the error
as it is the third argument of assert.fail that sets the message not the first.

This commit adds a new function to test/common.js that simply wraps assert.fail
and calls it with the provided message.

Tip of the hat to @trott for pointing me in the direction of this.