### PR TITLE
net: small code cleanup

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1079,7 +1079,6 @@ function Server(options, connectionListener) {
   EventEmitter.call(this);
 
   var self = this;
-  var options;
 
   if (typeof options === 'function') {
     connectionListener = options;


### PR DESCRIPTION
`options` is already a param of the function.