### PR TITLE
tls: Use SHA1 for sessionIdContext in FIPS mode

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -843,7 +843,8 @@ automatically set as a listener for the [secureConnection][] event.  The
 
   - `sessionIdContext`: A string containing an opaque identifier for session
     resumption. If `requestCert` is `true`, the default is MD5 hash value
-    generated from command-line. Otherwise, the default is not provided.
+    generated from command-line. (In FIPS mode a truncated SHA1 hash is 
+    used instead.) Otherwise, the default is not provided.
 
   - `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
     SSL version 3. The possible values depend on your installation of

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -14,6 +14,21 @@ const Timer = process.binding('timer_wrap').Timer;
 const tls_wrap = process.binding('tls_wrap');
 const TCP = process.binding('tcp_wrap').TCP;
 const Pipe = process.binding('pipe_wrap').Pipe;
+const defaultSessionIdContext = getDefaultSessionIdContext();
+
+function getDefaultSessionIdContext() {
+  var defaultText = process.argv.join(' ');
+  /* SSL_MAX_SID_CTX_LENGTH is 128 bits */
+  if (process.config.variables.openssl_fips) {
+    return crypto.createHash('sha1')
+      .update(defaultText)
+      .digest('hex').slice(0, 32);
+  } else {
+    return crypto.createHash('md5')
+      .update(defaultText)
+      .digest('hex');
+  }
+}
 
 function onhandshakestart() {
   debug('onhandshakestart');
@@ -893,9 +908,7 @@ Server.prototype.setOptions = function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
-    this.sessionIdContext = crypto.createHash('md5')
-                                  .update(process.argv.join(' '))
-                                  .digest('hex');
+    this.sessionIdContext = defaultSessionIdContext;
   }
 };
 


### PR DESCRIPTION
By default, a call to tls.createServer() without a sessionIdContext will use a “MD5 hash value generated from command-line” as per [documentation](
https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener).

In FIPS mode MD5 is not allowed, however createServer is often called without specifying an explicit sessionIdContext. A significant number of test cases and applications break. The simple solution is to to use an allowed hash function. I have chosen SHA1 and truncated the output to 128 bits (which is the hardcoded length required by OpenSSL’s SSL_MAX_SID_CTX_LENGTH). 

Note that I have opted to maintain the use of MD5 in non-FIPS mode, and updated the documentation accordingly.