### PR TITLE
 src: Revert nix stdin _readableState.reading

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -724,7 +724,7 @@
       // not-reading state.
       if (stdin._handle && stdin._handle.readStop) {
         stdin._handle.reading = false;
-        stdin.push('');
+        stdin._readableState.reading = false;
         stdin._handle.readStop();
       }
 
@@ -733,7 +733,7 @@
       stdin.on('pause', function() {
         if (!stdin._handle)
           return;
-        stdin.push('');
+        stdin._readableState.reading = false;
         stdin._handle.reading = false;
         stdin._handle.readStop();
       });


### PR DESCRIPTION
This reverts https://github.com/nodejs/node/commit/8cee8f54fc5fe3d340bf10ba2e9dbb5648b21b83 which was causing a regression through a possible race condition on stdin on Windows 8 and 10.

Fixes: https://github.com/nodejs/node/issues/2996
Fixes: https://github.com/nodejs/node/issues/2504

The test cases presented in #2996 seem to fail only sometimes, those in #2504 failed all the time for me.

I took one of the examples from #2504 and tried to make a test for it, but it appears to not trigger the bug when spawning in a child process. Running the fixture alone from powershell does show the issue, so I'm a bit out of ideas here. @anseki could you maybe have a look? An automated test for this bug would be great to have.

cc: @chrisdickinson @nodejs/platform-windows 