### PR TITLE
lib,test: remove publicly exposed freelist

### DIFF
--- a/lib/freelist.js
+++ b/lib/freelist.js
@@ -1,6 +1,0 @@
-'use strict';
-
-const util = require('internal/util');
-
-module.exports = require('internal/freelist');
-util.printDeprecationMessage('freelist module is deprecated.');

--- a/node.gyp
+++ b/node.gyp
@@ -29,7 +29,6 @@
       'lib/dns.js',
       'lib/domain.js',
       'lib/events.js',
-      'lib/freelist.js',
       'lib/fs.js',
       'lib/http.js',
       'lib/_http_agent.js',

--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -4,12 +4,10 @@
 
 require('../common');
 const assert = require('assert');
-const freelist = require('freelist');
-const internalFreelist = require('internal/freelist');
+const freelist = require('internal/freelist');
 
 assert.equal(typeof freelist, 'object');
 assert.equal(typeof freelist.FreeList, 'function');
-assert.strictEqual(freelist, internalFreelist);
 
 const flist1 = new freelist.FreeList('flist1', 3, String);
 


### PR DESCRIPTION
The `freelist` module was deprecated in io.js and moved to an internal module. This commit removes public access to `freelist`, while leaving the internal module, which is still in use.

This was discussed in #569, and [should be able to go into v6](https://github.com/nodejs/node/issues/569#issuecomment-155156119).