### PR TITLE
url: don't keep auth information when changing host

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -564,10 +564,17 @@ Url.prototype.resolveObject = function(relative) {
 
   if (isRelAbs) {
     // it's absolute.
-    result.host = (relative.host || relative.host === '') ?
-                  relative.host : result.host;
-    result.hostname = (relative.hostname || relative.hostname === '') ?
-                      relative.hostname : result.hostname;
+    if (relative.host || relative.host === '') {
+      result.host = relative.host;
+      result.auth = relative.auth;
+      result.port = relative.port;
+
+      if (result.port === null) {
+        result.hostname = result.host;
+      } else {
+        result.hostname = result.host + ':' + result.port;
+      }
+    }
     result.search = relative.search;
     result.query = relative.query;
     srcPath = relPath;

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1187,6 +1187,14 @@ var relativeTests = [
   ['http://example.com/b//c//d;p?q#blarg',
    'http://u:p@h.com/p/a/t/h?s#hash2',
    'http://u:p@h.com/p/a/t/h?s#hash2'],
+  ['http://user:pass@fakeurl2.com:80/path/resource.html?query#hash',
+   'http://fakeurl.com/path/resource.html?query#hash',
+   'http://fakeurl.com/path/resource.html?query#hash'
+  ],
+  ['mailto:user@example.org',
+   'example.com',
+   'mailto:user@example.com'
+  ],
   ['http://example.com/b//c//d;p?q#blarg',
    'http:/a/b/c/d',
    'http://example.com/a/b/c/d'],


### PR DESCRIPTION
This commit stops passing one domain's auth data to
another domain when passed as the relative path.

Fixes: https://github.com/nodejs/node/issues/1435