### PR TITLE
build: backport config for new CI infrastructure to v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,197 @@
-Evented I/O for V8 javascript.
-===
+Node.js
+=======
 
-### To build:
+[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/nodejs/node?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Prerequisites (Unix only):
+The Node.js project is supported by the
+[Node.js Foundation](https://nodejs.org/en/foundation/). Contributions,
+policies and releases are managed under an
+[open governance model](./GOVERNANCE.md). We are also bound by a
+[Code of Conduct](./CODE_OF_CONDUCT.md).
 
-    * GCC 4.2 or newer
-    * G++ 4.2 or newer
-    * Python 2.6 or 2.7
-    * GNU Make 3.81 or newer
-    * libexecinfo (FreeBSD and OpenBSD only)
+If you need help using or installing Node.js, please use the
+[nodejs/help](https://github.com/nodejs/help) issue tracker.
 
-Unix/Macintosh:
+## Release Types
 
-```sh
-./configure
-make
-make install
+The Node.js project maintains multiple types of releases:
+
+* **Stable**: Released from active development branches of this repository,
+  versioned by [SemVer](http://semver.org/) and signed by a member of the
+  [Release Team](#release-team).
+  Code for Stable releases is organized in this repository by major version
+  number, For example: [v4.x](https://github.com/nodejs/node/tree/v4.x).
+  The major version number of Stable releases will increment every 6 months
+  allowing for breaking changes to be introduced. This happens in April and
+  October every year. Stable release lines beginning in October each year have
+  a maximum support life of 8 months. Stable release lines beginning in April
+  each year will convert to LTS (see below) after 6 months and receive further
+  support for 30 months.
+* **LTS**: Releases that receive Long-term Support, with a focus on stability
+  and security. Every second Stable release line (major version) will become an
+  LTS line and receive 18 months of _Active LTS_ support and a further 12
+  months of _Maintenance_. LTS release lines are given alphabetically
+  ordered codenames, begining with v4 Argon. LTS releases are less frequent
+  and will attempt to maintain consistent major and minor version numbers,
+  only incrementing patch version numbers. There are no breaking changes or
+  feature additions, except in some special circumstances. More information
+  can be found in the [LTS README](https://github.com/nodejs/LTS/).
+* **Nightly**: Versions of code in this repository on the current Stable
+  branch, automatically built every 24-hours where changes exist. Use with
+  caution.
+
+## Download
+
+Binaries, installers, and source tarballs are available at
+<https://nodejs.org>.
+
+**Stable** and **LTS** releases are available at
+<https://nodejs.org/download/release/>, listed under their version strings.
+The [latest](https://nodejs.org/download/release/latest/) directory is an
+alias for the latest Stable release. The latest LTS release from an LTS
+line is available in the form: latest-lts-_codename_. For example:
+<https://nodejs.org/download/release/latest-lts-argon>
+
+**Nightly** builds are available at
+<https://nodejs.org/download/nightly/>, listed under their version
+string which includes their date (in UTC time) and the commit SHA at
+the HEAD of the release.
+
+**API documentation** is available in each release and nightly
+directory under _docs_. <https://nodejs.org/api/> points to the API
+documentation of the latest stable version.
+
+### Verifying Binaries
+
+Stable, LTS and Nightly download directories all contain a *SHASUM256.txt*
+file that lists the SHA checksums for each file available for
+download. To check that a downloaded file matches the checksum, run
+it through `sha256sum` with a command such as:
+
+```
+$ grep node-vx.y.z.tar.gz SHASUMS256.txt | sha256sum -c -
 ```
 
-If your python binary is in a non-standard location or has a
+_(Where "node-vx.y.z.tar.gz" is the name of the file you have
+downloaded)_
+
+Additionally, Stable and LTS releases (not Nightlies) have GPG signed
+copies of SHASUM256.txt files available as SHASUM256.txt.asc. You can use
+`gpg` to verify that the file has not been tampered with.
+
+To verify a SHASUM256.txt.asc, you will first need to import all of
+the GPG keys of individuals authorized to create releases. They are
+listed at the bottom of this README under [Release Team](#release-team).
+Use a command such as this to import the keys:
+
+```
+$ gpg --keyserver pool.sks-keyservers.net \
+  --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
+```
+
+_(See the bottom of this README for a full script to import active
+release keys)_
+
+You can then use `gpg --verify SHASUMS256.txt.asc` to verify that the
+file has been signed by an authorized member of the Node.js team.
+
+Once verified, use the SHASUMS256.txt.asc file to get the checksum for
+the binary verification command above.
+
+## Build
+
+### Unix / Macintosh
+
+Prerequisites:
+
+* GCC 4.2 or newer
+* G++ 4.2 or newer
+* Python 2.6 or 2.7
+* GNU Make 3.81 or newer
+* libexecinfo (FreeBSD and OpenBSD only)
+
+```text
+$ ./configure
+$ make
+$ [sudo] make install
+```
+
+If your Python binary is in a non-standard location or has a
 non-standard name, run the following instead:
 
-```sh
-export PYTHON=/path/to/python
-$PYTHON ./configure
-make
-make install
+```text
+$ export PYTHON=/path/to/python
+$ $PYTHON ./configure
+$ make
+$ [sudo] make install
 ```
 
-Prerequisites (Windows only):
+To run the tests:
 
-    * Python 2.6 or 2.7
-    * Visual Studio 2010 or 2012
-
-Windows:
-
-```sh
-vcbuild nosign
+```text
+$ make test
 ```
 
-You can download pre-built binaries for various operating systems from
-[http://nodejs.org/download/](http://nodejs.org/download/).  The Windows
-and OS X installers will prompt you for the location in which to install.
-The tarballs are self-contained; you can extract them to a local directory
-with:
+To build the documentation:
 
-```sh
-tar xzf /path/to/node-<version>-<platform>-<arch>.tar.gz
+```text
+$ make doc
 ```
 
-Or system-wide with:
+To read the documentation:
 
-```sh
-cd /usr/local && tar --strip-components 1 -xzf \
-                    /path/to/node-<version>-<platform>-<arch>.tar.gz
+```text
+$ man doc/node.1
 ```
 
-### To run the tests:
+To test if Node.js was built correctly:
 
-Unix/Macintosh:
-
-```sh
-make test
+```
+$ node -e "console.log('Hello from node.js ' + process.version)"
 ```
 
-Windows:
+### Windows
 
-```sh
-vcbuild test
+Prerequisites:
+
+* [Python 2.6 or 2.7](https://www.python.org/downloads/)
+* Visual Studio 2010 or 2012; or
+* Visual Studio 2013 for Windows Desktop; or
+* Visual Studio Express 2013 for Windows Desktop
+* Basic Unix tools required for some tests,
+  [Git for Windows](http://git-scm.com/download/win) includes Git Bash
+  and tools which can be included in the global `PATH`.
+
+```text
+> vcbuild nosign
 ```
 
-### To build the documentation:
+To run the tests:
 
-```sh
-make doc
+```text
+> vcbuild test
 ```
 
-### To read the documentation:
+To test if Node.js was built correctly:
 
-```sh
-man doc/node.1
+```
+$ node -e "console.log('Hello from node.js ' + process.version)"
+```
+
+### Android / Android based devices, aka. Firefox OS
+
+Be sure you have downloaded and extracted [Android NDK]
+(https://developer.android.com/tools/sdk/ndk/index.html)
+before in a folder. Then run:
+
+```
+$ ./android-configure /path/to/your/android-ndk
+$ make
 ```
 
 ### `Intl` (ECMA-402) support:
 
-[Intl](https://github.com/joyent/node/wiki/Intl) support is not
+[Intl](https://github.com/nodejs/node/wiki/Intl) support is not
 enabled by default.
 
 #### "small" (English only) support
@@ -94,63 +200,66 @@ This option will build with "small" (English only) support, but
 the full `Intl` (ECMA-402) APIs.  With `--download=all` it will
 download the ICU library as needed.
 
-Unix/Macintosh:
+Unix / Macintosh:
 
-```sh
-./configure --with-intl=small-icu --download=all
+```text
+$ ./configure --with-intl=small-icu --download=all
 ```
 
 Windows:
 
-```sh
-vcbuild small-icu download-all
+```text
+> vcbuild small-icu download-all
 ```
 
-The `small-icu` mode builds
-with English-only data. You can add full data at runtime.
+The `small-icu` mode builds with English-only data. You can add full
+data at runtime.
 
 *Note:* more docs are on
-[the wiki](https://github.com/joyent/node/wiki/Intl).
+[the node wiki](https://github.com/nodejs/node/wiki/Intl).
 
 #### Build with full ICU support (all locales supported by ICU):
 
-With the `--download=all`, this may download ICU if you don't
-have an ICU in `deps/icu`.
+With the `--download=all`, this may download ICU if you don't have an
+ICU in `deps/icu`.
 
-Unix/Macintosh:
+Unix / Macintosh:
 
-```sh
-./configure --with-intl=full-icu --download=all
+```text
+$ ./configure --with-intl=full-icu --download=all
 ```
 
 Windows:
 
-```sh
-vcbuild full-icu download-all
+```text
+> vcbuild full-icu download-all
 ```
 
 #### Build with no Intl support `:-(`
 
-The `Intl` object will not be available.
-This is the default at present, so this option is not normally needed.
+The `Intl` object will not be available. This is the default at
+present, so this option is not normally needed.
 
-Unix/Macintosh:
+Unix / Macintosh:
 
-```sh
-./configure --with-intl=none
+```text
+$ ./configure --with-intl=none
 ```
 
 Windows:
 
-```sh
-vcbuild intl-none
+```text
+> vcbuild intl-none
 ```
 
-#### Use existing installed ICU (Unix/Macintosh only):
+#### Use existing installed ICU (Unix / Macintosh only):
 
-```sh
-pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
+```text
+$ pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
 ```
+
+If you are cross compiling, your `pkg-config` must be able to supply a path
+that works for both your host and target environments.
 
 #### Build with a specific ICU:
 
@@ -159,42 +268,141 @@ You can find other ICU releases at
 Download the file named something like `icu4c-**##.#**-src.tgz` (or
 `.zip`).
 
-Unix/Macintosh: from an already-unpacked ICU
+Unix / Macintosh
 
-```sh
-./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu
+```text
+# from an already-unpacked ICU:
+$ ./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu
+
+# from a local ICU tarball
+$ ./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu.tgz
+
+# from a tarball URL
+$ ./configure --with-intl=full-icu --with-icu-source=http://url/to/icu.tgz
 ```
 
-Unix/Macintosh: from a local ICU tarball
+Windows
 
-```sh
-./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu.tgz
+First unpack latest ICU to `deps/icu`
+[icu4c-**##.#**-src.tgz](http://icu-project.org/download) (or `.zip`)
+as `deps/icu` (You'll have: `deps/icu/source/...`)
+
+```text
+> vcbuild full-icu
 ```
 
-Unix/Macintosh: from a tarball URL
+## Resources for Newcomers
 
-```sh
-./configure --with-intl=full-icu --with-icu-source=http://url/to/icu.tgz
+* [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+* [CONTRIBUTING.md](./CONTRIBUTING.md)
+* [GOVERNANCE.md](./GOVERNANCE.md)
+* IRC:
+  [#io.js on Freenode.net](http://webchat.freenode.net?channels=io.js&uio=d4)
+* [nodejs/node on Gitter](https://gitter.im/nodejs/node)
+
+## Security
+
+All security bugs in node.js are taken seriously and should be reported by
+emailing security@nodejs.org. This will be delivered to a subset of the project
+team who handle security issues. Please don't disclose security bugs
+public until they have been handled by the security team.
+
+Your email will be acknowledged within 24 hours, and you’ll receive a more
+detailed response to your email within 48 hours indicating the next steps in
+handling your report.
+
+## Current Project Team Members
+
+The Node.js project team comprises a group of core collaborators and a sub-group
+that forms the _Technical Steering Committee_ (TSC) which governs the project. For more
+information about the governance of the Node.js project, see
+[GOVERNANCE.md](./GOVERNANCE.md).
+
+### TSC (Technical Steering Committee)
+
+* [bnoordhuis](https://github.com/bnoordhuis) - **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
+* [chrisdickinson](https://github.com/chrisdickinson) - **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt;
+* [cjihrig](https://github.com/cjihrig) - **Colin Ihrig** &lt;cjihrig@gmail.com&gt;
+* [fishrock123](https://github.com/fishrock123) - **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
+* [indutny](https://github.com/indutny) - **Fedor Indutny** &lt;fedor.indutny@gmail.com&gt;
+* [jasnell](https://github.com/jasnell) - **James M Snell** &lt;jasnell@gmail.com&gt;
+* [misterdjules](https://github.com/misterdjules) - **Julien Gilli** &lt;jgilli@nodejs.org&gt;
+* [mscdex](https://github.com/mscdex) - **Brian White** &lt;mscdex@mscdex.net&gt;
+* [orangemocha](https://github.com/orangemocha) - **Alexis Campailla** &lt;orangemocha@nodejs.org&gt;
+* [piscisaureus](https://github.com/piscisaureus) - **Bert Belder** &lt;bertbelder@gmail.com&gt;
+* [rvagg](https://github.com/rvagg) - **Rod Vagg** &lt;rod@vagg.org&gt;
+* [shigeki](https://github.com/shigeki) - **Shigeki Ohtsu** &lt;ohtsu@iij.ad.jp&gt;
+* [trevnorris](https://github.com/trevnorris) - **Trevor Norris** &lt;trev.norris@gmail.com&gt;
+
+### Collaborators
+
+* [brendanashworth](https://github.com/brendanashworth) - **Brendan Ashworth** &lt;brendan.ashworth@me.com&gt;
+* [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt;
+* [domenic](https://github.com/domenic) - **Domenic Denicola** &lt;d@domenic.me&gt;
+* [evanlucas](https://github.com/evanlucas) - **Evan Lucas** &lt;evanlucas@me.com&gt;
+* [geek](https://github.com/geek) - **Wyatt Preul** &lt;wpreul@gmail.com&gt;
+* [isaacs](https://github.com/isaacs) - **Isaac Z. Schlueter** &lt;i@izs.me&gt;
+* [jbergstroem](https://github.com/jbergstroem) - **Johan Bergström** &lt;bugs@bergstroem.nu&gt;
+* [joaocgreis](https://github.com/joaocgreis) - **João Reis** &lt;reis@janeasystems.com&gt;
+* [julianduque](https://github.com/julianduque) - **Julian Duque** &lt;julianduquej@gmail.com&gt;
+* [lxe](https://github.com/lxe) - **Aleksey Smolenchuk** &lt;lxe@lxe.co&gt;
+* [mhdawson](https://github.com/mhdawson) - **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt;
+* [micnic](https://github.com/micnic) - **Nicu Micleușanu** &lt;micnic90@gmail.com&gt;
+* [mikeal](https://github.com/mikeal) - **Mikeal Rogers** &lt;mikeal.rogers@gmail.com&gt;
+* [monsanto](https://github.com/monsanto) - **Christopher Monsanto** &lt;chris@monsan.to&gt;
+* [ofrobots](https://github.com/ofrobots) - **Ali Ijaz Sheikh** &lt;ofrobots@google.com&gt;
+* [Olegas](https://github.com/Olegas) - **Oleg Elifantiev** &lt;oleg@elifantiev.ru&gt;
+* [petkaantonov](https://github.com/petkaantonov) - **Petka Antonov** &lt;petka_antonov@hotmail.com&gt;
+* [qard](https://github.com/qard) - **Stephen Belanger** &lt;admin@stephenbelanger.com&gt;
+* [rlidwka](https://github.com/rlidwka) - **Alex Kocharin** &lt;alex@kocharin.ru&gt;
+* [robertkowalski](https://github.com/robertkowalski) - **Robert Kowalski** &lt;rok@kowalski.gd&gt;
+* [romankl](https://github.com/romankl) - **Roman Klauke** &lt;romaaan.git@gmail.com&gt;
+* [saghul](https://github.com/saghul) - **Saúl Ibarra Corretgé** &lt;saghul@gmail.com&gt;
+* [sam-github](https://github.com/sam-github) - **Sam Roberts** &lt;vieuxtech@gmail.com&gt;
+* [seishun](https://github.com/seishun) - **Nikolai Vavilov** &lt;vvnicholas@gmail.com&gt;
+* [silverwind](https://github.com/silverwind) - **Roman Reiss** &lt;me@silverwind.io&gt;
+* [srl295](https://github.com/srl295) - **Steven R Loomis** &lt;srloomis@us.ibm.com&gt;
+* [targos](https://github.com/targos) - **Michaël Zasso** &lt;mic.besace@gmail.com&gt;
+* [tellnes](https://github.com/tellnes) - **Christian Tellnes** &lt;christian@tellnes.no&gt;
+* [thealphanerd](http://github.com/thealphanerd) - **Myles Borins** &lt;myles.borins@gmail.com&gt;
+* [thefourtheye](https://github.com/thefourtheye) - **Sakthipriyan Vairamani** &lt;thechargingvolcano@gmail.com&gt;
+* [thlorenz](https://github.com/thlorenz) - **Thorsten Lorenz** &lt;thlorenz@gmx.de&gt;
+* [Trott](https://github.com/Trott) - **Rich Trott** &lt;rtrott@gmail.com&gt;
+* [tunniclm](https://github.com/tunniclm) - **Mike Tunnicliffe** &lt;m.j.tunnicliffe@gmail.com&gt;
+* [vkurchatkin](https://github.com/vkurchatkin) - **Vladimir Kurchatkin** &lt;vladimir.kurchatkin@gmail.com&gt;
+* [yosuke-furukawa](https://github.com/yosuke-furukawa) - **Yosuke Furukawa** &lt;yosuke.furukawa@gmail.com&gt;
+
+Collaborators & TSC members follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
+maintaining the Node.js project.
+
+### Release Team
+
+Releases of Node.js and io.js will be signed with one of the following GPG keys:
+
+* **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt; `9554F04D7259F04124DE6B476D5A82AC7E37093B`
+* **Colin Ihrig** &lt;cjihrig@gmail.com&gt; `94AE36675C464D64BAFA68DD7434390BDBE9B9C5`
+* **Sam Roberts** &lt;octetcloud@keybase.io&gt; `0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93`
+* **Jeremiah Senkpiel** &lt;fishrock@keybase.io&gt; `FD3A5288F042B6850C66B31F09FE44734EB7990E`
+* **James M Snell** &lt;jasnell@keybase.io&gt; `71DCFD284A79C3B38668286BC97EC7A07EDE3FC1`
+* **Rod Vagg** &lt;rod@vagg.org&gt; `DD8F2338BAE7501E3DD5AC78C273792F7D83545D`
+
+The full set of trusted release keys can be imported by running:
+
+```
+gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B
+gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
+gpg --keyserver pool.sks-keyservers.net --recv-keys 0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93
+gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E
+gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1
+gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 ```
 
-Windows: first unpack latest ICU to `deps/icu`
-  [icu4c-**##.#**-src.tgz](http://icu-project.org/download) (or `.zip`)
-  as `deps/icu` (You'll have: `deps/icu/source/...`)
+See the section above on [Verifying Binaries](#verifying-binaries) for
+details on what to do with these keys to verify that a downloaded file is official.
 
-```sh
-vcbuild full-icu
-```
+Previous releases of Node.js have been signed with one of the following GPG
+keys:
 
-Resources for Newcomers
----
-  - [The Wiki](https://github.com/joyent/node/wiki)
-  - [nodejs.org](http://nodejs.org/)
-  - [how to install node.js and npm (node package manager)](http://www.joyent.com/blog/installing-node-and-npm/)
-  - [list of modules](https://github.com/joyent/node/wiki/modules)
-  - [searching the npm registry](http://npmjs.org/)
-  - [list of companies and projects using node](https://github.com/joyent/node/wiki/Projects,-Applications,-and-Companies-Using-Node)
-  - [node.js mailing list](http://groups.google.com/group/nodejs)
-  - irc chatroom, [#node.js on freenode.net](http://webchat.freenode.net?channels=node.js&uio=d4)
-  - [community](https://github.com/joyent/node/wiki/Community)
-  - [contributing](https://github.com/joyent/node/wiki/Contributing)
-  - [big list of all the helpful wiki pages](https://github.com/joyent/node/wiki/_pages)
+* Julien Gilli &lt;jgilli@fastmail.fm&gt; `114F43EE0176B71C7BC219DD50A3051F888C628D`
+* Timothy J Fontaine &lt;tjfontaine@gmail.com&gt; `7937DFD2AB06298B2293C3187D33FF9D0246406D`
+* Isaac Z. Schlueter &lt;i@izs.me&gt; `93C7E9E91B49E432C2F75674B0A78B0A6C481CF6`

--- a/configure
+++ b/configure
@@ -267,6 +267,11 @@ parser.add_option('--with-icu-source',
     dest='with_icu_source',
     help='Intl mode: optional local path to icu/ dir, or path/URL of icu source archive.')
 
+parser.add_option('--download-path',
+    dest='download_path',
+    default=os.path.join(root_dir, 'deps'),
+    help='Download directory [default: %default]')
+
 parser.add_option('--with-perfctr',
     action='store_true',
     dest='with_perfctr',
@@ -517,6 +522,10 @@ def configure_node(o):
 
   host_arch = host_arch_win() if os.name == 'nt' else host_arch_cc()
   target_arch = options.dest_cpu or host_arch
+  # ia32 is preferred by the build tools (GYP) over x86 even if we prefer the latter
+  # the Makefile resets this to x86 afterward
+  if target_arch == 'x86':
+    target_arch = 'ia32'
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
 
@@ -762,11 +771,15 @@ def configure_intl(o):
   ]
   def icu_download(path):
     # download ICU, if needed
+    if not os.access(options.download_path, os.W_OK):
+      print 'Error: cannot write to desired download path. ' \
+            'Either create it or verify permissions.'
+      sys.exit(1)
     for icu in icus:
       url = icu['url']
       md5 = icu['md5']
       local = url.split('/')[-1]
-      targetfile = os.path.join(root_dir, 'deps', local)
+      targetfile = os.path.join(options.download_path, local)
       if not os.path.isfile(targetfile):
         if nodedownload.candownload(auto_downloads, "icu"):
           nodedownload.retrievefile(url, targetfile)

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -28,25 +28,31 @@
 
 #define NODE_VERSION_IS_RELEASE 0
 
-#ifndef NODE_TAG
-# define NODE_TAG ""
-#endif
-
 #ifndef NODE_STRINGIFY
 #define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)
 #define NODE_STRINGIFY_HELPER(n) #n
 #endif
 
-#if NODE_VERSION_IS_RELEASE
+#ifndef NODE_TAG
+# if NODE_VERSION_IS_RELEASE
+#  define NODE_TAG ""
+# else
+#  define NODE_TAG "-pre"
+# endif
+#else
+// NODE_TAG is passed without quotes when rc.exe is run from msbuild
+# define NODE_EXE_VERSION NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
+                          NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
+                          NODE_STRINGIFY(NODE_PATCH_VERSION)     \
+                          NODE_STRINGIFY(NODE_TAG)
+#endif
+
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_PATCH_VERSION)     \
                               NODE_TAG
-#else
-# define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_PATCH_VERSION)     \
-                              NODE_TAG "-pre"
+#ifndef NODE_EXE_VERSION
+# define NODE_EXE_VERSION NODE_VERSION_STRING
 #endif
 
 #define NODE_VERSION "v" NODE_VERSION_STRING

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -6,7 +6,7 @@
     <ProductVersion>3.5</ProductVersion>
     <ProjectGuid>{1d808ff0-b5a9-4be9-859d-b334b6f48be2}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>node-v$(NodeVersion)-$(Platform)</OutputName>
+    <OutputName>node-v$(FullVersion)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
@@ -14,25 +14,25 @@
     <NodeVersion Condition=" '$(NodeVersion)' == '' ">0.0.0.0</NodeVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
     <Cultures>en-US</Cultures>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -4,7 +4,7 @@
 
   <?define ProductName = "Node.js" ?>
   <?define ProductDescription = "Node.js" ?>
-  <?define ProductAuthor = "Joyent, Inc. and other Node contributors" ?>
+  <?define ProductAuthor = "Node.js Foundation" ?>
 
   <?define RegistryKeyPath = "SOFTWARE\Node.js" ?>
 
@@ -23,7 +23,7 @@
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
     <MajorUpgrade AllowSameVersionUpgrades="yes"
-                  DowngradeErrorMessage="A later version of node.js is already installed. Setup will now exit."/>
+                  DowngradeErrorMessage="A later version of Node.js is already installed. Setup will now exit."/>
 
     <Icon Id="NodeIcon" SourceFile="$(var.RepoDir)\src\res\node.ico"/>
     <Property Id="ARPPRODUCTICON" Value="NodeIcon"/>

--- a/tools/osx-codesign.sh
+++ b/tools/osx-codesign.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-if ! [ -n "$SIGN" ] && [ $STEP -eq 1 ]; then
+if [ "X$SIGN" == "X" ]; then
   echo "No SIGN environment var.  Skipping codesign." >&2
   exit 0
 fi

--- a/tools/osx-productsign.sh
+++ b/tools/osx-productsign.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-if ! [ -n "$SIGN" ]; then
+if [ "X$SIGN" == "X" ]; then
   echo "No SIGN environment var.  Skipping codesign." >&2
   exit 0
 fi

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+# To promote and sign a release that has been prepared by the build slaves, use:
+#  release.sh
+
+# To _only_ sign an existing release, use:
+#  release.sh -s vx.y.z
+
+set -e
+
+webhost=direct.nodejs.org
+webuser=dist
+promotablecmd=dist-promotable
+promotecmd=dist-promote
+signcmd=dist-sign
+
+
+################################################################################
+## Select a GPG key to use
+
+echo "# Selecting GPG key ..."
+
+gpgkey=$(gpg --list-secret-keys | grep '^sec' | awk -F'( +|/)' '{print $3}')
+keycount=$(echo $gpgkey | wc -w)
+
+if [ $keycount -eq 0 ]; then
+  echo 'Need at least one GPG key, please make one with `gpg --gen-key`'
+  echo 'You will also need to submit your key to a public keyserver, e.g.'
+  echo '  https://sks-keyservers.net/i/#submit'
+  exit 1
+elif [ $keycount -ne 1 ]; then
+  echo -e 'You have multiple GPG keys:\n'
+
+  gpg --list-secret-keys
+
+  while true; do
+    echo $gpgkey | awk '{ for(i = 1; i <= NF; i++) { print i ") " $i; } }'
+    echo -n 'Select a key: '
+    read keynum
+
+    if $(test "$keynum" -eq "$keynum" > /dev/null 2>&1); then
+      _gpgkey=$(echo $gpgkey | awk '{ print $'${keynum}'}')
+      keycount=$(echo $_gpgkey | wc -w)
+      if [ $keycount -eq 1 ]; then
+        echo ""
+        gpgkey=$_gpgkey
+        break
+      fi
+    fi
+  done
+fi
+
+gpgfing=$(gpg --fingerprint $gpgkey | grep 'Key fingerprint =' | awk -F' = ' '{print $2}' | tr -d ' ')
+
+if ! test "$(grep $gpgfing README.md)"; then
+  echo 'Error: this GPG key fingerprint is not listed in ./README.md'
+  exit 1
+fi
+
+echo "Using GPG key: $gpgkey"
+echo "  Fingerprint: $gpgfing"
+
+
+################################################################################
+## Create and sign checksums file for a given version
+
+function sign {
+  echo -e "\n# Creating SHASUMS256.txt ..."
+
+  local version=$1
+
+  gpgtagkey=$(git tag -v $version 2>&1 | grep 'key ID' | awk '{print $NF}')
+
+  if [ "X${gpgtagkey}" == "X" ]; then
+    echo "Could not find signed tag for \"${version}\""
+    exit 1
+  fi
+
+  if [ "${gpgtagkey}" != "${gpgkey}" ]; then
+    echo "GPG key for \"${version}\" tag is not yours, cannot sign"
+  fi
+
+  shapath=$(ssh ${webuser}@${webhost} $signcmd nodejs $version)
+
+  if ! [[ ${shapath} =~ ^/.+/SHASUMS256.txt$ ]]; then
+    echo 'Error: No SHASUMS file returned by sign!'
+    exit 1
+  fi
+
+  echo -e "\n# Signing SHASUMS for ${version}..."
+
+  shadir=$(dirname $shapath)
+  tmpdir="/tmp/_node_release.$$"
+
+  mkdir -p $tmpdir
+
+  scp ${webuser}@${webhost}:${shadir}/SHASUMS*.txt ${tmpdir}/
+
+  for i in $(ls ${tmpdir}/SHASUMS*.txt); do
+    echo "Signing $i..."
+    gpg --default-key $gpgkey --clearsign ${i}
+    if [[ $version =~ ^v[0] ]]; then
+      echo "Encrpting $i..."
+      gpg --default-key $gpgkey -s ${i}
+    fi
+  done
+
+  echo "Wrote to ${tmpdir}/"
+
+  echo -e "Your signed SHASUMS256.txt.asc:\n"
+
+  cat ${tmpdir}/SHASUMS256.txt.asc
+
+  echo ""
+
+  while true; do
+    echo -n "Upload files? [y/n] "
+    yorn=""
+    read yorn
+
+    if [ "X${yorn}" == "Xn" ]; then
+      break
+    fi
+
+    if [ "X${yorn}" == "Xy" ]; then
+      if [[ $version =~ ^v[0] ]]; then
+        scp ${tmpdir}/SHASUMS* ${webuser}@${webhost}:${shadir}/
+      else
+        scp ${tmpdir}/SHASUMS256.txt ${tmpdir}/SHASUMS256.txt.asc ${webuser}@${webhost}:${shadir}/
+      fi
+      break
+    fi
+  done
+
+  rm -rf $tmpdir
+}
+
+
+if [ "X${1}" == "X-s" ]; then
+  if [ "X${2}" == "X" ]; then
+    echo "Please supply a version string to sign"
+    exit 1
+  fi
+
+  sign $2
+  exit 0
+fi
+
+
+# else: do a normal release & promote
+
+################################################################################
+## Look for releases to promote
+
+echo -e "\n# Checking for releases ..."
+
+promotable=$(ssh ${webuser}@${webhost} $promotablecmd nodejs)
+
+if [ "X${promotable}" == "X" ]; then
+  echo "No releases to promote!"
+  exit 0
+fi
+
+echo -e "Found the following releases / builds ready to promote:\n"
+echo "$promotable" | sed 's/^/ * /'
+echo ""
+
+versions=$(echo "$promotable" | cut -d: -f1)
+
+################################################################################
+## Promote releases
+
+for version in $versions; do
+  while true; do
+    files=$(echo "$promotable" | grep "^${version}" | sed 's/^'${version}': //')
+    echo -n "Promote ${version} files (${files})? [y/n] "
+    yorn=""
+    read yorn
+
+    if [ "X${yorn}" == "Xn" ]; then
+      break
+    fi
+
+    if [ "X${yorn}" != "Xy" ]; then
+      continue
+    fi
+
+    echo -e "\n# Promoting ${version}..."
+
+    ssh ${webuser}@${webhost} $promotecmd nodejs $version
+
+    sign $version
+
+    break
+  done
+done


### PR DESCRIPTION
Once complete, this work should be fairly easily transferable to v0.10 too, I'm starting off here because it's the closest to what we have with the new infra.

The goal is to require as little modification and special-casing of our new infra setup to get the old branches to spit out builds to staging. I'm aiming to try and have an RC build out for at least 0.12 later this week, likely not with all of the items below but I'd like to get the ball rolling with test builds at least. The ideal beyond that is to finish this work within 2 weeks if possible. It's hard to predict how much work is in here and what rabbit holes there are that lay ahead (and how much time I'll actually have to shave these yaks).

TODO:

 - [x] OSX binary tarballs, x86 and x64—Since we now only have a single build machine to do darwin tarballs because we only do 64-bit I've taken the approach of doing both 64-bit and 32-bit within the same Makefile task. This is the same as the way the .pkg is built with the universal binary being a munge of both 32-bit and 64-bit binaries so it takes a double-compile. It also means the build task we have in Jenkins for v4+ just works as is.
 - [x] OSX .pkg, universal binary
 - [x] Linux binary tarballs, 32-bit & 64-bit
 - [x] SmartOS binary tarballs, 32-bit & 64-bit, this is probably going to require using the old SmartOS machines still attached to jenkins.nodejs.org, will look to @misterdjules for guidance here
 - [x] Source tarball
 - [x] Windows .msi, 32-bit & 64-bit, located in ./ and ./x64/, unlike the newer ./win-x86/ and ./win-x64/ that we are using now. I'll need to consult with @nodejs/build on what servers we're going to use for Windows, I think they've all been disconnected from the old infra and converted to the new stuff but we probably need to compile with an older MSVC?
 - [x] Windows plain binaries, in ./ and ./x64/: node.exe, node.exp, node.lib, node.pdb, openssl-cli.exe, openssl-cli.pdb (we are only shipping node.exe and node.lib now, so far anyway, there have been no calls for node.pdb that I'm aware of, but we should probably stay consistent for v0.12 and v0.10).
 - [x] Docs, note that for v0.12 and v0.10 the website was built for the ./docs/ directory and we are now only shipping ./docs/api/, will look to @nodejs/documentation and @nodejs/tsc for guidance on whether we can strip down or whether we need to stay consistent here.
 - [x] Exclude unsupported arches and platforms—this is probably best done on Jenkins, some scripting in the job to make sure that the builds aren't attempted on the newer platforms we're shipping (arm, freebsd), we still want to use the same build job in Jenkins if possible but it has to be smart about which builds are performed.

/cc @nodejs/lts @nodejs/security 