### PR TITLE
doc: reword message.headers

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -806,7 +806,7 @@ Just like `'end'`, this event occurs only once per response.
 
 The request/response headers object.
 
-Read only map of header names and values. Header names are lower-cased.
+Key-value pairs of header names and values. Header names are lower-cased.
 Example:
 
     // Prints something like:


### PR DESCRIPTION
message.headers states that the headers are read-only, when in fact they
are not. This change rewords the docs to a more appropriate description,
while not promoting this kind of behavior.

Issue: #3146

---

```javascript
'use strict';

const http = require('http');

http.createServer(function(req, res){
	req.headers.host = 'anotherhost';

	res.writeHead(200, {'Content-Type': 'text/plain'});
	res.end(req.headers.host);
}).listen(8124);

console.log('Server running at http://127.0.0.1:8124/');

// "anotherhost"
```