### PR TITLE
debugger: propagate --debug-port= to debuggee

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -26,7 +26,7 @@ exports.start = function(argv, stdin, stdout) {
   stdin = stdin || process.stdin;
   stdout = stdout || process.stdout;
 
-  const args = ['--debug-brk'].concat(argv);
+  const args = [`--debug-brk=${exports.port}`].concat(argv);
   const interface_ = new Interface(stdin, stdout, args);
 
   stdin.resume();
@@ -41,7 +41,7 @@ exports.start = function(argv, stdin, stdout) {
   });
 };
 
-exports.port = 5858;
+exports.port = process.debugPort;
 
 
 //

--- a/test/parallel/test-debug-port-numbers.js
+++ b/test/parallel/test-debug-port-numbers.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+const children = [];
+for (let i = 0; i < 4; i += 1) {
+  const port = common.PORT + i;
+  const args = [`--debug-port=${port}`, '--interactive', 'debug', __filename];
+  const child = spawn(process.execPath, args, { stdio: 'pipe' });
+  child.test = { port: port, stdout: '' };
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', function(s) { child.test.stdout += s; update(); });
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  children.push(child);
+}
+
+function update() {
+  // Debugger prints relative paths except on Windows.
+  const filename = path.basename(__filename);
+
+  let ready = 0;
+  for (const child of children)
+    ready += RegExp(`break in .*?${filename}:1`).test(child.test.stdout);
+
+  if (ready === children.length)
+    for (const child of children)
+      child.kill();
+}
+
+process.on('exit', function() {
+  for (const child of children) {
+    const one = RegExp(`Debugger listening on port ${child.test.port}`);
+    const two = RegExp(`connecting to 127.0.0.1:${child.test.port}`);
+    assert(one.test(child.test.stdout));
+    assert(two.test(child.test.stdout));
+  }
+});


### PR DESCRIPTION
Before this commit `node --debug-port=1234 debug t.js` ignored the
--debug-port= argument, binding to the default port 5858 instead,
making it impossible to debug more than one process on the same
machine that way.

This commit also reduces the number of places where the default port
is hard-coded by one.

Fixes: https://github.com/nodejs/node/issues/3345

R=@indutny

CI: https://ci.nodejs.org/job/node-test-pull-request/550/