### PR TITLE
module: cache regular expressions

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,6 +11,9 @@ const path = require('path');
 const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 
+const splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
+const isIndexRe = /^index\.\w+?$/;
+const shebangRe = /^\#\!.*/;
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -191,7 +194,6 @@ Module._nodeModulePaths = function(from) {
   // note: this approach *only* works when the path is guaranteed
   // to be absolute.  Doing a fully-edge-case-correct path.split
   // that works on both Windows and Posix is non-trivial.
-  var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
   var paths = [];
   var parts = from.split(splitRe);
 
@@ -244,7 +246,7 @@ Module._resolveLookupPaths = function(request, parent) {
   // Is the parent an index module?
   // We can assume the parent has a valid extension,
   // as it already has been accepted as a module.
-  var isIndex = /^index\.\w+?$/.test(path.basename(parent.filename));
+  var isIndex = isIndexRe.test(path.basename(parent.filename));
   var parentIdPath = isIndex ? parent.id : path.dirname(parent.id);
   var id = path.resolve(parentIdPath, request);
 
@@ -377,7 +379,7 @@ var resolvedArgv;
 Module.prototype._compile = function(content, filename) {
   var self = this;
   // remove shebang
-  content = content.replace(/^\#\!.*/, '');
+  content = content.replace(shebangRe, '');
 
   function require(path) {
     return self.require(path);


### PR DESCRIPTION
None of these regular expressions will change, so there is no need to
generate them every time in hot code paths.

Provides a small performance improvement in module loading. (5-10%)