### PR TITLE
test: print helpful err msg on test-dns-ipv6.js

### DIFF
--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -165,7 +165,8 @@ TEST(function test_lookup_all_ipv6(done) {
     assert.ok(ips.length > 0);
 
     ips.forEach(function(ip) {
-      assert.ok(isIPv6(ip.address));
+      assert.ok(isIPv6(ip.address),
+                'Invalid IPv6: ' + ip.address.toString());
       assert.strictEqual(ip.family, 6);
     });
 


### PR DESCRIPTION
Test sometimes fail on this assertion but no useful error message was generated for debugging. Modify the test to generate useful debugging message.