### PR TITLE
AsyncWrap external API improvements

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -17,7 +17,8 @@ inline AsyncWrap::AsyncWrap(Environment* env,
                             v8::Local<v8::Object> object,
                             ProviderType provider,
                             AsyncWrap* parent)
-    : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1) {
+    : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1),
+      uid_(env->get_async_wrap_uid()) {
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 
@@ -63,6 +64,11 @@ inline bool AsyncWrap::ran_init_callback() const {
 
 inline AsyncWrap::ProviderType AsyncWrap::provider_type() const {
   return static_cast<ProviderType>(bits_ >> 1);
+}
+
+
+inline int64_t AsyncWrap::get_uid() const {
+  return uid_;
 }
 
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -131,6 +131,8 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
     env->set_async_hooks_pre_function(args[1].As<Function>());
   if (args[2]->IsFunction())
     env->set_async_hooks_post_function(args[2].As<Function>());
+  if (args[3]->IsFunction())
+    env->set_async_hooks_destroy_function(args[3].As<Function>());
 }
 
 
@@ -156,6 +158,7 @@ static void Initialize(Local<Object> target,
   env->set_async_hooks_init_function(Local<Function>());
   env->set_async_hooks_pre_function(Local<Function>());
   env->set_async_hooks_post_function(Local<Function>());
+  env->set_async_hooks_destroy_function(Local<Function>());
 }
 
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -55,6 +55,8 @@ class AsyncWrap : public BaseObject {
 
   inline ProviderType provider_type() const;
 
+  inline int64_t get_uid() const;
+
   // Only call these within a valid HandleScope.
   v8::Local<v8::Value> MakeCallback(const v8::Local<v8::Function> cb,
                                      int argc,
@@ -76,6 +78,7 @@ class AsyncWrap : public BaseObject {
   // expected the context object will receive a _asyncQueue object property
   // that will be used to call pre/post in MakeCallback.
   uint32_t bits_;
+  const int64_t uid_;
 };
 
 void LoadAsyncWrapperInfo(Environment* env);

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -51,7 +51,7 @@ class AsyncWrap : public BaseObject {
                    ProviderType provider,
                    AsyncWrap* parent = nullptr);
 
-  inline virtual ~AsyncWrap() override = default;
+  inline virtual ~AsyncWrap();
 
   inline ProviderType provider_type() const;
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -210,6 +210,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       using_domains_(false),
       printed_error_(false),
       trace_sync_io_(false),
+      async_wrap_uid_(0),
       debugger_agent_(this),
       http_parser_buffer_(nullptr),
       context_(context->GetIsolate(), context) {
@@ -357,6 +358,10 @@ inline void Environment::set_printed_error(bool value) {
 
 inline void Environment::set_trace_sync_io(bool value) {
   trace_sync_io_ = value;
+}
+
+inline int64_t Environment::get_async_wrap_uid() {
+  return ++async_wrap_uid_;
 }
 
 inline uint32_t* Environment::heap_statistics_buffer() const {

--- a/src/env.h
+++ b/src/env.h
@@ -446,6 +446,8 @@ class Environment {
   void PrintSyncTrace() const;
   inline void set_trace_sync_io(bool value);
 
+  inline int64_t get_async_wrap_uid();
+
   bool KickNextTick();
 
   inline uint32_t* heap_statistics_buffer() const;
@@ -541,6 +543,7 @@ class Environment {
   bool using_domains_;
   bool printed_error_;
   bool trace_sync_io_;
+  int64_t async_wrap_uid_;
   debugger::Agent debugger_agent_;
 
   HandleWrapQueue handle_wrap_queue_;

--- a/src/env.h
+++ b/src/env.h
@@ -236,6 +236,7 @@ namespace node {
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_pre_function, v8::Function)                                   \
   V(async_hooks_post_function, v8::Function)                                  \
+  V(async_hooks_destroy_function, v8::Function)                               \
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
   V(buffer_prototype_object, v8::Object)                                      \

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -10,7 +10,7 @@ let cntr = 0;
 let server;
 let client;
 
-function init(type, parent) {
+function init(type, id, parent) {
   if (parent) {
     cntr++;
     // Cannot assert in init callback or will abort.

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -9,7 +9,7 @@ let cntr = 0;
 let server;
 let client;
 
-function init(type, parent) {
+function init(type, id, parent) {
   if (parent) {
     cntr++;
     // Cannot assert in init callback or will abort.

--- a/test/parallel/test-async-wrap-throw-no-init.js
+++ b/test/parallel/test-async-wrap-throw-no-init.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const async_wrap = process.binding('async_wrap');
+
+
+assert.throws(function() {
+  async_wrap.setupHooks(null);
+}, /init callback must be a function/);
+
+assert.throws(function() {
+  async_wrap.enable();
+}, /init callback is not assigned to a function/);
+
+// Should not throw
+async_wrap.setupHooks(() => {});
+async_wrap.enable();
+
+assert.throws(function() {
+  async_wrap.setupHooks(() => {});
+}, /hooks should not be set while also enabled/);


### PR DESCRIPTION
Few improvements to make the `AsyncWrap` external API more usable. These include:

1) Hooks are optional (except the init hook).
2) All `AsyncWrap` instances receive a unique id.
3) Call callback from the `AsyncWrap` destructor.

R=@bnoordhuis 

CI: https://ci.nodejs.org/job/node-test-pull-request/548/