### PR TITLE
upgrade npm to 3.3.12

### DIFF
--- a/deps/npm/html/doc/README.html
+++ b/deps/npm/html/doc/README.html
@@ -140,7 +140,7 @@ specific purpose, or lack of malice in any given npm package.</p>
 <p>If you have a complaint about a package in the public npm registry,
 and cannot <a href="https://docs.npmjs.com/misc/disputes">resolve it with the package
 owner</a>, please email
-<a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#111;&#x3a;&#x73;&#117;&#x70;&#112;&#x6f;&#114;&#116;&#64;&#110;&#x70;&#109;&#106;&#115;&#46;&#x63;&#x6f;&#109;">&#x73;&#117;&#x70;&#112;&#x6f;&#114;&#116;&#64;&#110;&#x70;&#109;&#106;&#115;&#46;&#x63;&#x6f;&#109;</a> and explain the situation.</p>
+<a href="&#109;&#x61;&#x69;&#x6c;&#116;&#x6f;&#x3a;&#115;&#117;&#x70;&#112;&#x6f;&#114;&#116;&#x40;&#110;&#x70;&#x6d;&#x6a;&#115;&#46;&#x63;&#x6f;&#x6d;">&#115;&#117;&#x70;&#112;&#x6f;&#114;&#116;&#x40;&#110;&#x70;&#x6d;&#x6a;&#115;&#46;&#x63;&#x6f;&#x6d;</a> and explain the situation.</p>
 <p>Any data published to The npm Registry (including user account
 information) may be removed or modified at the sole discretion of the
 npm server administrators.</p>
@@ -183,5 +183,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@3.3.10</p>
+<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-access.html
+++ b/deps/npm/html/doc/cli/npm-access.html
@@ -84,5 +84,5 @@ with an HTTP 402 status code (logically enough), unless you use
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-access &mdash; npm@3.3.10</p>
+<p id="footer">npm-access &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-adduser.html
+++ b/deps/npm/html/doc/cli/npm-adduser.html
@@ -68,5 +68,5 @@ precedence over any global configuration.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-adduser &mdash; npm@3.3.10</p>
+<p id="footer">npm-adduser &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-bin.html
+++ b/deps/npm/html/doc/cli/npm-bin.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@3.3.10</p>
+<p id="footer">npm-bin &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-bugs.html
+++ b/deps/npm/html/doc/cli/npm-bugs.html
@@ -53,5 +53,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@3.3.10</p>
+<p id="footer">npm-bugs &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-build.html
+++ b/deps/npm/html/doc/cli/npm-build.html
@@ -40,5 +40,5 @@ directly, run:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-build &mdash; npm@3.3.10</p>
+<p id="footer">npm-build &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-bundle.html
+++ b/deps/npm/html/doc/cli/npm-bundle.html
@@ -31,5 +31,5 @@ install packages into the local space.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bundle &mdash; npm@3.3.10</p>
+<p id="footer">npm-bundle &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-cache.html
+++ b/deps/npm/html/doc/cli/npm-cache.html
@@ -81,5 +81,5 @@ they do not make an HTTP request to the registry.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@3.3.10</p>
+<p id="footer">npm-cache &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-completion.html
+++ b/deps/npm/html/doc/cli/npm-completion.html
@@ -44,5 +44,5 @@ completions based on the arguments.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-completion &mdash; npm@3.3.10</p>
+<p id="footer">npm-completion &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-config.html
+++ b/deps/npm/html/doc/cli/npm-config.html
@@ -65,5 +65,5 @@ global config.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@3.3.10</p>
+<p id="footer">npm-config &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-dedupe.html
+++ b/deps/npm/html/doc/cli/npm-dedupe.html
@@ -59,5 +59,5 @@ result in new modules being installed.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dedupe &mdash; npm@3.3.10</p>
+<p id="footer">npm-dedupe &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-deprecate.html
+++ b/deps/npm/html/doc/cli/npm-deprecate.html
@@ -38,5 +38,5 @@ something like this:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@3.3.10</p>
+<p id="footer">npm-deprecate &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-dist-tag.html
+++ b/deps/npm/html/doc/cli/npm-dist-tag.html
@@ -77,5 +77,5 @@ begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dist-tag &mdash; npm@3.3.10</p>
+<p id="footer">npm-dist-tag &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-docs.html
+++ b/deps/npm/html/doc/cli/npm-docs.html
@@ -56,5 +56,5 @@ the current folder and use the <code>name</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@3.3.10</p>
+<p id="footer">npm-docs &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-edit.html
+++ b/deps/npm/html/doc/cli/npm-edit.html
@@ -49,5 +49,5 @@ or <code>&quot;notepad&quot;</code> on Windows.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@3.3.10</p>
+<p id="footer">npm-edit &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-explore.html
+++ b/deps/npm/html/doc/cli/npm-explore.html
@@ -49,5 +49,5 @@ Windows</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@3.3.10</p>
+<p id="footer">npm-explore &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-help-search.html
+++ b/deps/npm/html/doc/cli/npm-help-search.html
@@ -46,5 +46,5 @@ where the terms were found in the documentation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@3.3.10</p>
+<p id="footer">npm-help-search &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-help.html
+++ b/deps/npm/html/doc/cli/npm-help.html
@@ -51,5 +51,5 @@ matches are equivalent to specifying a topic name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help &mdash; npm@3.3.10</p>
+<p id="footer">npm-help &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-init.html
+++ b/deps/npm/html/doc/cli/npm-init.html
@@ -48,5 +48,5 @@ defaults and not prompt you for any options.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@3.3.10</p>
+<p id="footer">npm-init &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-install.html
+++ b/deps/npm/html/doc/cli/npm-install.html
@@ -295,5 +295,5 @@ affects a real use-case, it will be investigated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@3.3.10</p>
+<p id="footer">npm-install &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-link.html
+++ b/deps/npm/html/doc/cli/npm-link.html
@@ -73,5 +73,5 @@ include that scope, e.g.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@3.3.10</p>
+<p id="footer">npm-link &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-logout.html
+++ b/deps/npm/html/doc/cli/npm-logout.html
@@ -55,5 +55,5 @@ that registry at the same time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-logout &mdash; npm@3.3.10</p>
+<p id="footer">npm-logout &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-ls.html
+++ b/deps/npm/html/doc/cli/npm-ls.html
@@ -21,7 +21,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
-<pre><code>npm@3.3.10 /path/to/npm
+<pre><code>npm@3.3.12 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre><p>It will print out extraneous, missing, and invalid packages.</p>
@@ -104,5 +104,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@3.3.10</p>
+<p id="footer">npm-ls &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-outdated.html
+++ b/deps/npm/html/doc/cli/npm-outdated.html
@@ -67,5 +67,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@3.3.10</p>
+<p id="footer">npm-outdated &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-owner.html
+++ b/deps/npm/html/doc/cli/npm-owner.html
@@ -49,5 +49,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@3.3.10</p>
+<p id="footer">npm-owner &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-pack.html
+++ b/deps/npm/html/doc/cli/npm-pack.html
@@ -41,5 +41,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@3.3.10</p>
+<p id="footer">npm-pack &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-ping.html
+++ b/deps/npm/html/doc/cli/npm-ping.html
@@ -32,4 +32,4 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ping &mdash; npm@3.3.10</p>
+<p id="footer">npm-ping &mdash; npm@3.3.12</p>

