### PR TITLE
lib: consistent callback checking across project

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -532,7 +532,7 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
 };
 
 ClientRequest.prototype.setTimeout = function(msecs, callback) {
-  if (callback) this.once('timeout', callback);
+  if (typeof callback === 'function') this.once('timeout', callback);
 
   var self = this;
   function emitTimeout() {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -63,7 +63,7 @@ exports.IncomingMessage = IncomingMessage;
 
 
 IncomingMessage.prototype.setTimeout = function(msecs, callback) {
-  if (callback)
+  if (typeof callback === 'function')
     this.on('timeout', callback);
   this.socket.setTimeout(msecs);
   return this;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -90,10 +90,11 @@ exports.OutgoingMessage = OutgoingMessage;
 
 OutgoingMessage.prototype.setTimeout = function(msecs, callback) {
 
-  if (callback) {
-    if (typeof callback !== 'function')
-      throw new TypeError('callback must be a function');
+  if (typeof callback === 'function') {
     this.on('timeout', callback);
+  }
+  else if (callback) {
+    throw new TypeError('callback must be a function');
   }
 
   if (!this.socket) {
@@ -482,7 +483,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
 
 function writeAfterEndNT(self, err, callback) {
   self.emit('error', err);
-  if (callback) callback(err);
+  if (typeof callback === 'function') callback(err);
 }
 
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -249,7 +249,7 @@ util.inherits(Server, net.Server);
 
 Server.prototype.setTimeout = function(msecs, callback) {
   this.timeout = msecs;
-  if (callback)
+  if (typeof callback === 'function')
     this.on('timeout', callback);
   return this;
 };

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -504,7 +504,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
     this._rejectUnauthorized = rejectUnauthorized;
   }
   if (!this._handle.renegotiate()) {
-    if (callback) {
+    if (typeof callback === 'function') {
       process.nextTick(callback, new Error('Failed to renegotiate'));
     }
     return false;
@@ -513,7 +513,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
   // Ensure that we'll cycle through internal openssl's state
   this.write('');
 
-  if (callback) {
+  if (typeof callback === 'function') {
     this.once('secure', function() {
       callback(null);
     });

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -563,7 +563,7 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
 
   // at this point, we need to handle encodings.
   var encoding = exports.DEFAULT_ENCODING;
-  if (callback) {
+  if (typeof callback === 'function') {
     var next = function(er, ret) {
       if (ret)
         ret = ret.toString(encoding);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -319,7 +319,7 @@ Socket.prototype.send = function(buffer,
       req.length = length;
       req.address = address;
       req.port = port;
-      if (callback) {
+      if (typeof callback === 'function') {
         req.callback = callback;
         req.oncomplete = afterSend;
       }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -213,7 +213,7 @@ fs.exists = function(path, callback) {
   req.oncomplete = cb;
   binding.stat(pathModule._makeLong(path), req);
   function cb(err, stats) {
-    if (callback) callback(err ? false : true);
+    if (typeof callback === 'function') callback(err ? false : true);
   }
 };
 
@@ -1151,16 +1151,16 @@ function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
   fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
     if (writeErr) {
       if (isUserFd) {
-        if (callback) callback(writeErr);
+        if (typeof callback === 'function') callback(writeErr);
       } else {
         fs.close(fd, function() {
-          if (callback) callback(writeErr);
+          if (typeof callback === 'function') callback(writeErr);
         });
       }
     } else {
       if (written === length) {
         if (isUserFd) {
-          if (callback) callback(null);
+          if (typeof callback === 'function') callback(null);
         } else {
           fs.close(fd, callback);
         }
@@ -1198,7 +1198,7 @@ fs.writeFile = function(path, data, options, callback_) {
 
   fs.open(path, flag, options.mode, function(openErr, fd) {
     if (openErr) {
-      if (callback) callback(openErr);
+      if (typeof callback === 'function') callback(openErr);
     } else {
       writeFd(fd, false);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -299,13 +299,13 @@ Socket.prototype.listen = function() {
 Socket.prototype.setTimeout = function(msecs, callback) {
   if (msecs === 0) {
     timers.unenroll(this);
-    if (callback) {
+    if (typeof callback === 'function') {
       this.removeListener('timeout', callback);
     }
   } else {
     timers.enroll(this, msecs);
     timers._unrefActive(this);
-    if (callback) {
+    if (typeof callback === 'function') {
       this.once('timeout', callback);
     }
   }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -410,7 +410,7 @@ Zlib.prototype.params = function(level, strategy, callback) {
       if (!self._hadError) {
         self._level = level;
         self._strategy = strategy;
-        if (callback) callback();
+        if (typeof callback === 'function') callback();
       }
     });
   } else {
@@ -438,10 +438,10 @@ Zlib.prototype.flush = function(kind, callback) {
   }
 
   if (ws.ended) {
-    if (callback)
+    if (typeof callback === 'function')
       process.nextTick(callback);
   } else if (ws.ending) {
-    if (callback)
+    if (typeof callback === 'function')
       this.once('end', callback);
   } else if (ws.needDrain) {
     var self = this;
@@ -455,7 +455,7 @@ Zlib.prototype.flush = function(kind, callback) {
 };
 
 Zlib.prototype.close = function(callback) {
-  if (callback)
+  if (typeof callback === 'function')
     process.nextTick(callback);
 
   if (this._closed)


### PR DESCRIPTION
Throughout the codebase there are two patterns for checking if a
callback has been provided as an argument. This PR replaces all
instances to do explicit type checking.

Closes #3536