### PR TITLE
test: fix path to module for repl test on Windows

### DIFF
--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -1,10 +1,14 @@
 'use strict';
-require('../../common');
+var common = require('../../common');
 var assert = require('assert');
 var repl = require('repl');
 var stream = require('stream');
+var path = require('path');
 var buildType = process.config.target_defaults.default_configuration;
-var buildPath = __dirname + '/build/' + buildType + '/binding';
+var buildPath = path.join(__dirname, 'build', buildType, 'binding');
+// On Windows, escape backslashes in the path before passing it to REPL.
+if (common.isWindows)
+  buildPath = buildPath.replace(/\\/g, '/');
 var cb_ran = false;
 
 process.on('exit', function() {


### PR DESCRIPTION
Use path join to construct the path instead of concatenating strings.
Replace backslash with double backslash so that they are escaped
correctly in the string passed to REPL.