### PR TITLE
fs: fail closed on nullcheck #3846

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -90,7 +90,9 @@ function assertEncoding(encoding) {
 }
 
 function nullCheck(path, callback) {
-  if (('' + path).indexOf('\u0000') !== -1) {
+  if (typeof path === 'string' && path.indexOf('\u0000') === -1) {
+    return true;
+  } else {
     var er = new Error('Path must be a string without null bytes');
     er.code = 'ENOENT';
     if (typeof callback !== 'function')
@@ -98,7 +100,6 @@ function nullCheck(path, callback) {
     process.nextTick(callback, er);
     return false;
   }
-  return true;
 }
 
 function isFd(path) {


### PR DESCRIPTION
Changes nullCheck from a fail-open validation to a fail-closed, re: issue #3846