### PR TITLE
doc: warn about reassigning _ in REPL

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -219,6 +219,9 @@ The special variable `_` (underscore) contains the result of the last expression
     > _ += 1
     4
 
+*NOTE*: Explicitly assigning a value to `_` in the REPL can produce unexpected
+results.
+
 The REPL provides access to any variables in the global scope. You can expose
 a variable to the REPL explicitly by assigning it to the `context` object
 associated with each `REPLServer`.  For example:


### PR DESCRIPTION
When users assign a value to `_` in REPL, it is prone to unexpected
results or messing up with REPL's internals. For example,
https://github.com/nodejs/node/issues/3704. This patch issues a warning
about the same.