### PR TITLE
doc: add note about timeout delay > TIMEOUT_MAX

### DIFF
--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -16,7 +16,7 @@ It is important to note that your callback will probably not be called in exactl
 the callback will fire, nor of the ordering things will fire in. The callback will
 be called as close as possible to the time specified.
 
-To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days), the timeout is executed immediately, as if the `delay` was set to 1.
+To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days) or less than 1, the timeout is executed immediately, as if the `delay` was set to 1.
 
 ## clearTimeout(timeoutObject)
 
@@ -28,7 +28,7 @@ To schedule the repeated execution of `callback` every `delay` milliseconds.
 Returns a `intervalObject` for possible use with `clearInterval()`. Optionally
 you can also pass arguments to the callback.
 
-To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days), Node.js will use 1 as the `delay`.
+To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days) or less than 1, Node.js will use 1 as the `delay`.
 
 ## clearInterval(intervalObject)
 

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -16,6 +16,8 @@ It is important to note that your callback will probably not be called in exactl
 the callback will fire, nor of the ordering things will fire in. The callback will
 be called as close as possible to the time specified.
 
+To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days), the timeout is executed immediately, as if the `delay` was set to 1.
+
 ## clearTimeout(timeoutObject)
 
 Prevents a timeout from triggering.
@@ -25,6 +27,8 @@ Prevents a timeout from triggering.
 To schedule the repeated execution of `callback` every `delay` milliseconds.
 Returns a `intervalObject` for possible use with `clearInterval()`. Optionally
 you can also pass arguments to the callback.
+
+To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days), Node.js will use 1 as the `delay`.
 
 ## clearInterval(intervalObject)
 

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -16,7 +16,9 @@ It is important to note that your callback will probably not be called in exactl
 the callback will fire, nor of the ordering things will fire in. The callback will
 be called as close as possible to the time specified.
 
-To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days) or less than 1, the timeout is executed immediately, as if the `delay` was set to 1.
+To follow browser behavior, when using delays larger than 2147483647
+milliseconds (approximately 25 days) or less than 1, the timeout is executed
+immediately, as if the `delay` was set to 1.
 
 ## clearTimeout(timeoutObject)
 
@@ -28,7 +30,9 @@ To schedule the repeated execution of `callback` every `delay` milliseconds.
 Returns a `intervalObject` for possible use with `clearInterval()`. Optionally
 you can also pass arguments to the callback.
 
-To follow browser behavior, when using delays larger than 2147483647 milliseconds (approximately 25 days) or less than 1, Node.js will use 1 as the `delay`.
+To follow browser behavior, when using delays larger than 2147483647
+milliseconds (approximately 25 days) or less than 1, Node.js will use 1 as the
+`delay`.
 
 ## clearInterval(intervalObject)
 


### PR DESCRIPTION
When setTimeout() and setInterval() are called with `delay` greater than TIMEOUT_MAX (2147483647), the supplied value is ignored and 1 is used instead. This adds a note about this in the timers docs.

I actually got surprised by this behavior when trying to schedule a job to run in the first day of every month:
```js
function schedule() {
    var now = new Date
    var nextMonth = new Date(now.getFullYear(), now.getMonth()+1)
    setTimeout(function () {
        shedule()
        doStuff()
    }, nextMonth - now)
}
```

It worked the first time, but afterwards it seemed to enter an infinite loop. I only found out why after searching and reading the [timers.js code](https://github.com/nodejs/node/blob/3eecdf9f1422640c7439507cb39ffb3dff57b3e4/lib/timers.js#L181-L183).
It only worked at first because it was past the 5th day of that month ;)


