### PR TITLE
fs: fix the error report on fs.link(Sync)

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -615,13 +615,13 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
 
   int len = args.Length();
   if (len < 1)
-    return TYPE_ERROR("dest path required");
-  if (len < 2)
     return TYPE_ERROR("src path required");
+  if (len < 2)
+    return TYPE_ERROR("dest path required");
   if (!args[0]->IsString())
-    return TYPE_ERROR("dest path must be a string");
-  if (!args[1]->IsString())
     return TYPE_ERROR("src path must be a string");
+  if (!args[1]->IsString())
+    return TYPE_ERROR("dest path must be a string");
 
   node::Utf8Value orig_path(env->isolate(), args[0]);
   node::Utf8Value new_path(env->isolate(), args[1]);

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -18,3 +18,19 @@ const callback = function(err) {
 };
 
 fs.link(srcPath, dstPath, common.mustCall(callback));
+
+// test error outputs
+
+assert.throws(
+  function() {
+    fs.link();
+  },
+  /src path/
+);
+
+assert.throws(
+  function() {
+    fs.link('abc');
+  },
+  /dest path/
+);


### PR DESCRIPTION
As the Node.js documentation specified:

> fs.link(srcpath, dstpath, callback)

But when we run:

```js
> fs.link()
```

We will get the below:

```js
TypeError: dest path must be a string
    at TypeError (native)
    at Object.fs.link (fs.js:915:11)
    at repl:1:4
```

Just correct the message of relevant 2 errors in this PR :-)