### PR TITLE
util: faster arrayToHash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,9 @@ bench-url: all
 bench-events: all
 	@$(NODE) benchmark/common.js events
 
+bench-util: all
+	@$(NODE) benchmark/common.js util
+
 bench-all: bench bench-misc bench-array bench-buffer bench-url bench-events
 
 bench: bench-net bench-http bench-fs bench-tls

--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -1,0 +1,15 @@
+var util = require('util');
+
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {n: [5e6]});
+
+function main(conf) {
+  var n = conf.n | 0;
+
+  bench.start();
+  for (var i = 0; i < n; i += 1) {
+    var r = util.inspect({a: 'a', b: 'b', c: 'c', d: 'd'});
+  }
+  bench.end(n);
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -161,9 +161,10 @@ function stylizeNoColor(str, styleType) {
 function arrayToHash(array) {
   var hash = Object.create(null);
 
-  array.forEach(function(val) {
+  for (var i = 0; i < array.length; i++) {
+    var val = array[i];
     hash[val] = true;
-  });
+  }
 
   return hash;
 }


### PR DESCRIPTION
The `util.format()` is used frequently, make the method faster
is better.