### PR TITLE
crypto: Disable crypto.createCipher in FIPS mode

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3027,6 +3027,11 @@ void CipherBase::Init(const char* cipher_type,
                       int key_buf_len) {
   HandleScope scope(env()->isolate());
 
+#ifdef NODE_FIPS_MODE
+  return env()->ThrowError(
+    "crypto.createCipher() is not supported in FIPS mode.");
+#endif  // NODE_FIPS_MODE
+
   CHECK_EQ(cipher_, nullptr);
   cipher_ = EVP_get_cipherbyname(cipher_type);
   if (cipher_ == nullptr) {

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -490,12 +490,13 @@ function testCipher4(key, iv) {
   assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
 }
 
+if (!common.hasFipsCrypto) {
+  testCipher1('MySecretKey123');
+  testCipher1(new Buffer('MySecretKey123'));
 
-testCipher1('MySecretKey123');
-testCipher1(new Buffer('MySecretKey123'));
-
-testCipher2('0123456789abcdef');
-testCipher2(new Buffer('0123456789abcdef'));
+  testCipher2('0123456789abcdef');
+  testCipher2(new Buffer('0123456789abcdef'));
+}
 
 testCipher3('0123456789abcd0123456789', '12345678');
 testCipher3('0123456789abcd0123456789', new Buffer('12345678'));

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -6,6 +6,10 @@ if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
   return;
 }
+if (common.hasFipsCrypto) {
+  console.log('1..0 # Skipped: not supported in FIPS mode');
+  return;
+}
 var crypto = require('crypto');
 
 function testCipher1(key) {
@@ -62,70 +66,11 @@ function testCipher2(key) {
   assert.equal(txt, plaintext, 'encryption and decryption with Base64');
 }
 
-
-function testCipher3(key, iv) {
-  // Test encyrption and decryption with explicit key and iv
-  var plaintext =
-      '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
-      'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
-      'jAfaFg**';
-  var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
-  var ciph = cipher.update(plaintext, 'utf8', 'hex');
-  ciph += cipher.final('hex');
-
-  var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
-  var txt = decipher.update(ciph, 'hex', 'utf8');
-  txt += decipher.final('utf8');
-
-  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
-
-  // streaming cipher interface
-  // NB: In real life, it's not guaranteed that you can get all of it
-  // in a single read() like this.  But in this case, we know it's
-  // quite small, so there's no harm.
-  var cStream = crypto.createCipheriv('des-ede3-cbc', key, iv);
-  cStream.end(plaintext);
-  ciph = cStream.read();
-
-  var dStream = crypto.createDecipheriv('des-ede3-cbc', key, iv);
-  dStream.end(ciph);
-  txt = dStream.read().toString('utf8');
-
-  assert.equal(txt, plaintext, 'streaming cipher iv');
-}
-
-
-function testCipher4(key, iv) {
-  // Test encyrption and decryption with explicit key and iv
-  var plaintext =
-      '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
-      'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
-      'jAfaFg**';
-  var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
-  var ciph = cipher.update(plaintext, 'utf8', 'buffer');
-  ciph = Buffer.concat([ciph, cipher.final('buffer')]);
-
-  var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
-  var txt = decipher.update(ciph, 'buffer', 'utf8');
-  txt += decipher.final('utf8');
-
-  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
-}
-
-
 testCipher1('MySecretKey123');
 testCipher1(new Buffer('MySecretKey123'));
 
 testCipher2('0123456789abcdef');
 testCipher2(new Buffer('0123456789abcdef'));
-
-testCipher3('0123456789abcd0123456789', '12345678');
-testCipher3('0123456789abcd0123456789', new Buffer('12345678'));
-testCipher3(new Buffer('0123456789abcd0123456789'), '12345678');
-testCipher3(new Buffer('0123456789abcd0123456789'), new Buffer('12345678'));
-
-testCipher4(new Buffer('0123456789abcd0123456789'), new Buffer('12345678'));
-
 
 // Base64 padding regression test, see #4837.
 (function() {

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -1,0 +1,66 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+var crypto = require('crypto');
+
+function testCipher1(key, iv) {
+  // Test encyrption and decryption with explicit key and iv
+  var plaintext =
+      '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
+      'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
+      'jAfaFg**';
+  var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
+  var ciph = cipher.update(plaintext, 'utf8', 'hex');
+  ciph += cipher.final('hex');
+
+  var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
+  var txt = decipher.update(ciph, 'hex', 'utf8');
+  txt += decipher.final('utf8');
+
+  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+
+  // streaming cipher interface
+  // NB: In real life, it's not guaranteed that you can get all of it
+  // in a single read() like this.  But in this case, we know it's
+  // quite small, so there's no harm.
+  var cStream = crypto.createCipheriv('des-ede3-cbc', key, iv);
+  cStream.end(plaintext);
+  ciph = cStream.read();
+
+  var dStream = crypto.createDecipheriv('des-ede3-cbc', key, iv);
+  dStream.end(ciph);
+  txt = dStream.read().toString('utf8');
+
+  assert.equal(txt, plaintext, 'streaming cipher iv');
+}
+
+
+function testCipher2(key, iv) {
+  // Test encyrption and decryption with explicit key and iv
+  var plaintext =
+      '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
+      'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
+      'jAfaFg**';
+  var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
+  var ciph = cipher.update(plaintext, 'utf8', 'buffer');
+  ciph = Buffer.concat([ciph, cipher.final('buffer')]);
+
+  var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
+  var txt = decipher.update(ciph, 'buffer', 'utf8');
+  txt += decipher.final('utf8');
+
+  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+}
+
+testCipher1('0123456789abcd0123456789', '12345678');
+testCipher1('0123456789abcd0123456789', new Buffer('12345678'));
+testCipher1(new Buffer('0123456789abcd0123456789'), '12345678');
+testCipher1(new Buffer('0123456789abcd0123456789'), new Buffer('12345678'));
+
+testCipher2(new Buffer('0123456789abcd0123456789'), new Buffer('12345678'));
+

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -58,7 +58,7 @@ assert.equal(secret1, secret3);
 
 // Run this one twice to make sure that the dh3 clears its error properly
 (function() {
-  var c = crypto.createDecipher('aes-128-ecb', '');
+  var c = crypto.createDecipheriv('aes-128-ecb', crypto.randomBytes(16), '');
   assert.throws(function() { c.final('utf8'); }, /wrong final block length/);
 })();
 
@@ -67,7 +67,7 @@ assert.throws(function() {
 }, /key is too small/i);
 
 (function() {
-  var c = crypto.createDecipher('aes-128-ecb', '');
+  var c = crypto.createDecipheriv('aes-128-ecb', crypto.randomBytes(16), '');
   assert.throws(function() { c.final('utf8'); }, /wrong final block length/);
 })();
 

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -93,11 +93,11 @@ assertSorted(crypto.getCurves());
 // throw, not assert in C++ land.
 assert.throws(function() {
   crypto.createCipher('aes192', 'test').update('0', 'hex');
-}, /Bad input string/);
+}, common.hasFipsCrypto ? /not supported in FIPS mode/ : /Bad input string/);
 
 assert.throws(function() {
   crypto.createDecipher('aes192', 'test').update('0', 'hex');
-}, /Bad input string/);
+}, common.hasFipsCrypto ? /not supported in FIPS mode/ : /Bad input string/);
 
 assert.throws(function() {
   crypto.createHash('sha1').update('0', 'hex');


### PR DESCRIPTION
FIPS 140-2 disallows MD5, which is used to derive the initialization vector and key for createCipher(). Using a different hashing function (e.g. SHA1) will work, but it will make a FIPS Node build incompatible with data produced by (de)crypt routines from a non-FIPS build, since the use of MD5 is explicitly mentioned by the [documentation](https://nodejs.org/api/crypto.html#crypto_crypto_createcipher_algorithm_password).

I’ve opted to simply disable this API completely in FIPS mode. Note that the createCipher() API is deprecated and the use of createCipheriv() is recommended in general. Where possible I split up test suites according to use of createCipher and createCipheriv. Some tests cover a large amount of functionality and have no clear delineation of responsibilities. In this case I modified the tests to either avoid calling disallowed API in FIPS mode or to expect an exception.