### PR TITLE
util: use Object.create(null) for dictionary object

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -159,9 +159,9 @@ function stylizeNoColor(str, styleType) {
 
 
 function arrayToHash(array) {
-  var hash = {};
+  var hash = Object.create(null);
 
-  array.forEach(function(val, idx) {
+  array.forEach(function(val) {
     hash[val] = true;
   });
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/3788
`arrayToHash()` needs to use `Object.create(null)` for its dictionary object.