### PR TITLE
test: fix tests that check error messages

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -566,7 +566,7 @@ posix.extname = function(path) {
 posix.format = function(pathObject) {
   if (pathObject === null || typeof pathObject !== 'object') {
     throw new TypeError(
-        "Parameter 'pathObject' must be an object, not " + typeof pathObject
+        'Parameter "pathObject" must be an object, not ' + typeof pathObject
     );
   }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -438,7 +438,8 @@ function testBlockTypeError(method, block) {
     method(block);
     threw = false;
   } catch (e) {
-    assert.equal(e.toString(), 'TypeError: block must be a function');
+    assert.equal(e.toString(),
+                 'TypeError: "block" argument must be a function');
   }
 
   assert.ok(threw);

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1222,11 +1222,11 @@ assert.throws(function() {
 
 assert.throws(function() {
   new Buffer();
-}, /must start with number, buffer, array or string/);
+}, /must start with number, buffer, array or string/i);
 
 assert.throws(function() {
   new Buffer(null);
-}, /must start with number, buffer, array or string/);
+}, /must start with number, buffer, array or string/i);
 
 
 // Test prototype getters don't throw

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -8,7 +8,7 @@ const common = require('../common');
 const cmd = common.isWindows ? 'rundll32' : 'ls';
 const invalidcmd = 'hopefully_you_dont_have_this_on_your_machine';
 const invalidArgsMsg = /Incorrect value of args option/;
-const invalidOptionsMsg = /options argument must be an object/;
+const invalidOptionsMsg = /"options" argument must be an object/;
 const empty = common.fixturesDir + '/empty.js';
 
 assert.throws(function() {

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -178,7 +178,7 @@ function run_test_4() {
       function() {
         file = fs.createWriteStream(filepath, options);
       },
-      /start must be/
+      /"start" must be/
   );
 
 }

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -96,11 +96,11 @@ assert.throws(function() {
 
 assert.throws(function() {
   fs.access(__filename, fs.F_OK);
-}, /callback must be a function/);
+}, /"callback" argument must be a function/);
 
 assert.throws(function() {
   fs.access(__filename, fs.F_OK, {});
-}, /callback must be a function/);
+}, /"callback" argument must be a function/);
 
 assert.doesNotThrow(function() {
   fs.accessSync(__filename);

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var fs = require('fs');
 
 function check(async, sync) {
-  var expected = /Path must be a string without null bytes./;
+  var expected = /Path must be a string without null bytes/;
   var argsSync = Array.prototype.slice.call(arguments, 2);
   var argsAsync = argsSync.concat(function(er) {
     assert(er && er.message.match(expected));

--- a/test/parallel/test-fs-read-buffer-tostring-fail.js
+++ b/test/parallel/test-fs-read-buffer-tostring-fail.js
@@ -29,7 +29,7 @@ stream.on('finish', common.mustCall(function() {
   fd = fs.openSync(file, 'r');
   fs.read(fd, kStringMaxLength + 1, 0, 'utf8', common.mustCall(function(err) {
     assert.ok(err instanceof Error);
-    assert.strictEqual('toString failed', err.message);
+    assert.strictEqual('"toString()" failed', err.message);
   }));
 }));
 

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -114,7 +114,7 @@ file6.on('end', function() {
 
 assert.throws(function() {
   fs.createReadStream(rangeFile, Object.create({start: 10, end: 2}));
-}, /start must be <= end/);
+}, /"start" option must be <= "end" option/);
 
 var stream = fs.createReadStream(rangeFile, Object.create({ start: 0,
                                  end: 0 }));

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -18,16 +18,16 @@ assert.doesNotThrow(function() {
 
 assert.throws(function() {
   fs.createReadStream(example, null);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createReadStream(example, 123);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createReadStream(example, 0);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createReadStream(example, true);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createReadStream(example, false);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -107,7 +107,7 @@ file6.on('end', function() {
 
 assert.throws(function() {
   fs.createReadStream(rangeFile, {start: 10, end: 2});
-}, /start must be <= end/);
+}, /"start" option must be <= "end" option/);
 
 var stream = fs.createReadStream(rangeFile, { start: 0, end: 0 });
 stream.data = '';

--- a/test/parallel/test-fs-readfile-tostring-fail.js
+++ b/test/parallel/test-fs-readfile-tostring-fail.js
@@ -25,7 +25,7 @@ stream.on('finish', common.mustCall(function() {
   // make sure that the toString does not throw an error
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
     assert.ok(err instanceof Error);
-    assert.strictEqual('toString failed', err.message);
+    assert.strictEqual('"toString()" failed', err.message);
   }));
 }));
 

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -8,11 +8,11 @@ const assert = require('assert');
 // Basic usage tests.
 assert.throws(function() {
   fs.watchFile('./some-file');
-}, /watchFile requires a listener function/);
+}, /"watchFile\(\)" requires a listener function/);
 
 assert.throws(function() {
   fs.watchFile('./another-file', {}, 'bad listener');
-}, /watchFile requires a listener function/);
+}, /"watchFile\(\)" requires a listener function/);
 
 assert.throws(function() {
   fs.watchFile(new Object(), function() {});

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -20,16 +20,16 @@ assert.doesNotThrow(function() {
 
 assert.throws(function() {
   fs.createWriteStream(example, null);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createWriteStream(example, 123);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createWriteStream(example, 0);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createWriteStream(example, true);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);
 assert.throws(function() {
   fs.createWriteStream(example, false);
-}, /options must be a string or an object/);
+}, /"options" argument must be a string or an object/);

--- a/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
+++ b/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
@@ -10,7 +10,7 @@ assert.throws(function() {
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "file:" not supported.' +
-                       ' Expected "http:".');
+                       ' Expected "http:"');
     return true;
   }
 });
@@ -20,7 +20,7 @@ assert.throws(function() {
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "mailto:" not supported.' +
-                       ' Expected "http:".');
+                       ' Expected "http:"');
     return true;
   }
 });
