### PR TITLE
test: use really invalid hostname

### DIFF
--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -1,21 +1,17 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
-var gotError = false;
+const client = net.connect({host: '...', port: common.PORT});
 
-var client = net.connect({
-  host: 'no.way.you.will.resolve.this',
-  port: common.PORT
-});
-
-client.once('error', function(err) {
-  gotError = true;
-});
+client.once('error', common.mustCall(function(err) {
+  assert(err);
+  assert.strictEqual(err.code, err.errno);
+  assert.strictEqual(err.code, 'ENOTFOUND');
+  assert.strictEqual(err.host, err.hostname);
+  assert.strictEqual(err.host, '...');
+  assert.strictEqual(err.syscall, 'getaddrinfo');
+}));
 
 client.end();
-
-process.on('exit', function() {
-  assert(gotError);
-});


### PR DESCRIPTION
On my slow Ubuntu 14.04 machine, this fails to resolve the host name
used (`no.way.you.will.resolve.this`) and it times out in local testing.
This patch uses an invalid name (`...`) and does stricter validation of
the error returned.