### PR TITLE
add no-extra-semi to .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,8 @@ rules:
   no-unreachable: 2
   ## require valid typeof compared string like typeof foo === 'strnig'
   valid-typeof: 2
+  ## disallow extra semicolons
+  no-extra-semi: 2
 
   # Best Practices
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#best-practices


### PR DESCRIPTION
Adds the rule [no-extra-semi](http://eslint.org/docs/rules/no-extra-semi) for ESLint which disallows unnecessary semicolons.