### PR TITLE
test: split independent tests into separate files

### DIFF
--- a/test/parallel/test-fs-watch-enoent.js
+++ b/test/parallel/test-fs-watch-enoent.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
 
 assert.throws(function() {
   fs.watch('non-existent-file');
@@ -12,7 +12,7 @@ assert.throws(function() {
   return true;
 });
 
-var watcher = fs.watch(__filename);
+const watcher = fs.watch(__filename);
 watcher.on('error', common.mustCall(function(err) {
   assert(err);
   assert(/non-existent-file/.test(err));

--- a/test/parallel/test-fs-watch-enoent.js
+++ b/test/parallel/test-fs-watch-enoent.js
@@ -1,0 +1,21 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+
+assert.throws(function() {
+  fs.watch('non-existent-file');
+}, function(err) {
+  assert(err);
+  assert(/non-existent-file/.test(err));
+  assert.equal(err.filename, 'non-existent-file');
+  return true;
+});
+
+var watcher = fs.watch(__filename);
+watcher.on('error', common.mustCall(function(err) {
+  assert(err);
+  assert(/non-existent-file/.test(err));
+  assert.equal(err.filename, 'non-existent-file');
+}));
+watcher._handle.onchange(-1, 'ENOENT', 'non-existent-file');

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -126,20 +126,3 @@ assert.throws(function() {
   w.stop();
 }, TypeError);
 oldhandle.stop(); // clean up
-
-assert.throws(function() {
-  fs.watch('non-existent-file');
-}, function(err) {
-  assert(err);
-  assert(/non-existent-file/.test(err));
-  assert.equal(err.filename, 'non-existent-file');
-  return true;
-});
-
-var watcher = fs.watch(__filename);
-watcher.on('error', common.mustCall(function(err) {
-  assert(err);
-  assert(/non-existent-file/.test(err));
-  assert.equal(err.filename, 'non-existent-file');
-}));
-watcher._handle.onchange(-1, 'ENOENT', 'non-existent-file');


### PR DESCRIPTION
Move `ENOENT` related tests out of general `fs.watch()` test file and into its own file. This may help diagnose #3541.

/cc @jbergstroem @cjihrig @charlierudolph 