### PR TITLE
Reland workaround for perf-basic-prof filename truncation issue

### DIFF
--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -125,8 +125,9 @@ class CodeEventLogger::NameBuffer {
   }
 
   void AppendInt(int n) {
-    Vector<char> buffer(utf8_buffer_ + utf8_pos_,
-                        kUtf8BufferSize - utf8_pos_);
+    int space = kUtf8BufferSize - utf8_pos_;
+    if (space <= 0) return;
+    Vector<char> buffer(utf8_buffer_ + utf8_pos_, space);
     int size = SNPrintF(buffer, "%d", n);
     if (size > 0 && utf8_pos_ + size <= kUtf8BufferSize) {
       utf8_pos_ += size;
@@ -134,8 +135,9 @@ class CodeEventLogger::NameBuffer {
   }
 
   void AppendHex(uint32_t n) {
-    Vector<char> buffer(utf8_buffer_ + utf8_pos_,
-                        kUtf8BufferSize - utf8_pos_);
+    int space = kUtf8BufferSize - utf8_pos_;
+    if (space <= 0) return;
+    Vector<char> buffer(utf8_buffer_ + utf8_pos_, space);
     int size = SNPrintF(buffer, "%x", n);
     if (size > 0 && utf8_pos_ + size <= kUtf8BufferSize) {
       utf8_pos_ += size;
@@ -147,7 +149,7 @@ class CodeEventLogger::NameBuffer {
 
  private:
   static const int kUtf8BufferSize = 512;
-  static const int kUtf16BufferSize = 128;
+  static const int kUtf16BufferSize = kUtf8BufferSize;
 
   int utf8_pos_;
   char utf8_buffer_[kUtf8BufferSize];


### PR DESCRIPTION
This is a proposed reland of https://github.com/nodejs/node/pull/3165 onto v4.x (EDIT: and v5.x and master). The patch abates
the truncation of script filenames in the perf-event output produced by V8. This greatly improves ability to work with perf profiles. This would be very useful to have in v4.x. 

V8 commits:
Original: https://github.com/v8/v8/commit/03ef3cd004c2fd31ae7e48772f106df67b8c2feb
Reland: https://github.com/v8/v8/commit/010897c16adb46d3fe403eab525502a63e174b0c

R=@bnoordhuis, @nodejs/lts 

Original commit message:
  improve perf_basic_prof filename reporting

  The buffer used for appending filenames to the string printed to the
  perf_basic_prof log was unnecessarily too small. Bump it up to be at least
  kUtf8BufferSize.

  Truncation of filenames makes it really hard to work with profiles gathered on
  Node.js. Because of the way Node.js works, you can have node module dependencies
  in deeply nested directories. The last thing you want when investigating a
  performance problem is to have script names be truncated.

  This patch is a stop-gap. Ideally, I want no truncation of the filename at all
  and use a dynamically growing buffer. That would be a larger change, and I
  wanted to have a quick fix available that can be back-ported to Node.js LTS
  release.

  R=yangguo@chromium.org,yurys@chromium.org
  BUG=

  Review URL: https://codereview.chromium.org/1388543002