### PR TITLE
test: improve tests for util.inherits

### DIFF
--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const inherits = require('util').inherits;
+
+// super constructor
+function A() {
+  this._a = 'a';
+}
+A.prototype.a = function() { return this._a; };
+
+// one level of inheritance
+function B(value) {
+  A.call(this);
+  this._b = value;
+}
+inherits(B, A);
+B.prototype.b = function() { return this._b; };
+
+const b = new B('b');
+assert.strictEqual(b.a(), 'a');
+assert.strictEqual(b.b(), 'b');
+assert.strictEqual(b.constructor, B);
+
+ // two levels of inheritance
+function C() {
+  B.call(this, 'b');
+  this._c = 'c';
+}
+inherits(C, B);
+C.prototype.c = function() { return this._c; };
+C.prototype.getValue = function() { return this.a() + this.b() + this.c(); };
+
+const c = new C();
+assert.strictEqual(c.getValue(), 'abc');
+
+// should throw with invalid arguments
+assert.throws(function() { inherits(A, {}); }, TypeError);
+assert.throws(function() { inherits(A, null); }, TypeError);
+assert.throws(function() { inherits(null, A); }, TypeError);

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -18,6 +18,8 @@ function B(value) {
 inherits(B, A);
 B.prototype.b = function() { return this._b; };
 
+assert.strictEqual(B.super_, A);
+
 const b = new B('b');
 assert.strictEqual(b.a(), 'a');
 assert.strictEqual(b.b(), 'b');
@@ -32,8 +34,11 @@ inherits(C, B);
 C.prototype.c = function() { return this._c; };
 C.prototype.getValue = function() { return this.a() + this.b() + this.c(); };
 
+assert.strictEqual(C.super_, B);
+
 const c = new C();
 assert.strictEqual(c.getValue(), 'abc');
+assert.strictEqual(c.constructor, C);
 
 // should throw with invalid arguments
 assert.throws(function() { inherits(A, {}); }, TypeError);

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -83,10 +83,3 @@ assert.deepEqual(util._extend({a:1}, true),       {a:1});
 assert.deepEqual(util._extend({a:1}, false),      {a:1});
 assert.deepEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
 assert.deepEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});
-
-// inherits
-var ctor = function() {};
-assert.throws(function() { util.inherits(ctor, {}); }, TypeError);
-assert.throws(function() { util.inherits(ctor, null); }, TypeError);
-assert.throws(function() { util.inherits(null, ctor); }, TypeError);
-assert.doesNotThrow(function() { util.inherits(ctor, ctor); }, TypeError);


### PR DESCRIPTION
inherits is used in lib and tests but its functionality itself is not
tested yet.

This is preparation for PR #3455 so I can add more tests to it.