### PR TITLE
module: optimize platform lookup and initPath

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,6 +11,7 @@ const path = require('path');
 const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 
+const isWindows = process.platform === 'win32';
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -191,7 +192,7 @@ Module._nodeModulePaths = function(from) {
   // note: this approach *only* works when the path is guaranteed
   // to be absolute.  Doing a fully-edge-case-correct path.split
   // that works on both Windows and Posix is non-trivial.
-  var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
+  var splitRe = isWindows ? /[\/\\]/ : /\//;
   var paths = [];
   var parts = from.split(splitRe);
 
@@ -460,29 +461,23 @@ Module.runMain = function() {
 };
 
 Module._initPaths = function() {
-  const isWindows = process.platform === 'win32';
-
-  if (isWindows) {
-    var homeDir = process.env.USERPROFILE;
-  } else {
-    var homeDir = process.env.HOME;
-  }
-
-  var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];
-
-  if (homeDir) {
-    paths.unshift(path.resolve(homeDir, '.node_libraries'));
-    paths.unshift(path.resolve(homeDir, '.node_modules'));
-  }
+  modulePaths = [];
 
   var nodePath = process.env['NODE_PATH'];
   if (nodePath) {
-    paths = nodePath.split(path.delimiter).filter(function(path) {
-      return !!path;
-    }).concat(paths);
+    var nodePaths = nodePath.split(path.delimiter);
+    for (var i = 0; i < nodePaths.length; i++) {
+      if (nodePaths[i]) modulePaths.push(nodePaths[i]);
+    }
   }
 
-  modulePaths = paths;
+  var homeDir = isWindows ? process.env.USERPROFILE : process.env.HOME;
+  if (homeDir) {
+    modulePaths.push(path.resolve(homeDir, '.node_modules'));
+    modulePaths.push(path.resolve(homeDir, '.node_libraries'));
+  }
+
+  modulePaths.push(path.resolve(process.execPath, '..', '..', 'lib', 'node'));
 
   // clone as a read-only copy, for introspection.
   Module.globalPaths = modulePaths.slice(0);


### PR DESCRIPTION
This caches the value of `process.platform` in a style that is consistent with the fs, os and path modules. It also improves `Module._initPath` in both legibility and simplicity. Instead of creating the `modulePaths` array from right-to-left via `concat`s and `unshift`s, its now built left-to-right with `push`s. Although it is a micro-optimization, the changes make it much easier to read and understand.