### PR TITLE
tls: remove util and calls to util.format

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -2,7 +2,6 @@
 
 const net = require('net');
 const url = require('url');
-const util = require('util');
 const binding = process.binding('crypto');
 const Buffer = require('buffer').Buffer;
 const constants = require('constants');
@@ -141,9 +140,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
       return ip === host;
     });
     if (!valid) {
-      reason = util.format('IP: %s is not in the cert\'s list: %s',
-                           host,
-                           ips.join(', '));
+      reason = `IP: ${host} is not in the cert's list: ${ips.join(', ')}`;
     }
   } else if (cert.subject) {
     // Transform hostname to canonical form
@@ -189,13 +186,11 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
 
     if (!valid) {
       if (cert.subjectaltname) {
-        reason = util.format('Host: %s is not in the cert\'s altnames: %s',
-                             host,
-                             cert.subjectaltname);
+        reason =
+            `Host: ${host} is not in the cert's altnames: ` +
+            `${cert.subjectaltname}`;
       } else {
-        reason = util.format('Host: %s is not cert\'s CN: %s',
-                             host,
-                             cert.subject.CN);
+        reason = `Host: ${host} is not cert's CN: ${cert.subject.CN}`;
       }
     }
   } else {
@@ -204,8 +199,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
 
   if (!valid) {
     var err = new Error(
-        util.format('Hostname/IP doesn\'t match certificate\'s altnames: %j',
-                    reason));
+        `Hostname/IP doesn't match certificate's altnames: "${reason}"`);
     err.reason = reason;
     err.host = host;
     err.cert = cert;


### PR DESCRIPTION
Currently util.format is being used for string templating in tls.
By replacing all of the instances of util.format with backtick
string we can remove the need to require util in tls all together.