### PR TITLE
Add task for building docs only, using existing Node

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -67,9 +67,19 @@ $ make test-npm
 
 To build the documentation:
 
+This will build Node.js first (if necessary) and then use it to build the docs:
+
 ```text
 $ make doc
 ```
+
+If you have an existing Node.js you can build just the docs with:
+
+```text
+$ NODE=node make doc-only
+```
+
+(Where `node` is the path to your executable.)
 
 To read the documentation:
 

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ BUILDTYPE_LOWER := $(shell echo $(BUILDTYPE) | tr '[A-Z]' '[a-z]')
 EXEEXT := $(shell $(PYTHON) -c \
 		"import sys; print('.exe' if sys.platform == 'win32' else '')")
 
-NODE ?= ./node$(EXEEXT)
 NODE_EXE = node$(EXEEXT)
+NODE ?= ./$(NODE_EXE)
 NODE_G_EXE = node_g$(EXEEXT)
 
 # Flags for packaging.
@@ -258,7 +258,9 @@ apidoc_dirs = out/doc out/doc/api/ out/doc/api/assets
 
 apiassets = $(subst api_assets,api/assets,$(addprefix out/,$(wildcard doc/api_assets/*)))
 
-doc: $(apidoc_dirs) $(apiassets) $(apidocs) tools/doc/ $(NODE_EXE)
+doc-only: $(apidoc_dirs) $(apiassets) $(apidocs) tools/doc/
+
+doc: $(NODE_EXE) doc-only
 
 $(apidoc_dirs):
 	mkdir -p $@
@@ -269,11 +271,11 @@ out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets/
 out/doc/%: doc/%
 	cp -r $< $@
 
-out/doc/api/%.json: doc/api/%.md $(NODE_EXE)
+out/doc/api/%.json: doc/api/%.md
 	$(NODE) tools/doc/generate.js --format=json $< > $@
 
-out/doc/api/%.html: doc/api/%.md $(NODE_EXE)
-	$(NODE) tools/doc/generate.js --format=html --template=doc/template.html $< > $@
+out/doc/api/%.html: doc/api/%.md
+	$(NODE) tools/doc/generate.js --node-version=$(FULLVERSION) --format=html --template=doc/template.html $< > $@
 
 docopen: out/doc/api/all.html
 	-google-chrome out/doc/api/all.html
@@ -663,5 +665,5 @@ endif
 	blog blogclean tar binary release-only bench-http-simple bench-idle \
 	bench-all bench bench-misc bench-array bench-buffer bench-net \
 	bench-http bench-fs bench-tls cctest run-ci test-v8 test-v8-intl \
-	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci \
+	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci doc-only \
 	$(TARBALL)-headers

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -10,6 +10,7 @@ const args = process.argv.slice(2);
 let format = 'json';
 let template = null;
 let inputFile = null;
+let nodeVersion = null;
 
 args.forEach(function(arg) {
   if (!arg.match(/^\-\-/)) {
@@ -18,14 +19,14 @@ args.forEach(function(arg) {
     format = arg.replace(/^\-\-format=/, '');
   } else if (arg.match(/^\-\-template=/)) {
     template = arg.replace(/^\-\-template=/, '');
+  } else if (arg.match(/^\-\-node\-version=/)) {
+    nodeVersion = arg.replace(/^\-\-node\-version=/, '');
   }
 });
-
 
 if (!inputFile) {
   throw new Error('No input file specified');
 }
-
 
 console.error('Input file = %s', inputFile);
 fs.readFile(inputFile, 'utf8', function(er, input) {
@@ -33,7 +34,6 @@ fs.readFile(inputFile, 'utf8', function(er, input) {
   // process the input for @include lines
   processIncludes(inputFile, input, next);
 });
-
 
 function next(er, input) {
   if (er) throw er;
@@ -46,7 +46,12 @@ function next(er, input) {
       break;
 
     case 'html':
-      require('./html.js')(input, inputFile, template, function(er, html) {
+      require('./html.js')({
+        input: input,
+        filename: inputFile,
+        template: template,
+        nodeVersion: nodeVersion,
+      }, function(er, html) {
         if (er) throw er;
         console.log(html);
       });

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -30,7 +30,12 @@ var gtocPath = path.resolve(path.join(
 var gtocLoading = null;
 var gtocData = null;
 
-function toHTML(input, filename, template, cb) {
+/**
+ * opts: input, filename, template, nodeVersion.
+ */
+function toHTML(opts, cb) {
+  var template = opts.template;
+
   if (gtocData) {
     return onGtocLoaded();
   }
@@ -51,10 +56,15 @@ function toHTML(input, filename, template, cb) {
   }
 
   function onGtocLoaded() {
-    var lexed = marked.lexer(input);
+    var lexed = marked.lexer(opts.input);
     fs.readFile(template, 'utf8', function(er, template) {
       if (er) return cb(er);
-      render(lexed, filename, template, cb);
+      render({
+        lexed: lexed,
+        filename: opts.filename,
+        template: template,
+        nodeVersion: opts.nodeVersion,
+      }, cb);
     });
   }
 }
@@ -81,7 +91,14 @@ function toID(filename) {
     .replace(/-+/g, '-');
 }
 
-function render(lexed, filename, template, cb) {
+/**
+ * opts: lexed, filename, template, nodeVersion.
+ */
+function render(opts, cb) {
+  var lexed = opts.lexed;
+  var filename = opts.filename;
+  var template = opts.template;
+
   // get the section
   var section = getSection(lexed);
 
@@ -100,7 +117,7 @@ function render(lexed, filename, template, cb) {
     template = template.replace(/__ID__/g, id);
     template = template.replace(/__FILENAME__/g, filename);
     template = template.replace(/__SECTION__/g, section);
-    template = template.replace(/__VERSION__/g, process.version);
+    template = template.replace(/__VERSION__/g, opts.nodeVersion);
     template = template.replace(/__TOC__/g, toc);
     template = template.replace(
       /__GTOC__/g,


### PR DESCRIPTION
This is a WIP attempt to make it easy to build just the docs using an existing Node, instead of having to build Node first, which can be prohibitively slow. Related #3749. The primary reason I call it a WIP is because Make is not my forte :/

/cc @nodejs/documentation @chrisdickinson (per [suggestion](https://github.com/nodejs/node/pull/3749#issuecomment-156583208)).

I saw that in `Makefile` there's a conditionally set `NODE` var that's used for building the docs (among other things), so I based this on utilizing that: `NODE=node make doc-only`.

Summary of changes:

* When it's not explicitly set, set `NODE` using `NODE_EXE` to reduce duplication.

* Setup `tools/doc/generate.js` to read a `--node-version` argument, which will be used to output the version to the docs instead of `process.version`. Setup the relevant Make recipe to pass it.

* Refactor `tools/doc/html.js`'s `toHTML` and `render()` to accept options hashes (the signatures would be getting pretty unwieldy if I'd added `node_version`, which I'm propagating to those functions from `generate.js`).

* Make targets

  * I added a `doc-only` phony target.

  * I made `$(NODE_EXE)` and `doc-only` prerequisites of `doc`.

  * I removed `$(NODE_EXE)` as a prerequisite of the `out/doc/api/%.json` and `out/doc/api/%.html` targets. I'm hoping that it being a prerequisite of `doc` takes care of it for any case where it's needed by these targets (the only one I'm sure of is `make doc`).
  
The changes to the Make targets are the parts I'm least confident about. I'd appreciate if someone who understands Make better can check that it's a sensible setup, and especially that it won't break stuff.
