### PR TITLE
assert: added objStrctEqual

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -261,6 +261,60 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
+function objStrctEquiv(a, b) {
+  if (typeof a !== 'object' || typeof b !== 'object')
+    return false;
+
+  const keys = Object.keys(a);
+  const nKeys = keys.length;
+
+  for (let i = 0, key, val; i < nKeys; ++i) {
+    key = keys[i];
+    val = a[key];
+
+    if (!b.hasOwnProperty(key) || !objStrctMatch(val, b[key]))
+      return false;
+  }
+
+  return true;
+}
+
+function objStrctMatch(a, b) {
+  if (a === null || b === null || a === undefined || b === undefined)
+    return a === b;
+
+  if (typeof a !== 'object' || typeof b !== 'object')
+    return typeof a === typeof b;
+
+  if (a instanceof Date || b instanceof Date)
+    return a instanceof Date && b instanceof Date;
+
+  if (a instanceof Boolean || b instanceof Boolean)
+    return a instanceof Boolean && b instanceof Boolean;
+
+  if (a instanceof Number || b instanceof Number)
+    return a instanceof Number && b instanceof Number;
+
+  if (a instanceof String || b instanceof String)
+    return a instanceof String && b instanceof String;
+
+  if ((a instanceof Array || b instanceof Array) && a.length !== b.length)
+    return false;
+
+  if (a instanceof Object && !objStrctEquiv(a, b))
+    return false;
+
+  if (b instanceof Object && !objStrctEquiv(b, a))
+    return false;
+
+  return true;
+}
+
+assert.objStrctEqual = function objStrctEqual(actual, expected, message) {
+  if (!objStrctMatch(actual, expected))
+    fail(actual, expected, message, 'objStrctEqual', objStrctEqual);
+};
+
 function expectedException(actual, expected) {
   if (!actual || !expected) {
     return false;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -467,4 +467,86 @@ testBlockTypeError(assert.doesNotThrow, undefined);
 assert.throws(() => { throw 'error'; }, err => err === 'error');
 assert.throws(() => { throw Error(); }, err => err instanceof Error);
 
+var objA = {
+  string: '',
+  integer: 0,
+  aFloat: 0.5,
+  aBoolean: true,
+  regex: /./g,
+  null: null,
+  undefined: undefined,
+  array: [
+    {
+      string: '',
+      integer: 0,
+      aFloat: 0.5,
+      aBoolean: true,
+      regex: /./g,
+      null: null,
+      undefined: undefined
+    }, {
+      string: '',
+      integer: 0,
+      aFloat: 0.5,
+      aBoolean: true,
+      regex: /./g,
+      null: null,
+      undefined: undefined
+    }
+  ],
+  object: {
+    string: '',
+    integer: 0,
+    aFloat: 0.5,
+    aBoolean: true,
+    regex: /./g,
+    null: null,
+    undefined: undefined
+  }
+};
+
+var objB = {
+  string: 'abc',
+  integer: 1,
+  aFloat: 1.5,
+  aBoolean: false,
+  regex: /abc/g,
+  null: null,
+  undefined: undefined,
+  array: [
+    {
+      string: 'abc',
+      integer: 1,
+      aFloat: 1.5,
+      aBoolean: false,
+      regex: /abc/g,
+      null: null,
+      undefined: undefined
+    }, {
+      string: 'abc',
+      integer: 1,
+      aFloat: 1.5,
+      aBoolean: false,
+      regex: /abc/g,
+      null: null,
+      undefined: undefined
+    }
+  ],
+  object: {
+    string: 'abc',
+    integer: 1,
+    aFloat: 1.5,
+    aBoolean: false,
+    regex: /abc/g,
+    null: null,
+    undefined: undefined
+  }
+};
+
+assert.doesNotThrow(makeBlock(a.objStrctEqual, objA, objB));
+
+objA.object.string = 0;
+
+assert.throws(makeBlock(a.objStrctEqual, objA, objB));
+
 console.log('All OK');


### PR DESCRIPTION
```
- Added the objStrctEqual assertion function.
  This test does a deep data type comparison. It only cares about the data
  type of the variables, not the actual value. Giving the ability to test
  APIs that do not give consistent values for the same API function.
- Added appropriate tests to test-assert.js
```

I read through the assert lib and could not find anything exactly like this. I know ```assert.deepEqual``` does something very similar to this, but it checks that primitive values match, which is what this PR explicitly does not do.

Thoughts?