### PR TITLE
doc typofix: fetaures -> features

### DIFF
--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -178,7 +178,7 @@ DEFINE_BOOL(strong_this, true, "don't allow 'this' to escape from constructors")
 
 DEFINE_BOOL(es_staging, false, "enable all completed harmony features")
 DEFINE_BOOL(harmony, false, "enable all completed harmony features")
-DEFINE_BOOL(harmony_shipping, true, "enable all shipped harmony fetaures")
+DEFINE_BOOL(harmony_shipping, true, "enable all shipped harmony features")
 DEFINE_IMPLICATION(harmony, es_staging)
 DEFINE_IMPLICATION(es_staging, harmony)
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -98,7 +98,7 @@ value to an empty string ("") disables persistent REPL history.
         type: bool  default: false
   --harmony (enable all completed harmony features)
         type: bool  default: false
-  --harmony_shipping (enable all shipped harmony fetaures)
+  --harmony_shipping (enable all shipped harmony features)
         type: bool  default: true
   --legacy_const (legacy semantics for const in sloppy mode)
         type: bool  default: true


### PR DESCRIPTION
Noticed it when using `node --v8-options | grep harmony`.