### PR TITLE
console: prevent internal timers storage from growing

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -68,6 +68,7 @@ Console.prototype.timeEnd = function(label) {
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;
   this.log('%s: %sms', label, ms.toFixed(3));
+  this._times.delete(label);
 };
 
 

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -57,6 +57,16 @@ console.timeEnd('hasOwnProperty');
 
 global.process.stdout.write = stdout_write;
 
+// verify that console.timeEnd() doesn't leave dead links
+const timesMapSize = console._times.size;
+console.time('label1');
+console.time('label2');
+console.time('label3');
+console.timeEnd('label1');
+console.timeEnd('label2');
+console.timeEnd('label3');
+assert.strictEqual(console._times.size, timesMapSize);
+
 assert.equal('foo\n', strings.shift());
 assert.equal('foo bar\n', strings.shift());
 assert.equal('foo bar hop\n', strings.shift());


### PR DESCRIPTION
The instance of `Console` class doesn't remove links to arrays that come from hrtimer after `timeEnd` had been called.

As far as I understand, such links won't be collected by v8's gc.