### PR TITLE
child_process: add safety checks on stdio access

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -222,14 +222,22 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
   function errorhandler(e) {
     ex = e;
-    child.stdout.destroy();
-    child.stderr.destroy();
+
+    if (child.stdout)
+      child.stdout.destroy();
+
+    if (child.stderr)
+      child.stderr.destroy();
+
     exithandler();
   }
 
   function kill() {
-    child.stdout.destroy();
-    child.stderr.destroy();
+    if (child.stdout)
+      child.stdout.destroy();
+
+    if (child.stderr)
+      child.stderr.destroy();
 
     killed = true;
     try {
@@ -247,37 +255,42 @@ exports.execFile = function(file /*, args, options, callback*/) {
     }, options.timeout);
   }
 
-  child.stdout.addListener('data', function(chunk) {
-    stdoutLen += chunk.length;
+  if (child.stdout) {
+    if (encoding)
+      child.stdout.setEncoding(encoding);
 
-    if (stdoutLen > options.maxBuffer) {
-      ex = new Error('stdout maxBuffer exceeded');
-      kill();
-    } else {
-      if (!encoding)
-        _stdout.push(chunk);
-      else
-        _stdout += chunk;
-    }
-  });
+    child.stdout.addListener('data', function(chunk) {
+      stdoutLen += chunk.length;
 
-  child.stderr.addListener('data', function(chunk) {
-    stderrLen += chunk.length;
+      if (stdoutLen > options.maxBuffer) {
+        ex = new Error('stdout maxBuffer exceeded');
+        kill();
+      } else {
+        if (!encoding)
+          _stdout.push(chunk);
+        else
+          _stdout += chunk;
+      }
+    });
+  }
 
-    if (stderrLen > options.maxBuffer) {
-      ex = new Error('stderr maxBuffer exceeded');
-      kill();
-    } else {
-      if (!encoding)
-        _stderr.push(chunk);
-      else
-        _stderr += chunk;
-    }
-  });
+  if (child.stderr) {
+    if (encoding)
+      child.stderr.setEncoding(encoding);
 
-  if (encoding) {
-    child.stderr.setEncoding(encoding);
-    child.stdout.setEncoding(encoding);
+    child.stderr.addListener('data', function(chunk) {
+      stderrLen += chunk.length;
+
+      if (stderrLen > options.maxBuffer) {
+        ex = new Error('stderr maxBuffer exceeded');
+        kill();
+      } else {
+        if (!encoding)
+          _stderr.push(chunk);
+        else
+          _stderr += chunk;
+      }
+    });
   }
 
   child.addListener('close', exithandler);


### PR DESCRIPTION
When a child process is spawned, there is no guarantee that `stdout` and `stderr` will be created successfully. This commit adds checks before attempting to access the streams.

This is related to https://github.com/nodejs/node/issues/1321. It prevents Node from synchronously throwing `TypeError: Cannot read property 'addListener' of undefined`. Instead, an async error, `EAGAIN` is provided to the callback.