--- a/deps/npm/html/doc/cli/npm-prefix.html
+++ b/deps/npm/html/doc/cli/npm-prefix.html
@@ -38,5 +38,5 @@ to contain a package.json file unless <code>-g</code> is also specified.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@3.3.10</p>
+<p id="footer">npm-prefix &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-prune.html
+++ b/deps/npm/html/doc/cli/npm-prune.html
@@ -40,5 +40,5 @@ negate <code>NODE_ENV</code> being set to <code>production</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@3.3.10</p>
+<p id="footer">npm-prune &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-publish.html
+++ b/deps/npm/html/doc/cli/npm-publish.html
@@ -68,5 +68,5 @@ it is removed with <a href="../cli/npm-unpublish.html">npm-unpublish(1)</a>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@3.3.10</p>
+<p id="footer">npm-publish &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-rebuild.html
+++ b/deps/npm/html/doc/cli/npm-rebuild.html
@@ -35,5 +35,5 @@ the new binary.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@3.3.10</p>
+<p id="footer">npm-rebuild &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-repo.html
+++ b/deps/npm/html/doc/cli/npm-repo.html
@@ -41,5 +41,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@3.3.10</p>
+<p id="footer">npm-repo &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-restart.html
+++ b/deps/npm/html/doc/cli/npm-restart.html
@@ -53,5 +53,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@3.3.10</p>
+<p id="footer">npm-restart &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-root.html
+++ b/deps/npm/html/doc/cli/npm-root.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@3.3.10</p>
+<p id="footer">npm-root &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-run-script.html
+++ b/deps/npm/html/doc/cli/npm-run-script.html
@@ -58,5 +58,5 @@ you should write:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@3.3.10</p>
+<p id="footer">npm-run-script &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-search.html
+++ b/deps/npm/html/doc/cli/npm-search.html
@@ -49,5 +49,5 @@ fall on multiple lines.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@3.3.10</p>
+<p id="footer">npm-search &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/cli/npm-shrinkwrap.html
@@ -169,5 +169,5 @@ contents rather than versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@3.3.10</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-star.html
+++ b/deps/npm/html/doc/cli/npm-star.html
@@ -36,5 +36,5 @@ a vaguely positive way to show that you care.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-star &mdash; npm@3.3.10</p>
+<p id="footer">npm-star &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-stars.html
+++ b/deps/npm/html/doc/cli/npm-stars.html
@@ -36,5 +36,5 @@ you will most certainly enjoy this command.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stars &mdash; npm@3.3.10</p>
+<p id="footer">npm-stars &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-start.html
+++ b/deps/npm/html/doc/cli/npm-start.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@3.3.10</p>
+<p id="footer">npm-start &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-stop.html
+++ b/deps/npm/html/doc/cli/npm-stop.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@3.3.10</p>
+<p id="footer">npm-stop &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-tag.html
+++ b/deps/npm/html/doc/cli/npm-tag.html
@@ -63,5 +63,5 @@ that do not begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@3.3.10</p>
+<p id="footer">npm-tag &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-team.html
+++ b/deps/npm/html/doc/cli/npm-team.html
@@ -67,4 +67,4 @@ use the <code>npm access</code> command to grant or revoke the appropriate permi
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-team &mdash; npm@3.3.10</p>
+<p id="footer">npm-team &mdash; npm@3.3.12</p>

--- a/deps/npm/html/doc/cli/npm-test.html
+++ b/deps/npm/html/doc/cli/npm-test.html
@@ -37,5 +37,5 @@ true.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@3.3.10</p>
+<p id="footer">npm-test &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-uninstall.html
+++ b/deps/npm/html/doc/cli/npm-uninstall.html
@@ -60,5 +60,5 @@ npm uninstall dtrace-provider --save-optional
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@3.3.10</p>
+<p id="footer">npm-uninstall &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-unpublish.html
+++ b/deps/npm/html/doc/cli/npm-unpublish.html
@@ -47,5 +47,5 @@ package again, a new version number must be used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@3.3.10</p>
+<p id="footer">npm-unpublish &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-update.html
+++ b/deps/npm/html/doc/cli/npm-update.html
@@ -120,5 +120,5 @@ be <em>downgraded</em>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@3.3.10</p>
+<p id="footer">npm-update &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-version.html
+++ b/deps/npm/html/doc/cli/npm-version.html
@@ -99,5 +99,5 @@ and tag up to the server, and deletes the <code>build/temp</code> directory.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@3.3.10</p>
+<p id="footer">npm-version &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-view.html
+++ b/deps/npm/html/doc/cli/npm-view.html
@@ -83,5 +83,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@3.3.10</p>
+<p id="footer">npm-view &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm-whoami.html
+++ b/deps/npm/html/doc/cli/npm-whoami.html
@@ -33,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@3.3.10</p>
+<p id="footer">npm-whoami &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/cli/npm.html
+++ b/deps/npm/html/doc/cli/npm.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <pre><code>npm &lt;command&gt; [args]
 </code></pre><h2 id="version">VERSION</h2>
-<p>3.3.10</p>
+<p>3.3.12</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -110,7 +110,7 @@ easily by doing <code>npm view npm contributors</code>.</p>
 the issues list or ask on the mailing list.</p>
 <ul>
 <li><a href="http://github.com/npm/npm/issues">http://github.com/npm/npm/issues</a></li>
-<li><a href="&#x6d;&#x61;&#x69;&#108;&#116;&#111;&#58;&#110;&#112;&#109;&#x2d;&#x40;&#x67;&#x6f;&#111;&#103;&#108;&#101;&#x67;&#114;&#111;&#117;&#112;&#115;&#x2e;&#x63;&#111;&#109;">&#110;&#112;&#109;&#x2d;&#x40;&#x67;&#x6f;&#111;&#103;&#108;&#101;&#x67;&#114;&#111;&#117;&#112;&#115;&#x2e;&#x63;&#111;&#109;</a></li>
+<li><a href="&#x6d;&#x61;&#105;&#x6c;&#116;&#111;&#58;&#110;&#112;&#x6d;&#45;&#64;&#103;&#x6f;&#111;&#x67;&#108;&#101;&#103;&#x72;&#x6f;&#117;&#112;&#x73;&#x2e;&#x63;&#111;&#109;">&#110;&#112;&#x6d;&#45;&#64;&#103;&#x6f;&#111;&#x67;&#108;&#101;&#103;&#x72;&#x6f;&#117;&#112;&#x73;&#x2e;&#x63;&#111;&#109;</a></li>
 </ul>
 <h2 id="bugs">BUGS</h2>
 <p>When you find issues, please report them:</p>
@@ -118,7 +118,7 @@ the issues list or ask on the mailing list.</p>
 <li>web:
 <a href="http://github.com/npm/npm/issues">http://github.com/npm/npm/issues</a></li>
 <li>email:
-<a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#58;&#x6e;&#x70;&#x6d;&#x2d;&#x40;&#x67;&#x6f;&#x6f;&#x67;&#x6c;&#x65;&#x67;&#x72;&#x6f;&#x75;&#112;&#x73;&#46;&#99;&#111;&#x6d;">&#x6e;&#x70;&#x6d;&#x2d;&#x40;&#x67;&#x6f;&#x6f;&#x67;&#x6c;&#x65;&#x67;&#x72;&#x6f;&#x75;&#112;&#x73;&#46;&#99;&#111;&#x6d;</a></li>
+<a href="&#x6d;&#x61;&#x69;&#108;&#116;&#111;&#58;&#110;&#x70;&#109;&#x2d;&#64;&#x67;&#x6f;&#x6f;&#x67;&#108;&#x65;&#103;&#x72;&#111;&#x75;&#112;&#x73;&#46;&#99;&#111;&#109;">&#110;&#x70;&#109;&#x2d;&#64;&#x67;&#x6f;&#x6f;&#x67;&#108;&#x65;&#103;&#x72;&#111;&#x75;&#112;&#x73;&#46;&#99;&#111;&#109;</a></li>
 </ul>
 <p>Be sure to include <em>all</em> of the output from the npm command that didn&#39;t work
 as expected.  The <code>npm-debug.log</code> file is also helpful to provide.</p>
@@ -128,7 +128,7 @@ will no doubt tell you to put the output in a gist or email.</p>
 <p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
 <a href="https://github.com/isaacs/">isaacs</a> ::
 <a href="http://twitter.com/izs">@izs</a> ::
-<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#58;&#x69;&#64;&#x69;&#122;&#115;&#46;&#x6d;&#x65;">&#x69;&#64;&#x69;&#122;&#115;&#46;&#x6d;&#x65;</a></p>
+<a href="&#109;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#109;&#x65;">&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#109;&#x65;</a></p>
 <h2 id="see-also">SEE ALSO</h2>
 <ul>
 <li><a href="../cli/npm-help.html">npm-help(1)</a></li>
@@ -154,5 +154,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@3.3.10</p>
+<p id="footer">npm &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/files/npm-folders.html
+++ b/deps/npm/html/doc/files/npm-folders.html
@@ -184,5 +184,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@3.3.10</p>
+<p id="footer">npm-folders &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/files/npm-global.html
+++ b/deps/npm/html/doc/files/npm-global.html
@@ -184,5 +184,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@3.3.10</p>
+<p id="footer">npm-folders &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/files/npm-json.html
+++ b/deps/npm/html/doc/files/npm-json.html
@@ -559,5 +559,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@3.3.10</p>
+<p id="footer">package.json &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/files/npmrc.html
+++ b/deps/npm/html/doc/files/npmrc.html
@@ -83,5 +83,5 @@ manner.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npmrc &mdash; npm@3.3.10</p>
+<p id="footer">npmrc &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/files/package.json.html
+++ b/deps/npm/html/doc/files/package.json.html
@@ -559,5 +559,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@3.3.10</p>
+<p id="footer">package.json &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/index.html
+++ b/deps/npm/html/doc/index.html
@@ -162,5 +162,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@3.3.10</p>
+<p id="footer">npm-index &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-coding-style.html
+++ b/deps/npm/html/doc/misc/npm-coding-style.html
@@ -154,5 +154,5 @@ set to anything.&quot;</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-coding-style &mdash; npm@3.3.10</p>
+<p id="footer">npm-coding-style &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-config.html
+++ b/deps/npm/html/doc/misc/npm-config.html
@@ -829,5 +829,5 @@ exit successfully.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@3.3.10</p>
+<p id="footer">npm-config &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-developers.html
+++ b/deps/npm/html/doc/misc/npm-developers.html
@@ -195,5 +195,5 @@ from a fresh checkout.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-developers &mdash; npm@3.3.10</p>
+<p id="footer">npm-developers &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-disputes.html
+++ b/deps/npm/html/doc/misc/npm-disputes.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <ol>
 <li>Get the author email with <code>npm owner ls &lt;pkgname&gt;</code></li>
