### PR TITLE
Add caveats section in the doc of crypto 

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -102,7 +102,7 @@ version of OpenSSL on the platform. Examples are `'sha256'`,
 list-message-digest-algorithms` will display the available digest
 algorithms.
 
-Example: this program that takes the sha1 sum of a file
+Example: this program that takes the sha256 sum of a file
 
     var filename = process.argv[2];
     var crypto = require('crypto');

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -768,6 +768,25 @@ default, set the `crypto.DEFAULT_ENCODING` field to 'binary'.  Note
 that new programs will probably expect buffers, so only use this as a
 temporary measure.
 
+## Caveats
+
+The crypto module still supports some algorithms which are already
+compromised. And the API also allows to use ciphers and hashes with a
+small key size that are consider to be weak for a safe use.
+
+Users should take full responsibility for selecting the crypto
+algorithm and its key size according to their security requirements.
+
+The following descriptions only show some of recommendations to use
+crypto module. See [NIST SP 800-131A] for details.
+
+- MD5 and SHA-1 are no longer acceptable where collision resistance is
+required such as digital signatures.
+- The key size of RSA, DSA and DH is recommended to use more than 2048
+bits and that of the curve of ECDSA and ECDH is more than 224 bits to
+be safe to use for several years.
+- The DH groups of `modp1`, `modp2` and `modp5` have a small key size
+  less than 2048 bits so they are not recommended.
 
 [createCipher()]: #crypto_crypto_createcipher_algorithm_password
 [createCipheriv()]: #crypto_crypto_createcipheriv_algorithm_key_iv
@@ -779,3 +798,4 @@ temporary measure.
 [RFC 3526]: http://www.rfc-editor.org/rfc/rfc3526.txt
 [crypto.pbkdf2]: #crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
 [EVP_BytesToKey]: https://www.openssl.org/docs/crypto/EVP_BytesToKey.html
+[NIST SP 800-131A]: http://csrc.nist.gov/publications/nistpubs/800-131A/sp800-131A.pdf

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -781,12 +781,12 @@ The following descriptions only show some of recommendations to use
 crypto module. See [NIST SP 800-131A] for details.
 
 - MD5 and SHA-1 are no longer acceptable where collision resistance is
-required such as digital signatures.
-- The key size of RSA, DSA and DH is recommended to use more than 2048
-bits and that of the curve of ECDSA and ECDH is more than 224 bits to
-be safe to use for several years.
-- The DH groups of `modp1`, `modp2` and `modp5` have a small key size
-  less than 2048 bits so they are not recommended.
+  required such as digital signatures.
+- The key used with RSA, DSA and DH algorithms is recommended to have
+  at least 2048 bits and that of the curve of ECDSA and ECDH at least
+  224 bits, to be safe to use for several years.
+- The DH groups of `modp1`, `modp2` and `modp5` have a key size
+  smaller than 2048 bits and are not recommended.
 
 [createCipher()]: #crypto_crypto_createcipher_algorithm_password
 [createCipheriv()]: #crypto_crypto_createcipheriv_algorithm_key_iv

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -772,12 +772,12 @@ temporary measure.
 
 The crypto module still supports some algorithms which are already
 compromised. And the API also allows to use ciphers and hashes with a
-small key size that are consider to be weak for a safe use.
+small key size that are considered to be too weak for safe use.
 
 Users should take full responsibility for selecting the crypto
-algorithm and its key size according to their security requirements.
+algorithm and key size according to their security requirements.
 
-The following descriptions only show some of recommendations to use
+The following descriptions only show some recommendations to use
 crypto module. See [NIST SP 800-131A] for details.
 
 - MD5 and SHA-1 are no longer acceptable where collision resistance is

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -511,21 +511,21 @@ expected.
 ## crypto.getDiffieHellman(group_name)
 
 Creates a predefined Diffie-Hellman key exchange object.  The
-supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in [RFC
-2412][]) and `'modp14'`, `'modp15'`, `'modp16'`, `'modp17'`,
-`'modp18'` (defined in [RFC 3526][]).  The returned object mimics the
-interface of objects created by [crypto.createDiffieHellman()][]
-above, but will not allow to change the keys (with
-[diffieHellman.setPublicKey()][] for example).  The advantage of using
-this routine is that the parties don't have to generate nor exchange
-group modulus beforehand, saving both processor and communication
-time.
+supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in
+[RFC 2412][], but see [Caveats](#crypto_caveats)) and `'modp14'`,
+`'modp15'`, `'modp16'`, `'modp17'`, `'modp18'` (defined in
+[RFC 3526][]).  The returned object mimics the interface of objects
+created by [crypto.createDiffieHellman()][] above, but will not allow
+to change the keys (with [diffieHellman.setPublicKey()][] for
+example).  The advantage of using this routine is that the parties do
+not have to generate nor exchange group modulus beforehand, saving
+both processor and communication time.
 
 Example (obtaining a shared secret):
 
     var crypto = require('crypto');
-    var alice = crypto.getDiffieHellman('modp5');
-    var bob = crypto.getDiffieHellman('modp5');
+    var alice = crypto.getDiffieHellman('modp14');
+    var bob = crypto.getDiffieHellman('modp14');
 
     alice.generateKeys();
     bob.generateKeys();

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -516,10 +516,10 @@ supported groups are: `'modp1'`, `'modp2'`, `'modp5'` (defined in
 `'modp15'`, `'modp16'`, `'modp17'`, `'modp18'` (defined in
 [RFC 3526][]).  The returned object mimics the interface of objects
 created by [crypto.createDiffieHellman()][] above, but will not allow
-to change the keys (with [diffieHellman.setPublicKey()][] for
-example).  The advantage of using this routine is that the parties do
-not have to generate nor exchange group modulus beforehand, saving
-both processor and communication time.
+changing the keys (with [diffieHellman.setPublicKey()][] for example).
+The advantage of using this routine is that the parties do not have to
+generate nor exchange group modulus beforehand, saving both processor
+and communication time.
 
 Example (obtaining a shared secret):
 
@@ -771,14 +771,13 @@ temporary measure.
 ## Caveats
 
 The crypto module still supports some algorithms which are already
-compromised. And the API also allows to use ciphers and hashes with a
-small key size that are considered to be too weak for safe use.
+compromised. And the API also allows the use of ciphers and hashes
+with a small key size that are considered to be too weak for safe use.
 
 Users should take full responsibility for selecting the crypto
 algorithm and key size according to their security requirements.
 
-The following descriptions only show some recommendations to use
-crypto module. See [NIST SP 800-131A] for details.
+Based on the recommendations of [NIST SP 800-131A]:
 
 - MD5 and SHA-1 are no longer acceptable where collision resistance is
   required such as digital signatures.
@@ -787,6 +786,8 @@ crypto module. See [NIST SP 800-131A] for details.
   224 bits, to be safe to use for several years.
 - The DH groups of `modp1`, `modp2` and `modp5` have a key size
   smaller than 2048 bits and are not recommended.
+
+See the reference for other recommendations and details.
 
 [createCipher()]: #crypto_crypto_createcipher_algorithm_password
 [createCipheriv()]: #crypto_crypto_createcipheriv_algorithm_key_iv

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -97,8 +97,8 @@ Creates and returns a hash object, a cryptographic hash with the given
 algorithm which can be used to generate hash digests.
 
 `algorithm` is dependent on the available algorithms supported by the
-version of OpenSSL on the platform. Examples are `'sha1'`, `'md5'`,
-`'sha256'`, `'sha512'`, etc.  On recent releases, `openssl
+version of OpenSSL on the platform. Examples are `'sha256'`,
+`'sha512'`, etc.  On recent releases, `openssl
 list-message-digest-algorithms` will display the available digest
 algorithms.
 
@@ -108,7 +108,7 @@ Example: this program that takes the sha1 sum of a file
     var crypto = require('crypto');
     var fs = require('fs');
 
-    var shasum = crypto.createHash('sha1');
+    var shasum = crypto.createHash('sha256');
 
     var s = fs.ReadStream(filename);
     s.on('data', function(d) {


### PR DESCRIPTION
This is originally from https://github.com/nodejs/node-v0.x-archive/pull/25564. 

This adds caveats section in the crypto api documentation to notify users of the risks of weak algorithms and small keys and revises examples to use safe ones.

Fix: https://github.com/nodejs/node/issues/3406