### PR TITLE
child_process: don't fork bomb ourselves from -e

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -32,6 +32,16 @@ exports.fork = function(modulePath /*, args, options*/) {
 
   // Prepare arguments for fork:
   execArgv = options.execArgv || process.execArgv;
+
+  if (execArgv === process.execArgv && process._eval != null) {
+    const index = execArgv.lastIndexOf(process._eval);
+    if (index > 0) {
+      // Remove the -e switch to avoid fork bombing ourselves.
+      execArgv = execArgv.slice();
+      execArgv.splice(index - 1, 2);
+    }
+  }
+
   args = execArgv.concat([modulePath], args);
 
   // Leave stdin open for the IPC channel. stdout and stderr should be the

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -8,6 +8,7 @@ if (module.parent) {
 var common = require('../common'),
     assert = require('assert'),
     child = require('child_process'),
+    path = require('path'),
     nodejs = '"' + process.execPath + '"';
 
 
@@ -74,4 +75,12 @@ child.exec(nodejs + ' -p "\\-42"',
 child.exec(nodejs + ' --use-strict -p process.execArgv',
     function(status, stdout, stderr) {
       assert.equal(stdout, "[ '--use-strict', '-p', 'process.execArgv' ]\n");
+    });
+
+// Regression test for https://github.com/nodejs/node/issues/3574
+const emptyFile = path.join(common.fixturesDir, 'empty.js');
+child.exec(nodejs + ` -e 'require("child_process").fork("${emptyFile}")'`,
+    function(status, stdout, stderr) {
+      assert.equal(stdout, '');
+      assert.equal(stderr, '');
     });


### PR DESCRIPTION
Remove the `-e` argument from process.execArgv in child_process.fork()
to keep `node -e 'require("child_process").fork("empty.js")'` from
spawning itself recursively.

Fixes: https://github.com/nodejs/node/issues/3574

R=@Trott

CI: https://ci.nodejs.org/job/node-test-pull-request/643/