### PR TITLE
dns: fix empty elem in result array

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -922,18 +922,11 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
     struct addrinfo *address;
     int n = 0;
 
-    // Count the number of responses.
-    for (address = res; address; address = address->ai_next) {
-      n++;
-    }
-
     // Create the response array.
-    Local<Array> results = Array::New(env->isolate(), n);
+    Local<Array> results = Array::New(env->isolate());
 
     char ip[INET6_ADDRSTRLEN];
     const char *addr;
-
-    n = 0;
 
     // Iterate over the IPv4 responses again this time creating javascript
     // strings for each IP and filling the results array.


### PR DESCRIPTION
When getaddrinfo linked-list results contain entries other than AF_INET
and AF_INET6, the resulting v8::Array will contain undefined value.
That's because initialization of v8::Array pre-allocate entries for all
linked-list nodes, but we may actually some of them after the 2 while
loops.