### PR TITLE
doc: fix misaligned columns on Firefox/Linux

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -356,7 +356,7 @@ span.type {
 
 #column1.interior {
   width: 702px;
-  border-left: 13em solid #f2f5f0;
+  border-left: 234px solid #f2f5f0;
   padding-left: 2.0em;
 }
 


### PR DESCRIPTION
`13em` and `234px` are equivalent here. By using the same unit as is used to specify the [width of the TOC](https://github.com/nodejs/node/blob/8b97249893390d144630382f17a98fe0f804a492/doc/api_assets/style.css#L364), we can work around a presumed Firefox layout bug, see https://github.com/nodejs/help/issues/32.