### PR TITLE
doc: move deprecation message

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -364,10 +364,10 @@ non-existent.
 
 ## fs.existsSync(path)
 
+    Stability: 0 - Deprecated: Use [fs.statSync][] or [fs.accessSync][] instead.
+
 Synchronous version of [`fs.exists`][].
 Returns `true` if the file exists, `false` otherwise.
-
-    Stability: 0 - Deprecated: Use [fs.statSync][] or [fs.accessSync][] instead.
 
 ## fs.fchmod(fd, mode, callback)
 


### PR DESCRIPTION
Move deprecation message for fs.existsSync above the function
description making message placement uniform across the documentation.