### PR TITLE
lib: add  'pid' prefix in `internal/util`

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const prefix = '(node) ';
+const prefix = `(${process.release.name}:${process.pid}) `;
 
 // All the internal deprecations have to use this function only, as this will
 // prepend the prefix to the actual message.

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -16,8 +16,7 @@ execFile(node, normal, function(er, stdout, stderr) {
   console.error('normal: show deprecation warning');
   assert.equal(er, null);
   assert.equal(stdout, '');
-  assert.equal(stderr, '(node) util.debug is deprecated. Use console.error ' +
-                       'instead.\nDEBUG: This is deprecated\n');
+  assert(/util\.debug is deprecated/.test(stderr));
   console.log('normal ok');
 });
 


### PR DESCRIPTION
This PR improves `prefix` in `util` that we've agreed on https://github.com/nodejs/node/pull/3833
(separate PR for javascript in `lib`, and the original PR will be updated to move the printing function to C++  in `src` directly)