### PR TITLE
process: nextTick should not be handled lazily

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -486,11 +486,11 @@
     }
 
     function nextTick(callback) {
+      if (typeof callback !== 'function')
+        throw new TypeError('callback is not a function');
       // on the way out, don't bother. it won't get fired anyway.
       if (process._exiting)
         return;
-      if (typeof callback !== 'function')
-        throw new TypeError('callback is not a function');
 
       var args;
       if (arguments.length > 1) {

--- a/src/node.js
+++ b/src/node.js
@@ -490,7 +490,7 @@
       if (process._exiting)
         return;
       if (typeof callback !== 'function')
-        throw new Error('callback is not a function');
+        throw new TypeError('callback is not a function');
 
       var args;
       if (arguments.length > 1) {

--- a/src/node.js
+++ b/src/node.js
@@ -489,6 +489,8 @@
       // on the way out, don't bother. it won't get fired anyway.
       if (process._exiting)
         return;
+      if (typeof callback !== 'function')
+        throw new Error('callback is not a function');
 
       var args;
       if (arguments.length > 1) {

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -20,6 +20,15 @@ process.nextTick(function() {
   order.push('C');
 });
 
+try {
+  process.nextTick();
+} catch (e) {
+  // should handle this error at try...catch
+  if (!e) {
+    assert.fail();
+  }
+}
+
 process.on('uncaughtException', function() {
   if (!exceptionHandled) {
     exceptionHandled = true;

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -20,12 +20,6 @@ process.nextTick(function() {
   order.push('C');
 });
 
-assert.throws(
-  function () {
-    process.nextTick
-  }
-);
-
 function testNextTickWith(val) {
   assert.throws(
     function() {

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -20,14 +20,27 @@ process.nextTick(function() {
   order.push('C');
 });
 
-try {
-  process.nextTick();
-} catch (e) {
-  // should handle this error at try...catch
-  if (!e) {
-    assert.fail();
+assert.throws(
+  function () {
+    process.nextTick
   }
+);
+
+function testNextTickWith(val) {
+  assert.throws(
+    function() {
+      process.nextTick(val);
+    },
+    TypeError
+  );
 }
+
+testNextTickWith(false);
+testNextTickWith(true);
+testNextTickWith(1);
+testNextTickWith('str');
+testNextTickWith({});
+testNextTickWith([]);
 
 process.on('uncaughtException', function() {
   if (!exceptionHandled) {


### PR DESCRIPTION
I got this log from my production clusters:

```sh
node.js:430
        callback();
        ^
TypeError: callback is not a function
    at doNTCallback0 (node.js:430:9)
    at process._tickCallback (node.js:359:13)
```

The stack trace sucks us in some ways, right? Because we can't start debugging from the log, so after we check the type of the `callback` at first, the terminal will tell us:

```sh
node.js:493
        throw new Error('callback is not a function');
        ^
Error: callback is not a function
    at process.nextTick (node.js:493:15)
    at startup (/Users/yorkieliu/workspace/weflex/api/index.js:3:11)
    at Object.<anonymous> (/Users/yorkieliu/workspace/weflex/api/index.js:6:1)
    at Module._compile (module.js:423:26)
    at Object.Module._extensions..js (module.js:430:10)
    at Module.load (module.js:354:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:455:10)
    at startup (node.js:138:18)
    at node.js:976:3
```

The location `/Users/yorkieliu/workspace/weflex/api/index.js:3:11` is in my source file, so I'm able to debug my program with this stack. Obviously, this is an enhancement on stack trace, isn't it :-)

/cc @trevnorris 