### PR TITLE
test: remove unused module from test

### DIFF
--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var os = require('os');
 
 var spawnSync = require('child_process').spawnSync;
 


### PR DESCRIPTION
`os` is loaded but not used in `test-child-process-spawnsync-input.js`.
Remove it.