### PR TITLE
repl: don't crash if cannot open history file

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -92,7 +92,16 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
 
   function oninit(err, hnd) {
     if (err) {
-      return ready(err);
+      // Cannot open history file.
+      // Don't crash, just don't persist history.
+      repl._writeToOutput('\nError: Could not open history file.\n' +
+                          'REPL session history will not be persisted.\n');
+      repl._refreshLine();
+      debug(err.stack);
+
+      repl._historyPrev = _replHistoryMessage;
+      repl.resume();
+      return ready(null, repl);
     }
     fs.close(hnd, onclose);
   }

--- a/test/sequential/test-repl-persistent-history.js
+++ b/test/sequential/test-repl-persistent-history.js
@@ -64,10 +64,13 @@ const convertMsg = '\nConverting old JSON repl history to line-separated ' +
                    path.join(common.tmpDir, '.node_repl_history') + '.\n';
 const homedirErr = '\nError: Could not get the home directory.\n' +
                    'REPL session history will not be persisted.\n';
+const replFailedRead = '\nError: Could not open history file.\n' +
+                       'REPL session history will not be persisted.\n';
 // File paths
 const fixtures = path.join(common.testDir, 'fixtures');
 const historyFixturePath = path.join(fixtures, '.node_repl_history');
 const historyPath = path.join(common.tmpDir, '.fixture_copy_repl_history');
+const historyPathFail = path.join(common.tmpDir, '.node_repl\u0000_history');
 const oldHistoryPath = path.join(fixtures, 'old-repl-history-file.json');
 const enoentHistoryPath = path.join(fixtures, 'enoent-repl-history-file.json');
 const defaultHistoryPath = path.join(common.tmpDir, '.node_repl_history');
@@ -146,6 +149,12 @@ const tests = [{
          NODE_REPL_HISTORY_SIZE: 1 },
   test: [UP, UP, UP, CLEAR],
   expected: [prompt, convertMsg, prompt, prompt + '\'=^.^=\'', prompt]
+},
+{
+  env: { NODE_REPL_HISTORY: historyPathFail,
+         NODE_REPL_HISTORY_SIZE: 1 },
+  test: [UP],
+  expected: [prompt, replFailedRead, prompt, replDisabled, prompt]
 },
 { // Make sure this is always the last test, since we change os.homedir()
   before: function mockHomedirFailure() {


### PR DESCRIPTION
Previously, if we are unable to open the history file, an error would
be thrown. Now, fail and print an error message that we could not open
the history file.

Fixes: https://github.com/nodejs/node/issues/3610

R= @Fishrock123 