### PR TITLE
doc: update g++ requirement from 4.8 to 4.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ the binary verification command above.
 
 Prerequisites:
 
-* `gcc` and `g++` 4.8 or newer, or
+* `gcc` and `g++` 4.8.5 or newer, or
 * `clang` and `clang++` 3.4 or newer
 * Python 2.6 or 2.7
 * GNU Make 3.81 or newer


### PR DESCRIPTION
Lest people think that g++ 4.8.0, released in March 2013, is acceptable.
4.8.5 was released in June of this year and contains numerous bug fixes.

R=@misterdjules?