### PR TITLE
src, build: Enable Intel Vtune profiling for JavaScript

### DIFF
--- a/configure
+++ b/configure
@@ -86,6 +86,14 @@ parser.add_option("--fully-static",
     help="Generate an executable without external dynamic libraries. This "
          "will not work on OSX when using default compilation environment")
 
+parser.add_option("--enable-vtune-profiling",
+    action="store_true",
+    dest="enable_vtune_profiling",
+    help="Enable profiling support for Intel Vtune profiler to profile"
+         "JavaScript code executed in nodejs. This feature is only available "
+         "for ia32, x32 or x64 platform.")
+
+
 parser.add_option("--link-module",
     action="append",
     dest="linked_module",
@@ -678,6 +686,15 @@ def configure_node(o):
   if flavor == 'aix':
     o['variables']['node_core_target_name'] = 'node_base'
     o['variables']['node_target_type'] = 'static_library'
+
+  if target_arch in ('x86', 'x64', 'ia32', 'x32'):
+    o['variables']['node_enable_v8_vtunejit'] = b(options.enable_vtune_profiling)
+  elif options.enable_vtune_profiling:
+    raise Exception(
+       'vtune profiler for JavaScript is only supported on x86, x32 or x64 '
+       'platform.')
+  else:
+    o['variables']['node_enable_v8_vtunejit'] = 'false'
 
   if flavor in ('solaris', 'mac', 'linux', 'freebsd'):
     use_dtrace = not options.without_dtrace

--- a/node.gyp
+++ b/node.gyp
@@ -12,6 +12,7 @@
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'node_v8_options%': '',
+    'node_enable_v8_vtunejit%': 'false',
     'node_target_type%': 'executable',
     'node_core_target_name%': 'node',
     'library_files': [
@@ -220,6 +221,13 @@
             [ 'icu_small=="true"', {
               'defines': [ 'NODE_HAVE_SMALL_ICU=1' ],
           }]],
+        }],
+        [ 'node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
+           target_arch=="ia32" or target_arch=="x32")', {
+          'defines': [ 'NODE_ENABLE_VTUNE_PROFILING' ],
+          'dependencies': [
+            'deps/v8/src/third_party/vtune/v8vtune.gyp:v8_vtune'
+          ],
         }],
         [ 'node_use_openssl=="true"', {
           'defines': [ 'HAVE_OPENSSL=1' ],

--- a/src/node.cc
+++ b/src/node.cc
@@ -43,6 +43,10 @@
 #include "v8-profiler.h"
 #include "zlib.h"
 
+#ifdef NODE_ENABLE_VTUNE_PROFILING
+#include "../deps/v8/src/third_party/vtune/v8-vtune.h"
+#endif
+
 #include <errno.h>
 #include <limits.h>  // PATH_MAX
 #include <locale.h>
@@ -4025,6 +4029,9 @@ static void StartNodeInstance(void* arg) {
   Isolate::CreateParams params;
   ArrayBufferAllocator* array_buffer_allocator = new ArrayBufferAllocator();
   params.array_buffer_allocator = array_buffer_allocator;
+#ifdef NODE_ENABLE_VTUNE_PROFILING
+  params.code_event_handler = vTune::GetVtuneCodeEventHandler();
+#endif
   Isolate* isolate = Isolate::New(params);
   if (track_heap_objects) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -37,6 +37,7 @@ set i18n_arg=
 set download_arg=
 set release_urls_arg=
 set build_release=
+set enable_vtune_profiling=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -71,6 +72,7 @@ if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
 if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
+if /i "%1"=="enable-vtune"  set enable_vtune_profiling="--enable-vtune-profiling"&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -168,7 +170,7 @@ goto run
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
+python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% %enable_vtune_profiling% --dest-cpu=%target_arch% --tag=%TAG%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -259,13 +261,14 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all] [enable-vtune]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build
 echo   vcbuild.bat release msi    : builds release build and MSI installer package
 echo   vcbuild.bat test           : builds debug build and runs tests
 echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
+echo   vcbuild.bat enable-vtune   : builds nodejs with Intel Vtune profiling support to profile JavaScript
 goto exit
 
 :exit


### PR DESCRIPTION
src, build: Enable Intel Vtune profiling for JavaScript.

   This feature supports the Intel Vtune profiling support for JITted
   JavaScript on IA32 / X64 / X32 platform. The advantage of this 
   profiling is that the user / developer of NodeJS application can
   get the detailed profiling information for every line of the Java-
   Script source  code. This information will be very useful for the
   owner to optimize their applications.

   This feature is a compile-time option. For windows platform, The
   user needs to pass the following parameter to vcbuid.bat:
          "enable-vtune".

   For other OS, the user needs to pass the following parameter to 
  ./configure command:
          --enable-vtune-profiling

   Please refer to #3688 for detailed description for this feature.