### PR TITLE
Add a check of the OPENSSL_FIPS environment variable around each call…

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ Instructions:
    /usr/local/ssl/fips-2.0
 8. Build Node.js with `make -j`
 9. Verify with `node -p "process.versions.openssl"` (`1.0.2a-fips`)
+10. For FIPS mode to be enabled at runtime, the OPENSSL_FIPS environment
+    variable must be set to 1.
 
 ## Resources for Newcomers
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5522,10 +5522,12 @@ void InitCryptoOnce() {
   CRYPTO_THREADID_set_callback(crypto_threadid_cb);
 
 #ifdef NODE_FIPS_MODE
-  if (!FIPS_mode_set(1)) {
-    int err = ERR_get_error();
-    fprintf(stderr, "openssl fips failed: %s\n", ERR_error_string(err, NULL));
-    UNREACHABLE();
+  if (getenv("OPENSSL_FIPS")) {
+    if (!FIPS_mode_set(1)) {
+      int err = ERR_get_error();
+      fprintf(stderr, "openssl fips failed: %s\n", ERR_error_string(err, NULL));
+      UNREACHABLE();
+    }
   }
 #endif  // NODE_FIPS_MODE
 


### PR DESCRIPTION
As currently implemented, when Node is compiled with FIPS support
(`./configure fips`), there is no way to disable engaging FIPS mode
during execution (Issue #3819). This means that several functions that rely on
non-FIPS approved algorithms (e.g. md5 hashing) will fail, as will
any code that depends on them (most obviously, `npm`).

What seems needed to me is a way to explicitly enable or disable
FIPS operation each time node is invoked. The way this is done
with the openssl CLI is via the OPENSSL_FIPS environment variable.

This change adds a check to OPENSSL_FIPS at every place where
FIPS_mode_set(1) is called (which enables FIPS mode). If Node
is not compiled in FIPS mode these calls will not even be
compiled since they're all wrapped with IFDEFs.

Those who are trying to run Node.js in FIPS mode should be
familiar with this variable and using it will be natural.