### PR TITLE
Use real OS tmp dir on Linux for long path tests

### DIFF
--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -3,15 +3,37 @@ var common = require('../common');
 var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
+var os = require('os');
 
 var successes = 0;
 
+var tmpDir = common.tmpDir;
+var useOsTmpDir = false;
+
+// use real OS tmp dir on Linux when it is readable/writable
+// to avoid failing tests on ecryptfs filesystems:
+// https://github.com/nodejs/node/issues/2255
+if (os.type() == 'Linux') {
+  try {
+    fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
+    useOsTmpDir = true;
+    tmpDir = path.join(os.tmpdir(),
+      'node-' + process.version + '-test-' + (Math.random() * 1e6 | 0));
+    fs.mkdirSync(tmpDir);
+  } catch (e) {
+    useOsTmpDir = false;
+    tmpDir = common.tmpDir;
+  }
+}
+
 // make a path that will be at least 260 chars long.
-var fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
-var fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
+var fileNameLen = Math.max(260 - tmpDir.length - 1, 1);
+var fileName = path.join(tmpDir, new Array(fileNameLen + 1).join('x'));
 var fullPath = path.resolve(fileName);
 
-common.refreshTmpDir();
+if (!useOsTmpDir) {
+  common.refreshTmpDir();
+}
 
 console.log({
   filenameLength: fileName.length,
@@ -30,5 +52,8 @@ fs.writeFile(fullPath, 'ok', function(err) {
 
 process.on('exit', function() {
   fs.unlinkSync(fullPath);
+  if (useOsTmpDir) {
+    fs.rmdirSync(tmpDir);
+  }
   assert.equal(2, successes);
 });

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -2,16 +2,38 @@
 const common = require('../common');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
+
+var tmpDir = common.tmpDir;
+var useOsTmpDir = false;
+
+// use real OS tmp dir on Linux when it is readable/writable
+// to avoid failing tests on ecryptfs filesystems:
+// https://github.com/nodejs/node/issues/2255
+if (os.type() == 'Linux') {
+  try {
+    fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
+    useOsTmpDir = true;
+    tmpDir = path.join(os.tmpdir(),
+      'node-' + process.version + '-test-' + (Math.random() * 1e6 | 0));
+    fs.mkdirSync(tmpDir);
+  } catch (e) {
+    useOsTmpDir = false;
+    tmpDir = common.tmpDir;
+  }
+}
 
 // make a path that is more than 260 chars long.
-const dirNameLen = Math.max(260 - common.tmpDir.length, 1);
-const dirName = path.join(common.tmpDir, 'x'.repeat(dirNameLen));
+const dirNameLen = Math.max(260 - tmpDir.length, 1);
+const dirName = path.join(tmpDir, 'x'.repeat(dirNameLen));
 const fullDirPath = path.resolve(dirName);
 
 const indexFile = path.join(fullDirPath, 'index.js');
 const otherFile = path.join(fullDirPath, 'other.js');
 
-common.refreshTmpDir();
+if (!useOsTmpDir) {
+  common.refreshTmpDir();
+}
 
 fs.mkdirSync(fullDirPath);
 fs.writeFileSync(indexFile, 'require("./other");');
@@ -20,4 +42,11 @@ fs.writeFileSync(otherFile, '');
 require(indexFile);
 require(otherFile);
 
-common.refreshTmpDir();
+if (useOsTmpDir) {
+  fs.unlinkSync(indexFile);
+  fs.unlinkSync(otherFile);
+  fs.rmdirSync(fullDirPath);
+  fs.rmdirSync(tmpDir);
+} else {
+  common.refreshTmpDir();
+}


### PR DESCRIPTION
Use os.tmpdir() on Linux if it is readable/writable
in test-fs-long-path.js and test-require-long-path.js
to avoid failing tests on ecryptfs filesystems - see issue #2255