### PR TITLE
repl: allow leading period in multiline input

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -387,7 +387,7 @@ function REPLServer(prompt,
       var rest = matches && matches[2];
       if (self.parseREPLKeyword(keyword, rest) === true) {
         return;
-      } else {
+      } else if (!self.bufferedCommand) {
         self.outputStream.write('Invalid REPL keyword\n');
         skipCatchall = true;
       }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -117,6 +117,11 @@ function error_test() {
       expect: prompt_multiline },
     { client: client_unix, send: '+ ".2"}`',
       expect: `'io.js 1.0.2'\n${prompt_unix}` },
+    // Dot prefix in multiline commands aren't treated as commands
+    { client: client_unix, send: '("a"',
+      expect: prompt_multiline },
+    { client: client_unix, send: '.charAt(0))',
+      expect: `'a'\n${prompt_unix}` },
     // Floating point numbers are not interpreted as REPL commands.
     { client: client_unix, send: '.1234',
       expect: '0.1234' },


### PR DESCRIPTION
When writing multiline input, one can't chain function calls as if the
lines begin with a period, since those are treated as REPL commands.

Before:

```javascript
> ([0, 1, 2]
... .map(x => x + 1))
Invalid REPL keyword
```

After:

```javascript
> ([0, 1, 2]
... .map(x => x + 1))
[ 1, 2, 3 ]
```