### PR TITLE
doc: issue-3530 assert.markdown updated

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -14,7 +14,7 @@ separated by the provided operator.
 ## assert(value[, message]), assert.ok(value[, message])
 
 Tests if value is truthy. It is equivalent to
-`assert.equal(true, !!value, message)`.
+`assert.equal(!!value, true, message)`.
 
 ## assert.equal(actual, expected[, message])
 


### PR DESCRIPTION
Documentation for `assert` describes:

    assert(value[, message]), assert.ok(value[, message])
    Tests if value is truthy. It is equivalent to assert.equal(true, !!value, message).

But `assert.equal` parameters are actual value first, then expected value. The documentation should read:

    assert(value[, message]), assert.ok(value[, message])#
    Tests if value is truthy. It is equivalent to assert.equal(!!value, true, message).