### PR TITLE
test: fix race condition in unrefd interval test

### DIFF
--- a/test/parallel/test-timers-unrefd-interval-still-fires.js
+++ b/test/parallel/test-timers-unrefd-interval-still-fires.js
@@ -2,27 +2,27 @@
 /*
  * This test is a regression test for joyent/node#8900.
  */
-require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var N = 5;
+const TEST_DURATION = common.platformTimeout(100);
+const N = 5;
 var nbIntervalFired = 0;
-var timer = setInterval(function() {
+
+const keepOpen = setTimeout(() => {
+  console.error('[FAIL] Interval fired %d/%d times.', nbIntervalFired, N);
+  throw new Error('Test timed out. keepOpen was not canceled.');
+}, TEST_DURATION);
+
+const timer = setInterval(() => {
   ++nbIntervalFired;
-  if (nbIntervalFired === N)
+  if (nbIntervalFired === N) {
     clearInterval(timer);
+    timer._onTimeout = () => {
+      throw new Error('Unrefd interval fired after being cleared.');
+    };
+    setImmediate(() => clearTimeout(keepOpen));
+  }
 }, 1);
 
 timer.unref();
-
-var checkInterval = 100;
-var maxNbChecks = 5;
-var nbChecks = 1;
-setTimeout(function check() {
-  if (nbChecks >= maxNbChecks || nbIntervalFired == N) {
-    assert.strictEqual(nbIntervalFired, N);
-    return;
-  }
-  ++nbChecks;
-  setTimeout(check, checkInterval);
-}, checkInterval);

--- a/test/parallel/test-timers-unrefd-interval-still-fires.js
+++ b/test/parallel/test-timers-unrefd-interval-still-fires.js
@@ -15,6 +15,14 @@ var timer = setInterval(function() {
 
 timer.unref();
 
-setTimeout(function onTimeout() {
-  assert.strictEqual(nbIntervalFired, N);
-}, 100);
+var checkInterval = 100;
+var maxNbChecks = 5;
+var nbChecks = 1;
+setTimeout(function check() {
+  if (nbChecks >= maxNbChecks || nbIntervalFired == N) {
+    assert.strictEqual(nbIntervalFired, N);
+    return;
+  }
+  ++nbChecks;
+  setTimeout(check, checkInterval);
+}, checkInterval);


### PR DESCRIPTION
Before this commit, test-timers-unrefd-interval-still-fire required a
1ms interval to fire 5 times before a 100ms timeout to pass which could
cause intermittent failures in CI and in issue #1781.

This commit gives the test up to 5x as long to complete while allowing
the test to complete as quickly as before when possible.
cc @mhdawson 