### PR TITLE
lib: remove unused `all` variable in `_tls_common`

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -160,7 +160,7 @@ exports.translatePeerCertificate = function translatePeerCertificate(c) {
     c.infoAccess = {};
 
     // XXX: More key validation?
-    info.replace(/([^\n:]*):([^\n]*)(?:\n|$)/g, function(all, key, val) {
+    info.replace(/([^\n:]*):([^\n]*)(?:\n|$)/g, function(key, val) {
       if (key === '__proto__')
         return;
 


### PR DESCRIPTION
The variable `all` is not used in the function.
Therefore, remove unused `all` variable for optimization.