-<li>Email the author, CC <a href="&#x6d;&#97;&#105;&#108;&#116;&#111;&#58;&#x73;&#x75;&#x70;&#x70;&#111;&#114;&#116;&#x40;&#110;&#x70;&#109;&#106;&#x73;&#x2e;&#x63;&#111;&#x6d;">&#x73;&#x75;&#x70;&#x70;&#111;&#114;&#116;&#x40;&#110;&#x70;&#109;&#106;&#x73;&#x2e;&#x63;&#111;&#x6d;</a></li>
+<li>Email the author, CC <a href="&#x6d;&#97;&#105;&#x6c;&#116;&#111;&#x3a;&#115;&#x75;&#112;&#x70;&#x6f;&#114;&#x74;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#46;&#99;&#x6f;&#109;">&#115;&#x75;&#112;&#x70;&#x6f;&#114;&#x74;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#46;&#99;&#x6f;&#109;</a></li>
 <li>After a few weeks, if there&#39;s no resolution, we&#39;ll sort it out.</li>
 </ol>
 <p>Don&#39;t squat on package names.  Publish code or move out of the way.</p>
@@ -51,12 +51,12 @@ Joe&#39;s appropriate course of action in each case is the same.</p>
 owner (Bob).</li>
 <li>Joe emails Bob, explaining the situation <strong>as respectfully as
 possible</strong>, and what he would like to do with the module name.  He
-adds the npm support staff <a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#58;&#115;&#x75;&#112;&#112;&#111;&#114;&#x74;&#64;&#x6e;&#112;&#109;&#x6a;&#x73;&#46;&#x63;&#111;&#x6d;">&#115;&#x75;&#112;&#112;&#111;&#114;&#x74;&#64;&#x6e;&#112;&#109;&#x6a;&#x73;&#46;&#x63;&#111;&#x6d;</a> to the CC list of
+adds the npm support staff <a href="&#x6d;&#97;&#105;&#108;&#116;&#x6f;&#x3a;&#x73;&#x75;&#x70;&#112;&#x6f;&#x72;&#116;&#x40;&#110;&#112;&#109;&#106;&#115;&#x2e;&#x63;&#111;&#x6d;">&#x73;&#x75;&#x70;&#112;&#x6f;&#x72;&#116;&#x40;&#110;&#112;&#109;&#106;&#115;&#x2e;&#x63;&#111;&#x6d;</a> to the CC list of
 the email.  Mention in the email that Bob can run <code>npm owner add
 joe foo</code> to add Joe as an owner of the <code>foo</code> package.</li>
 <li>After a reasonable amount of time, if Bob has not responded, or if
 Bob and Joe can&#39;t come to any sort of resolution, email support
-<a href="&#109;&#x61;&#105;&#108;&#x74;&#x6f;&#x3a;&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#x6a;&#x73;&#46;&#99;&#x6f;&#109;">&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#x6a;&#x73;&#46;&#99;&#x6f;&#109;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
+<a href="&#109;&#x61;&#105;&#108;&#116;&#x6f;&#58;&#115;&#117;&#112;&#112;&#111;&#114;&#x74;&#64;&#x6e;&#112;&#109;&#x6a;&#x73;&#46;&#99;&#x6f;&#x6d;">&#115;&#117;&#112;&#112;&#111;&#114;&#x74;&#64;&#x6e;&#112;&#109;&#x6a;&#x73;&#46;&#99;&#x6f;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
 usually at least 4 weeks, but extra time is allowed around common
 holidays.)</li>
 </ol>
@@ -112,5 +112,5 @@ things into it.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-disputes &mdash; npm@3.3.10</p>
+<p id="footer">npm-disputes &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-faq.html
+++ b/deps/npm/html/doc/misc/npm-faq.html
@@ -237,7 +237,7 @@ that has a package.json in its root, or a git url.
 <p>To check if the registry is down, open up
 <a href="https://registry.npmjs.org/">https://registry.npmjs.org/</a> in a web browser.  This will also tell
 you if you are just unable to access the internet for some reason.</p>
-<p>If the registry IS down, let us know by emailing <a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#x6f;&#58;&#x73;&#x75;&#x70;&#112;&#x6f;&#114;&#116;&#x40;&#x6e;&#112;&#x6d;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;">&#x73;&#x75;&#x70;&#112;&#x6f;&#114;&#116;&#x40;&#x6e;&#112;&#x6d;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;</a>
+<p>If the registry IS down, let us know by emailing <a href="&#109;&#x61;&#x69;&#108;&#x74;&#111;&#x3a;&#115;&#x75;&#112;&#112;&#x6f;&#x72;&#x74;&#x40;&#110;&#x70;&#109;&#106;&#x73;&#46;&#x63;&#111;&#109;">&#115;&#x75;&#112;&#112;&#x6f;&#x72;&#x74;&#x40;&#110;&#x70;&#109;&#106;&#x73;&#46;&#x63;&#111;&#109;</a>
 or posting an issue at <a href="https://github.com/npm/npm/issues">https://github.com/npm/npm/issues</a>.  If it&#39;s
 down for the world (and not just on your local network) then we&#39;re
 probably already being pinged about it.</p>
