### PR TITLE
Change doc to follow major browser console api

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -32,7 +32,7 @@ In daily use, the blocking/non-blocking dichotomy is not something you
 should worry about unless you log huge amounts of data.
 
 
-### console.log([data][, ...])
+### console.log(object [, object, ...])
 
 Prints to stdout with newline. This function can take multiple arguments in a
 `printf()`-like way. Example:
@@ -44,15 +44,15 @@ Prints to stdout with newline. This function can take multiple arguments in a
 If formatting elements are not found in the first string then `util.inspect`
 is used on each argument.  See [util.format()][] for more information.
 
-### console.info([data][, ...])
+### console.info(object [, object, ...])
 
 Same as `console.log`.
 
-### console.error([data][, ...])
+### console.error(object [, object, ...])
 
 Same as `console.log` but prints to stderr.
 
-### console.warn([data][, ...])
+### console.warn(object [, object, ...])
 
 Same as `console.error`.
 
@@ -72,15 +72,15 @@ object. This is useful for inspecting large complicated objects. Defaults to
 - `colors` - if `true`, then the output will be styled with ANSI color codes.
 Defaults to `false`. Colors are customizable, see below.
 
-### console.time(timerName)
+### console.time(label)
 
 Starts a timer that can be used to compute the duration of an operation. Timers
-are identified by a unique name. Use the same name when you call
+are identified by a unique label. Use the same label when you call
 [`console.timeEnd()`](#console_console_timeend_timername) to stop the timer and
 output the elapsed time in milliseconds. Timer durations are accurate to the
 sub-millisecond.
 
-### console.timeEnd(timerName)
+### console.timeEnd(label)
 
 Stops a timer that was previously started by calling
 [`console.time()`](#console_console_time_timername) and prints the result to the

--- a/lib/console.js
+++ b/lib/console.js
@@ -40,12 +40,18 @@ Console.prototype.log = function() {
 Console.prototype.info = Console.prototype.log;
 
 
+Console.prototype.debug = Console.prototype.log;
+
+
 Console.prototype.warn = function() {
   this._stderr.write(util.format.apply(this, arguments) + '\n');
 };
 
 
 Console.prototype.error = Console.prototype.warn;
+
+
+Console.prototype.exception = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object, options) {

--- a/lib/console.js
+++ b/lib/console.js
@@ -90,5 +90,44 @@ Console.prototype.assert = function(expression) {
 };
 
 
+Console.prototype.group = function() {};
+
+
+Console.prototype.groupCollapsed = function() {};
+
+
+Console.prototype.groupEnd = function() {};
+
+
+Console.prototype.clear = function() {};
+
+
+Console.prototype.count = function() {};
+
+
+Console.prototype.dirxml = function() {};
+
+
+Console.prototype.isIndependentlyComposed = function() {};
+
+
+Console.prototype.table = function() {};
+
+
+Console.prototype.profile = function() {};
+
+
+Console.prototype.profileEnd = function() {};
+
+
+Console.prototype.timeline = function() {};
+
+
+Console.prototype.timelineEnd = function() {};
+
+
+Console.prototype.timeStamp = function() {};
+
+
 module.exports = new Console(process.stdout, process.stderr);
 module.exports.Console = Console;

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -17,6 +17,36 @@ assert.doesNotThrow(function() {
   console.timeEnd('label');
 });
 
+assert.doesNotThrow(function() {
+  console.group('test');
+  console.groupEnd();
+});
+
+assert.doesNotThrow(function() {
+  console.groupCollapsed('test');
+  console.groupEnd();
+});
+
+assert.doesNotThrow(console.clear);
+
+assert.doesNotThrow(console.count);
+
+assert.doesNotThrow(console.dirxml);
+
+assert.doesNotThrow(console.exception);
+
+assert.doesNotThrow(console.isIndependentlyComposed);
+
+assert.doesNotThrow(console.profile);
+
+assert.doesNotThrow(console.profileEnd);
+
+assert.doesNotThrow(console.timeline);
+
+assert.doesNotThrow(console.timelineEnd);
+
+assert.doesNotThrow(console.timeStamp);
+
 // an Object with a custom .inspect() function
 var custom_inspect = { foo: 'bar', inspect: function() { return 'inspect'; } };
 


### PR DESCRIPTION
I have changed the doc to follow this spec https://github.com/DeveloperToolsWG/console-object/blob/master/api.md There are few methods whose signatures are not changed as the behaviour of those methods in node is different than the browser spec (e.g. console.assert).
