### PR TITLE
lib: replace self/bind usage with arrow func

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -49,9 +49,8 @@ function Agent() {
   this.first = true;
   this.binding = process._debugAPI;
 
-  var self = this;
-  this.binding.onmessage = function(msg) {
-    self.clients.forEach(function(client) {
+  this.binding.onmessage = (msg) => {
+    this.clients.forEach(function(client) {
       client.send({}, msg);
     });
   };
@@ -67,11 +66,10 @@ Agent.prototype.onConnection = function onConnection(socket) {
   c.start();
   this.clients.push(c);
 
-  var self = this;
-  c.once('close', function() {
-    var index = self.clients.indexOf(c);
+  c.once('close', () => {
+    var index = this.clients.indexOf(c);
     assert(index !== -1);
-    self.clients.splice(index, 1);
+    this.clients.splice(index, 1);
   });
 };
 
@@ -98,9 +96,8 @@ function Client(agent, socket) {
 
   this.on('data', this.onCommand);
 
-  var self = this;
-  this.socket.on('close', function() {
-    self.destroy();
+  this.socket.on('close', () => {
+    this.destroy();
   });
 }
 util.inherits(Client, Transform);

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -209,13 +209,12 @@ Client.prototype._onResponse = function(res) {
     }
   });
 
-  var self = this;
   var handled = false;
 
   if (res.headers.Type == 'connect') {
     // Request a list of scripts for our own storage.
-    self.reqScripts();
-    self.emit('ready');
+    this.reqScripts();
+    this.emit('ready');
     handled = true;
 
   } else if (res.body && res.body.event == 'break') {
@@ -271,8 +270,6 @@ Client.prototype.reqVersion = function(cb) {
 
 
 Client.prototype.reqLookup = function(refs, cb) {
-  var self = this;
-
   // TODO: We have a cache of handle's we've already seen in this.handles
   // This can be used if we're careful.
   var req = {
@@ -283,11 +280,11 @@ Client.prototype.reqLookup = function(refs, cb) {
   };
 
   cb = cb || function() {};
-  this.req(req, function(err, res) {
+  this.req(req, (err, res) => {
     if (err) return cb(err);
     for (var ref in res) {
       if (res[ref] !== null && typeof res[ref] === 'object') {
-        self._addHandle(res[ref]);
+        this._addHandle(res[ref]);
       }
     }
 
@@ -296,20 +293,19 @@ Client.prototype.reqLookup = function(refs, cb) {
 };
 
 Client.prototype.reqScopes = function(cb) {
-  const self = this;
   const req = {
     command: 'scopes',
     arguments: {}
   };
 
   cb = cb || function() {};
-  this.req(req, function(err, res) {
+  this.req(req, (err, res) => {
     if (err) return cb(err);
     var refs = res.scopes.map(function(scope) {
       return scope.object.ref;
     });
 
-    self.reqLookup(refs, function(err, res) {
+    this.reqLookup(refs, function(err, res) {
       if (err) return cb(err);
 
       var globals = Object.keys(res).map(function(key) {
@@ -326,8 +322,6 @@ Client.prototype.reqScopes = function(cb) {
 // This is like reqEval, except it will look up the expression in each of the
 // scopes associated with the current frame.
 Client.prototype.reqEval = function(expression, cb) {
-  var self = this;
-
   if (this.currentFrame == NO_FRAME) {
     // Only need to eval in global scope.
     this.reqFrameEval(expression, NO_FRAME, cb);
@@ -336,13 +330,13 @@ Client.prototype.reqEval = function(expression, cb) {
 
   cb = cb || function() {};
   // Otherwise we need to get the current frame to see which scopes it has.
-  this.reqBacktrace(function(err, bt) {
+  this.reqBacktrace((err, bt) => {
     if (err || !bt.frames) {
       // ??
       return cb(null, {});
     }
 
-    var frame = bt.frames[self.currentFrame];
+    var frame = bt.frames[this.currentFrame];
 
     var evalFrames = frame.scopes.map(function(s) {
       if (!s) return;
@@ -351,7 +345,7 @@ Client.prototype.reqEval = function(expression, cb) {
       return x.index;
     });
 
-    self._reqFramesEval(expression, evalFrames, cb);
+    this._reqFramesEval(expression, evalFrames, cb);
   });
 };
 
@@ -364,19 +358,17 @@ Client.prototype._reqFramesEval = function(expression, evalFrames, cb) {
     return;
   }
 
-  var self = this;
   var i = evalFrames.shift();
 
   cb = cb || function() {};
-  this.reqFrameEval(expression, i, function(err, res) {
+  this.reqFrameEval(expression, i, (err, res) => {
     if (!err) return cb(null, res);
-    self._reqFramesEval(expression, evalFrames, cb);
+    this._reqFramesEval(expression, evalFrames, cb);
   });
 };
 
 
 Client.prototype.reqFrameEval = function(expression, frame, cb) {
-  var self = this;
   var req = {
     command: 'evaluate',
     arguments: { expression: expression }
@@ -389,8 +381,8 @@ Client.prototype.reqFrameEval = function(expression, frame, cb) {
   }
 
   cb = cb || function() {};
-  this.req(req, function(err, res) {
-    if (!err) self._addHandle(res);
+  this.req(req, (err, res) => {
+    if (!err) this._addHandle(res);
     cb(err, res);
   });
 };
@@ -430,14 +422,13 @@ Client.prototype.reqSetExceptionBreak = function(type, cb) {
 //     text: 'node.js (lines: 562)' }
 //
 Client.prototype.reqScripts = function(cb) {
-  var self = this;
   cb = cb || function() {};
 
-  this.req({ command: 'scripts' }, function(err, res) {
+  this.req({ command: 'scripts' }, (err, res) => {
     if (err) return cb(err);
 
     for (var i = 0; i < res.length; i++) {
-      self._addHandle(res[i]);
+      this._addHandle(res[i]);
     }
     cb(null);
   });
@@ -495,8 +486,6 @@ Client.prototype.step = function(action, count, cb) {
 
 
 Client.prototype.mirrorObject = function(handle, depth, cb) {
-  var self = this;
-
   var val;
 
   if (handle.type === 'object') {
@@ -519,7 +508,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
     });
 
     cb = cb || function() {};
-    this.reqLookup(propertyRefs, function(err, res) {
+    this.reqLookup(propertyRefs, (err, res) => {
       if (err) {
         internalUtil.error('problem with reqLookup');
         cb(null, handle);
@@ -539,7 +528,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
 
 
       var keyValues = [];
-      handle.properties.forEach(function(prop, i) {
+      handle.properties.forEach((prop, i) => {
         var value = res[prop.ref];
         var mirrorValue;
         if (value) {
@@ -559,7 +548,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
         };
         if (value && value.handle && depth > 0) {
           waiting++;
-          self.mirrorObject(value, depth - 1, function(err, result) {
+          this.mirrorObject(value, depth - 1, function(err, result) {
             if (!err) keyValues[i].value = result;
             waitForOthers();
           });
@@ -593,10 +582,8 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
 
 
 Client.prototype.fullTrace = function(cb) {
-  var self = this;
-
   cb = cb || function() {};
-  this.reqBacktrace(function(err, trace) {
+  this.reqBacktrace((err, trace) => {
     if (err) return cb(err);
     if (trace.totalFrames <= 0) return cb(Error('No frames'));
 
@@ -626,7 +613,7 @@ Client.prototype.fullTrace = function(cb) {
       refs.push(frame.receiver.ref);
     }
 
-    self.reqLookup(refs, function(err, res) {
+    this.reqLookup(refs, function(err, res) {
       if (err) return cb(err);
 
       for (var i = 0; i < trace.frames.length; i++) {
@@ -723,8 +710,6 @@ function SourceInfo(body) {
 // This class is the repl-enabled debugger interface which is invoked on
 // "node debug"
 function Interface(stdin, stdout, args) {
-  var self = this;
-
   this.stdin = stdin;
   this.stdout = stdout;
   this.args = args;
@@ -746,8 +731,8 @@ function Interface(stdin, stdout, args) {
 
     // Emulate Ctrl+C if we're emulating terminal
     if (!this.stdout.isTTY) {
-      process.on('SIGINT', function() {
-        self.repl.rli.emit('SIGINT');
+      process.on('SIGINT', () => {
+        this.repl.rli.emit('SIGINT');
       });
     }
   }
@@ -787,18 +772,18 @@ function Interface(stdin, stdout, args) {
     'pause_': 'pause'
   };
 
-  function defineProperty(key, protoKey) {
+  const defineProperty = (key, protoKey) => {
     // Check arity
-    var fn = proto[protoKey].bind(self);
+    var fn = proto[protoKey].bind(this);
 
     if (proto[protoKey].length === 0) {
-      Object.defineProperty(self.repl.context, key, {
+      Object.defineProperty(this.repl.context, key, {
         get: fn,
         enumerable: true,
         configurable: false
       });
     } else {
-      self.repl.context[key] = fn;
+      this.repl.context[key] = fn;
     }
   }
 
@@ -827,10 +812,10 @@ function Interface(stdin, stdout, args) {
   this.pause();
 
   // XXX Need to figure out why we need this delay
-  setTimeout(function() {
+  setTimeout(() => {
 
-    self.run(function() {
-      self.resume();
+    this.run(() => {
+      this.resume();
     });
   }, 10);
 }
@@ -903,8 +888,6 @@ Interface.prototype.error = function(text) {
 
 // Debugger's `break` event handler
 Interface.prototype.handleBreak = function(r) {
-  var self = this;
-
   this.pause();
 
   // Save execution context's data
@@ -918,13 +901,13 @@ Interface.prototype.handleBreak = function(r) {
   this.print(SourceInfo(r));
 
   // Show watchers' values
-  this.watchers(true, function(err) {
-    if (err) return self.error(err);
+  this.watchers(true, (err) => {
+    if (err) return this.error(err);
 
     // And list source
-    self.list(2);
+    this.list(2);
 
-    self.resume(true);
+    this.resume(true);
   });
 };
 
@@ -977,7 +960,6 @@ Interface.prototype.controlEval = function(code, context, filename, callback) {
 Interface.prototype.debugEval = function(code, context, filename, callback) {
   if (!this.requireConnection()) return;
 
-  const self = this;
   const client = this.client;
 
   // Repl asked for scope variables
@@ -988,20 +970,20 @@ Interface.prototype.debugEval = function(code, context, filename, callback) {
 
   var frame = client.currentFrame === NO_FRAME ? frame : undefined;
 
-  self.pause();
+  this.pause();
 
   // Request remote evaluation globally or in current frame
-  client.reqFrameEval(code, frame, function(err, res) {
+  client.reqFrameEval(code, frame, (err, res) => {
     if (err) {
       callback(err);
-      self.resume(true);
+      this.resume(true);
       return;
     }
 
     // Request object by handles (and it's sub-properties)
-    client.mirrorObject(res, 3, function(err, mirror) {
+    client.mirrorObject(res, 3, (err, mirror) => {
       callback(null, mirror);
-      self.resume(true);
+      this.resume(true);
     });
   });
 };
@@ -1050,15 +1032,13 @@ Interface.prototype.run = function() {
 Interface.prototype.restart = function() {
   if (!this.requireConnection()) return;
 
-  var self = this;
-
-  self.pause();
-  self.killChild();
+  this.pause();
+  this.killChild();
 
   // XXX need to wait a little bit for the restart to work?
-  setTimeout(function() {
-    self.trySpawn();
-    self.resume();
+  setTimeout(() => {
+    this.trySpawn();
+    this.resume();
   }, 1000);
 };
 
@@ -1067,16 +1047,14 @@ Interface.prototype.restart = function() {
 Interface.prototype.version = function() {
   if (!this.requireConnection()) return;
 
-  var self = this;
-
   this.pause();
-  this.client.reqVersion(function(err, v) {
+  this.client.reqVersion((err, v) => {
     if (err) {
-      self.error(err);
+      this.error(err);
     } else {
-      self.print(v);
+      this.print(v);
     }
-    self.resume();
+    this.resume();
   });
 };
 
@@ -1086,16 +1064,15 @@ Interface.prototype.list = function(delta) {
 
   delta || (delta = 5);
 
-  const self = this;
   const client = this.client;
   const from = client.currentSourceLine - delta + 1;
   const to = client.currentSourceLine + delta + 1;
 
-  self.pause();
-  client.reqSource(from, to, function(err, res) {
+  this.pause();
+  client.reqSource(from, to, (err, res) => {
     if (err || !res) {
-      self.error('You can\'t list source code right now');
-      self.resume();
+      this.error('You can\'t list source code right now');
+      this.resume();
       return;
     }
 
@@ -1125,7 +1102,7 @@ Interface.prototype.list = function(delta) {
       if (current) {
         line = SourceUnderline(lines[i],
                                client.currentSourceColumn,
-                               self.repl);
+                               this.repl);
       } else {
         line = lines[i];
       }
@@ -1137,9 +1114,9 @@ Interface.prototype.list = function(delta) {
         prefixChar = '*';
       }
 
-      self.print(leftPad(lineno, prefixChar, to) + ' ' + line);
+      this.print(leftPad(lineno, prefixChar, to) + ' ' + line);
     }
-    self.resume();
+    this.resume();
   });
 };
 
@@ -1147,19 +1124,18 @@ Interface.prototype.list = function(delta) {
 Interface.prototype.backtrace = function() {
   if (!this.requireConnection()) return;
 
-  const self = this;
   const client = this.client;
 
-  self.pause();
-  client.fullTrace(function(err, bt) {
+  this.pause();
+  client.fullTrace((err, bt) => {
     if (err) {
-      self.error('Can\'t request backtrace now');
-      self.resume();
+      this.error('Can\'t request backtrace now');
+      this.resume();
       return;
     }
 
     if (bt.totalFrames == 0) {
-      self.print('(empty stack)');
+      this.print('(empty stack)');
     } else {
       const trace = [];
       const firstFrameNative = bt.frames[0].script.isNative;
@@ -1178,10 +1154,10 @@ Interface.prototype.backtrace = function() {
         trace.push(text);
       }
 
-      self.print(trace.join('\n'));
+      this.print(trace.join('\n'));
     }
 
-    self.resume();
+    this.resume();
   });
 };
 
@@ -1220,10 +1196,9 @@ Interface.prototype.cont = function() {
   if (!this.requireConnection()) return;
   this.pause();
 
-  var self = this;
-  this.client.reqContinue(function(err) {
-    if (err) self.error(err);
-    self.resume();
+  this.client.reqContinue((err) => {
+    if (err) this.error(err);
+    this.resume();
   });
 };
 
@@ -1233,12 +1208,10 @@ Interface.stepGenerator = function(type, count) {
   return function() {
     if (!this.requireConnection()) return;
 
-    var self = this;
-
-    self.pause();
-    self.client.step(type, count, function(err, res) {
-      if (err) self.error(err);
-      self.resume();
+    this.pause();
+    this.client.step(type, count, (err, res) => {
+      if (err) this.error(err);
+      this.resume();
     });
   };
 };
@@ -1273,7 +1246,6 @@ Interface.prototype.unwatch = function(expr) {
 
 // List watchers
 Interface.prototype.watchers = function() {
-  var self = this;
   var verbose = arguments[0] || false;
   var callback = arguments[1] || function() {};
   var waiting = this._watchers.length;
@@ -1287,42 +1259,40 @@ Interface.prototype.watchers = function() {
     return callback();
   }
 
-  this._watchers.forEach(function(watcher, i) {
-    self.debugEval(watcher, null, null, function(err, value) {
+  this._watchers.forEach((watcher, i) => {
+    this.debugEval(watcher, null, null, function(err, value) {
       values[i] = err ? '<error>' : value;
       wait();
     });
   });
 
-  function wait() {
+  const wait = () => {
     if (--waiting === 0) {
-      if (verbose) self.print('Watchers:');
+      if (verbose) this.print('Watchers:');
 
-      self._watchers.forEach(function(watcher, i) {
-        self.print(leftPad(i, ' ', self._watchers.length - 1) +
+      this._watchers.forEach((watcher, i) => {
+        this.print(leftPad(i, ' ', this._watchers.length - 1) +
                    ': ' + watcher + ' = ' +
                    JSON.stringify(values[i]));
       });
 
-      if (verbose) self.print('');
+      if (verbose) this.print('');
 
-      self.resume();
+      this.resume();
 
       callback(null);
     }
-  }
+  };
 };
 
 // Break on exception
 Interface.prototype.breakOnException = function breakOnException() {
   if (!this.requireConnection()) return;
 
-  var self = this;
-
   // Break on exceptions
   this.pause();
-  this.client.reqSetExceptionBreak('all', function(err, res) {
-    self.resume();
+  this.client.reqSetExceptionBreak('all', (err, res) => {
+    this.resume();
   });
 };
 
@@ -1331,7 +1301,6 @@ Interface.prototype.setBreakpoint = function(script, line,
                                              condition, silent) {
   if (!this.requireConnection()) return;
 
-  const self = this;
   var scriptId;
   var ambiguous;
 
@@ -1402,15 +1371,15 @@ Interface.prototype.setBreakpoint = function(script, line,
     }
   }
 
-  self.pause();
-  self.client.setBreakpoint(req, function(err, res) {
+  this.pause();
+  this.client.setBreakpoint(req, (err, res) => {
     if (err) {
       if (!silent) {
-        self.error(err);
+        this.error(err);
       }
     } else {
       if (!silent) {
-        self.list(5);
+        this.list(5);
       }
 
       // Try load scriptId and line from response
@@ -1420,16 +1389,16 @@ Interface.prototype.setBreakpoint = function(script, line,
       }
 
       // Remember this breakpoint even if scriptId is not resolved yet
-      self.client.breakpoints.push({
+      this.client.breakpoints.push({
         id: res.breakpoint,
         scriptId: scriptId,
-        script: (self.client.scripts[scriptId] || {}).name,
+        script: (this.client.scripts[scriptId] || {}).name,
         line: line,
         condition: condition,
         scriptReq: script
       });
     }
-    self.resume();
+    this.resume();
   });
 };
 
@@ -1482,18 +1451,17 @@ Interface.prototype.clearBreakpoint = function(script, line) {
     return this.error('Breakpoint not found on line ' + line);
   }
 
-  var self = this;
   const req = {breakpoint};
 
-  self.pause();
-  self.client.clearBreakpoint(req, function(err, res) {
+  this.pause();
+  this.client.clearBreakpoint(req, (err, res) => {
     if (err) {
-      self.error(err);
+      this.error(err);
     } else {
-      self.client.breakpoints.splice(index, 1);
-      self.list(5);
+      this.client.breakpoints.splice(index, 1);
+      this.list(5);
     }
-    self.resume();
+    this.resume();
   });
 };
 
@@ -1503,13 +1471,12 @@ Interface.prototype.breakpoints = function() {
   if (!this.requireConnection()) return;
 
   this.pause();
-  var self = this;
-  this.client.listbreakpoints(function(err, res) {
+  this.client.listbreakpoints((err, res) => {
     if (err) {
-      self.error(err);
+      this.error(err);
     } else {
-      self.print(res);
-      self.resume();
+      this.print(res);
+      this.resume();
     }
   });
 };
@@ -1519,15 +1486,14 @@ Interface.prototype.breakpoints = function() {
 Interface.prototype.pause_ = function() {
   if (!this.requireConnection()) return;
 
-  const self = this;
   const cmd = 'process._debugPause();';
 
   this.pause();
-  this.client.reqFrameEval(cmd, NO_FRAME, function(err, res) {
+  this.client.reqFrameEval(cmd, NO_FRAME, (err, res) => {
     if (err) {
-      self.error(err);
+      this.error(err);
     } else {
-      self.resume();
+      this.resume();
     }
   });
 };
@@ -1556,28 +1522,26 @@ Interface.prototype.kill = function() {
 Interface.prototype.repl = function() {
   if (!this.requireConnection()) return;
 
-  var self = this;
-
-  self.print('Press Ctrl + C to leave debug repl');
+  this.print('Press Ctrl + C to leave debug repl');
 
   // Don't display any default messages
   var listeners = this.repl.rli.listeners('SIGINT').slice(0);
   this.repl.rli.removeAllListeners('SIGINT');
 
-  function exitDebugRepl() {
+  const exitDebugRepl = () => {
     // Restore all listeners
-    process.nextTick(function() {
-      listeners.forEach(function(listener) {
-        self.repl.rli.on('SIGINT', listener);
+    process.nextTick(() => {
+      listeners.forEach((listener) => {
+        this.repl.rli.on('SIGINT', listener);
       });
     });
 
     // Exit debug repl
-    self.exitRepl();
+    this.exitRepl();
 
-    self.repl.rli.removeListener('SIGINT', exitDebugRepl);
-    self.repl.removeListener('exit', exitDebugRepl);
-  }
+    this.repl.rli.removeListener('SIGINT', exitDebugRepl);
+    this.repl.removeListener('exit', exitDebugRepl);
+  };
 
   // Exit debug repl on SIGINT
   this.repl.rli.on('SIGINT', exitDebugRepl);
@@ -1641,7 +1605,6 @@ Interface.prototype.killChild = function() {
 
 // Spawns child process (and restores breakpoints)
 Interface.prototype.trySpawn = function(cb) {
-  const self = this;
   const breakpoints = this.breakpoints || [];
   var port = exports.port;
   var host = '127.0.0.1';
@@ -1696,43 +1659,49 @@ Interface.prototype.trySpawn = function(cb) {
 
   this.pause();
 
-  const client = self.client = new Client();
+  const client = this.client = new Client();
   var connectionAttempts = 0;
 
-  client.once('ready', function() {
-    self.stdout.write(' ok\n');
+  client.once('ready', () => {
+    this.stdout.write(' ok\n');
 
     // Restore breakpoints
-    breakpoints.forEach(function(bp) {
-      self.print('Restoring breakpoint ' + bp.scriptReq + ':' + bp.line);
-      self.setBreakpoint(bp.scriptReq, bp.line, bp.condition, true);
+    breakpoints.forEach((bp) => {
+      this.print('Restoring breakpoint ' + bp.scriptReq + ':' + bp.line);
+      this.setBreakpoint(bp.scriptReq, bp.line, bp.condition, true);
     });
 
-    client.on('close', function() {
-      self.pause();
-      self.print('program terminated');
-      self.resume();
-      self.client = null;
-      self.killChild();
+    client.on('close', () => {
+      this.pause();
+      this.print('program terminated');
+      this.resume();
+      this.client = null;
+      this.killChild();
     });
 
     if (cb) cb();
-    self.resume();
+    this.resume();
   });
 
-  client.on('unhandledResponse', function(res) {
-    self.pause();
-    self.print('\nunhandled res:' + JSON.stringify(res));
-    self.resume();
+  client.on('unhandledResponse', (res) => {
+    this.pause();
+    this.print('\nunhandled res:' + JSON.stringify(res));
+    this.resume();
   });
 
-  client.on('break', function(res) {
-    self.handleBreak(res.body);
+  client.on('break', (res) => {
+    this.handleBreak(res.body);
   });
 
-  client.on('exception', function(res) {
-    self.handleBreak(res.body);
+  client.on('exception', (res) => {
+    this.handleBreak(res.body);
   });
+
+  const attemptConnect = () => {
+    ++connectionAttempts;
+    this.stdout.write('.');
+    client.connect(port, host);
+  };
 
   client.on('error', connectError);
   function connectError() {
@@ -1744,18 +1713,12 @@ Interface.prototype.trySpawn = function(cb) {
     setTimeout(attemptConnect, 500);
   }
 
-  function attemptConnect() {
-    ++connectionAttempts;
-    self.stdout.write('.');
-    client.connect(port, host);
-  }
-
   if (isRemote) {
-    self.print('connecting to ' + host + ':' + port + ' ..', true);
+    this.print('connecting to ' + host + ':' + port + ' ..', true);
     attemptConnect();
   } else {
-    this.child.stderr.once('data', function() {
-      self.print('connecting to ' + host + ':' + port + ' ..', true);
+    this.child.stderr.once('data', () => {
+      this.print('connecting to ' + host + ':' + port + ' ..', true);
       setImmediate(attemptConnect);
     });
   }

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -785,7 +785,7 @@ function Interface(stdin, stdout, args) {
     } else {
       this.repl.context[key] = fn;
     }
-  }
+  };
 
   // Copy all prototype methods in repl context
   // Setup them as getters if possible
@@ -1259,13 +1259,6 @@ Interface.prototype.watchers = function() {
     return callback();
   }
 
-  this._watchers.forEach((watcher, i) => {
-    this.debugEval(watcher, null, null, function(err, value) {
-      values[i] = err ? '<error>' : value;
-      wait();
-    });
-  });
-
   const wait = () => {
     if (--waiting === 0) {
       if (verbose) this.print('Watchers:');
@@ -1283,6 +1276,13 @@ Interface.prototype.watchers = function() {
       callback(null);
     }
   };
+
+  this._watchers.forEach((watcher, i) => {
+    this.debugEval(watcher, null, null, function(err, value) {
+      values[i] = err ? '<error>' : value;
+      wait();
+    });
+  });
 };
 
 // Break on exception

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -23,33 +23,31 @@ function Agent(options) {
 
   EventEmitter.call(this);
 
-  var self = this;
+  this.defaultPort = 80;
+  this.protocol = 'http:';
 
-  self.defaultPort = 80;
-  self.protocol = 'http:';
-
-  self.options = util._extend({}, options);
+  this.options = util._extend({}, options);
 
   // don't confuse net and make it think that we're connecting to a pipe
-  self.options.path = null;
-  self.requests = {};
-  self.sockets = {};
-  self.freeSockets = {};
-  self.keepAliveMsecs = self.options.keepAliveMsecs || 1000;
-  self.keepAlive = self.options.keepAlive || false;
-  self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets;
-  self.maxFreeSockets = self.options.maxFreeSockets || 256;
+  this.options.path = null;
+  this.requests = {};
+  this.sockets = {};
+  this.freeSockets = {};
+  this.keepAliveMsecs = this.options.keepAliveMsecs || 1000;
+  this.keepAlive = this.options.keepAlive || false;
+  this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
+  this.maxFreeSockets = this.options.maxFreeSockets || 256;
 
-  self.on('free', function(socket, options) {
-    var name = self.getName(options);
+  this.on('free', (socket, options) => {
+    var name = this.getName(options);
     debug('agent.on(free)', name);
 
     if (!socket.destroyed &&
-        self.requests[name] && self.requests[name].length) {
-      self.requests[name].shift().onSocket(socket);
-      if (self.requests[name].length === 0) {
+        this.requests[name] && this.requests[name].length) {
+      this.requests[name].shift().onSocket(socket);
+      if (this.requests[name].length === 0) {
         // don't leak
-        delete self.requests[name];
+        delete this.requests[name];
       }
     } else {
       // If there are no pending requests, then put it in
@@ -58,22 +56,22 @@ function Agent(options) {
       if (req &&
           req.shouldKeepAlive &&
           !socket.destroyed &&
-          self.keepAlive) {
-        var freeSockets = self.freeSockets[name];
+          this.keepAlive) {
+        var freeSockets = this.freeSockets[name];
         var freeLen = freeSockets ? freeSockets.length : 0;
         var count = freeLen;
-        if (self.sockets[name])
-          count += self.sockets[name].length;
+        if (this.sockets[name])
+          count += this.sockets[name].length;
 
-        if (count > self.maxSockets || freeLen >= self.maxFreeSockets) {
+        if (count > this.maxSockets || freeLen >= this.maxFreeSockets) {
           socket.destroy();
         } else {
           freeSockets = freeSockets || [];
-          self.freeSockets[name] = freeSockets;
-          socket.setKeepAlive(true, self.keepAliveMsecs);
+          this.freeSockets[name] = freeSockets;
+          socket.setKeepAlive(true, this.keepAliveMsecs);
           socket.unref();
           socket._httpMessage = null;
-          self.removeSocket(socket, options);
+          this.removeSocket(socket, options);
           freeSockets.push(socket);
         }
       } else {
@@ -150,9 +148,8 @@ Agent.prototype.addRequest = function(req, options) {
 };
 
 Agent.prototype.createSocket = function(req, options) {
-  var self = this;
   options = util._extend({}, options);
-  options = util._extend(options, self.options);
+  options = util._extend(options, this.options);
 
   if (!options.servername) {
     options.servername = options.host;
@@ -164,42 +161,42 @@ Agent.prototype.createSocket = function(req, options) {
     }
   }
 
-  var name = self.getName(options);
+  var name = this.getName(options);
   options._agentKey = name;
 
   debug('createConnection', name, options);
   options.encoding = null;
-  var s = self.createConnection(options);
-  if (!self.sockets[name]) {
-    self.sockets[name] = [];
+  var s = this.createConnection(options);
+  if (!this.sockets[name]) {
+    this.sockets[name] = [];
   }
   this.sockets[name].push(s);
   debug('sockets', name, this.sockets[name].length);
 
-  function onFree() {
-    self.emit('free', s, options);
-  }
+  const onFree = () => {
+    this.emit('free', s, options);
+  };
   s.on('free', onFree);
 
-  function onClose(err) {
+  const onClose = (err) => {
     debug('CLIENT socket onClose');
     // This is the only place where sockets get removed from the Agent.
     // If you want to remove a socket from the pool, just close it.
     // All socket errors end in a close event anyway.
-    self.removeSocket(s, options);
-  }
+    this.removeSocket(s, options);
+  };
   s.on('close', onClose);
 
-  function onRemove() {
+  const onRemove = () => {
     // We need this function for cases like HTTP 'upgrade'
     // (defined by WebSockets) where we need to remove a socket from the
     // pool because it'll be locked up indefinitely
     debug('CLIENT socket onRemove');
-    self.removeSocket(s, options);
+    this.removeSocket(s, options);
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
     s.removeListener('agentRemove', onRemove);
-  }
+  };
   s.on('agentRemove', onRemove);
   return s;
 };

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -149,6 +149,8 @@ function ClientRequest(options, cb) {
 
   self._deferToConnect(null, null, function() {
     self._flush();
+    // This null assignment is what blocks us from avoiding the use of self
+    // this = this is invalid, but self = this; self = null is valid
     self = null;
   });
 }
@@ -516,26 +518,25 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
   // calls that happen either now (when a socket is assigned) or
   // in the future (when a socket gets assigned out of the pool and is
   // eventually writable).
-  var self = this;
 
-  function callSocketMethod() {
+  const callSocketMethod = () => {
     if (method)
-      self.socket[method].apply(self.socket, arguments_);
+      this.socket[method].apply(this.socket, arguments_);
 
     if (typeof cb === 'function')
       cb();
-  }
+  };
 
-  var onSocket = function() {
-    if (self.socket.writable) {
+  const onSocket = () => {
+    if (this.socket.writable) {
       callSocketMethod();
     } else {
-      self.socket.once('connect', callSocketMethod);
+      this.socket.once('connect', callSocketMethod);
     }
   };
 
-  if (!self.socket) {
-    self.once('socket', onSocket);
+  if (!this.socket) {
+    this.once('socket', onSocket);
   } else {
     onSocket();
   }
@@ -544,10 +545,9 @@ ClientRequest.prototype._deferToConnect = function(method, arguments_, cb) {
 ClientRequest.prototype.setTimeout = function(msecs, callback) {
   if (callback) this.once('timeout', callback);
 
-  var self = this;
-  function emitTimeout() {
-    self.emit('timeout');
-  }
+  var emitTimeout = () => {
+    this.emit('timeout');
+  };
 
   if (this.socket && this.socket.writable) {
     if (this.timeoutCb)

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -540,10 +540,9 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
     return false;
   }
 
-  var self = this;
-  function finish() {
-    self.emit('finish');
-  }
+  var finish = () => {
+    this.emit('finish');
+  };
 
   if (typeof callback === 'function')
     this.once('finish', callback);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -255,7 +255,6 @@ exports.Server = Server;
 
 
 function connectionListener(socket) {
-  var self = this;
   var outgoing = [];
   var incoming = [];
   var outgoingData = 0;
@@ -296,14 +295,14 @@ function connectionListener(socket) {
   // If the user has added a listener to the server,
   // request, or response, then it's their responsibility.
   // otherwise, destroy on timeout by default
-  if (self.timeout)
-    socket.setTimeout(self.timeout);
-  socket.on('timeout', function() {
+  if (this.timeout)
+    socket.setTimeout(this.timeout);
+  socket.on('timeout', () => {
     var req = socket.parser && socket.parser.incoming;
     var reqTimeout = req && !req.complete && req.emit('timeout', socket);
     var res = socket._httpMessage;
     var resTimeout = res && res.emit('timeout', socket);
-    var serverTimeout = self.emit('timeout', socket);
+    var serverTimeout = this.emit('timeout', socket);
 
     if (!reqTimeout && !resTimeout && !serverTimeout)
       socket.destroy();
@@ -347,14 +346,14 @@ function connectionListener(socket) {
   parser[kOnExecute] = onParserExecute;
 
   // TODO(isaacs): Move all these functions out of here
-  function socketOnError(e) {
+  const socketOnError = (e) => {
     // Ignore further errors
     this.removeListener('error', socketOnError);
     this.on('error', () => {});
 
-    if (!self.emit('clientError', e, this))
+    if (!this.emit('clientError', e, this))
       this.destroy(e);
-  }
+  };
 
   function socketOnData(d) {
     assert(!socket._paused);
@@ -369,7 +368,7 @@ function connectionListener(socket) {
     onParserExecuteCommon(ret, undefined);
   }
 
-  function onParserExecuteCommon(ret, d) {
+  const onParserExecuteCommon = (ret, d) => {
     if (ret instanceof Error) {
       debug('parse error');
       socketOnError.call(socket, ret);
@@ -391,14 +390,14 @@ function connectionListener(socket) {
       parser = null;
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-      if (self.listenerCount(eventName) > 0) {
+      if (this.listenerCount(eventName) > 0) {
         debug('SERVER have listener for %s', eventName);
         var bodyHead = d.slice(bytesParsed, d.length);
 
         // TODO(isaacs): Need a way to reset a stream to fresh state
         // IE, not flowing, and not explicitly paused.
         socket._readableState.flowing = null;
-        self.emit(eventName, req, socket, bodyHead);
+        this.emit(eventName, req, socket, bodyHead);
       } else {
         // Got upgrade header or CONNECT method, but have no handler.
         socket.destroy();
@@ -410,9 +409,9 @@ function connectionListener(socket) {
       debug('pause parser');
       socket.parser.pause();
     }
-  }
+  };
 
-  function socketOnEnd() {
+  const socketOnEnd = () => {
     var socket = this;
     var ret = parser.finish();
 
@@ -422,7 +421,7 @@ function connectionListener(socket) {
       return;
     }
 
-    if (!self.httpAllowHalfOpen) {
+    if (!this.httpAllowHalfOpen) {
       abortIncoming();
       if (socket.writable) socket.end();
     } else if (outgoing.length) {
@@ -432,7 +431,7 @@ function connectionListener(socket) {
     } else {
       if (socket.writable) socket.end();
     }
-  }
+  };
 
 
   // The following callback is issued after the headers have been read on a
@@ -452,7 +451,7 @@ function connectionListener(socket) {
     }
   }
 
-  function parserOnIncoming(req, shouldKeepAlive) {
+  const parserOnIncoming = (req, shouldKeepAlive) => {
     incoming.push(req);
 
     // If the writable end isn't consuming, then stop reading
@@ -488,7 +487,7 @@ function connectionListener(socket) {
     // When we're finished writing the response, check if this is the last
     // respose, if so destroy the socket.
     res.on('finish', resOnFinish);
-    function resOnFinish() {
+    const resOnFinish = () => {
       // Usually the first incoming element should be our request.  it may
       // be that in the case abortIncoming() was called that the incoming
       // array will be empty.
@@ -520,22 +519,22 @@ function connectionListener(socket) {
       if (continueExpression.test(req.headers.expect)) {
         res._expect_continue = true;
 
-        if (self.listenerCount('checkContinue') > 0) {
-          self.emit('checkContinue', req, res);
+        if (this.listenerCount('checkContinue') > 0) {
+          this.emit('checkContinue', req, res);
         } else {
           res.writeContinue();
-          self.emit('request', req, res);
+          this.emit('request', req, res);
         }
       } else {
-        if (self.listenerCount('checkExpectation') > 0) {
-          self.emit('checkExpectation', req, res);
+        if (this.listenerCount('checkExpectation') > 0) {
+          this.emit('checkExpectation', req, res);
         } else {
           res.writeHead(417);
           res.end();
         }
       }
     } else {
-      self.emit('request', req, res);
+      this.emit('request', req, res);
     }
     return false; // Not a HEAD response. (Not even a response!)
   }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -322,56 +322,129 @@ function connectionListener(socket) {
     parser.maxHeaderPairs = 2000;
   }
 
-  socket.addListener('error', socketOnError);
-  socket.addListener('close', serverSocketCloseListener);
-  parser.onIncoming = parserOnIncoming;
-  socket.on('end', socketOnEnd);
-  socket.on('data', socketOnData);
-
-  // We are consuming socket, so it won't get any actual data
-  socket.on('resume', onSocketResume);
-  socket.on('pause', onSocketPause);
-
-  socket.on('drain', socketOnDrain);
-
-  // Override on to unconsume on `data`, `readable` listeners
-  socket.on = socketOnWrap;
-
-  var external = socket._handle._externalStream;
-  if (external) {
-    parser._consumed = true;
-    parser.consume(external);
-  }
-  external = null;
-  parser[kOnExecute] = onParserExecute;
-
   // TODO(isaacs): Move all these functions out of here
   const socketOnError = (e) => {
     // Ignore further errors
-    this.removeListener('error', socketOnError);
-    this.on('error', () => {});
+    socket.removeListener('error', socketOnError);
+    socket.on('error', () => {});
 
-    if (!this.emit('clientError', e, this))
-      this.destroy(e);
+    if (!this.emit('clientError', e, socket))
+      socket.destroy(e);
   };
 
-  function socketOnData(d) {
-    assert(!socket._paused);
-    debug('SERVER socketOnData %d', d.length);
-    var ret = parser.execute(d);
+  const parserOnIncoming = (req, shouldKeepAlive) => {
+    incoming.push(req);
 
-    onParserExecuteCommon(ret, d);
-  }
+    // If the writable end isn't consuming, then stop reading
+    // so that we don't become overwhelmed by a flood of
+    // pipelined requests that may never be resolved.
+    if (!socket._paused) {
+      var needPause = socket._writableState.needDrain ||
+          outgoingData >= socket._writableState.highWaterMark;
+      if (needPause) {
+        socket._paused = true;
+        // We also need to pause the parser, but don't do that until after
+        // the call to execute, because we may still be processing the last
+        // chunk.
+        socket.pause();
+      }
+    }
 
-  function onParserExecute(ret, d) {
-    debug('SERVER socketOnParserExecute %d', ret);
-    onParserExecuteCommon(ret, undefined);
-  }
+    var res = new ServerResponse(req);
+    res._onPendingData = updateOutgoingData;
+
+    res.shouldKeepAlive = shouldKeepAlive;
+    DTRACE_HTTP_SERVER_REQUEST(req, socket);
+    LTTNG_HTTP_SERVER_REQUEST(req, socket);
+    COUNTER_HTTP_SERVER_REQUEST();
+
+    if (socket._httpMessage) {
+      // There are already pending outgoing res, append.
+      outgoing.push(res);
+    } else {
+      res.assignSocket(socket);
+    }
+
+    // When we're finished writing the response, check if this is the last
+    // respose, if so destroy the socket.
+    const resOnFinish = () => {
+      // Usually the first incoming element should be our request.  it may
+      // be that in the case abortIncoming() was called that the incoming
+      // array will be empty.
+      assert(incoming.length === 0 || incoming[0] === req);
+
+      incoming.shift();
+
+      // if the user never called req.read(), and didn't pipe() or
+      // .resume() or .on('data'), then we call req._dump() so that the
+      // bytes will be pulled off the wire.
+      if (!req._consuming && !req._readableState.resumeScheduled)
+        req._dump();
+
+      res.detachSocket(socket);
+
+      if (res._last) {
+        socket.destroySoon();
+      } else {
+        // start sending the next message
+        var m = outgoing.shift();
+        if (m) {
+          m.assignSocket(socket);
+        }
+      }
+    };
+    res.on('finish', resOnFinish);
+
+    if (req.headers.expect !== undefined &&
+        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1)) {
+      if (continueExpression.test(req.headers.expect)) {
+        res._expect_continue = true;
+
+        if (this.listenerCount('checkContinue') > 0) {
+          this.emit('checkContinue', req, res);
+        } else {
+          res.writeContinue();
+          this.emit('request', req, res);
+        }
+      } else {
+        if (this.listenerCount('checkExpectation') > 0) {
+          this.emit('checkExpectation', req, res);
+        } else {
+          res.writeHead(417);
+          res.end();
+        }
+      }
+    } else {
+      this.emit('request', req, res);
+    }
+    return false; // Not a HEAD response. (Not even a response!)
+  };
+
+  const socketOnEnd = () => {
+    var ret = parser.finish();
+
+    if (ret instanceof Error) {
+      debug('parse error');
+      socketOnError(ret);
+      return;
+    }
+
+    if (!this.httpAllowHalfOpen) {
+      abortIncoming();
+      if (socket.writable) socket.end();
+    } else if (outgoing.length) {
+      outgoing[outgoing.length - 1]._last = true;
+    } else if (socket._httpMessage) {
+      socket._httpMessage._last = true;
+    } else {
+      if (socket.writable) socket.end();
+    }
+  };
 
   const onParserExecuteCommon = (ret, d) => {
     if (ret instanceof Error) {
       debug('parse error');
-      socketOnError.call(socket, ret);
+      socketOnError(ret);
     } else if (parser.incoming && parser.incoming.upgrade) {
       // Upgrade or CONNECT
       var bytesParsed = ret;
@@ -411,28 +484,43 @@ function connectionListener(socket) {
     }
   };
 
-  const socketOnEnd = () => {
-    var socket = this;
-    var ret = parser.finish();
+  socket.addListener('error', socketOnError);
+  socket.addListener('close', serverSocketCloseListener);
+  parser.onIncoming = parserOnIncoming;
+  socket.on('end', socketOnEnd);
+  socket.on('data', socketOnData);
 
-    if (ret instanceof Error) {
-      debug('parse error');
-      socketOnError.call(socket, ret);
-      return;
-    }
+  // We are consuming socket, so it won't get any actual data
+  socket.on('resume', onSocketResume);
+  socket.on('pause', onSocketPause);
 
-    if (!this.httpAllowHalfOpen) {
-      abortIncoming();
-      if (socket.writable) socket.end();
-    } else if (outgoing.length) {
-      outgoing[outgoing.length - 1]._last = true;
-    } else if (socket._httpMessage) {
-      socket._httpMessage._last = true;
-    } else {
-      if (socket.writable) socket.end();
-    }
-  };
+  socket.on('drain', socketOnDrain);
 
+  // Override on to unconsume on `data`, `readable` listeners
+  socket.on = socketOnWrap;
+
+  var external = socket._handle._externalStream;
+  if (external) {
+    parser._consumed = true;
+    parser.consume(external);
+  }
+  external = null;
+  parser[kOnExecute] = onParserExecute;
+
+  // TODO(isaacs): Move all these functions out of here
+
+  function socketOnData(d) {
+    assert(!socket._paused);
+    debug('SERVER socketOnData %d', d.length);
+    var ret = parser.execute(d);
+
+    onParserExecuteCommon(ret, d);
+  }
+
+  function onParserExecute(ret, d) {
+    debug('SERVER socketOnParserExecute %d', ret);
+    onParserExecuteCommon(ret, undefined);
+  }
 
   // The following callback is issued after the headers have been read on a
   // new message. In this callback we setup the response object and pass it
@@ -449,94 +537,6 @@ function connectionListener(socket) {
         socket.parser.resume();
       socket.resume();
     }
-  }
-
-  const parserOnIncoming = (req, shouldKeepAlive) => {
-    incoming.push(req);
-
-    // If the writable end isn't consuming, then stop reading
-    // so that we don't become overwhelmed by a flood of
-    // pipelined requests that may never be resolved.
-    if (!socket._paused) {
-      var needPause = socket._writableState.needDrain ||
-          outgoingData >= socket._writableState.highWaterMark;
-      if (needPause) {
-        socket._paused = true;
-        // We also need to pause the parser, but don't do that until after
-        // the call to execute, because we may still be processing the last
-        // chunk.
-        socket.pause();
-      }
-    }
-
-    var res = new ServerResponse(req);
-    res._onPendingData = updateOutgoingData;
-
-    res.shouldKeepAlive = shouldKeepAlive;
-    DTRACE_HTTP_SERVER_REQUEST(req, socket);
-    LTTNG_HTTP_SERVER_REQUEST(req, socket);
-    COUNTER_HTTP_SERVER_REQUEST();
-
-    if (socket._httpMessage) {
-      // There are already pending outgoing res, append.
-      outgoing.push(res);
-    } else {
-      res.assignSocket(socket);
-    }
-
-    // When we're finished writing the response, check if this is the last
-    // respose, if so destroy the socket.
-    res.on('finish', resOnFinish);
-    const resOnFinish = () => {
-      // Usually the first incoming element should be our request.  it may
-      // be that in the case abortIncoming() was called that the incoming
-      // array will be empty.
-      assert(incoming.length === 0 || incoming[0] === req);
-
-      incoming.shift();
-
-      // if the user never called req.read(), and didn't pipe() or
-      // .resume() or .on('data'), then we call req._dump() so that the
-      // bytes will be pulled off the wire.
-      if (!req._consuming && !req._readableState.resumeScheduled)
-        req._dump();
-
-      res.detachSocket(socket);
-
-      if (res._last) {
-        socket.destroySoon();
-      } else {
-        // start sending the next message
-        var m = outgoing.shift();
-        if (m) {
-          m.assignSocket(socket);
-        }
-      }
-    }
-
-    if (req.headers.expect !== undefined &&
-        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1)) {
-      if (continueExpression.test(req.headers.expect)) {
-        res._expect_continue = true;
-
-        if (this.listenerCount('checkContinue') > 0) {
-          this.emit('checkContinue', req, res);
-        } else {
-          res.writeContinue();
-          this.emit('request', req, res);
-        }
-      } else {
-        if (this.listenerCount('checkExpectation') > 0) {
-          this.emit('checkExpectation', req, res);
-        } else {
-          res.writeHead(417);
-          res.end();
-        }
-      }
-    } else {
-      this.emit('request', req, res);
-    }
-    return false; // Not a HEAD response. (Not even a response!)
   }
 }
 exports._connectionListener = connectionListener;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -753,19 +753,18 @@ Readable.prototype.wrap = function(stream) {
   var state = this._readableState;
   var paused = false;
 
-  var self = this;
-  stream.on('end', function() {
+  stream.on('end', () => {
     debug('wrapped end');
     if (state.decoder && !state.ended) {
       var chunk = state.decoder.end();
       if (chunk && chunk.length)
-        self.push(chunk);
+        this.push(chunk);
     }
 
-    self.push(null);
+    this.push(null);
   });
 
-  stream.on('data', function(chunk) {
+  stream.on('data', (chunk) => {
     debug('wrapped data');
     if (state.decoder)
       chunk = state.decoder.write(chunk);
@@ -776,7 +775,7 @@ Readable.prototype.wrap = function(stream) {
     else if (!state.objectMode && (!chunk || !chunk.length))
       return;
 
-    var ret = self.push(chunk);
+    var ret = this.push(chunk);
     if (!ret) {
       paused = true;
       stream.pause();
@@ -795,13 +794,13 @@ Readable.prototype.wrap = function(stream) {
 
   // proxy certain important events.
   const events = ['error', 'close', 'destroy', 'pause', 'resume'];
-  events.forEach(function(ev) {
-    stream.on(ev, self.emit.bind(self, ev));
+  events.forEach((ev) => {
+    stream.on(ev, () => this.emit(ev));
   });
 
   // when we try to consume some more bytes, simply unpause the
   // underlying stream.
-  self._read = function(n) {
+  this._read = function(n) {
     debug('wrapped _read', n);
     if (paused) {
       paused = false;
@@ -809,7 +808,7 @@ Readable.prototype.wrap = function(stream) {
     }
   };
 
-  return self;
+  return this;
 };
 
 

--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -15,52 +15,50 @@ function StreamWrap(stream) {
 
   this._list = null;
 
-  const self = this;
-  handle.close = function(cb) {
+  handle.close = (cb) => {
     debug('close');
-    self.doClose(cb);
+    this.doClose(cb);
   };
-  handle.isAlive = function() {
-    return self.isAlive();
+  handle.isAlive = () => {
+    return this.isAlive();
   };
-  handle.isClosing = function() {
-    return self.isClosing();
+  handle.isClosing = () => {
+    return this.isClosing();
   };
-  handle.onreadstart = function() {
-    return self.readStart();
+  handle.onreadstart = () => {
+    return this.readStart();
   };
-  handle.onreadstop = function() {
-    return self.readStop();
+  handle.onreadstop = () => {
+    return this.readStop();
   };
-  handle.onshutdown = function(req) {
-    return self.doShutdown(req);
+  handle.onshutdown = (req) => {
+    return this.doShutdown(req);
   };
-  handle.onwrite = function(req, bufs) {
-    return self.doWrite(req, bufs);
+  handle.onwrite = (req, bufs) => {
+    return this.doWrite(req, bufs);
   };
 
   this.stream.pause();
-  this.stream.on('error', function onerror(err) {
-    self.emit('error', err);
+  this.stream.on('error', (err) => {
+    this.emit('error', err);
   });
-  this.stream.on('data', function ondata(chunk) {
+  this.stream.on('data', (chunk) => {
     if (!(chunk instanceof Buffer)) {
       // Make sure that no further `data` events will happen
       this.pause();
       this.removeListener('data', ondata);
 
-      self.emit('error', new Error('Stream has StringDecoder'));
+      this.emit('error', new Error('Stream has StringDecoder'));
       return;
     }
-
     debug('data', chunk.length);
-    if (self._handle)
-      self._handle.readBuffer(chunk);
+    if (this._handle)
+      this._handle.readBuffer(chunk);
   });
-  this.stream.once('end', function onend() {
+  this.stream.once('end', () => {
     debug('end');
-    if (self._handle)
-      self._handle.emitEOF();
+    if (this._handle)
+      this._handle.emitEOF();
   });
 
   Socket.call(this, {
@@ -92,14 +90,13 @@ StreamWrap.prototype.readStop = function readStop() {
 };
 
 StreamWrap.prototype.doShutdown = function doShutdown(req) {
-  const self = this;
   const handle = this._handle;
   const item = this._enqueue('shutdown', req);
 
-  this.stream.end(function() {
+  this.stream.end(() => {
     // Ensure that write was dispatched
-    setImmediate(function() {
-      if (!self._dequeue(item))
+    setImmediate(() => {
+      if (!this._dequeue(item))
         return;
 
       handle.finishShutdown(req, 0);
@@ -109,21 +106,20 @@ StreamWrap.prototype.doShutdown = function doShutdown(req) {
 };
 
 StreamWrap.prototype.doWrite = function doWrite(req, bufs) {
-  const self = this;
-  const handle = self._handle;
+  const handle = this._handle;
 
   var pending = bufs.length;
 
   // Queue the request to be able to cancel it
-  const item = self._enqueue('write', req);
+  const item = this._enqueue('write', req);
 
-  self.stream.cork();
-  bufs.forEach(function(buf) {
-    self.stream.write(buf, done);
+  this.stream.cork();
+  bufs.forEach((buf) => {
+    this.stream.write(buf, done);
   });
-  self.stream.uncork();
+  this.stream.uncork();
 
-  function done(err) {
+  const done = (err) => {
     if (!err && --pending !== 0)
       return;
 
@@ -131,9 +127,9 @@ StreamWrap.prototype.doWrite = function doWrite(req, bufs) {
     pending = 0;
 
     // Ensure that write was dispatched
-    setImmediate(function() {
+    setImmediate(() => {
       // Do not invoke callback twice
-      if (!self._dequeue(item))
+      if (!this._dequeue(item))
         return;
 
       var errCode = 0;
@@ -147,7 +143,7 @@ StreamWrap.prototype.doWrite = function doWrite(req, bufs) {
       handle.doAfterWrite(req);
       handle.finishWrite(req, errCode);
     });
-  }
+  };
 
   return 0;
 };
@@ -201,14 +197,13 @@ StreamWrap.prototype._dequeue = function dequeue(item) {
 };
 
 StreamWrap.prototype.doClose = function doClose(cb) {
-  const self = this;
-  const handle = self._handle;
+  const handle = this._handle;
 
-  setImmediate(function() {
-    while (self._list !== null) {
-      const item = self._list;
+  setImmediate(() => {
+    while (this._list !== null) {
+      const item = this._list;
       const req = item.req;
-      self._dequeue(item);
+      this._dequeue(item);
 
       const errCode = uv.UV_ECANCELED;
       if (item.type === 'write') {
@@ -220,7 +215,7 @@ StreamWrap.prototype.doClose = function doClose(cb) {
     }
 
     // Should be already set by net.js
-    assert(self._handle === null);
+    assert(this._handle === null);
     cb();
   });
 };

--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -38,11 +38,11 @@ function StreamWrap(stream) {
     return this.doWrite(req, bufs);
   };
 
-  this.stream.pause();
-  this.stream.on('error', (err) => {
+  const onerror = (err) => {
     this.emit('error', err);
-  });
-  this.stream.on('data', (chunk) => {
+  };
+
+  const ondata = (chunk) => {
     if (!(chunk instanceof Buffer)) {
       // Make sure that no further `data` events will happen
       this.pause();
@@ -54,7 +54,11 @@ function StreamWrap(stream) {
     debug('data', chunk.length);
     if (this._handle)
       this._handle.readBuffer(chunk);
-  });
+  };
+
+  this.stream.pause();
+  this.stream.on('error', onerror);
+  this.stream.on('data', ondata);
   this.stream.once('end', () => {
     debug('end');
     if (this._handle)
@@ -113,12 +117,6 @@ StreamWrap.prototype.doWrite = function doWrite(req, bufs) {
   // Queue the request to be able to cancel it
   const item = this._enqueue('write', req);
 
-  this.stream.cork();
-  bufs.forEach((buf) => {
-    this.stream.write(buf, done);
-  });
-  this.stream.uncork();
-
   const done = (err) => {
     if (!err && --pending !== 0)
       return;
@@ -144,6 +142,12 @@ StreamWrap.prototype.doWrite = function doWrite(req, bufs) {
       handle.finishWrite(req, errCode);
     });
   };
+
+  this.stream.cork();
+  bufs.forEach((buf) => {
+    this.stream.write(buf, done);
+  });
+  this.stream.uncork();
 
   return 0;
 };

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -131,11 +131,10 @@ function onCryptoStreamEnd() {
 
 // NOTE: Called once `this._opposite` is set.
 CryptoStream.prototype.init = function init() {
-  var self = this;
-  this._opposite.on('sslOutEnd', function() {
-    if (self._sslOutCb) {
-      var cb = self._sslOutCb;
-      self._sslOutCb = null;
+  this._opposite.on('sslOutEnd', () => {
+    if (this._sslOutCb) {
+      var cb = this._sslOutCb;
+      this._sslOutCb = null;
       cb(null);
     }
   });
@@ -422,10 +421,9 @@ CryptoStream.prototype.destroySoon = function(err) {
   } else {
     // Wait for both `finish` and `end` events to ensure that all data that
     // was written on this side was read from the other side.
-    var self = this;
     var waiting = 1;
-    var finish = function() {
-      if (--waiting === 0) self.destroy();
+    var finish = () => {
+      if (--waiting === 0) this.destroy();
     };
     this._opposite.once('end', finish);
     if (!this._finished) {
@@ -500,16 +498,15 @@ function CleartextStream(pair, options) {
 
   // This is a fake kludge to support how the http impl sits
   // on top of net Sockets
-  var self = this;
   this._handle = {
-    readStop: function() {
-      self._reading = false;
+    readStop: () => {
+      this._reading = false;
     },
-    readStart: function() {
-      if (self._reading && self._readableState.length > 0) return;
-      self._reading = true;
-      self.read(0);
-      if (self._opposite.readable) self._opposite.read(0);
+    readStart: () => {
+      if (this._reading && this._readableState.length > 0) return;
+      this._reading = true;
+      this.read(0);
+      if (this._opposite.readable) this._opposite.read(0);
     }
   };
 }
@@ -571,8 +568,7 @@ EncryptedStream.prototype._internallyPendingBytes = function() {
 function onhandshakestart() {
   debug('onhandshakestart');
 
-  var self = this;
-  var ssl = self.ssl;
+  var ssl = this.ssl;
   var now = Timer.now();
 
   assert(now >= ssl.lastHandshakeTime);
@@ -589,9 +585,9 @@ function onhandshakestart() {
     // Defer the error event to the next tick. We're being called from OpenSSL's
     // state machine and OpenSSL is not re-entrant. We cannot allow the user's
     // callback to destroy the connection right now, it would crash and burn.
-    setImmediate(function() {
+    setImmediate(() => {
       var err = new Error('TLS session renegotiation attack detected');
-      if (self.cleartext) self.cleartext.emit('error', err);
+      if (this.cleartext) this.cleartext.emit('error', err);
     });
   }
 }
@@ -604,26 +600,25 @@ function onhandshakedone() {
 
 
 function onclienthello(hello) {
-  const self = this;
   var once = false;
 
   this._resumingSession = true;
-  function callback(err, session) {
+  const callback = (err, session) => {
     if (once) return;
     once = true;
 
-    if (err) return self.socket.destroy(err);
+    if (err) return this.socket.destroy(err);
 
-    setImmediate(function() {
-      self.ssl.loadSession(session);
-      self.ssl.endParser();
+    setImmediate(() => {
+      this.ssl.loadSession(session);
+      this.ssl.endParser();
 
       // Cycle data
-      self._resumingSession = false;
-      self.cleartext.read(0);
-      self.encrypted.read(0);
+      this._resumingSession = false;
+      this.cleartext.read(0);
+      this.encrypted.read(0);
     });
-  }
+  };
 
   if (hello.sessionId.length <= 0 ||
       !this.server ||
@@ -636,20 +631,19 @@ function onclienthello(hello) {
 function onnewsession(key, session) {
   if (!this.server) return;
 
-  var self = this;
   var once = false;
 
-  if (!self.server.emit('newSession', key, session, done))
+  if (!this.server.emit('newSession', key, session, done))
     done();
 
-  function done() {
+  const done = () => {
     if (once)
       return;
     once = true;
 
-    if (self.ssl)
-      self.ssl.newSessionDone();
-  }
+    if (this.ssl)
+      this.ssl.newSessionDone();
+  };
 }
 
 

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -633,9 +633,6 @@ function onnewsession(key, session) {
 
   var once = false;
 
-  if (!this.server.emit('newSession', key, session, done))
-    done();
-
   const done = () => {
     if (once)
       return;
@@ -644,6 +641,9 @@ function onnewsession(key, session) {
     if (this.ssl)
       this.ssl.newSessionDone();
   };
+
+  if (!this.server.emit('newSession', key, session, done))
+    done();
 }
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -177,10 +177,6 @@ function onnewsession(key, session) {
 
   var once = false;
 
-  this._newSessionPending = true;
-  if (!this.server.emit('newSession', key, session, done))
-    done();
-
   const done = () => {
     if (once)
       return;
@@ -196,6 +192,10 @@ function onnewsession(key, session) {
       this._finishInit();
     this._securePending = false;
   };
+
+  this._newSessionPending = true;
+  if (!this.server.emit('newSession', key, session, done))
+    done();
 }
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -18,8 +18,7 @@ const Pipe = process.binding('pipe_wrap').Pipe;
 function onhandshakestart() {
   debug('onhandshakestart');
 
-  var self = this;
-  var ssl = self._handle;
+  var ssl = this._handle;
   var now = Timer.now();
 
   assert(now >= ssl.lastHandshakeTime);
@@ -36,9 +35,9 @@ function onhandshakestart() {
     // Defer the error event to the next tick. We're being called from OpenSSL's
     // state machine and OpenSSL is not re-entrant. We cannot allow the user's
     // callback to destroy the connection right now, it would crash and burn.
-    setImmediate(function() {
+    setImmediate(() => {
       var err = new Error('TLS session renegotiation attack detected');
-      self._emitTLSError(err);
+      this._emitTLSError(err);
     });
   }
 }
@@ -144,32 +143,29 @@ function requestOCSP(self, hello, ctx, cb) {
 
 
 function onclienthello(hello) {
-  var self = this;
-
-  loadSession(self, hello, function(err, session) {
+  loadSession(this, hello, (err, session) => {
     if (err)
-      return self.destroy(err);
+      return this.destroy(err);
 
-    self._handle.endParser();
+    this._handle.endParser();
   });
 }
 
 
 function oncertcb(info) {
-  var self = this;
   var servername = info.servername;
 
-  loadSNI(self, servername, function(err, ctx) {
+  loadSNI(this, servername, (err, ctx) => {
     if (err)
-      return self.destroy(err);
-    requestOCSP(self, info, ctx, function(err) {
+      return this.destroy(err);
+    requestOCSP(this, info, ctx, (err) => {
       if (err)
-        return self.destroy(err);
+        return this.destroy(err);
 
-      if (!self._handle)
-        return self.destroy(new Error('Socket is closed'));
+      if (!this._handle)
+        return this.destroy(new Error('Socket is closed'));
 
-      self._handle.certCbDone();
+      this._handle.certCbDone();
     });
   });
 }
@@ -179,28 +175,27 @@ function onnewsession(key, session) {
   if (!this.server)
     return;
 
-  var self = this;
   var once = false;
 
   this._newSessionPending = true;
   if (!this.server.emit('newSession', key, session, done))
     done();
 
-  function done() {
+  const done = () => {
     if (once)
       return;
     once = true;
 
-    if (!self._handle)
-      return self.destroy(new Error('Socket is closed'));
+    if (!this._handle)
+      return this.destroy(new Error('Socket is closed'));
 
-    self._handle.newSessionDone();
+    this._handle.newSessionDone();
 
-    self._newSessionPending = false;
-    if (self._securePending)
-      self._finishInit();
-    self._securePending = false;
-  }
+    this._newSessionPending = false;
+    if (this._securePending)
+      this._finishInit();
+    this._securePending = false;
+  };
 }
 
 
@@ -363,7 +358,6 @@ TLSSocket.prototype._destroySSL = function _destroySSL() {
 };
 
 TLSSocket.prototype._init = function(socket, wrap) {
-  var self = this;
   var options = this._tlsOptions;
   var ssl = this._handle;
 
@@ -417,24 +411,24 @@ TLSSocket.prototype._init = function(socket, wrap) {
       ssl.setSession(options.session);
   }
 
-  ssl.onerror = function(err) {
-    if (self._writableState.errorEmitted)
+  ssl.onerror = (err) => {
+    if (this._writableState.errorEmitted)
       return;
 
     // Destroy socket if error happened before handshake's finish
-    if (!self._secureEstablished) {
-      self.destroy(self._tlsError(err));
+    if (!this._secureEstablished) {
+      this.destroy(this._tlsError(err));
     } else if (options.isServer &&
                rejectUnauthorized &&
                /peer did not return a certificate/.test(err.message)) {
       // Ignore server's authorization errors
-      self.destroy();
+      this.destroy();
     } else {
       // Throw error
-      self._emitTLSError(err);
+      this._emitTLSError(err);
     }
 
-    self._writableState.errorEmitted = true;
+    this._writableState.errorEmitted = true;
   };
 
   // If custom SNICallback was given, or if
@@ -468,16 +462,16 @@ TLSSocket.prototype._init = function(socket, wrap) {
 
     // To prevent assertion in afterConnect() and properly kick off readStart
     this._connecting = socket._connecting || !socket._handle;
-    socket.once('connect', function() {
-      self._connecting = false;
-      self.emit('connect');
+    socket.once('connect', () => {
+      this._connecting = false;
+      this.emit('connect');
     });
   }
 
   // Assume `tls.connect()`
   if (wrap) {
-    wrap.on('error', function(err) {
-      self._emitTLSError(err);
+    wrap.on('error', (err) => {
+      this._emitTLSError(err);
     });
   } else {
     assert(!socket);
@@ -731,25 +725,23 @@ function Server(/* [options], listener */) {
 
   this._contexts = [];
 
-  var self = this;
-
   // Handle option defaults:
   this.setOptions(options);
 
   var sharedCreds = tls.createSecureContext({
-    pfx: self.pfx,
-    key: self.key,
-    passphrase: self.passphrase,
-    cert: self.cert,
-    ca: self.ca,
-    ciphers: self.ciphers,
-    ecdhCurve: self.ecdhCurve,
-    dhparam: self.dhparam,
-    secureProtocol: self.secureProtocol,
-    secureOptions: self.secureOptions,
-    honorCipherOrder: self.honorCipherOrder,
-    crl: self.crl,
-    sessionIdContext: self.sessionIdContext
+    pfx: this.pfx,
+    key: this.key,
+    passphrase: this.passphrase,
+    cert: this.cert,
+    ca: this.ca,
+    ciphers: this.ciphers,
+    ecdhCurve: this.ecdhCurve,
+    dhparam: this.dhparam,
+    secureProtocol: this.secureProtocol,
+    secureOptions: this.secureOptions,
+    honorCipherOrder: this.honorCipherOrder,
+    crl: this.crl,
+    sessionIdContext: this.sessionIdContext
   });
   this._sharedCreds = sharedCreds;
 
@@ -759,29 +751,29 @@ function Server(/* [options], listener */) {
     throw new TypeError('"handshakeTimeout" option must be a number');
   }
 
-  if (self.sessionTimeout) {
-    sharedCreds.context.setSessionTimeout(self.sessionTimeout);
+  if (this.sessionTimeout) {
+    sharedCreds.context.setSessionTimeout(this.sessionTimeout);
   }
 
-  if (self.ticketKeys) {
-    sharedCreds.context.setTicketKeys(self.ticketKeys);
+  if (this.ticketKeys) {
+    sharedCreds.context.setTicketKeys(this.ticketKeys);
   }
 
   // constructor call
-  net.Server.call(this, function(raw_socket) {
+  net.Server.call(this, (raw_socket) => {
     var socket = new TLSSocket(raw_socket, {
       secureContext: sharedCreds,
       isServer: true,
-      server: self,
-      requestCert: self.requestCert,
-      rejectUnauthorized: self.rejectUnauthorized,
+      server: this,
+      requestCert: this.requestCert,
+      rejectUnauthorized: this.rejectUnauthorized,
       handshakeTimeout: timeout,
-      NPNProtocols: self.NPNProtocols,
-      ALPNProtocols: self.ALPNProtocols,
+      NPNProtocols: this.NPNProtocols,
+      ALPNProtocols: this.ALPNProtocols,
       SNICallback: options.SNICallback || SNICallback
     });
 
-    socket.on('secure', function() {
+    socket.on('secure', () => {
       if (socket._requestCert) {
         var verifyError = socket._handle.verifyError();
         if (verifyError) {
@@ -795,11 +787,11 @@ function Server(/* [options], listener */) {
       }
 
       if (!socket.destroyed && socket._releaseControl())
-        self.emit('secureConnection', socket);
+        this.emit('secureConnection', socket);
     });
 
     var errorEmitted = false;
-    socket.on('close', function(err) {
+    socket.on('close', (err) => {
       // Closed because of error - no need to emit it twice
       if (err)
         return;
@@ -809,14 +801,14 @@ function Server(/* [options], listener */) {
         errorEmitted = true;
         var connReset = new Error('socket hang up');
         connReset.code = 'ECONNRESET';
-        self.emit('tlsClientError', connReset, socket);
+        this.emit('tlsClientError', connReset, socket);
       }
     });
 
-    socket.on('_tlsError', function(err) {
+    socket.on('_tlsError', (err) => {
       if (!socket._controlReleased && !errorEmitted) {
         errorEmitted = true;
-        self.emit('tlsClientError', err, socket);
+        this.emit('tlsClientError', err, socket);
       }
     });
   });

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -114,12 +114,11 @@ function RoundRobinHandle(key, address, port, addressType, backlog, fd) {
   else
     this.server.listen(address);  // UNIX socket path.
 
-  var self = this;
-  this.server.once('listening', function() {
-    self.handle = self.server._handle;
-    self.handle.onconnection = self.distribute.bind(self);
-    self.server._handle = null;
-    self.server = null;
+  this.server.once('listening', () => {
+    this.handle = this.server._handle;
+    this.handle.onconnection = () => this.distribute();
+    this.server._handle = null;
+    this.server = null;
   });
 }
 
@@ -127,18 +126,17 @@ RoundRobinHandle.prototype.add = function(worker, send) {
   assert(worker.id in this.all === false);
   this.all[worker.id] = worker;
 
-  var self = this;
-  function done() {
-    if (self.handle.getsockname) {
+  const done = () => {
+    if (this.handle.getsockname) {
       var out = {};
-      self.handle.getsockname(out);
+      this.handle.getsockname(out);
       // TODO(bnoordhuis) Check err.
       send(null, { sockname: out }, null);
     } else {
       send(null, null, null);  // UNIX socket.
     }
-    self.handoff(worker);  // In case there are connections pending.
-  }
+    this.handoff(worker);  // In case there are connections pending.
+  };
 
   if (this.server === null) return done();
   // Still busy binding.
@@ -180,13 +178,12 @@ RoundRobinHandle.prototype.handoff = function(worker) {
     return;
   }
   var message = { act: 'newconn', key: this.key };
-  var self = this;
-  sendHelper(worker.process, message, handle, function(reply) {
+  sendHelper(worker.process, message, handle, (reply) => {
     if (reply.accepted)
       handle.close();
     else
-      self.distribute(0, handle);  // Worker is shutting down. Send to another.
-    self.handoff(worker);
+      this.distribute(0, handle);  // Worker is shutting down. Send to another.
+    this.handoff(worker);
   });
 };
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -135,10 +135,9 @@ function replaceHandle(self, newHandle) {
 }
 
 Socket.prototype.bind = function(port_ /*, address, callback*/) {
-  var self = this;
   let port = port_;
 
-  self._healthCheck();
+  this._healthCheck();
 
   if (this._bindState != BIND_STATE_UNBOUND)
     throw new Error('Socket is already bound');
@@ -146,12 +145,12 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
   this._bindState = BIND_STATE_BINDING;
 
   if (typeof arguments[arguments.length - 1] === 'function')
-    self.once('listening', arguments[arguments.length - 1]);
+    this.once('listening', arguments[arguments.length - 1]);
 
   if (port instanceof UDP) {
-    replaceHandle(self, port);
-    startListening(self);
-    return self;
+    replaceHandle(this, port);
+    startListening(this);
+    return this;
   }
 
   var address;
@@ -167,10 +166,10 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
   }
 
   // resolve address first
-  self._handle.lookup(address, function(err, ip) {
+  this._handle.lookup(address, (err, ip) => {
     if (err) {
-      self._bindState = BIND_STATE_UNBOUND;
-      self.emit('error', err);
+      this._bindState = BIND_STATE_UNBOUND;
+      this.emit('error', err);
       return;
     }
 
@@ -178,51 +177,51 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
       cluster = require('cluster');
 
     var flags = 0;
-    if (self._reuseAddr)
+    if (this._reuseAddr)
       flags |= constants.UV_UDP_REUSEADDR;
 
     if (cluster.isWorker && !exclusive) {
-      function onHandle(err, handle) {
+      const onHandle = (err, handle) => {
         if (err) {
           var ex = exceptionWithHostPort(err, 'bind', ip, port);
-          self.emit('error', ex);
-          self._bindState = BIND_STATE_UNBOUND;
+          this.emit('error', ex);
+          this._bindState = BIND_STATE_UNBOUND;
           return;
         }
 
-        if (!self._handle)
+        if (!this._handle)
           // handle has been closed in the mean time.
           return handle.close();
 
-        replaceHandle(self, handle);
-        startListening(self);
-      }
-      cluster._getServer(self, {
+        replaceHandle(this, handle);
+        startListening(this);
+      };
+      cluster._getServer(this, {
         address: ip,
         port: port,
-        addressType: self.type,
+        addressType: this.type,
         fd: -1,
         flags: flags
       }, onHandle);
 
     } else {
-      if (!self._handle)
+      if (!this._handle)
         return; // handle has been closed in the mean time
 
-      var err = self._handle.bind(ip, port || 0, flags);
+      var err = this._handle.bind(ip, port || 0, flags);
       if (err) {
         var ex = exceptionWithHostPort(err, 'bind', ip, port);
-        self.emit('error', ex);
-        self._bindState = BIND_STATE_UNBOUND;
+        this.emit('error', ex);
+        this._bindState = BIND_STATE_UNBOUND;
         // Todo: close?
         return;
       }
 
-      startListening(self);
+      startListening(this);
     }
   });
 
-  return self;
+  return this;
 };
 
 
@@ -249,8 +248,6 @@ Socket.prototype.send = function(buffer,
                                  port,
                                  address,
                                  callback) {
-  var self = this;
-
   if (typeof buffer === 'string')
     buffer = new Buffer(buffer);
   else if (!(buffer instanceof Buffer))
@@ -282,38 +279,38 @@ Socket.prototype.send = function(buffer,
   if (typeof callback !== 'function')
     callback = undefined;
 
-  self._healthCheck();
+  this._healthCheck();
 
-  if (self._bindState == BIND_STATE_UNBOUND)
-    self.bind({port: 0, exclusive: true}, null);
+  if (this._bindState == BIND_STATE_UNBOUND)
+    this.bind({port: 0, exclusive: true}, null);
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.
-  if (self._bindState != BIND_STATE_BOUND) {
+  if (this._bindState != BIND_STATE_BOUND) {
     // If the send queue hasn't been initialized yet, do it, and install an
     // event handler that flushes the send queue after binding is done.
-    if (!self._sendQueue) {
-      self._sendQueue = [];
-      self.once('listening', function() {
+    if (!this._sendQueue) {
+      this._sendQueue = [];
+      this.once('listening', () => {
         // Flush the send queue.
-        for (var i = 0; i < self._sendQueue.length; i++)
-          self.send.apply(self, self._sendQueue[i]);
-        self._sendQueue = undefined;
+        for (var i = 0; i < this._sendQueue.length; i++)
+          this.send.apply(this, this._sendQueue[i]);
+        this._sendQueue = undefined;
       });
     }
-    self._sendQueue.push([buffer, offset, length, port, address, callback]);
+    this._sendQueue.push([buffer, offset, length, port, address, callback]);
     return;
   }
 
-  self._handle.lookup(address, function(ex, ip) {
+  this._handle.lookup(address, (ex, ip) => {
     if (ex) {
       if (typeof callback === 'function') {
         callback(ex);
         return;
       }
 
-      self.emit('error', ex);
-    } else if (self._handle) {
+      this.emit('error', ex);
+    } else if (this._handle) {
       var req = new SendWrap();
       req.buffer = buffer;  // Keep reference alive.
       req.length = length;
@@ -323,7 +320,7 @@ Socket.prototype.send = function(buffer,
         req.callback = callback;
         req.oncomplete = afterSend;
       }
-      var err = self._handle.send(req,
+      var err = this._handle.send(req,
                                   buffer,
                                   offset,
                                   length,
@@ -355,8 +352,7 @@ Socket.prototype.close = function(callback) {
   this._stopReceiving();
   this._handle.close();
   this._handle = null;
-  var self = this;
-  process.nextTick(socketCloseNT, self);
+  process.nextTick(socketCloseNT, this);
 
   return this;
 };

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -60,7 +60,6 @@ Domain.prototype._disposed = undefined;
 // Called by process._fatalException in case an error was thrown.
 Domain.prototype._errorHandler = function errorHandler(er) {
   var caught = false;
-  var self = this;
 
   // ignore errors on disposed domains.
   //
@@ -89,13 +88,13 @@ Domain.prototype._errorHandler = function errorHandler(er) {
     // as this would throw an error, make the process exit, and thus
     // prevent the process 'uncaughtException' event from being emitted
     // if a listener is set.
-    if (EventEmitter.listenerCount(self, 'error') > 0) {
+    if (EventEmitter.listenerCount(this, 'error') > 0) {
       try {
         // Set the _emittingTopLevelDomainError so that we know that, even
         // if technically the top-level domain is still active, it would
         // be ok to abort on an uncaught exception at this point
         process._emittingTopLevelDomainError = true;
-        caught = self.emit('error', er);
+        caught = this.emit('error', er);
       } finally {
         process._emittingTopLevelDomainError = false;
       }
@@ -111,7 +110,7 @@ Domain.prototype._errorHandler = function errorHandler(er) {
       //
       // If caught is false after this, then there's no need to exit()
       // the domain, because we're going to crash the process anyway.
-      caught = self.emit('error', er);
+      caught = this.emit('error', er);
     } catch (er2) {
       // The domain error handler threw!  oh no!
       // See if another domain can catch THIS error,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1300,18 +1300,17 @@ fs.appendFileSync = function(path, data, options) {
 function FSWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new FSEvent();
   this._handle.owner = this;
 
-  this._handle.onchange = function(status, event, filename) {
+  this._handle.onchange = (status, event, filename) => {
     if (status < 0) {
-      self._handle.close();
+      this._handle.close();
       const error = errnoException(status, `watch ${filename}`);
       error.filename = filename;
-      self.emit('error', error);
+      this.emit('error', error);
     } else {
-      self.emit('change', event, filename);
+      this.emit('change', event, filename);
     }
   };
 }
@@ -1367,24 +1366,23 @@ fs.watch = function(filename) {
 function StatWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new binding.StatWatcher();
 
   // uv_fs_poll is a little more powerful than ev_stat but we curb it for
   // the sake of backwards compatibility
   var oldStatus = -1;
 
-  this._handle.onchange = function(current, previous, newStatus) {
+  this._handle.onchange = (current, previous, newStatus) => {
     if (oldStatus === -1 &&
         newStatus === -1 &&
         current.nlink === previous.nlink) return;
 
     oldStatus = newStatus;
-    self.emit('change', current, previous);
+    this.emit('change', current, previous);
   };
 
-  this._handle.onstop = function() {
-    self.emit('stop');
+  this._handle.onstop = () => {
+    this.emit('stop');
   };
 }
 util.inherits(StatWatcher, EventEmitter);
@@ -1766,20 +1764,19 @@ function ReadStream(path, options) {
 fs.FileReadStream = fs.ReadStream; // support the legacy name
 
 ReadStream.prototype.open = function() {
-  var self = this;
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+  fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
-      self.emit('error', er);
+      this.emit('error', er);
       return;
     }
 
-    self.fd = fd;
-    self.emit('open', fd);
+    this.fd = fd;
+    this.emit('open', fd);
     // start the flow of data.
-    self.read();
+    this.read();
   });
 };
 
@@ -1814,7 +1811,6 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
-  var self = this;
   fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
 
   // move the pool positions, and internal position for reading.
@@ -1822,18 +1818,18 @@ ReadStream.prototype._read = function(n) {
     this.pos += toRead;
   pool.used += toRead;
 
-  function onread(er, bytesRead) {
+  const onread = (er, bytesRead) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
-      self.emit('error', er);
+      this.emit('error', er);
     } else {
       var b = null;
       if (bytesRead > 0)
         b = thisPool.slice(start, start + bytesRead);
 
-      self.push(b);
+      this.push(b);
     }
   }
 };
@@ -1848,7 +1844,6 @@ ReadStream.prototype.destroy = function() {
 
 
 ReadStream.prototype.close = function(cb) {
-  var self = this;
   if (cb)
     this.once('close', cb);
   if (this.closed || typeof this.fd !== 'number') {
@@ -1861,14 +1856,14 @@ ReadStream.prototype.close = function(cb) {
   this.closed = true;
   close();
 
-  function close(fd) {
-    fs.close(fd || self.fd, function(er) {
+  const close = (fd) => {
+    fs.close(fd || this.fd, (er) => {
       if (er)
-        self.emit('error', er);
+        this.emit('error', er);
       else
-        self.emit('close');
+        this.emit('close');
     });
-    self.fd = null;
+    this.fd = null;
   }
 };
 
@@ -1933,7 +1928,7 @@ fs.FileWriteStream = fs.WriteStream; // support the legacy name
 
 
 WriteStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+  fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -1944,7 +1939,7 @@ WriteStream.prototype.open = function() {
 
     this.fd = fd;
     this.emit('open', fd);
-  }.bind(this));
+  });
 };
 
 
@@ -1957,15 +1952,14 @@ WriteStream.prototype._write = function(data, encoding, cb) {
       this._write(data, encoding, cb);
     });
 
-  var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+  fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 
@@ -1992,7 +1986,6 @@ WriteStream.prototype._writev = function(data, cb) {
       this._writev(data, cb);
     });
 
-  const self = this;
   const len = data.length;
   const chunks = new Array(len);
   var size = 0;
@@ -2004,12 +1997,12 @@ WriteStream.prototype._writev = function(data, cb) {
     size += chunk.length;
   }
 
-  writev(this.fd, chunks, this.pos, function(er, bytes) {
+  writev(this.fd, chunks, this.pos, (er, bytes) => {
     if (er) {
-      self.destroy();
+      this.destroy();
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1811,13 +1811,6 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
-  fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
-
-  // move the pool positions, and internal position for reading.
-  if (this.pos !== undefined)
-    this.pos += toRead;
-  pool.used += toRead;
-
   const onread = (er, bytesRead) => {
     if (er) {
       if (this.autoClose) {
@@ -1831,7 +1824,14 @@ ReadStream.prototype._read = function(n) {
 
       this.push(b);
     }
-  }
+  };
+
+  fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
+
+  // move the pool positions, and internal position for reading.
+  if (this.pos !== undefined)
+    this.pos += toRead;
+  pool.used += toRead;
 };
 
 
@@ -1846,6 +1846,15 @@ ReadStream.prototype.destroy = function() {
 ReadStream.prototype.close = function(cb) {
   if (cb)
     this.once('close', cb);
+  const close = (fd) => {
+    fs.close(fd || this.fd, (er) => {
+      if (er)
+        this.emit('error', er);
+      else
+        this.emit('close');
+    });
+    this.fd = null;
+  };
   if (this.closed || typeof this.fd !== 'number') {
     if (typeof this.fd !== 'number') {
       this.once('open', close);
@@ -1855,16 +1864,6 @@ ReadStream.prototype.close = function(cb) {
   }
   this.closed = true;
   close();
-
-  const close = (fd) => {
-    fs.close(fd || this.fd, (er) => {
-      if (er)
-        this.emit('error', er);
-      else
-        this.emit('close');
-    });
-    this.fd = null;
-  }
 };
 
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -59,10 +59,9 @@ function Client(port, host) {
 }
 util.inherits(Client, EventEmitter);
 Client.prototype.request = function(method, path, headers) {
-  var self = this;
   var options = {};
-  options.host = self.host;
-  options.port = self.port;
+  options.host = this.host;
+  options.port = this.port;
   if (method[0] === '/') {
     headers = path;
     path = method;
@@ -71,22 +70,22 @@ Client.prototype.request = function(method, path, headers) {
   options.method = method;
   options.path = path;
   options.headers = headers;
-  options.agent = self.agent;
+  options.agent = this.agent;
   var c = new ClientRequest(options);
-  c.on('error', function(e) {
-    self.emit('error', e);
+  c.on('error', (e) => {
+    this.emit('error', e);
   });
   // The old Client interface emitted 'end' on socket end.
   // This doesn't map to how we want things to operate in the future
   // but it will get removed when we remove this legacy interface.
-  c.on('socket', function(s) {
-    s.on('end', function() {
-      if (self._decoder) {
-        var ret = self._decoder.end();
+  c.on('socket', (s) => {
+    s.on('end', () => {
+      if (this._decoder) {
+        var ret = this._decoder.end();
         if (ret)
-          self.emit('data', ret);
+          this.emit('data', ret);
       }
-      self.emit('end');
+      this.emit('end');
     });
   });
   return c;

--- a/lib/https.js
+++ b/lib/https.js
@@ -77,12 +77,11 @@ function createConnection(port, host, options) {
     }
   }
 
-  const self = this;
-  const socket = tls.connect(options, function() {
+  const socket = tls.connect(options, () => {
     if (!options._agentKey)
       return;
 
-    self._cacheSession(options._agentKey, socket.getSession());
+    this._cacheSession(options._agentKey, socket.getSession());
   });
   return socket;
 }

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -149,8 +149,6 @@ const handleConversion = {
 function ChildProcess() {
   EventEmitter.call(this);
 
-  var self = this;
-
   this._closesNeeded = 1;
   this._closesGot = 0;
   this.connected = false;
@@ -163,7 +161,7 @@ function ChildProcess() {
   this._handle = new Process();
   this._handle.owner = this;
 
-  this._handle.onexit = function(exitCode, signalCode) {
+  this._handle.onexit = (exitCode, signalCode) => {
     //
     // follow 0.4.x behaviour:
     //
@@ -174,30 +172,30 @@ function ChildProcess() {
     //
     // - spawn failures are reported with exitCode < 0
     //
-    var syscall = self.spawnfile ? 'spawn ' + self.spawnfile : 'spawn';
+    var syscall = this.spawnfile ? 'spawn ' + this.spawnfile : 'spawn';
     var err = (exitCode < 0) ? errnoException(exitCode, syscall) : null;
 
     if (signalCode) {
-      self.signalCode = signalCode;
+      this.signalCode = signalCode;
     } else {
-      self.exitCode = exitCode;
+      this.exitCode = exitCode;
     }
 
-    if (self.stdin) {
-      self.stdin.destroy();
+    if (this.stdin) {
+      this.stdin.destroy();
     }
 
-    self._handle.close();
-    self._handle = null;
+    this._handle.close();
+    this._handle = null;
 
     if (exitCode < 0) {
-      if (self.spawnfile)
-        err.path = self.spawnfile;
+      if (this.spawnfile)
+        err.path = this.spawnfile;
 
-      err.spawnargs = self.spawnargs.slice(1);
-      self.emit('error', err);
+      err.spawnargs = this.spawnargs.slice(1);
+      this.emit('error', err);
     } else {
-      self.emit('exit', self.exitCode, self.signalCode);
+      this.emit('exit', this.exitCode, this.signalCode);
     }
 
     // if any of the stdio streams have not been touched,
@@ -206,9 +204,9 @@ function ChildProcess() {
     // Do it on nextTick so that the user has one last chance
     // to consume the output, if for example they only want to
     // start reading the data once the process exits.
-    process.nextTick(flushStdio, self);
+    process.nextTick(flushStdio, this);
 
-    maybeClose(self);
+    maybeClose(this);
   };
 }
 util.inherits(ChildProcess, EventEmitter);
@@ -250,7 +248,6 @@ function getHandleWrapType(stream) {
 
 
 ChildProcess.prototype.spawn = function(options) {
-  const self = this;
   var ipc;
   var ipcFd;
   // If no `stdio` option was given - use default
@@ -278,7 +275,7 @@ ChildProcess.prototype.spawn = function(options) {
       err === uv.UV_EMFILE ||
       err === uv.UV_ENFILE ||
       err === uv.UV_ENOENT) {
-    process.nextTick(onErrorNT, self, err);
+    process.nextTick(onErrorNT, this, err);
     // There is no point in continuing when we've hit EMFILE or ENFILE
     // because we won't be able to set up the stdio file descriptors.
     // It's kind of silly that the de facto spec for ENOENT (the test suite)
@@ -300,23 +297,23 @@ ChildProcess.prototype.spawn = function(options) {
 
   this.pid = this._handle.pid;
 
-  stdio.forEach(function(stdio, i) {
+  stdio.forEach((stdio, i) => {
     if (stdio.type === 'ignore') return;
 
     if (stdio.ipc) {
-      self._closesNeeded++;
+      this._closesNeeded++;
       return;
     }
 
     if (stdio.handle) {
       // when i === 0 - we're dealing with stdin
       // (which is the only one writable pipe)
-      stdio.socket = createSocket(self.pid !== 0 ? stdio.handle : null, i > 0);
+      stdio.socket = createSocket(this.pid !== 0 ? stdio.handle : null, i > 0);
 
-      if (i > 0 && self.pid !== 0) {
-        self._closesNeeded++;
-        stdio.socket.on('close', function() {
-          maybeClose(self);
+      if (i > 0 && this.pid !== 0) {
+        this._closesNeeded++;
+        stdio.socket.on('close', () => {
+          maybeClose(this);
         });
       }
     }

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -16,7 +16,7 @@ function makeRequireFunction() {
     } finally {
       exports.requireDepth -= 1;
     }
-  }
+  };
 
   require.resolve = (request) => {
     return Module._resolveFilename(request, this);

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -8,19 +8,18 @@ exports.requireDepth = 0;
 // Module object to use as the context for the require() function.
 function makeRequireFunction() {
   const Module = this.constructor;
-  const self = this;
 
-  function require(path) {
+  const require = (path) => {
     try {
       exports.requireDepth += 1;
-      return self.require(path);
+      return this.require(path);
     } finally {
       exports.requireDepth -= 1;
     }
   }
 
-  require.resolve = function(request) {
-    return Module._resolveFilename(request, self);
+  require.resolve = (request) => {
+    return Module._resolveFilename(request, this);
   };
 
   require.main = process.mainModule;

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -15,23 +15,21 @@ function SocketListSend(slave, key) {
 util.inherits(SocketListSend, EventEmitter);
 
 SocketListSend.prototype._request = function(msg, cmd, callback) {
-  var self = this;
-
   if (!this.slave.connected) return onclose();
   this.slave.send(msg);
 
-  function onclose() {
-    self.slave.removeListener('internalMessage', onreply);
+  const onclose = () => {
+    this.slave.removeListener('internalMessage', onreply);
     callback(new Error('Slave closed before reply'));
-  }
+  };
 
-  function onreply(msg) {
-    if (!(msg.cmd === cmd && msg.key === self.key)) return;
-    self.slave.removeListener('disconnect', onclose);
-    self.slave.removeListener('internalMessage', onreply);
+  const onreply = (msg) => {
+    if (!(msg.cmd === cmd && msg.key === this.key)) return;
+    this.slave.removeListener('disconnect', onclose);
+    this.slave.removeListener('internalMessage', onreply);
 
     callback(null, msg);
-  }
+  };
 
   this.slave.once('disconnect', onclose);
   this.slave.on('internalMessage', onreply);
@@ -58,36 +56,34 @@ SocketListSend.prototype.getConnections = function getConnections(callback) {
 function SocketListReceive(slave, key) {
   EventEmitter.call(this);
 
-  var self = this;
-
   this.connections = 0;
   this.key = key;
   this.slave = slave;
 
-  function onempty() {
-    if (!self.slave.connected) return;
+  const onempty = () => {
+    if (!this.slave.connected) return;
 
-    self.slave.send({
+    this.slave.send({
       cmd: 'NODE_SOCKET_ALL_CLOSED',
-      key: self.key
+      key: this.key
     });
-  }
+  };
 
-  this.slave.on('internalMessage', function(msg) {
-    if (msg.key !== self.key) return;
+  this.slave.on('internalMessage', (msg) => {
+    if (msg.key !== this.key) return;
 
     if (msg.cmd === 'NODE_SOCKET_NOTIFY_CLOSE') {
       // Already empty
-      if (self.connections === 0) return onempty();
+      if (this.connections === 0) return onempty();
 
       // Wait for sockets to get closed
-      self.once('empty', onempty);
+      this.once('empty', onempty);
     } else if (msg.cmd === 'NODE_SOCKET_GET_COUNT') {
-      if (!self.slave.connected) return;
-      self.slave.send({
+      if (!this.slave.connected) return;
+      this.slave.send({
         cmd: 'NODE_SOCKET_COUNT',
-        key: self.key,
-        count: self.connections
+        key: this.key,
+        count: this.connections
       });
     }
   });
@@ -95,14 +91,12 @@ function SocketListReceive(slave, key) {
 util.inherits(SocketListReceive, EventEmitter);
 
 SocketListReceive.prototype.add = function(obj) {
-  var self = this;
-
   this.connections++;
 
   // Notify previous owner of socket about its state change
-  obj.socket.once('close', function() {
-    self.connections--;
+  obj.socket.once('close', () => {
+    this.connections--;
 
-    if (self.connections === 0) self.emit('empty');
+    if (this.connections === 0) this.emit('empty');
   });
 };

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -15,9 +15,6 @@ function SocketListSend(slave, key) {
 util.inherits(SocketListSend, EventEmitter);
 
 SocketListSend.prototype._request = function(msg, cmd, callback) {
-  if (!this.slave.connected) return onclose();
-  this.slave.send(msg);
-
   const onclose = () => {
     this.slave.removeListener('internalMessage', onreply);
     callback(new Error('Slave closed before reply'));
@@ -30,6 +27,9 @@ SocketListSend.prototype._request = function(msg, cmd, callback) {
 
     callback(null, msg);
   };
+
+  if (!this.slave.connected) return onclose();
+  this.slave.send(msg);
 
   this.slave.once('disconnect', onclose);
   this.slave.on('internalMessage', onreply);

--- a/lib/net.js
+++ b/lib/net.js
@@ -267,9 +267,9 @@ function writeAfterFIN(chunk, encoding, cb) {
 
   var er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  var self = this;
+
   // TODO: defer error events consistently everywhere, not just the cb
-  self.emit('error', er);
+  this.emit('error', er);
   if (typeof cb === 'function') {
     process.nextTick(cb, er);
   }
@@ -290,9 +290,8 @@ Socket.prototype.read = function(n) {
 
 Socket.prototype.listen = function() {
   debug('socket.listen');
-  var self = this;
-  self.on('connection', arguments[0]);
-  listen(self, null, null, null);
+  this.on('connection', arguments[0]);
+  listen(this, null, null, null);
 };
 
 
@@ -436,15 +435,13 @@ Socket.prototype.destroySoon = function() {
 Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');
 
-  var self = this;
-
-  function fireErrorCallbacks() {
+  const fireErrorCallbacks = () => {
     if (cb) cb(exception);
-    if (exception && !self._writableState.errorEmitted) {
-      process.nextTick(emitErrorNT, self, exception);
-      self._writableState.errorEmitted = true;
+    if (exception && !this._writableState.errorEmitted) {
+      process.nextTick(emitErrorNT, this, exception);
+      this._writableState.errorEmitted = true;
     }
-  }
+  };
 
   if (this.destroyed) {
     debug('already destroyed, fire error callbacks');
@@ -452,7 +449,7 @@ Socket.prototype._destroy = function(exception, cb) {
     return;
   }
 
-  self._connecting = false;
+  this._connecting = false;
 
   this.readable = this.writable = false;
 
@@ -464,9 +461,9 @@ Socket.prototype._destroy = function(exception, cb) {
     if (this !== process.stderr)
       debug('close handle');
     var isException = exception ? true : false;
-    this._handle.close(function() {
+    this._handle.close(() => {
       debug('emit close');
-      self.emit('close', isException);
+      this.emit('close', isException);
     });
     this._handle.onread = noop;
     this._handle = null;
@@ -881,7 +878,6 @@ Socket.prototype.connect = function(options, cb) {
     this._sockname = null;
   }
 
-  var self = this;
   var pipe = !!options.path;
   debug('pipe', pipe, options.path);
 
@@ -891,21 +887,21 @@ Socket.prototype.connect = function(options, cb) {
   }
 
   if (typeof cb === 'function') {
-    self.once('connect', cb);
+    this.once('connect', cb);
   }
 
   this._unrefTimer();
 
-  self._connecting = true;
-  self.writable = true;
+  this._connecting = true;
+  this.writable = true;
 
   if (pipe) {
-    connect(self, options.path);
+    connect(this, options.path);
 
   } else {
-    lookupAndConnect(self, options);
+    lookupAndConnect(this, options);
   }
-  return self;
+  return this;
 };
 
 
@@ -1081,33 +1077,31 @@ function Server(options, connectionListener) {
 
   EventEmitter.call(this);
 
-  var self = this;
-
   if (typeof options === 'function') {
     connectionListener = options;
     options = {};
-    self.on('connection', connectionListener);
+    this.on('connection', connectionListener);
   } else {
     options = options || {};
 
     if (typeof connectionListener === 'function') {
-      self.on('connection', connectionListener);
+      this.on('connection', connectionListener);
     }
   }
 
   this._connections = 0;
 
   Object.defineProperty(this, 'connections', {
-    get: internalUtil.deprecate(function() {
+    get: internalUtil.deprecate(() => {
 
-      if (self._usingSlaves) {
+      if (this._usingSlaves) {
         return null;
       }
-      return self._connections;
+      return this._connections;
     }, 'Server.connections property is deprecated. ' +
        'Use Server.getConnections method instead.'),
     set: internalUtil.deprecate(function(val) {
-      return (self._connections = val);
+      return (this._connections = val);
     }, 'Server.connections property is deprecated.'),
     configurable: true, enumerable: false
   });
@@ -1194,11 +1188,10 @@ exports._createServerHandle = createServerHandle;
 
 Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   debug('listen2', address, port, addressType, backlog, fd);
-  var self = this;
 
   // If there is not yet a handle, we need to create one and bind.
   // In the case of a server sent via IPC, we don't need to do this.
-  if (self._handle) {
+  if (this._handle) {
     debug('_listen2: have a handle already');
   } else {
     debug('_listen2: create a handle');
@@ -1223,22 +1216,22 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
     if (typeof rval === 'number') {
       var error = exceptionWithHostPort(rval, 'listen', address, port);
-      process.nextTick(emitErrorNT, self, error);
+      process.nextTick(emitErrorNT, this, error);
       return;
     }
-    self._handle = rval;
+    this._handle = rval;
   }
 
-  self._handle.onconnection = onconnection;
-  self._handle.owner = self;
+  this._handle.onconnection = onconnection;
+  this._handle.owner = this;
 
-  var err = _listen(self._handle, backlog);
+  var err = _listen(this._handle, backlog);
 
   if (err) {
     var ex = exceptionWithHostPort(err, 'listen', address, port);
-    self._handle.close();
-    self._handle = null;
-    process.nextTick(emitErrorNT, self, ex);
+    this._handle.close();
+    this._handle = null;
+    process.nextTick(emitErrorNT, this, ex);
     return;
   }
 
@@ -1249,7 +1242,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   if (this._unref)
     this.unref();
 
-  process.nextTick(emitListeningNT, self);
+  process.nextTick(emitListeningNT, this);
 };
 
 
@@ -1311,11 +1304,9 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
 
 
 Server.prototype.listen = function() {
-  var self = this;
-
   var lastArg = arguments[arguments.length - 1];
   if (typeof lastArg === 'function') {
-    self.once('listening', lastArg);
+    this.once('listening', lastArg);
   }
 
   var port = toNumber(arguments[0]);
@@ -1326,16 +1317,16 @@ Server.prototype.listen = function() {
 
   if (arguments.length === 0 || typeof arguments[0] === 'function') {
     // Bind to a random port.
-    listen(self, null, 0, null, backlog);
+    listen(this, null, 0, null, backlog);
   } else if (arguments[0] !== null && typeof arguments[0] === 'object') {
     var h = arguments[0];
     h = h._handle || h.handle || h;
 
     if (h instanceof TCP) {
-      self._handle = h;
-      listen(self, null, -1, -1, backlog);
+      this._handle = h;
+      listen(this, null, -1, -1, backlog);
     } else if (typeof h.fd === 'number' && h.fd >= 0) {
-      listen(self, null, null, null, backlog, h.fd);
+      listen(this, null, null, null, backlog, h.fd);
     } else {
       // The first argument is a configuration object
       if (h.backlog)
@@ -1351,42 +1342,42 @@ Server.prototype.listen = function() {
         if (h.host)
           listenAfterLookup(h.port | 0, h.host, backlog, h.exclusive);
         else
-          listen(self, null, h.port | 0, 4, backlog, undefined, h.exclusive);
+          listen(this, null, h.port | 0, 4, backlog, undefined, h.exclusive);
       } else if (h.path && isPipeName(h.path)) {
-        var pipeName = self._pipeName = h.path;
-        listen(self, pipeName, -1, -1, backlog, undefined, h.exclusive);
+        var pipeName = this._pipeName = h.path;
+        listen(this, pipeName, -1, -1, backlog, undefined, h.exclusive);
       } else {
         throw new Error('Invalid listen argument: ' + h);
       }
     }
   } else if (isPipeName(arguments[0])) {
     // UNIX socket or Windows pipe.
-    var pipeName = self._pipeName = arguments[0];
-    listen(self, pipeName, -1, -1, backlog);
+    var pipeName = this._pipeName = arguments[0];
+    listen(this, pipeName, -1, -1, backlog);
 
   } else if (arguments[1] === undefined ||
              typeof arguments[1] === 'function' ||
              typeof arguments[1] === 'number') {
     // The first argument is the port, no IP given.
-    listen(self, null, port, 4, backlog);
+    listen(this, null, port, 4, backlog);
 
   } else {
     // The first argument is the port, the second an IP.
     listenAfterLookup(port, arguments[1], backlog);
   }
 
-  function listenAfterLookup(port, address, backlog, exclusive) {
-    require('dns').lookup(address, function(err, ip, addressType) {
+  const listenAfterLookup = (port, address, backlog, exclusive) => {
+    require('dns').lookup(address, (err, ip, addressType) => {
       if (err) {
-        self.emit('error', err);
+        this.emit('error', err);
       } else {
         addressType = ip ? addressType : 4;
-        listen(self, ip, port, addressType, backlog, undefined, exclusive);
+        listen(this, ip, port, addressType, backlog, undefined, exclusive);
       }
     });
-  }
+  };
 
-  return self;
+  return this;
 };
 
 Object.defineProperty(Server.prototype, 'listening', {
@@ -1474,12 +1465,12 @@ Server.prototype.getConnections = function(cb) {
 
 
 Server.prototype.close = function(cb) {
-  function onSlaveClose() {
+  const onSlaveClose = () => {
     if (--left !== 0) return;
 
-    self._connections = 0;
-    self._emitCloseIfDrained();
-  }
+    this._connections = 0;
+    this._emitCloseIfDrained();
+  };
 
   if (typeof cb === 'function') {
     if (!this._handle) {
@@ -1497,7 +1488,6 @@ Server.prototype.close = function(cb) {
   }
 
   if (this._usingSlaves) {
-    var self = this;
     var left = this._slaves.length;
 
     // Increment connections to be sure that, even if all sockets will be closed
@@ -1517,15 +1507,14 @@ Server.prototype.close = function(cb) {
 
 Server.prototype._emitCloseIfDrained = function() {
   debug('SERVER _emitCloseIfDrained');
-  var self = this;
 
-  if (self._handle || self._connections) {
+  if (this._handle || this._connections) {
     debug('SERVER handle? %j   connections? %d',
-          !!self._handle, self._connections);
+          !!this._handle, this._connections);
     return;
   }
 
-  process.nextTick(emitCloseNT, self);
+  process.nextTick(emitCloseNT, this);
 };
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1315,6 +1315,17 @@ Server.prototype.listen = function() {
   // When the ip is omitted it can be the second argument.
   var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
 
+  const listenAfterLookup = (port, address, backlog, exclusive) => {
+    require('dns').lookup(address, (err, ip, addressType) => {
+      if (err) {
+        this.emit('error', err);
+      } else {
+        addressType = ip ? addressType : 4;
+        listen(this, ip, port, addressType, backlog, undefined, exclusive);
+      }
+    });
+  };
+
   if (arguments.length === 0 || typeof arguments[0] === 'function') {
     // Bind to a random port.
     listen(this, null, 0, null, backlog);
@@ -1365,17 +1376,6 @@ Server.prototype.listen = function() {
     // The first argument is the port, the second an IP.
     listenAfterLookup(port, arguments[1], backlog);
   }
-
-  const listenAfterLookup = (port, address, backlog, exclusive) => {
-    require('dns').lookup(address, (err, ip, addressType) => {
-      if (err) {
-        this.emit('error', err);
-      } else {
-        addressType = ip ? addressType : 4;
-        listen(this, ip, port, addressType, backlog, undefined, exclusive);
-      }
-    });
-  };
 
   return this;
 };

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -71,8 +71,6 @@ function Interface(input, output, completer, terminal) {
     terminal = !!output.isTTY;
   }
 
-  var self = this;
-
   this.output = output;
   this.input = input;
   this.historySize = historySize;
@@ -88,37 +86,37 @@ function Interface(input, output, completer, terminal) {
 
   this.terminal = !!terminal;
 
-  function ondata(data) {
-    self._normalWrite(data);
-  }
+  const ondata = (data) => {
+    this._normalWrite(data);
+  };
 
-  function onend() {
-    if (typeof self._line_buffer === 'string' &&
-        self._line_buffer.length > 0) {
-      self.emit('line', self._line_buffer);
+  const onend = () => {
+    if (typeof this._line_buffer === 'string' &&
+        this._line_buffer.length > 0) {
+      this.emit('line', this._line_buffer);
     }
-    self.close();
-  }
+    this.close();
+  };
 
-  function ontermend() {
-    if (typeof self.line === 'string' && self.line.length > 0) {
-      self.emit('line', self.line);
+  const ontermend = () => {
+    if (typeof this.line === 'string' && this.line.length > 0) {
+      this.emit('line', this.line);
     }
-    self.close();
-  }
+    this.close();
+  };
 
-  function onkeypress(s, key) {
-    self._ttyWrite(s, key);
-  }
+  const onkeypress = (s, key) => {
+    this._ttyWrite(s, key);
+  };
 
-  function onresize() {
-    self._refreshLine();
-  }
+  const onresize = () => {
+    this._refreshLine();
+  };
 
   if (!this.terminal) {
     input.on('data', ondata);
     input.on('end', onend);
-    self.once('close', function() {
+    this.once('close', function() {
       input.removeListener('data', ondata);
       input.removeListener('end', onend);
     });
@@ -148,7 +146,7 @@ function Interface(input, output, completer, terminal) {
     if (output !== null && output !== undefined)
       output.on('resize', onresize);
 
-    self.once('close', function() {
+    this.once('close', function() {
       input.removeListener('keypress', onkeypress);
       input.removeListener('end', ontermend);
       if (output !== null && output !== undefined) {
@@ -374,11 +372,9 @@ Interface.prototype._insertString = function(c) {
 };
 
 Interface.prototype._tabComplete = function() {
-  var self = this;
-
-  self.pause();
-  self.completer(self.line.slice(0, self.cursor), function(err, rv) {
-    self.resume();
+  this.pause();
+  this.completer(this.line.slice(0, this.cursor), (err, rv) => {
+    this.resume();
 
     if (err) {
       debug('tab completion error %j', err);
@@ -390,13 +386,13 @@ Interface.prototype._tabComplete = function() {
     if (completions && completions.length) {
       // Apply/show completions.
       if (completions.length === 1) {
-        self._insertString(completions[0].slice(completeOn.length));
+        this._insertString(completions[0].slice(completeOn.length));
       } else {
-        self._writeToOutput('\r\n');
+        this._writeToOutput('\r\n');
         var width = completions.reduce(function(a, b) {
           return a.length > b.length ? a : b;
         }).length + 2;  // 2 space padding
-        var maxColumns = Math.floor(self.columns / width);
+        var maxColumns = Math.floor(this.columns / width);
         if (!maxColumns || maxColumns === Infinity) {
           maxColumns = 1;
         }
@@ -404,24 +400,24 @@ Interface.prototype._tabComplete = function() {
         for (var i = 0, compLen = completions.length; i < compLen; i++) {
           c = completions[i];
           if (c === '') {
-            handleGroup(self, group, width, maxColumns);
+            handleGroup(this, group, width, maxColumns);
             group = [];
           } else {
             group.push(c);
           }
         }
-        handleGroup(self, group, width, maxColumns);
+        handleGroup(this, group, width, maxColumns);
 
         // If there is a common prefix to all matches, then apply that
         // portion.
         var f = completions.filter(function(e) { if (e) return e; });
         var prefix = commonPrefix(f);
         if (prefix.length > completeOn.length) {
-          self._insertString(prefix.slice(completeOn.length));
+          this._insertString(prefix.slice(completeOn.length));
         }
 
       }
-      self._refreshLine();
+      this._refreshLine();
     }
   });
 };

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -207,8 +207,6 @@ function REPLServer(prompt,
                                   `${sep}(.*)${sep}(.*)${sep}(.*)${sep}(.*)` +
                                   `${sep}(.*)$`);
 
-  eval_ = eval_ || defaultEval;
-
   const defaultEval = (code, context, file, cb) => {
     var err, result, retry = false;
     // first, create the Script object to check the syntax
@@ -270,6 +268,8 @@ function REPLServer(prompt,
 
     cb(err, result);
   };
+
+  eval_ = eval_ || defaultEval;
 
   this.eval = this._domain.bind(eval_);
 
@@ -396,27 +396,6 @@ function REPLServer(prompt,
       }
     }
 
-    if (!skipCatchall && (cmd || (!cmd && this.bufferedCommand))) {
-      var evalCmd = this.bufferedCommand + cmd;
-      if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
-        // It's confusing for `{ a : 1 }` to be interpreted as a block
-        // statement rather than an object literal.  So, we first try
-        // to wrap it in parentheses, so that it will be interpreted as
-        // an expression.
-        evalCmd = '(' + evalCmd + ')\n';
-      } else {
-        // otherwise we just append a \n so that it will be either
-        // terminated, or continued onto the next expression if it's an
-        // unexpected end of input.
-        evalCmd = evalCmd + '\n';
-      }
-
-      debug('eval %j', evalCmd);
-      this.eval(evalCmd, this.context, 'repl', finish);
-    } else {
-      finish(null);
-    }
-
     const finish = (e, ret) => {
       debug('finish', e, ret);
       this.memory(cmd);
@@ -464,6 +443,27 @@ function REPLServer(prompt,
       // Display prompt again
       this.displayPrompt();
     };
+
+    if (!skipCatchall && (cmd || (!cmd && this.bufferedCommand))) {
+      var evalCmd = this.bufferedCommand + cmd;
+      if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
+        // It's confusing for `{ a : 1 }` to be interpreted as a block
+        // statement rather than an object literal.  So, we first try
+        // to wrap it in parentheses, so that it will be interpreted as
+        // an expression.
+        evalCmd = '(' + evalCmd + ')\n';
+      } else {
+        // otherwise we just append a \n so that it will be either
+        // terminated, or continued onto the next expression if it's an
+        // unexpected end of input.
+        evalCmd = evalCmd + '\n';
+      }
+
+      debug('eval %j', evalCmd);
+      this.eval(evalCmd, this.context, 'repl', finish);
+    } else {
+      finish(null);
+    }
   });
 
   this.on('SIGCONT', () => {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -370,6 +370,7 @@ function REPLServer(prompt,
     this.displayPrompt();
   });
 
+  var self = this;
   this.on('line', (cmd) => {
     debug('line %j', cmd);
     sawSIGINT = false;
@@ -396,54 +397,6 @@ function REPLServer(prompt,
       }
     }
 
-    const finish = (e, ret) => {
-      debug('finish', e, ret);
-      this.memory(cmd);
-
-      if (e && !this.bufferedCommand && cmd.trim().match(/^npm /)) {
-        this.outputStream.write('npm should be run outside of the ' +
-                                'node repl, in your normal shell.\n' +
-                                '(Press Control-D to exit.)\n');
-        this.lineParser.reset();
-        this.bufferedCommand = '';
-        this.displayPrompt();
-        return;
-      }
-
-      // If error was SyntaxError and not JSON.parse error
-      if (e) {
-        if (e instanceof Recoverable && !this.lineParser.shouldFail) {
-          // Start buffering data like that:
-          // {
-          // ...  x: 1
-          // ... }
-          this.bufferedCommand += cmd + '\n';
-          this.displayPrompt();
-          return;
-        } else {
-          this._domain.emit('error', e.err || e);
-        }
-      }
-
-      // Clear buffer if no SyntaxErrors
-      this.lineParser.reset();
-      this.bufferedCommand = '';
-
-      // If we got any output - print it (if no error)
-      if (!e &&
-          // When an invalid REPL command is used, error message is printed
-          // immediately. We don't have to print anything else. So, only when
-          // the second argument to this function is there, print it.
-          arguments.length === 2 &&
-          (!this.ignoreUndefined || ret !== undefined)) {
-        this.context._ = ret;
-        this.outputStream.write(this.writer(ret) + '\n');
-      }
-
-      // Display prompt again
-      this.displayPrompt();
-    };
-
     if (!skipCatchall && (cmd || (!cmd && this.bufferedCommand))) {
       var evalCmd = this.bufferedCommand + cmd;
       if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
@@ -463,6 +416,54 @@ function REPLServer(prompt,
       this.eval(evalCmd, this.context, 'repl', finish);
     } else {
       finish(null);
+    }
+
+    function finish(e, ret) {
+      debug('finish', e, ret);
+      self.memory(cmd);
+
+      if (e && !self.bufferedCommand && cmd.trim().match(/^npm /)) {
+        self.outputStream.write('npm should be run outside of the ' +
+                                'node repl, in your normal shell.\n' +
+                                '(Press Control-D to exit.)\n');
+        self.lineParser.reset();
+        self.bufferedCommand = '';
+        self.displayPrompt();
+        return;
+      }
+
+      // If error was SyntaxError and not JSON.parse error
+      if (e) {
+        if (e instanceof Recoverable && !self.lineParser.shouldFail) {
+          // Start buffering data like that:
+          // {
+          // ...  x: 1
+          // ... }
+          self.bufferedCommand += cmd + '\n';
+          self.displayPrompt();
+          return;
+        } else {
+          self._domain.emit('error', e.err || e);
+        }
+      }
+
+      // Clear buffer if no SyntaxErrors
+      self.lineParser.reset();
+      self.bufferedCommand = '';
+
+      // If we got any output - print it (if no error)
+      if (!e &&
+          // When an invalid REPL command is used, error message is printed
+          // immediately. We don't have to print anything else. So, only when
+          // the second argument to this function is there, print it.
+          arguments.length === 2 &&
+          (!self.ignoreUndefined || ret !== undefined)) {
+        self.context._ = ret;
+        self.outputStream.write(self.writer(ret) + '\n');
+      }
+
+      // Display prompt again
+      self.displayPrompt();
     }
   });
 
@@ -1109,10 +1110,10 @@ REPLServer.prototype.convertToContext = function(cmd) {
   const scopeFunc = /^\s*function\s*([_\w\$]+)/;
   var matches;
 
-  // Replaces: var foo = "bar";  with: this.context.foo = bar;
+  // DOUBLECHECK(tflanagan) should "self" be replaced with "this"?
+  // Replaces: var foo = "bar";  with: self.context.foo = bar;
   matches = scopeVar.exec(cmd);
   if (matches && matches.length === 3) {
-    // DOUBLECHECK(tristian): should "self" be "this"?
     return 'self.context.' + matches[1] + matches[2];
   }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -190,18 +190,16 @@ function REPLServer(prompt,
     options = {};
   }
 
-  var self = this;
+  this._domain = dom || domain.create();
 
-  self._domain = dom || domain.create();
+  this.useGlobal = !!useGlobal;
+  this.ignoreUndefined = !!ignoreUndefined;
+  this.replMode = replMode || exports.REPL_MODE_SLOPPY;
 
-  self.useGlobal = !!useGlobal;
-  self.ignoreUndefined = !!ignoreUndefined;
-  self.replMode = replMode || exports.REPL_MODE_SLOPPY;
-
-  self._inTemplateLiteral = false;
+  this._inTemplateLiteral = false;
 
   // just for backwards compat, see github.com/joyent/node/pull/7127
-  self.rli = this;
+  this.rli = this;
 
   const savedRegExMatches = ['', '', '', '', '', '', '', '', '', ''];
   const sep = '\u0000\u0000\u0000';
@@ -211,13 +209,13 @@ function REPLServer(prompt,
 
   eval_ = eval_ || defaultEval;
 
-  function defaultEval(code, context, file, cb) {
+  const defaultEval = (code, context, file, cb) => {
     var err, result, retry = false;
     // first, create the Script object to check the syntax
     while (true) {
       try {
         if (!/^\s*$/.test(code) &&
-            (self.replMode === exports.REPL_MODE_STRICT || retry)) {
+            (this.replMode === exports.REPL_MODE_STRICT || retry)) {
           // "void 0" keeps the repl from returning "use strict" as the
           // result value for let/const statements.
           code = `'use strict'; void 0; ${code}`;
@@ -228,13 +226,13 @@ function REPLServer(prompt,
         });
       } catch (e) {
         debug('parse error %j', code, e);
-        if (self.replMode === exports.REPL_MODE_MAGIC &&
+        if (this.replMode === exports.REPL_MODE_MAGIC &&
             e.message === BLOCK_SCOPED_ERROR &&
             !retry) {
           retry = true;
           continue;
         }
-        if (isRecoverableError(e, self))
+        if (isRecoverableError(e, this))
           err = new Recoverable(e);
         else
           err = e;
@@ -248,7 +246,7 @@ function REPLServer(prompt,
 
     if (!err) {
       try {
-        if (self.useGlobal) {
+        if (this.useGlobal) {
           result = script.runInThisContext({ displayErrors: false });
         } else {
           result = script.runInContext(context, { displayErrors: false });
@@ -271,13 +269,13 @@ function REPLServer(prompt,
     }
 
     cb(err, result);
-  }
+  };
 
-  self.eval = self._domain.bind(eval_);
+  this.eval = this._domain.bind(eval_);
 
-  self._domain.on('error', function(e) {
+  this._domain.on('error', (e) => {
     debug('domain error');
-    const top = replMap.get(self);
+    const top = replMap.get(this);
     internalUtil.decorateErrorStack(e);
     top.outputStream.write((e.stack || e) + '\n');
     top.lineParser.reset();
@@ -303,85 +301,85 @@ function REPLServer(prompt,
     }
   }
 
-  self.inputStream = input;
-  self.outputStream = output;
+  this.inputStream = input;
+  this.outputStream = output;
 
-  self.resetContext();
-  self.lineParser = new LineParser();
-  self.bufferedCommand = '';
-  self.lines.level = [];
+  this.resetContext();
+  this.lineParser = new LineParser();
+  this.bufferedCommand = '';
+  this.lines.level = [];
 
-  function complete(text, callback) {
-    self.complete(text, callback);
-  }
+  const complete = (text, callback) => {
+    this.complete(text, callback);
+  };
 
   Interface.call(this, {
-    input: self.inputStream,
-    output: self.outputStream,
+    input: this.inputStream,
+    output: this.outputStream,
     completer: complete,
     terminal: options.terminal,
     historySize: options.historySize
   });
 
-  self.setPrompt(prompt !== undefined ? prompt : '> ');
+  this.setPrompt(prompt !== undefined ? prompt : '> ');
 
   this.commands = Object.create(null);
   defineDefaultCommands(this);
 
   // figure out which "writer" function to use
-  self.writer = options.writer || exports.writer;
+  this.writer = options.writer || exports.writer;
 
   if (options.useColors === undefined) {
-    options.useColors = self.terminal;
+    options.useColors = this.terminal;
   }
-  self.useColors = !!options.useColors;
+  this.useColors = !!options.useColors;
 
-  if (self.useColors && self.writer === util.inspect) {
+  if (this.useColors && this.writer === util.inspect) {
     // Turn on ANSI coloring.
-    self.writer = function(obj, showHidden, depth) {
+    this.writer = function(obj, showHidden, depth) {
       return util.inspect(obj, showHidden, depth, true);
     };
   }
 
-  self.setPrompt(self._prompt);
+  this.setPrompt(this._prompt);
 
-  self.on('close', function() {
-    self.emit('exit');
+  this.on('close', () => {
+    this.emit('exit');
   });
 
   var sawSIGINT = false;
-  self.on('SIGINT', function() {
-    var empty = self.line.length === 0;
-    self.clearLine();
+  this.on('SIGINT', () => {
+    var empty = this.line.length === 0;
+    this.clearLine();
 
-    if (!(self.bufferedCommand && self.bufferedCommand.length > 0) && empty) {
+    if (!(this.bufferedCommand && this.bufferedCommand.length > 0) && empty) {
       if (sawSIGINT) {
-        self.close();
+        this.close();
         sawSIGINT = false;
         return;
       }
-      self.output.write('(To exit, press ^C again or type .exit)\n');
+      this.output.write('(To exit, press ^C again or type .exit)\n');
       sawSIGINT = true;
     } else {
       sawSIGINT = false;
     }
 
-    self.lineParser.reset();
-    self.bufferedCommand = '';
-    self.lines.level = [];
-    self.displayPrompt();
+    this.lineParser.reset();
+    this.bufferedCommand = '';
+    this.lines.level = [];
+    this.displayPrompt();
   });
 
-  self.on('line', function(cmd) {
+  this.on('line', (cmd) => {
     debug('line %j', cmd);
     sawSIGINT = false;
     var skipCatchall = false;
 
     // leading whitespaces in template literals should not be trimmed.
-    if (self._inTemplateLiteral) {
-      self._inTemplateLiteral = false;
+    if (this._inTemplateLiteral) {
+      this._inTemplateLiteral = false;
     } else {
-      cmd = self.lineParser.parseLine(cmd);
+      cmd = this.lineParser.parseLine(cmd);
     }
 
     // Check to see if a REPL keyword was used. If it returns true,
@@ -390,16 +388,16 @@ function REPLServer(prompt,
       var matches = cmd.match(/^\.([^\s]+)\s*(.*)$/);
       var keyword = matches && matches[1];
       var rest = matches && matches[2];
-      if (self.parseREPLKeyword(keyword, rest) === true) {
+      if (this.parseREPLKeyword(keyword, rest) === true) {
         return;
-      } else if (!self.bufferedCommand) {
-        self.outputStream.write('Invalid REPL keyword\n');
+      } else if (!this.bufferedCommand) {
+        this.outputStream.write('Invalid REPL keyword\n');
         skipCatchall = true;
       }
     }
 
-    if (!skipCatchall && (cmd || (!cmd && self.bufferedCommand))) {
-      var evalCmd = self.bufferedCommand + cmd;
+    if (!skipCatchall && (cmd || (!cmd && this.bufferedCommand))) {
+      var evalCmd = this.bufferedCommand + cmd;
       if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
         // It's confusing for `{ a : 1 }` to be interpreted as a block
         // statement rather than an object literal.  So, we first try
@@ -414,43 +412,43 @@ function REPLServer(prompt,
       }
 
       debug('eval %j', evalCmd);
-      self.eval(evalCmd, self.context, 'repl', finish);
+      this.eval(evalCmd, this.context, 'repl', finish);
     } else {
       finish(null);
     }
 
-    function finish(e, ret) {
+    const finish = (e, ret) => {
       debug('finish', e, ret);
-      self.memory(cmd);
+      this.memory(cmd);
 
-      if (e && !self.bufferedCommand && cmd.trim().match(/^npm /)) {
-        self.outputStream.write('npm should be run outside of the ' +
+      if (e && !this.bufferedCommand && cmd.trim().match(/^npm /)) {
+        this.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
-        self.lineParser.reset();
-        self.bufferedCommand = '';
-        self.displayPrompt();
+        this.lineParser.reset();
+        this.bufferedCommand = '';
+        this.displayPrompt();
         return;
       }
 
       // If error was SyntaxError and not JSON.parse error
       if (e) {
-        if (e instanceof Recoverable && !self.lineParser.shouldFail) {
+        if (e instanceof Recoverable && !this.lineParser.shouldFail) {
           // Start buffering data like that:
           // {
           // ...  x: 1
           // ... }
-          self.bufferedCommand += cmd + '\n';
-          self.displayPrompt();
+          this.bufferedCommand += cmd + '\n';
+          this.displayPrompt();
           return;
         } else {
-          self._domain.emit('error', e.err || e);
+          this._domain.emit('error', e.err || e);
         }
       }
 
       // Clear buffer if no SyntaxErrors
-      self.lineParser.reset();
-      self.bufferedCommand = '';
+      this.lineParser.reset();
+      this.bufferedCommand = '';
 
       // If we got any output - print it (if no error)
       if (!e &&
@@ -458,21 +456,21 @@ function REPLServer(prompt,
           // immediately. We don't have to print anything else. So, only when
           // the second argument to this function is there, print it.
           arguments.length === 2 &&
-          (!self.ignoreUndefined || ret !== undefined)) {
-        self.context._ = ret;
-        self.outputStream.write(self.writer(ret) + '\n');
+          (!this.ignoreUndefined || ret !== undefined)) {
+        this.context._ = ret;
+        this.outputStream.write(this.writer(ret) + '\n');
       }
 
       // Display prompt again
-      self.displayPrompt();
-    }
+      this.displayPrompt();
+    };
   });
 
-  self.on('SIGCONT', function() {
-    self.displayPrompt(true);
+  this.on('SIGCONT', () => {
+    this.displayPrompt(true);
   });
 
-  self.displayPrompt();
+  this.displayPrompt();
 }
 inherits(REPLServer, Interface);
 exports.REPLServer = REPLServer;
@@ -590,9 +588,8 @@ function ArrayStream() {
   Stream.call(this);
 
   this.run = function(data) {
-    var self = this;
-    data.forEach(function(line) {
-      self.emit('data', line + '\n');
+    data.forEach((line) => {
+      this.emit('data', line + '\n');
     });
   };
 }
@@ -913,19 +910,17 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
 };
 
 REPLServer.prototype.memory = function memory(cmd) {
-  var self = this;
-
-  self.lines = self.lines || [];
-  self.lines.level = self.lines.level || [];
+  this.lines = this.lines || [];
+  this.lines.level = this.lines.level || [];
 
   // save the line so I can do magic later
   if (cmd) {
     // TODO should I tab the level?
-    const len = self.lines.level.length ? self.lines.level.length - 1 : 0;
-    self.lines.push('  '.repeat(len) + cmd);
+    const len = this.lines.level.length ? this.lines.level.length - 1 : 0;
+    this.lines.push('  '.repeat(len) + cmd);
   } else {
     // I don't want to not change the format too much...
-    self.lines.push('');
+    this.lines.push('');
   }
 
   // I need to know "depth."
@@ -941,7 +936,7 @@ REPLServer.prototype.memory = function memory(cmd) {
     var depth = dw - up;
 
     if (depth) {
-      (function workIt() {
+      const workIt = () => {
         if (depth > 0) {
           // going... down.
           // push the line#, depth count, and if the line is a function.
@@ -950,14 +945,14 @@ REPLServer.prototype.memory = function memory(cmd) {
           // "function()
           // {" but nothing should break, only tab completion for local
           // scope will not work for this function.
-          self.lines.level.push({
-            line: self.lines.length - 1,
+          this.lines.level.push({
+            line: this.lines.length - 1,
             depth: depth,
             isFunction: /\s*function\s*/.test(cmd)
           });
         } else if (depth < 0) {
           // going... up.
-          var curr = self.lines.level.pop();
+          var curr = this.lines.level.pop();
           if (curr) {
             var tmp = curr.depth + depth;
             if (tmp < 0) {
@@ -967,22 +962,24 @@ REPLServer.prototype.memory = function memory(cmd) {
             } else if (tmp > 0) {
               //remove and push back
               curr.depth += depth;
-              self.lines.level.push(curr);
+              this.lines.level.push(curr);
             }
           }
         }
-      }());
+      };
+
+      workIt();
     }
 
     // it is possible to determine a syntax error at this point.
     // if the REPL still has a bufferedCommand and
-    // self.lines.level.length === 0
+    // this.lines.level.length === 0
     // TODO? keep a log of level so that any syntax breaking lines can
     // be cleared on .break and in the case of a syntax error?
     // TODO? if a log was kept, then I could clear the bufferedComand and
     // eval these lines and throw the syntax error
   } else {
-    self.lines.level = [];
+    this.lines.level = [];
   }
 };
 
@@ -1047,10 +1044,9 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('help', {
     help: 'Show repl options',
     action: function() {
-      var self = this;
-      Object.keys(this.commands).sort().forEach(function(name) {
-        var cmd = self.commands[name];
-        self.outputStream.write(name + '\t' + (cmd.help || '') + '\n');
+      Object.keys(this.commands).sort().forEach((name) => {
+        var cmd = this.commands[name];
+        this.outputStream.write(name + '\t' + (cmd.help || '') + '\n');
       });
       this.displayPrompt();
     }
@@ -1075,13 +1071,12 @@ function defineDefaultCommands(repl) {
       try {
         var stats = fs.statSync(file);
         if (stats && stats.isFile()) {
-          var self = this;
           var data = fs.readFileSync(file, 'utf8');
           var lines = data.split('\n');
           this.displayPrompt();
-          lines.forEach(function(line) {
+          lines.forEach((line) => {
             if (line) {
-              self.write(line + '\n');
+              this.write(line + '\n');
             }
           });
         } else {
@@ -1112,18 +1107,19 @@ function regexpEscape(s) {
 REPLServer.prototype.convertToContext = function(cmd) {
   const scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m;
   const scopeFunc = /^\s*function\s*([_\w\$]+)/;
-  var self = this, matches;
+  var matches;
 
-  // Replaces: var foo = "bar";  with: self.context.foo = bar;
+  // Replaces: var foo = "bar";  with: this.context.foo = bar;
   matches = scopeVar.exec(cmd);
   if (matches && matches.length === 3) {
+    // DOUBLECHECK(tristian): should "self" be "this"?
     return 'self.context.' + matches[1] + matches[2];
   }
 
   // Replaces: function foo() {};  with: foo = function foo() {};
-  matches = scopeFunc.exec(self.bufferedCommand);
+  matches = scopeFunc.exec(this.bufferedCommand);
   if (matches && matches.length === 2) {
-    return matches[1] + ' = ' + self.bufferedCommand;
+    return matches[1] + ' = ' + this.bufferedCommand;
   }
 
   return cmd;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -352,18 +352,17 @@ function Zlib(opts, mode) {
 
   this._handle = new binding.Zlib(mode);
 
-  var self = this;
   this._hadError = false;
-  this._handle.onerror = function(message, errno) {
+  this._handle.onerror = (message, errno) => {
     // there is no way to cleanly recover.
     // continuing only obscures problems.
-    self._handle = null;
-    self._hadError = true;
+    this._handle = null;
+    this._hadError = true;
 
     var error = new Error(message);
     error.errno = errno;
     error.code = exports.codes[errno];
-    self.emit('error', error);
+    this.emit('error', error);
   };
 
   var level = exports.Z_DEFAULT_COMPRESSION;
@@ -403,13 +402,12 @@ Zlib.prototype.params = function(level, strategy, callback) {
   }
 
   if (this._level !== level || this._strategy !== strategy) {
-    var self = this;
-    this.flush(binding.Z_SYNC_FLUSH, function() {
-      assert(!self._closed, 'zlib binding closed');
-      self._handle.params(level, strategy);
-      if (!self._hadError) {
-        self._level = level;
-        self._strategy = strategy;
+    this.flush(binding.Z_SYNC_FLUSH, () => {
+      assert(!this._closed, 'zlib binding closed');
+      this._handle.params(level, strategy);
+      if (!this._hadError) {
+        this._level = level;
+        this._strategy = strategy;
         if (callback) callback();
       }
     });
@@ -506,8 +504,6 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
   var availOutBefore = this._chunkSize - this._offset;
   var inOff = 0;
 
-  var self = this;
-
   var async = typeof cb === 'function';
 
   if (!async) {
@@ -557,19 +553,19 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
   req.buffer = chunk;
   req.callback = callback;
 
-  function callback(availInAfter, availOutAfter) {
-    if (self._hadError)
+  const callback = (availInAfter, availOutAfter) => {
+    if (this._hadError)
       return;
 
     var have = availOutBefore - availOutAfter;
     assert(have >= 0, 'have should not go down');
 
     if (have > 0) {
-      var out = self._buffer.slice(self._offset, self._offset + have);
-      self._offset += have;
+      var out = this._buffer.slice(this._offset, this._offset + have);
+      this._offset += have;
       // serve some output to the consumer.
       if (async) {
-        self.push(out);
+        this.push(out);
       } else {
         buffers.push(out);
         nread += out.length;
@@ -577,10 +573,10 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
     }
 
     // exhausted the output buffer, or used all the input create a new one.
-    if (availOutAfter === 0 || self._offset >= self._chunkSize) {
-      availOutBefore = self._chunkSize;
-      self._offset = 0;
-      self._buffer = new Buffer(self._chunkSize);
+    if (availOutAfter === 0 || this._offset >= this._chunkSize) {
+      availOutBefore = this._chunkSize;
+      this._offset = 0;
+      this._buffer = new Buffer(this._chunkSize);
     }
 
     if (availOutAfter === 0) {
@@ -594,13 +590,13 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
       if (!async)
         return true;
 
-      var newReq = self._handle.write(flushFlag,
+      var newReq = this._handle.write(flushFlag,
                                       chunk,
                                       inOff,
                                       availInBefore,
-                                      self._buffer,
-                                      self._offset,
-                                      self._chunkSize);
+                                      this._buffer,
+                                      this._offset,
+                                      this._chunkSize);
       newReq.callback = callback; // this same function
       newReq.buffer = chunk;
       return;
@@ -611,7 +607,7 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
 
     // finished with the chunk.
     cb();
-  }
+  };
 };
 
 util.inherits(Deflate, Zlib);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -506,53 +506,6 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
 
   var async = typeof cb === 'function';
 
-  if (!async) {
-    var buffers = [];
-    var nread = 0;
-
-    var error;
-    this.on('error', function(er) {
-      error = er;
-    });
-
-    assert(!this._closed, 'zlib binding closed');
-    do {
-      var res = this._handle.writeSync(flushFlag,
-                                       chunk, // in
-                                       inOff, // in_off
-                                       availInBefore, // in_len
-                                       this._buffer, // out
-                                       this._offset, //out_off
-                                       availOutBefore); // out_len
-    } while (!this._hadError && callback(res[0], res[1]));
-
-    if (this._hadError) {
-      throw error;
-    }
-
-    if (nread >= kMaxLength) {
-      this.close();
-      throw new RangeError(kRangeErrorMessage);
-    }
-
-    var buf = Buffer.concat(buffers, nread);
-    this.close();
-
-    return buf;
-  }
-
-  assert(!this._closed, 'zlib binding closed');
-  var req = this._handle.write(flushFlag,
-                               chunk, // in
-                               inOff, // in_off
-                               availInBefore, // in_len
-                               this._buffer, // out
-                               this._offset, //out_off
-                               availOutBefore); // out_len
-
-  req.buffer = chunk;
-  req.callback = callback;
-
   const callback = (availInAfter, availOutAfter) => {
     if (this._hadError)
       return;
@@ -608,6 +561,53 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
     // finished with the chunk.
     cb();
   };
+
+  if (!async) {
+    var buffers = [];
+    var nread = 0;
+
+    var error;
+    this.on('error', function(er) {
+      error = er;
+    });
+
+    assert(!this._closed, 'zlib binding closed');
+    do {
+      var res = this._handle.writeSync(flushFlag,
+                                       chunk, // in
+                                       inOff, // in_off
+                                       availInBefore, // in_len
+                                       this._buffer, // out
+                                       this._offset, //out_off
+                                       availOutBefore); // out_len
+    } while (!this._hadError && callback(res[0], res[1]));
+
+    if (this._hadError) {
+      throw error;
+    }
+
+    if (nread >= kMaxLength) {
+      this.close();
+      throw new RangeError(kRangeErrorMessage);
+    }
+
+    var buf = Buffer.concat(buffers, nread);
+    this.close();
+
+    return buf;
+  }
+
+  assert(!this._closed, 'zlib binding closed');
+  var req = this._handle.write(flushFlag,
+                               chunk, // in
+                               inOff, // in_off
+                               availInBefore, // in_len
+                               this._buffer, // out
+                               this._offset, //out_off
+                               availOutBefore); // out_len
+
+  req.buffer = chunk;
+  req.callback = callback;
 };
 
 util.inherits(Deflate, Zlib);


### PR DESCRIPTION
This commit replaces trivial occurances of var self = this and .bind()
where appropriate.

---

FWIW, passes local tests.

May be adding to this over the next day - this is the result of a couple simple greps.

This is in parallel to #3622.