### PR TITLE
test: move test-specific function out of common

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -380,11 +380,6 @@ exports.mustCall = function(fn, expected) {
   };
 };
 
-exports.checkSpawnSyncRet = function(ret) {
-  assert.strictEqual(ret.status, 0);
-  assert.strictEqual(ret.error, undefined);
-};
-
 var etcServicesFileName = path.join('/etc', 'services');
 if (exports.isWindows) {
   etcServicesFileName = path.join(process.env.SystemRoot, 'System32', 'drivers',

--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -1,18 +1,18 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var os = require('os');
+require('../common');
 
-var spawnSync = require('child_process').spawnSync;
+const assert = require('assert');
 
-var msgOut = 'this is stdout';
-var msgErr = 'this is stderr';
+const spawnSync = require('child_process').spawnSync;
+
+const msgOut = 'this is stdout';
+const msgErr = 'this is stderr';
 
 // this is actually not os.EOL?
-var msgOutBuf = new Buffer(msgOut + '\n');
-var msgErrBuf = new Buffer(msgErr + '\n');
+const msgOutBuf = new Buffer(msgOut + '\n');
+const msgErrBuf = new Buffer(msgErr + '\n');
 
-var args = [
+const args = [
   '-e',
   `console.log("${msgOut}"); console.error("${msgErr}");`
 ];
@@ -20,30 +20,33 @@ var args = [
 var ret;
 
 
+function checkSpawnSyncRet(ret) {
+  assert.strictEqual(ret.status, 0);
+  assert.strictEqual(ret.error, undefined);
+};
+
+function verifyBufOutput(ret) {
+  checkSpawnSyncRet(ret);
+  assert.deepEqual(ret.stdout, msgOutBuf);
+  assert.deepEqual(ret.stderr, msgErrBuf);
+}
+
 if (process.argv.indexOf('spawnchild') !== -1) {
   switch (process.argv[3]) {
     case '1':
       ret = spawnSync(process.execPath, args, { stdio: 'inherit' });
-      common.checkSpawnSyncRet(ret);
+      checkSpawnSyncRet(ret);
       break;
     case '2':
       ret = spawnSync(process.execPath, args, {
         stdio: ['inherit', 'inherit', 'inherit']
       });
-      common.checkSpawnSyncRet(ret);
+      checkSpawnSyncRet(ret);
       break;
   }
   process.exit(0);
   return;
 }
-
-
-function verifyBufOutput(ret) {
-  common.checkSpawnSyncRet(ret);
-  assert.deepEqual(ret.stdout, msgOutBuf);
-  assert.deepEqual(ret.stderr, msgErrBuf);
-}
-
 
 verifyBufOutput(spawnSync(process.execPath, [__filename, 'spawnchild', 1]));
 verifyBufOutput(spawnSync(process.execPath, [__filename, 'spawnchild', 2]));
@@ -63,7 +66,7 @@ options = {
 
 ret = spawnSync('cat', [], options);
 
-common.checkSpawnSyncRet(ret);
+checkSpawnSyncRet(ret);
 assert.strictEqual(ret.stdout.toString('utf8'), options.input);
 assert.strictEqual(ret.stderr.toString('utf8'), '');
 
@@ -73,7 +76,7 @@ options = {
 
 ret = spawnSync('cat', [], options);
 
-common.checkSpawnSyncRet(ret);
+checkSpawnSyncRet(ret);
 assert.deepEqual(ret.stdout, options.input);
 assert.deepEqual(ret.stderr, new Buffer(''));
 
@@ -81,7 +84,7 @@ verifyBufOutput(spawnSync(process.execPath, args));
 
 ret = spawnSync(process.execPath, args, { encoding: 'utf8' });
 
-common.checkSpawnSyncRet(ret);
+checkSpawnSyncRet(ret);
 assert.strictEqual(ret.stdout, msgOut + '\n');
 assert.strictEqual(ret.stderr, msgErr + '\n');
 


### PR DESCRIPTION
`common.checkSpawnSyncRet()` is only used in one test. Move it out of
`common.js` and into that test (`test-child-process-spawnsync-input.js`).