### PR TITLE
buffer: let WriteFloatGeneric silently drop values

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -735,7 +735,9 @@ uint32_t WriteFloatGeneric(const FunctionCallbackInfo<Value>& args) {
 
   T val = args[1]->NumberValue();
   uint32_t offset = args[2]->Uint32Value();
-  CHECK_LE(offset + sizeof(T), ts_obj_length);
+  size_t memcpy_num = sizeof(T);
+  if (offset + sizeof(T) > ts_obj_length)
+    memcpy_num = ts_obj_length - offset;
 
   union NoAlias {
     T val;
@@ -746,8 +748,8 @@ uint32_t WriteFloatGeneric(const FunctionCallbackInfo<Value>& args) {
   char* ptr = static_cast<char*>(ts_obj_data) + offset;
   if (endianness != GetEndianness())
     Swizzle(na.bytes, sizeof(na.bytes));
-  memcpy(ptr, na.bytes, sizeof(na.bytes));
-  return offset + sizeof(na.bytes);
+  memcpy(ptr, na.bytes, memcpy_num);
+  return offset + memcpy_num;
 }
 
 

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -44,3 +44,10 @@ assert.throws(function() {
   AB.prototype.__proto__ = ArrayBuffer.prototype;
   new Buffer(new AB());
 }, TypeError);
+
+// write{Double,Float}{LE,BE} with noAssert should not crash, cf. #3766
+var b = new Buffer(1);
+b.writeFloatLE(11.11, 0, true);
+b.writeFloatBE(11.11, 0, true);
+b.writeDoubleLE(11.11, 0, true);
+b.writeDoubleBE(11.11, 0, true);


### PR DESCRIPTION
Fixes #3766 

Quoted from `buffer.markdown`,

> Set `noAssert` to true to skip validation of `value` and `offset`. This means
> that `value` may be too large for the specific function and `offset` may be
> beyond the end of the buffer leading to the values being silently dropped.

Therefore I let `node::Buffer::WriteFloatGeneric` silently drop values instead of crashing.