@@ -308,5 +308,5 @@ good folks at <a href="http://www.npmjs.com">npm, Inc.</a></p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-faq &mdash; npm@3.3.10</p>
+<p id="footer">npm-faq &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-index.html
+++ b/deps/npm/html/doc/misc/npm-index.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html>
+  <title>npm-index</title>
+  <meta http-equiv="content-type" value="text/html;utf-8">
+  <link rel="stylesheet" type="text/css" href="../../static/style.css">
+  <link rel="canonical" href="https://www.npmjs.org/doc/misc/npm-index.html">
+  <script async=true src="../../static/toc.js"></script>
+
+  <body>
+    <div id="wrapper">
+
+<h1><a href="../misc/npm-index.html">npm-index</a></h1> <p>Index of all npm documentation</p>
+<h3 id="readme-1-"><a href="../../doc/README.html">README</a></h3>
+<p>a JavaScript package manager</p>
+<h2 id="command-line-documentation">Command Line Documentation</h2>
+<p>Using npm on the command line</p>
+<h3 id="npm-1-"><a href="../cli/npm.html">npm(1)</a></h3>
+<p>javascript package manager</p>
+<h3 id="npm-access-1-"><a href="../cli/npm-access.html">npm-access(1)</a></h3>
+<p>Set access level on published packages</p>
+<h3 id="npm-adduser-1-"><a href="../cli/npm-adduser.html">npm-adduser(1)</a></h3>
+<p>Add a registry user account</p>
+<h3 id="npm-bin-1-"><a href="../cli/npm-bin.html">npm-bin(1)</a></h3>
+<p>Display npm bin folder</p>
+<h3 id="npm-bugs-1-"><a href="../cli/npm-bugs.html">npm-bugs(1)</a></h3>
+<p>Bugs for a package in a web browser maybe</p>
+<h3 id="npm-build-1-"><a href="../cli/npm-build.html">npm-build(1)</a></h3>
+<p>Build a package</p>
+<h3 id="npm-bundle-1-"><a href="../cli/npm-bundle.html">npm-bundle(1)</a></h3>
+<p>REMOVED</p>
+<h3 id="npm-cache-1-"><a href="../cli/npm-cache.html">npm-cache(1)</a></h3>
+<p>Manipulates packages cache</p>
+<h3 id="npm-completion-1-"><a href="../cli/npm-completion.html">npm-completion(1)</a></h3>
+<p>Tab Completion for npm</p>
+<h3 id="npm-config-1-"><a href="../cli/npm-config.html">npm-config(1)</a></h3>
+<p>Manage the npm configuration files</p>
+<h3 id="npm-dedupe-1-"><a href="../cli/npm-dedupe.html">npm-dedupe(1)</a></h3>
+<p>Reduce duplication</p>
+<h3 id="npm-deprecate-1-"><a href="../cli/npm-deprecate.html">npm-deprecate(1)</a></h3>
+<p>Deprecate a version of a package</p>
+<h3 id="npm-dist-tag-1-"><a href="../cli/npm-dist-tag.html">npm-dist-tag(1)</a></h3>
+<p>Modify package distribution tags</p>
+<h3 id="npm-docs-1-"><a href="../cli/npm-docs.html">npm-docs(1)</a></h3>
+<p>Docs for a package in a web browser maybe</p>
+<h3 id="npm-edit-1-"><a href="../cli/npm-edit.html">npm-edit(1)</a></h3>
+<p>Edit an installed package</p>
+<h3 id="npm-explore-1-"><a href="../cli/npm-explore.html">npm-explore(1)</a></h3>
+<p>Browse an installed package</p>
+<h3 id="npm-help-search-1-"><a href="../cli/npm-help-search.html">npm-help-search(1)</a></h3>
+<p>Search npm help documentation</p>
+<h3 id="npm-help-1-"><a href="../cli/npm-help.html">npm-help(1)</a></h3>
+<p>Get help on npm</p>
+<h3 id="npm-init-1-"><a href="../cli/npm-init.html">npm-init(1)</a></h3>
+<p>Interactively create a package.json file</p>
+<h3 id="npm-install-1-"><a href="../cli/npm-install.html">npm-install(1)</a></h3>
+<p>Install a package</p>
+<h3 id="npm-link-1-"><a href="../cli/npm-link.html">npm-link(1)</a></h3>
+<p>Symlink a package folder</p>
+<h3 id="npm-logout-1-"><a href="../cli/npm-logout.html">npm-logout(1)</a></h3>
+<p>Log out of the registry</p>
+<h3 id="npm-ls-1-"><a href="../cli/npm-ls.html">npm-ls(1)</a></h3>
+<p>List installed packages</p>
+<h3 id="npm-outdated-1-"><a href="../cli/npm-outdated.html">npm-outdated(1)</a></h3>
+<p>Check for outdated packages</p>
+<h3 id="npm-owner-1-"><a href="../cli/npm-owner.html">npm-owner(1)</a></h3>
+<p>Manage package owners</p>
+<h3 id="npm-pack-1-"><a href="../cli/npm-pack.html">npm-pack(1)</a></h3>
+<p>Create a tarball from a package</p>
+<h3 id="npm-ping-1-"><a href="../cli/npm-ping.html">npm-ping(1)</a></h3>
+<p>Ping npm registry</p>
+<h3 id="npm-prefix-1-"><a href="../cli/npm-prefix.html">npm-prefix(1)</a></h3>
+<p>Display prefix</p>
+<h3 id="npm-prune-1-"><a href="../cli/npm-prune.html">npm-prune(1)</a></h3>
+<p>Remove extraneous packages</p>
+<h3 id="npm-publish-1-"><a href="../cli/npm-publish.html">npm-publish(1)</a></h3>
+<p>Publish a package</p>
+<h3 id="npm-rebuild-1-"><a href="../cli/npm-rebuild.html">npm-rebuild(1)</a></h3>
+<p>Rebuild a package</p>
+<h3 id="npm-repo-1-"><a href="../cli/npm-repo.html">npm-repo(1)</a></h3>
+<p>Open package repository page in the browser</p>
+<h3 id="npm-restart-1-"><a href="../cli/npm-restart.html">npm-restart(1)</a></h3>
+<p>Restart a package</p>
+<h3 id="npm-root-1-"><a href="../cli/npm-root.html">npm-root(1)</a></h3>
+<p>Display npm root</p>
+<h3 id="npm-run-script-1-"><a href="../cli/npm-run-script.html">npm-run-script(1)</a></h3>
+<p>Run arbitrary package scripts</p>
+<h3 id="npm-search-1-"><a href="../cli/npm-search.html">npm-search(1)</a></h3>
+<p>Search for packages</p>
+<h3 id="npm-shrinkwrap-1-"><a href="../cli/npm-shrinkwrap.html">npm-shrinkwrap(1)</a></h3>
+<p>Lock down dependency versions</p>
+<h3 id="npm-star-1-"><a href="../cli/npm-star.html">npm-star(1)</a></h3>
+<p>Mark your favorite packages</p>
+<h3 id="npm-stars-1-"><a href="../cli/npm-stars.html">npm-stars(1)</a></h3>
+<p>View packages marked as favorites</p>
+<h3 id="npm-start-1-"><a href="../cli/npm-start.html">npm-start(1)</a></h3>
+<p>Start a package</p>
+<h3 id="npm-stop-1-"><a href="../cli/npm-stop.html">npm-stop(1)</a></h3>
+<p>Stop a package</p>
+<h3 id="npm-tag-1-"><a href="../cli/npm-tag.html">npm-tag(1)</a></h3>
+<p>Tag a published version</p>
+<h3 id="npm-team-1-"><a href="../cli/npm-team.html">npm-team(1)</a></h3>
+<p>Manage organization teams and team memberships</p>
+<h3 id="npm-test-1-"><a href="../cli/npm-test.html">npm-test(1)</a></h3>
+<p>Test a package</p>
+<h3 id="npm-uninstall-1-"><a href="../cli/npm-uninstall.html">npm-uninstall(1)</a></h3>
+<p>Remove a package</p>
+<h3 id="npm-unpublish-1-"><a href="../cli/npm-unpublish.html">npm-unpublish(1)</a></h3>
+<p>Remove a package from the registry</p>
+<h3 id="npm-update-1-"><a href="../cli/npm-update.html">npm-update(1)</a></h3>
+<p>Update a package</p>
+<h3 id="npm-version-1-"><a href="../cli/npm-version.html">npm-version(1)</a></h3>
+<p>Bump a package version</p>
+<h3 id="npm-view-1-"><a href="../cli/npm-view.html">npm-view(1)</a></h3>
+<p>View registry info</p>
+<h3 id="npm-whoami-1-"><a href="../cli/npm-whoami.html">npm-whoami(1)</a></h3>
+<p>Display npm username</p>
+<h2 id="api-documentation">API Documentation</h2>
+<p>Using npm in your Node programs</p>
+<h2 id="files">Files</h2>
+<p>File system structures npm uses</p>
+<h3 id="npm-folders-5-"><a href="../files/npm-folders.html">npm-folders(5)</a></h3>
+<p>Folder Structures Used by npm</p>
+<h3 id="npmrc-5-"><a href="../files/npmrc.html">npmrc(5)</a></h3>
+<p>The npm config files</p>
+<h3 id="package-json-5-"><a href="../files/package.json.html">package.json(5)</a></h3>
+<p>Specifics of npm&#39;s package.json handling</p>
+<h2 id="misc">Misc</h2>
+<p>Various other bits and bobs</p>
+<h3 id="npm-coding-style-7-"><a href="../misc/npm-coding-style.html">npm-coding-style(7)</a></h3>
+<p>npm&#39;s &quot;funny&quot; coding style</p>
+<h3 id="npm-config-7-"><a href="../misc/npm-config.html">npm-config(7)</a></h3>
+<p>More than you probably want to know about npm configuration</p>
+<h3 id="npm-developers-7-"><a href="../misc/npm-developers.html">npm-developers(7)</a></h3>
+<p>Developer Guide</p>
+<h3 id="npm-disputes-7-"><a href="../misc/npm-disputes.html">npm-disputes(7)</a></h3>
+<p>Handling Module Name Disputes</p>
+<h3 id="npm-faq-7-"><a href="../misc/npm-faq.html">npm-faq(7)</a></h3>
+<p>Frequently Asked Questions</p>
+<h3 id="npm-index-7-"><a href="../misc/npm-index.html">npm-index(7)</a></h3>
+<p>Index of all npm documentation</p>
+<h3 id="npm-orgs-7-"><a href="../misc/npm-orgs.html">npm-orgs(7)</a></h3>
+<p>Working with Teams &amp; Orgs</p>
+<h3 id="npm-registry-7-"><a href="../misc/npm-registry.html">npm-registry(7)</a></h3>
+<p>The JavaScript Package Registry</p>
+<h3 id="npm-scope-7-"><a href="../misc/npm-scope.html">npm-scope(7)</a></h3>
+<p>Scoped packages</p>
+<h3 id="npm-scripts-7-"><a href="../misc/npm-scripts.html">npm-scripts(7)</a></h3>
+<p>How npm handles the &quot;scripts&quot; field</p>
+<h3 id="removing-npm-7-"><a href="../misc/removing-npm.html">removing-npm(7)</a></h3>
+<p>Cleaning the Slate</p>
+<h3 id="semver-7-"><a href="../misc/semver.html">semver(7)</a></h3>
+<p>The semantic versioner for npm</p>
+
+</div>
+
+<table border=0 cellspacing=0 cellpadding=0 id=npmlogo>
+<tr><td style="width:180px;height:10px;background:rgb(237,127,127)" colspan=18>&nbsp;</td></tr>
+<tr><td rowspan=4 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td><td style="width:40px;height:10px;background:#fff" colspan=4>&nbsp;</td><td style="width:10px;height:10px;background:rgb(237,127,127)" rowspan=4>&nbsp;</td><td style="width:40px;height:10px;background:#fff" colspan=4>&nbsp;</td><td rowspan=4 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td><td colspan=6 style="width:60px;height:10px;background:#fff">&nbsp;</td><td style="width:10px;height:10px;background:rgb(237,127,127)" rowspan=4>&nbsp;</td></tr>
+<tr><td colspan=2 style="width:20px;height:30px;background:#fff" rowspan=3>&nbsp;</td><td style="width:10px;height:10px;background:rgb(237,127,127)" rowspan=3>&nbsp;</td><td style="width:10px;height:10px;background:#fff" rowspan=3>&nbsp;</td><td style="width:20px;height:10px;background:#fff" rowspan=4 colspan=2>&nbsp;</td><td style="width:10px;height:20px;background:rgb(237,127,127)" rowspan=2>&nbsp;</td><td style="width:10px;height:10px;background:#fff" rowspan=3>&nbsp;</td><td style="width:20px;height:10px;background:#fff" rowspan=3 colspan=2>&nbsp;</td><td style="width:10px;height:10px;background:rgb(237,127,127)" rowspan=3>&nbsp;</td><td style="width:10px;height:10px;background:#fff" rowspan=3>&nbsp;</td><td style="width:10px;height:10px;background:rgb(237,127,127)" rowspan=3>&nbsp;</td></tr>
+<tr><td style="width:10px;height:10px;background:#fff" rowspan=2>&nbsp;</td></tr>
+<tr><td style="width:10px;height:10px;background:#fff">&nbsp;</td></tr>
+<tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
+<tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
+</table>
+<p id="footer">npm-index &mdash; npm@3.3.12</p>

