### PR TITLE
src: wrap source before doing syntax check

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -106,6 +106,8 @@
           var source = fs.readFileSync(filename, 'utf-8');
           // remove shebang and BOM
           source = internalModule.stripBOM(source.replace(/^\#\!.*/, ''));
+          // wrap it
+          source = Module.wrap(source);
           // compile the script, this will throw if it fails
           new vm.Script(source, {filename: filename, displayErrors: true});
           process.exit(0);

--- a/test/fixtures/syntax/illegal_if_not_wrapped.js
+++ b/test/fixtures/syntax/illegal_if_not_wrapped.js
@@ -1,0 +1,3 @@
+if (true) {
+  return;
+}

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -20,6 +20,7 @@ var syntaxArgs = [
   'syntax/good_syntax',
   'syntax/good_syntax_shebang.js',
   'syntax/good_syntax_shebang',
+  'syntax/illegal_if_not_wrapped.js'
 ].forEach(function(file) {
   file = path.join(common.fixturesDir, file);
 


### PR DESCRIPTION
This is to ensure that it is evaluated the same way it would be if it
were to be run by node or required.

Before, the following would pass if run by node, but fail if run via
the syntax check flag:

    if (true) {
      return;
    }

Now, this will pass the syntax check

Reported in https://github.com/nodejs/node/pull/2411#issuecomment-152220348