### PR TITLE
doc,fs: keep consistent with fs.link and fs.linkSync

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -656,16 +656,22 @@ information.
 
 Synchronous stat(2). Returns an instance of `fs.Stats`.
 
-## fs.symlink(destination, path[, type], callback)
+## fs.symlink(target, path[, type], callback)
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
 The `type` argument can be set to `'dir'`, `'file'`, or `'junction'` (default
 is `'file'`) and is only available on Windows (ignored on other platforms).
 Note that Windows junction points require the destination path to be absolute.  When using
-`'junction'`, the `destination` argument will automatically be normalized to absolute path.
+`'junction'`, the `target` argument will automatically be normalized to absolute path.
 
-## fs.symlinkSync(destination, path[, type])
+Here is an example below:
+
+    fs.symlink('./foo', './new-port');
+
+It would create a symlic link named with "new-port" that points to "foo".
+
+## fs.symlinkSync(target, path[, type])
 
 Synchronous symlink(2). Returns `undefined`.
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -920,29 +920,29 @@ function preprocessSymlinkDestination(path, type, linkPath) {
   }
 }
 
-fs.symlink = function(destination, path, type_, callback_) {
+fs.symlink = function(target, path, type_, callback_) {
   var type = (typeof type_ === 'string' ? type_ : null);
   var callback = makeCallback(arguments[arguments.length - 1]);
 
-  if (!nullCheck(destination, callback)) return;
+  if (!nullCheck(target, callback)) return;
   if (!nullCheck(path, callback)) return;
 
   var req = new FSReqWrap();
   req.oncomplete = callback;
 
-  binding.symlink(preprocessSymlinkDestination(destination, type, path),
+  binding.symlink(preprocessSymlinkDestination(target, type, path),
                   pathModule._makeLong(path),
                   type,
                   req);
 };
 
-fs.symlinkSync = function(destination, path, type) {
+fs.symlinkSync = function(target, path, type) {
   type = (typeof type === 'string' ? type : null);
 
-  nullCheck(destination);
+  nullCheck(target);
   nullCheck(path);
 
-  return binding.symlink(preprocessSymlinkDestination(destination, type, path),
+  return binding.symlink(preprocessSymlinkDestination(target, type, path),
                          pathModule._makeLong(path),
                          type);
 };

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -580,15 +580,15 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
 
   int len = args.Length();
   if (len < 1)
-    return TYPE_ERROR("dest path required");
+    return TYPE_ERROR("target path required");
   if (len < 2)
     return TYPE_ERROR("src path required");
   if (!args[0]->IsString())
-    return TYPE_ERROR("dest path must be a string");
+    return TYPE_ERROR("target path must be a string");
   if (!args[1]->IsString())
     return TYPE_ERROR("src path must be a string");
 
-  node::Utf8Value dest(env->isolate(), args[0]);
+  node::Utf8Value target(env->isolate(), args[0]);
   node::Utf8Value path(env->isolate(), args[1]);
   int flags = 0;
 
@@ -604,9 +604,9 @@ static void Symlink(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (args[3]->IsObject()) {
-    ASYNC_DEST_CALL(symlink, args[3], *path, *dest, *path, flags)
+    ASYNC_DEST_CALL(symlink, args[3], *path, *target, *path, flags)
   } else {
-    SYNC_DEST_CALL(symlink, *dest, *path, *dest, *path, flags)
+    SYNC_DEST_CALL(symlink, *target, *path, *target, *path, flags)
   }
 }
 


### PR DESCRIPTION
So firstly, the destination has a little confusion like I got the log:

```
Error: EEXIST: file already exists, symlink 'dist/node_modules' -> 'node_modules'
```

And my source call is:

```js
fs.symlinkSync('dist/node_modules', 'node_modules', 'dir');
```

Because I thought the first argument stands for destination as the original doc is telling, but it actually is `source`. Plus, I also make `link*` and  `symlinkSync` be consistent :-)