### PR TITLE
console: timeEnd printf-like support

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -80,11 +80,11 @@ are identified by a unique name. Use the same name when you call
 output the elapsed time in milliseconds. Timer durations are accurate to the
 sub-millisecond.
 
-### console.timeEnd(timerName)
+### console.timeEnd(timerName, [...])
 
 Stops a timer that was previously started by calling
 [`console.time()`](#console_console_time_timername) and prints the result to the
-console.
+console. This function can take multiple arguments in a printf()-like way.
 
 Example:
 
@@ -94,6 +94,12 @@ Example:
     }
     console.timeEnd('100-elements');
     // prints 100-elements: 225.438ms
+
+    console.time('%d-elements');
+    ...
+    console.timeEnd('%d-elements', 100);
+    // prints 100-elements: 225.438ms
+
 
 ### console.trace(message[, ...])
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -67,7 +67,11 @@ Console.prototype.timeEnd = function(timerName) {
   }
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;
-  this.log('%s: %sms', timerName, ms.toFixed(3));
+  if (arguments.length === 1) {
+    this.log('%s: %sms', timerName, ms.toFixed(3));
+  } else {
+    this.log('%s: %sms', util.format.apply(timerName, arguments), ms.toFixed(3));
+  }
 };
 
 

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -46,6 +46,10 @@ console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
 // test console.time() and console.timeEnd() output
 console.time('label');
 console.timeEnd('label');
+console.time('label %s');
+console.timeEnd('label %s', 'hello');
+console.time('label %s %s');
+console.timeEnd('label %s %s', 'hello', 'world');
 
 // verify that Object.prototype properties can be used as labels
 console.time('__proto__');
@@ -69,6 +73,10 @@ assert.equal(-1, strings.shift().indexOf('baz'));
 assert.equal('Trace: This is a {"formatted":"trace"} 10 foo',
              strings.shift().split('\n').shift());
 assert.ok(/^label: \d+\.\d{3}ms$/.test(strings.shift().trim()));
+assert.ok(/^label hello: \d+\.\d{3}ms\n/.test(strings.shift()),
+          'timeEnd with one extra arg');
+assert.ok(/^label hello world: \d+\.\d{3}ms\n/.test(strings.shift()),
+          'timeEnd with more than one extra arg');
 assert.ok(/^__proto__: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^constructor: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^hasOwnProperty: \d+\.\d{3}ms$/.test(strings.shift().trim()));


### PR DESCRIPTION
Hello,

I've made a small patch to allow us to use format on timeEnd.

```javascript
console.time('Found %d places');
console.timeEnd('Found %d places', 2);

> Found 2 places: 262.450ms

console.time('Found %d places and %d faces');
console.timeEnd('Found %d places and %d faces', 2, 5);

> Found 2 places and 5 faces: 801.239ms
```
It's useful to profile and log at the same time.

What do you guys think about it?