### PR TITLE
deps: backport 9da3ab6 from V8 upstream

### DIFF
--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -929,6 +929,9 @@ DEFINE_BOOL(ll_prof, false, "Enable low-level linux profiler.")
 DEFINE_BOOL(perf_basic_prof, false,
             "Enable perf linux profiler (basic support).")
 DEFINE_NEG_IMPLICATION(perf_basic_prof, compact_code_space)
+DEFINE_BOOL(perf_basic_prof_only_functions, false,
+            "Only report function code ranges to perf (i.e. no stubs).")
+DEFINE_IMPLICATION(perf_basic_prof_only_functions, perf_basic_prof)
 DEFINE_STRING(gc_fake_mmap, "/tmp/__v8_gc__",
               "Specify the name of the file for fake gc mmap used in ll_prof")
 DEFINE_BOOL(log_internal_timer_events, false, "Time internal events.")

--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -290,6 +290,12 @@ void PerfBasicLogger::LogRecordedBuffer(Code* code,
                                        int length) {
   DCHECK(code->instruction_start() == code->address() + Code::kHeaderSize);
 
+  if (FLAG_perf_basic_prof_only_functions &&
+      (code->kind() != Code::FUNCTION &&
+       code->kind() != Code::OPTIMIZED_FUNCTION)) {
+    return;
+  }
+
   base::OS::FPrint(perf_output_handle_, "%llx %x %.*s\n",
                    reinterpret_cast<uint64_t>(code->instruction_start()),
                    code->instruction_size(), length, name);


### PR DESCRIPTION
This patch exposes a new flag perf_basic_prof_only_functions (disabled by
default) that can be useful for the use-case of running always-on profiling on
long running production jobs.

This is already present on master, but would be good to get back-ported to v4.x.
R=@bnoordhuis, @nodejs/v8 

Original commit
https://github.com/v8/v8/commit/9da3ab661fe7190fcb99bd99db30cf95913d3659
  New flag --perf_basic_prof_only_functions
  Restricts linux perf-event code range reporting to functions only (i.e. on
  stubs.) While this makes the gathered ticks less accurate, it reduces the
  growth of the /tmp/perf-${pid}.map file.

  BUG=v8:3453
  R=hablich@chromium.org,danno@chromium.org
  LOG=N

  Review URL: https://codereview.chromium.org/1292743002

  Cr-Commit-Position: refs/heads/master@{#30179}