### PR TITLE
Revert "console: rename argument of time and timeEnd"

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -72,18 +72,18 @@ object. This is useful for inspecting large complicated objects. Defaults to
 - `colors` - if `true`, then the output will be styled with ANSI color codes.
 Defaults to `false`. Colors are customizable, see below.
 
-### console.time(timerName)
+### console.time(label)
 
 Starts a timer that can be used to compute the duration of an operation. Timers
 are identified by a unique name. Use the same name when you call
-[`console.timeEnd()`](#console_console_timeend_timername) to stop the timer and
+[`console.timeEnd()`](#console_console_timeend_label) to stop the timer and
 output the elapsed time in milliseconds. Timer durations are accurate to the
 sub-millisecond.
 
-### console.timeEnd(timerName)
+### console.timeEnd(label)
 
 Stops a timer that was previously started by calling
-[`console.time()`](#console_console_time_timername) and prints the result to the
+[`console.time()`](#console_console_time_label) and prints the result to the
 console.
 
 Example:

--- a/lib/console.js
+++ b/lib/console.js
@@ -55,19 +55,19 @@ Console.prototype.dir = function(object, options) {
 };
 
 
-Console.prototype.time = function(timerName) {
-  this._times.set(timerName, process.hrtime());
+Console.prototype.time = function(label) {
+  this._times.set(label, process.hrtime());
 };
 
 
-Console.prototype.timeEnd = function(timerName) {
-  var time = this._times.get(timerName);
+Console.prototype.timeEnd = function(label) {
+  var time = this._times.get(label);
   if (!time) {
-    throw new Error('No such timer name: ' + timerName);
+    throw new Error('No such label: ' + label);
   }
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;
-  this.log('%s: %sms', timerName, ms.toFixed(3));
+  this.log('%s: %sms', label, ms.toFixed(3));
 };
 
 


### PR DESCRIPTION
The argument name in the documentation was changed to match [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Console/time) in 8c043c12456d9b5a500f9cefcca27a61a1a381cf, but as it turns out the argument is actually called `label` in the [console spec](https://github.com/DeveloperToolsWG/console-object/blob/master/api.md#consoletimelabel). I'll fix this on MDN soon after this commit lands.

cc: @targos @aks-