### PR TITLE
test: avoid test timeouts on rpi

### DIFF
--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -513,7 +513,7 @@ assert.throws(function() {
 
 // Test Diffie-Hellman with two parties sharing a secret,
 // using various encodings as we go along
-var dh1 = crypto.createDiffieHellman(1024);
+var dh1 = crypto.createDiffieHellman(common.hasFipsCrypto ? 1024 : 256);
 var p1 = dh1.getPrime('buffer');
 var dh2 = crypto.createDiffieHellman(p1, 'base64');
 var key1 = dh1.generateKeys();

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -11,7 +11,7 @@ var crypto = require('crypto');
 
 // Test Diffie-Hellman with two parties sharing a secret,
 // using various encodings as we go along
-var dh1 = crypto.createDiffieHellman(1024);
+var dh1 = crypto.createDiffieHellman(common.hasFipsCrypto ? 1024 : 256);
 var p1 = dh1.getPrime('buffer');
 var dh2 = crypto.createDiffieHellman(p1, 'buffer');
 var key1 = dh1.generateKeys();


### PR DESCRIPTION
Generating 1024-bit primes on rpi test machines sometimes causes timeouts. We can avoid this situation by using 256-bit primes when not running in FIPS mode.

Resolves https://github.com/nodejs/node/issues/3881.