### PR TITLE
Retry long path tests on Linux under real tmp dir

### DIFF
--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -3,32 +3,44 @@ var common = require('../common');
 var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
+var os = require('os');
 
-var successes = 0;
+// when it fails test again under real OS tmp dir on Linux when it is
+// readable/writable to avoid failing tests on ecryptfs filesystems:
+// https://github.com/nodejs/node/issues/2255
+// it follows advice in comments to:
+// https://github.com/nodejs/node/pull/3925
+try {
+  common.refreshTmpDir();
+  testFsLongPath(common.tmpDir);
+  common.refreshTmpDir();
+} catch (e) {
+  if (os.type() == 'Linux') {
+    fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
+    var tmpDir = path.join(os.tmpdir(),
+      'node-' + process.version + '-test-' + (Math.random() * 1e6 | 0));
+    fs.mkdirSync(tmpDir);
+    testFsLongPath(tmpDir);
+    fs.rmdirSync(tmpDir);
+  } else {
+    throw e;
+  }
+}
 
-// make a path that will be at least 260 chars long.
-var fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
-var fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
-var fullPath = path.resolve(fileName);
+function testFsLongPath(tmpDir) {
 
-common.refreshTmpDir();
+  // make a path that will be at least 260 chars long.
+  var fileNameLen = Math.max(260 - tmpDir.length - 1, 1);
+  var fileName = path.join(tmpDir, new Array(fileNameLen + 1).join('x'));
+  var fullPath = path.resolve(fileName);
 
-console.log({
-  filenameLength: fileName.length,
-  fullPathLength: fullPath.length
-});
-
-fs.writeFile(fullPath, 'ok', function(err) {
-  if (err) throw err;
-  successes++;
-
-  fs.stat(fullPath, function(err, stats) {
-    if (err) throw err;
-    successes++;
+  console.log({
+    filenameLength: fileName.length,
+    fullPathLength: fullPath.length
   });
-});
 
-process.on('exit', function() {
+  fs.writeFileSync(fullPath, 'ok');
+  fs.statSync(fullPath);
   fs.unlinkSync(fullPath);
-  assert.equal(2, successes);
-});
+
+}

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common');
-var fs = require('fs');
-var path = require('path');
-var assert = require('assert');
-var os = require('os');
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
 // when it fails test again under real OS tmp dir on Linux when it is
 // readable/writable to avoid failing tests on ecryptfs filesystems:
 // https://github.com/nodejs/node/issues/2255
 // it follows advice in comments to:
 // https://github.com/nodejs/node/pull/3925
+// https://github.com/nodejs/node/pull/3929
 try {
   common.refreshTmpDir();
   testFsLongPath(common.tmpDir);
@@ -17,8 +17,8 @@ try {
 } catch (e) {
   if (os.type() == 'Linux') {
     fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
-    var tmpDir = path.join(os.tmpdir(),
-      'node-' + process.version + '-test-' + (Math.random() * 1e6 | 0));
+    const tmpDir = path.join(os.tmpdir(),
+      `node-${process.version}-test-${1e6 * Math.random() | 0}`);
     fs.mkdirSync(tmpDir);
     testFsLongPath(tmpDir);
     fs.rmdirSync(tmpDir);
@@ -30,9 +30,9 @@ try {
 function testFsLongPath(tmpDir) {
 
   // make a path that will be at least 260 chars long.
-  var fileNameLen = Math.max(260 - tmpDir.length - 1, 1);
-  var fileName = path.join(tmpDir, new Array(fileNameLen + 1).join('x'));
-  var fullPath = path.resolve(fileName);
+  const fileNameLen = Math.max(260 - tmpDir.length - 1, 1);
+  const fileName = path.join(tmpDir, new Array(fileNameLen + 1).join('x'));
+  const fullPath = path.resolve(fileName);
 
   console.log({
     filenameLength: fileName.length,

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -15,7 +15,7 @@ try {
   testFsLongPath(common.tmpDir);
   common.refreshTmpDir();
 } catch (e) {
-  if (os.type() == 'Linux') {
+  if (process.platform == 'linux') {
     fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
     const tmpDir = path.join(os.tmpdir(),
       `node-${process.version}-test-${1e6 * Math.random() | 0}`);

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -15,7 +15,7 @@ try {
   testRequireLongPath(common.tmpDir);
   common.refreshTmpDir();
 } catch (e) {
-  if (os.type() == 'Linux') {
+  if (process.platform == 'linux') {
     fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
     const tmpDir = path.join(os.tmpdir(),
       `node-${process.version}-test-${1e6 * Math.random() | 0}`);

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -7,8 +7,9 @@ const os = require('os');
 // when it fails test again under real OS tmp dir on Linux when it is
 // readable/writable to avoid failing tests on ecryptfs filesystems:
 // https://github.com/nodejs/node/issues/2255
-// it takes into account comments in:
+// it follows advice in comments to:
 // https://github.com/nodejs/node/pull/3925
+// https://github.com/nodejs/node/pull/3929
 try {
   common.refreshTmpDir();
   testRequireLongPath(common.tmpDir);
@@ -16,8 +17,8 @@ try {
 } catch (e) {
   if (os.type() == 'Linux') {
     fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
-    var tmpDir = path.join(os.tmpdir(),
-      'node-' + process.version + '-test-' + (Math.random() * 1e6 | 0));
+    const tmpDir = path.join(os.tmpdir(),
+      `node-${process.version}-test-${1e6 * Math.random() | 0}`);
     fs.mkdirSync(tmpDir);
     testRequireLongPath(tmpDir);
     fs.rmdirSync(tmpDir);


### PR DESCRIPTION
Use os.tmpdir() on Linux if it is readable/writable
but *only* when the original tests fail
in test-fs-long-path.js and test-require-long-path.js
to avoid failing tests on ecryptfs filesystems
See issue #2255 and comments to PR #3925