### PR TITLE
querystring: Parse multiple separator characters

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -202,6 +202,7 @@ QueryString.stringify = QueryString.encode = function(obj, sep, eq, options) {
 QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   sep = sep || '&';
   eq = eq || '=';
+  const eqLen = eq.length;
   var obj = {};
 
   if (typeof qs !== 'string' || qs.length === 0) {
@@ -235,7 +236,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
 
     if (idx >= 0) {
       k = decodeStr(x.substring(0, idx), decode);
-      v = decodeStr(x.substring(idx + 1), decode);
+      v = decodeStr(x.substring(idx + eqLen), decode);
     } else {
       k = decodeStr(x, decode);
       v = '';

--- a/test/parallel/test-querystring-multichar-separator.js
+++ b/test/parallel/test-querystring-multichar-separator.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const qs = require('querystring');
+
+assert.deepEqual(
+  qs.parse('foo=>bar&&bar=>baz', '&&', '=>'), 
+  {foo: 'bar', bar: 'baz'}
+);
+
+assert.strictEqual(
+  qs.stringify({foo: 'bar', bar: 'baz'}, '&&', '=>'), 
+  'foo=>bar&&bar=>baz'
+);
+
+assert.deepEqual(
+  qs.parse('foo==>bar, bar==>baz', ', ', '==>'), 
+  {foo: 'bar', bar: 'baz'}
+);
+
+assert.strictEqual(
+  qs.stringify({foo: 'bar', bar: 'baz'}, ', ', '==>'), 
+  'foo==>bar, bar==>baz'
+);


### PR DESCRIPTION
When I explained `querystring` API for node beginners, I found a weird problem.

```javascript
var q = qs.stringify({foo: 'bar', bar: 'baz'}, '&&', '=>');
console.log(q); // foo=>bar&&bar=>baz

var parsedQs = qs.parse('foo=>bar&&bar=>baz', '&&', '=>');
console.log(parsedQs); // { foo: '>bar', bar: '>baz' }
```

I expect `{foo: 'bar', bar: 'baz'}` but the actual result is `{foo: '>bar', bar: '>baz'}`.

This PR solves the problem.