### PR TITLE
module: move unnecessary work for early return

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -136,18 +136,17 @@ function tryExtensions(p, exts) {
 
 var warned = false;
 Module._findPath = function(request, paths) {
-  var exts = Object.keys(Module._extensions);
-
   if (path.isAbsolute(request)) {
     paths = [''];
   }
-
-  var trailingSlash = (request.slice(-1) === '/');
 
   var cacheKey = JSON.stringify({request: request, paths: paths});
   if (Module._pathCache[cacheKey]) {
     return Module._pathCache[cacheKey];
   }
+
+  const exts = Object.keys(Module._extensions);
+  const trailingSlash = request.slice(-1) === '/';
 
   // For each path
   for (var i = 0, PL = paths.length; i < PL; i++) {


### PR DESCRIPTION
`exts` and `trailingSlash` are only used if the path isn't cached.