### PR TITLE
domains: emit uncaughtException when appropriate

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -45,8 +45,13 @@ Object.defineProperty(process, 'domain', {
 // between js and c++ w/o much overhead
 var _domain_flag = {};
 
+// it's possible to enter one domain while already inside
+// another one.  the stack is each entered domain.
+var stack = [];
+exports._stack = stack;
+
 // let the process know we're using domains
-process._setupDomainUse(_domain, _domain_flag);
+process._setupDomainUse(_domain, _domain_flag, stack);
 
 exports.Domain = Domain;
 
@@ -54,10 +59,6 @@ exports.create = exports.createDomain = function() {
   return new Domain();
 };
 
-// it's possible to enter one domain while already inside
-// another one.  the stack is each entered domain.
-var stack = [];
-exports._stack = stack;
 // the active domain is always the one that we're currently in.
 exports.active = null;
 

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -114,14 +114,20 @@ Domain.prototype._errorHandler = function errorHandler(er) {
   // that these exceptions are caught, and thus would prevent it from
   // aborting in these cases.
   if (stack.length === 1) {
-    try {
-      // Set the _emittingTopLevelDomainError so that we know that, even
-      // if technically the top-level domain is still active, it would
-      // be ok to abort on an uncaught exception at this point
-      process._emittingTopLevelDomainError = true;
-      caught = emitError();
-    } finally {
-      process._emittingTopLevelDomainError = false;
+    // If there's no error handler, do not emit an 'error' event
+    // as this would throw an error, make the process exit, and thus
+    // prevent the process 'uncaughtException' event from being emitted
+    // if a listener is set.
+    if (self.listeners('error').length > 0) {
+      try {
+        // Set the _emittingTopLevelDomainError so that we know that, even
+        // if technically the top-level domain is still active, it would
+        // be ok to abort on an uncaught exception at this point
+        process._emittingTopLevelDomainError = true;
+        caught = emitError();
+      } finally {
+        process._emittingTopLevelDomainError = false;
+      }
     }
   } else {
     // wrap this in a try/catch so we don't get infinite throwing

--- a/src/env.h
+++ b/src/env.h
@@ -258,6 +258,7 @@ namespace node {
   V(buffer_constructor_function, v8::Function)                                \
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
+  V(domains_stack_array, v8::Array)                                           \
   V(fs_stats_constructor_function, v8::Function)                              \
   V(gc_info_callback_function, v8::Function)                                  \
   V(module_load_list_array, v8::Array)                                        \

--- a/src/node.cc
+++ b/src/node.cc
@@ -908,21 +908,57 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 }
 #endif
 
+static bool domainHasErrorHandler(const Environment* env,
+  const Local<Object>& domain) {
+  HandleScope scope(env->isolate());
 
-static bool IsDomainActive(const Environment* env) {
-  if (!env->using_domains()) {
-    return false;
-  }
-
-  Local<Array> domain_array = env->domain_array().As<Array>();
-  uint32_t domains_array_length = domain_array->Length();
-  if (domains_array_length == 0)
+  Local<Value> domain_event_listeners_v = domain->Get(env->events_string());
+  if (!domain_event_listeners_v->IsObject())
     return false;
 
-  Local<Value> domain_v = domain_array->Get(0);
-  return !domain_v->IsNull();
+  Local<Object> domain_event_listeners_o =
+    domain_event_listeners_v->ToObject();
+
+  if (domain_event_listeners_o->IsNull())
+    return false;
+
+  Local<Value> domain_error_listeners_v =
+    domain_event_listeners_o->Get(env->error_string());
+
+  if (domain_error_listeners_v->IsFunction() ||
+      (domain_error_listeners_v->IsArray() &&
+      domain_error_listeners_v.As<Array>()->Length() > 0))
+    return true;
+
+  return false;
 }
 
+static bool domainsStackHasErrorHandler(const Environment* env) {
+  HandleScope scope(env->isolate());
+
+  if (!env->using_domains())
+    return false;
+
+  Local<Array> domains_stack_array = env->domains_stack_array().As<Array>();
+  if (domains_stack_array->Length() == 0)
+    return false;
+
+  uint32_t domains_stack_length = domains_stack_array->Length();
+  for (int i = domains_stack_length - 1; i >= 0; --i) {
+    Local<Value> domain_v = domains_stack_array->Get(i);
+    if (domain_v->IsNull())
+      return false;
+
+    Local<Object> domain = domain_v->ToObject();
+    if (domain->IsNull())
+      return false;
+
+    if (domainHasErrorHandler(env, domain))
+      return true;
+  }
+
+  return false;
+}
 
 bool ShouldAbortOnUncaughtException(v8::Isolate* isolate) {
   Environment* env = Environment::GetCurrent(isolate);
@@ -932,7 +968,7 @@ bool ShouldAbortOnUncaughtException(v8::Isolate* isolate) {
   bool isEmittingTopLevelDomainError =
     process_object->Get(emitting_top_level_domain_error_key)->BooleanValue();
 
-  return !IsDomainActive(env) || isEmittingTopLevelDomainError;
+  return isEmittingTopLevelDomainError || !domainsStackHasErrorHandler(env);
 }
 
 
@@ -960,8 +996,10 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
 
   assert(args[0]->IsArray());
   assert(args[1]->IsObject());
+  assert(args[2]->IsArray());
 
   env->set_domain_array(args[0].As<Array>());
+  env->set_domains_stack_array(args[2].As<Array>());
 
   Local<Object> domain_flag_obj = args[1].As<Object>();
   Environment::DomainFlag* domain_flag = env->domain_flag();

--- a/test/simple/test-domain-abort-on-uncaught.js
+++ b/test/simple/test-domain-abort-on-uncaught.js
@@ -1,0 +1,259 @@
+'use strict';
+
+/*
+ * This test makes sure that when using --abort-on-uncaught-exception and
+ * when throwing an error from within a domain that has an error handler
+ * setup, the process _does not_ abort.
+ */
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var child_process = require('child_process');
+
+var errorHandlerCalled = false;
+
+var tests = [
+  function nextTick() {
+    var d = domain.create();
+
+    d.once('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      process.nextTick(function() {
+        throw new Error('exceptional!');
+      });
+    });
+  },
+
+  function timer() {
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      setTimeout(function() {
+        throw new Error('exceptional!');
+      }, 33);
+    });
+  },
+
+  function immediate() {
+    console.log('starting test');
+    var d = domain.create();
+
+    d.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      setImmediate(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function timerPlusNextTick() {
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      setTimeout(function() {
+        process.nextTick(function() {
+          throw new Error('exceptional!');
+        });
+      }, 33);
+    });
+  },
+
+  function firstRun() {
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      throw new Error('exceptional!');
+    });
+  },
+
+  function fsAsync() {
+    var d = domain.create();
+
+    d.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      var fs = require('fs');
+      fs.exists('/non/existing/file', function onExists(exists) {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function netServer() {
+    var net = require('net');
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      var server = net.createServer(function(conn) {
+        conn.pipe(conn);
+      });
+      server.listen(common.PORT, '0.0.0.0', function() {
+        var conn = net.connect(common.PORT, '0.0.0.0');
+        conn.once('data', function() {
+          throw new Error('ok');
+        });
+        conn.end('ok');
+        server.close();
+      });
+    });
+  },
+
+  function firstRunOnlyTopLevelErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function firstRunNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function timeoutNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setTimeout(function() {
+          console.log('foo');
+          throw new Error('boom!');
+        }, 33);
+      });
+    });
+  },
+
+  function setImmediateNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setImmediate(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function nextTickNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        process.nextTick(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function fsAsyncNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        var fs = require('fs');
+        fs.exists('/non/existing/file', function onExists(exists) {
+          throw new Error('boom!');
+        });
+      });
+    });
+  }
+];
+
+if (process.argv[2] === 'child') {
+  var testIndex = +process.argv[3];
+
+  tests[testIndex]();
+
+  process.on('exit', function onExit() {
+    assert.equal(errorHandlerCalled, true);
+  });
+} else {
+
+  tests.forEach(function(test, testIndex) {
+    var testCmd = '';
+    if (process.platform !== 'win32') {
+      // Do not create core files, as it can take a lot of disk space on
+      // continuous testing and developers' machines
+      testCmd += 'ulimit -c 0 && ';
+    }
+
+    testCmd +=  process.argv[0];
+    testCmd += ' ' + '--abort-on-uncaught-exception';
+    testCmd += ' ' + process.argv[1];
+    testCmd += ' ' + 'child';
+    testCmd += ' ' + testIndex;
+
+    var child = child_process.exec(testCmd);
+
+    child.on('exit', function onExit(code, signal) {
+      assert.equal(code, 0, 'Test at index ' + testIndex +
+        ' should have exited with exit code 0 but instead exited with code ' +
+        code + ' and signal ' + signal);
+    });
+
+  });
+}