--- a/deps/npm/html/doc/misc/npm-orgs.html
+++ b/deps/npm/html/doc/misc/npm-orgs.html
@@ -86,4 +86,4 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-orgs &mdash; npm@3.3.10</p>
+<p id="footer">npm-orgs &mdash; npm@3.3.12</p>

--- a/deps/npm/html/doc/misc/npm-registry.html
+++ b/deps/npm/html/doc/misc/npm-registry.html
@@ -70,5 +70,5 @@ effectively implement the entire CouchDB API anyway.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-registry &mdash; npm@3.3.10</p>
+<p id="footer">npm-registry &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-scope.html
+++ b/deps/npm/html/doc/misc/npm-scope.html
@@ -91,5 +91,5 @@ that registry instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scope &mdash; npm@3.3.10</p>
+<p id="footer">npm-scope &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/npm-scripts.html
+++ b/deps/npm/html/doc/misc/npm-scripts.html
@@ -207,5 +207,5 @@ scripts is for compilation which must be done on the target architecture.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scripts &mdash; npm@3.3.10</p>
+<p id="footer">npm-scripts &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/removing-npm.html
+++ b/deps/npm/html/doc/misc/removing-npm.html
@@ -57,5 +57,5 @@ modules.  To track those down, you can do the following:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">removing-npm &mdash; npm@3.3.10</p>
+<p id="footer">removing-npm &mdash; npm@3.3.12</p>
 

--- a/deps/npm/html/doc/misc/semver.html
+++ b/deps/npm/html/doc/misc/semver.html
@@ -282,5 +282,5 @@ range, use the <code>satisfies(version, range)</code> function.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">semver &mdash; npm@3.3.10</p>
+<p id="footer">semver &mdash; npm@3.3.12</p>
 

--- a/deps/npm/lib/fetch-package-metadata.js
+++ b/deps/npm/lib/fetch-package-metadata.js
@@ -15,6 +15,7 @@ var rimraf = require('rimraf')
 var clone = require('lodash.clonedeep')
 var validate = require('aproba')
 var unpipe = require('unpipe')
+var normalizePackageData = require('normalize-package-data')
 
 var npm = require('./npm.js')
 var mapToRegistry = require('./utils/map-to-registry.js')
@@ -68,6 +69,15 @@ module.exports = function fetchPackageMetadata (spec, where, tracker, done) {
       pkg._where = where
       if (!pkg._args) pkg._args = []
       pkg._args.push([pkg._spec, pkg._where])
+      // non-npm registries can and will return unnormalized data, plus
+      // even the npm registry may have package data normalized with older
+      // normalization rules. This ensures we get package data in a consistent,
+      // stable format.
+      try {
+        normalizePackageData(pkg)
+      } catch (ex) {
+        // don't care
+      }
     }
     logAndFinish(er, pkg)
   }

