### PR TITLE
deps: update http-parser to 2.6.0

### DIFF
--- a/deps/http_parser/AUTHORS
+++ b/deps/http_parser/AUTHORS
@@ -65,3 +65,4 @@ Romain Giraud <giraud.romain@gmail.com>
 Jay Satiro <raysatiro@yahoo.com>
 Arne Steen <Arne.Steen@gmx.de>
 Kjell Schubert <kjell.schubert@gmail.com>
+Olivier Mengué <dolmen@cpan.org>

--- a/deps/http_parser/Makefile
+++ b/deps/http_parser/Makefile
@@ -19,7 +19,19 @@
 # IN THE SOFTWARE.
 
 PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
-SONAME ?= libhttp_parser.so.2.5.0
+HELPER ?=
+BINEXT ?=
+ifeq (darwin,$(PLATFORM))
+SONAME ?= libhttp_parser.2.6.0.dylib
+SOEXT ?= dylib
+else ifeq (wine,$(PLATFORM))
+CC = winegcc
+BINEXT = .exe.so
+HELPER = wine
+else
+SONAME ?= libhttp_parser.so.2.6.0
+SOEXT ?= so
+endif
 
 CC?=gcc
 AR?=ar
@@ -53,8 +65,8 @@ LDFLAGS_LIB += -Wl,-soname=$(SONAME)
 endif
 
 test: test_g test_fast
-	./test_g
-	./test_fast
+	$(HELPER) ./test_g$(BINEXT)
+	$(HELPER) ./test_fast$(BINEXT)
 
 test_g: http_parser_g.o test_g.o
 	$(CC) $(CFLAGS_DEBUG) $(LDFLAGS) http_parser_g.o test_g.o -o $@
@@ -81,7 +93,7 @@ http_parser.o: http_parser.c http_parser.h Makefile
 	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_FAST) -c http_parser.c
 
 test-run-timed: test_fast
-	while(true) do time ./test_fast > /dev/null; done
+	while(true) do time $(HELPER) ./test_fast$(BINEXT) > /dev/null; done
 
 test-valgrind: test_g
 	valgrind ./test_g
@@ -102,10 +114,10 @@ url_parser_g: http_parser_g.o contrib/url_parser.c
 	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) $^ -o $@
 
 parsertrace: http_parser.o contrib/parsertrace.c
-	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_FAST) $^ -o parsertrace
+	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_FAST) $^ -o parsertrace$(BINEXT)
 
 parsertrace_g: http_parser_g.o contrib/parsertrace.c
-	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) $^ -o parsertrace_g
+	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) $^ -o parsertrace_g$(BINEXT)
 
 tags: http_parser.c http_parser.h test.c
 	ctags $^
@@ -113,12 +125,12 @@ tags: http_parser.c http_parser.h test.c
 install: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
+	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
+	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
 
 uninstall:
 	rm $(INCLUDEDIR)/http_parser.h
@@ -128,7 +140,8 @@ uninstall:
 clean:
 	rm -f *.o *.a tags test test_fast test_g \
 		http_parser.tar libhttp_parser.so.* \
-		url_parser url_parser_g parsertrace parsertrace_g
+		url_parser url_parser_g parsertrace parsertrace_g \
+		*.exe *.exe.so
 
 contrib/url_parser.c:	http_parser.h
 contrib/parsertrace.c:	http_parser.h

--- a/deps/http_parser/README.md
+++ b/deps/http_parser/README.md
@@ -94,7 +94,7 @@ The Special Problem of Upgrade
 ------------------------------
 
 HTTP supports upgrading the connection to a different protocol. An
-increasingly common example of this is the Web Socket protocol which sends
+increasingly common example of this is the WebSocket protocol which sends
 a request like
 
         GET /demo HTTP/1.1
@@ -106,8 +106,8 @@ a request like
 
 followed by non-HTTP data.
 
