### PR TITLE
tools: update gyp to b3cef02

### DIFF
--- a/tools/gyp/PRESUBMIT.py
+++ b/tools/gyp/PRESUBMIT.py
@@ -125,14 +125,13 @@ def CheckChangeOnCommit(input_api, output_api):
 
 
 TRYBOTS = [
-    'gyp-win32',
-    'gyp-win64',
-    'gyp-linux',
-    'gyp-mac',
+    'linux_try',
+    'mac_try',
+    'win_try',
 ]
 
 
 def GetPreferredTryMasters(_, change):
   return {
-      'tryserver.nacl': { t: set(['defaulttests']) for t in TRYBOTS },
+      'client.gyp': { t: set(['defaulttests']) for t in TRYBOTS },
   }

--- a/tools/gyp/gyp_main.py
+++ b/tools/gyp/gyp_main.py
@@ -4,15 +4,13 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import os
 import sys
 
-# TODO(mark): sys.path manipulation is some temporary testing stuff.
-try:
-  import gyp
-except ImportError, e:
-  import os.path
-  sys.path.append(os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
-  import gyp
+# Make sure we're using the version of pylib in this repo, not one installed
+# elsewhere on the system.
+sys.path.insert(0, os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
+import gyp
 
 if __name__ == '__main__':
   sys.exit(gyp.script_main())

--- a/tools/gyp/pylib/gyp/MSVSSettings.py
+++ b/tools/gyp/pylib/gyp/MSVSSettings.py
@@ -708,10 +708,7 @@ _MSVSOnly(_compile, 'UseUnicodeResponseFiles', _boolean)
 _MSBuildOnly(_compile, 'BuildingInIDE', _boolean)
 _MSBuildOnly(_compile, 'CompileAsManaged',
              _Enumeration([], new=['false',
-                                   'true',  # /clr
-                                   'Pure',  # /clr:pure
-                                   'Safe',  # /clr:safe
-                                   'OldSyntax']))  # /clr:oldSyntax
+                                   'true']))  # /clr
 _MSBuildOnly(_compile, 'CreateHotpatchableImage', _boolean)  # /hotpatch
 _MSBuildOnly(_compile, 'MultiProcessorCompilation', _boolean)  # /MP
 _MSBuildOnly(_compile, 'PreprocessOutputPath', _string)  # /Fi

--- a/tools/gyp/pylib/gyp/MSVSSettings_test.py
+++ b/tools/gyp/pylib/gyp/MSVSSettings_test.py
@@ -296,7 +296,7 @@ class TestSequenceFunctions(unittest.TestCase):
             'BuildingInIDE': 'true',
             'CallingConvention': 'Cdecl',
             'CompileAs': 'CompileAsC',
-            'CompileAsManaged': 'Pure',
+            'CompileAsManaged': 'true',
             'CreateHotpatchableImage': 'true',
             'DebugInformationFormat': 'ProgramDatabase',
             'DisableLanguageExtensions': 'true',

--- a/tools/gyp/pylib/gyp/common.py
+++ b/tools/gyp/pylib/gyp/common.py
@@ -131,13 +131,20 @@ def QualifiedTarget(build_file, target, toolset):
 
 
 @memoize
-def RelativePath(path, relative_to):
+def RelativePath(path, relative_to, follow_path_symlink=True):
   # Assuming both |path| and |relative_to| are relative to the current
   # directory, returns a relative path that identifies path relative to
   # relative_to.
+  # If |follow_symlink_path| is true (default) and |path| is a symlink, then
+  # this method returns a path to the real file represented by |path|. If it is
+  # false, this method returns a path to the symlink. If |path| is not a
+  # symlink, this option has no effect.
 
   # Convert to normalized (and therefore absolute paths).
-  path = os.path.realpath(path)
+  if follow_path_symlink:
+    path = os.path.realpath(path)
+  else:
+    path = os.path.abspath(path)
   relative_to = os.path.realpath(relative_to)
 
   # On Windows, we can't create a relative path to a different drive, so just

