### PR TITLE
test: fix test-net-keepalive for AIX

### DIFF
--- a/test/parallel/test-net-keepalive.js
+++ b/test/parallel/test-net-keepalive.js
@@ -4,8 +4,17 @@ var assert = require('assert');
 var net = require('net');
 
 var serverConnection;
+var clientConnection;
 var echoServer = net.createServer(function(connection) {
   serverConnection = connection;
+  setTimeout(function() {
+    // make sure both connections are still open
+    assert.equal(serverConnection.readyState, 'open');
+    assert.equal(clientConnection.readyState, 'open');
+    serverConnection.end();
+    clientConnection.end();
+    echoServer.close();
+  }, common.platformTimeout(100));
   connection.setTimeout(0);
   assert.notEqual(connection.setKeepAlive, undefined);
   // send a keepalive packet after 50 ms
@@ -17,15 +26,6 @@ var echoServer = net.createServer(function(connection) {
 echoServer.listen(common.PORT);
 
 echoServer.on('listening', function() {
-  var clientConnection = net.createConnection(common.PORT);
+  clientConnection = net.createConnection(common.PORT);
   clientConnection.setTimeout(0);
-
-  setTimeout(function() {
-    // make sure both connections are still open
-    assert.equal(serverConnection.readyState, 'open');
-    assert.equal(clientConnection.readyState, 'open');
-    serverConnection.end();
-    clientConnection.end();
-    echoServer.close();
-  }, common.platformTimeout(100));
 });


### PR DESCRIPTION
Fixed an intermittent issue on AIX where the 100ms timeout was reached
before the 'connection' event was fired. This resulted in a failure as
serverConnection would be undefined and the assert.equal would throw an
error. Changed the flow of the test so that the timeout is only set
after a connection has been made.