### PR TITLE
doc: add note to util.isBuffer

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -404,6 +404,8 @@ Returns `true` if the given "object" is a primitive type. `false` otherwise.
 
     Stability: 0 - Deprecated
 
+Use `Buffer.isBuffer()` instead.
+
 Returns `true` if the given "object" is a `Buffer`. `false` otherwise.
 
     var util = require('util');


### PR DESCRIPTION
Since `util.isBuffer` is deprecated, we should be explicit that
`Buffer.isBuffer` should be used instead.