### PR TITLE
Release clarification and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,45 @@ policies and releases are managed under an
 If you need help using or installing Node.js, please use the
 [nodejs/help](https://github.com/nodejs/help) issue tracker.
 
+## Release Types
+
+The Node.js project maintains multiple types of releases:
+
+* **Stable**: Released from active development branches of this repository,
+  versioned by [SemVer](http://semver.org/) and signed by a member of the
+  [Release Team](#release-team).
+  Code for Stable releases is organized in this repository by major version
+  number, For example: [v4.x](https://github.com/nodejs/node/tree/v4.x).
+  The major version number of Stable releases will increment every 6 months
+  allowing for breaking changes to be introduced. This happens in April and
+  October every year. Stable release lines beginning in October each year have
+  a maximum support life of 8 months. Stable release lines beginning in April
+  each year will convert to LTS (see below) after 6 months and receive further
+  support for 30 months.
+* **LTS**: Releases that receive Long-term Support, with a focus on stability
+  and security. Every second Stable release line (major version) will become an
+  LTS line and receive 18 months of _Active LTS_ support and a further 12
+  months of _Maintenance_. LTS release lines are given alphabetically
+  ordered codenames, begining with v4 Argon. LTS releases are less frequent
+  and will attempt to maintain consistent major and minor version numbers,
+  only incrementing patch version numbers. There are no breaking changes or
+  feature additions, except in some special circumstances. More information
+  can be found in the [LTS README](https://github.com/nodejs/LTS/).
+* **Nightly**: Versions of code in this repository on the current Stable
+  branch, automatically built every 24-hours where changes exist. Use with
+  caution.
+
 ## Download
 
 Binaries, installers, and source tarballs are available at
 <https://nodejs.org>.
 
-**Releases** are available at <https://nodejs.org/dist/>, listed under
-their version string. The <https://nodejs.org/dist/latest/> symlink
-will point to the latest release directory.
+**Stable** and **LTS** releases are available at
+<https://nodejs.org/download/release/>, listed under their version strings.
+The [latest](https://nodejs.org/download/release/latest/) directory is an
+alias for the latest Stable release. The latest LTS release from an LTS
+line is available in the form: latest-lts-_codename_. For example:
+<https://nodejs.org/download/release/latest-lts-argon>
 
 **Nightly** builds are available at
 <https://nodejs.org/download/nightly/>, listed under their version
@@ -27,11 +58,12 @@ string which includes their date (in UTC time) and the commit SHA at
 the HEAD of the release.
 
 **API documentation** is available in each release and nightly
-directory under _docs_. <https://nodejs.org/api/> points to the latest version.
+directory under _docs_. <https://nodejs.org/api/> points to the API
+documentation of the latest stable version.
 
 ### Verifying Binaries
 
-Release and nightly download directories all contain a *SHASUM256.txt*
+Stable, LTS and Nightly download directories all contain a *SHASUM256.txt*
 file that lists the SHA checksums for each file available for
 download. To check that a downloaded file matches the checksum, run
 it through `sha256sum` with a command such as:
@@ -43,9 +75,9 @@ $ grep node-vx.y.z.tar.gz SHASUMS256.txt | sha256sum -c -
 _(Where "node-vx.y.z.tar.gz" is the name of the file you have
 downloaded)_
 
-Additionally, releases (not nightlies) have GPG signed copies of
-SHASUM256.txt files available as SHASUM256.txt.asc. You can use `gpg`
-to verify that the file has not been tampered with.
+Additionally, Stable and LTS releases (not Nightlies) have GPG signed
+copies of SHASUM256.txt files available as SHASUM256.txt.asc. You can use
+`gpg` to verify that the file has not been tampered with.
 
 To verify a SHASUM256.txt.asc, you will first need to import all of
 the GPG keys of individuals authorized to create releases. They are

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
-
 Node.js
-=====
+=======
 
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/nodejs/node?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This repository began as a GitHub fork of
-[joyent/node](https://github.com/joyent/node).
+The Node.js project is supported by the
+[Node.js Foundation](https://nodejs.org/en/foundation/). Contributions,
+policies and releases are managed under an
+[open governance model](./GOVERNANCE.md). We are also bound by a
+[Code of Conduct](./CODE_OF_CONDUCT.md).
 
-Node.js contributions, releases, and contributorship are under an
-[open governance model](./GOVERNANCE.md).
-We intend to land, with increasing regularity, releases which are
-compatible with the npm ecosystem that has been built to date for
-Node.js.
-
-We also have a Code of Conduct. [Please read it.](./CODE_OF_CONDUCT.md)
+If you need help using or installing Node.js, please use the
+[nodejs/help](https://github.com/nodejs/help) issue tracker.
 
 ## Download
 


### PR DESCRIPTION
Some cleaning up and additions to README. Trying to explain the release types is really hard without using lots of words, if you have better wording please suggest it.

Before this gets bogged down in bikeshedding, I'd like to get confirmation from @nodejs/tsc on this point which is something we've floated in discussions but never pinned down as policy:

> Stable release lines beginning in October each year have a maximum support life of 8 months.

i.e. every second (odd version as it happens) version will continue to get releases for 8 months max. We will switch to a new Stable after 6 but will allow for a 2 month overlap.

Messaging about this will be going out in a press release and blog post along with v5.0.0 so I'd like this to be pinned down instead of hand-wavy (currently "6 to 8 months").