### PR TITLE
doc: add warning about Windows process groups

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -548,7 +548,8 @@ string describing the signal to send.  Signal names are strings like
 See [Signal Events](#process_signal_events) and kill(2) for more information.
 
 Will throw an error if target does not exist, and as a special case, a signal
-of `0` can be used to test for the existence of a process.
+of `0` can be used to test for the existence of a process. Windows platforms
+will throw an error if the `pid` is used to kill a process group.
 
 Note that even though the name of this function is `process.kill`, it is really
 just a signal sender, like the `kill` system call.  The signal sent may do


### PR DESCRIPTION
This commit adds a warning for Windows platforms. `process.kill` wont kill a process group on Windows and instead it throws an error.

Ref.-Issue: #3617