### PR TITLE
module: remove unnecessary JSON.stringify

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -254,8 +254,8 @@ Module._resolveLookupPaths = function(request, parent) {
     id = './' + id;
   }
 
-  debug('RELATIVE: requested:' + request +
-        ' set ID to: ' + id + ' from ' + parent.id);
+  debug('RELATIVE: requested: %s set ID to: %s from %s', request, id,
+        parent.id);
 
   return [id, [path.dirname(parent.filename)]];
 };
@@ -270,7 +270,7 @@ Module._resolveLookupPaths = function(request, parent) {
 //    object.
 Module._load = function(request, parent, isMain) {
   if (parent) {
-    debug('Module._load REQUEST  ' + (request) + ' parent: ' + parent.id);
+    debug('Module._load REQUEST %s parent: %s', request, parent.id);
   }
 
   // REPL is a special case, because it needs the real require.
@@ -292,7 +292,7 @@ Module._load = function(request, parent, isMain) {
   }
 
   if (NativeModule.nonInternalExists(filename)) {
-    debug('load native module ' + request);
+    debug('load native module %s', request);
     return NativeModule.require(filename);
   }
 
@@ -329,8 +329,7 @@ Module._resolveFilename = function(request, parent) {
   var paths = resolvedModule[1];
 
   // look up the filename first, since that's the cache key.
-  debug('looking for ' + JSON.stringify(id) +
-        ' in ' + JSON.stringify(paths));
+  debug('looking for %j in %j', id, paths);
 
   var filename = Module._findPath(request, paths);
   if (!filename) {
@@ -344,8 +343,7 @@ Module._resolveFilename = function(request, parent) {
 
 // Given a file name, pass it to the proper extension handler.
 Module.prototype.load = function(filename) {
-  debug('load ' + JSON.stringify(filename) +
-        ' for module ' + JSON.stringify(this.id));
+  debug('load %j for module %j', filename, this.id);
 
   assert(!this.loaded);
   this.filename = filename;


### PR DESCRIPTION
Use `debulog`'s placeholder replacement `%j` for stringification. So calls to `JSON.stringify` are only made by `debuglog` when you're actually debugging. Also, made the remaining calls to `debuglog` consistent with this style.