--- a/deps/npm/lib/install/diff-trees.js
+++ b/deps/npm/lib/install/diff-trees.js
@@ -132,6 +132,7 @@ function diffTrees (oldTree, newTree) {
                    requiredByAllLinked(pkg)
     if (pkg.fromBundle) {
       if (npm.config.get('rebuild-bundle')) differences.push(['rebuild', pkg])
+      if (pkg.oldPkg) differences.push(['remove', pkg])
     } else if (pkg.oldPkg) {
       if (!pkg.directlyRequested && pkgAreEquiv(pkg.oldPkg.package, pkg.package)) return
       if (!pkg.isInLink && (isLink(pkg.oldPkg) || isLink(pkg))) {

--- a/deps/npm/man/man1/npm-README.1
+++ b/deps/npm/man/man1/npm-README.1
@@ -1,4 +1,4 @@
-.TH "NPM" "1" "October 2015" "" ""
+.TH "NPM" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm\fR \- a JavaScript package manager
 .P

--- a/deps/npm/man/man1/npm-access.1
+++ b/deps/npm/man/man1/npm-access.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ACCESS" "1" "October 2015" "" ""
+.TH "NPM\-ACCESS" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-access\fR \- Set access level on published packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-adduser.1
+++ b/deps/npm/man/man1/npm-adduser.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ADDUSER" "1" "October 2015" "" ""
+.TH "NPM\-ADDUSER" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-adduser\fR \- Add a registry user account
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-bin.1
+++ b/deps/npm/man/man1/npm-bin.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BIN" "1" "October 2015" "" ""
+.TH "NPM\-BIN" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-bin\fR \- Display npm bin folder
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-bugs.1
+++ b/deps/npm/man/man1/npm-bugs.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUGS" "1" "October 2015" "" ""
+.TH "NPM\-BUGS" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-bugs\fR \- Bugs for a package in a web browser maybe
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-build.1
+++ b/deps/npm/man/man1/npm-build.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUILD" "1" "October 2015" "" ""
+.TH "NPM\-BUILD" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-build\fR \- Build a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-bundle.1
+++ b/deps/npm/man/man1/npm-bundle.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUNDLE" "1" "October 2015" "" ""
+.TH "NPM\-BUNDLE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-bundle\fR \- REMOVED
 .SH DESCRIPTION

--- a/deps/npm/man/man1/npm-cache.1
+++ b/deps/npm/man/man1/npm-cache.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CACHE" "1" "October 2015" "" ""
+.TH "NPM\-CACHE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-cache\fR \- Manipulates packages cache
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-completion.1
+++ b/deps/npm/man/man1/npm-completion.1
@@ -1,4 +1,4 @@
-.TH "NPM\-COMPLETION" "1" "October 2015" "" ""
+.TH "NPM\-COMPLETION" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-completion\fR \- Tab Completion for npm
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-config.1
+++ b/deps/npm/man/man1/npm-config.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CONFIG" "1" "October 2015" "" ""
+.TH "NPM\-CONFIG" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-config\fR \- Manage the npm configuration files
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-dedupe.1
+++ b/deps/npm/man/man1/npm-dedupe.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DEDUPE" "1" "October 2015" "" ""
+.TH "NPM\-DEDUPE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-dedupe\fR \- Reduce duplication
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-deprecate.1
+++ b/deps/npm/man/man1/npm-deprecate.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DEPRECATE" "1" "October 2015" "" ""
+.TH "NPM\-DEPRECATE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-deprecate\fR \- Deprecate a version of a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-dist-tag.1
+++ b/deps/npm/man/man1/npm-dist-tag.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DIST\-TAG" "1" "October 2015" "" ""
+.TH "NPM\-DIST\-TAG" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-dist-tag\fR \- Modify package distribution tags
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-docs.1
+++ b/deps/npm/man/man1/npm-docs.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DOCS" "1" "October 2015" "" ""
+.TH "NPM\-DOCS" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-docs\fR \- Docs for a package in a web browser maybe
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-edit.1
+++ b/deps/npm/man/man1/npm-edit.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EDIT" "1" "October 2015" "" ""
+.TH "NPM\-EDIT" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-edit\fR \- Edit an installed package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-explore.1
+++ b/deps/npm/man/man1/npm-explore.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EXPLORE" "1" "October 2015" "" ""
+.TH "NPM\-EXPLORE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-explore\fR \- Browse an installed package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-help-search.1
+++ b/deps/npm/man/man1/npm-help-search.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HELP\-SEARCH" "1" "October 2015" "" ""
+.TH "NPM\-HELP\-SEARCH" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-help-search\fR \- Search npm help documentation
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-help.1
+++ b/deps/npm/man/man1/npm-help.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HELP" "1" "October 2015" "" ""
+.TH "NPM\-HELP" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-help\fR \- Get help on npm
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-init.1
+++ b/deps/npm/man/man1/npm-init.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INIT" "1" "October 2015" "" ""
+.TH "NPM\-INIT" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-init\fR \- Interactively create a package\.json file
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-install-test.1
+++ b/deps/npm/man/man1/npm-install-test.1
@@ -1,0 +1,32 @@
+.TH "NPM" "" "November 2015" "" ""
+.SH "NAME"
+\fBnpm\fR
+.SH SYNOPSIS
+.P
+.RS 2
+.nf
+npm install\-test (with no args, in package dir)
+npm install\-test [<@scope>/]<name>
+npm install\-test [<@scope>/]<name>@<tag>
+npm install\-test [<@scope>/]<name>@<version>
+npm install\-test [<@scope>/]<name>@<version range>
+npm install\-test <tarball file>
+npm install\-test <tarball url>
+npm install\-test <folder>
+
+alias: npm it
+common options: [\-\-save|\-\-save\-dev|\-\-save\-optional] [\-\-save\-exact] [\-\-dry\-run]
+.fi
+.RE
+.SH DESCRIPTION
+.P
+This command runs an \fBnpm install\fP followed immediately by an \fBnpm test\fP\|\. It
+takes exactly the same arguments as \fBnpm install\fP\|\.
+.SH SEE ALSO
+.RS 0
+.IP \(bu 2
+npm help install
+.IP \(bu 2
+npm help test
+
+.RE

--- a/deps/npm/man/man1/npm-install.1
+++ b/deps/npm/man/man1/npm-install.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INSTALL" "1" "October 2015" "" ""
+.TH "NPM\-INSTALL" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-install\fR \- Install a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-link.1
+++ b/deps/npm/man/man1/npm-link.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LINK" "1" "October 2015" "" ""
+.TH "NPM\-LINK" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-link\fR \- Symlink a package folder
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-logout.1
+++ b/deps/npm/man/man1/npm-logout.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LOGOUT" "1" "October 2015" "" ""
+.TH "NPM\-LOGOUT" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-logout\fR \- Log out of the registry
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LS" "1" "October 2015" "" ""
+.TH "NPM\-LS" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-ls\fR \- List installed packages
 .SH SYNOPSIS
@@ -22,7 +22,7 @@ For example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@3.3.10 /path/to/npm
+npm@3.3.12 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm-outdated.1
+++ b/deps/npm/man/man1/npm-outdated.1
@@ -1,4 +1,4 @@
-.TH "NPM\-OUTDATED" "1" "October 2015" "" ""
+.TH "NPM\-OUTDATED" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-outdated\fR \- Check for outdated packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-owner.1
+++ b/deps/npm/man/man1/npm-owner.1
@@ -1,4 +1,4 @@
-.TH "NPM\-OWNER" "1" "October 2015" "" ""
+.TH "NPM\-OWNER" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-owner\fR \- Manage package owners
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-pack.1
+++ b/deps/npm/man/man1/npm-pack.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PACK" "1" "October 2015" "" ""
+.TH "NPM\-PACK" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-pack\fR \- Create a tarball from a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-ping.1
+++ b/deps/npm/man/man1/npm-ping.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PING" "1" "October 2015" "" ""
+.TH "NPM\-PING" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-ping\fR \- Ping npm registry
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-prefix.1
+++ b/deps/npm/man/man1/npm-prefix.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PREFIX" "1" "October 2015" "" ""
+.TH "NPM\-PREFIX" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-prefix\fR \- Display prefix
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-prune.1
+++ b/deps/npm/man/man1/npm-prune.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PRUNE" "1" "October 2015" "" ""
+.TH "NPM\-PRUNE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-prune\fR \- Remove extraneous packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-publish.1
+++ b/deps/npm/man/man1/npm-publish.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PUBLISH" "1" "October 2015" "" ""
+.TH "NPM\-PUBLISH" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-publish\fR \- Publish a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-rebuild.1
+++ b/deps/npm/man/man1/npm-rebuild.1
@@ -1,4 +1,4 @@
-.TH "NPM\-REBUILD" "1" "October 2015" "" ""
+.TH "NPM\-REBUILD" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-rebuild\fR \- Rebuild a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-repo.1
+++ b/deps/npm/man/man1/npm-repo.1
@@ -1,4 +1,4 @@
-.TH "NPM\-REPO" "1" "October 2015" "" ""
+.TH "NPM\-REPO" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-repo\fR \- Open package repository page in the browser
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-restart.1
+++ b/deps/npm/man/man1/npm-restart.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RESTART" "1" "October 2015" "" ""
+.TH "NPM\-RESTART" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-restart\fR \- Restart a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-rm.1
+++ b/deps/npm/man/man1/npm-rm.1
@@ -1,0 +1,33 @@
+.TH "NPM\-RM" "1" "October 2015" "" ""
+.SH "NAME"
+\fBnpm-rm\fR \- Remove a package
+.SH SYNOPSIS
+.P
+.RS 2
+.nf
+npm rm <name>
+npm r <name>
+npm uninstall <name>
+npm un <name>
+.fi
+.RE
+.SH DESCRIPTION
+.P
+This uninstalls a package, completely removing everything npm installed
+on its behalf\.
+.SH SEE ALSO
+.RS 0
+.IP \(bu 2
+npm help prune
+.IP \(bu 2
+npm help install
+.IP \(bu 2
+npm help 5 folders
+.IP \(bu 2
+npm help config
+.IP \(bu 2
+npm help 7 config
+.IP \(bu 2
+npm help 5 npmrc
+
+.RE

--- a/deps/npm/man/man1/npm-root.1
+++ b/deps/npm/man/man1/npm-root.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ROOT" "1" "October 2015" "" ""
+.TH "NPM\-ROOT" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-root\fR \- Display npm root
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-run-script.1
+++ b/deps/npm/man/man1/npm-run-script.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RUN\-SCRIPT" "1" "October 2015" "" ""
+.TH "NPM\-RUN\-SCRIPT" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-run-script\fR \- Run arbitrary package scripts
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-search.1
+++ b/deps/npm/man/man1/npm-search.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SEARCH" "1" "October 2015" "" ""
+.TH "NPM\-SEARCH" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-search\fR \- Search for packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-shrinkwrap.1
+++ b/deps/npm/man/man1/npm-shrinkwrap.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SHRINKWRAP" "1" "October 2015" "" ""
+.TH "NPM\-SHRINKWRAP" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-shrinkwrap\fR \- Lock down dependency versions
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-star.1
+++ b/deps/npm/man/man1/npm-star.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STAR" "1" "October 2015" "" ""
+.TH "NPM\-STAR" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-star\fR \- Mark your favorite packages
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-stars.1
+++ b/deps/npm/man/man1/npm-stars.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STARS" "1" "October 2015" "" ""
+.TH "NPM\-STARS" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-stars\fR \- View packages marked as favorites
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-start.1
+++ b/deps/npm/man/man1/npm-start.1
@@ -1,4 +1,4 @@
-.TH "NPM\-START" "1" "October 2015" "" ""
+.TH "NPM\-START" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-start\fR \- Start a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-stop.1
+++ b/deps/npm/man/man1/npm-stop.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STOP" "1" "October 2015" "" ""
+.TH "NPM\-STOP" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-stop\fR \- Stop a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-tag.1
+++ b/deps/npm/man/man1/npm-tag.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TAG" "1" "October 2015" "" ""
+.TH "NPM\-TAG" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-tag\fR \- Tag a published version
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-team.1
+++ b/deps/npm/man/man1/npm-team.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TEAM" "1" "October 2015" "" ""
+.TH "NPM\-TEAM" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-team\fR \- Manage organization teams and team memberships
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-test.1
+++ b/deps/npm/man/man1/npm-test.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TEST" "1" "October 2015" "" ""
+.TH "NPM\-TEST" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-test\fR \- Test a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-uninstall.1
+++ b/deps/npm/man/man1/npm-uninstall.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RM" "1" "October 2015" "" ""
+.TH "NPM\-RM" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-rm\fR \- Remove a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-unpublish.1
+++ b/deps/npm/man/man1/npm-unpublish.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UNPUBLISH" "1" "October 2015" "" ""
+.TH "NPM\-UNPUBLISH" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-unpublish\fR \- Remove a package from the registry
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-update.1
+++ b/deps/npm/man/man1/npm-update.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UPDATE" "1" "October 2015" "" ""
+.TH "NPM\-UPDATE" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-update\fR \- Update a package
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-version.1
+++ b/deps/npm/man/man1/npm-version.1
@@ -1,4 +1,4 @@
-.TH "NPM\-VERSION" "1" "October 2015" "" ""
+.TH "NPM\-VERSION" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-version\fR \- Bump a package version
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-view.1
+++ b/deps/npm/man/man1/npm-view.1
@@ -1,4 +1,4 @@
-.TH "NPM\-VIEW" "1" "October 2015" "" ""
+.TH "NPM\-VIEW" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-view\fR \- View registry info
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm-whoami.1
+++ b/deps/npm/man/man1/npm-whoami.1
@@ -1,4 +1,4 @@
-.TH "NPM\-WHOAMI" "1" "October 2015" "" ""
+.TH "NPM\-WHOAMI" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-whoami\fR \- Display npm username
 .SH SYNOPSIS

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -1,4 +1,4 @@
-.TH "NPM" "1" "October 2015" "" ""
+.TH "NPM" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm\fR \- javascript package manager
 .SH SYNOPSIS
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SH VERSION
 .P
-3.3.10
+3.3.12
 .SH DESCRIPTION
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man5/npm-folders.5
+++ b/deps/npm/man/man5/npm-folders.5
@@ -1,4 +1,4 @@
-.TH "NPM\-FOLDERS" "5" "October 2015" "" ""
+.TH "NPM\-FOLDERS" "5" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-folders\fR \- Folder Structures Used by npm
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npm-global.5
+++ b/deps/npm/man/man5/npm-global.5
@@ -1,4 +1,4 @@
-.TH "NPM\-FOLDERS" "5" "October 2015" "" ""
+.TH "NPM\-FOLDERS" "5" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-folders\fR \- Folder Structures Used by npm
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npm-json.5
+++ b/deps/npm/man/man5/npm-json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\.JSON" "5" "October 2015" "" ""
+.TH "PACKAGE\.JSON" "5" "November 2015" "" ""
 .SH "NAME"
 \fBpackage.json\fR \- Specifics of npm's package\.json handling
 .SH DESCRIPTION

--- a/deps/npm/man/man5/npmrc.5
+++ b/deps/npm/man/man5/npmrc.5
@@ -1,4 +1,4 @@
-.TH "NPMRC" "5" "October 2015" "" ""
+.TH "NPMRC" "5" "November 2015" "" ""
 .SH "NAME"
 \fBnpmrc\fR \- The npm config files
 .SH DESCRIPTION

--- a/deps/npm/man/man5/package.json.5
+++ b/deps/npm/man/man5/package.json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\.JSON" "5" "October 2015" "" ""
+.TH "PACKAGE\.JSON" "5" "November 2015" "" ""
 .SH "NAME"
 \fBpackage.json\fR \- Specifics of npm's package\.json handling
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-coding-style.7
+++ b/deps/npm/man/man7/npm-coding-style.7
@@ -1,4 +1,4 @@
-.TH "NPM\-CODING\-STYLE" "7" "October 2015" "" ""
+.TH "NPM\-CODING\-STYLE" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-coding-style\fR \- npm's "funny" coding style
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-config.7
+++ b/deps/npm/man/man7/npm-config.7
@@ -1,4 +1,4 @@
-.TH "NPM\-CONFIG" "7" "October 2015" "" ""
+.TH "NPM\-CONFIG" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-config\fR \- More than you probably want to know about npm configuration
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-developers.7
+++ b/deps/npm/man/man7/npm-developers.7
@@ -1,4 +1,4 @@
-.TH "NPM\-DEVELOPERS" "7" "October 2015" "" ""
+.TH "NPM\-DEVELOPERS" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-developers\fR \- Developer Guide
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-disputes.7
+++ b/deps/npm/man/man7/npm-disputes.7
@@ -1,4 +1,4 @@
-.TH "NPM\-DISPUTES" "7" "October 2015" "" ""
+.TH "NPM\-DISPUTES" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-disputes\fR \- Handling Module Name Disputes
 .SH SYNOPSIS

--- a/deps/npm/man/man7/npm-faq.7
+++ b/deps/npm/man/man7/npm-faq.7
@@ -1,4 +1,4 @@
-.TH "NPM\-FAQ" "7" "October 2015" "" ""
+.TH "NPM\-FAQ" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-faq\fR \- Frequently Asked Questions
 .SH Where can I find these docs in HTML?

--- a/deps/npm/man/man7/npm-index.7
+++ b/deps/npm/man/man7/npm-index.7
@@ -1,4 +1,4 @@
-.TH "NPM\-INDEX" "7" "October 2015" "" ""
+.TH "NPM\-INDEX" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-index\fR \- Index of all npm documentation
 .SS npm help README

--- a/deps/npm/man/man7/npm-orgs.7
+++ b/deps/npm/man/man7/npm-orgs.7
@@ -1,4 +1,4 @@
-.TH "NPM\-ORGS" "7" "October 2015" "" ""
+.TH "NPM\-ORGS" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-orgs\fR \- Working with Teams & Orgs
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-registry.7
+++ b/deps/npm/man/man7/npm-registry.7
@@ -1,4 +1,4 @@
-.TH "NPM\-REGISTRY" "7" "October 2015" "" ""
+.TH "NPM\-REGISTRY" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-registry\fR \- The JavaScript Package Registry
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-scope.7
+++ b/deps/npm/man/man7/npm-scope.7
@@ -1,4 +1,4 @@
-.TH "NPM\-SCOPE" "7" "October 2015" "" ""
+.TH "NPM\-SCOPE" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-scope\fR \- Scoped packages
 .SH DESCRIPTION

--- a/deps/npm/man/man7/npm-scripts.7
+++ b/deps/npm/man/man7/npm-scripts.7
@@ -1,4 +1,4 @@
-.TH "NPM\-SCRIPTS" "7" "October 2015" "" ""
+.TH "NPM\-SCRIPTS" "7" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-scripts\fR \- How npm handles the "scripts" field
 .SH DESCRIPTION

--- a/deps/npm/man/man7/removing-npm.7
+++ b/deps/npm/man/man7/removing-npm.7
@@ -1,4 +1,4 @@
-.TH "NPM\-REMOVAL" "1" "October 2015" "" ""
+.TH "NPM\-REMOVAL" "1" "November 2015" "" ""
 .SH "NAME"
 \fBnpm-removal\fR \- Cleaning the Slate
 .SH SYNOPSIS

--- a/deps/npm/man/man7/semver.7
+++ b/deps/npm/man/man7/semver.7
@@ -1,4 +1,4 @@
-.TH "SEMVER" "7" "October 2015" "" ""
+.TH "SEMVER" "7" "November 2015" "" ""
 .SH "NAME"
 \fBsemver\fR \- The semantic versioner for npm
 .SH Usage

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.10",
+  "version": "3.3.12",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -187,14 +187,14 @@
     "deep-equal": "~1.0.1",
     "marked": "~0.3.5",
     "marked-man": "~0.1.5",
-    "nock": "~2.15.0",
+    "nock": "~2.17.0",
     "npm-registry-couchapp": "~2.6.11",
     "npm-registry-mock": "~1.0.1",
     "readable-stream": "~2.0.2",
     "require-inject": "~1.2.1",
     "sprintf-js": "~1.0.3",
     "standard": "~5.3.1",
-    "tap": "~2.1.1"
+    "tap": "~2.2.0"
   },
   "scripts": {
     "dumpconf": "env | grep npm | sort | uniq",

--- a/deps/npm/test/tap/bugs.js
+++ b/deps/npm/test/tap/bugs.js
@@ -120,7 +120,7 @@ test('npm bugs test-repo-url-http - non-github (http://)', function (t) {
   })
 })
 
-test('npm bugs test-repo-url-https - non-github (https://)', function (t) {
+test('npm bugs test-repo-url-https - gitlab (https://)', function (t) {
   mr({ port: common.port }, function (er, s) {
     common.npm(
       [
@@ -136,7 +136,7 @@ test('npm bugs test-repo-url-https - non-github (https://)', function (t) {
         t.equal(code, 0, 'exit ok')
         var res = fs.readFileSync(outFile, 'ascii')
         s.close()
-        t.equal(res, 'https://www.npmjs.org/package/test-repo-url-https\n')
+        t.equal(res, 'https://gitlab.com/evanlucas/test-repo-url-https/issues\n')
         rimraf.sync(outFile)
         t.end()
       }
@@ -144,7 +144,7 @@ test('npm bugs test-repo-url-https - non-github (https://)', function (t) {
   })
 })
 
-test('npm bugs test-repo-url-ssh - non-github (ssh://)', function (t) {
+test('npm bugs test-repo-url-ssh - gitlab (ssh://)', function (t) {
   mr({ port: common.port }, function (er, s) {
     common.npm(
       [
@@ -160,7 +160,7 @@ test('npm bugs test-repo-url-ssh - non-github (ssh://)', function (t) {
         t.equal(code, 0, 'exit ok')
         var res = fs.readFileSync(outFile, 'ascii')
         s.close()
-        t.equal(res, 'https://www.npmjs.org/package/test-repo-url-ssh\n')
+        t.equal(res, 'https://gitlab.com/evanlucas/test-repo-url-ssh/issues\n')
         rimraf.sync(outFile)
         t.end()
       }

--- a/deps/npm/test/tap/override-bundled.js
+++ b/deps/npm/test/tap/override-bundled.js
@@ -1,0 +1,106 @@
+'use strict'
+var test = require('tap').test
+var fs = require('fs')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var path = require('path')
+var common = require('../common-tap.js')
+
+var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
+var testjson = {
+  dependencies: {'top-test': 'file:top-test/'}
+}
+
+var testmod = path.resolve(testdir, 'top-test')
+var testmodjson = {
+  name: 'top-test',
+  version: '1.0.0',
+  dependencies: {
+    'bundle-update': 'file:bundle-update/',
+    'bundle-keep': 'file:bundle-keep/'
+  },
+  bundledDependencies: ['bundle-update', 'bundle-keep']
+}
+
+var bundleupdatesrc = path.resolve(testmod, 'bundle-update')
+var bundleupdateNEW = path.resolve(bundleupdatesrc, 'NEW')
+var bundleupdateNEWpostinstall = path.resolve(testdir, 'node_modules', 'top-test', 'node_modules', 'bundle-update', 'NEW')
+var bundleupdatebad = path.resolve(testmod, 'node_modules', 'bundle-update')
+var bundlekeepsrc = path.resolve(testmod, 'bundle-keep')
+var bundlekeep = path.resolve(testmod, 'node_modules', 'bundle-keep')
+var bundlekeepOLD = path.resolve(bundlekeep, 'OLD')
+var bundlekeepOLDpostinstall = path.resolve(testdir, 'node_modules', 'top-test', 'node_modules', 'bundle-keep', 'OLD')
+var bundlejson = {
+  name: 'bundle-update',
+  version: '1.0.0'
+}
+var bundlekeepjson = {
+  name: 'bundle-keep',
+  _requested: {
+    rawSpec: 'file:bundle-keep/'
+  }
+}
+
+function writepjs (dir, content) {
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(content, null, 2))
+}
+
+function setup () {
+  mkdirp.sync(testdir)
+  writepjs(testdir, testjson)
+  mkdirp.sync(testmod)
+  writepjs(testmod, testmodjson)
+  mkdirp.sync(bundleupdatesrc)
+  writepjs(bundleupdatesrc, bundlejson)
+  fs.writeFileSync(bundleupdateNEW, '')
+  mkdirp.sync(bundleupdatebad)
+  writepjs(bundleupdatebad, bundlejson)
+  mkdirp.sync(bundlekeepsrc)
+  writepjs(bundlekeepsrc, bundlekeepjson)
+  mkdirp.sync(bundlekeep)
+  writepjs(bundlekeep, bundlekeepjson)
+  fs.writeFileSync(bundlekeepOLD, '')
+}
+
+function cleanup () {
+  rimraf.sync(testdir)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+test('bundled', function (t) {
+  common.npm(['install', '--loglevel=warn'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.plan(5)
+    t.is(code, 0, 'npm itself completed ok')
+
+    // This tests that after the install we have a freshly installed version
+    // of `bundle-update` (in alignment with the package.json), instead of the
+    // version that was bundled with `top-test`.
+    // If npm doesn't do this, and selects the bundled version, things go very
+    // wrong because npm thinks it has a different module (with different
+    // metadata) installed in that location and will go off and try to do
+    // _things_ to it.  Things like chmod in particular, which in turn results
+    // in the dreaded ENOENT errors.
+    t.like(stderr, /EPACKAGEJSON override-bundled/, "didn't stomp on other warnings")
+    t.like(stderr, /EBUNDLEOVERRIDE/, 'included warning about bundled dep')
+    fs.stat(bundleupdateNEWpostinstall, function (missing) {
+      t.ok(!missing, 'package.json overrode bundle')
+    })
+
+    // Relatedly, when upgrading, if a bundled module is replacing an existing
+    // module we want to choose the bundled version, not the version we're replacing.
+    fs.stat(bundlekeepOLDpostinstall, function (missing) {
+      t.ok(!missing, 'package.json overrode bundle')
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})

--- a/deps/npm/test/tap/shrinkwrap-version-match.js
+++ b/deps/npm/test/tap/shrinkwrap-version-match.js
@@ -1,0 +1,120 @@
+'use strict'
+var test = require('tap').test
+var fs = require('fs')
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var path = require('path')
+var common = require('../common-tap.js')
+
+var testdir = path.resolve(__dirname, path.basename(__filename, '.js'))
+var modAdir = path.resolve(testdir, 'modA')
+var modB1dir = path.resolve(testdir, 'modB@1')
+var modB2dir = path.resolve(testdir, 'modB@2')
+var modCdir = path.resolve(testdir, 'modC')
+var testjson = {
+  dependencies: {
+    modA: 'file://' + modAdir,
+    modC: 'file://' + modCdir
+  }
+}
+var testshrinkwrap = {
+  dependencies: {
+    modA: {
+      version: '1.0.0',
+      from: 'modA',
+      resolved: 'file://' + modAdir
+    },
+    modB: {
+      version: '1.0.0',
+      from: 'modB@1',
+      resolved: 'file://' + modB1dir
+    }
+  }
+}
+var modAjson = {
+  name: 'modA',
+  version: '1.0.0',
+  dependencies: {
+    'modB': 'file://' + modB1dir
+  }
+}
+var modCjson = {
+  name: 'modC',
+  version: '1.0.0',
+  dependencies: {
+    'modB': 'file://' + modB2dir
+  }
+}
+var modB1json = {
+  name: 'modB',
+  version: '1.0.0'
+}
+var modB2json = {
+  name: 'modB',
+  version: '2.0.0'
+}
+
+function writepjson (dir, content) {
+  writejson(dir, 'package.json', content)
+}
+function writejson (dir, file, content) {
+  writefile(dir, file, JSON.stringify(content, null, 2))
+}
+function writefile (dir, file, content) {
+  fs.writeFileSync(path.join(dir, file), content)
+}
+
+function setup () {
+  mkdirp.sync(testdir)
+  writepjson(testdir, testjson)
+  writejson(testdir, 'npm-shrinkwrap.json', testshrinkwrap)
+  mkdirp.sync(modAdir)
+  writepjson(modAdir, modAjson)
+  mkdirp.sync(modB1dir)
+  writepjson(modB1dir, modB1json)
+  writefile(modB1dir, 'B1', '')
+  mkdirp.sync(modB2dir)
+  writepjson(modB2dir, modB2json)
+  writefile(modB2dir, 'B2', '')
+  mkdirp.sync(modCdir)
+  writepjson(modCdir, modCjson)
+}
+
+function cleanup () {
+  rimraf.sync(testdir)
+}
+
+test('setup', function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+// Shrinkwraps need to let you override dependency versions specified in
+// package.json files.  Indeed, this was already supported, but it was a bit
+// to keen on this.  Previously, if you had a dep in your shrinkwrap then
+// anything that required that dependency would count as a match, regardless
+// of version.
+
+// This test ensures that the broad matching is not done when the matched
+// module is not a direct child of the module doing the requiring.
+
+test('bundled', function (t) {
+  common.npm(['install'], {cwd: testdir}, function (err, code, out, stderr) {
+    t.is(err, null, 'No fatal errors running npm')
+    t.is(code, 0, 'npm itself completed ok')
+    // Specifically, if B2 exists (or the modB directory under modC at all)
+    // that means modC was given its own copy of modB.  Without the patch
+    // that went with this test, it wouldn't have been installed because npm
+    // would have consider modB@1 to have fulfilled modC's requirement.
+    fs.stat(path.join(testdir, 'node_modules', 'modC', 'node_modules', 'modB', 'B2'), function (missing) {
+      t.ok(!missing, 'modC got the right version of modB')
+      t.end()
+    })
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})

--- a/deps/npm/test/tap/version-no-package.js
+++ b/deps/npm/test/tap/version-no-package.js
@@ -25,9 +25,8 @@ test('npm version in a prefix with no package.json', function (t) {
       t.doesNotThrow(function () {
         var metadata = JSON.parse(stdout)
         t.equal(metadata.node, process.versions.node, 'node versions match')
-
-        t.end()
       }, 'able to reconstitute version object from stdout')
+      t.end()
     }
   )
 })


### PR DESCRIPTION
Please find enclosed:

1. A fix for some of the `ENOENT` issues people see when updating modules that have bundled dependencies that are invalid according to the included package.json.
2. An important fix to how partial shrinkwraps are handled. This is an underspecified and undocumented feature that a few popular modules take advantage of.
3. A fix for crashes on non-object `bin` fields in package information returned from some third party registries. (npm's registry does not return non-object `bin` fields due to normalization of that field and others during publication.)

As always, the full details are available in our [changelog](https://github.com/npm/npm/blob/v3.3.12/CHANGELOG.md).

**r**: @Fishrock123
**r**: @chrisdickinson