### PR TITLE
deps: backport bc2e393 from v8 upstream

### DIFF
--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -274,6 +274,20 @@ footer = '''
 '''
 
 #
+# Get the base class
+#
+def get_base_class(klass):
+        if (klass == 'Object'):
+                return klass;
+
+        if (not (klass in klasses)):
+                return None;
+
+        k = klasses[klass];
+
+        return get_base_class(k['parent']);
+
+#
 # Loads class hierarchy and type information from "objects.h".
 #
 def load_objects():
@@ -311,12 +325,14 @@ def load_objects():
                         typestr += line;
                         continue;
 
-                match = re.match('class (\w[^\s:]*)(: public (\w[^\s{]*))?\s*{',
+                match = re.match('class (\w[^:]*)(: public (\w[^{]*))?\s*{\s*',
                     line);
 
                 if (match):
-                        klass = match.group(1);
+                        klass = match.group(1).rstrip().lstrip();
                         pklass = match.group(3);
+                        if (pklass):
+                                pklass = pklass.rstrip().lstrip();
                         klasses[klass] = { 'parent': pklass };
 
         #
@@ -567,6 +583,9 @@ def emit_config():
         keys.sort();
         for klassname in keys:
                 pklass = klasses[klassname]['parent'];
+                bklass = get_base_class(klassname);
+                if (bklass != 'Object'):
+                        continue;
                 if (pklass == None):
                         continue;
 


### PR DESCRIPTION
Original commit message:

    [tools] Make gen-postmortem-metadata.py more reliable

    Instead of basing matches off of whitespace, walk the
    inheritance chain and include any classes that inherit
    from Object.

    R=machenbach@chromium.org,jkummerow@chromium.org
    NOTRY=true

    Review URL: https://codereview.chromium.org/1435643002

    Cr-Commit-Position: refs/heads/master@{#31964}

This adds some missing classes to postmortem info like
JSMap and JSSet.

R=@indutny 