### PR TITLE
doc: fix the exception description

### DIFF
--- a/doc/api/errors.markdown
+++ b/doc/api/errors.markdown
@@ -242,7 +242,7 @@ by other contexts.
 
 <!--type=misc-->
 
-A JavaScript "exception" is a value that is thrown as a result of an invalid operation or
+A JavaScript exception is a value that is thrown as a result of an invalid operation or
 as the target of a `throw` statement. While it is not required that these values are instances of
 `Error` or classes which inherit from `Error`, all exceptions thrown by Node.js or the JavaScript
 runtime *will* be instances of Error.

--- a/doc/api/errors.markdown
+++ b/doc/api/errors.markdown
@@ -243,8 +243,9 @@ by other contexts.
 <!--type=misc-->
 
 A JavaScript "exception" is a value that is thrown as a result of an invalid operation or
-as the target of a `throw` statement. While it is not required that these values inherit from
-`Error`, all exceptions thrown by Node.js or the JavaScript runtime *will* be instances of Error.
+as the target of a `throw` statement. While it is not required that these values are instances of
+`Error` or classes which inherit from `Error`, all exceptions thrown by Node.js or the JavaScript
+runtime *will* be instances of Error.
 
 Some exceptions are *unrecoverable* at the JavaScript layer. These exceptions will always bring
 down the process. These are usually failed `assert()` checks or `abort()` calls in the C++ layer.


### PR DESCRIPTION
A value shouldn't be described as doing inherit from some class, more
strictly, the value is an instance of the class `Error`.

Just read the new documentation of Node.js, and raise this up :-)

/cc @chrisdickinson