### PR TITLE
streams: performance improvements for clearBuffer in Writable

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -7,6 +7,7 @@
 module.exports = Writable;
 Writable.WritableState = WritableState;
 
+const assert = require('assert');
 const util = require('util');
 const internalUtil = require('internal/util');
 const Stream = require('stream');
@@ -108,6 +109,31 @@ function WritableState(options, stream) {
 
   // True if the error was already emitted and should not be thrown again
   this.errorEmitted = false;
+
+  // count buffered requests
+  this.bufferedRequestCount = 0;
+
+  // the requests that needs to be called by uncork
+  this.corkedCbs = null;
+
+  // call all the corked requests
+  this.afterCorkedWrite = function afterCorkedWrite(err) {
+    var state = stream._writableState;
+    var entry = state.corkedCbs;
+    var cbs = entry.cbs;
+
+    state.corkedCbs = entry.next;
+
+    for (var i = 0; i < cbs.length; i++) {
+      state.pendingcb--;
+      cbs[i](err);
+    }
+  };
+}
+
+function CorkedCbs(cbs) {
+  this.cbs = cbs;
+  this.next = null;
 }
 
 WritableState.prototype.getBuffer = function writableStateGetBuffer() {
@@ -274,6 +300,7 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
     } else {
       state.bufferedRequest = state.lastBufferedRequest;
     }
+    state.bufferedRequestCount++;
   } else {
     doWrite(stream, state, false, len, chunk, encoding, cb);
   }
@@ -362,27 +389,37 @@ function onwriteDrain(stream, state) {
 function clearBuffer(stream, state) {
   state.bufferProcessing = true;
   var entry = state.bufferedRequest;
+  var bufferedRequestCount = state.bufferedRequestCount;
+
+  state.bufferedRequestCount = 0;
 
   if (stream._writev && entry && entry.next) {
     // Fast case, write everything using _writev()
-    var buffer = [];
-    var cbs = [];
+    var buffer = new Array(bufferedRequestCount);
+    var cbs = new Array(bufferedRequestCount);
+    var count = 0;
+
     while (entry) {
-      cbs.push(entry.callback);
-      buffer.push(entry);
+      cbs[count] = entry.callback;
+      buffer[count] = entry;
+      count++;
       entry = entry.next;
     }
 
     // count the one we are adding, as well.
-    // TODO(isaacs) clean this up
     state.pendingcb++;
     state.lastBufferedRequest = null;
-    doWrite(stream, state, true, state.length, buffer, '', function(err) {
-      for (var i = 0; i < cbs.length; i++) {
-        state.pendingcb--;
-        cbs[i](err);
-      }
-    });
+
+    if (state.corkedCbs) {
+      // only two corkedCbs objects are supported
+      assert(!state.corkedCbs.next);
+      state.corkedCbs.next = new CorkedCbs(cbs);
+    } else {
+      state.corkedCbs = new CorkedCbs(cbs);
+    }
+
+    doWrite(stream, state, true, state.length, buffer, '',
+            state.afterCorkedWrite);
 
     // Clear buffer
   } else {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -114,26 +114,21 @@ function WritableState(options, stream) {
   this.bufferedRequestCount = 0;
 
   // the requests that needs to be called by uncork
-  this.corkedCbs = null;
+  this.corkedCbs = new Array(2);
+  this.corkedCbsId = 0;
 
   // call all the corked requests
   this.afterCorkedWrite = function afterCorkedWrite(err) {
     var state = stream._writableState;
-    var entry = state.corkedCbs;
-    var cbs = entry.cbs;
-
-    state.corkedCbs = entry.next;
+    var id = state.corkedCbsId === 1 ? 0 : 1;
+    var cbs = state.corkedCbs[id];
+    state.corkedCbs[id] = null;
 
     for (var i = 0; i < cbs.length; i++) {
       state.pendingcb--;
       cbs[i](err);
     }
   };
-}
-
-function CorkedCbs(cbs) {
-  this.cbs = cbs;
-  this.next = null;
 }
 
 WritableState.prototype.getBuffer = function writableStateGetBuffer() {
@@ -410,13 +405,9 @@ function clearBuffer(stream, state) {
     state.pendingcb++;
     state.lastBufferedRequest = null;
 
-    if (state.corkedCbs) {
-      // only two corkedCbs objects are supported
-      assert(!state.corkedCbs.next);
-      state.corkedCbs.next = new CorkedCbs(cbs);
-    } else {
-      state.corkedCbs = new CorkedCbs(cbs);
-    }
+    assert(!state.corkedCbs[state.corkedCbsId], 'only two sets of callbacks');
+    state.corkedCbs[state.corkedCbsId] = cbs;
+    state.corkedCbsId = ++state.corkedCbsId % 2;
 
     doWrite(stream, state, true, state.length, buffer, '',
             state.afterCorkedWrite);


### PR DESCRIPTION
This commits removes a function allocation inside the clearBuffer function. Moreover, it adds counting of buffered chunks to instantiate a fixed-sized Array. The performance improvements are in the range
5-50%, depending on the usecase.

Here is gist of the results of the http benchmarks in node on my MacBook Pro Late 2014 (i7, 16GB of RAM): https://gist.github.com/mcollina/5c59c057cb5b138fcd70.

cc @trevnorris @lucamaraschi @nodejs/benchmarking 