### PR TITLE
test: http complete list of non-concat headers

### DIFF
--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -4,8 +4,21 @@ const common = require('../common');
 const http = require('http');
 const assert = require('assert');
 
-// Test that certain response header fields do not repeat
+// Test that certain response header fields do not repeat.
+// 'content-length' should also be in this list, but it needs
+// a numeric header, so it's tested slightly differently.
 const norepeat = [
+  'content-type',
+  'user-agent',
+  'referer',
+  'host',
+  'authorization',
+  'proxy-authorization',
+  'if-modified-since',
+  'if-unmodified-since',
+  'from',
+  'location',
+  'max-forwards',
   'retry-after',
   'etag',
   'last-modified',
@@ -17,12 +30,14 @@ const norepeat = [
 const server = http.createServer(function(req, res) {
   var num = req.headers['x-num'];
   if (num == 1) {
+    res.setHeader('content-length', [1, 2]);
     for (const name of norepeat) {
       res.setHeader(name, ['A', 'B']);
     }
     res.setHeader('X-A', ['A', 'B']);
   } else if (num == 2) {
     const headers = {};
+    headers['content-length'] = [1, 2];
     for (const name of norepeat) {
       headers[name] = ['A', 'B'];
     }
@@ -44,6 +59,7 @@ server.listen(common.PORT, common.mustCall(function() {
       {port:common.PORT, headers:{'x-num': n}},
       common.mustCall(function(res) {
         if (n == 2) server.close();
+        assert.equal(res.headers['content-length'], 1);
         for (const name of norepeat) {
           assert.equal(res.headers[name], 'A');
         }


### PR DESCRIPTION
The original test was only testing *some* of the headers that shouldn't be concatenated as per `lib/_http_incoming.js`, so now the full list is there and matches what's in the docs as well.

`content-length` gives a `ParseError` if you set it to a string, so the test for that header uses numbers.