### PR TITLE
test: disable test-tick-processor - aix and be ppc

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -14,6 +14,11 @@ exports.tmpDirName = 'tmp';
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 exports.isWindows = process.platform === 'win32';
 exports.isAix = process.platform === 'aix';
+exports.isLinuxPPCBE = (process.platform === 'linux') &&
+                       (process.arch === 'ppc64') &&
+                       (os.endianness() === 'BE');
+exports.isSunOS = process.platform === 'sunos';
+exports.isFreeBSD = process.platform === 'freebsd';
 
 function rimrafSync(p) {
   try {

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -20,9 +20,11 @@ runTest(/LazyCompile.*\[eval\]:1|.*%  UNKNOWN/,
    };
    setTimeout(function() { process.exit(0); }, 2000);
    f();`);
-if (process.platform === 'win32' ||
-    process.platform === 'sunos' ||
-    process.platform === 'freebsd') {
+if (common.isWindows ||
+    common.isSunOS ||
+    common.isAix ||
+    common.isLinuxPPCBE ||
+    common.isFreeBSD) {
   console.log('1..0 # Skipped: C++ symbols are not mapped for this os.');
   return;
 }


### PR DESCRIPTION
This test is already partially disabled for several platforms with
the comment that the required info is not provided at the C++ level.
I'm adding AIX as and PPC BE linux as they currently fall into
the same category.  We are working to see if we can change that
in v8 but it will be non-trivial if is possible at all so I don't
want to leave the CI with failing tests until that point.