### PR TITLE
doc,lib: correct child.send() return value docs

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -220,7 +220,6 @@ See `kill(2)`
 * `message` {Object}
 * `sendHandle` {Handle object}
 * `callback` {Function}
-* Return: Boolean
 
 When using [`child_process.fork()`](#child_process_child_process_fork_modulepath_args_options) you can write to the child using
 `child.send(message[, sendHandle][, callback])` and messages are received by
@@ -265,10 +264,6 @@ argument: `null` on success, or an `Error` object on failure.
 
 `child.send()` emits an `'error'` event if no callback was given and the message
 cannot be sent, for example because the child process has already exited.
-
-Returns `true` under normal circumstances or `false` when the backlog of
-unsent messages exceeds a threshold that makes it unwise to send more.
-Use the callback mechanism to implement flow control.
 
 #### Example: sending server object
 

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -428,7 +428,6 @@ exit, the master may choose not to respawn a worker based on this value.
 * `message` {Object}
 * `sendHandle` {Handle object}
 * `callback` {Function}
-* Return: Boolean
 
 Send a message to a worker or master, optionally with a handle.
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -610,9 +610,6 @@ function setupChannel(target, channel) {
         this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
       }
     }
-
-    /* If the master is > 2 read() calls behind, please stop sending. */
-    return channel.writeQueueSize < (65536 * 2);
   };
 
   // connected will be set to false immediately when a disconnect() is


### PR DESCRIPTION
child.send() returns undefined, contrary to the docs. Update docs and
remove related dead code.

This is an alternative to https://github.com/nodejs/node/pull/3516. That PR updates the behavior of the code to reflect the docs. This updates the docs to reflect the behavior of the code.