### PR TITLE
test: fix heap-profiler link error LNK1194 on win

### DIFF
--- a/test/addons/heap-profiler/binding.gyp
+++ b/test/addons/heap-profiler/binding.gyp
@@ -2,7 +2,8 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.cc' ],
+      'win_delay_load_hook' : 'false'
     }
   ]
 }


### PR DESCRIPTION
Fix the following error on windows with VS 2013:
```
LINK : fatal error LNK1194: cannot delay-load 'node.exe' due to import of data symbol '"__declspec(dllimport) const v8::OutputStream::`vftable'" (__imp_??_7OutputStream@v8@@6B@)'; link without /DELAYLOAD:node.exe [K:\johnyan\node\test\addons\heap-profiler\build\binding.vcxproj]
```
