### PR TITLE
fs: fix readFile will pass undefined to callback but not null

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -405,7 +405,7 @@ function readFileAfterClose(err) {
 }
 
 function tryToString(buf, encoding, callback) {
-  var e;
+  var e = null;
   try {
     buf = buf.toString(encoding);
   } catch (err) {


### PR DESCRIPTION
In [PR-3485](https://github.com/nodejs/node/pull/3485), if encoding set, fs.readFile will pass undefined not null to callback.