--- a/tools/gyp/pylib/gyp/generator/analyzer.py
+++ b/tools/gyp/pylib/gyp/generator/analyzer.py
@@ -338,7 +338,7 @@ def _GenerateTargets(data, target_list, target_dicts, toplevel_dir, files,
       sources = _ExtractSources(target_name, target_dicts[target_name],
                                 toplevel_dir)
       for source in sources:
-        if source in files:
+        if _ToGypPath(os.path.normpath(source)) in files:
           print 'target', target_name, 'matches', source
           target.match_status = MATCH_STATUS_MATCHES
           matching_targets.append(target)
@@ -498,7 +498,7 @@ def _WasGypIncludeFileModified(params, files):
   files."""
   if params['options'].includes:
     for include in params['options'].includes:
-      if _ToGypPath(include) in files:
+      if _ToGypPath(os.path.normpath(include)) in files:
         print 'Include file modified, assuming all changed', include
         return True
   return False

--- a/tools/gyp/pylib/gyp/generator/msvs.py
+++ b/tools/gyp/pylib/gyp/generator/msvs.py
@@ -87,6 +87,8 @@ generator_additional_non_configuration_keys = [
     'msvs_requires_importlibrary',
     'msvs_enable_winphone',
     'msvs_application_type_revision',
+    'msvs_target_platform_version',
+    'msvs_target_platform_minversion',
 ]
 
 
@@ -2644,6 +2646,17 @@ def _GetMSBuildGlobalProperties(spec, guid, gyp_file_name):
     else:
       properties[0].append(['ApplicationTypeRevision', '8.1'])
 
+    if spec.get('msvs_target_platform_version'):
+      target_platform_version = spec.get('msvs_target_platform_version')
+      properties[0].append(['WindowsTargetPlatformVersion',
+                            target_platform_version])
+      if spec.get('msvs_target_platform_minversion'):
+        target_platform_minversion = spec.get('msvs_target_platform_minversion')
+        properties[0].append(['WindowsTargetPlatformMinVersion',
+                              target_platform_minversion])
+      else:
+        properties[0].append(['WindowsTargetPlatformMinVersion',
+                              target_platform_version])
     if spec.get('msvs_enable_winphone'):
       properties[0].append(['ApplicationType', 'Windows Phone'])
     else:

--- a/tools/gyp/pylib/gyp/msvs_emulation.py
+++ b/tools/gyp/pylib/gyp/msvs_emulation.py
@@ -442,6 +442,7 @@ class MsvsSettings(object):
     cl('FloatingPointModel',
         map={'0': 'precise', '1': 'strict', '2': 'fast'}, prefix='/fp:',
         default='0')
+    cl('CompileAsManaged', map={'false': '', 'true': '/clr'})
     cl('WholeProgramOptimization', map={'true': '/GL'})
     cl('WarningLevel', prefix='/W')
     cl('WarnAsError', map={'true': '/WX'})
@@ -592,6 +593,15 @@ class MsvsSettings(object):
        map={'1': 'CONSOLE%s' % minimum_required_version,
             '2': 'WINDOWS%s' % minimum_required_version},
        prefix='/SUBSYSTEM:')
+
+    stack_reserve_size = self._Setting(
+        ('VCLinkerTool', 'StackReserveSize'), config, default='')
+    if stack_reserve_size:
+      stack_commit_size = self._Setting(
+          ('VCLinkerTool', 'StackCommitSize'), config, default='')
+      if stack_commit_size:
+        stack_commit_size = ',' + stack_commit_size
+      ldflags.append('/STACK:%s%s' % (stack_reserve_size, stack_commit_size))
 
     ld('TerminalServerAware', map={'1': ':NO', '2': ''}, prefix='/TSAWARE')
     ld('LinkIncremental', map={'1': ':NO', '2': ''}, prefix='/INCREMENTAL')

--- a/tools/gyp/pylib/gyp/win_tool.py
+++ b/tools/gyp/pylib/gyp/win_tool.py
@@ -123,7 +123,9 @@ class WinTool(object):
                             stderr=subprocess.STDOUT)
     out, _ = link.communicate()
     for line in out.splitlines():
-      if not line.startswith('   Creating library '):
+      if (not line.startswith('   Creating library ') and
+          not line.startswith('Generating code') and
+          not line.startswith('Finished generating code')):
         print line
     return link.returncode
 

--- a/tools/gyp/pylib/gyp/xcode_emulation.py
+++ b/tools/gyp/pylib/gyp/xcode_emulation.py
@@ -1495,6 +1495,8 @@ def _GetXcodeEnv(xcode_settings, built_products_dir, srcroot, configuration,
     sdk_root = xcode_settings._SdkRoot(configuration)
     if not sdk_root:
       sdk_root = xcode_settings._XcodeSdkPath('')
+    if sdk_root is None:
+      sdk_root = ''
     env['SDKROOT'] = sdk_root
 
   if not additional_settings:

--- a/tools/gyp/pylib/gyp/xcode_emulation.py
+++ b/tools/gyp/pylib/gyp/xcode_emulation.py
@@ -1032,7 +1032,23 @@ class XcodeSettings(object):
     sdk_root = self._SdkPath(config_name)
     if not sdk_root:
       sdk_root = ''
-    return l.replace('$(SDKROOT)', sdk_root)
+    # Xcode 7 started shipping with ".tbd" (text based stubs) files instead of
+    # ".dylib" without providing a real support for them. What it does, for
+    # "/usr/lib" libraries, is do "-L/usr/lib -lname" which is dependent on the
+    # library order and cause collision when building Chrome.
+    #
+    # Instead substitude ".tbd" to ".dylib" in the generated project when the
+    # following conditions are both true:
+    # - library is referenced in the gyp file as "$(SDKROOT)/**/*.dylib",
+    # - the ".dylib" file does not exists but a ".tbd" file do.
+    library = l.replace('$(SDKROOT)', sdk_root)
+    if l.startswith('$(SDKROOT)'):
+      basename, ext = os.path.splitext(library)
+      if ext == '.dylib' and not os.path.exists(library):
+        tbd_library = basename + '.tbd'
+        if os.path.exists(tbd_library):
+          library = tbd_library
+    return library
 
   def AdjustLibraries(self, libraries, config_name=None):
     """Transforms entries like 'Cocoa.framework' in libraries into entries like
@@ -1479,8 +1495,6 @@ def _GetXcodeEnv(xcode_settings, built_products_dir, srcroot, configuration,
     sdk_root = xcode_settings._SdkRoot(configuration)
     if not sdk_root:
       sdk_root = xcode_settings._XcodeSdkPath('')
-    if sdk_root is None:
-      sdk_root = ''
     env['SDKROOT'] = sdk_root
 
   if not additional_settings:


### PR DESCRIPTION
Includes two patches for AIX. Adds support for both 32-bit and 64-bit
files[0] and uses -RPf for cp instead of -af (which is unsupported)[1]

[0] https://codereview.chromium.org/1319663007
[1] https://codereview.chromium.org/1368133002

CI run here https://ci.nodejs.org/job/node-test-commit/882/
Intermittent failure that passed on rerun:
https://ci.nodejs.org/job/node-test-commit-arm/958/