### PR TITLE
lts-doc: sort documentation alphabetically

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -6,24 +6,10 @@ This module is used so that Node.js can test itself. It can be accessed with
 `require('assert')`. However, it is recommended that a userland assertion
 library be used instead.
 
-## assert.fail(actual, expected, message, operator)
-
-Throws an exception that displays the values for `actual` and `expected`
-separated by the provided operator.
-
 ## assert(value[, message]), assert.ok(value[, message])
 
 Tests if value is truthy. It is equivalent to
 `assert.equal(true, !!value, message)`.
-
-## assert.equal(actual, expected[, message])
-
-Tests shallow, coercive equality with the equal comparison operator ( `==` ).
-
-## assert.notEqual(actual, expected[, message])
-
-Tests shallow, coercive inequality with the not equal comparison operator
-( `!=` ).
 
 ## assert.deepEqual(actual, expected[, message])
 
@@ -39,27 +25,72 @@ non-enumerable:
     // WARNING: This does not throw an AssertionError!
     assert.deepEqual(Error('a'), Error('b'));
 
+## assert.deepStrictEqual(actual, expected[, message])
+
+Tests for deep equality. Primitive values are compared with the strict equality
+operator ( `===` ).
+
+## assert.doesNotThrow(block[, error][, message])
+
+Expects `block` not to throw an error. See [assert.throws()](#assert_assert_throws_block_error_message) for more details.
+
+If `block` throws an error and if it is of a different type from `error`, the
+thrown error will get propagated back to the caller. The following call will
+throw the `TypeError`, since we're not matching the error types in the
+assertion.
+
+    assert.doesNotThrow(
+      function() {
+        throw new TypeError("Wrong value");
+      },
+      SyntaxError
+    );
+
+In case `error` matches with the error thrown by `block`, an `AssertionError`
+is thrown instead.
+
+    assert.doesNotThrow(
+      function() {
+        throw new TypeError("Wrong value");
+      },
+      TypeError
+    );
+
+## assert.equal(actual, expected[, message])
+
+Tests shallow, coercive equality with the equal comparison operator ( `==` ).
+
+## assert.fail(actual, expected, message, operator)
+
+Throws an exception that displays the values for `actual` and `expected`
+separated by the provided operator.
+
+## assert.ifError(value)
+
+Throws `value` if `value` is truthy. This is useful when testing the `error`
+argument in callbacks.
+
 ## assert.notDeepEqual(actual, expected[, message])
 
 Tests for any deep inequality. Opposite of `assert.deepEqual`.
 
-## assert.strictEqual(actual, expected[, message])
+## assert.notDeepStrictEqual(actual, expected[, message])
 
-Tests strict equality as determined by the strict equality operator ( `===` ).
+Tests for deep inequality. Opposite of `assert.deepStrictEqual`.
+
+## assert.notEqual(actual, expected[, message])
+
+Tests shallow, coercive inequality with the not equal comparison operator
+( `!=` ).
 
 ## assert.notStrictEqual(actual, expected[, message])
 
 Tests strict inequality as determined by the strict not equal operator
 ( `!==` ).
 
-## assert.deepStrictEqual(actual, expected[, message])
+## assert.strictEqual(actual, expected[, message])
 
-Tests for deep equality. Primitive values are compared with the strict equality
-operator ( `===` ).
-
-## assert.notDeepStrictEqual(actual, expected[, message])
-
-Tests for deep inequality. Opposite of `assert.deepStrictEqual`.
+Tests strict equality as determined by the strict equality operator ( `===` ).
 
 ## assert.throws(block[, error][, message])
 
@@ -97,34 +128,3 @@ Custom error validation:
       },
       "unexpected error"
     );
-
-## assert.doesNotThrow(block[, error][, message])
-
-Expects `block` not to throw an error. See [assert.throws()](#assert_assert_throws_block_error_message) for more details.
-
-If `block` throws an error and if it is of a different type from `error`, the
-thrown error will get propagated back to the caller. The following call will
-throw the `TypeError`, since we're not matching the error types in the
-assertion.
-
-    assert.doesNotThrow(
-      function() {
-        throw new TypeError("Wrong value");
-      },
-      SyntaxError
-    );
-
-In case `error` matches with the error thrown by `block`, an `AssertionError`
-is thrown instead.
-
-    assert.doesNotThrow(
-      function() {
-        throw new TypeError("Wrong value");
-      },
-      TypeError
-    );
-
-## assert.ifError(value)
-
-Throws `value` if `value` is truthy. This is useful when testing the `error`
-argument in callbacks.

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -57,6 +57,18 @@ arrays specification.  `ArrayBuffer#slice()` makes a copy of the slice while
 The Buffer class is a global type for dealing with binary data directly.
 It can be constructed in a variety of ways.
 
+### new Buffer(array)
+
+* `array` Array
+
+Allocates a new buffer using an `array` of octets.
+
+### new Buffer(buffer)
+
+* `buffer` {Buffer}
+
+Copies the passed `buffer` data onto a new `Buffer` instance.
+
 ### new Buffer(size)
 
 * `size` Number
@@ -70,18 +82,6 @@ Unlike `ArrayBuffers`, the underlying memory for buffers is not initialized. So
 the contents of a newly created `Buffer` are unknown and could contain
 sensitive data. Use `buf.fill(0)` to initialize a buffer to zeroes.
 
-### new Buffer(array)
-
-* `array` Array
-
-Allocates a new buffer using an `array` of octets.
-
-### new Buffer(buffer)
-
-* `buffer` {Buffer}
-
-Copies the passed `buffer` data onto a new `Buffer` instance.
-
 ### new Buffer(str[, encoding])
 
 * `str` String - string to encode.
@@ -89,20 +89,6 @@ Copies the passed `buffer` data onto a new `Buffer` instance.
 
 Allocates a new buffer containing the given `str`.
 `encoding` defaults to `'utf8'`.
-
-### Class Method: Buffer.isEncoding(encoding)
-
-* `encoding` {String} The encoding string to test
-
-Returns true if the `encoding` is a valid encoding argument, or false
-otherwise.
-
-### Class Method: Buffer.isBuffer(obj)
-
-* `obj` Object
-* Return: Boolean
-
-Tests if `obj` is a `Buffer`.
 
 ### Class Method: Buffer.byteLength(string[, encoding])
 
@@ -122,6 +108,17 @@ Example:
       Buffer.byteLength(str, 'utf8') + " bytes");
 
     // ½ + ¼ = ¾: 9 characters, 12 bytes
