### PR TITLE
build: fix --without-ssl compile time error

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3034,9 +3034,13 @@ static void ParseArgs(int* argc,
       printf("%s\n", NODE_VERSION);
       exit(0);
     } else if (strcmp(arg, "--enable-ssl2") == 0) {
+#if HAVE_OPENSSL
       SSL2_ENABLE = true;
+#endif
     } else if (strcmp(arg, "--enable-ssl3") == 0) {
+#if HAVE_OPENSSL
       SSL3_ENABLE = true;
+#endif
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);


### PR DESCRIPTION
Fix the following build error by putting #if guards around the
variables:

    ../src/node.cc: In function 'void node::ParseArgs(int*,
    const char**, int*, const char***, int*, const char***)':
    ../src/node.cc:3037:7: error: 'SSL2_ENABLE' was not declared
    in this scope
           SSL2_ENABLE = true;
           ^
    ../src/node.cc:3039:7: error: 'SSL3_ENABLE' was not declared
    in this scope
           SSL3_ENABLE = true;

Fixes: https://github.com/nodejs/node-v0.x-archive/issues/8645

R=@jasnell or @rvagg?

CI: https://ci.nodejs.org/job/node-test-pull-request/733/ (not sure if it works yet for v0.12)