### PR TITLE
repl: exports `Recoverable`

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1177,3 +1177,4 @@ function Recoverable(err) {
   this.err = err;
 }
 inherits(Recoverable, SyntaxError);
+exports.Recoverable = Recoverable;

--- a/test/parallel/test-repl-recoverable.js
+++ b/test/parallel/test-repl-recoverable.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+let evalCount = 0;
+let recovered = false;
+let rendered = false;
+
+function customEval(code, context, file, cb) {
+  evalCount++;
+
+  return cb(evalCount === 1 ? new repl.Recoverable() : null, true);
+}
+
+const putIn = new common.ArrayStream();
+
+putIn.write = function(msg) {
+  if (msg === '... ') {
+    recovered = true;
+  }
+
+  if (msg === 'true\n') {
+    rendered = true;
+  }
+};
+
+repl.start('', putIn, customEval);
+
+// https://github.com/nodejs/node/issues/2939
+// Expose recoverable errors to the consumer.
+putIn.emit('data', '1\n');
+putIn.emit('data', '2\n');
+
+process.on('exit', function() {
+  assert(recovered, 'REPL never recovered');
+  assert(rendered, 'REPL never rendered the result');
+  assert.strictEqual(evalCount, 2);
+});


### PR DESCRIPTION
Allow REPL consumers to callback with a `Recoverable` error instance and trigger multi-line REPL prompts.

Closes #2939