### PR TITLE
lib,src: Ensure '(node:pid)' prefix for stdout logging

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const internalUtil = require('internal/util');
 const util = require('util');
 const path = require('path');
 const net = require('net');
@@ -31,8 +32,8 @@ exports.start = function(argv, stdin, stdout) {
   stdin.resume();
 
   process.on('uncaughtException', function(e) {
-    console.error("There was an internal error in Node's debugger. " +
-        'Please report this bug.');
+    internalUtil.error('There was an internal error in Node\'s debugger. ' +
+                       'Please report this bug.');
     console.error(e.message);
     console.error(e.stack);
     if (interface_.child) interface_.child.kill();
@@ -520,7 +521,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
     cb = cb || function() {};
     this.reqLookup(propertyRefs, function(err, res) {
       if (err) {
-        console.error('problem with reqLookup');
+        internalUtil.error('problem with reqLookup');
         cb(null, handle);
         return;
       }
@@ -1668,7 +1669,7 @@ Interface.prototype.trySpawn = function(cb) {
         process._debugProcess(pid);
       } catch (e) {
         if (e.code === 'ESRCH') {
-          console.error(`Target process: ${pid} doesn't exist.`);
+          internalUtil.error(`Target process: ${pid} doesn't exist.`);
           process.exit(1);
         }
         throw e;
@@ -1737,7 +1738,7 @@ Interface.prototype.trySpawn = function(cb) {
   function connectError() {
     // If it's failed to connect 10 times then print failed message
     if (connectionAttempts >= 10) {
-      console.error(' failed, please retry');
+      internalUtil.error(' failed to connect, please retry');
       process.exit(1);
     }
     setTimeout(attemptConnect, 500);

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const internalUtil = require('internal/util');
 const constants = require('constants');
 const tls = require('tls');
 
@@ -102,7 +103,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   if (options.dhparam) {
     var warning = c.context.setDHParam(options.dhparam);
     if (warning)
-      console.trace(warning);
+      internalUtil.trace(warning);
   }
 
   if (options.crl) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var internalUtil;
 var domain;
 
 function EventEmitter() {
@@ -232,10 +233,13 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
       m = $getMaxListeners(this);
       if (m && m > 0 && existing.length > m) {
         existing.warned = true;
-        console.error('(node) warning: possible EventEmitter memory ' +
-                      'leak detected. %d %s listeners added. ' +
-                      'Use emitter.setMaxListeners() to increase limit.',
-                      existing.length, type);
+        if (!internalUtil)
+          internalUtil = require('internal/util');
+
+        internalUtil.error('warning: possible EventEmitter memory ' +
+                           'leak detected. %d %s listeners added. ' +
+                           'Use emitter.setMaxListeners() to increase limit.',
+                           existing.length, type);
         console.trace();
       }
     }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -14,6 +14,14 @@ exports.printDeprecationMessage = function(msg, warned) {
   return exports._printDeprecationMessage(`${prefix}${msg}`, warned);
 };
 
+exports.error = function(msg) {
+  console.error(`${prefix}${msg}`);
+};
+
+exports.trace = function(msg) {
+  console.trace(`${prefix}${msg}`);
+};
+
 exports._printDeprecationMessage = function(msg, warned) {
   if (process.noDeprecation)
     return true;

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,6 +1,7 @@
 #include "env.h"
 #include "env-inl.h"
 #include "v8.h"
+#include "unistd.h"
 #include <stdio.h>
 
 namespace node {
@@ -20,7 +21,7 @@ void Environment::PrintSyncTrace() const {
   Local<v8::StackTrace> stack =
       StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed);
 
-  fprintf(stderr, "WARNING: Detected use of sync API\n");
+  fprintf(stderr, "(node:%d) WARNING: Detected use of sync API\n", getpid());
 
   for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
     Local<StackFrame> stack_frame = stack->GetFrame(i);

--- a/test/parallel/test-sync-io-option.js
+++ b/test/parallel/test-sync-io-option.js
@@ -20,7 +20,7 @@ if (process.argv[2] === 'child') {
     execFile(process.execPath, args, function(err, stdout, stderr) {
       assert.equal(err, null);
       assert.equal(stdout, '');
-      if (/^WARNING[\s\S]*fs\.readFileSync/.test(stderr))
+      if (/WARNING[\s\S]*fs\.readFileSync/.test(stderr))
         cntr++;
       if (args[0] === '--trace-sync-io') {
         assert.equal(cntr, 1);


### PR DESCRIPTION
Fixes issue: #3789
add '(node:pid)' prefix message for stdout logging