### PR TITLE
lib: use arrow functions instead of bind

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -160,7 +160,7 @@ function Client() {
     protocol.execute(d);
   });
 
-  protocol.onResponse = this._onResponse.bind(this);
+  protocol.onResponse = (res) => this._onResponse(res);
 }
 inherits(Client, net.Socket);
 exports.Client = Client;
@@ -735,7 +735,7 @@ function Interface(stdin, stdout, args) {
     prompt: 'debug> ',
     input: this.stdin,
     output: this.stdout,
-    eval: this.controlEval.bind(this),
+    eval: (code, ctx, file, cb) => this.controlEval(code, ctx, file, cb),
     useGlobal: false,
     ignoreUndefined: true
   };
@@ -766,7 +766,7 @@ function Interface(stdin, stdout, args) {
   });
 
   // Handle all possible exits
-  process.on('exit', this.killChild.bind(this));
+  process.on('exit', () => this.killChild());
   process.once('SIGTERM', process.exit.bind(process, 0));
   process.once('SIGHUP', process.exit.bind(process, 0));
 
@@ -1588,7 +1588,8 @@ Interface.prototype.repl = function() {
   this.repl.on('exit', exitDebugRepl);
 
   // Set new
-  this.repl.eval = this.debugEval.bind(this);
+  this.repl.eval = (code, ctx, file, cb) =>
+    this.debugEval(code, ctx, file, cb);
   this.repl.context = {};
 
   // Swap history
@@ -1603,7 +1604,8 @@ Interface.prototype.repl = function() {
 // Exit debug repl
 Interface.prototype.exitRepl = function() {
   // Restore eval
-  this.repl.eval = this.controlEval.bind(this);
+  this.repl.eval = (code, ctx, file, cb) =>
+    this.controlEval(code, ctx, file, cb);
 
   // Swap history
   this.history.debug = this.repl.rli.history;
@@ -1690,8 +1692,8 @@ Interface.prototype.trySpawn = function(cb) {
     // pipe stream into debugger
     this.child = spawn(process.execPath, childArgs);
 
-    this.child.stdout.on('data', this.childPrint.bind(this));
-    this.child.stderr.on('data', this.childPrint.bind(this));
+    this.child.stdout.on('data', (text) => this.childPrint(text));
+    this.child.stderr.on('data', (text) => this.childPrint(text));
   }
 
   this.pause();

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -704,14 +704,15 @@ function SecurePair(context, isServer, requestCert, rejectUnauthorized,
                             this._rejectUnauthorized);
 
   if (this._isServer) {
-    this.ssl.onhandshakestart = onhandshakestart.bind(this);
-    this.ssl.onhandshakedone = onhandshakedone.bind(this);
-    this.ssl.onclienthello = onclienthello.bind(this);
-    this.ssl.onnewsession = onnewsession.bind(this);
+    this.ssl.onhandshakestart = () => onhandshakestart.call(this);
+    this.ssl.onhandshakedone = () => onhandshakedone.call(this);
+    this.ssl.onclienthello = (hello) => onclienthello.call(this, hello);
+    this.ssl.onnewsession =
+        (key, session) => onnewsession.call(this, key, session);
     this.ssl.lastHandshakeTime = 0;
     this.ssl.handshakes = 0;
   } else {
-    this.ssl.onocspresponse = onocspresponse.bind(this);
+    this.ssl.onocspresponse = (resp) => onocspresponse.call(this, resp);
   }
 
   if (process.features.tls_sni) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -392,11 +392,11 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.setVerifyMode(requestCert, rejectUnauthorized);
 
   if (options.isServer) {
-    ssl.onhandshakestart = onhandshakestart.bind(this);
-    ssl.onhandshakedone = onhandshakedone.bind(this);
-    ssl.onclienthello = onclienthello.bind(this);
-    ssl.oncertcb = oncertcb.bind(this);
-    ssl.onnewsession = onnewsession.bind(this);
+    ssl.onhandshakestart = () => onhandshakestart.call(this);
+    ssl.onhandshakedone = () => onhandshakedone.call(this);
+    ssl.onclienthello = (hello) => onclienthello.call(this, hello);
+    ssl.oncertcb = (info) => oncertcb.call(this, info);
+    ssl.onnewsession = (key, session) => onnewsession.call(this, key, session);
     ssl.lastHandshakeTime = 0;
     ssl.handshakes = 0;
 
@@ -410,8 +410,8 @@ TLSSocket.prototype._init = function(socket, wrap) {
     }
   } else {
     ssl.onhandshakestart = function() {};
-    ssl.onhandshakedone = this._finishInit.bind(this);
-    ssl.onocspresponse = onocspresponse.bind(this);
+    ssl.onhandshakedone = () => this._finishInit();
+    ssl.onocspresponse = (resp) => onocspresponse.call(this, resp);
 
     if (options.session)
       ssl.setSession(options.session);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -33,8 +33,12 @@ function Worker(options) {
 
   if (options.process) {
     this.process = options.process;
-    this.process.on('error', this.emit.bind(this, 'error'));
-    this.process.on('message', this.emit.bind(this, 'message'));
+    this.process.on('error', (code, signal) =>
+      this.emit('error', code, signal)
+    );
+    this.process.on('message', (message, handle) =>
+      this.emit('message', message, handle)
+    );
   }
 }
 util.inherits(Worker, EventEmitter);
@@ -337,7 +341,9 @@ function masterInit() {
       process: workerProcess
     });
 
-    worker.on('message', this.emit.bind(this, 'message'));
+    worker.on('message', (message, handle) =>
+      this.emit('message', message, handle)
+    );
 
     worker.process.once('exit', function(exitCode, signalCode) {
       /*

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1842,7 +1842,7 @@ ReadStream.prototype.close = function(cb) {
       this.once('open', close);
       return;
     }
-    return process.nextTick(this.emit.bind(this, 'close'));
+    return process.nextTick(() => this.emit('close'));
   }
   this.closed = true;
   close();

--- a/lib/net.js
+++ b/lib/net.js
@@ -322,7 +322,7 @@ Socket.prototype._onTimeout = function() {
 Socket.prototype.setNoDelay = function(enable) {
   if (!this._handle) {
     this.once('connect',
-              enable ? this.setNoDelay : this.setNoDelay.bind(this, enable));
+              enable ? this.setNoDelay : () => this.setNoDelay(enable));
     return this;
   }
 
@@ -336,7 +336,7 @@ Socket.prototype.setNoDelay = function(enable) {
 
 Socket.prototype.setKeepAlive = function(setting, msecs) {
   if (!this._handle) {
-    this.once('connect', this.setKeepAlive.bind(this, setting, msecs));
+    this.once('connect', () => this.setKeepAlive(setting, msecs));
     return this;
   }
 
@@ -384,7 +384,7 @@ Socket.prototype._read = function(n) {
 
   if (this._connecting || !this._handle) {
     debug('_read wait for connection');
-    this.once('connect', this._read.bind(this, n));
+    this.once('connect', () => this._read(n));
   } else if (!this._handle.reading) {
     // not already reading, start the flow
     debug('Socket._read readStart');


### PR DESCRIPTION
use `arrow functions` instead of `bind(this)` in order to improve
performance through optimizations.