### PR TITLE
buffer: Add Buffer#includes()

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -428,6 +428,14 @@ Buffer.prototype.indexOf = function indexOf(val, byteOffset) {
   throw new TypeError('val must be string, number or Buffer');
 };
 
+Buffer.prototype.includes = function includes(val) {
+  if (this.indexOf(val) === -1)
+    return false;
+  else
+    return true;
+
+  throw new TypeError('val must be number');
+};
 
 Buffer.prototype.fill = function fill(val, start, end) {
   start = start >> 0;


### PR DESCRIPTION
Ref: [https://github.com/nodejs/node/issues/3552](https://github.com/nodejs/node/issues/3552)

This adds an includes() method to buffer, bypassing future implementations from V8.

includes() wraps around buffer's indexOf() method. 