### PR TITLE
test: use port number from env in tls socket test

### DIFF
--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -36,9 +36,9 @@ server.on('resumeSession', function(id, cb) {
   next();
 });
 
-server.listen(1443, function() {
+server.listen(common.PORT, function() {
   var clientOpts = {
-    port: 1443,
+    port: common.PORT,
     rejectUnauthorized: false,
     session: false
   };


### PR DESCRIPTION
Tests normally use common.PORT to allow the user to select which port
number to listen on. Hardcoding the port number will cause parallel
instances of the test to fail.