### PR TITLE
tls: Use SHA1 for sessionIdContext

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -841,9 +841,9 @@ automatically set as a listener for the [secureConnection][] event.  The
     NOTE: Automatically shared between `cluster` module workers.
 
   - `sessionIdContext`: A string containing an opaque identifier for session
-    resumption. If `requestCert` is `true`, the default is MD5 hash value
-    generated from command-line. (In FIPS mode a truncated SHA1 hash is
-    used instead.) Otherwise, the default is not provided.
+    resumption. If `requestCert` is `true`, the default is a 128 bit
+    truncated SHA1 hash value generated from command-line. Otherwise,
+    the default is not provided.
 
   - `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
     SSL version 3. The possible values depend on your installation of

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -14,21 +14,6 @@ const Timer = process.binding('timer_wrap').Timer;
 const tls_wrap = process.binding('tls_wrap');
 const TCP = process.binding('tcp_wrap').TCP;
 const Pipe = process.binding('pipe_wrap').Pipe;
-const defaultSessionIdContext = getDefaultSessionIdContext();
-
-function getDefaultSessionIdContext() {
-  var defaultText = process.argv.join(' ');
-  /* SSL_MAX_SID_CTX_LENGTH is 128 bits */
-  if (process.config.variables.openssl_fips) {
-    return crypto.createHash('sha1')
-      .update(defaultText)
-      .digest('hex').slice(0, 32);
-  } else {
-    return crypto.createHash('md5')
-      .update(defaultText)
-      .digest('hex');
-  }
-}
 
 function onhandshakestart() {
   debug('onhandshakestart');
@@ -908,7 +893,10 @@ Server.prototype.setOptions = function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
-    this.sessionIdContext = defaultSessionIdContext;
+    this.sessionIdContext = crypto.createHash('sha1')
+                                  .update(process.argv.join(' '))
+                                  .digest('hex')
+                                  .slice(0, 32);
   }
 };
 


### PR DESCRIPTION
As discussed in https://github.com/nodejs/node/pull/3755/, moving forward we won't use MD5 after a semver-major change.