### PR TITLE
repl: allow multiline function call

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1126,7 +1126,10 @@ function isRecoverableError(e, self) {
       self._inTemplateLiteral = true;
       return true;
     }
-    return /^(Unexpected end of input|Unexpected token)/.test(message);
+
+    return message.startsWith('Unexpected end of input') ||
+      message.startsWith('Unexpected token') ||
+      message.startsWith('missing ) after argument list');
   }
   return false;
 }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -180,6 +180,13 @@ function error_test() {
       expect: prompt_multiline },
     { client: client_unix, send: '})()',
       expect: '1' },
+    // Multiline function call
+    { client: client_unix, send: 'function f(){}; f(f(1,',
+      expect: prompt_multiline },
+    { client: client_unix, send: '2)',
+      expect: prompt_multiline },
+    { client: client_unix, send: ')',
+      expect: 'undefined\n' + prompt_unix },
     // npm prompt error message
     { client: client_unix, send: 'npm install foobar',
       expect: expect_npm },


### PR DESCRIPTION
Currently, the repl allows multiline function declarations, strings, and
all sorts of niceties by catching the SyntaxErrors they issue and
ignoring them. However, the SyntaxError raised by multiline function
calls was not caught. This commit adds to the whitelist.

Behaviour before this commit:

```javascript
> console.log(console.log(1,
... 2)
SyntaxError: missing ) after argument list
```

After:

```javascript
> console.log(console.log(1,
... 2),
... 3)
1 2
undefined 3
undefined
```