### PR TITLE
test: fix test-module-loading-error for AlpineLinux

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -9,6 +9,7 @@ var error_desc = {
   linux: 'file too short',
   sunos: 'unknown file type'
 };
+var musl_errno_enoexec = 'Exec format error';
 
 var dlerror_msg = error_desc[process.platform];
 
@@ -20,6 +21,9 @@ if (!dlerror_msg) {
 try {
   require('../fixtures/module-loading-error.node');
 } catch (e) {
+  if (platform === 'linux' && e.toString().indexOf(musl_errno_enoexec) !== -1) {
+    dlerror_msg = musl_errno_enoexec;
+  }
   assert.notEqual(e.toString().indexOf(dlerror_msg), -1);
 }
 


### PR DESCRIPTION
node's testsuite fails only 3 cases on AlpineLinux: https://github.com/nodejs/docker-iojs/issues/44#issuecomment-153606107

Please let us know if it is a good idea to tackle this even if we are not officially supporting a musl-libc build of node.

Here is a patch for one of those tests.

Thanks!