### PR TITLE
doc: Describe FIPSDIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ Instructions:
    Appendix A in the [security policy]
    (http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp1747.pdf).
    The only exception is that `./config no-asm` can be
-   used in place of `./config` )
+   used in place of `./config`, and the FIPSDIR environment variable
+   may be used to specify a non-standard install folder for the
+   validated module, as per User Guide sections 4.2.1, 4.2.2, and 4.2.3.
 6. Get into Node.js checkout folder
 7. `./configure --openssl-fips=/path/to/openssl-fips/installdir`
    For example on ubuntu 12 the installation directory was


### PR DESCRIPTION
It is possible to install the FIPS validated OpenSSL cryptographic module to a custom location, without violating the requirement for calling ./configure without custom arguments.