### PR TITLE
lib: return boolean from child.send()

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -551,7 +551,7 @@ function setupChannel(target, channel) {
           handle: handle,
           message: message.msg,
         });
-        return;
+        return this._handleQueue.length === 1;
       }
 
       var obj = handleConversion[message.type];

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -13,8 +13,8 @@ const n = fork(emptyFile);
 const rv = n.send({ hello: 'world' });
 assert.strictEqual(rv, true);
 
-const s = spawn(process.execPath, [emptyFile],
-  { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] });
+const spawnOptions = { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] };
+const s = spawn(process.execPath, [emptyFile], spawnOptions);
 var handle = null;
 s.on('exit', function() {
   handle.close();

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -1,9 +1,29 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const path = require('path');
+const net = require('net');
 const fork = require('child_process').fork;
+const spawn = require('child_process').spawn;
 
-const n = fork(common.fixturesDir + '/empty.js');
+const emptyFile = path.join(common.fixturesDir, 'empty.js');
+
+const n = fork(emptyFile);
 
 const rv = n.send({ hello: 'world' });
 assert.strictEqual(rv, true);
+
+const s = spawn(process.execPath, [emptyFile],
+  { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] });
+var handle = null;
+s.on('exit', function() {
+  handle.close();
+});
+
+net.createServer(common.fail).listen(common.PORT, function() {
+  handle = this._handle;
+  assert.strictEqual(s.send('one', handle), true);
+  assert.strictEqual(s.send('two', handle), true);
+  assert.strictEqual(s.send('three'), false);
+  assert.strictEqual(s.send('four'), false);
+});


### PR DESCRIPTION
Previous change reinstated returning boolean from child.send() but
missed one instance where undefined might be returned instead.

R=@bnoordhuis