-(See http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-75 for more
-information the Web Socket protocol.)
+(See [RFC6455](https://tools.ietf.org/html/rfc6455) for more information the
+WebSocket protocol.)
 
 To support this, the parser will treat this as a normal HTTP message without a
 body, issuing both on_headers_complete and on_message_complete callbacks. However
@@ -136,6 +136,69 @@ There are two types of callbacks:
 
 Callbacks must return 0 on success. Returning a non-zero value indicates
 error to the parser, making it exit immediately.
+
+For cases where it is necessary to pass local information to/from a callback,
+the `http_parser` object's `data` field can be used.
+An example of such a case is when using threads to handle a socket connection,
+parse a request, and then give a response over that socket. By instantiation
+of a thread-local struct containing relevant data (e.g. accepted socket,
+allocated memory for callbacks to write into, etc), a parser's callbacks are
+able to communicate data between the scope of the thread and the scope of the
+callback in a threadsafe manner. This allows http-parser to be used in
+multi-threaded contexts.
+
+Example:
+```
+ typedef struct {
+  socket_t sock;
+  void* buffer;
+  int buf_len;
+ } custom_data_t;
+
+
+int my_url_callback(http_parser* parser, const char *at, size_t length) {
+  /* access to thread local custom_data_t struct.
+  Use this access save parsed data for later use into thread local
+  buffer, or communicate over socket
+  */
+  parser->data;
+  ...
+  return 0;
+}
+
+...
+
+void http_parser_thread(socket_t sock) {
+ int nparsed = 0;
+ /* allocate memory for user data */
+ custom_data_t *my_data = malloc(sizeof(custom_data_t));
+
+ /* some information for use by callbacks.
+ * achieves thread -> callback information flow */
+ my_data->sock = sock;
+
+ /* instantiate a thread-local parser */
+ http_parser *parser = malloc(sizeof(http_parser));
+ http_parser_init(parser, HTTP_REQUEST); /* initialise parser */
+ /* this custom data reference is accessible through the reference to the
+ parser supplied to callback functions */
+ parser->data = my_data;
+
+ http_parser_settings settings; / * set up callbacks */
+ settings.on_url = my_url_callback;
+
+ /* execute parser */
+ nparsed = http_parser_execute(parser, &settings, buf, recved);
+
+ ...
+ /* parsed information copied from callback.
+ can now perform action on data copied into thread-local memory from callbacks.
+ achieves callback -> thread information flow */
+ my_data->buffer;
+ ...
+}
+
+```
 
 In case you parse HTTP message in chunks (i.e. `read()` request line
 from socket, parse, read half headers, parse, etc) your data callbacks

--- a/deps/http_parser/contrib/url_parser.c
+++ b/deps/http_parser/contrib/url_parser.c
@@ -35,6 +35,7 @@ int main(int argc, char ** argv) {
   connect = strcmp("connect", argv[1]) == 0 ? 1 : 0;
   printf("Parsing %s, connect %d\n", argv[2], connect);
 
+  http_parser_url_init(&u);
   result = http_parser_parse_url(argv[2], len, connect, &u);
   if (result != 0) {
     printf("Parse error : %d\n", result);

--- a/deps/http_parser/http_parser.h
+++ b/deps/http_parser/http_parser.h
@@ -26,11 +26,12 @@ extern "C" {
 
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 5
+#define HTTP_PARSER_VERSION_MINOR 6
 #define HTTP_PARSER_VERSION_PATCH 0
 
 #include <sys/types.h>
-#if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
+#if defined(_WIN32) && !defined(__MINGW32__) && \
+  (!defined(_MSC_VER) || _MSC_VER<1600) && !defined(__WINE__)
 #include <BaseTsd.h>
 #include <stddef.h>
 typedef __int8 int8_t;
@@ -95,7 +96,7 @@ typedef int (*http_cb) (http_parser*);
   XX(5,  CONNECT,     CONNECT)      \
   XX(6,  OPTIONS,     OPTIONS)      \
   XX(7,  TRACE,       TRACE)        \
-  /* webdav */                      \
+  /* WebDAV */                      \
   XX(8,  COPY,        COPY)         \
   XX(9,  LOCK,        LOCK)         \
   XX(10, MKCOL,       MKCOL)        \
@@ -104,21 +105,28 @@ typedef int (*http_cb) (http_parser*);
   XX(13, PROPPATCH,   PROPPATCH)    \
   XX(14, SEARCH,      SEARCH)       \
   XX(15, UNLOCK,      UNLOCK)       \
+  XX(16, BIND,        BIND)         \
+  XX(17, REBIND,      REBIND)       \
+  XX(18, UNBIND,      UNBIND)       \
+  XX(19, ACL,         ACL)          \
   /* subversion */                  \
-  XX(16, REPORT,      REPORT)       \
-  XX(17, MKACTIVITY,  MKACTIVITY)   \
-  XX(18, CHECKOUT,    CHECKOUT)     \
-  XX(19, MERGE,       MERGE)        \
+  XX(20, REPORT,      REPORT)       \
+  XX(21, MKACTIVITY,  MKACTIVITY)   \
+  XX(22, CHECKOUT,    CHECKOUT)     \
+  XX(23, MERGE,       MERGE)        \
   /* upnp */                        \
-  XX(20, MSEARCH,     M-SEARCH)     \
-  XX(21, NOTIFY,      NOTIFY)       \
-  XX(22, SUBSCRIBE,   SUBSCRIBE)    \
-  XX(23, UNSUBSCRIBE, UNSUBSCRIBE)  \
+  XX(24, MSEARCH,     M-SEARCH)     \
+  XX(25, NOTIFY,      NOTIFY)       \
+  XX(26, SUBSCRIBE,   SUBSCRIBE)    \
+  XX(27, UNSUBSCRIBE, UNSUBSCRIBE)  \
   /* RFC-5789 */                    \
-  XX(24, PATCH,       PATCH)        \
-  XX(25, PURGE,       PURGE)        \
+  XX(28, PATCH,       PATCH)        \
+  XX(29, PURGE,       PURGE)        \
   /* CalDAV */                      \
-  XX(26, MKCALENDAR,  MKCALENDAR)   \
+  XX(30, MKCALENDAR,  MKCALENDAR)   \
+  /* RFC-2068, section 19.6.1.2 */  \
+  XX(31, LINK,        LINK)         \
+  XX(32, UNLINK,      UNLINK)       \
 
 enum http_method
   {
@@ -144,7 +152,7 @@ enum flags
 
 
 /* Map for errno-related constants
- * 
+ *
  * The provided argument should be a macro that takes 2 arguments.
  */
 #define HTTP_ERRNO_MAP(XX)                                           \
@@ -324,6 +332,9 @@ const char *http_errno_name(enum http_errno err);
 
 /* Return a string description of the given error */
 const char *http_errno_description(enum http_errno err);
+
+/* Initialize all http_parser_url members to 0 */
+void http_parser_url_init(struct http_parser_url *u);
 
 /* Parse a URL; return nonzero on failure */
 int http_parser_parse_url(const char *buf, size_t buflen,


### PR DESCRIPTION
@nodejs/tsc @nodejs/http 

significant updates:

* [[`777ba4eded`](https://github.com/nodejs/node/commit/777ba4eded)] - **src**: introduce `http_parser_url_init` (Fedor Indutny) [nodejs/http-parser#225](https://github.com/nodejs/http-parser/pull/225)
* [[`e557b62744`](https://github.com/nodejs/node/commit/e557b62744)] - **src**: support LINK/UNLINK (RFC 2068, draft-snell-link-method) (Olivier Mengué) [nodejs/http-parser#267](https://github.com/nodejs/http-parser/pull/267)
* [[`eb5e9928b4`](https://github.com/nodejs/node/commit/eb5e9928b4)] - **src**: support ACL (WebDAV, RFC3744, Section 8.1). (Ivan Enderlin) [joyent/http-parser#260](https://github.com/joyent/http-parser/pull/260)
* [[`8b1d652322`](https://github.com/nodejs/node/commit/8b1d652322)] - **src**: support BIND/REBIND/UNBIND (WebDAV, RFC5842) (Ivan Enderlin) [joyent/http-parser#242](https://github.com/joyent/http-parser/pull/242)
* [[`7d75dd7325`](https://github.com/nodejs/node/commit/7d75dd7325)] - **src**: support IPv6 Zone ID as per RFC 6874 (Tatsuhiro Tsujikawa) [joyent/http-parser#253](https://github.com/joyent/http-parser/pull/253)

Full changelog (since v2.5.0):

* [[`39c2c1e573`](https://github.com/nodejs/node/commit/39c2c1e573)] - Bump version to 2.5.0 (Fedor Indutny)
* [[`483eca7989`](https://github.com/nodejs/node/commit/483eca7989)] - **doc**: updated README.md to include multi-threading example (Lucas Berezy) [nodejs/http-parser#256](https://github.com/nodejs/http-parser/pull/256)
* [[`b36c2a9ece`](https://github.com/nodejs/node/commit/b36c2a9ece)] - **header**: treat Wine like MinGW (Andrew Udvare) [joyent/http-parser#259](https://github.com/joyent/http-parser/pull/259)
* [[`2896229a13`](https://github.com/nodejs/node/commit/2896229a13)] - **make**: fix dynamic library extension for OS X (Guo Xiao)
* [[`4f69be2221`](https://github.com/nodejs/node/commit/4f69be2221)] - **readme**: update WebSocket link to RFC6455 (Ivan Enderlin) [joyent/http-parser#240](https://github.com/joyent/http-parser/pull/240)
* [[`777ba4eded`](https://github.com/nodejs/node/commit/777ba4eded)] - **(SEMVER-MINOR)** **src**: introduce `http_parser_url_init` (Fedor Indutny) [nodejs/http-parser#225](https://github.com/nodejs/http-parser/pull/225)
* [[`e557b62744`](https://github.com/nodejs/node/commit/e557b62744)] - **(SEMVER-MINOR)** **src**: support LINK/UNLINK (RFC 2068, draft-snell-link-method) (Olivier Mengué) [nodejs/http-parser#267](https://github.com/nodejs/http-parser/pull/267)
* [[`e01811e7f4`](https://github.com/nodejs/node/commit/e01811e7f4)] - **src**: fixed compile error C2143 for vs2012 (Sebastian Philipp) [joyent/http-parser#261](https://github.com/joyent/http-parser/pull/261)
* [[`eb5e9928b4`](https://github.com/nodejs/node/commit/eb5e9928b4)] - **(SEMVER-MINOR)** **src**: support ACL (WebDAV, RFC3744, Section 8.1). (Ivan Enderlin) [joyent/http-parser#260](https://github.com/joyent/http-parser/pull/260)
* [[`8b1d652322`](https://github.com/nodejs/node/commit/8b1d652322)] - **(SEMVER-MINOR)** **src**: support BIND/REBIND/UNBIND (WebDAV, RFC5842) (Ivan Enderlin) [joyent/http-parser#242](https://github.com/joyent/http-parser/pull/242)
* [[`7d75dd7325`](https://github.com/nodejs/node/commit/7d75dd7325)] - **(SEMVER-MINOR)** **src**: support IPv6 Zone ID as per RFC 6874 (Tatsuhiro Tsujikawa) [joyent/http-parser#253](https://github.com/joyent/http-parser/pull/253)
* [[`ab0b162ef6`](https://github.com/nodejs/node/commit/ab0b162ef6)] - **src**: use ARRAY_SIZE instead of sizeof() (dlmeetei@gmail.com) [joyent/http-parser#252](https://github.com/joyent/http-parser/pull/252)
* [[`39ff0975c2`](https://github.com/nodejs/node/commit/39ff0975c2)] - **src**: remove double check (Jan Schär) [joyent/http-parser#248](https://github.com/joyent/http-parser/pull/248)
* [[`f6f436a12e`](https://github.com/nodejs/node/commit/f6f436a12e)] - **src**: fix invalid memory access in http_parse_host (Daniel Knoppel (Phusion)) [joyent/http-parser#246](https://github.com/joyent/http-parser/pull/246)
* [[`b5bcca8f92`](https://github.com/nodejs/node/commit/b5bcca8f92)] - **test**: `SEARCH`, `PURGE` and `MKCALENDAR` (Ivan Enderlin) [joyent/http-parser#241](https://github.com/joyent/http-parser/pull/241)
