### PR TITLE
tls: copy client CAs and cert store on CertCb

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2321,7 +2321,7 @@ void SSLWrap<Base>::DestroySSL() {
 template <class Base>
 void SSLWrap<Base>::SetSNIContext(SecureContext* sc) {
   InitNPN(sc);
-  SSL_set_SSL_CTX(ssl_, sc->ctx_);
+  CHECK_EQ(SSL_set_SSL_CTX(ssl_, sc->ctx_), sc->ctx_);
 
   SetCACerts(sc);
 }
@@ -2335,6 +2335,8 @@ int SSLWrap<Base>::SetCACerts(SecureContext* sc) {
 
   STACK_OF(X509_NAME)* list = SSL_dup_CA_list(
       SSL_CTX_get_client_CA_list(sc->ctx_));
+
+  // NOTE: `SSL_set_client_CA_list` takes the ownership of `list`
   SSL_set_client_CA_list(ssl_, list);
   return 1;
 }

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -271,6 +271,8 @@ class SSLWrap {
 
   void DestroySSL();
   void WaitForCertCb(CertCb cb, void* arg);
+  void SetSNIContext(SecureContext* sc);
+  int SetCACerts(SecureContext* sc);
 
   inline Environment* ssl_env() const {
     return env_;

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -857,8 +857,7 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   p->sni_context_.Reset(env->isolate(), ctx);
 
   SecureContext* sc = Unwrap<SecureContext>(ctx.As<Object>());
-  InitNPN(sc);
-  SSL_set_SSL_CTX(s, sc->ctx_);
+  p->SetSNIContext(sc);
   return SSL_TLSEXT_ERR_OK;
 }
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -26,6 +26,8 @@ function loadPEM(n) {
 var serverOptions = {
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
+  requestCert: true,
+  rejectUnauthorized: false,
   SNICallback: function(servername, callback) {
     var context = SNIContexts[servername];
 
@@ -46,7 +48,8 @@ var serverOptions = {
 var SNIContexts = {
   'a.example.com': {
     key: loadPEM('agent1-key'),
-    cert: loadPEM('agent1-cert')
+    cert: loadPEM('agent1-cert'),
+    ca: [ loadPEM('ca2-cert') ]
   },
   'b.example.com': {
     key: loadPEM('agent3-key'),
@@ -63,6 +66,13 @@ var clientsOptions = [{
   port: serverPort,
   key: loadPEM('agent1-key'),
   cert: loadPEM('agent1-cert'),
+  ca: [loadPEM('ca1-cert')],
+  servername: 'a.example.com',
+  rejectUnauthorized: false
+}, {
+  port: serverPort,
+  key: loadPEM('agent4-key'),
+  cert: loadPEM('agent4-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com',
   rejectUnauthorized: false
@@ -97,7 +107,7 @@ var serverResults = [],
     clientError;
 
 var server = tls.createServer(serverOptions, function(c) {
-  serverResults.push(c.servername);
+  serverResults.push({ sni: c.servername, authorized: c.authorized });
 });
 
 server.on('clientError', function(err) {
@@ -144,9 +154,16 @@ function startTest() {
 }
 
 process.on('exit', function() {
-  assert.deepEqual(serverResults, ['a.example.com', 'b.example.com',
-                                   'c.wrong.com', null]);
-  assert.deepEqual(clientResults, [true, true, false, false]);
-  assert.deepEqual(clientErrors, [null, null, null, 'socket hang up']);
-  assert.deepEqual(serverErrors, [null, null, null, 'Invalid SNI context']);
+  assert.deepEqual(serverResults, [
+    { sni: 'a.example.com', authorized: false },
+    { sni: 'a.example.com', authorized: true },
+    { sni: 'b.example.com', authorized: false },
+    { sni: 'c.wrong.com', authorized: false },
+    null
+  ]);
+  assert.deepEqual(clientResults, [true, true, true, false, false]);
+  assert.deepEqual(clientErrors, [null, null, null, null, 'socket hang up']);
+  assert.deepEqual(serverErrors, [
+    null, null, null, null, 'Invalid SNI context'
+  ]);
 });


### PR DESCRIPTION
Copy client CA certs and cert store when asynchronously selecting
`SecureContext` during `SNICallback`.

Fix: #2772

cc @nodejs/crypto 