### PR TITLE
tools: enforce `throw new Error()` with lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -87,6 +87,8 @@ rules:
 
   # Custom rules in tools/eslint-rules
   require-buffer: 2
+  new-with-error: [2, "Error", "RangeError", "TypeError", "SyntaxError", "ReferenceError"]
+
 
 # Global scoped method and vars
 globals:

--- a/test/addons/make-callback/test.js
+++ b/test/addons/make-callback/test.js
@@ -40,7 +40,7 @@ assert.strictEqual(42, makeCallback(recv, 'two', 1337));
 const target = vm.runInNewContext(`
     (function($Object) {
       if (Object === $Object)
-        throw Error('bad');
+        throw new Error('bad');
       return Object;
     })
 `);
@@ -55,7 +55,7 @@ const forward = vm.runInNewContext(`
 // Runs in outer context.
 const endpoint = function($Object) {
   if (Object === $Object)
-    throw Error('bad');
+    throw new Error('bad');
   return Object;
 };
 assert.strictEqual(Object, makeCallback(process, forward, endpoint));

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -466,6 +466,6 @@ testBlockTypeError(assert.doesNotThrow, undefined);
 
 // https://github.com/nodejs/node/issues/3275
 assert.throws(() => { throw 'error'; }, err => err === 'error');
-assert.throws(() => { throw Error(); }, err => err instanceof Error);
+assert.throws(() => { throw new Error(); }, err => err instanceof Error);
 
 console.log('All OK');

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -110,7 +110,7 @@ function nextTest() {
         break;
 
       default:
-        throw Error('?');
+        throw new Error('?');
     }
 
     response.setEncoding('utf8');

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -46,7 +46,7 @@ var timeToQuit = Date.now() + 8e3; //Test during no more than this seconds.
     }
   }
   else {
-    throw Error("Buffer GC'ed test -> FAIL");
+    throw new Error("Buffer GC'ed test -> FAIL");
   }
 
   if (Date.now() < timeToQuit) {

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -21,7 +21,7 @@ function tailCB(data) {
     console.error('[FAIL]\n DATA -> ');
     console.error(data);
     console.error('\n');
-    throw Error('Buffers GC test -> FAIL');
+    throw new Error('Buffers GC test -> FAIL');
   }
 }
 

--- a/tools/eslint-rules/new-with-error.js
+++ b/tools/eslint-rules/new-with-error.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Require `throw new Error()` rather than `throw Error()`
+ * @author Rich Trott
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  var errorList = context.options.length !== 0 ? context.options : ['Error'];
+
+  return {
+    'ThrowStatement': function(node) {
+      if (node.argument.type === 'CallExpression' &&
+          errorList.indexOf(node.argument.callee.name) !== -1) {
+        context.report(node, 'Use new keyword when throwing.');
+      }
+    }
+  };
+};
+
+module.exports.schema = {
+  'type': 'array',
+  'items': [
+    {
+      'enum': [0, 1, 2]
+    }
+  ],
+  'additionalItems': {
+    'type': 'string'
+  },
+  'uniqueItems': true
+};


### PR DESCRIPTION
@evanlucas left [a comment on another PR](https://github.com/nodejs/node/pull/3636#discussion_r44224106) pointing out that the convention in the code base is `throw new Error()` over `throw Error().` This PR changes the five instances of `throw Error()` in the code base and enforces it with a linting rule.