### PR TITLE
doc: Updated streams simplified constructor API

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -1375,6 +1375,10 @@ Examples:
 var readable = new stream.Readable({
   read: function(n) {
     // sets this._read under the hood
+
+    // push data onto the read queue, passing null
+    // will signal the end of the stream (EOF)
+    this.push(chunk);
   }
 });
 ```
@@ -1384,6 +1388,9 @@ var readable = new stream.Readable({
 var writable = new stream.Writable({
   write: function(chunk, encoding, next) {
     // sets this._write under the hood
+
+    // An optional error can be passed as the first argument
+    next()
   }
 });
 
@@ -1392,6 +1399,9 @@ var writable = new stream.Writable({
 var writable = new stream.Writable({
   writev: function(chunks, next) {
     // sets this._writev under the hood
+
+    // An optional error can be passed as the first argument
+    next()
   }
 });
 ```
@@ -1401,9 +1411,16 @@ var writable = new stream.Writable({
 var duplex = new stream.Duplex({
   read: function(n) {
     // sets this._read under the hood
+
+    // push data onto the read queue, passing null
+    // will signal the end of the stream (EOF)
+    this.push(chunk);
   },
   write: function(chunk, encoding, next) {
     // sets this._write under the hood
+
+    // An optional error can be passed as the first argument
+    next()
   }
 });
 
@@ -1412,9 +1429,16 @@ var duplex = new stream.Duplex({
 var duplex = new stream.Duplex({
   read: function(n) {
     // sets this._read under the hood
+
+    // push data onto the read queue, passing null
+    // will signal the end of the stream (EOF)
+    this.push(chunk);
   },
   writev: function(chunks, next) {
     // sets this._writev under the hood
+
+    // An optional error can be passed as the first argument
+    next()
   }
 });
 ```
@@ -1424,9 +1448,20 @@ var duplex = new stream.Duplex({
 var transform = new stream.Transform({
   transform: function(chunk, encoding, next) {
     // sets this._transform under the hood
+
+    // generate output as many times as needed
+    // this.push(chunk);
+
+    // call when the current chunk is consumed
+    next();
   },
   flush: function(done) {
     // sets this._flush under the hood
+
+    // generate output as many times as needed
+    // this.push(chunk);
+
+    done();
   }
 });
 ```


### PR DESCRIPTION
The examples for implementing the simplified constructor API was missing some details on its correct usages.
 
I have updated them to reflect this.