### PR TITLE
doc: made code spans more visible

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -339,6 +339,8 @@ p code,
 li code {
   font-size: 0.9em;
   color: #040404;
+  background-color: #f2f5f0;
+  padding: 0.2em 0.4em;
 }
 
 span.type {


### PR DESCRIPTION
This makes the code spans in the API docs alot more visible and therefore readable by adding some background color. Its more or less what github.com does, and what we decided to do on nodejs.org with https://github.com/nodejs/new.nodejs.org/pull/146. 

Closes an issue raised about API docs readability in https://github.com/nodejs/new.nodejs.org/issues/121.

<img width="414" alt="skjermbilde 2015-10-28 kl 21 01 38" src="https://cloud.githubusercontent.com/assets/1231635/10801517/fc38a0d6-7db7-11e5-817e-e9ca76e76cc6.png">