--- a/test/simple/test-domain-no-error-handler-abort-on-uncaught.js
+++ b/test/simple/test-domain-no-error-handler-abort-on-uncaught.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/*
+ * This test makes sure that when using --abort-on-uncaught-exception and
+ * when throwing an error from within a domain that does not have an error
+ * handler setup, the process aborts.
+ */
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var child_process = require('child_process');
+
+var tests = [
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      throw new Error('boom!');
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.run(function() {
+      d2.run(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      setTimeout(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      setImmediate(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      process.nextTick(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      var fs = require('fs');
+      fs.exists('/non/existing/file', function onExists(exists) {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setTimeout(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setImmediate(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        process.nextTick(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        var fs = require('fs');
+        fs.exists('/non/existing/file', function onExists(exists) {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+];
+
+if (process.argv[2] === 'child') {
+  var testIndex = +process.argv[3];
+  tests[testIndex]();
+} else {
+
+  tests.forEach(function(test, testIndex) {
+    var testCmd = '';
+    if (process.platform !== 'win32') {
+      // Do not create core files, as it can take a lot of disk space on
+      // continuous testing and developers' machines
+      testCmd += 'ulimit -c 0 && ';
+    }
+
+    testCmd +=  process.argv[0];
+    testCmd += ' ' + '--abort-on-uncaught-exception';
+    testCmd += ' ' + process.argv[1];
+    testCmd += ' ' + 'child';
+    testCmd += ' ' + testIndex;
+
+    var child = child_process.exec(testCmd);
+
+    child.on('exit', function onExit(code, signal) {
+      assert.ok([132, 133, 134].indexOf(code) !== -1, 'Test at index ' +
+        testIndex + ' should have aborted but instead exited with code ' +
+        code + ' and signal ' + signal);
+    });
+  });
+}

--- a/test/simple/test-domain-uncaught-exception.js
+++ b/test/simple/test-domain-uncaught-exception.js
@@ -194,7 +194,8 @@ if (process.argv[2] === 'child') {
         test.messagesReceived.forEach(function(receivedMessage) {
           if (test.expectedMessages.indexOf(receivedMessage) === -1) {
             assert(false, 'test ' + test.fn.name +
-              ' should have sent message: ' + receivedMessage + ' but did');
+              ' should not have sent message: ' + receivedMessage +
+              ' but did');
           }
         });
       }

--- a/test/simple/test-domain-uncaught-exception.js
+++ b/test/simple/test-domain-uncaught-exception.js
@@ -1,0 +1,203 @@
+'use strict';
+
+/*
+ * The goal of this test is to make sure that errors thrown within domains
+ * are handled correctly. It checks that the process 'uncaughtException' event
+ * is emitted when appropriate, and not emitted when it shouldn't. It also
+ * checks that the proper domain error handlers are called when they should
+ * be called, and not called when they shouldn't.
+ */
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var child_process = require('child_process');
+
+var uncaughtExceptions = {};
+
+var tests = [];
+
+function test1() {
+  /*
+   * Throwing from an async callback from within a domain that doesn't have
+   * an error handler must result in emitting the process' uncaughtException
+   * event.
+   */
+  var d = domain.create();
+  d.run(function() {
+    setTimeout(function onTimeout() {
+      throw new Error('boom!');
+   });
+  });
+}
+
+tests.push({
+  fn: test1,
+  expectedMessages: ['uncaughtException']
+});
+
+function test2() {
+  /*
+   * Throwing from from within a domain that doesn't have an error handler must
+   * result in emitting the process' uncaughtException event.
+   */
+  var d2 = domain.create();
+  d2.run(function() {
+    throw new Error('boom!');
+  });
+}
+
+tests.push({
+  fn: test2,
+  expectedMessages: ['uncaughtException']
+});
+
+function test3() {
+  /*
+   * This test creates two nested domains: d3 and d4. d4 doesn't register an
+   * error handler, but d3 does. The error is handled by the d3 domain and thus
+   * and 'uncaughtException' event should _not_ be emitted.
+   */
+  var d3 = domain.create();
+  var d4 = domain.create();
+
+  d3.on('error', function onErrorInD3Domain(err) {
+    process.send('errorHandledByDomain');
+  });
+
+  d3.run(function() {
+    d4.run(function() {
+      throw new Error('boom!');
+    });
+  });
+}
+
+tests.push({
+  fn: test3,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+function test4() {
+  /*
+   * This test creates two nested domains: d5 and d6. d6 doesn't register an
+   * error handler. When the timer's callback is called, because async
+   * operations like timer callbacks are bound to the domain that was active
+   * at the time of their creation, and because both d5 and d6 domains have
+   * exited by the time the timer's callback is called, its callback runs with
+   * only d6 on the domains stack. Since d6 doesn't register an error handler,
+   * the process' uncaughtException event should be emitted.
+   */
+  var d5 = domain.create();
+  var d6 = domain.create();
+
+  d5.on('error', function onErrorInD2Domain(err) {
+    process.send('errorHandledByDomain');
+  });
+
+  d5.run(function () {
+    d6.run(function() {
+      setTimeout(function onTimeout() {
+        throw new Error('boom!');
+      });
+    });
+  });
+}
+
+tests.push({
+  fn: test4,
+  expectedMessages: ['uncaughtException']
+});
+
+function test5() {
+  /*
+   * This test creates two nested domains: d7 and d4. d8 _does_ register an
+   * error handler, so throwing within that domain should not emit an uncaught
+   * exception.
+   */
+  var d7 = domain.create();
+  var d8 = domain.create();
+
+  d8.on('error', function onErrorInD3Domain(err) {
+    process.send('errorHandledByDomain')
+  });
+
+  d7.run(function() {
+    d8.run(function() {
+      throw new Error('boom!');
+    });
+  });
+}
+tests.push({
+  fn: test5,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+function test6() {
+  /*
+   * This test creates two nested domains: d9 and d10. d10 _does_ register an
+   * error handler, so throwing within that domain in an async callback should
+   * _not_ emit an uncaught exception.
+   */
+  var d9 = domain.create();
+  var d10 = domain.create();
+
+  d10.on('error', function onErrorInD2Domain(err) {
+    process.send('errorHandledByDomain');
+  });
+
+  d9.run(function () {
+    d10.run(function() {
+      setTimeout(function onTimeout() {
+        throw new Error('boom!');
+      });
+    });
+  });
+}
+
+tests.push({
+  fn: test6,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+if (process.argv[2] === 'child') {
+  var testIndex = process.argv[3];
+  process.on('uncaughtException', function onUncaughtException() {
+    process.send('uncaughtException');
+  });
+
+  tests[testIndex].fn();
+} else {
+  // Run each test's function in a child process. Listen on
+  // messages sent by each child process and compare expected
+  // messages defined for each ttest from the actual received messages.
+  tests.forEach(function doTest(test, testIndex) {
+    var testProcess = child_process.fork(__filename, ['child', testIndex]);
+
+    testProcess.on('message', function onMsg(msg) {
+      if (test.messagesReceived === undefined)
+        test.messagesReceived = [];
+
+      test.messagesReceived.push(msg);
+    });
+
+    testProcess.on('exit', function onExit() {
+      // Make sure that all expected messages were sent from the
+      // child process
+      test.expectedMessages.forEach(function(expectedMessage) {
+        if (test.messagesReceived === undefined ||
+          test.messagesReceived.indexOf(expectedMessage) === -1)
+          assert(false, 'test ' + test.fn.name + ' should have sent message: '
+            + expectedMessage + ' but didn\'t');
+      });
+
+      if (test.messagesReceived) {
+        test.messagesReceived.forEach(function(receivedMessage) {
+          if (test.expectedMessages.indexOf(receivedMessage) === -1) {
+            assert(false, 'test ' + test.fn.name +
+              ' should have sent message: ' + receivedMessage + ' but did');
+          }
+        });
+      }
+    })
+  });
+}


### PR DESCRIPTION
Fix node exiting due to an exception being thrown rather than emitting
an `'uncaughtException'` event on the process object when no error
handler is set on the domain within which an error is thrown and an
`'uncaughtException'` event listener is set on the process.

Fixes #3607.

/cc @nodejs/lts @nodejs/tsc @nodejs/collaborators