### PR TITLE
doc: add link to [customizing util.inspect colors].

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -70,7 +70,7 @@ object. This is useful for inspecting large complicated objects. Defaults to
 `2`. To make it recurse indefinitely pass `null`.
 
 - `colors` - if `true`, then the output will be styled with ANSI color codes.
-Defaults to `false`. Colors are customizable, see below.
+Defaults to `false`. Colors are customizable, see [customizing util.inspect colors][].
 
 ### console.time(timerName)
 
@@ -140,3 +140,4 @@ The global `console` is a special `Console` whose output is sent to
 
 [assert.ok()]: assert.html#assert_assert_value_message_assert_ok_value_message
 [util.format()]: util.html#util_util_format_format
+[customizing util.inspect colors]: util.html#util_customizing_util_inspect_colors


### PR DESCRIPTION
Previously this said "see below" to nowhere.

I have the [same thing for v4.x](https://github.com/nodejs/node/compare/v4.x...jmm:console-colors-docs-v4).

1. Another option would be to link to the `util.inspect()` documentation for all of the options (`showHidden|depth|colors`) instead of duplicating them (that'd be my preference, unless the build system can accomodate that content being located in one place and inserted in both places in the output).

1. The task for building the docs depends on building Node? That is prohibitively slow for making docs changes. (I'm doing it where I already have a functioning Node installation.) I had to hack the build scripts to get around that to be able to make these changes, and I wouldn't attempt this again without being able to build them using the existing Node install. It's possible I've misunderstood or done something wrong -- I just followed the instructions from the README: `$ make doc`.

1. What does [`CONTRIBUTING.md`](https://github.com/nodejs/node/blob/19bf72ddc5dbe78e50ff736052a4448421b3510a/CONTRIBUTING.md#respect-the-stability-index) mean?:

  > The rules for the master branch are less strict;

  Less strict than what?