@@ -30,7 +30,7 @@ assert.throws(function() {
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "ftp:" not supported.' +
-                       ' Expected "http:".');
+                       ' Expected "http:"');
     return true;
   }
 });
@@ -40,7 +40,7 @@ assert.throws(function() {
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "javascript:" not supported.' +
-                       ' Expected "http:".');
+                       ' Expected "http:"');
     return true;
   }
 });
@@ -50,7 +50,7 @@ assert.throws(function() {
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "xmpp:" not supported.' +
-                       ' Expected "http:".');
+                       ' Expected "http:"');
     return true;
   }
 });
@@ -60,7 +60,7 @@ assert.throws(function() {
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "f:" not supported.' +
-                       ' Expected "http:".');
+                       ' Expected "http:"');
     return true;
   }
 });

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -25,7 +25,7 @@ var s = http.createServer(function(req, res) {
     res.setHeader('foo', undefined);
   } catch (e) {
     assert.ok(e instanceof Error);
-    assert.equal(e.message, '`value` required in setHeader("foo", value).');
+    assert.equal(e.message, '"value" required in setHeader("foo", value)');
     threw = true;
   }
   assert.ok(threw, 'Undefined value should throw');

--- a/test/parallel/test-net-create-connection.js
+++ b/test/parallel/test-net-create-connection.js
@@ -38,55 +38,55 @@ server.listen(tcpPort, 'localhost', function() {
 
   fail({
     port: true
-  }, TypeError, 'port should be a number or string: true');
+  }, TypeError, '"port" option should be a number or string: true');
 
   fail({
     port: false
-  }, TypeError, 'port should be a number or string: false');
+  }, TypeError, '"port" option should be a number or string: false');
 
   fail({
     port: []
-  }, TypeError, 'port should be a number or string: ');
+  }, TypeError, '"port" option should be a number or string: ');
 
   fail({
     port: {}
-  }, TypeError, 'port should be a number or string: [object Object]');
+  }, TypeError, '"port" option should be a number or string: [object Object]');
 
   fail({
     port: null
-  }, TypeError, 'port should be a number or string: null');
+  }, TypeError, '"port" option should be a number or string: null');
 
   fail({
     port: ''
-  }, RangeError, 'port should be >= 0 and < 65536: ');
+  }, RangeError, '"port" option should be >= 0 and < 65536: ');
 
   fail({
     port: ' '
-  }, RangeError, 'port should be >= 0 and < 65536:  ');
+  }, RangeError, '"port" option should be >= 0 and < 65536:  ');
 
   fail({
     port: '0x'
-  }, RangeError, 'port should be >= 0 and < 65536: 0x');
+  }, RangeError, '"port" option should be >= 0 and < 65536: 0x');
 
   fail({
     port: '-0x1'
-  }, RangeError, 'port should be >= 0 and < 65536: -0x1');
+  }, RangeError, '"port" option should be >= 0 and < 65536: -0x1');
 
   fail({
     port: NaN
-  }, RangeError, 'port should be >= 0 and < 65536: NaN');
+  }, RangeError, '"port" option should be >= 0 and < 65536: NaN');
 
   fail({
     port: Infinity
-  }, RangeError, 'port should be >= 0 and < 65536: Infinity');
+  }, RangeError, '"port" option should be >= 0 and < 65536: Infinity');
 
   fail({
     port: -1
-  }, RangeError, 'port should be >= 0 and < 65536: -1');
+  }, RangeError, '"port" option should be >= 0 and < 65536: -1');
 
   fail({
     port: 65536
-  }, RangeError, 'port should be >= 0 and < 65536: 65536');
+  }, RangeError, '"port" option should be >= 0 and < 65536: 65536');
 });
 
 // Try connecting to random ports, but do so once the server is closed

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -17,7 +17,7 @@ net.Server().listen({ port: '' + common.PORT }, close);
   '-Infinity' ].forEach(function(port) {
   assert.throws(function() {
     net.Server().listen({ port: port }, assert.fail);
-  }, /port should be >= 0 and < 65536/i);
+  }, /"port" option should be >= 0 and < 65536/i);
 });
 
 [null, true, false].forEach(function(port) {

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -56,17 +56,17 @@ var errors = [
   {method: 'parse', input: [],
    message: /Path must be a string. Received undefined/},
   {method: 'format', input: [null],
-   message: /Parameter 'pathObject' must be an object, not/},
+   message: /Parameter "pathObject" must be an object, not/},
   {method: 'format', input: [''],
-   message: /Parameter 'pathObject' must be an object, not string/},
+   message: /Parameter "pathObject" must be an object, not string/},
   {method: 'format', input: [true],
-   message: /Parameter 'pathObject' must be an object, not boolean/},
+   message: /Parameter "pathObject" must be an object, not boolean/},
   {method: 'format', input: [1],
-   message: /Parameter 'pathObject' must be an object, not number/},
+   message: /Parameter "pathObject" must be an object, not number/},
   {method: 'format', input: [{root: true}],
-   message: /'pathObject.root' must be a string or undefined, not boolean/},
+   message: /"pathObject\.root" must be a string or undefined, not boolean/},
   {method: 'format', input: [{root: 12}],
-   message: /'pathObject.root' must be a string or undefined, not number/},
+   message: /"pathObject\.root" must be a string or undefined, not number/},
 ];
 
 checkParseFormat(path.win32, winPaths);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -222,7 +222,7 @@ function isWarned(emitter) {
     });
   }, function(err) {
     if (err instanceof TypeError) {
-      if (/Argument \'completer\' must be a function/.test(err)) {
+      if (/Argument "completer" must be a function/.test(err)) {
         return true;
       }
     }
@@ -380,4 +380,3 @@ function isWarned(emitter) {
   });
 
 });
