### PR TITLE
test: fix flaky test-child-process-spawnsync-input

### DIFF
--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -87,15 +87,3 @@ ret = spawnSync(process.execPath, args, { encoding: 'utf8' });
 checkSpawnSyncRet(ret);
 assert.strictEqual(ret.stdout, msgOut + '\n');
 assert.strictEqual(ret.stderr, msgErr + '\n');
-
-options = {
-  maxBuffer: 1
-};
-
-ret = spawnSync(process.execPath, args, options);
-
-assert.ok(ret.error, 'maxBuffer should error');
-assert.strictEqual(ret.error.errno, 'ENOBUFS');
-// we can have buffers larger than maxBuffer because underneath we alloc 64k
-// that matches our read sizes
-assert.deepEqual(ret.stdout, msgOutBuf);

--- a/test/parallel/test-child-process-spawnsync-maxbuf.js
+++ b/test/parallel/test-child-process-spawnsync-maxbuf.js
@@ -1,0 +1,27 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const spawnSync = require('child_process').spawnSync;
+
+const msgOut = 'this is stdout';
+
+// this is actually not os.EOL?
+const msgOutBuf = new Buffer(msgOut + '\n');
+
+const args = [
+  '-e',
+  `console.log("${msgOut}");`
+];
+
+const options = {
+  maxBuffer: 1
+};
+
+const ret = spawnSync(process.execPath, args, options);
+
+assert.ok(ret.error, 'maxBuffer should error');
+assert.strictEqual(ret.error.errno, 'ENOBUFS');
+// we can have buffers larger than maxBuffer because underneath we alloc 64k
+// that matches our read sizes
+assert.deepEqual(ret.stdout, msgOutBuf);


### PR DESCRIPTION
Move portion of `test-child-process-spawnsync-input.js` (that has been
flaky on CentOS in CI) to its own file. This allows us to more easily
eliminate the cause of the flakiness without affecting other unrelated
portions of the test.

Fixes: https://github.com/nodejs/node/issues/3863