### PR TITLE
zlib: only apply drain listener if given callback

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -444,10 +444,9 @@ Zlib.prototype.flush = function(kind, callback) {
     if (callback)
       this.once('end', callback);
   } else if (ws.needDrain) {
-    var self = this;
-    this.once('drain', function() {
-      self.flush(kind, callback);
-    });
+    if (callback) {
+      this.once('drain', () => this.flush(kind, callback));
+    }
   } else {
     this._flushFlag = kind;
     this.write(new Buffer(0), '', callback);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -446,7 +446,7 @@ Zlib.prototype.flush = function(kind, callback) {
   } else if (ws.needDrain) {
     var self = this;
     this.once('drain', function() {
-      self.flush(callback);
+      self.flush(kind, callback);
     });
   } else {
     this._flushFlag = kind;

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -1,0 +1,49 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const path = require('path');
+
+const bigData = new Buffer(10240).fill('x');
+
+const opts = {
+  level: 0,
+  highWaterMark: 16
+};
+
+const deflater = zlib.createDeflate(opts);
+
+// shim deflater.flush so we can count times executed
+var flushCount = 0;
+var drainCount = 0;
+
+const flush = deflater.flush;
+deflater.flush = function(kind, callback) {
+  flushCount++;
+  flush.call(this, kind, callback);
+};
+
+deflater.write(bigData);
+
+const ws = deflater._writableState;
+const beforeFlush = ws.needDrain;
+var afterFlush = ws.needDrain;
+
+deflater.flush(function(err) {
+  afterFlush = ws.needDrain;
+});
+
+deflater.on('drain', function() {
+  drainCount++;;
+});
+
+process.once('exit', function() {
+  assert.equal(beforeFlush, true,
+    'before calling flush the writable stream should need to drain');
+  assert.equal(afterFlush, false,
+    'after calling flush the writable stream should not need to drain');
+  assert.equal(drainCount, 1,
+    'the deflater should have emitted a single drain event');
+  assert.equal(flushCount, 2,
+    'flush should be called twice');
+});


### PR DESCRIPTION
When stream.flush() is called without a callback, an empty listener is
being added. Since flush may be called multiple times to push SSE's
down to the client, multiple noop listeners are being added. This in
turn causes the memory leak detected message.

fixes #3529

This commit has been cherry picked from a pr on v0.x-archive
https://github.com/nodejs/node-v0.x-archive/pull/25679