### PR TITLE
doc: add note about tls connection meta data methods

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -764,6 +764,10 @@ of written data and all required TLS negotiation.
 This instance implements a duplex [Stream][] interfaces.  It has all the
 common stream methods and events.
 
+Methods that return TLS connection meta data (e.g.
+[getPeerCertificate](#tlssocketgetpeercertificate-detailed-))
+will only return data while the connection is open.
+
 ### Event: 'secureConnect'
 
 This event is emitted after a new connection has been successfully handshaked.


### PR DESCRIPTION
Document current behavior of TLSSocket, as discussed in https://github.com/nodejs/node/issues/3545