### PR TITLE
Test & document numeric flags to fs.open on unix

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -307,6 +307,8 @@ start at 0. The `encoding` can be any one of those accepted by [Buffer][].
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
 the specified file descriptor. This means that no `open` event will be emitted.
+Note that `fd` should be blocking; non-blocking `fd`s should be passed to
+`net.Socket`.
 
 If `autoClose` is false, then the file descriptor won't be closed, even if
 there's an error.  It is your responsibility to close it and make sure
@@ -341,7 +343,8 @@ default mode `w`. The `defaultEncoding` can be any one of those accepted by [Buf
 
 Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the
 `path` argument and will use the specified file descriptor. This means that no
-`open` event will be emitted.
+`open` event will be emitted. Note that `fd` should be blocking; non-blocking
+`fd`s should be passed to `net.Socket`.
 
 If `options` is a string, then it specifies the encoding.
 

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -529,6 +529,11 @@ created. On POSIX systems, `path` is considered to exist even if it is a symlink
 to a non-existent file. The exclusive flag may or may not work with network file
 systems.
 
+`flags` can also be a number as documented by open(2); commonly used constants
+are available from `require('constants')`.  On Windows, flags are translated to
+their equivalent ones where applicable, e.g. `O_WRONLY` to `FILE_GENERIC_WRITE`,
+or `O_EXCL|O_CREAT` to `CREATE_NEW`, as accepted by CreateFileW.
+
 On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.

--- a/test/parallel/test-fs-open-numeric-flags.js
+++ b/test/parallel/test-fs-open-numeric-flags.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+
+const constants = require('constants');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+common.refreshTmpDir();
+
+// O_WRONLY without O_CREAT shall fail with ENOENT
+const pathNE = path.join(common.tmpDir, 'file-should-not-exist');
+assert.throws(
+  () => fs.openSync(pathNE, constants.O_WRONLY),
+  (e) => e.code === 'ENOENT'
+);


### PR DESCRIPTION
For #3628.

Do we prefer two commits here or one?  Also, shall we backport the doc commit to older versions?