### PR TITLE
cluster: send suicide message on disconnect

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -654,26 +654,24 @@ function workerInit() {
 
   Worker.prototype.disconnect = function() {
     this.suicide = true;
-    var waitingHandles = 0;
+    let waitingCount = 1;
 
-    function checkRemainingHandles() {
-      waitingHandles--;
-      if (waitingHandles === 0) {
+    function checkWaitingCount() {
+      waitingCount--;
+      if (waitingCount === 0) {
+        send({ act: 'suicide' });
         process.disconnect();
       }
     }
 
-    for (var key in handles) {
-      var handle = handles[key];
+    for (const key in handles) {
+      const handle = handles[key];
       delete handles[key];
-      waitingHandles++;
-      handle.owner.close(checkRemainingHandles);
+      waitingCount++;
+      handle.owner.close(checkWaitingCount);
     }
 
-    if (waitingHandles === 0) {
-      process.disconnect();
-    }
-
+    checkWaitingCount();
   };
 
   Worker.prototype.destroy = function() {

--- a/test/parallel/test-regress-GH-3238.js
+++ b/test/parallel/test-regress-GH-3238.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+  let disconnected = false;
+
+  worker.on('disconnect', common.mustCall(function() {
+    assert.strictEqual(worker.suicide, true);
+    disconnected = true;
+  }));
+
+  worker.on('exit', common.mustCall(function() {
+    assert.strictEqual(worker.suicide, true);
+    assert.strictEqual(disconnected, true);
+  }));
+} else {
+  cluster.worker.disconnect();
+}


### PR DESCRIPTION
This commit causes `Worker.prototype.disconnect()` to send a suicide message to the cluster master. The function is also restructured to eliminate redundant code.

Fixes: https://github.com/nodejs/node/issues/3238