### PR TITLE
test: module loading error fix solaris #3798

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -5,12 +5,10 @@ var assert = require('assert');
 console.error('load test-module-loading-error.js');
 
 var error_desc = {
-  win32: '%1 is not a valid Win32 application',
-  linux: 'file too short',
-  sunos: 'unknown file type'
+  win32: ['%1 is not a valid Win32 application'],
+  linux: ['file too short', 'Exec format error'],
+  sunos: ['unknown file type', 'not an ELF file']
 };
-var musl_errno_enoexec = 'Exec format error';
-
 var dlerror_msg = error_desc[process.platform];
 
 if (!dlerror_msg) {
@@ -21,11 +19,9 @@ if (!dlerror_msg) {
 try {
   require('../fixtures/module-loading-error.node');
 } catch (e) {
-  if (process.platform === 'linux' &&
-      e.toString().indexOf(musl_errno_enoexec) !== -1) {
-    dlerror_msg = musl_errno_enoexec;
-  }
-  assert.notEqual(e.toString().indexOf(dlerror_msg), -1);
+  assert.strictEqual(dlerror_msg.some((errMsgCase) => {
+    return e.toString().indexOf(errMsgCase) !== -1;
+  }), true);
 }
 
 try {


### PR DESCRIPTION
- refactor test-module-loading-error to accept multiple error messages per
platform
- add new message to be found in Solaris 11.3 as per #3798