### PR TITLE
test: skip test if FreeBSD jail will break it

### DIFF
--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -15,6 +15,11 @@ var common = require('../common'),
       new Buffer('Fourth message to send')
     ];
 
+if (common.inFreeBSDJail) {
+  console.log('1..0 # Skipped: in a FreeBSD jail');
+  return;
+}
+
 // take the first non-internal interface as the address for binding
 get_bindAddress: for (var name in networkInterfaces) {
   var interfaces = networkInterfaces[name];


### PR DESCRIPTION
`test/internet/test-dgram-broadcast-multi-process.js` fails if it is in a FreeBSD jail. This issue is with the way FreeBSD jails work and not with Node. Skip the test if in a FreeBSD jail.