### PR TITLE
test: reduce memory use in test stringbytes

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -20,6 +20,8 @@ exports.isLinuxPPCBE = (process.platform === 'linux') &&
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
 
+exports.enoughTestMem = os.totalmem() > 0x20000000; /* 512MB */
+
 function rimrafSync(p) {
   try {
     var st = fs.lstatSync(p);

--- a/test/parallel/test-stringbytes-external-at-max.js
+++ b/test/parallel/test-stringbytes-external-at-max.js
@@ -1,22 +1,32 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
-try {
-  new Buffer(kStringMaxLength * 3);
-} catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
   return;
 }
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
-const buf = new Buffer(kStringMaxLength);
+try {
+  var buf = new Buffer(kStringMaxLength);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
+} catch(e) {
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
 
 const maxString = buf.toString('binary');
 assert.equal(maxString.length, kStringMaxLength);

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -1,22 +1,32 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  new Buffer(kStringMaxLength * 3);
+  var buf = new Buffer(kStringMaxLength + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
 } catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
   return;
 }
-
-const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('base64');

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -1,22 +1,32 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  new Buffer(kStringMaxLength * 3);
+  var buf = new Buffer(kStringMaxLength + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
 } catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
   return;
 }
-
-const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('binary');

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -1,22 +1,32 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  new Buffer(kStringMaxLength * 3);
+  var buf = new Buffer(kStringMaxLength + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
 } catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
   return;
 }
-
-const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('hex');

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -1,22 +1,32 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  new Buffer(kStringMaxLength * 3);
+  var buf = new Buffer(kStringMaxLength + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
 } catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
   return;
 }
-
-const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString();

--- a/test/parallel/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-2.js
@@ -1,22 +1,32 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  new Buffer(kStringMaxLength * 3);
+  var buf = new Buffer(kStringMaxLength + 2);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
 } catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
   return;
 }
 
-const buf2 = new Buffer(kStringMaxLength + 2);
-
-const maxString = buf2.toString('utf16le');
+const maxString = buf.toString('utf16le');
 assert.equal(maxString.length, (kStringMaxLength + 2) / 2);

--- a/test/parallel/test-stringbytes-external-exceed-max.js
+++ b/test/parallel/test-stringbytes-external-exceed-max.js
@@ -1,23 +1,33 @@
 'use strict';
+// Flags: --expose-gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  new Buffer(kStringMaxLength * 3);
+  var buf = new Buffer(kStringMaxLength * 2 + 2);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kStringMaxLength);
+  gc();
 } catch(e) {
-  assert.equal(e.message, 'Invalid array buffer length');
-  console.log(
-      '1..0 # Skipped: intensive toString tests due to memory confinements');
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
   return;
 }
 
-const buf0 = new Buffer(kStringMaxLength * 2 + 2);
-
 assert.throws(function() {
-  buf0.toString('utf16le');
+  buf.toString('utf16le');
 }, /"toString\(\)" failed/);


### PR DESCRIPTION
When I run the string bytes tests dealing with strings of length kStringMaxLength or more on a Windows test machine with 4GB memory I see the tests skipped or failed with the following outputs respectively.
* `1..0 # Skipped: intensive toString tests due to memory confinements`
* `RangeError: Invalid array buffer length`

The code being used to determine if the test should be skipped is:
```
 try {
  new Buffer(kStringMaxLength * 3);
 } catch(e) {
  assert.equal(e.message, 'Invalid array buffer length');
  console.log(
       '1..0 # Skipped: intensive toString tests due to memory confinements');
   return;
 }
```

A problem with this approach is that the garbage collector does not necessarily run between the tried allocation and the necessary allocations later. That means that even though no exception is thrown in the try block since the machine has enough memory, the later allocations fail since the memory is now taken.

To verify this, I ran the test with `Release\node.exe --expose-gc test\parallel\test-stringbytes-external-at-max.js` to expose `global.gc()` which I used after the try catch block. With this setup the test would either skip or succeed as desired.

To solve the issue, I removed the Buffer allocations that were used to check if the tests should be skipped and moved the actual Buffer allocations into the try block so the test can still be skipped if memory allocation fails here. The tests should now use less total memory and be less likely to be skipped and more importantly, less likely to fail due to a memory constraint when they are not skipped.
