### PR TITLE
test: add test for repl.defineCommand

### DIFF
--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -1,0 +1,43 @@
+'use strict';
+
+require('../common');
+
+const stream = require('stream'),
+      assert = require('assert'),
+      repl = require('repl');
+
+var output = '';
+const inputStream = new stream.PassThrough();
+const outputStream = new stream.PassThrough();
+outputStream.on('data', function(d) {
+  output += d;
+});
+
+const r = repl.start({
+  input: inputStream,
+  output: outputStream,
+  terminal: true
+});
+
+r.defineCommand('say1', {
+  help: 'help for say1',
+  action: function(thing) {
+    output = '';
+    this.write('hello ' + thing);
+    this.displayPrompt();
+  }
+});
+
+r.defineCommand('say2', function() {
+  output = '';
+  this.write('hello from say2');
+  this.displayPrompt();
+});
+
+inputStream.write('.help\n');
+assert(/\nsay1\thelp for say1\n/.test(output), 'help for say1 not present');
+assert(/\nsay2\t\n/.test(output), 'help for say2 not present');
+inputStream.write('.say1 node developer\n');
+assert(/> hello node developer/.test(output), 'say1 outputted incorrectly');
+inputStream.write('.say2 node developer\n');
+assert(/> hello from say2/.test(output), 'say2 outputted incorrectly');


### PR DESCRIPTION
There didn't appear to be a test for `REPLServer#defineCommand`, probably because it wasn't documented before, so here's a test for it.