### PR TITLE
console: Add common aliases for console methods

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -48,11 +48,19 @@ is used on each argument.  See [util.format()][] for more information.
 
 Same as `console.log`.
 
+### console.debug(object [,object, ...])
+
+Same as `console.log`.
+
 ### console.error([data][, ...])
 
 Same as `console.log` but prints to stderr.
 
 ### console.warn([data][, ...])
+
+Same as `console.error`.
+
+### console.exception(object [, object, ...])
 
 Same as `console.error`.
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -40,12 +40,18 @@ Console.prototype.log = function() {
 Console.prototype.info = Console.prototype.log;
 
 
+Console.prototype.debug = Console.prototype.log;
+
+
 Console.prototype.warn = function() {
   this._stderr.write(util.format.apply(this, arguments) + '\n');
 };
 
 
 Console.prototype.error = Console.prototype.warn;
+
+
+Console.prototype.exception = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object, options) {

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -36,9 +36,18 @@ assert(!called);
 c.log('test');
 assert(called);
 
+assert.equal(Console.prototype.log, Console.prototype.debug);
+assert.equal(c.log('test'), c.debug('test'));
+
 called = false;
 c.error('test');
 assert(called);
+
+assert.equal(Console.prototype.error, Console.prototype.warn);
+assert.equal(c.error('test'), c.warn('test'));
+
+assert.equal(Console.prototype.exception, Console.prototype.warn);
+assert.equal(c.exception('test'), c.warn('test'));
 
 out.write = function(d) {
   assert.equal('{ foo: 1 }\n', d);


### PR DESCRIPTION
- add common aliases as per following spec
- https://github.com/DeveloperToolsWG/console-object/blob/master/api.md