+
+### Class Method: Buffer.compare(buf1, buf2)
+
+* `buf1` {Buffer}
+* `buf2` {Buffer}
+
+The same as [`buf1.compare(buf2)`](#buffer_buf_compare_otherbuffer). Useful
+for sorting an Array of Buffers:
+
+    var arr = [Buffer('1234'), Buffer('0123')];
+    arr.sort(Buffer.compare);
 
 ### Class Method: Buffer.concat(list[, totalLength])
 
@@ -164,151 +161,32 @@ Example: build a single buffer from a list of three buffers:
     // <Buffer 00 00 00 00 ...>
     // 42
 
-### Class Method: Buffer.compare(buf1, buf2)
+### Class Method: Buffer.isBuffer(obj)
 
-* `buf1` {Buffer}
-* `buf2` {Buffer}
+* `obj` Object
+* Return: Boolean
 
-The same as [`buf1.compare(buf2)`](#buffer_buf_compare_otherbuffer). Useful
-for sorting an Array of Buffers:
+Tests if `obj` is a `Buffer`.
 
-    var arr = [Buffer('1234'), Buffer('0123')];
-    arr.sort(Buffer.compare);
+### Class Method: Buffer.isEncoding(encoding)
 
+* `encoding` {String} The encoding string to test
 
-### buf.length
+Returns true if the `encoding` is a valid encoding argument, or false
+otherwise.
 
-* Number
+### buffer.entries()
 
-The size of the buffer in bytes.  Note that this is not necessarily the size
-of the contents. `length` refers to the amount of memory allocated for the
-buffer object.  It does not change when the contents of the buffer are changed.
+Creates iterator for `[index, byte]` arrays.
 
-    buf = new Buffer(1234);
+### buffer.keys()
 
-    console.log(buf.length);
-    buf.write("some string", 0, "ascii");
-    console.log(buf.length);
+Creates iterator for buffer keys (indices).
 
-    // 1234
-    // 1234
+### buffer.values()
 
-While the `length` property is not immutable, changing the value of `length`
-can result in undefined and inconsistent behavior. Applications that wish to
-modify the length of a buffer should therefore treat `length` as read-only and
-use `buf.slice` to create a new buffer.
-
-    buf = new Buffer(10);
-    buf.write("abcdefghj", 0, "ascii");
-    console.log(buf.length); // 10
-    buf = buf.slice(0,5);
-    console.log(buf.length); // 5
-
-### buf.write(string[, offset][, length][, encoding])
-
-* `string` String - data to be written to buffer
-* `offset` Number, Optional, Default: 0
-* `length` Number, Optional, Default: `buffer.length - offset`
-* `encoding` String, Optional, Default: 'utf8'
-
-Writes `string` to the buffer at `offset` using the given encoding.
-`offset` defaults to `0`, `encoding` defaults to `'utf8'`. `length` is
-the number of bytes to write. Returns number of octets written. If `buffer` did
-not contain enough space to fit the entire string, it will write a partial
-amount of the string. `length` defaults to `buffer.length - offset`.
-The method will not write partial characters.
-
-    buf = new Buffer(256);
-    len = buf.write('\u00bd + \u00bc = \u00be', 0);
-    console.log(len + " bytes: " + buf.toString('utf8', 0, len));
-
-### buf.writeUIntLE(value, offset, byteLength[, noAssert])
-### buf.writeUIntBE(value, offset, byteLength[, noAssert])
-### buf.writeIntLE(value, offset, byteLength[, noAssert])
-### buf.writeIntBE(value, offset, byteLength[, noAssert])
-
-* `value` {Number} Bytes to be written to buffer
-* `offset` {Number} `0 <= offset <= buf.length`
-* `byteLength` {Number} `0 < byteLength <= 6`
-* `noAssert` {Boolean} Default: false
-* Return: {Number}
-
-Writes `value` to the buffer at the specified `offset` and `byteLength`.
-Supports up to 48 bits of accuracy. For example:
-
-    var b = new Buffer(6);
-    b.writeUIntBE(0x1234567890ab, 0, 6);
-    // <Buffer 12 34 56 78 90 ab>
-
-Set `noAssert` to `true` to skip validation of `value` and `offset`. Defaults
-to `false`.
-
-### buf.readUIntLE(offset, byteLength[, noAssert])
-### buf.readUIntBE(offset, byteLength[, noAssert])
-### buf.readIntLE(offset, byteLength[, noAssert])
-### buf.readIntBE(offset, byteLength[, noAssert])
-
-* `offset` {Number} `0 <= offset <= buf.length`
-* `byteLength` {Number} `0 < byteLength <= 6`
-* `noAssert` {Boolean} Default: false
-* Return: {Number}
-
-A generalized version of all numeric read methods. Supports up to 48 bits of
-accuracy. For example:
-
-    var b = new Buffer(6);
-    b.writeUInt16LE(0x90ab, 0);
-    b.writeUInt32LE(0x12345678, 2);
-    b.readUIntLE(0, 6).toString(16);  // Specify 6 bytes (48 bits)
-    // output: '1234567890ab'
-
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
-
-### buf.toString([encoding][, start][, end])
-
-* `encoding` String, Optional, Default: 'utf8'
-* `start` Number, Optional, Default: 0
-* `end` Number, Optional, Default: `buffer.length`
-
-Decodes and returns a string from buffer data encoded using the specified
-character set encoding. If `encoding` is `undefined` or `null`, then `encoding`
-defaults to `'utf8'`. The `start` and `end` parameters default to `0` and
-`buffer.length` when `undefined`.
-
-    buf = new Buffer(26);
-    for (var i = 0 ; i < 26 ; i++) {
-      buf[i] = i + 97; // 97 is ASCII a
-    }
-    buf.toString('ascii'); // outputs: abcdefghijklmnopqrstuvwxyz
-    buf.toString('ascii',0,5); // outputs: abcde
-    buf.toString('utf8',0,5); // outputs: abcde
-    buf.toString(undefined,0,5); // encoding defaults to 'utf8', outputs abcde
-
-See `buffer.write()` example, above.
-
-
-### buf.toJSON()
-
-Returns a JSON-representation of the Buffer instance.  `JSON.stringify`
-implicitly calls this function when stringifying a Buffer instance.
-
-Example:
-
-    var buf = new Buffer('test');
-    var json = JSON.stringify(buf);
-
-    console.log(json);
-    // '{"type":"Buffer","data":[116,101,115,116]}'
-
-    var copy = JSON.parse(json, function(key, value) {
-        return value && value.type === 'Buffer'
-          ? new Buffer(value.data)
-          : value;
-      });
-
-    console.log(copy);
-    // <Buffer 74 65 73 74>
+Creates iterator for buffer values (bytes). This function is called automatically
+when `buffer` is used in a `for..of` statement.
 
 ### buf[index]
 
@@ -330,10 +208,6 @@ Example: copy an ASCII string into a buffer, one byte at a time:
     console.log(buf);
 
     // Node.js
-
-### buf.equals(otherBuffer)
-
-* `otherBuffer` {Buffer}
 
 Returns a boolean of whether `this` and `otherBuffer` have the same
 bytes.
@@ -388,35 +262,22 @@ region in the same buffer
 
     // efghijghijklmnopqrstuvwxyz
 
+### buf.equals(otherBuffer)
 
-### buf.slice([start[, end]])
+* `otherBuffer` {Buffer}
 
-* `start` Number, Optional, Default: 0
-* `end` Number, Optional, Default: `buffer.length`
+### buf.fill(value[, offset][, end])
 
-Returns a new buffer which references the same memory as the old, but offset
-and cropped by the `start` (defaults to `0`) and `end` (defaults to
-`buffer.length`) indexes.  Negative indexes start from the end of the buffer.
+* `value`
+* `offset` Number, Optional
+* `end` Number, Optional
 
-**Modifying the new buffer slice will modify memory in the original buffer!**
+Fills the buffer with the specified value. If the `offset` (defaults to `0`)
+and `end` (defaults to `buffer.length`) are not given it will fill the entire
+buffer.
 
-Example: build a Buffer with the ASCII alphabet, take a slice, then modify one
-byte from the original Buffer.
-
-    var buf1 = new Buffer(26);
-
-    for (var i = 0 ; i < 26 ; i++) {
-      buf1[i] = i + 97; // 97 is ASCII a
-    }
-
-    var buf2 = buf1.slice(0, 3);
-    console.log(buf2.toString('ascii', 0, buf2.length));
-    buf1[0] = 33;
-    console.log(buf2.toString('ascii', 0, buf2.length));
-
-    // abc
-    // !bc
-
+    var b = new Buffer(50);
+    b.fill("h");
 
 ### buf.indexOf(value[, byteOffset])
 
@@ -429,6 +290,156 @@ Operates similar to
 Accepts a String, Buffer or Number. Strings are interpreted as UTF8. Buffers
 will use the entire buffer. So in order to compare a partial Buffer use
 `Buffer#slice()`. Numbers can range from 0 to 255.
+
+### buf.length
+
+* Number
+
+The size of the buffer in bytes.  Note that this is not necessarily the size
+of the contents. `length` refers to the amount of memory allocated for the
+buffer object.  It does not change when the contents of the buffer are changed.
+
+    buf = new Buffer(1234);
+
+    console.log(buf.length);
+    buf.write("some string", 0, "ascii");
+    console.log(buf.length);
+
+    // 1234
+    // 1234
+
+While the `length` property is not immutable, changing the value of `length`
+can result in undefined and inconsistent behavior. Applications that wish to
+modify the length of a buffer should therefore treat `length` as read-only and
+use `buf.slice` to create a new buffer.
+
+    buf = new Buffer(10);
+    buf.write("abcdefghj", 0, "ascii");
+    console.log(buf.length); // 10
+    buf = buf.slice(0,5);
+    console.log(buf.length); // 5
+
+### buf.readDoubleBE(offset[, noAssert])
+### buf.readDoubleLE(offset[, noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads a 64 bit double from the buffer at the specified offset with specified
+endian format.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Example:
+
+    var buf = new Buffer(8);
+
+    buf[0] = 0x55;
+    buf[1] = 0x55;
+    buf[2] = 0x55;
+    buf[3] = 0x55;
+    buf[4] = 0x55;
+    buf[5] = 0x55;
+    buf[6] = 0xd5;
+    buf[7] = 0x3f;
+
+    console.log(buf.readDoubleLE(0));
+
+    // 0.3333333333333333
+
+### buf.readFloatBE(offset[, noAssert])
+### buf.readFloatLE(offset[, noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads a 32 bit float from the buffer at the specified offset with specified
+endian format.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Example:
+
+    var buf = new Buffer(4);
+
+    buf[0] = 0x00;
+    buf[1] = 0x00;
+    buf[2] = 0x80;
+    buf[3] = 0x3f;
+
+    console.log(buf.readFloatLE(0));
+
+    // 0x01
+
+### buf.readInt8(offset[, noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads a signed 8 bit integer from the buffer at the specified offset.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Works as `buffer.readUInt8`, except buffer contents are treated as two's
+complement signed values.
+
+### buf.readInt16BE(offset[, noAssert])
+### buf.readInt16LE(offset[, noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads a signed 16 bit integer from the buffer at the specified offset with
+specified endian format.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Works as `buffer.readUInt16*`, except buffer contents are treated as two's
+complement signed values.
+
+### buf.readInt32BE(offset[, noAssert])
+### buf.readInt32LE(offset[, noAssert])
+
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+* Return: Number
+
+Reads a signed 32 bit integer from the buffer at the specified offset with
+specified endian format.
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
+
+Works as `buffer.readUInt32*`, except buffer contents are treated as two's
+complement signed values.
+
+### buf.readIntBE(offset, byteLength[, noAssert])
+### buf.readIntLE(offset, byteLength[, noAssert])
+
+* `offset` {Number} `0 <= offset <= buf.length`
+* `byteLength` {Number} `0 < byteLength <= 6`
+* `noAssert` {Boolean} Default: false
+* Return: {Number}
+
+A generalized version of all numeric read methods. Supports up to 48 bits of
+accuracy. For example:
+
+    var b = new Buffer(6);
+    b.writeUInt16LE(0x90ab, 0);
+    b.writeUInt32LE(0x12345678, 2);
+    b.readUIntLE(0, 6).toString(16);  // Specify 6 bytes (48 bits)
+    // output: '1234567890ab'
+
+Set `noAssert` to true to skip validation of `offset`. This means that `offset`
+may be beyond the end of the buffer. Defaults to `false`.
 
 ### buf.readUInt8(offset[, noAssert])
 
@@ -459,8 +470,8 @@ Example:
     // 0x23
     // 0x42
 
-### buf.readUInt16LE(offset[, noAssert])
 ### buf.readUInt16BE(offset[, noAssert])
+### buf.readUInt16LE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -495,8 +506,8 @@ Example:
     // 0x2342
     // 0x4223
 
-### buf.readUInt32LE(offset[, noAssert])
 ### buf.readUInt32BE(offset[, noAssert])
+### buf.readUInt32LE(offset[, noAssert])
 
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
@@ -523,107 +534,243 @@ Example:
     // 0x03042342
     // 0x42230403
 
-### buf.readInt8(offset[, noAssert])
+### buf.readUIntBE(offset, byteLength[, noAssert])
+### buf.readUIntLE(offset, byteLength[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number} `0 <= offset <= buf.length`
+* `byteLength` {Number} `0 < byteLength <= 6`
+* `noAssert` {Boolean} Default: false
+* Return: {Number}
 
-Reads a signed 8 bit integer from the buffer at the specified offset.
+A generalized version of all numeric read methods. Supports up to 48 bits of
+accuracy. For example:
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+    var b = new Buffer(6);
+    b.writeUInt16LE(0x90ab, 0);
+    b.writeUInt32LE(0x12345678, 2);
+    b.readUIntLE(0, 6).toString(16);  // Specify 6 bytes (48 bits)
+    // output: '1234567890ab'
 
-Works as `buffer.readUInt8`, except buffer contents are treated as two's
-complement signed values.
+### buf.slice([start[, end]])
 
-### buf.readInt16LE(offset[, noAssert])
-### buf.readInt16BE(offset[, noAssert])
+* `start` Number, Optional, Default: 0
+* `end` Number, Optional, Default: `buffer.length`
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+Returns a new buffer which references the same memory as the old, but offset
+and cropped by the `start` (defaults to `0`) and `end` (defaults to
+`buffer.length`) indexes.  Negative indexes start from the end of the buffer.
 
-Reads a signed 16 bit integer from the buffer at the specified offset with
-specified endian format.
+**Modifying the new buffer slice will modify memory in the original buffer!**
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+Example: build a Buffer with the ASCII alphabet, take a slice, then modify one
+byte from the original Buffer.
 
-Works as `buffer.readUInt16*`, except buffer contents are treated as two's
-complement signed values.
+    var buf1 = new Buffer(26);
 
-### buf.readInt32LE(offset[, noAssert])
-### buf.readInt32BE(offset[, noAssert])
+    for (var i = 0 ; i < 26 ; i++) {
+      buf1[i] = i + 97; // 97 is ASCII a
+    }
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+    var buf2 = buf1.slice(0, 3);
+    console.log(buf2.toString('ascii', 0, buf2.length));
+    buf1[0] = 33;
+    console.log(buf2.toString('ascii', 0, buf2.length));
 
-Reads a signed 32 bit integer from the buffer at the specified offset with
-specified endian format.
+    // abc
+    // !bc
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+### buf.toString([encoding][, start][, end])
 
-Works as `buffer.readUInt32*`, except buffer contents are treated as two's
-complement signed values.
+* `encoding` String, Optional, Default: 'utf8'
+* `start` Number, Optional, Default: 0
+* `end` Number, Optional, Default: `buffer.length`
 
-### buf.readFloatLE(offset[, noAssert])
-### buf.readFloatBE(offset[, noAssert])
+Decodes and returns a string from buffer data encoded using the specified
+character set encoding. If `encoding` is `undefined` or `null`, then `encoding`
+defaults to `'utf8'`. The `start` and `end` parameters default to `0` and
+`buffer.length` when `undefined`.
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+    buf = new Buffer(26);
+    for (var i = 0 ; i < 26 ; i++) {
+      buf[i] = i + 97; // 97 is ASCII a
+    }
+    buf.toString('ascii'); // outputs: abcdefghijklmnopqrstuvwxyz
+    buf.toString('ascii',0,5); // outputs: abcde
+    buf.toString('utf8',0,5); // outputs: abcde
+    buf.toString(undefined,0,5); // encoding defaults to 'utf8', outputs abcde
 
-Reads a 32 bit float from the buffer at the specified offset with specified
-endian format.
+See `buffer.write()` example, above.
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+
+### buf.toJSON()
+
+Returns a JSON-representation of the Buffer instance.  `JSON.stringify`
+implicitly calls this function when stringifying a Buffer instance.
 
 Example:
 
-    var buf = new Buffer(4);
+    var buf = new Buffer('test');
+    var json = JSON.stringify(buf);
 
-    buf[0] = 0x00;
-    buf[1] = 0x00;
-    buf[2] = 0x80;
-    buf[3] = 0x3f;
+    console.log(json);
+    // '{"type":"Buffer","data":[116,101,115,116]}'
 
-    console.log(buf.readFloatLE(0));
+    var copy = JSON.parse(json, function(key, value) {
+        return value && value.type === 'Buffer'
+          ? new Buffer(value.data)
+          : value;
+      });
 
-    // 0x01
+    console.log(copy);
+    // <Buffer 74 65 73 74>
 
-### buf.readDoubleLE(offset[, noAssert])
-### buf.readDoubleBE(offset[, noAssert])
+### buf.write(string[, offset][, length][, encoding])
 
+* `string` String - data to be written to buffer
+* `offset` Number, Optional, Default: 0
+* `length` Number, Optional, Default: `buffer.length - offset`
+* `encoding` String, Optional, Default: 'utf8'
+
+Writes `string` to the buffer at `offset` using the given encoding.
+`offset` defaults to `0`, `encoding` defaults to `'utf8'`. `length` is
+the number of bytes to write. Returns number of octets written. If `buffer` did
+not contain enough space to fit the entire string, it will write a partial
+amount of the string. `length` defaults to `buffer.length - offset`.
+The method will not write partial characters.
+
+    buf = new Buffer(256);
+    len = buf.write('\u00bd + \u00bc = \u00be', 0);
+    console.log(len + " bytes: " + buf.toString('utf8', 0, len));
+
+### buf.writeDoubleBE(value, offset[, noAssert])
+### buf.writeDoubleLE(value, offset[, noAssert])
+
+* `value` Number
 * `offset` Number
 * `noAssert` Boolean, Optional, Default: false
-* Return: Number
 
-Reads a 64 bit double from the buffer at the specified offset with specified
-endian format.
+Writes `value` to the buffer at the specified offset with specified endian
+format. Note, `value` must be a valid 64 bit double.
 
-Set `noAssert` to true to skip validation of `offset`. This means that `offset`
-may be beyond the end of the buffer. Defaults to `false`.
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
 
 Example:
 
     var buf = new Buffer(8);
+    buf.writeDoubleBE(0xdeadbeefcafebabe, 0);
 
-    buf[0] = 0x55;
-    buf[1] = 0x55;
-    buf[2] = 0x55;
-    buf[3] = 0x55;
-    buf[4] = 0x55;
-    buf[5] = 0x55;
-    buf[6] = 0xd5;
-    buf[7] = 0x3f;
+    console.log(buf);
 
-    console.log(buf.readDoubleLE(0));
+    buf.writeDoubleLE(0xdeadbeefcafebabe, 0);
 
-    // 0.3333333333333333
+    console.log(buf);
+
+    // <Buffer 43 eb d5 b7 dd f9 5f d7>
+    // <Buffer d7 5f f9 dd b7 d5 eb 43>
+
+### buf.writeFloatBE(value, offset[, noAssert])
+### buf.writeFloatLE(value, offset[, noAssert])
+
+* `value` Number
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset with specified endian
+format. Note, behavior is unspecified if `value` is not a 32 bit float.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+Example:
+
+    var buf = new Buffer(4);
+    buf.writeFloatBE(0xcafebabe, 0);
+
+    console.log(buf);
+
+    buf.writeFloatLE(0xcafebabe, 0);
+
+    console.log(buf);
+
+    // <Buffer 4f 4a fe bb>
+    // <Buffer bb fe 4a 4f>
+
+### buf.writeInt8(value, offset[, noAssert])
+
+* `value` Number
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset. Note, `value` must be a
+valid signed 8 bit integer.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+Works as `buffer.writeUInt8`, except value is written out as a two's complement
+signed integer into `buffer`.
+
+### buf.writeInt16BE(value, offset[, noAssert])
+### buf.writeInt16LE(value, offset[, noAssert])
+
+* `value` Number
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset with specified endian
+format. Note, `value` must be a valid signed 16 bit integer.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+Works as `buffer.writeUInt16*`, except value is written out as a two's
+complement signed integer into `buffer`.
+
+### buf.writeInt32BE(value, offset[, noAssert])
+### buf.writeInt32LE(value, offset[, noAssert])
+
+* `value` Number
+* `offset` Number
+* `noAssert` Boolean, Optional, Default: false
+
+Writes `value` to the buffer at the specified offset with specified endian
+format. Note, `value` must be a valid signed 32 bit integer.
+
+Set `noAssert` to true to skip validation of `value` and `offset`. This means
+that `value` may be too large for the specific function and `offset` may be
+beyond the end of the buffer leading to the values being silently dropped. This
+should not be used unless you are certain of correctness. Defaults to `false`.
+
+Works as `buffer.writeUInt32*`, except value is written out as a two's
+complement signed integer into `buffer`.
+
+### buf.writeIntBE(value, offset, byteLength[, noAssert])
+### buf.writeIntLE(value, offset, byteLength[, noAssert])
+
+* `value` {Number} Bytes to be written to buffer
+* `offset` {Number} `0 <= offset <= buf.length`
+* `byteLength` {Number} `0 < byteLength <= 6`
+* `noAssert` {Boolean} Default: false
+* Return: {Number}
+
+Writes `value` to the buffer at the specified `offset` and `byteLength`.
+Supports up to 48 bits of accuracy. For example:
+
+    var b = new Buffer(6);
+    b.writeUIntBE(0x1234567890ab, 0, 6);
+    // <Buffer 12 34 56 78 90 ab>
+
+Set `noAssert` to `true` to skip validation of `value` and `offset`. Defaults
+to `false`.
 
 ### buf.writeUInt8(value, offset[, noAssert])
 
@@ -651,8 +798,8 @@ Example:
 
     // <Buffer 03 04 23 42>
 
-### buf.writeUInt16LE(value, offset[, noAssert])
 ### buf.writeUInt16BE(value, offset[, noAssert])
+### buf.writeUInt16LE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -682,8 +829,8 @@ Example:
     // <Buffer de ad be ef>
     // <Buffer ad de ef be>
 
-### buf.writeUInt32LE(value, offset[, noAssert])
 ### buf.writeUInt32BE(value, offset[, noAssert])
+### buf.writeUInt32LE(value, offset[, noAssert])
 
 * `value` Number
 * `offset` Number
@@ -711,142 +858,24 @@ Example:
     // <Buffer fe ed fa ce>
     // <Buffer ce fa ed fe>
 
-### buf.writeInt8(value, offset[, noAssert])
+### buf.writeUIntBE(value, offset, byteLength[, noAssert])
+### buf.writeUIntLE(value, offset, byteLength[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number} Bytes to be written to buffer
+* `offset` {Number} `0 <= offset <= buf.length`
+* `byteLength` {Number} `0 < byteLength <= 6`
+* `noAssert` {Boolean} Default: false
+* Return: {Number}
 
-Writes `value` to the buffer at the specified offset. Note, `value` must be a
-valid signed 8 bit integer.
+Writes `value` to the buffer at the specified `offset` and `byteLength`.
+Supports up to 48 bits of accuracy. For example:
 
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
+    var b = new Buffer(6);
+    b.writeUIntBE(0x1234567890ab, 0, 6);
+    // <Buffer 12 34 56 78 90 ab>
 
-Works as `buffer.writeUInt8`, except value is written out as a two's complement
-signed integer into `buffer`.
-
-### buf.writeInt16LE(value, offset[, noAssert])
-### buf.writeInt16BE(value, offset[, noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid signed 16 bit integer.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Works as `buffer.writeUInt16*`, except value is written out as a two's
-complement signed integer into `buffer`.
-
-### buf.writeInt32LE(value, offset[, noAssert])
-### buf.writeInt32BE(value, offset[, noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid signed 32 bit integer.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Works as `buffer.writeUInt32*`, except value is written out as a two's
-complement signed integer into `buffer`.
-
-### buf.writeFloatLE(value, offset[, noAssert])
-### buf.writeFloatBE(value, offset[, noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, behavior is unspecified if `value` is not a 32 bit float.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Example:
-
-    var buf = new Buffer(4);
-    buf.writeFloatBE(0xcafebabe, 0);
-
-    console.log(buf);
-
-    buf.writeFloatLE(0xcafebabe, 0);
-
-    console.log(buf);
-
-    // <Buffer 4f 4a fe bb>
-    // <Buffer bb fe 4a 4f>
-
-### buf.writeDoubleLE(value, offset[, noAssert])
-### buf.writeDoubleBE(value, offset[, noAssert])
-
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-
-Writes `value` to the buffer at the specified offset with specified endian
-format. Note, `value` must be a valid 64 bit double.
-
-Set `noAssert` to true to skip validation of `value` and `offset`. This means
-that `value` may be too large for the specific function and `offset` may be
-beyond the end of the buffer leading to the values being silently dropped. This
-should not be used unless you are certain of correctness. Defaults to `false`.
-
-Example:
-
-    var buf = new Buffer(8);
-    buf.writeDoubleBE(0xdeadbeefcafebabe, 0);
-
-    console.log(buf);
-
-    buf.writeDoubleLE(0xdeadbeefcafebabe, 0);
-
-    console.log(buf);
-
-    // <Buffer 43 eb d5 b7 dd f9 5f d7>
-    // <Buffer d7 5f f9 dd b7 d5 eb 43>
-
-### buf.fill(value[, offset][, end])
-
-* `value`
-* `offset` Number, Optional
-* `end` Number, Optional
-
-Fills the buffer with the specified value. If the `offset` (defaults to `0`)
-and `end` (defaults to `buffer.length`) are not given it will fill the entire
-buffer.
-
-    var b = new Buffer(50);
-    b.fill("h");
-
-### buffer.values()
-
-Creates iterator for buffer values (bytes). This function is called automatically
-when `buffer` is used in a `for..of` statement.
-
-### buffer.keys()
-
-Creates iterator for buffer keys (indices).
-
-### buffer.entries()
-
-Creates iterator for `[index, byte]` arrays.
+Set `noAssert` to `true` to skip validation of `value` and `offset`. Defaults
+to `false`.
 
 ## buffer.INSPECT_MAX_BYTES
 

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -31,6 +31,22 @@ The ChildProcess class is not intended to be used directly.  Use the
 `spawn()`, `exec()`, `execFile()`, or `fork()` methods to create a Child
 Process instance.
 
+### Event: 'close'
+
+* `code` {Number} the exit code, if it exited normally.
+* `signal` {String} the signal passed to kill the child process, if it
+  was killed by the parent.
+
+This event is emitted when the stdio streams of a child process have all
+terminated.  This is distinct from 'exit', since multiple processes
+might share the same stdio streams.
+
+### Event: 'disconnect'
+
+This event is emitted after calling the `.disconnect()` method in the parent
+or in the child. After disconnecting it is no longer possible to send messages,
+and the `.connected` property is false.
+
 ### Event:  'error'
 
 * `err` {Error Object} the error.
@@ -67,22 +83,6 @@ it will exit.
 
 See `waitpid(2)`.
 
-### Event: 'close'
-
-* `code` {Number} the exit code, if it exited normally.
-* `signal` {String} the signal passed to kill the child process, if it
-  was killed by the parent.
-
-This event is emitted when the stdio streams of a child process have all
-terminated.  This is distinct from 'exit', since multiple processes
-might share the same stdio streams.
-
-### Event: 'disconnect'
-
-This event is emitted after calling the `.disconnect()` method in the parent
-or in the child. After disconnecting it is no longer possible to send messages,
-and the `.connected` property is false.
-
 ### Event: 'message'
 
 * `message` {Object} a parsed JSON object or primitive value.
@@ -92,99 +92,24 @@ and the `.connected` property is false.
 Messages sent by `.send(message, [sendHandle])` are obtained using the
 `message` event.
 
-### child.stdin
-
-* {Stream object}
-
-A `Writable Stream` that represents the child process's `stdin`.
-If the child is waiting to read all its input, it will not continue until this
-stream has been closed via `end()`.
-
-If the child was not spawned with `stdio[0]` set to `'pipe'`, then this will
-not be set.
-
-`child.stdin` is shorthand for `child.stdio[0]`. Both properties will refer
-to the same object, or null.
-
-### child.stdout
-
-* {Stream object}
-
-A `Readable Stream` that represents the child process's `stdout`.
-
-If the child was not spawned with `stdio[1]` set to `'pipe'`, then this will
-not be set.
-
-`child.stdout` is shorthand for `child.stdio[1]`. Both properties will refer
-to the same object, or null.
-
-### child.stderr
-
-* {Stream object}
-
-A `Readable Stream` that represents the child process's `stderr`.
-
-If the child was not spawned with `stdio[2]` set to `'pipe'`, then this will
-not be set.
-
-`child.stderr` is shorthand for `child.stdio[2]`. Both properties will refer
-to the same object, or null.
-
-### child.stdio
-
-* {Array}
-
-A sparse array of pipes to the child process, corresponding with positions in
-the [stdio](#child_process_options_stdio) option to
-[spawn](#child_process_child_process_spawn_command_args_options) that have been
-set to `'pipe'`.
-Note that streams 0-2 are also available as ChildProcess.stdin,
-ChildProcess.stdout, and ChildProcess.stderr, respectively.
-
-In the following example, only the child's fd `1` is setup as a pipe, so only
-the parent's `child.stdio[1]` is a stream, all other values in the array are
-`null`.
-
-    var assert = require('assert');
-    var fs = require('fs');
-    var child_process = require('child_process');
-
-    child = child_process.spawn('ls', {
-        stdio: [
-          0, // use parents stdin for child
-          'pipe', // pipe child's stdout to parent
-          fs.openSync('err.out', 'w') // direct child's stderr to a file
-        ]
-    });
-
-    assert.equal(child.stdio[0], null);
-    assert.equal(child.stdio[0], child.stdin);
-
-    assert(child.stdout);
-    assert.equal(child.stdio[1], child.stdout);
-
-    assert.equal(child.stdio[2], null);
-    assert.equal(child.stdio[2], child.stderr);
-
-### child.pid
-
-* {Integer}
-
-The PID of the child process.
-
-Example:
-
-    var spawn = require('child_process').spawn,
-        grep  = spawn('grep', ['ssh']);
-
-    console.log('Spawned child pid: ' + grep.pid);
-    grep.stdin.end();
-
 ### child.connected
 
 * {Boolean} Set to false after `.disconnect` is called
 
 If `.connected` is false, it is no longer possible to send messages.
+
+### child.disconnect()
+
+Close the IPC channel between parent and child, allowing the child to exit
+gracefully once there are no other connections keeping it alive. After calling
+this method the `.connected` flag will be set to `false` in both the parent and
+child, and it is no longer possible to send messages.
+
+The 'disconnect' event will be emitted when there are no messages in the process
+of being received, most likely immediately.
+
+Note that you can also call `process.disconnect()` in the child process when the
+child process has any open IPC channels with the parent (i.e `fork()`).
 
 ### child.kill([signal])
 
@@ -214,6 +139,20 @@ child process may not actually kill it.  `kill` really just sends a signal
 to a process.
 
 See `kill(2)`
+
+### child.pid
+
+* {Integer}
+
+The PID of the child process.
+
+Example:
+
+    var spawn = require('child_process').spawn,
+        grep  = spawn('grep', ['ssh']);
+
+    console.log('Spawned child pid: ' + grep.pid);
+    grep.stdin.end();
 
 ### child.send(message[, sendHandle][, callback])
 
@@ -339,208 +278,84 @@ longer keep track of when the socket is destroyed. To indicate this condition
 the `.connections` property becomes `null`.
 It is also recommended not to use `.maxConnections` in this condition.
 
-### child.disconnect()
+### child.stderr
 
-Close the IPC channel between parent and child, allowing the child to exit
-gracefully once there are no other connections keeping it alive. After calling
-this method the `.connected` flag will be set to `false` in both the parent and
-child, and it is no longer possible to send messages.
+* {Stream object}
 
-The 'disconnect' event will be emitted when there are no messages in the process
-of being received, most likely immediately.
+A `Readable Stream` that represents the child process's `stderr`.
 
-Note that you can also call `process.disconnect()` in the child process when the
-child process has any open IPC channels with the parent (i.e `fork()`).
+If the child was not spawned with `stdio[2]` set to `'pipe'`, then this will
+not be set.
+
+`child.stderr` is shorthand for `child.stdio[2]`. Both properties will refer
+to the same object, or null.
+
+### child.stdin
+
+* {Stream object}
+
+A `Writable Stream` that represents the child process's `stdin`.
+If the child is waiting to read all its input, it will not continue until this
+stream has been closed via `end()`.
+
+If the child was not spawned with `stdio[0]` set to `'pipe'`, then this will
+not be set.
+
+`child.stdin` is shorthand for `child.stdio[0]`. Both properties will refer
+to the same object, or null.
+
+### child.stdio
+
+* {Array}
+
+A sparse array of pipes to the child process, corresponding with positions in
+the [stdio](#child_process_options_stdio) option to
+[spawn](#child_process_child_process_spawn_command_args_options) that have been
+set to `'pipe'`.
+Note that streams 0-2 are also available as ChildProcess.stdin,
+ChildProcess.stdout, and ChildProcess.stderr, respectively.
+
+In the following example, only the child's fd `1` is setup as a pipe, so only
+the parent's `child.stdio[1]` is a stream, all other values in the array are
+`null`.
+
+    var assert = require('assert');
+    var fs = require('fs');
+    var child_process = require('child_process');
+
+    child = child_process.spawn('ls', {
+        stdio: [
+          0, // use parents stdin for child
+          'pipe', // pipe child's stdout to parent
+          fs.openSync('err.out', 'w') // direct child's stderr to a file
+        ]
+    });
+
+    assert.equal(child.stdio[0], null);
+    assert.equal(child.stdio[0], child.stdin);
+
+    assert(child.stdout);
+    assert.equal(child.stdio[1], child.stdout);
+
+    assert.equal(child.stdio[2], null);
+    assert.equal(child.stdio[2], child.stderr);
+
+### child.stdout
+
+* {Stream object}
+
+A `Readable Stream` that represents the child process's `stdout`.
+
+If the child was not spawned with `stdio[1]` set to `'pipe'`, then this will
+not be set.
+
+`child.stdout` is shorthand for `child.stdio[1]`. Both properties will refer
+to the same object, or null.
 
 ## Asynchronous Process Creation
 
 These methods follow the common async programming patterns (accepting a
 callback or returning an EventEmitter).
-
-### child_process.spawn(command[, args][, options])
-
-* `command` {String} The command to run
-* `args` {Array} List of string arguments
-* `options` {Object}
-  * `cwd` {String} Current working directory of the child process
-  * `env` {Object} Environment key-value pairs
-  * `stdio` {Array|String} Child's stdio configuration. (See
-    [below](#child_process_options_stdio))
-  * `detached` {Boolean} Prepare child to run independently of its parent
-    process. Specific behavior depends on the platform, see
-    [below](#child_process_options_detached))
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-* return: {ChildProcess object}
-
-Launches a new process with the given `command`, with  command line arguments in
-`args`. If omitted, `args` defaults to an empty Array.
-
-The third argument is used to specify additional options, with these defaults:
-
-    { cwd: undefined,
-      env: process.env
-    }
-
-Use `cwd` to specify the working directory from which the process is spawned.
-If not given, the default is to inherit the current working directory.
-
-Use `env` to specify environment variables that will be visible to the new
-process, the default is `process.env`.
-
-Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit code:
-
-    var spawn = require('child_process').spawn,
-        ls    = spawn('ls', ['-lh', '/usr']);
-
-    ls.stdout.on('data', function (data) {
-      console.log('stdout: ' + data);
-    });
-
-    ls.stderr.on('data', function (data) {
-      console.log('stderr: ' + data);
-    });
-
-    ls.on('close', function (code) {
-      console.log('child process exited with code ' + code);
-    });
-
-
-Example: A very elaborate way to run 'ps ax | grep ssh'
-
-    var spawn = require('child_process').spawn,
-        ps    = spawn('ps', ['ax']),
-        grep  = spawn('grep', ['ssh']);
-
-    ps.stdout.on('data', function (data) {
-      grep.stdin.write(data);
-    });
-
-    ps.stderr.on('data', function (data) {
-      console.log('ps stderr: ' + data);
-    });
-
-    ps.on('close', function (code) {
-      if (code !== 0) {
-        console.log('ps process exited with code ' + code);
-      }
-      grep.stdin.end();
-    });
-
-    grep.stdout.on('data', function (data) {
-      console.log('' + data);
-    });
-
-    grep.stderr.on('data', function (data) {
-      console.log('grep stderr: ' + data);
-    });
-
-    grep.on('close', function (code) {
-      if (code !== 0) {
-        console.log('grep process exited with code ' + code);
-      }
-    });
-
-
-Example of checking for failed exec:
-
-    var spawn = require('child_process').spawn,
-        child = spawn('bad_command');
-
-    child.on('error', function (err) {
-      console.log('Failed to start child process.');
-    });
-
-#### options.stdio
-
-As a shorthand, the `stdio` argument may be one of the following strings:
-
-* `'pipe'` - `['pipe', 'pipe', 'pipe']`, this is the default value
-* `'ignore'` - `['ignore', 'ignore', 'ignore']`
-* `'inherit'` - `[process.stdin, process.stdout, process.stderr]` or `[0,1,2]`
-
-Otherwise, the 'stdio' option to `child_process.spawn()` is an array where each
-index corresponds to a fd in the child.  The value is one of the following:
-
-1. `'pipe'` - Create a pipe between the child process and the parent process.
-   The parent end of the pipe is exposed to the parent as a property on the
-   `child_process` object as `ChildProcess.stdio[fd]`. Pipes created for
-   fds 0 - 2 are also available as ChildProcess.stdin, ChildProcess.stdout
-   and ChildProcess.stderr, respectively.
-2. `'ipc'` - Create an IPC channel for passing messages/file descriptors
-   between parent and child. A ChildProcess may have at most *one* IPC stdio
-   file descriptor. Setting this option enables the ChildProcess.send() method.
-   If the child writes JSON messages to this file descriptor, then this will
-   trigger ChildProcess.on('message').  If the child is an Node.js program, then
-   the presence of an IPC channel will enable process.send() and
-   process.on('message').
-3. `'ignore'` - Do not set this file descriptor in the child. Note that Node.js
-   will always open fd 0 - 2 for the processes it spawns. When any of these is
-   ignored Node.js will open `/dev/null` and attach it to the child's fd.
-4. `Stream` object - Share a readable or writable stream that refers to a tty,
-   file, socket, or a pipe with the child process. The stream's underlying
-   file descriptor is duplicated in the child process to the fd that
-   corresponds to the index in the `stdio` array. Note that the stream must
-   have an underlying descriptor (file streams do not until the `'open'`
-   event has occurred).
-5. Positive integer - The integer value is interpreted as a file descriptor
-   that is is currently open in the parent process. It is shared with the child
-   process, similar to how `Stream` objects can be shared.
-6. `null`, `undefined` - Use default value. For stdio fds 0, 1 and 2 (in other
-   words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the
-   default is `'ignore'`.
-
-Example:
-
-    var spawn = require('child_process').spawn;
-
-    // Child will use parent's stdios
-    spawn('prg', [], { stdio: 'inherit' });
-
-    // Spawn child sharing only stderr
-    spawn('prg', [], { stdio: ['pipe', 'pipe', process.stderr] });
-
-    // Open an extra fd=4, to interact with programs present a
-    // startd-style interface.
-    spawn('prg', [], { stdio: ['pipe', null, null, null, 'pipe'] });
-
-#### options.detached
-
-On Windows, this makes it possible for the child to continue running after the
-parent exits. The child will have a new console window (this cannot be
-disabled).
-
-On non-Windows, if the `detached` option is set, the child process will be made
-the leader of a new process group and session. Note that child processes may
-continue running after the parent exits whether they are detached or not.  See
-`setsid(2)` for more information.
-
-By default, the parent will wait for the detached child to exit.  To prevent
-the parent from waiting for a given `child`, use the `child.unref()` method,
-and the parent's event loop will not include the child in its reference count.
-
-Example of detaching a long-running process and redirecting its output to a
-file:
-
-     var fs = require('fs'),
-         spawn = require('child_process').spawn,
-         out = fs.openSync('./out.log', 'a'),
-         err = fs.openSync('./out.log', 'a');
-
-     var child = spawn('prg', [], {
-       detached: true,
-       stdio: [ 'ignore', out, err ]
-     });
-
-     child.unref();
-
-When using the `detached` option to start a long-running process, the process
-will not stay running in the background after the parent exits unless it is
-provided with a `stdio` configuration that is not connected to the parent.
-If the parent's `stdio` is inherited, the child will remain attached to the
-controlling terminal.
-
-See also: [`child_process.exec()`](#child_process_child_process_exec_command_options_callback) and [`child_process.fork()`](#child_process_child_process_fork_modulepath_args_options)
 
 ### child_process.exec(command[, options], callback)
 
@@ -664,6 +479,191 @@ output on this fd is expected to be line delimited JSON objects.
 *Note: Unlike the `fork()` POSIX system call, `child_process.fork()` does not clone the
 current process.*
 
+### child_process.spawn(command[, args][, options])
+
+* `command` {String} The command to run
+* `args` {Array} List of string arguments
+* `options` {Object}
+  * `cwd` {String} Current working directory of the child process
+  * `env` {Object} Environment key-value pairs
+  * `stdio` {Array|String} Child's stdio configuration. (See
+    [below](#child_process_options_stdio))
+  * `detached` {Boolean} Prepare child to run independently of its parent
+    process. Specific behavior depends on the platform, see
+    [below](#child_process_options_detached))
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+* return: {ChildProcess object}
+
+Launches a new process with the given `command`, with  command line arguments in
+`args`. If omitted, `args` defaults to an empty Array.
+
+The third argument is used to specify additional options, with these defaults:
+
+    { cwd: undefined,
+      env: process.env
+    }
+
+Use `cwd` to specify the working directory from which the process is spawned.
+If not given, the default is to inherit the current working directory.
+
+Use `env` to specify environment variables that will be visible to the new
+process, the default is `process.env`.
+
+Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit code:
+
+    var spawn = require('child_process').spawn,
+        ls    = spawn('ls', ['-lh', '/usr']);
+
+    ls.stdout.on('data', function (data) {
+      console.log('stdout: ' + data);
+    });
+
+    ls.stderr.on('data', function (data) {
+      console.log('stderr: ' + data);
+    });
+
+    ls.on('close', function (code) {
+      console.log('child process exited with code ' + code);
+    });
+
+
+Example: A very elaborate way to run 'ps ax | grep ssh'
+
+    var spawn = require('child_process').spawn,
+        ps    = spawn('ps', ['ax']),
+        grep  = spawn('grep', ['ssh']);
+
+    ps.stdout.on('data', function (data) {
+      grep.stdin.write(data);
+    });
+
+    ps.stderr.on('data', function (data) {
+      console.log('ps stderr: ' + data);
+    });
+
+    ps.on('close', function (code) {
+      if (code !== 0) {
+        console.log('ps process exited with code ' + code);
+      }
+      grep.stdin.end();
+    });
+
+    grep.stdout.on('data', function (data) {
+      console.log('' + data);
+    });
+
+    grep.stderr.on('data', function (data) {
+      console.log('grep stderr: ' + data);
+    });
+
+    grep.on('close', function (code) {
+      if (code !== 0) {
+        console.log('grep process exited with code ' + code);
+      }
+    });
+
+
+Example of checking for failed exec:
+
+    var spawn = require('child_process').spawn,
+        child = spawn('bad_command');
+
+    child.on('error', function (err) {
+      console.log('Failed to start child process.');
+    });
+
+#### options.detached
+
+On Windows, this makes it possible for the child to continue running after the
+parent exits. The child will have a new console window (this cannot be
+disabled).
+
+On non-Windows, if the `detached` option is set, the child process will be made
+the leader of a new process group and session. Note that child processes may
+continue running after the parent exits whether they are detached or not.  See
+`setsid(2)` for more information.
+
+By default, the parent will wait for the detached child to exit.  To prevent
+the parent from waiting for a given `child`, use the `child.unref()` method,
+and the parent's event loop will not include the child in its reference count.
+
+Example of detaching a long-running process and redirecting its output to a
+file:
+
+     var fs = require('fs'),
+         spawn = require('child_process').spawn,
+         out = fs.openSync('./out.log', 'a'),
+         err = fs.openSync('./out.log', 'a');
+
+     var child = spawn('prg', [], {
+       detached: true,
+       stdio: [ 'ignore', out, err ]
+     });
+
+     child.unref();
+
+When using the `detached` option to start a long-running process, the process
+will not stay running in the background after the parent exits unless it is
+provided with a `stdio` configuration that is not connected to the parent.
+If the parent's `stdio` is inherited, the child will remain attached to the
+controlling terminal.
+
+#### options.stdio
+
+As a shorthand, the `stdio` argument may be one of the following strings:
+
+* `'pipe'` - `['pipe', 'pipe', 'pipe']`, this is the default value
+* `'ignore'` - `['ignore', 'ignore', 'ignore']`
+* `'inherit'` - `[process.stdin, process.stdout, process.stderr]` or `[0,1,2]`
+
+Otherwise, the 'stdio' option to `child_process.spawn()` is an array where each
+index corresponds to a fd in the child.  The value is one of the following:
+
+1. `'pipe'` - Create a pipe between the child process and the parent process.
+   The parent end of the pipe is exposed to the parent as a property on the
+   `child_process` object as `ChildProcess.stdio[fd]`. Pipes created for
+   fds 0 - 2 are also available as ChildProcess.stdin, ChildProcess.stdout
+   and ChildProcess.stderr, respectively.
+2. `'ipc'` - Create an IPC channel for passing messages/file descriptors
+   between parent and child. A ChildProcess may have at most *one* IPC stdio
+   file descriptor. Setting this option enables the ChildProcess.send() method.
+   If the child writes JSON messages to this file descriptor, then this will
+   trigger ChildProcess.on('message').  If the child is an Node.js program, then
+   the presence of an IPC channel will enable process.send() and
+   process.on('message').
+3. `'ignore'` - Do not set this file descriptor in the child. Note that Node.js
+   will always open fd 0 - 2 for the processes it spawns. When any of these is
+   ignored Node.js will open `/dev/null` and attach it to the child's fd.
+4. `Stream` object - Share a readable or writable stream that refers to a tty,
+   file, socket, or a pipe with the child process. The stream's underlying
+   file descriptor is duplicated in the child process to the fd that
+   corresponds to the index in the `stdio` array. Note that the stream must
+   have an underlying descriptor (file streams do not until the `'open'`
+   event has occurred).
+5. Positive integer - The integer value is interpreted as a file descriptor
+   that is is currently open in the parent process. It is shared with the child
+   process, similar to how `Stream` objects can be shared.
+6. `null`, `undefined` - Use default value. For stdio fds 0, 1 and 2 (in other
+   words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the
+   default is `'ignore'`.
+
+Example:
+
+    var spawn = require('child_process').spawn;
+
+    // Child will use parent's stdios
+    spawn('prg', [], { stdio: 'inherit' });
+
+    // Spawn child sharing only stderr
+    spawn('prg', [], { stdio: ['pipe', 'pipe', process.stderr] });
+
+    // Open an extra fd=4, to interact with programs present a
+    // startd-style interface.
+    spawn('prg', [], { stdio: ['pipe', null, null, null, 'pipe'] });
+
+See also: [`child_process.exec()`](#child_process_child_process_exec_command_options_callback) and [`child_process.fork()`](#child_process_child_process_fork_modulepath_args_options)
+
 ## Synchronous Process Creation
 
 These methods are **synchronous**, meaning they **WILL** block the event loop,
@@ -672,72 +672,6 @@ pausing execution of your code until the spawned process exits.
 Blocking calls like these are mostly useful for simplifying general purpose
 scripting tasks and for simplifying the loading/processing of application
 configuration at startup.
-
-### child_process.spawnSync(command[, args][, options])
-
-* `command` {String} The command to run
-* `args` {Array} List of string arguments
-* `options` {Object}
-  * `cwd` {String} Current working directory of the child process
-  * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
-    - supplying this value will override `stdio[0]`
-  * `stdio` {Array} Child's stdio configuration.
-  * `env` {Object} Environment key-value pairs
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-  * `timeout` {Number} In milliseconds the maximum amount of time the process is allowed to run. (Default: undefined)
-  * `killSignal` {String} The signal value to be used when the spawned process will be killed. (Default: 'SIGTERM')
-  * `maxBuffer` {Number} largest amount of data (in bytes) allowed on stdout or
-    stderr - if exceeded child process is killed
-  * `encoding` {String} The encoding used for all stdio inputs and outputs. (Default: 'buffer')
-* return: {Object}
-  * `pid` {Number} Pid of the child process
-  * `output` {Array} Array of results from stdio output
-  * `stdout` {Buffer|String} The contents of `output[1]`
-  * `stderr` {Buffer|String} The contents of `output[2]`
-  * `status` {Number} The exit code of the child process
-  * `signal` {String} The signal used to kill the child process
-  * `error` {Error} The error object if the child process failed or timed out
-
-`spawnSync` will not return until the child process has fully closed. When a
-timeout has been encountered and `killSignal` is sent, the method won't return
-until the process has completely exited. That is to say, if the process handles
-the `SIGTERM` signal and doesn't exit, your process will wait until the child
-process has exited.
-
-### child_process.execSync(command[, options])
-
-* `command` {String} The command to run
-* `options` {Object}
-  * `cwd` {String} Current working directory of the child process
-  * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
-    - supplying this value will override `stdio[0]`
-  * `stdio` {Array} Child's stdio configuration. (Default: 'pipe')
-    - `stderr` by default will be output to the parent process' stderr unless
-      `stdio` is specified
-  * `env` {Object} Environment key-value pairs
-  * `shell` {String} Shell to execute the command with
-    (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,  The shell should
-     understand the `-c` switch on UNIX or `/s /c` on Windows. On Windows,
-     command line parsing should be compatible with `cmd.exe`.)
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-  * `timeout` {Number} In milliseconds the maximum amount of time the process is allowed to run. (Default: undefined)
-  * `killSignal` {String} The signal value to be used when the spawned process will be killed. (Default: 'SIGTERM')
-  * `maxBuffer` {Number} largest amount of data (in bytes) allowed on stdout or
-    stderr - if exceeded child process is killed
-  * `encoding` {String} The encoding used for all stdio inputs and outputs. (Default: 'buffer')
-* return: {Buffer|String} The stdout from the command
-
-`execSync` will not return until the child process has fully closed. When a
-timeout has been encountered and `killSignal` is sent, the method won't return
-until the process has completely exited. That is to say, if the process handles
-the `SIGTERM` signal and doesn't exit, your process will wait until the child
-process has exited.
-
-If the process times out, or has a non-zero exit code, this method ***will***
-throw.  The `Error` object will contain the entire result from
-[`child_process.spawnSync()`](#child_process_child_process_spawnsync_command_args_options)
 
 ### child_process.execFileSync(file[, args][, options])
 
@@ -773,3 +707,69 @@ throw.  The `Error` object will contain the entire result from
 [EventEmitter]: events.html#events_class_events_eventemitter
 [net.Server]: net.html#net_class_net_server
 [net.Socket]: net.html#net_class_net_socket
+
+### child_process.execSync(command[, options])
+
+* `command` {String} The command to run
+* `options` {Object}
+  * `cwd` {String} Current working directory of the child process
+  * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
+    - supplying this value will override `stdio[0]`
+  * `stdio` {Array} Child's stdio configuration. (Default: 'pipe')
+    - `stderr` by default will be output to the parent process' stderr unless
+      `stdio` is specified
+  * `env` {Object} Environment key-value pairs
+  * `shell` {String} Shell to execute the command with
+    (Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows,  The shell should
+     understand the `-c` switch on UNIX or `/s /c` on Windows. On Windows,
+     command line parsing should be compatible with `cmd.exe`.)
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+  * `timeout` {Number} In milliseconds the maximum amount of time the process is allowed to run. (Default: undefined)
+  * `killSignal` {String} The signal value to be used when the spawned process will be killed. (Default: 'SIGTERM')
+  * `maxBuffer` {Number} largest amount of data (in bytes) allowed on stdout or
+    stderr - if exceeded child process is killed
+  * `encoding` {String} The encoding used for all stdio inputs and outputs. (Default: 'buffer')
+* return: {Buffer|String} The stdout from the command
+
+`execSync` will not return until the child process has fully closed. When a
+timeout has been encountered and `killSignal` is sent, the method won't return
+until the process has completely exited. That is to say, if the process handles
+the `SIGTERM` signal and doesn't exit, your process will wait until the child
+process has exited.
+
+If the process times out, or has a non-zero exit code, this method ***will***
+throw.  The `Error` object will contain the entire result from
+[`child_process.spawnSync()`](#child_process_child_process_spawnsync_command_args_options)
+
+### child_process.spawnSync(command[, args][, options])
+
+* `command` {String} The command to run
+* `args` {Array} List of string arguments
+* `options` {Object}
+  * `cwd` {String} Current working directory of the child process
+  * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
+    - supplying this value will override `stdio[0]`
+  * `stdio` {Array} Child's stdio configuration.
+  * `env` {Object} Environment key-value pairs
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+  * `timeout` {Number} In milliseconds the maximum amount of time the process is allowed to run. (Default: undefined)
+  * `killSignal` {String} The signal value to be used when the spawned process will be killed. (Default: 'SIGTERM')
+  * `maxBuffer` {Number} largest amount of data (in bytes) allowed on stdout or
+    stderr - if exceeded child process is killed
+  * `encoding` {String} The encoding used for all stdio inputs and outputs. (Default: 'buffer')
+* return: {Object}
+  * `pid` {Number} Pid of the child process
+  * `output` {Array} Array of results from stdio output
+  * `stdout` {Buffer|String} The contents of `output[1]`
+  * `stderr` {Buffer|String} The contents of `output[2]`
+  * `status` {Number} The exit code of the child process
+  * `signal` {String} The signal used to kill the child process
+  * `error` {Error} The error object if the child process failed or timed out
+
+`spawnSync` will not return until the child process has fully closed. When a
+timeout has been encountered and `killSignal` is sent, the method won't return
+until the process has completely exited. That is to say, if the process handles
+the `SIGTERM` signal and doesn't exit, your process will wait until the child
+process has exited.

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -101,278 +101,7 @@ will be dropped and new connections will be refused.  Node.js does not
 automatically manage the number of workers for you, however.  It is your
 responsibility to manage the worker pool for your application's needs.
 
-## cluster.schedulingPolicy
 
-The scheduling policy, either `cluster.SCHED_RR` for round-robin or
-`cluster.SCHED_NONE` to leave it to the operating system. This is a
-global setting and effectively frozen once you spawn the first worker
-or call `cluster.setupMaster()`, whatever comes first.
-
-`SCHED_RR` is the default on all operating systems except Windows.
-Windows will change to `SCHED_RR` once libuv is able to effectively
-distribute IOCP handles without incurring a large performance hit.
-
-`cluster.schedulingPolicy` can also be set through the
-`NODE_CLUSTER_SCHED_POLICY` environment variable. Valid
-values are `"rr"` and `"none"`.
-
-## cluster.settings
-
-* {Object}
-  * `execArgv` {Array} list of string arguments passed to the Node.js
-    executable. (Default=`process.execArgv`)
-  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
-  * `args` {Array} string arguments passed to worker.
-    (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
-    (Default=`false`)
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-
-After calling `.setupMaster()` (or `.fork()`) this settings object will contain
-the settings, including the default values.
-
-It is effectively frozen after being set, because `.setupMaster()` can
-only be called once.
-
-This object is not supposed to be changed or set manually, by you.
-
-## cluster.isMaster
-
-* {Boolean}
-
-True if the process is a master. This is determined
-by the `process.env.NODE_UNIQUE_ID`. If `process.env.NODE_UNIQUE_ID` is
-undefined, then `isMaster` is `true`.
-
-## cluster.isWorker
-
-* {Boolean}
-
-True if the process is not a master (it is the negation of `cluster.isMaster`).
-
-## Event: 'fork'
-
-* `worker` {Worker object}
-
-When a new worker is forked the cluster module will emit a 'fork' event.
-This can be used to log worker activity, and create your own timeout.
-
-    var timeouts = [];
-    function errorMsg() {
-      console.error("Something must be wrong with the connection ...");
-    }
-
-    cluster.on('fork', function(worker) {
-      timeouts[worker.id] = setTimeout(errorMsg, 2000);
-    });
-    cluster.on('listening', function(worker, address) {
-      clearTimeout(timeouts[worker.id]);
-    });
-    cluster.on('exit', function(worker, code, signal) {
-      clearTimeout(timeouts[worker.id]);
-      errorMsg();
-    });
-
-## Event: 'online'
-
-* `worker` {Worker object}
-
-After forking a new worker, the worker should respond with an online message.
-When the master receives an online message it will emit this event.
-The difference between 'fork' and 'online' is that fork is emitted when the
-master forks a worker, and 'online' is emitted when the worker is running.
-
-    cluster.on('online', function(worker) {
-      console.log("Yay, the worker responded after it was forked");
-    });
-
-## Event: 'listening'
-
-* `worker` {Worker object}
-* `address` {Object}
-
-After calling `listen()` from a worker, when the 'listening' event is emitted on
-the server, a listening event will also be emitted on `cluster` in the master.
-
-The event handler is executed with two arguments, the `worker` contains the worker
-object and the `address` object contains the following connection properties:
-`address`, `port` and `addressType`. This is very useful if the worker is listening
-on more than one address.
-
-    cluster.on('listening', function(worker, address) {
-      console.log("A worker is now connected to " + address.address + ":" + address.port);
-    });
-
-The `addressType` is one of:
-
-* `4` (TCPv4)
-* `6` (TCPv6)
-* `-1` (unix domain socket)
-* `"udp4"` or `"udp6"` (UDP v4 or v6)
-
-## Event: 'disconnect'
-
-* `worker` {Worker object}
-
-Emitted after the worker IPC channel has disconnected. This can occur when a
-worker exits gracefully, is killed, or is disconnected manually (such as with
-worker.disconnect()).
-
-There may be a delay between the `disconnect` and `exit` events.  These events
-can be used to detect if the process is stuck in a cleanup or if there are
-long-living connections.
-
-    cluster.on('disconnect', function(worker) {
-      console.log('The worker #' + worker.id + ' has disconnected');
-    });
-
-## Event: 'exit'
-
-* `worker` {Worker object}
-* `code` {Number} the exit code, if it exited normally.
-* `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
-  the process to be killed.
-
-When any of the workers die the cluster module will emit the 'exit' event.
-
-This can be used to restart the worker by calling `.fork()` again.
-
-    cluster.on('exit', function(worker, code, signal) {
-      console.log('worker %d died (%s). restarting...',
-        worker.process.pid, signal || code);
-      cluster.fork();
-    });
-
-See [child_process event: 'exit'](child_process.html#child_process_event_exit).
-
-## Event: 'message'
-
-* `worker` {Worker object}
-* `message` {Object}
-
-Emitted when any worker receives a message.
-
-See
-[child_process event: 'message'](child_process.html#child_process_event_message).
-
-## Event: 'setup'
-
-* `settings` {Object}
-
-Emitted every time `.setupMaster()` is called.
-
-The `settings` object is the `cluster.settings` object at the time
-`.setupMaster()` was called and is advisory only, since multiple calls to
-`.setupMaster()` can be made in a single tick.
-
-If accuracy is important, use `cluster.settings`.
-
-## cluster.setupMaster([settings])
-
-* `settings` {Object}
-  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
-  * `args` {Array} string arguments passed to worker.
-    (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
-    (Default=`false`)
-
-`setupMaster` is used to change the default 'fork' behavior. Once called,
-the settings will be present in `cluster.settings`.
-
-Note that:
-
-* any settings changes only affect future calls to `.fork()` and have no
-  effect on workers that are already running
-* The *only* attribute of a worker that cannot be set via `.setupMaster()` is
-  the `env` passed to `.fork()`
-* the defaults above apply to the first call only, the defaults for later
-  calls is the current value at the time of `cluster.setupMaster()` is called
-
-Example:
-
-    var cluster = require('cluster');
-    cluster.setupMaster({
-      exec: 'worker.js',
-      args: ['--use', 'https'],
-      silent: true
-    });
-    cluster.fork(); // https worker
-    cluster.setupMaster({
-      args: ['--use', 'http']
-    });
-    cluster.fork(); // http worker
-
-This can only be called from the master process.
-
-## cluster.fork([env])
-
-* `env` {Object} Key/value pairs to add to worker process environment.
-* return {Worker object}
-
-Spawn a new worker process.
-
-This can only be called from the master process.
-
-## cluster.disconnect([callback])
-
-* `callback` {Function} called when all workers are disconnected and handles are
-  closed
-
-Calls `.disconnect()` on each worker in `cluster.workers`.
-
-When they are disconnected all internal handles will be closed, allowing the
-master process to die gracefully if no other event is waiting.
-
-The method takes an optional callback argument which will be called when finished.
-
-This can only be called from the master process.
-
-## cluster.worker
-
-* {Object}
-
-A reference to the current worker object. Not available in the master process.
-
-    var cluster = require('cluster');
-
-    if (cluster.isMaster) {
-      console.log('I am master');
-      cluster.fork();
-      cluster.fork();
-    } else if (cluster.isWorker) {
-      console.log('I am worker #' + cluster.worker.id);
-    }
-
-## cluster.workers
-
-* {Object}
-
-A hash that stores the active worker objects, keyed by `id` field. Makes it
-easy to loop through all the workers. It is only available in the master
-process.
-
-A worker is removed from cluster.workers after the worker has disconnected _and_
-exited. The order between these two events cannot be determined in advance.
-However, it is guaranteed that the removal from the cluster.workers list happens
-before last `'disconnect'` or `'exit'` event is emitted.
-
-    // Go through all workers
-    function eachWorker(callback) {
-      for (var id in cluster.workers) {
-        callback(cluster.workers[id]);
-      }
-    }
-    eachWorker(function(worker) {
-      worker.send('big announcement to all workers');
-    });
-
-Should you wish to reference a worker over a communication channel, using
-the worker's unique id is the easiest way to find the worker.
-
-    socket.on('data', function(id) {
-      var worker = cluster.workers[id];
-    });
 
 ## Class: Worker
 
@@ -380,161 +109,52 @@ A Worker object contains all public information and method about a worker.
 In the master it can be obtained using `cluster.workers`. In a worker
 it can be obtained using `cluster.worker`.
 
-### worker.id
+### Event: 'disconnect'
 
-* {Number}
+Similar to the `cluster.on('disconnect')` event, but specific to this worker.
 
-Each new worker is given its own unique id, this id is stored in the
-`id`.
+    cluster.fork().on('disconnect', function() {
+      // Worker has disconnected
+    });
 
-While a worker is alive, this is the key that indexes it in
-cluster.workers
+### Event: 'error'
 
-### worker.process
+This event is the same as the one provided by `child_process.fork()`.
 
-* {ChildProcess object}
+In a worker you can also use `process.on('error')`.
 
-All workers are created using `child_process.fork()`, the returned object
-from this function is stored as `.process`. In a worker, the global `process`
-is stored.
+[ChildProcess.send()]: child_process.html#child_process_child_send_message_sendhandle_callback
 
-See: [Child Process module](
-child_process.html#child_process_child_process_fork_modulepath_args_options)
+### Event: 'exit'
 
-Note that workers will call `process.exit(0)` if the `'disconnect'` event occurs
-on `process` and `.suicide` is not `true`. This protects against accidental
-disconnection.
+* `code` {Number} the exit code, if it exited normally.
+* `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
+  the process to be killed.
 
-### worker.suicide
+Similar to the `cluster.on('exit')` event, but specific to this worker.
 
-* {Boolean}
-
-Set by calling `.kill()` or `.disconnect()`, until then it is `undefined`.
-
-The boolean `worker.suicide` lets you distinguish between voluntary and accidental
-exit, the master may choose not to respawn a worker based on this value.
-
-    cluster.on('exit', function(worker, code, signal) {
-      if (worker.suicide === true) {
-        console.log('Oh, it was just suicide\' – no need to worry').
+    var worker = cluster.fork();
+    worker.on('exit', function(code, signal) {
+      if( signal ) {
+        console.log("worker was killed by signal: "+signal);
+      } else if( code !== 0 ) {
+        console.log("worker exited with error code: "+code);
+      } else {
+        console.log("worker success!");
       }
     });
 
-    // kill worker
-    worker.kill();
+### Event: 'listening'
 
-### worker.send(message[, sendHandle][, callback])
+* `address` {Object}
 
-* `message` {Object}
-* `sendHandle` {Handle object}
-* `callback` {Function}
-* Return: Boolean
+Similar to the `cluster.on('listening')` event, but specific to this worker.
 
-Send a message to a worker or master, optionally with a handle.
+    cluster.fork().on('listening', function(address) {
+      // Worker is listening
+    });
 
-In the master this sends a message to a specific worker. It is identical to
-[ChildProcess.send()][].
-
-In a worker this sends a message to the master. It is identical to
-`process.send()`.
-
-This example will echo back all messages from the master:
-
-    if (cluster.isMaster) {
-      var worker = cluster.fork();
-      worker.send('hi there');
-
-    } else if (cluster.isWorker) {
-      process.on('message', function(msg) {
-        process.send(msg);
-      });
-    }
-
-### worker.kill([signal='SIGTERM'])
-
-* `signal` {String} Name of the kill signal to send to the worker
-  process.
-
-This function will kill the worker. In the master, it does this by disconnecting
-the `worker.process`, and once disconnected, killing with `signal`. In the
-worker, it does it by disconnecting the channel, and then exiting with code `0`.
-
-Causes `.suicide` to be set.
-
-This method is aliased as `worker.destroy()` for backwards compatibility.
-
-Note that in a worker, `process.kill()` exists, but it is not this function,
-it is [kill](process.html#process_process_kill_pid_signal).
-
-### worker.disconnect()
-
-In a worker, this function will close all servers, wait for the 'close' event on
-those servers, and then disconnect the IPC channel.
-
-In the master, an internal message is sent to the worker causing it to call
-`.disconnect()` on itself.
-
-Causes `.suicide` to be set.
-
-Note that after a server is closed, it will no longer accept new connections,
-but connections may be accepted by any other listening worker. Existing
-connections will be allowed to close as usual. When no more connections exist,
-see [server.close()](net.html#net_event_close), the IPC channel to the worker
-will close allowing it to die gracefully.
-
-The above applies *only* to server connections, client connections are not
-automatically closed by workers, and disconnect does not wait for them to close
-before exiting.
-
-Note that in a worker, `process.disconnect` exists, but it is not this function,
-it is [disconnect](child_process.html#child_process_child_disconnect).
-
-Because long living server connections may block workers from disconnecting, it
-may be useful to send a message, so application specific actions may be taken to
-close them. It also may be useful to implement a timeout, killing a worker if
-the `disconnect` event has not been emitted after some time.
-
-    if (cluster.isMaster) {
-      var worker = cluster.fork();
-      var timeout;
-
-      worker.on('listening', function(address) {
-        worker.send('shutdown');
-        worker.disconnect();
-        timeout = setTimeout(function() {
-          worker.kill();
-        }, 2000);
-      });
-
-      worker.on('disconnect', function() {
-        clearTimeout(timeout);
-      });
-
-    } else if (cluster.isWorker) {
-      var net = require('net');
-      var server = net.createServer(function(socket) {
-        // connections never end
-      });
-
-      server.listen(8000);
-
-      process.on('message', function(msg) {
-        if(msg === 'shutdown') {
-          // initiate graceful close of any connections to server
-        }
-      });
-    }
-
-### worker.isDead()
-
-This function returns `true` if the worker's process has terminated (either
-because of exiting or being signaled). Otherwise, it returns `false`.
-
-### worker.isConnected()
-
-This function returns `true` if the worker is connected to its master via its IPC
-channel, `false` otherwise. A worker is connected to its master after it's been
-created. It is disconnected after the `disconnect` event is emitted.
+It is not emitted in the worker.
 
 ### Event: 'message'
 
@@ -599,49 +219,431 @@ Similar to the `cluster.on('online')` event, but specific to this worker.
 
 It is not emitted in the worker.
 
-### Event: 'listening'
+### worker.disconnect()
 
-* `address` {Object}
+In a worker, this function will close all servers, wait for the 'close' event on
+those servers, and then disconnect the IPC channel.
 
-Similar to the `cluster.on('listening')` event, but specific to this worker.
+In the master, an internal message is sent to the worker causing it to call
+`.disconnect()` on itself.
 
-    cluster.fork().on('listening', function(address) {
-      // Worker is listening
+Causes `.suicide` to be set.
+
+Note that after a server is closed, it will no longer accept new connections,
+but connections may be accepted by any other listening worker. Existing
+connections will be allowed to close as usual. When no more connections exist,
+see [server.close()](net.html#net_event_close), the IPC channel to the worker
+will close allowing it to die gracefully.
+
+The above applies *only* to server connections, client connections are not
+automatically closed by workers, and disconnect does not wait for them to close
+before exiting.
+
+Note that in a worker, `process.disconnect` exists, but it is not this function,
+it is [disconnect](child_process.html#child_process_child_disconnect).
+
+Because long living server connections may block workers from disconnecting, it
+may be useful to send a message, so application specific actions may be taken to
+close them. It also may be useful to implement a timeout, killing a worker if
+the `disconnect` event has not been emitted after some time.
+
+    if (cluster.isMaster) {
+      var worker = cluster.fork();
+      var timeout;
+
+      worker.on('listening', function(address) {
+        worker.send('shutdown');
+        worker.disconnect();
+        timeout = setTimeout(function() {
+          worker.kill();
+        }, 2000);
+      });
+
+      worker.on('disconnect', function() {
+        clearTimeout(timeout);
+      });
+
+    } else if (cluster.isWorker) {
+      var net = require('net');
+      var server = net.createServer(function(socket) {
+        // connections never end
+      });
+
+      server.listen(8000);
+
+      process.on('message', function(msg) {
+        if(msg === 'shutdown') {
+          // initiate graceful close of any connections to server
+        }
+      });
+    }
+
+### worker.id
+
+* {Number}
+
+Each new worker is given its own unique id, this id is stored in the
+`id`.
+
+While a worker is alive, this is the key that indexes it in
+cluster.workers
+
+### worker.isConnected()
+
+This function returns `true` if the worker is connected to its master via its IPC
+channel, `false` otherwise. A worker is connected to its master after it's been
+created. It is disconnected after the `disconnect` event is emitted.
+
+### worker.isDead()
+
+This function returns `true` if the worker's process has terminated (either
+because of exiting or being signaled). Otherwise, it returns `false`.
+
+### worker.kill([signal='SIGTERM'])
+
+* `signal` {String} Name of the kill signal to send to the worker
+  process.
+
+This function will kill the worker. In the master, it does this by disconnecting
+the `worker.process`, and once disconnected, killing with `signal`. In the
+worker, it does it by disconnecting the channel, and then exiting with code `0`.
+
+Causes `.suicide` to be set.
+
+This method is aliased as `worker.destroy()` for backwards compatibility.
+
+Note that in a worker, `process.kill()` exists, but it is not this function,
+it is [kill](process.html#process_process_kill_pid_signal).
+
+### worker.process
+
+* {ChildProcess object}
+
+All workers are created using `child_process.fork()`, the returned object
+from this function is stored as `.process`. In a worker, the global `process`
+is stored.
+
+See: [Child Process module](
+child_process.html#child_process_child_process_fork_modulepath_args_options)
+
+Note that workers will call `process.exit(0)` if the `'disconnect'` event occurs
+on `process` and `.suicide` is not `true`. This protects against accidental
+disconnection.
+
+### worker.send(message[, sendHandle][, callback])
+
+* `message` {Object}
+* `sendHandle` {Handle object}
+* `callback` {Function}
+* Return: Boolean
+
+Send a message to a worker or master, optionally with a handle.
+
+In the master this sends a message to a specific worker. It is identical to
+[ChildProcess.send()][].
+
+In a worker this sends a message to the master. It is identical to
+`process.send()`.
+
+This example will echo back all messages from the master:
+
+    if (cluster.isMaster) {
+      var worker = cluster.fork();
+      worker.send('hi there');
+
+    } else if (cluster.isWorker) {
+      process.on('message', function(msg) {
+        process.send(msg);
+      });
+    }
+
+### worker.suicide
+
+* {Boolean}
+
+Set by calling `.kill()` or `.disconnect()`, until then it is `undefined`.
+
+The boolean `worker.suicide` lets you distinguish between voluntary and accidental
+exit, the master may choose not to respawn a worker based on this value.
+
+    cluster.on('exit', function(worker, code, signal) {
+      if (worker.suicide === true) {
+        console.log('Oh, it was just suicide\' – no need to worry').
+      }
     });
 
-It is not emitted in the worker.
+    // kill worker
+    worker.kill();
 
-### Event: 'disconnect'
+## Event: 'disconnect'
 
-Similar to the `cluster.on('disconnect')` event, but specific to this worker.
+* `worker` {Worker object}
 
-    cluster.fork().on('disconnect', function() {
-      // Worker has disconnected
+Emitted after the worker IPC channel has disconnected. This can occur when a
+worker exits gracefully, is killed, or is disconnected manually (such as with
+worker.disconnect()).
+
+There may be a delay between the `disconnect` and `exit` events.  These events
+can be used to detect if the process is stuck in a cleanup or if there are
+long-living connections.
+
+    cluster.on('disconnect', function(worker) {
+      console.log('The worker #' + worker.id + ' has disconnected');
     });
 
-### Event: 'exit'
+## Event: 'exit'
 
+* `worker` {Worker object}
 * `code` {Number} the exit code, if it exited normally.
 * `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
   the process to be killed.
 
-Similar to the `cluster.on('exit')` event, but specific to this worker.
+When any of the workers die the cluster module will emit the 'exit' event.
 
-    var worker = cluster.fork();
-    worker.on('exit', function(code, signal) {
-      if( signal ) {
-        console.log("worker was killed by signal: "+signal);
-      } else if( code !== 0 ) {
-        console.log("worker exited with error code: "+code);
-      } else {
-        console.log("worker success!");
-      }
+This can be used to restart the worker by calling `.fork()` again.
+
+    cluster.on('exit', function(worker, code, signal) {
+      console.log('worker %d died (%s). restarting...',
+        worker.process.pid, signal || code);
+      cluster.fork();
     });
 
-### Event: 'error'
+See [child_process event: 'exit'](child_process.html#child_process_event_exit).
 
-This event is the same as the one provided by `child_process.fork()`.
+## Event: 'fork'
 
-In a worker you can also use `process.on('error')`.
+* `worker` {Worker object}
 
-[ChildProcess.send()]: child_process.html#child_process_child_send_message_sendhandle_callback
+When a new worker is forked the cluster module will emit a 'fork' event.
+This can be used to log worker activity, and create your own timeout.
+
+    var timeouts = [];
+    function errorMsg() {
+      console.error("Something must be wrong with the connection ...");
+    }
+
+    cluster.on('fork', function(worker) {
+      timeouts[worker.id] = setTimeout(errorMsg, 2000);
+    });
+    cluster.on('listening', function(worker, address) {
+      clearTimeout(timeouts[worker.id]);
+    });
+    cluster.on('exit', function(worker, code, signal) {
+      clearTimeout(timeouts[worker.id]);
+      errorMsg();
+    });
+
+## Event: 'listening'
+
+* `worker` {Worker object}
+* `address` {Object}
+
+After calling `listen()` from a worker, when the 'listening' event is emitted on
+the server, a listening event will also be emitted on `cluster` in the master.
+
+The event handler is executed with two arguments, the `worker` contains the worker
+object and the `address` object contains the following connection properties:
+`address`, `port` and `addressType`. This is very useful if the worker is listening
+on more than one address.
+
+    cluster.on('listening', function(worker, address) {
+      console.log("A worker is now connected to " + address.address + ":" + address.port);
+    });
+
+The `addressType` is one of:
+
+* `4` (TCPv4)
+* `6` (TCPv6)
+* `-1` (unix domain socket)
+* `"udp4"` or `"udp6"` (UDP v4 or v6)
+
+## Event: 'message'
+
+* `worker` {Worker object}
+* `message` {Object}
+
+Emitted when any worker receives a message.
+
+See
+[child_process event: 'message'](child_process.html#child_process_event_message).
+
+## Event: 'online'
+
+* `worker` {Worker object}
+
+After forking a new worker, the worker should respond with an online message.
+When the master receives an online message it will emit this event.
+The difference between 'fork' and 'online' is that fork is emitted when the
+master forks a worker, and 'online' is emitted when the worker is running.
+
+    cluster.on('online', function(worker) {
+      console.log("Yay, the worker responded after it was forked");
+    });
+
+## Event: 'setup'
+
+* `settings` {Object}
+
+Emitted every time `.setupMaster()` is called.
+
+The `settings` object is the `cluster.settings` object at the time
+`.setupMaster()` was called and is advisory only, since multiple calls to
+`.setupMaster()` can be made in a single tick.
+
+If accuracy is important, use `cluster.settings`.
+
+## cluster.disconnect([callback])
+
+* `callback` {Function} called when all workers are disconnected and handles are
+  closed
+
+Calls `.disconnect()` on each worker in `cluster.workers`.
+
+When they are disconnected all internal handles will be closed, allowing the
+master process to die gracefully if no other event is waiting.
+
+The method takes an optional callback argument which will be called when finished.
+
+This can only be called from the master process.
+
+## cluster.fork([env])
+
+* `env` {Object} Key/value pairs to add to worker process environment.
+* return {Worker object}
+
+Spawn a new worker process.
+
+This can only be called from the master process.
+
+## cluster.isMaster
+
+* {Boolean}
+
+True if the process is a master. This is determined
+by the `process.env.NODE_UNIQUE_ID`. If `process.env.NODE_UNIQUE_ID` is
+undefined, then `isMaster` is `true`.
+
+## cluster.isWorker
+
+* {Boolean}
+
+True if the process is not a master (it is the negation of `cluster.isMaster`).
+
+## cluster.schedulingPolicy
+
+The scheduling policy, either `cluster.SCHED_RR` for round-robin or
+`cluster.SCHED_NONE` to leave it to the operating system. This is a
+global setting and effectively frozen once you spawn the first worker
+or call `cluster.setupMaster()`, whatever comes first.
+
+`SCHED_RR` is the default on all operating systems except Windows.
+Windows will change to `SCHED_RR` once libuv is able to effectively
+distribute IOCP handles without incurring a large performance hit.
+
+`cluster.schedulingPolicy` can also be set through the
+`NODE_CLUSTER_SCHED_POLICY` environment variable. Valid
+values are `"rr"` and `"none"`.
+
+## cluster.settings
+
+* {Object}
+  * `execArgv` {Array} list of string arguments passed to the Node.js
+    executable. (Default=`process.execArgv`)
+  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `args` {Array} string arguments passed to worker.
+    (Default=`process.argv.slice(2)`)
+  * `silent` {Boolean} whether or not to send output to parent's stdio.
+    (Default=`false`)
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+
+After calling `.setupMaster()` (or `.fork()`) this settings object will contain
+the settings, including the default values.
+
+It is effectively frozen after being set, because `.setupMaster()` can
+only be called once.
+
+This object is not supposed to be changed or set manually, by you.
+
+## cluster.setupMaster([settings])
+
+* `settings` {Object}
+  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `args` {Array} string arguments passed to worker.
+    (Default=`process.argv.slice(2)`)
+  * `silent` {Boolean} whether or not to send output to parent's stdio.
+    (Default=`false`)
+
+`setupMaster` is used to change the default 'fork' behavior. Once called,
+the settings will be present in `cluster.settings`.
+
+Note that:
+
+* any settings changes only affect future calls to `.fork()` and have no
+  effect on workers that are already running
+* The *only* attribute of a worker that cannot be set via `.setupMaster()` is
+  the `env` passed to `.fork()`
+* the defaults above apply to the first call only, the defaults for later
+  calls is the current value at the time of `cluster.setupMaster()` is called
+
+Example:
+
+    var cluster = require('cluster');
+    cluster.setupMaster({
+      exec: 'worker.js',
+      args: ['--use', 'https'],
+      silent: true
+    });
+    cluster.fork(); // https worker
+    cluster.setupMaster({
+      args: ['--use', 'http']
+    });
+    cluster.fork(); // http worker
+
+This can only be called from the master process.
+
+## cluster.worker
+
+* {Object}
+
+A reference to the current worker object. Not available in the master process.
+
+    var cluster = require('cluster');
+
+    if (cluster.isMaster) {
+      console.log('I am master');
+      cluster.fork();
+      cluster.fork();
+    } else if (cluster.isWorker) {
+      console.log('I am worker #' + cluster.worker.id);
+    }
+
+## cluster.workers
+
+* {Object}
+
+A hash that stores the active worker objects, keyed by `id` field. Makes it
+easy to loop through all the workers. It is only available in the master
+process.
+
+A worker is removed from cluster.workers after the worker has disconnected _and_
+exited. The order between these two events cannot be determined in advance.
+However, it is guaranteed that the removal from the cluster.workers list happens
+before last `'disconnect'` or `'exit'` event is emitted.
+
+    // Go through all workers
+    function eachWorker(callback) {
+      for (var id in cluster.workers) {
+        callback(cluster.workers[id]);
+      }
+    }
+    eachWorker(function(worker) {
+      worker.send('big announcement to all workers');
+    });
+
+Should you wish to reference a worker over a communication channel, using
+the worker's unique id is the easiest way to find the worker.
+
+    socket.on('data', function(id) {
+      var worker = cluster.workers[id];
+    });

--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -10,101 +10,6 @@ sent to stdout or stderr.
 For ease of use, `console` is defined as a global object and can be used
 directly without `require`.
 
-## console
-
-* {Object}
-
-<!--type=global-->
-
-For printing to stdout and stderr. Similar to the console object functions
-provided by most web browsers, here the output is sent to stdout or stderr.
-
-The console functions are synchronous when the destination is a terminal or
-a file (to avoid lost messages in case of premature exit) and asynchronous
-when it's a pipe (to avoid blocking for long periods of time).
-
-That is, in the following example, stdout is non-blocking while stderr
-is blocking:
-
-    $ node script.js 2> error.log | tee info.log
-
-In daily use, the blocking/non-blocking dichotomy is not something you
-should worry about unless you log huge amounts of data.
-
-
-### console.log([data][, ...])
-
-Prints to stdout with newline. This function can take multiple arguments in a
-`printf()`-like way. Example:
-
-    var count = 5;
-    console.log('count: %d', count);
-    // prints 'count: 5'
-
-If formatting elements are not found in the first string then `util.inspect`
-is used on each argument.  See [util.format()][] for more information.
-
-### console.info([data][, ...])
-
-Same as `console.log`.
-
-### console.error([data][, ...])
-
-Same as `console.log` but prints to stderr.
-
-### console.warn([data][, ...])
-
-Same as `console.error`.
-
-### console.dir(obj[, options])
-
-Uses `util.inspect` on `obj` and prints resulting string to stdout. This function
-bypasses any custom `inspect()` function on `obj`. An optional *options* object
-may be passed that alters certain aspects of the formatted string:
-
-- `showHidden` - if `true` then the object's non-enumerable and symbol
-properties will be shown too. Defaults to `false`.
-
-- `depth` - tells `inspect` how many times to recurse while formatting the
-object. This is useful for inspecting large complicated objects. Defaults to
-`2`. To make it recurse indefinitely pass `null`.
-
-- `colors` - if `true`, then the output will be styled with ANSI color codes.
-Defaults to `false`. Colors are customizable, see below.
-
-### console.time(label)
-
-Used to calculate the duration of a specific operation. To start a timer, call
-the `console.time()` method, giving it a name as only parameter. To stop the
-timer, and to get the elapsed time in milliseconds, just call the
-[`console.timeEnd()`](#console_console_timeend_label) method, again passing the
-timer's name as the parameter.
-
-### console.timeEnd(label)
-
-Stops a timer that was previously started by calling
-[`console.time()`](#console_console_time_label) and print the result to the
-console.
-
-Example:
-
-    console.time('100-elements');
-    for (var i = 0; i < 100; i++) {
-      ;
-    }
-    console.timeEnd('100-elements');
-    // prints 100-elements: 262ms
-
-### console.trace(message[, ...])
-
-Print to stderr `'Trace :'`, followed by the formatted message and stack trace
-to the current position.
-
-### console.assert(value[, message][, ...])
-
-Similar to [assert.ok()][], but the error message is formatted as
-`util.format(message...)`.
-
 ## Class: Console
 
 <!--type=class-->
@@ -140,3 +45,97 @@ The global `console` is a special `Console` whose output is sent to
 
 [assert.ok()]: assert.html#assert_assert_value_message_assert_ok_value_message
 [util.format()]: util.html#util_util_format_format
+
+## console
+
+* {Object}
+
+<!--type=global-->
+
+For printing to stdout and stderr. Similar to the console object functions
+provided by most web browsers, here the output is sent to stdout or stderr.
+
+The console functions are synchronous when the destination is a terminal or
+a file (to avoid lost messages in case of premature exit) and asynchronous
+when it's a pipe (to avoid blocking for long periods of time).
+
+That is, in the following example, stdout is non-blocking while stderr
+is blocking:
+
+    $ node script.js 2> error.log | tee info.log
+
+In daily use, the blocking/non-blocking dichotomy is not something you
+should worry about unless you log huge amounts of data.
+
+### console.assert(value[, message][, ...])
+
+Similar to [assert.ok()][], but the error message is formatted as
+`util.format(message...)`.
+
+### console.dir(obj[, options])
+
+Uses `util.inspect` on `obj` and prints resulting string to stdout. This function
+bypasses any custom `inspect()` function on `obj`. An optional *options* object
+may be passed that alters certain aspects of the formatted string:
+
+- `showHidden` - if `true` then the object's non-enumerable and symbol
+properties will be shown too. Defaults to `false`.
+
+- `depth` - tells `inspect` how many times to recurse while formatting the
+object. This is useful for inspecting large complicated objects. Defaults to
+`2`. To make it recurse indefinitely pass `null`.
+
+- `colors` - if `true`, then the output will be styled with ANSI color codes.
+Defaults to `false`. Colors are customizable, see below.
+
+### console.error([data][, ...])
+
+Same as `console.log` but prints to stderr.
+
+### console.info([data][, ...])
+
+Same as `console.log`.
+
+### console.log([data][, ...])
+
+Prints to stdout with newline. This function can take multiple arguments in a
+`printf()`-like way. Example:
+
+    var count = 5;
+    console.log('count: %d', count);
+    // prints 'count: 5'
+
+If formatting elements are not found in the first string then `util.inspect`
+is used on each argument.  See [util.format()][] for more information.
+
+### console.time(label)
+
+Used to calculate the duration of a specific operation. To start a timer, call
+the `console.time()` method, giving it a name as only parameter. To stop the
+timer, and to get the elapsed time in milliseconds, just call the
+[`console.timeEnd()`](#console_console_timeend_label) method, again passing the
+timer's name as the parameter.
+
+### console.timeEnd(label)
+
+Stops a timer that was previously started by calling
+[`console.time()`](#console_console_time_label) and print the result to the
+console.
+
+Example:
+
+    console.time('100-elements');
+    for (var i = 0; i < 100; i++) {
+      ;
+    }
+    console.timeEnd('100-elements');
+    // prints 100-elements: 262ms
+
+### console.trace(message[, ...])
+
+Print to stderr `'Trace :'`, followed by the formatted message and stack trace
+to the current position.
+
+### console.warn([data][, ...])
+
+Same as `console.error`.

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -54,6 +54,11 @@ There are subtle consequences in choosing one or another, please consult the
 [Implementation considerations section](#dns_implementation_considerations)
 for more information.
 
+## dns.getServers()
+
+Returns an array of IP addresses as strings that are currently being used for
+resolution
+
 ## dns.lookup(hostname[, options], callback)
 
 Resolves a hostname (e.g. `'google.com'`) into the first found A (IPv4) or
@@ -152,6 +157,11 @@ The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but on
 
 The same as [`dns.resolve4()`](#dns_dns_resolve4_hostname_callback) except for IPv6 queries (an `AAAA` query).
 
+## dns.resolveCname(hostname, callback)
+
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for canonical name records (`CNAME`
+records). `addresses` is an array of the canonical name records available for
+`hostname` (e.g., `['bar.example.com']`).
 
 ## dns.resolveMx(hostname, callback)
 
@@ -160,20 +170,11 @@ The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but on
 `addresses` is an array of MX records, each with a priority and an exchange
 attribute (e.g. `[{'priority': 10, 'exchange': 'mx.example.com'},...]`).
 
-## dns.resolveTxt(hostname, callback)
+## dns.resolveNs(hostname, callback)
 
-The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for text queries (`TXT` records).
-`addresses` is a 2-d array of the text records available for `hostname` (e.g.,
-`[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`). Each sub-array contains TXT chunks of
-one record. Depending on the use case, the could be either joined together or
-treated separately.
-
-## dns.resolveSrv(hostname, callback)
-
-The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for service records (`SRV` records).
-`addresses` is an array of the SRV records available for `hostname`. Properties
-of SRV records are priority, weight, port, and name (e.g.,
-`[{'priority': 10, 'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]`).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for name server records (`NS` records).
+`addresses` is an array of the name server records available for `hostname`
+(e.g., `['ns1.example.com', 'ns2.example.com']`).
 
 ## dns.resolveSoa(hostname, callback)
 
@@ -194,17 +195,20 @@ The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but on
 }
 ```
 
-## dns.resolveNs(hostname, callback)
+## dns.resolveSrv(hostname, callback)
 
-The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for name server records (`NS` records).
-`addresses` is an array of the name server records available for `hostname`
-(e.g., `['ns1.example.com', 'ns2.example.com']`).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for service records (`SRV` records).
+`addresses` is an array of the SRV records available for `hostname`. Properties
+of SRV records are priority, weight, port, and name (e.g.,
+`[{'priority': 10, 'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]`).
 
-## dns.resolveCname(hostname, callback)
+## dns.resolveTxt(hostname, callback)
 
-The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for canonical name records (`CNAME`
-records). `addresses` is an array of the canonical name records available for
-`hostname` (e.g., `['bar.example.com']`).
+The same as [`dns.resolve()`](#dns_dns_resolve_hostname_rrtype_callback), but only for text queries (`TXT` records).
+`addresses` is a 2-d array of the text records available for `hostname` (e.g.,
+`[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`). Each sub-array contains TXT chunks of
+one record. Depending on the use case, the could be either joined together or
+treated separately.
 
 ## dns.reverse(ip, callback)
 
@@ -214,11 +218,6 @@ The callback has arguments `(err, hostnames)`.
 
 On error, `err` is an `Error` object, where `err.code` is
 one of the error codes listed below.
-
-## dns.getServers()
-
-Returns an array of IP addresses as strings that are currently being used for
-resolution
 
 ## dns.setServers(servers)
 


### PR DESCRIPTION
As a follow up to #3651, and to #393, I've started from the top and am working my way down.

**This is a WIP! Against v4.x!**

I am posting this now because it is a big diff and will need eyes.

Docs that have been completed:
- [x] assert
- [x] buffer
- [x] child_process
- [x] cluster
- [x] console
- [ ] crypto
- [x] dns
- [ ] _filling in as I go_

Help is more than welcome!