### PR TITLE
test: add OS X to module loading error test

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -7,7 +7,8 @@ console.error('load test-module-loading-error.js');
 var error_desc = {
   win32: ['%1 is not a valid Win32 application'],
   linux: ['file too short', 'Exec format error'],
-  sunos: ['unknown file type', 'not an ELF file']
+  sunos: ['unknown file type', 'not an ELF file'],
+  darwin: ['file too short']
 };
 var dlerror_msg = error_desc[process.platform];
 


### PR DESCRIPTION
Previously, this test was not supported on OS X. This change makes sure
that it is no longer skipped.