### PR TITLE
build: don't compile and test in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,3 +542,5 @@ lint: jslint cpplint
 	blog blogclean tar binary release-only bench-http-simple bench-idle \
 	bench-all bench bench-misc bench-array bench-buffer bench-net \
 	bench-http bench-fs bench-tls cctest run-ci
+
+.NOTPARALLEL: build-addons


### PR DESCRIPTION
While invoking `make -j2 test-addons` the rules `all` and `test-build` (as part of `build-addons`) would be run simultaneously. Avoid this by telling `make` to not run `build-addons` in parallel.

/R=@bnoordhuis ?