### PR TITLE
build: omit -gline-tables-only for --enable-asan

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -183,7 +183,6 @@
           '-fsanitize=address',
           '-DLEAK_SANITIZER'
         ],
-        'cflags_cc+': [ '-gline-tables-only' ],
         'cflags!': [ '-fomit-frame-pointer' ],
         'ldflags': [ '-fsanitize=address' ],
       }],


### PR DESCRIPTION
`-gline-tables-only` is a clang-only flag.  Drop it, it's not needed for
address sanitizer-enabled builds and it makes it impossible to build
with gcc.

Fixes: https://github.com/nodejs/node/issues/3656

No CI, we don't build with ASAN yet.