### PR TITLE
test: mark http-pipeline-flood flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -7,6 +7,7 @@ prefix sequential
 [true] # This section applies to all platforms
 
 [$system==win32]
+test-http-pipeline-flood                        : PASS,FLAKY
 
 [$system==linux]
 test-vm-syntax-error-stderr                     : PASS,FLAKY


### PR DESCRIPTION
test-http-pipeline-flood has been flaky on Windows for some time.
Hopefully, https://github.com/nodejs/node/pull/2862 fixes it and
lands soon, but until then, let's mark it as flaky.

Recent examples of the test failing on Windows in CI:
* https://ci.nodejs.org/job/node-test-binary-windows/177/RUN_SUBSET=1,VS_VERSION=vs2015,label=win2012r2/tapTestReport/test.tap-228/
* https://ci.nodejs.org/job/node-test-binary-windows/176/RUN_SUBSET=1,VS_VERSION=vs2015,label=win2012r2/tapTestReport/test.tap-228/
* https://ci.nodejs.org/job/node-test-binary-windows/174/RUN_SUBSET=1,VS_VERSION=vs2015,label=win2012r2/tapTestReport/test.tap-228/
* https://ci.nodejs.org/job/node-test-binary-windows/173/RUN_SUBSET=1,VS_VERSION=vs2015,label=win2012r2/tapTestReport/test.tap-228/
* https://ci.nodejs.org/job/node-test-binary-windows/172/RUN_SUBSET=1,VS_VERSION=vs2015,label=win2012r2/tapTestReport/test.tap-228/