### PR TITLE
buffer: don't CHECK on zero-sized realloc

### DIFF
--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -550,6 +550,9 @@ for (var i = 0; i < segments.length; ++i) {
 }
 assert.equal(b.toString('binary', 0, pos), 'Madness?! This is node.js!');
 
+// Regression test for https://github.com/nodejs/node/issues/3496.
+assert.equal(Buffer('=bad'.repeat(1e4), 'base64').length, 0);
+
 // Creating buffers larger than pool size.
 var l = Buffer.poolSize + 5;
 var s = '';


### PR DESCRIPTION
malloc(0) and realloc(ptr, 0) have implementation-defined behavior in
that the standard allows them to either return a unique pointer or a
nullptr for zero-sized allocation requests.  Normalize by always using
a nullptr.

Fixes: https://github.com/nodejs/node/issues/3496

R=@trevnorris

CI: https://ci.nodejs.org/job/node-test-pull-request/582/