-

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -20,4 +20,4 @@ const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('ascii');
-}, /toString failed/);
+}, /"toString\(\)" failed/);

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -20,4 +20,4 @@ const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('base64');
-}, /toString failed/);
+}, /"toString\(\)" failed/);

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -20,7 +20,7 @@ const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('binary');
-}, /toString failed/);
+}, /"toString\(\)" failed/);
 
 var maxString = buf.toString('binary', 1);
 assert.equal(maxString.length, kStringMaxLength);

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -20,4 +20,4 @@ const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString('hex');
-}, /toString failed/);
+}, /"toString\(\)" failed/);

--- a/test/parallel/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/parallel/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -20,8 +20,8 @@ const buf = new Buffer(kStringMaxLength + 1);
 
 assert.throws(function() {
   buf.toString();
-}, /toString failed|Invalid array buffer length/);
+}, /"toString\(\)" failed|Invalid array buffer length/);
 
 assert.throws(function() {
   buf.toString('utf8');
-}, /toString failed/);
+}, /"toString\(\)" failed/);

--- a/test/parallel/test-stringbytes-external-exceed-max.js
+++ b/test/parallel/test-stringbytes-external-exceed-max.js
@@ -20,4 +20,4 @@ const buf0 = new Buffer(kStringMaxLength * 2 + 2);
 
 assert.throws(function() {
   buf0.toString('utf16le');
-}, /toString failed/);
+}, /"toString\(\)" failed/);

--- a/test/parallel/test-writeuint.js
+++ b/test/parallel/test-writeuint.js
@@ -131,10 +131,10 @@ function testUint(clazz) {
     const errmsg = `byteLength: ${i}`;
     ASSERT.throws(function() {
       data.writeUIntBE(val, 0, i);
-    }, /value is out of bounds/, errmsg);
+    }, /"value" argument is out of bounds/, errmsg);
     ASSERT.throws(function() {
       data.writeUIntLE(val, 0, i);
-    }, /value is out of bounds/, errmsg);
+    }, /"value" argument is out of bounds/, errmsg);
     val *= 0x100;
   }
 }


### PR DESCRIPTION
20285ad17755187ece16b8a5effeaa87f5407da2 changed the format of error messages throughout lib. However, the tests were not updated to reflect these changes. This commit makes those changes.