### PR TITLE
test: Skip weak crypto tests in FIPS mode

### DIFF
--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -324,11 +324,13 @@ var rfc2202_sha1 = [
 ];
 
 for (var i = 0, l = rfc2202_md5.length; i < l; i++) {
-  assert.equal(rfc2202_md5[i]['hmac'],
-               crypto.createHmac('md5', rfc2202_md5[i]['key'])
-                   .update(rfc2202_md5[i]['data'])
-                   .digest('hex'),
-               'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202');
+  if (!common.hasFipsCrypto) {
+    assert.equal(rfc2202_md5[i]['hmac'],
+                 crypto.createHmac('md5', rfc2202_md5[i]['key'])
+                     .update(rfc2202_md5[i]['data'])
+                     .digest('hex'),
+                 'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202');
+  }
 }
 for (var i = 0, l = rfc2202_sha1.length; i < l; i++) {
   assert.equal(rfc2202_sha1[i]['hmac'],
@@ -339,15 +341,19 @@ for (var i = 0, l = rfc2202_sha1.length; i < l; i++) {
 }
 
 // Test hashing
-var a0 = crypto.createHash('sha1').update('Test123').digest('hex');
-var a1 = crypto.createHash('md5').update('Test123').digest('binary');
+var a1 = crypto.createHash('sha1').update('Test123').digest('hex');
 var a2 = crypto.createHash('sha256').update('Test123').digest('base64');
 var a3 = crypto.createHash('sha512').update('Test123').digest(); // binary
 var a4 = crypto.createHash('sha1').update('Test123').digest('buffer');
 
-assert.equal(a0, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
-assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
-             '\u00bd\u008c', 'Test MD5 as binary');
+if (!common.hasFipsCrypto) {
+  var a0 = crypto.createHash('md5').update('Test123').digest('binary');
+  assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
+               '\u00bd\u008c', 'Test MD5 as binary');
+}
+
+assert.equal(a1, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
+
 assert.equal(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
              'Test SHA256 as base64');
 

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -348,7 +348,7 @@ var a4 = crypto.createHash('sha1').update('Test123').digest('buffer');
 
 if (!common.hasFipsCrypto) {
   var a0 = crypto.createHash('md5').update('Test123').digest('binary');
-  assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
+  assert.equal(a0, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
                '\u00bd\u008c', 'Test MD5 as binary');
 }
 

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -11,8 +11,7 @@ if (!common.hasCrypto) {
 var crypto = require('crypto');
 
 // Test hashing
-var a0 = crypto.createHash('sha1').update('Test123').digest('hex');
-var a1 = crypto.createHash('md5').update('Test123').digest('binary');
+var a1 = crypto.createHash('sha1').update('Test123').digest('hex');
 var a2 = crypto.createHash('sha256').update('Test123').digest('base64');
 var a3 = crypto.createHash('sha512').update('Test123').digest(); // binary
 var a4 = crypto.createHash('sha1').update('Test123').digest('buffer');
@@ -38,9 +37,12 @@ a8.write('');
 a8.end();
 a8 = a8.read();
 
-assert.equal(a0, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
-assert.equal(a1, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
-             '\u00bd\u008c', 'Test MD5 as binary');
+if (!common.hasFipsCrypto) {
+  var a0 = crypto.createHash('md5').update('Test123').digest('binary');
+  assert.equal(a0, 'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca' +
+               '\u00bd\u008c', 'Test MD5 as binary');
+}
+assert.equal(a1, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
 assert.equal(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
              'Test SHA256 as base64');
 assert.deepEqual(

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -61,6 +61,9 @@ var wikipedia = [
 
 for (var i = 0, l = wikipedia.length; i < l; i++) {
   for (var hash in wikipedia[i]['hmac']) {
+    // FIPS does not support MD5.
+    if (common.hasFipsCrypto && hash == 'md5' )
+      continue;
     var result = crypto.createHmac(hash, wikipedia[i]['key'])
                      .update(wikipedia[i]['data'])
                      .digest('hex');
@@ -346,12 +349,14 @@ var rfc2202_sha1 = [
   }
 ];
 
-for (var i = 0, l = rfc2202_md5.length; i < l; i++) {
-  assert.equal(rfc2202_md5[i]['hmac'],
-               crypto.createHmac('md5', rfc2202_md5[i]['key'])
-                   .update(rfc2202_md5[i]['data'])
-                   .digest('hex'),
-               'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202');
+if (!common.hasFipsCrypto) {
+  for (var i = 0, l = rfc2202_md5.length; i < l; i++) {
+    assert.equal(rfc2202_md5[i]['hmac'],
+                 crypto.createHmac('md5', rfc2202_md5[i]['key'])
+                     .update(rfc2202_md5[i]['data'])
+                     .digest('hex'),
+                 'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202');
+  }
 }
 for (var i = 0, l = rfc2202_sha1.length; i < l; i++) {
   assert.equal(rfc2202_sha1[i]['hmac'],

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -26,19 +26,21 @@ Stream2buffer.prototype._write = function(data, encodeing, done) {
   return done(null);
 };
 
-// Create an md5 hash of "Hallo world"
-var hasher1 = crypto.createHash('md5');
-hasher1.pipe(new Stream2buffer(common.mustCall(function end(err, hash) {
-  assert.equal(err, null);
-  assert.equal(hash.toString('hex'), '06460dadb35d3d503047ce750ceb2d07');
-})));
-hasher1.end('Hallo world');
+if (!common.hasFipsCrypto) {
+  // Create an md5 hash of "Hallo world"
+  var hasher1 = crypto.createHash('md5');
+  hasher1.pipe(new Stream2buffer(common.mustCall(function end(err, hash) {
+    assert.equal(err, null);
+    assert.equal(hash.toString('hex'), '06460dadb35d3d503047ce750ceb2d07');
+  })));
+  hasher1.end('Hallo world');
 
-// Simpler check for unpipe, setEncoding, pause and resume
-crypto.createHash('md5').unpipe({});
-crypto.createHash('md5').setEncoding('utf8');
-crypto.createHash('md5').pause();
-crypto.createHash('md5').resume();
+  // Simpler check for unpipe, setEncoding, pause and resume
+  crypto.createHash('md5').unpipe({});
+  crypto.createHash('md5').setEncoding('utf8');
+  crypto.createHash('md5').pause();
+  crypto.createHash('md5').resume();
+}
 
 // Decipher._flush() should emit an error event, not an exception.
 var key = new Buffer('48fb56eb10ffeb13fc0ef551bbca3b1b', 'hex'),

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -14,7 +14,7 @@ var fs = require('fs');
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
-  ciphers: '-ALL:ECDHE-RSA-RC4-SHA',
+  ciphers: '-ALL:ECDHE-RSA-AES128-SHA256',
   ecdhCurve: 'prime256v1'
 };
 

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -9,7 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var cipher_list = ['RC4-SHA', 'AES256-SHA'];
+var cipher_list = ['AES128-SHA256', 'AES256-SHA256'];
 var cipher_version_pattern = /TLS|SSL/;
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -19,7 +19,7 @@ var fs = require('fs');
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
-  ciphers: 'RC4-MD5'
+  ciphers: 'DES-CBC3-SHA'
 };
 
 var reply = 'I AM THE WALRUS'; // something recognizable

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -20,27 +20,30 @@ assert.throws(function() {
 });
 
 var hashes = {
-  modp1 : 'b4b330a6ffeacfbd861e7fe2135b4431',
-  modp2 : '7c3c5cad8b9f378d88f1dd64a4b6413a',
-  modp5 : 'b1d2acc22c542e08669a5c5ae812694d',
-  modp14 : '8d041538cecc1a7d915ba4b718f8ad20',
-  modp15 : 'dc3b93def24e078c4fbf92d5e14ba69b',
-  modp16 : 'a273487f46f699461f613b3878d9dfd9',
-  modp17 : 'dc76e09935310348c492de9bd82014d0',
-  modp18 : 'db08973bfd2371758a69db180871c993'
+  modp1 : '630e9acd2cc63f7e80d8507624ba60ac0757201a',
+  modp2 : '18f7aa964484137f57bca64b21917a385b6a0b60',
+  modp5 : 'c0a8eec0c2c8a5ec2f9c26f9661eb339a010ec61',
+  modp14 : 'af5455606fe74cec49782bb374e4c63c9b1d132c',
+  modp15 : '7bdd39e5cdbb9748113933e5c2623b559c534e74',
+  modp16 : 'daea5277a7ad0116e734a8e0d2f297ef759d1161',
+  modp17 : '3b62aaf0142c2720f0bf26a9589b0432c00eadc1',
+  modp18 : 'a870b491bbbec9b131ae9878d07449d32e54f160'
 };
 
 for (var name in hashes) {
   var group = crypto.getDiffieHellman(name);
   var private_key = group.getPrime('hex');
   var hash1 = hashes[name];
-  var hash2 = crypto.createHash('md5')
+  var hash2 = crypto.createHash('sha1')
                     .update(private_key.toUpperCase()).digest('hex');
   assert.equal(hash1, hash2);
   assert.equal(group.getGenerator('hex'), '02');
 }
 
 for (var name in hashes) {
+  // modp1 is 768 bits, FIPS requires >= 1024
+  if (name == 'modp1' && common.hasFipsCrypto)
+    continue;
   var group1 = crypto.getDiffieHellman(name);
   var group2 = crypto.getDiffieHellman(name);
   group1.generateKeys();


### PR DESCRIPTION
FIPS 140-2 does not permit the use of MD5 and RC4, skip tests that use them in FIPS mode, or substitute with stronger crypto where applicable.