### PR TITLE
test: fix long path tests to avoid issue #2255

### DIFF
--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -1,34 +1,46 @@
 'use strict';
-var common = require('../common');
-var fs = require('fs');
-var path = require('path');
-var assert = require('assert');
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-var successes = 0;
+// when it fails test again under real OS tmp dir on Linux when it is
+// readable/writable to avoid failing tests on ecryptfs filesystems:
+// https://github.com/nodejs/node/issues/2255
+// it follows advice in comments to:
+// https://github.com/nodejs/node/pull/3925
+// https://github.com/nodejs/node/pull/3929
+try {
+  common.refreshTmpDir();
+  testFsLongPath(common.tmpDir);
+  common.refreshTmpDir();
+} catch (e) {
+  if (os.type() == 'Linux') {
+    fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
+    const tmpDir = path.join(os.tmpdir(),
+      `node-${process.version}-test-${1e6 * Math.random() | 0}`);
+    fs.mkdirSync(tmpDir);
+    testFsLongPath(tmpDir);
+    fs.rmdirSync(tmpDir);
+  } else {
+    throw e;
+  }
+}
 
-// make a path that will be at least 260 chars long.
-var fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
-var fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
-var fullPath = path.resolve(fileName);
+function testFsLongPath(tmpDir) {
 
-common.refreshTmpDir();
+  // make a path that will be at least 260 chars long.
+  const fileNameLen = Math.max(260 - tmpDir.length - 1, 1);
+  const fileName = path.join(tmpDir, new Array(fileNameLen + 1).join('x'));
+  const fullPath = path.resolve(fileName);
 
-console.log({
-  filenameLength: fileName.length,
-  fullPathLength: fullPath.length
-});
-
-fs.writeFile(fullPath, 'ok', function(err) {
-  if (err) throw err;
-  successes++;
-
-  fs.stat(fullPath, function(err, stats) {
-    if (err) throw err;
-    successes++;
+  console.log({
+    filenameLength: fileName.length,
+    fullPathLength: fullPath.length
   });
-});
 
-process.on('exit', function() {
+  fs.writeFileSync(fullPath, 'ok');
+  fs.statSync(fullPath);
   fs.unlinkSync(fullPath);
-  assert.equal(2, successes);
-});
+
+}

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -2,22 +2,50 @@
 const common = require('../common');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
-// make a path that is more than 260 chars long.
-const dirNameLen = Math.max(260 - common.tmpDir.length, 1);
-const dirName = path.join(common.tmpDir, 'x'.repeat(dirNameLen));
-const fullDirPath = path.resolve(dirName);
+// when it fails test again under real OS tmp dir on Linux when it is
+// readable/writable to avoid failing tests on ecryptfs filesystems:
+// https://github.com/nodejs/node/issues/2255
+// it follows advice in comments to:
+// https://github.com/nodejs/node/pull/3925
+// https://github.com/nodejs/node/pull/3929
+try {
+  common.refreshTmpDir();
+  testRequireLongPath(common.tmpDir);
+  common.refreshTmpDir();
+} catch (e) {
+  if (os.type() == 'Linux') {
+    fs.accessSync(os.tmpdir(), fs.R_OK | fs.W_OK);
+    const tmpDir = path.join(os.tmpdir(),
+      `node-${process.version}-test-${1e6 * Math.random() | 0}`);
+    fs.mkdirSync(tmpDir);
+    testRequireLongPath(tmpDir);
+    fs.rmdirSync(tmpDir);
+  } else {
+    throw e;
+  }
+}
 
-const indexFile = path.join(fullDirPath, 'index.js');
-const otherFile = path.join(fullDirPath, 'other.js');
+function testRequireLongPath(tmpDir) {
 
-common.refreshTmpDir();
+  // make a path that is more than 260 chars long.
+  const dirNameLen = Math.max(260 - tmpDir.length, 1);
+  const dirName = path.join(tmpDir, 'x'.repeat(dirNameLen));
+  const fullDirPath = path.resolve(dirName);
 
-fs.mkdirSync(fullDirPath);
-fs.writeFileSync(indexFile, 'require("./other");');
-fs.writeFileSync(otherFile, '');
+  const indexFile = path.join(fullDirPath, 'index.js');
+  const otherFile = path.join(fullDirPath, 'other.js');
 
-require(indexFile);
-require(otherFile);
+  fs.mkdirSync(fullDirPath);
+  fs.writeFileSync(indexFile, 'require("./other");');
+  fs.writeFileSync(otherFile, '');
 
-common.refreshTmpDir();
+  require(indexFile);
+  require(otherFile);
+
+  fs.unlinkSync(indexFile);
+  fs.unlinkSync(otherFile);
+  fs.rmdirSync(fullDirPath);
+
+}


### PR DESCRIPTION
In test-fs-long-path.js and test-require-long-path.js:
Use os.tmpdir() on Linux if it is readable/writable
but only when the original tests fail
to avoid failing tests on ecryptfs filesystems
See issue #2255 and comments to PR #3925
Change vars to const per advice to PR #3929