### PR TITLE
buffer: Fixing deopt when constructed with strings

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -40,7 +40,7 @@ function alignPool() {
 }
 
 
-function Buffer(arg) {
+function Buffer(arg, encoding) {
   // Common case.
   if (typeof arg === 'number') {
     // If less than zero, or NaN.
@@ -51,7 +51,11 @@ function Buffer(arg) {
 
   // Slightly less common case.
   if (typeof arg === 'string') {
-    return fromString(arg, arguments[1]);
+    encoding = encoding || '';
+    if (typeof encoding !== 'string' || encoding === '')
+      encoding = 'utf8';
+
+    return fromString(arg, encoding);
   }
 
   // Unusual.
@@ -103,9 +107,6 @@ function allocate(size) {
 
 
 function fromString(string, encoding) {
-  if (typeof encoding !== 'string' || encoding === '')
-    encoding = 'utf8';
-
   var length = byteLength(string, encoding);
   if (length >= (Buffer.poolSize >>> 1))
     return binding.createFromString(string, encoding);


### PR DESCRIPTION
When a buffer was created using `new Buffer('A String')`, internally
within the buffer class we would read arguments[1], however in this case
we would be reading outside of the array causing a deopt to occur.

This fixes this issue by casting the type to a string before use, and
removing the usage of the arguments object.