### PR TITLE
crypto: ecdh - generate public key when setting private key and more

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -260,7 +260,23 @@ then a buffer is returned.
 
 Sets the EC Diffie-Hellman private key. Key encoding can be `'binary'`,
 `'hex'` or `'base64'`. If no encoding is provided, then a buffer is
-expected.
+expected. If `private_key` is not valid for the curve specified when
+the ECDH object was created, then an error is thrown. Upon setting
+the private key, the associated public point (key) is also generated
+and set in the ECDH object.
+
+### ECDH.setPublicKey(public_key[, encoding])
+
+    Stability: 0 - Deprecated
+
+Sets the EC Diffie-Hellman public key. Key encoding can be `'binary'`,
+`'hex'` or `'base64'`. If no encoding is provided, then a buffer is
+expected. Note that there is not normally a reason to call this
+method. This is because ECDH only needs your private key and the
+other party's public key to compute the shared secret. Thus, usually
+either `generateKeys` or `setPrivateKey` will be called.
+Note that `setPrivateKey` attempts to generate the public point/key
+associated with the private key being set.
 
 Example (obtaining a shared secret):
 
@@ -268,20 +284,21 @@ Example (obtaining a shared secret):
     var alice = crypto.createECDH('secp256k1');
     var bob = crypto.createECDH('secp256k1');
 
-    alice.generateKeys();
+    // Note: This is a shortcut way to specify one of Alice's previous private
+    // keys. It would be unwise to use such a predictable private key in a real
+    // application.
+    alice.setPrivateKey(
+      crypto.createHash('sha256').update('alice', 'utf8').digest()
+    );
+
+    // Bob uses a newly generated cryptographically strong pseudorandom key pair
     bob.generateKeys();
 
     var alice_secret = alice.computeSecret(bob.getPublicKey(), null, 'hex');
     var bob_secret = bob.computeSecret(alice.getPublicKey(), null, 'hex');
 
-    /* alice_secret and bob_secret should be the same */
-    console.log(alice_secret == bob_secret);
-
-### ECDH.setPublicKey(public_key[, encoding])
-
-Sets the EC Diffie-Hellman public key. Key encoding can be `'binary'`,
-`'hex'` or `'base64'`. If no encoding is provided, then a buffer is
-expected.
+    // alice_secret and bob_secret should be the same shared secret value
+    console.log(alice_secret === bob_secret);
 
 ## Class: Hash
 
@@ -753,6 +770,17 @@ use.  To switch to the previous style of using binary strings by
 default, set the `crypto.DEFAULT_ENCODING` field to 'binary'.  Note
 that new programs will probably expect buffers, so only use this as a
 temporary measure.
+
+Usage of `ECDH` with non-dynamically generated key pairs has been simplified.
+Now, `setPrivateKey` can be called with a preselected private key and the
+associated public point (key) will be computed and stored in the object.
+This allows you to only store and provide the private part of the EC key pair.
+`setPrivateKey` now also validates that the private key is valid for the curve.
+`ECDH.setPublicKey` is now deprecated as its inclusion in the API is not
+useful. Either a previously stored private key should be set, which
+automatically generates the associated public key, or `generateKeys` should be
+called. The main drawback of `ECDH.setPublicKey` is that it can be used to put
+the ECDH key pair into an inconsistent state.
 
 ## Caveats
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -693,7 +693,6 @@ class ECDH : public BaseObject {
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, EC_KEY* key)
       : BaseObject(env, wrap),
-        generated_(false),
         key_(key),
         group_(EC_KEY_get0_group(key_)) {
     MakeWeak<ECDH>(this);
@@ -710,7 +709,9 @@ class ECDH : public BaseObject {
 
   EC_POINT* BufferToPoint(char* data, size_t len);
 
-  bool generated_;
+  bool IsKeyPairValid();
+  bool IsKeyValidForCurve(const BIGNUM* private_key);
+
   EC_KEY* key_;
   const EC_GROUP* group_;
 };


### PR DESCRIPTION
crypto: ecdh updates to support using previously known private keys
- generate public key when setting private key
- remove "generated" checks from getters
- added tests
- updated docs
- check the key pair before computing the secret to avoid computing a garbage shared secret
- added ECDH.validKeyPair
- marked ECDH.setPublicKey as deprecated

This pull request shares many similarities with #1020.

I decided not to add the public key generation as a separate method like was proposed in #1020.
Rather I made it part of setting the private key.
I liked this way more because then it leaves two main ways to use the class. Either generate the keys, or set the private key then compute the shared secret.

Originally I started looking at this code because the following error was annoying and unnecessary (and is why I removed the generated_ member from ECDH):

    > node -p "require('crypto').createECDH('secp256k1').setPrivateKey(new Buffer('1111111111111111111111111111111111111111111111111111111111111111', 'hex')).getPublicKey()"
      crypto.js:526
        var key = this._handle.getPublicKey(f);
                               ^

      Error: You should generate ECDH keys first
          at Error (native)
          at ECDH.getPublicKey (crypto.js:526:26)