### PR TITLE
buffer: neuter external `nullptr` buffers

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -362,6 +362,11 @@ MaybeLocal<Object> New(Environment* env,
   }
 
   Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), data, length);
+  // `Neuter()`ing is required here to prevent materialization of the backing
+  // store in v8. `nullptr` buffers are not writable, so this is semantically
+  // correct.
+  if (data == nullptr)
+    ab->Neuter();
   Local<Uint8Array> ui = Uint8Array::New(ab, 0, length);
   Maybe<bool> mb =
       ui->SetPrototype(env->context(), env->buffer_prototype_object());

--- a/test/addons/null-buffer-neuter/binding.cc
+++ b/test/addons/null-buffer-neuter/binding.cc
@@ -1,0 +1,40 @@
+#include <node.h>
+#include <node_buffer.h>
+#include <util.h>
+#include <v8.h>
+
+static int alive;
+
+static void FreeCallback(char* data, void* hint) {
+  CHECK_EQ(data, nullptr);
+  alive--;
+}
+
+void Run(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  alive++;
+
+  {
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Object> buf = node::Buffer::New(
+          isolate,
+          nullptr,
+          0,
+          FreeCallback,
+          nullptr).ToLocalChecked();
+
+    char* data = node::Buffer::Data(buf);
+    CHECK_EQ(data, nullptr);
+  }
+
+  isolate->RequestGarbageCollectionForTesting(
+      v8::Isolate::kFullGarbageCollection);
+
+  CHECK_EQ(alive, 0);
+}
+
+void init(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "run", Run);
+}
+
+NODE_MODULE(binding, init);

--- a/test/addons/null-buffer-neuter/binding.gyp
+++ b/test/addons/null-buffer-neuter/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/null-buffer-neuter/test.js
+++ b/test/addons/null-buffer-neuter/test.js
@@ -1,0 +1,7 @@
+'use strict';
+// Flags: --expose-gc
+
+require('../../common');
+var binding = require('./build/Release/binding');
+
+binding.run();


### PR DESCRIPTION
Neuter external `nullptr` buffers, otherwise their contents will be materialized on access, and the buffer instance will be internalized.

This leads to a crash like this:

    v8::ArrayBuffer::Neuter Only externalized ArrayBuffers can be
    neutered

Fix: #3619

cc @Trott @trevnorris 