### PR TITLE
deps: update V8 to 4.6.85.31

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 6
 #define V8_BUILD_NUMBER 85
-#define V8_PATCH_LEVEL 28
+#define V8_PATCH_LEVEL 31
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/arm64/lithium-codegen-arm64.cc
+++ b/deps/v8/src/arm64/lithium-codegen-arm64.cc
@@ -2819,6 +2819,8 @@ void LCodeGen::DoDoubleToIntOrSmi(LDoubleToIntOrSmi* instr) {
 
 void LCodeGen::DoDrop(LDrop* instr) {
   __ Drop(instr->count());
+
+  RecordPushedArgumentsDelta(instr->hydrogen_value()->argument_delta());
 }
 
 

--- a/deps/v8/src/i18n.js
+++ b/deps/v8/src/i18n.js
@@ -1103,14 +1103,15 @@ function initializeNumberFormat(numberFormat, locales, options) {
 
   var mnfd = options['minimumFractionDigits'];
   var mxfd = options['maximumFractionDigits'];
-  if (!IS_UNDEFINED(mnfd) || !internalOptions.style === 'currency') {
+  if (!IS_UNDEFINED(mnfd) || internalOptions.style !== 'currency') {
     mnfd = getNumberOption(options, 'minimumFractionDigits', 0, 20, 0);
     defineWEProperty(internalOptions, 'minimumFractionDigits', mnfd);
   }
 
-  if (!IS_UNDEFINED(mxfd) || !internalOptions.style === 'currency') {
+  if (!IS_UNDEFINED(mxfd) || internalOptions.style !== 'currency') {
+    var min_mxfd = internalOptions.style === 'percent' ? 0 : 3;
     mnfd = IS_UNDEFINED(mnfd) ? 0 : mnfd;
-    fallback_limit = (mnfd > 3) ? mnfd : 3;
+    fallback_limit = (mnfd > min_mxfd) ? mnfd : min_mxfd;
     mxfd = getNumberOption(options, 'maximumFractionDigits', mnfd, 20, fallback_limit);
     defineWEProperty(internalOptions, 'maximumFractionDigits', mxfd);
   }

--- a/deps/v8/test/intl/number-format/check-minimum-fraction-digits.js
+++ b/deps/v8/test/intl/number-format/check-minimum-fraction-digits.js
@@ -2,8 +2,56 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Make sure minimumFractionDigits is honored
+// Make sure minimumFractionDigits and maximumFractionDigits are honored
 
-var nf = new Intl.NumberFormat("en-us",{ useGrouping: false, minimumFractionDigits: 4});
+var nf = new Intl.NumberFormat("en-us", { useGrouping: false, minimumFractionDigits: 4, maximumFractionDigits: 8});
 
 assertEquals("12345.6789", nf.format(12345.6789));
+assertEquals("12345.678912", nf.format(12345.678912));
+assertEquals("12345.6700", nf.format(12345.67));
+assertEquals("12345.67891234", nf.format(12345.6789123421));
+
+nf = new Intl.NumberFormat("en-us", { useGrouping: false, minimumFractionDigits: 4, maximumFractionDigits: 8, style: 'percent'});
+
+assertEquals("12345.6789%", nf.format(123.456789));
+assertEquals("12345.678912%", nf.format(123.45678912));
+assertEquals("12345.6700%", nf.format(123.4567));
+assertEquals("12345.67891234%", nf.format(123.456789123421));
+
+nf = new Intl.NumberFormat('en', {minimumFractionDigits: 4, maximumFractionDigits: 8, style: 'currency', currency: 'USD'});
+
+assertEquals("$54,306.404797", nf.format(54306.4047970));
+assertEquals("$54,306.4000", nf.format(54306.4));
+assertEquals("$54,306.40000001", nf.format(54306.400000011));
+
+// Ensure that appropriate defaults exist when minimum and maximum are not specified
+
+nf = new Intl.NumberFormat("en-us", { useGrouping: false });
+
+assertEquals("12345.679", nf.format(12345.6789));
+assertEquals("12345.679", nf.format(12345.678912));
+assertEquals("12345.67", nf.format(12345.6700));
+assertEquals("12345", nf.format(12345));
+assertEquals("12345.679", nf.format(12345.6789123421));
+
+nf = new Intl.NumberFormat("en-us", { useGrouping: false, style: 'percent'});
+
+assertEquals("12346%", nf.format(123.456789));
+assertEquals("12346%", nf.format(123.45678912));
+assertEquals("12346%", nf.format(123.456700));
+assertEquals("12346%", nf.format(123.456789123421));
+assertEquals("12345%", nf.format(123.45));
+
+// For currency, the minimum or the maximum can be overwritten individually
+
+nf = new Intl.NumberFormat('en', {minimumFractionDigits: 0, style: 'currency', currency: 'USD'});
+
+assertEquals("$54,306.4", nf.format(54306.4047970));
+assertEquals("$54,306.4", nf.format(54306.4));
+assertEquals("$54,306", nf.format(54306));
+
+nf = new Intl.NumberFormat('en', {maximumFractionDigits: 3, style: 'currency', currency: 'USD'});
+
+assertEquals("$54,306.405", nf.format(54306.4047970));
+assertEquals("$54,306.40", nf.format(54306.4));
+assertEquals("$54,306.00", nf.format(54306));

--- a/deps/v8/test/mjsunit/regress/regress-arm64-spillslots.js
+++ b/deps/v8/test/mjsunit/regress/regress-arm64-spillslots.js
@@ -1,0 +1,34 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+"use strict";
+
+function Message(message) {
+  this.message = message;
+}
+
+function Inlined(input) {
+  var dummy = arguments[1] === undefined;
+  if (input instanceof Message) {
+    return input;
+  }
+  print("unreachable, but we must create register allocation complexity");
+  return [];
+}
+
+function Process(input) {
+  var ret = [];
+  ret.push(Inlined(input[0], 1, 2));
+  return ret;
+}
+
+var input = [new Message("TEST PASS")];
+
+Process(input);
+Process(input);
+%OptimizeFunctionOnNextCall(Process);
+var result = Process(input);
+assertEquals("TEST PASS", result[0].message);


### PR DESCRIPTION
This update contains the patch floated in
https://github.com/nodejs/node/issues/3390 and a fix for
Intl.NumberFormat.

Diff: https://chromium.googlesource.com/v8/v8.git/+/4.6.85.28..4.6.85.31

cc @nodejs/v8 