### PR TITLE
debugger,test: fix flaky debug logging on SmartOS

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -7,7 +7,12 @@ const Buffer = require('buffer').Buffer;
 const Transform = require('stream').Transform;
 
 exports.start = function start() {
-  var agent = new Agent();
+  const agent = new Agent();
+
+  // SmartOS sometimes munges output from `process._rawDebug()`
+  // but Windows can't use `console.error()`.
+  // https://github.com/nodejs/node/issues/2476
+  const log = process.platform === 'win32' ? process._rawDebug : console.error;
 
   // Do not let `agent.listen()` request listening from cluster master
   const cluster = require('cluster');
@@ -15,19 +20,12 @@ exports.start = function start() {
   cluster.isMaster = true;
 
   agent.on('error', function(err) {
-    process._rawDebug(err.stack || err);
+    log(err.stack || err);
   });
 
   agent.listen(process._debugAPI.port, function() {
-    var addr = this.address();
-    // SmartOS sometimes munges output from `process._rawDebug()`
-    // but Windows can't use `console.error()`.
-    // https://github.com/nodejs/node/issues/2476
-    if (process.platform == 'win32') {
-      process._rawDebug('Debugger listening on port %d', addr.port);
-    } else {
-      console.error('Debugger listening on port %d', addr.port);
-    }
+    const addr = this.address();
+    log(`Debugger listening on port ${addr.port}`);
     process._debugAPI.notifyListen();
   });
 

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -20,7 +20,14 @@ exports.start = function start() {
 
   agent.listen(process._debugAPI.port, function() {
     var addr = this.address();
-    process._rawDebug('Debugger listening on port %d', addr.port);
+    // SmartOS sometimes munges output from `process._rawDebug()`
+    // but Windows can't use `console.error()`.
+    // https://github.com/nodejs/node/issues/2476
+    if (process.platform == 'win32') {
+      process._rawDebug('Debugger listening on port %d', addr.port);
+    } else {
+      console.error('Debugger listening on port %d', addr.port);
+    }
     process._debugAPI.notifyListen();
   });
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -18,7 +18,6 @@ test-child-process-exit-code      : PASS,FLAKY
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS
-test-debug-signal-cluster         : PASS,FLAKY
 
 [$system==freebsd]
 test-net-socket-local-address     : PASS,FLAKY


### PR DESCRIPTION
SmartOS sometimes munges output from `process._rawDebug()`
but Windows can't use `console.error()` in the debug agent.
So inject logic to chose the right thing based on platform.

Fixes: https://github.com/nodejs/node/issues/2476