### PR TITLE
test: remove flaky flag on test-tls-ticket-cluster

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-tls-ticket-cluster           : PASS,FLAKY
 
 [$system==linux]
 test-cluster-worker-forced-exit   : PASS,FLAKY


### PR DESCRIPTION
The test hasn't failed since August so the flaky designation can be
removed.

Ref: https://github.com/nodejs/node/issues/2510