### PR TITLE
test: fix new line characters for readability

### DIFF
--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -87,7 +87,7 @@ RandomReadStream.prototype._process = function() {
 
   this._remaining -= block;
 
-  console.error('block=%d\nremain=%d\n', block, this._remaining);
+  console.error('block=%d\r\nremain=%d\r\n', block, this._remaining);
   this._processing = false;
 
   this.emit('data', buf);

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -17,7 +17,7 @@ execFile(node, normal, function(er, stdout, stderr) {
   assert.equal(er, null);
   assert.equal(stdout, '');
   assert.equal(stderr, '(node) util.debug is deprecated. Use console.error ' +
-                       'instead.\nDEBUG: This is deprecated\n');
+                       'instead.\r\nDEBUG: This is deprecated\r\n');
   console.log('normal ok');
 });
 
@@ -25,7 +25,7 @@ execFile(node, noDep, function(er, stdout, stderr) {
   console.error('--no-deprecation: silence deprecations');
   assert.equal(er, null);
   assert.equal(stdout, '');
-  assert.equal(stderr, 'DEBUG: This is deprecated\n');
+  assert.equal(stderr, 'DEBUG: This is deprecated\r\n');
   console.log('silent ok');
 });
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -105,7 +105,7 @@ assert.equal(require('path').dirname(__filename), __dirname);
 console.error('load custom file types with extensions');
 require.extensions['.test'] = function(module, filename) {
   var content = fs.readFileSync(filename).toString();
-  assert.equal('this is custom source\n', content);
+  assert.equal('this is custom source\r\n', content);
   content = content.replace('this is custom source',
                             'exports.test = \'passed\'');
   module._compile(content, filename);


### PR DESCRIPTION
There are some inadequate new line characters in `test`.
using `\n` just prints itself in the console log.
In order to solve this, replace `\n` with `\r\n` for readability.