### PR TITLE
Force line-buffering for stderr

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -41,6 +41,7 @@ int wmain(int argc, wchar_t *wargv[]) {
 #else
 // UNIX
 int main(int argc, char *argv[]) {
+  setvbuf(stderr, NULL, _IOLBF, 1024);
   return node::Start(argc, argv);
 }
 #endif

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -18,7 +18,6 @@ test-child-process-exit-code      : PASS,FLAKY
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS
-test-debug-signal-cluster         : PASS,FLAKY
 
 [$system==freebsd]
 test-net-socket-local-address     : PASS,FLAKY


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/2476
Refs: https://github.com/nodejs/node/pull/3615

On CI, it appears that stderr on SmartOS is not line buffered and that was resulting in some interleaving in test-debug-signal-cluster, causing the test to be flaky. This change forces stderr to be line-buffered, fixing the issue. 