### PR TITLE
build: backport config for new CI infrastructure to v0.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ NINJA ?= ninja
 DESTDIR ?=
 SIGN ?=
 FLAKY_TESTS ?= run
+STAGINGSERVER ?= node-www
 
+OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
+
+# Flags for packaging.
 NODE ?= ./node
 
 # Default to verbose builds.
@@ -206,9 +210,45 @@ run-ci:
 
 RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)
 VERSION=v$(RAWVER)
+
+# For nightly builds, you must set DISTTYPE to "nightly", "next-nightly" or
+# "custom". For the nightly and next-nightly case, you need to set DATESTRING
+# and COMMIT in order to properly name the build.
+# For the rc case you need to set CUSTOMTAG to an appropriate CUSTOMTAG number
+
+ifndef DISTTYPE
+DISTTYPE=release
+endif
+ifeq ($(DISTTYPE),release)
+FULLVERSION=$(VERSION)
+else # ifeq ($(DISTTYPE),release)
+ifeq ($(DISTTYPE),custom)
+ifndef CUSTOMTAG
+$(error CUSTOMTAG is not set for DISTTYPE=custom)
+endif # ifndef CUSTOMTAG
+TAG=$(CUSTOMTAG)
+else # ifeq ($(DISTTYPE),custom)
+ifndef DATESTRING
+$(error DATESTRING is not set for nightly)
+endif # ifndef DATESTRING
+ifndef COMMIT
+$(error COMMIT is not set for nightly)
+endif # ifndef COMMIT
+ifneq ($(DISTTYPE),nightly)
+ifneq ($(DISTTYPE),next-nightly)
+$(error DISTTYPE is not release, custom, nightly or next-nightly)
+endif # ifneq ($(DISTTYPE),next-nightly)
+endif # ifneq ($(DISTTYPE),nightly)
+TAG=$(DISTTYPE)$(DATESTRING)$(COMMIT)
+endif # ifeq ($(DISTTYPE),custom)
+FULLVERSION=$(VERSION)-$(TAG)
+endif # ifeq ($(DISTTYPE),release)
+
+DISTTYPEDIR ?= $(DISTTYPE)
+RELEASE=$(shell sed -ne 's/\#define NODE_VERSION_IS_RELEASE \([01]\)/\1/p' src/node_version.h)
 NODE_DOC_VERSION=$(VERSION)
-RELEASE=$(shell $(PYTHON) tools/getnodeisrelease.py)
-PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
+NPMVERSION=v$(shell cat deps/npm/package.json | grep '"version"' | sed 's/^[^:]*: "\([^"]*\)",.*/\1/')
+
 ifeq ($(findstring x86_64,$(shell uname -m)),x86_64)
 DESTCPU ?= x64
 else
@@ -223,31 +263,28 @@ else
 ARCH=x86
 endif
 endif
-TARNAME=node-$(VERSION)
-ifdef NIGHTLY
-TAG = nightly-$(NIGHTLY)
-TARNAME=node-$(VERSION)-$(TAG)
+
+# enforce "x86" over "ia32" as the generally accepted way of referring to 32-bit intel
+ifeq ($(ARCH),ia32)
+override ARCH=x86
 endif
-TARBALL=$(TARNAME).tar.gz
-BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)
-BINARYTAR=$(BINARYNAME).tar.gz
-PKG=out/$(TARNAME).pkg
+ifeq ($(DESTCPU),ia32)
+override DESTCPU=x86
+endif
+
+TARNAME=node-$(FULLVERSION)
+TARBALL=$(TARNAME).tar
+BINARYNAME=$(TARNAME)-$(OSTYPE)-$(ARCH)
+BINARYTAR=$(BINARYNAME).tar
+PKG=$(TARNAME).pkg
 PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker
-
-PKGSRC=nodejs-$(DESTCPU)-$(RAWVER).tgz
-ifdef NIGHTLY
-PKGSRC=nodejs-$(DESTCPU)-$(RAWVER)-$(TAG).tgz
-endif
-
-dist: doc $(TARBALL) $(PKG)
-
 PKGDIR=out/dist-osx
 
 release-only:
 	@if [ "$(shell git status --porcelain | egrep -v '^\?\? ')" = "" ]; then \
 		exit 0 ; \
 	else \
-	  echo "" >&2 ; \
+		echo "" >&2 ; \
 		echo "The git repository is not clean." >&2 ; \
 		echo "Please commit changes before building release tarball." >&2 ; \
 		echo "" >&2 ; \
@@ -255,27 +292,33 @@ release-only:
 		echo "" >&2 ; \
 		exit 1 ; \
 	fi
-	@if [ "$(NIGHTLY)" != "" -o "$(RELEASE)" = "1" ]; then \
+	@if [ "$(DISTTYPE)" != "release" -o "$(RELEASE)" = "1" ]; then \
 		exit 0; \
 	else \
-	  echo "" >&2 ; \
+		echo "" >&2 ; \
 		echo "#NODE_VERSION_IS_RELEASE is set to $(RELEASE)." >&2 ; \
-	  echo "Did you remember to update src/node_version.cc?" >&2 ; \
-	  echo "" >&2 ; \
+		echo "Did you remember to update src/node_version.h?" >&2 ; \
+		echo "" >&2 ; \
 		exit 1 ; \
 	fi
-
-pkg: $(PKG)
 
 $(PKG): release-only
 	rm -rf $(PKGDIR)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --without-snapshot --dest-cpu=ia32 --tag=$(TAG)
+	$(PYTHON) ./configure \
+		--dest-cpu=ia32 \
+		--tag=$(TAG) \
+		--without-snapshot \
+		$(CONFIG_FLAGS)
 	$(MAKE) install V=$(V) DESTDIR=$(PKGDIR)/32
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --without-snapshot --dest-cpu=x64 --tag=$(TAG)
+	$(PYTHON) ./configure \
+		--dest-cpu=x64 \
+		--tag=$(TAG) \
+		--without-snapshot \
+		$(CONFIG_FLAGS)
 	$(MAKE) install V=$(V) DESTDIR=$(PKGDIR)
-	SIGN="$(APP_SIGN)" PKGDIR="$(PKGDIR)" bash tools/osx-codesign.sh
+	SIGN="$(CODESIGN_CERT)" PKGDIR="$(PKGDIR)" bash tools/osx-codesign.sh
 	lipo $(PKGDIR)/32/usr/local/bin/node \
 		$(PKGDIR)/usr/local/bin/node \
 		-output $(PKGDIR)/usr/local/bin/node-universal \
@@ -286,7 +329,15 @@ $(PKG): release-only
 		--id "org.nodejs.Node" \
 		--doc tools/osx-pkg.pmdoc \
 		--out $(PKG)
-	SIGN="$(INT_SIGN)" PKG="$(PKG)" bash tools/osx-productsign.sh
+	SIGN="$(PRODUCTSIGN_CERT)" PKG="$(PKG)" bash tools/osx-productsign.sh
+
+pkg: $(PKG)
+
+pkg-upload: pkg
+	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"
+	chmod 664 node-$(FULLVERSION).pkg
+	scp -p node-$(FULLVERSION).pkg $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION).pkg
+	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION).pkg.done"
 
 $(TARBALL): release-only node doc
 	git archive --format=tar --prefix=$(TARNAME)/ HEAD | tar xf -
@@ -302,6 +353,39 @@ $(TARBALL): release-only node doc
 
 tar: $(TARBALL)
 
+tar-upload: tar
+	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"
+	chmod 664 node-$(FULLVERSION).tar.gz
+	scp -p node-$(FULLVERSION).tar.gz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION).tar.gz
+	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION).tar.gz.done"
+
+doc-upload: tar
+	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"
+	chmod -R ug=rw-x+X,o=r+X out/doc/
+	scp -pr out/doc/ $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs/
+	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs.done"
+
+$(TARBALL)-headers: config.gypi release-only
+	$(PYTHON) ./configure \
+		--prefix=/ \
+		--dest-cpu=$(DESTCPU) \
+		--tag=$(TAG) \
+		$(CONFIG_FLAGS)
+	HEADERS_ONLY=1 $(PYTHON) tools/install.py install '$(TARNAME)' '/'
+	find $(TARNAME)/ -type l | xargs rm # annoying on windows
+	tar -cf $(TARNAME)-headers.tar $(TARNAME)
+	rm -rf $(TARNAME)
+	gzip -c -f -9 $(TARNAME)-headers.tar > $(TARNAME)-headers.tar.gz
+	rm $(TARNAME)-headers.tar
+
+tar-headers: $(TARBALL)-headers
+
+tar-headers-upload: tar-headers
+	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"
+	chmod 664 $(TARNAME)-headers.tar.gz
+	scp -p $(TARNAME)-headers.tar.gz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.tar.gz
+	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.tar.gz.done"
+
 $(BINARYTAR): release-only
 	rm -rf $(BINARYNAME)
 	rm -rf out/deps out/Release
@@ -316,6 +400,35 @@ $(BINARYTAR): release-only
 
 binary: $(BINARYTAR)
 
+binary-upload-arch: binary
+	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"
+	chmod 664 node-$(FULLVERSION)-$(OSTYPE)-$(ARCH).tar.gz
+	scp -p node-$(FULLVERSION)-$(OSTYPE)-$(ARCH).tar.gz $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION)-$(OSTYPE)-$(ARCH).tar.gz
+	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION)-$(OSTYPE)-$(ARCH).tar.gz.done"
+
+ifeq ($(OSTYPE),darwin)
+binary-upload:
+	$(MAKE) binary-upload-arch \
+		DESTCPU=ia32 \
+		ARCH=x86 \
+		DISTTYPE=$(DISTTYPE) \
+		DATESTRING=$(DATESTRING) \
+		COMMIT=$(COMMIT) \
+		CUSTOMTAG=$(CUSTOMTAG) \
+		CONFIG_FLAGS=$(CONFIG_FLAGS)
+	$(MAKE) binary-upload-arch \
+		DESTCPU=x64 \
+		ARCH=x64 \
+		DISTTYPE=$(DISTTYPE) \
+		DATESTRING=$(DATESTRING) \
+		COMMIT=$(COMMIT) \
+		CUSTOMTAG=$(CUSTOMTAG) \
+		CONFIG_FLAGS=$(CONFIG_FLAGS)
+else
+binary-upload: binary-upload-arch
+endif
+
+
 $(PKGSRC): release-only
 	rm -rf dist out
 	$(PYTHON) configure --prefix=/ --without-snapshot \
@@ -328,11 +441,6 @@ $(PKGSRC): release-only
 		-f packlist -I /opt/local -p dist -U $(PKGSRC)
 
 pkgsrc: $(PKGSRC)
-
-dist-upload: $(TARBALL) $(PKG)
-	ssh node@nodejs.org mkdir -p web/nodejs.org/dist/$(VERSION)
-	scp $(TARBALL) node@nodejs.org:~/web/nodejs.org/dist/$(VERSION)/$(TARBALL)
-	scp $(PKG) node@nodejs.org:~/web/nodejs.org/dist/$(VERSION)/$(TARNAME).pkg
 
 wrkclean:
 	$(MAKE) -C tools/wrk/ clean

--- a/README.md
+++ b/README.md
@@ -1,74 +1,306 @@
-Evented I/O for V8 javascript. [![Build Status](https://secure.travis-ci.org/joyent/node.png)](http://travis-ci.org/joyent/node)
-===
+Node.js
+=======
 
-### To build:
+[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/nodejs/node?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Prerequisites (Unix only):
+The Node.js project is supported by the
+[Node.js Foundation](https://nodejs.org/en/foundation/). Contributions,
+policies and releases are managed under an
+[open governance model](./GOVERNANCE.md). We are also bound by a
+[Code of Conduct](./CODE_OF_CONDUCT.md).
 
-    * GCC 4.2 or newer
-    * Python 2.6 or 2.7
-    * GNU Make 3.81 or newer
-    * libexecinfo (FreeBSD and OpenBSD only)
+If you need help using or installing Node.js, please use the
+[nodejs/help](https://github.com/nodejs/help) issue tracker.
 
-Unix/Macintosh:
+## Release Types
 
-    ./configure
-    make
-    make install
+The Node.js project maintains multiple types of releases:
 
-If your python binary is in a non-standard location or has a
+* **Stable**: Released from active development branches of this repository,
+  versioned by [SemVer](http://semver.org/) and signed by a member of the
+  [Release Team](#release-team).
+  Code for Stable releases is organized in this repository by major version
+  number, For example: [v4.x](https://github.com/nodejs/node/tree/v4.x).
+  The major version number of Stable releases will increment every 6 months
+  allowing for breaking changes to be introduced. This happens in April and
+  October every year. Stable release lines beginning in October each year have
+  a maximum support life of 8 months. Stable release lines beginning in April
+  each year will convert to LTS (see below) after 6 months and receive further
+  support for 30 months.
+* **LTS**: Releases that receive Long-term Support, with a focus on stability
+  and security. Every second Stable release line (major version) will become an
+  LTS line and receive 18 months of _Active LTS_ support and a further 12
+  months of _Maintenance_. LTS release lines are given alphabetically
+  ordered codenames, begining with v4 Argon. LTS releases are less frequent
+  and will attempt to maintain consistent major and minor version numbers,
+  only incrementing patch version numbers. There are no breaking changes or
+  feature additions, except in some special circumstances. More information
+  can be found in the [LTS README](https://github.com/nodejs/LTS/).
+* **Nightly**: Versions of code in this repository on the current Stable
+  branch, automatically built every 24-hours where changes exist. Use with
+  caution.
+
+## Download
+
+Binaries, installers, and source tarballs are available at
+<https://nodejs.org>.
+
+**Stable** and **LTS** releases are available at
+<https://nodejs.org/download/release/>, listed under their version strings.
+The [latest](https://nodejs.org/download/release/latest/) directory is an
+alias for the latest Stable release. The latest LTS release from an LTS
+line is available in the form: latest-lts-_codename_. For example:
+<https://nodejs.org/download/release/latest-lts-argon>
+
+**Nightly** builds are available at
+<https://nodejs.org/download/nightly/>, listed under their version
+string which includes their date (in UTC time) and the commit SHA at
+the HEAD of the release.
+
+**API documentation** is available in each release and nightly
+directory under _docs_. <https://nodejs.org/api/> points to the API
+documentation of the latest stable version.
+
+### Verifying Binaries
+
+Stable, LTS and Nightly download directories all contain a *SHASUM256.txt*
+file that lists the SHA checksums for each file available for
+download. To check that a downloaded file matches the checksum, run
+it through `sha256sum` with a command such as:
+
+```
+$ grep node-vx.y.z.tar.gz SHASUMS256.txt | sha256sum -c -
+```
+
+_(Where "node-vx.y.z.tar.gz" is the name of the file you have
+downloaded)_
+
+Additionally, Stable and LTS releases (not Nightlies) have GPG signed
+copies of SHASUM256.txt files available as SHASUM256.txt.asc. You can use
+`gpg` to verify that the file has not been tampered with.
+
+To verify a SHASUM256.txt.asc, you will first need to import all of
+the GPG keys of individuals authorized to create releases. They are
+listed at the bottom of this README under [Release Team](#release-team).
+Use a command such as this to import the keys:
+
+```
+$ gpg --keyserver pool.sks-keyservers.net \
+  --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
+```
+
+_(See the bottom of this README for a full script to import active
+release keys)_
+
+You can then use `gpg --verify SHASUMS256.txt.asc` to verify that the
+file has been signed by an authorized member of the Node.js team.
+
+Once verified, use the SHASUMS256.txt.asc file to get the checksum for
+the binary verification command above.
+
+## Build
+
+### Unix / Macintosh
+
+Prerequisites:
+
+* GCC 4.2 or newer
+* G++ 4.2 or newer
+* Python 2.6 or 2.7
+* GNU Make 3.81 or newer
+* libexecinfo (FreeBSD and OpenBSD only)
+
+```text
+$ ./configure
+$ make
+$ [sudo] make install
+```
+
+If your Python binary is in a non-standard location or has a
 non-standard name, run the following instead:
 
-    export PYTHON=/path/to/python
-    $PYTHON ./configure
-    make
-    make install
+```text
+$ export PYTHON=/path/to/python
+$ $PYTHON ./configure
+$ make
+$ [sudo] make install
+```
 
-Windows:
+To run the tests:
 
-    vcbuild.bat
+```text
+$ make test
+```
 
-You can download pre-built binaries for various operating systems from
-[http://nodejs.org/download/](http://nodejs.org/download/).  The Windows
-and OS X installers will prompt you for the location to install to.
-The tarballs are self-contained; you can extract them to a local directory
-with:
+To build the documentation:
 
-    tar xzf /path/to/node-<version>-<platform>-<arch>.tar.gz
+```text
+$ make doc
+```
 
-Or system-wide with:
+To read the documentation:
 
-    cd /usr/local && tar --strip-components 1 -xzf \
-                         /path/to/node-<version>-<platform>-<arch>.tar.gz
+```text
+$ man doc/node.1
+```
 
-### To run the tests:
+To test if Node.js was built correctly:
 
-Unix/Macintosh:
+```
+$ node -e "console.log('Hello from node.js ' + process.version)"
+```
 
-    make test
+### Windows
 
-Windows:
+Prerequisites:
 
-    vcbuild.bat test
+* [Python 2.6 or 2.7](https://www.python.org/downloads/)
+* Visual Studio 2010 or 2012; or
+* Visual Studio 2013 for Windows Desktop; or
+* Visual Studio Express 2013 for Windows Desktop
+* Basic Unix tools required for some tests,
+  [Git for Windows](http://git-scm.com/download/win) includes Git Bash
+  and tools which can be included in the global `PATH`.
 
-### To build the documentation:
+```text
+> vcbuild nosign
+```
 
-    make doc
+To run the tests:
 
-### To read the documentation:
+```text
+> vcbuild test
+```
 
-    man doc/node.1
+To test if Node.js was built correctly:
 
-Resources for Newcomers
----
-  - [The Wiki](https://github.com/joyent/node/wiki)
-  - [nodejs.org](http://nodejs.org/)
-  - [how to install node.js and npm (node package manager)](http://www.joyent.com/blog/installing-node-and-npm/)
-  - [list of modules](https://github.com/joyent/node/wiki/modules)
-  - [searching the npm registry](http://npmjs.org/)
-  - [list of companies and projects using node](https://github.com/joyent/node/wiki/Projects,-Applications,-and-Companies-Using-Node)
-  - [node.js mailing list](http://groups.google.com/group/nodejs)
-  - irc chatroom, [#node.js on freenode.net](http://webchat.freenode.net?channels=node.js&uio=d4)
-  - [community](https://github.com/joyent/node/wiki/Community)
-  - [contributing](https://github.com/joyent/node/wiki/Contributing)
-  - [big list of all the helpful wiki pages](https://github.com/joyent/node/wiki/_pages)
+```
+$ node -e "console.log('Hello from node.js ' + process.version)"
+```
+
+### Android / Android based devices, aka. Firefox OS
+
+Be sure you have downloaded and extracted [Android NDK]
+(https://developer.android.com/tools/sdk/ndk/index.html)
+before in a folder. Then run:
+
+```
+$ ./android-configure /path/to/your/android-ndk
+$ make
+```
+
+## Resources for Newcomers
+
+* [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+* [CONTRIBUTING.md](./CONTRIBUTING.md)
+* [GOVERNANCE.md](./GOVERNANCE.md)
+* IRC:
+  [#io.js on Freenode.net](http://webchat.freenode.net?channels=io.js&uio=d4)
+* [nodejs/node on Gitter](https://gitter.im/nodejs/node)
+
+## Security
+
+All security bugs in node.js are taken seriously and should be reported by
+emailing security@nodejs.org. This will be delivered to a subset of the project
+team who handle security issues. Please don't disclose security bugs
+public until they have been handled by the security team.
+
+Your email will be acknowledged within 24 hours, and you’ll receive a more
+detailed response to your email within 48 hours indicating the next steps in
+handling your report.
+
+## Current Project Team Members
+
+The Node.js project team comprises a group of core collaborators and a sub-group
+that forms the _Technical Steering Committee_ (TSC) which governs the project. For more
+information about the governance of the Node.js project, see
+[GOVERNANCE.md](./GOVERNANCE.md).
+
+### TSC (Technical Steering Committee)
+
+* [bnoordhuis](https://github.com/bnoordhuis) - **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
+* [chrisdickinson](https://github.com/chrisdickinson) - **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt;
+* [cjihrig](https://github.com/cjihrig) - **Colin Ihrig** &lt;cjihrig@gmail.com&gt;
+* [fishrock123](https://github.com/fishrock123) - **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
+* [indutny](https://github.com/indutny) - **Fedor Indutny** &lt;fedor.indutny@gmail.com&gt;
+* [jasnell](https://github.com/jasnell) - **James M Snell** &lt;jasnell@gmail.com&gt;
+* [misterdjules](https://github.com/misterdjules) - **Julien Gilli** &lt;jgilli@nodejs.org&gt;
+* [mscdex](https://github.com/mscdex) - **Brian White** &lt;mscdex@mscdex.net&gt;
+* [orangemocha](https://github.com/orangemocha) - **Alexis Campailla** &lt;orangemocha@nodejs.org&gt;
+* [piscisaureus](https://github.com/piscisaureus) - **Bert Belder** &lt;bertbelder@gmail.com&gt;
+* [rvagg](https://github.com/rvagg) - **Rod Vagg** &lt;rod@vagg.org&gt;
+* [shigeki](https://github.com/shigeki) - **Shigeki Ohtsu** &lt;ohtsu@iij.ad.jp&gt;
+* [trevnorris](https://github.com/trevnorris) - **Trevor Norris** &lt;trev.norris@gmail.com&gt;
+
+### Collaborators
+
+* [brendanashworth](https://github.com/brendanashworth) - **Brendan Ashworth** &lt;brendan.ashworth@me.com&gt;
+* [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt;
+* [domenic](https://github.com/domenic) - **Domenic Denicola** &lt;d@domenic.me&gt;
+* [evanlucas](https://github.com/evanlucas) - **Evan Lucas** &lt;evanlucas@me.com&gt;
+* [geek](https://github.com/geek) - **Wyatt Preul** &lt;wpreul@gmail.com&gt;
+* [isaacs](https://github.com/isaacs) - **Isaac Z. Schlueter** &lt;i@izs.me&gt;
+* [jbergstroem](https://github.com/jbergstroem) - **Johan Bergström** &lt;bugs@bergstroem.nu&gt;
+* [joaocgreis](https://github.com/joaocgreis) - **João Reis** &lt;reis@janeasystems.com&gt;
+* [julianduque](https://github.com/julianduque) - **Julian Duque** &lt;julianduquej@gmail.com&gt;
+* [lxe](https://github.com/lxe) - **Aleksey Smolenchuk** &lt;lxe@lxe.co&gt;
+* [mhdawson](https://github.com/mhdawson) - **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt;
+* [micnic](https://github.com/micnic) - **Nicu Micleușanu** &lt;micnic90@gmail.com&gt;
+* [mikeal](https://github.com/mikeal) - **Mikeal Rogers** &lt;mikeal.rogers@gmail.com&gt;
+* [monsanto](https://github.com/monsanto) - **Christopher Monsanto** &lt;chris@monsan.to&gt;
+* [ofrobots](https://github.com/ofrobots) - **Ali Ijaz Sheikh** &lt;ofrobots@google.com&gt;
+* [Olegas](https://github.com/Olegas) - **Oleg Elifantiev** &lt;oleg@elifantiev.ru&gt;
+* [petkaantonov](https://github.com/petkaantonov) - **Petka Antonov** &lt;petka_antonov@hotmail.com&gt;
+* [qard](https://github.com/qard) - **Stephen Belanger** &lt;admin@stephenbelanger.com&gt;
+* [rlidwka](https://github.com/rlidwka) - **Alex Kocharin** &lt;alex@kocharin.ru&gt;
+* [robertkowalski](https://github.com/robertkowalski) - **Robert Kowalski** &lt;rok@kowalski.gd&gt;
+* [romankl](https://github.com/romankl) - **Roman Klauke** &lt;romaaan.git@gmail.com&gt;
+* [saghul](https://github.com/saghul) - **Saúl Ibarra Corretgé** &lt;saghul@gmail.com&gt;
+* [sam-github](https://github.com/sam-github) - **Sam Roberts** &lt;vieuxtech@gmail.com&gt;
+* [seishun](https://github.com/seishun) - **Nikolai Vavilov** &lt;vvnicholas@gmail.com&gt;
+* [silverwind](https://github.com/silverwind) - **Roman Reiss** &lt;me@silverwind.io&gt;
+* [srl295](https://github.com/srl295) - **Steven R Loomis** &lt;srloomis@us.ibm.com&gt;
+* [targos](https://github.com/targos) - **Michaël Zasso** &lt;mic.besace@gmail.com&gt;
+* [tellnes](https://github.com/tellnes) - **Christian Tellnes** &lt;christian@tellnes.no&gt;
+* [thealphanerd](http://github.com/thealphanerd) - **Myles Borins** &lt;myles.borins@gmail.com&gt;
+* [thefourtheye](https://github.com/thefourtheye) - **Sakthipriyan Vairamani** &lt;thechargingvolcano@gmail.com&gt;
+* [thlorenz](https://github.com/thlorenz) - **Thorsten Lorenz** &lt;thlorenz@gmx.de&gt;
+* [Trott](https://github.com/Trott) - **Rich Trott** &lt;rtrott@gmail.com&gt;
+* [tunniclm](https://github.com/tunniclm) - **Mike Tunnicliffe** &lt;m.j.tunnicliffe@gmail.com&gt;
+* [vkurchatkin](https://github.com/vkurchatkin) - **Vladimir Kurchatkin** &lt;vladimir.kurchatkin@gmail.com&gt;
+* [yosuke-furukawa](https://github.com/yosuke-furukawa) - **Yosuke Furukawa** &lt;yosuke.furukawa@gmail.com&gt;
+
+Collaborators & TSC members follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
+maintaining the Node.js project.
+
+### Release Team
+
+Releases of Node.js and io.js will be signed with one of the following GPG keys:
+
+* **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt; `9554F04D7259F04124DE6B476D5A82AC7E37093B`
+* **Colin Ihrig** &lt;cjihrig@gmail.com&gt; `94AE36675C464D64BAFA68DD7434390BDBE9B9C5`
+* **Sam Roberts** &lt;octetcloud@keybase.io&gt; `0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93`
+* **Jeremiah Senkpiel** &lt;fishrock@keybase.io&gt; `FD3A5288F042B6850C66B31F09FE44734EB7990E`
+* **James M Snell** &lt;jasnell@keybase.io&gt; `71DCFD284A79C3B38668286BC97EC7A07EDE3FC1`
+* **Rod Vagg** &lt;rod@vagg.org&gt; `DD8F2338BAE7501E3DD5AC78C273792F7D83545D`
+
+The full set of trusted release keys can be imported by running:
+
+```
+gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B
+gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
+gpg --keyserver pool.sks-keyservers.net --recv-keys 0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93
+gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E
+gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1
+gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
+```
+
+See the section above on [Verifying Binaries](#verifying-binaries) for
+details on what to do with these keys to verify that a downloaded file is official.
+
+Previous releases of Node.js have been signed with one of the following GPG
+keys:
+
+* Julien Gilli &lt;jgilli@fastmail.fm&gt; `114F43EE0176B71C7BC219DD50A3051F888C628D`
+* Timothy J Fontaine &lt;tjfontaine@gmail.com&gt; `7937DFD2AB06298B2293C3187D33FF9D0246406D`
+* Isaac Z. Schlueter &lt;i@izs.me&gt; `93C7E9E91B49E432C2F75674B0A78B0A6C481CF6`

--- a/configure
+++ b/configure
@@ -478,6 +478,10 @@ def configure_node(o):
 
   host_arch = host_arch_win() if os.name == 'nt' else host_arch_cc()
   target_arch = options.dest_cpu or host_arch
+  # ia32 is preferred by the build tools (GYP) over x86 even if we prefer the latter
+  # the Makefile resets this to x86 afterward
+  if target_arch == 'x86':
+    target_arch = 'ia32'
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
 
@@ -664,7 +668,6 @@ def configure_winsdk(o):
     return
 
   print "ctrpp not found in WinSDK path--using pre-gen files from tools/msvs/genfiles."
-
 
 # determine the "flavor" (operating system) we're building for,
 # leveraging gyp's GetFlavor function

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -28,25 +28,31 @@
 
 #define NODE_VERSION_IS_RELEASE 0
 
-#ifndef NODE_TAG
-# define NODE_TAG ""
-#endif
-
 #ifndef NODE_STRINGIFY
 #define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)
 #define NODE_STRINGIFY_HELPER(n) #n
 #endif
 
-#if NODE_VERSION_IS_RELEASE
+#ifndef NODE_TAG
+# if NODE_VERSION_IS_RELEASE
+#  define NODE_TAG ""
+# else
+#  define NODE_TAG "-pre"
+# endif
+#else
+// NODE_TAG is passed without quotes when rc.exe is run from msbuild
+# define NODE_EXE_VERSION NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
+                          NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
+                          NODE_STRINGIFY(NODE_PATCH_VERSION)     \
+                          NODE_STRINGIFY(NODE_TAG)
+#endif
+
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_PATCH_VERSION)     \
                               NODE_TAG
-#else
-# define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_PATCH_VERSION)     \
-                              NODE_TAG "-pre"
+#ifndef NODE_EXE_VERSION
+# define NODE_EXE_VERSION NODE_VERSION_STRING
 #endif
 
 #define NODE_VERSION "v" NODE_VERSION_STRING

--- a/src/res/node.rc
+++ b/src/res/node.rc
@@ -53,8 +53,8 @@ BEGIN
             VALUE "CompanyName", "Joyent, Inc"
             VALUE "ProductName", "Node.js"
             VALUE "FileDescription", "Evented I/O for V8 JavaScript"
-            VALUE "FileVersion", NODE_VERSION_STRING
-            VALUE "ProductVersion", NODE_VERSION_STRING
+            VALUE "FileVersion", NODE_EXE_VERSION
+            VALUE "ProductVersion", NODE_EXE_VERSION
             VALUE "OriginalFilename", "node.exe"
             VALUE "InternalName", "node"
             VALUE "LegalCopyright", "Copyright Joyent, Inc. and other Node contributors. MIT license."

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -6,7 +6,7 @@
     <ProductVersion>3.5</ProductVersion>
     <ProjectGuid>{1d808ff0-b5a9-4be9-859d-b334b6f48be2}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>node-v$(NodeVersion)-$(Platform)</OutputName>
+    <OutputName>node-v$(FullVersion)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
@@ -14,25 +14,25 @@
     <NodeVersion Condition=" '$(NodeVersion)' == '' ">0.0.0.0</NodeVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
     <Cultures>en-US</Cultures>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -4,7 +4,7 @@
 
   <?define ProductName = "Node.js" ?>
   <?define ProductDescription = "Node.js" ?>
-  <?define ProductAuthor = "Joyent, Inc. and other Node contributors" ?>
+  <?define ProductAuthor = "Node.js Foundation" ?>
 
   <?define RegistryKeyPath = "SOFTWARE\Node.js" ?>
 
@@ -23,7 +23,7 @@
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
     <MajorUpgrade AllowSameVersionUpgrades="yes"
-                  DowngradeErrorMessage="A later version of node.js is already installed. Setup will now exit."/>
+                  DowngradeErrorMessage="A later version of Node.js is already installed. Setup will now exit."/>
 
     <Icon Id="NodeIcon" SourceFile="$(var.RepoDir)\src\res\node.ico"/>
     <Property Id="ARPPRODUCTICON" Value="NodeIcon"/>

--- a/tools/osx-codesign.sh
+++ b/tools/osx-codesign.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-if ! [ -n "$SIGN" ] && [ $STEP -eq 1 ]; then
+if [ "X$SIGN" == "X" ]; then
   echo "No SIGN environment var.  Skipping codesign." >&2
   exit 0
 fi

--- a/tools/osx-productsign.sh
+++ b/tools/osx-productsign.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-if ! [ -n "$SIGN" ]; then
+if [ "X$SIGN" == "X" ]; then
   echo "No SIGN environment var.  Skipping codesign." >&2
   exit 0
 fi

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+# To promote and sign a release that has been prepared by the build slaves, use:
+#  release.sh
+
+# To _only_ sign an existing release, use:
+#  release.sh -s vx.y.z
+
+set -e
+
+webhost=direct.nodejs.org
+webuser=dist
+promotablecmd=dist-promotable
+promotecmd=dist-promote
+signcmd=dist-sign
+
+
+################################################################################
+## Select a GPG key to use
+
+echo "# Selecting GPG key ..."
+
+gpgkey=$(gpg --list-secret-keys | grep '^sec' | awk -F'( +|/)' '{print $3}')
+keycount=$(echo $gpgkey | wc -w)
+
+if [ $keycount -eq 0 ]; then
+  echo 'Need at least one GPG key, please make one with `gpg --gen-key`'
+  echo 'You will also need to submit your key to a public keyserver, e.g.'
+  echo '  https://sks-keyservers.net/i/#submit'
+  exit 1
+elif [ $keycount -ne 1 ]; then
+  echo -e 'You have multiple GPG keys:\n'
+
+  gpg --list-secret-keys
+
+  while true; do
+    echo $gpgkey | awk '{ for(i = 1; i <= NF; i++) { print i ") " $i; } }'
+    echo -n 'Select a key: '
+    read keynum
+
+    if $(test "$keynum" -eq "$keynum" > /dev/null 2>&1); then
+      _gpgkey=$(echo $gpgkey | awk '{ print $'${keynum}'}')
+      keycount=$(echo $_gpgkey | wc -w)
+      if [ $keycount -eq 1 ]; then
+        echo ""
+        gpgkey=$_gpgkey
+        break
+      fi
+    fi
+  done
+fi
+
+gpgfing=$(gpg --fingerprint $gpgkey | grep 'Key fingerprint =' | awk -F' = ' '{print $2}' | tr -d ' ')
+
+if ! test "$(grep $gpgfing README.md)"; then
+  echo 'Error: this GPG key fingerprint is not listed in ./README.md'
+  exit 1
+fi
+
+echo "Using GPG key: $gpgkey"
+echo "  Fingerprint: $gpgfing"
+
+
+################################################################################
+## Create and sign checksums file for a given version
+
+function sign {
+  echo -e "\n# Creating SHASUMS256.txt ..."
+
+  local version=$1
+
+  gpgtagkey=$(git tag -v $version 2>&1 | grep 'key ID' | awk '{print $NF}')
+
+  if [ "X${gpgtagkey}" == "X" ]; then
+    echo "Could not find signed tag for \"${version}\""
+    exit 1
+  fi
+
+  if [ "${gpgtagkey}" != "${gpgkey}" ]; then
+    echo "GPG key for \"${version}\" tag is not yours, cannot sign"
+  fi
+
+  shapath=$(ssh ${webuser}@${webhost} $signcmd nodejs $version)
+
+  if ! [[ ${shapath} =~ ^/.+/SHASUMS256.txt$ ]]; then
+    echo 'Error: No SHASUMS file returned by sign!'
+    exit 1
+  fi
+
+  echo -e "\n# Signing SHASUMS for ${version}..."
+
+  shadir=$(dirname $shapath)
+  tmpdir="/tmp/_node_release.$$"
+
+  mkdir -p $tmpdir
+
+  scp ${webuser}@${webhost}:${shadir}/SHASUMS*.txt ${tmpdir}/
+
+  for i in $(ls ${tmpdir}/SHASUMS*.txt); do
+    echo "Signing $i..."
+    gpg --default-key $gpgkey --clearsign ${i}
+    if [[ $version =~ ^v[0] ]]; then
+      echo "Encrpting $i..."
+      gpg --default-key $gpgkey -s ${i}
+    fi
+  done
+
+  echo "Wrote to ${tmpdir}/"
+
+  echo -e "Your signed SHASUMS256.txt.asc:\n"
+
+  cat ${tmpdir}/SHASUMS256.txt.asc
+
+  echo ""
+
+  while true; do
+    echo -n "Upload files? [y/n] "
+    yorn=""
+    read yorn
+
+    if [ "X${yorn}" == "Xn" ]; then
+      break
+    fi
+
+    if [ "X${yorn}" == "Xy" ]; then
+      if [[ $version =~ ^v[0] ]]; then
+        scp ${tmpdir}/SHASUMS* ${webuser}@${webhost}:${shadir}/
+      else
+        scp ${tmpdir}/SHASUMS256.txt ${tmpdir}/SHASUMS256.txt.asc ${webuser}@${webhost}:${shadir}/
+      fi
+      break
+    fi
+  done
+
+  rm -rf $tmpdir
+}
+
+
+if [ "X${1}" == "X-s" ]; then
+  if [ "X${2}" == "X" ]; then
+    echo "Please supply a version string to sign"
+    exit 1
+  fi
+
+  sign $2
+  exit 0
+fi
+
+
+# else: do a normal release & promote
+
+################################################################################
+## Look for releases to promote
+
+echo -e "\n# Checking for releases ..."
+
+promotable=$(ssh ${webuser}@${webhost} $promotablecmd nodejs)
+
+if [ "X${promotable}" == "X" ]; then
+  echo "No releases to promote!"
+  exit 0
+fi
+
+echo -e "Found the following releases / builds ready to promote:\n"
+echo "$promotable" | sed 's/^/ * /'
+echo ""
+
+versions=$(echo "$promotable" | cut -d: -f1)
+
+################################################################################
+## Promote releases
+
+for version in $versions; do
+  while true; do
+    files=$(echo "$promotable" | grep "^${version}" | sed 's/^'${version}': //')
+    echo -n "Promote ${version} files (${files})? [y/n] "
+    yorn=""
+    read yorn
+
+    if [ "X${yorn}" == "Xn" ]; then
+      break
+    fi
+
+    if [ "X${yorn}" != "Xy" ]; then
+      continue
+    fi
+
+    echo -e "\n# Promoting ${version}..."
+
+    ssh ${webuser}@${webhost} $promotecmd nodejs $version
+
+    sign $version
+
+    break
+  done
+done

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -13,11 +13,8 @@ if /i "%1"=="/?" goto help
 
 @rem Process arguments.
 set config=Release
-set msiplatform=x86
 set target=Build
-set target_arch=ia32
-set debug_arg=
-set nosnapshot_arg=
+set target_arch=x86
 set noprojgen=
 set nobuild=
 set nosign=
@@ -30,20 +27,19 @@ set upload=
 set jslint=
 set buildnodeweak=
 set noetw=
-set noetw_arg=
 set noetw_msi_arg=
 set noperfctr=
-set noperfctr_arg=
 set noperfctr_msi_arg=
 set flaky_tests_arg=
+set configure_flags=
 
 :next-arg
 if "%1"=="" goto args-done
 if /i "%1"=="debug"         set config=Debug&goto arg-ok
 if /i "%1"=="release"       set config=Release&goto arg-ok
 if /i "%1"=="clean"         set target=Clean&goto arg-ok
-if /i "%1"=="ia32"          set target_arch=ia32&goto arg-ok
-if /i "%1"=="x86"           set target_arch=ia32&goto arg-ok
+if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
+if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
@@ -75,13 +71,17 @@ shift
 goto next-arg
 
 :args-done
-if defined upload goto upload
 
-if "%config%"=="Debug" set debug_arg=--debug
-if "%target_arch%"=="x64" set msiplatform=x64
-if defined nosnapshot set nosnapshot_arg=--without-snapshot
-if defined noetw set noetw_arg=--without-etw& set noetw_msi_arg=/p:NoETW=1
-if defined noperfctr set noperfctr_arg=--without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
+if "%config%"=="Debug" set configure_flags=%configure_flags% --debug
+if defined nosnapshot set configure_flags=%configure_flags% --without-snapshot
+if defined noetw set configure_flags=%configure_flags% --without-etw& set noetw_msi_arg=/p:NoETW=1
+if defined noperfctr set configure_flags=%configure_flags% --without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
+
+if defined config_flags set configure_flags=%configure_flags% %config_flags%
+
+call :getnodeversion || exit /b 1
+
+@rem Set environment for msbuild
 
 @rem Look for Visual Studio 2015
 echo Looking for Visual Studio 2015
@@ -176,7 +176,8 @@ if defined noprojgen goto msbuild
 if defined NIGHTLY set TAG=nightly-%NIGHTLY%
 
 @rem Generate the VS project.
-python configure %debug_arg% %nosnapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
+echo configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
+python configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -193,7 +194,7 @@ if errorlevel 1 goto exit
 @rem Skip signing if the `nosign` option was specified.
 if defined nosign goto licensertf
 
-signtool sign /a /d "Node.js" /t http://timestamp.globalsign.com/scripts/timestamp.dll Release\node.exe
+signtool sign /a /d "node" /t http://timestamp.globalsign.com/scripts/timestamp.dll Release\node.exe
 if errorlevel 1 echo Failed to sign exe&goto exit
 
 :licensertf
@@ -206,19 +207,41 @@ if errorlevel 1 echo Failed to generate license.rtf&goto exit
 :msi
 @rem Skip msi generation if not requested
 if not defined msi goto run
-call :getnodeversion
-
-if not defined NIGHTLY goto msibuild
-set NODE_VERSION=%NODE_VERSION%.%NIGHTLY%
 
 :msibuild
-echo Building node-%NODE_VERSION%
-msbuild "%~dp0tools\msvs\msi\nodemsi.sln" /m /t:Clean,Build /p:PlatformToolset=%PLATFORM_TOOLSET% /p:GypMsvsVersion=%GYP_MSVS_VERSION% /p:Configuration=%config% /p:Platform=%msiplatform% /p:NodeVersion=%NODE_VERSION% %noetw_msi_arg% %noperfctr_msi_arg% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
+echo Building node-v%FULLVERSION%-%target_arch%.msi
+msbuild "%~dp0tools\msvs\msi\nodemsi.sln" /m /t:Clean,Build /p:PlatformToolset=%PLATFORM_TOOLSET% /p:GypMsvsVersion=%GYP_MSVS_VERSION% /p:Configuration=%config% /p:Platform=%target_arch% /p:NodeVersion=%NODE_VERSION% /p:FullVersion=%FULLVERSION% /p:DistTypeDir=%DISTTYPEDIR% %noetw_msi_arg% %noperfctr_msi_arg% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 
-if defined nosign goto run
-signtool sign /a /d "Node.js" /t http://timestamp.globalsign.com/scripts/timestamp.dll Release\node-v%NODE_VERSION%-%msiplatform%.msi
+if defined nosign goto upload
+signtool sign /a /d "node" /t http://timestamp.globalsign.com/scripts/timestamp.dll node-v%FULLVERSION%-%target_arch%.msi
 if errorlevel 1 echo Failed to sign msi&goto exit
+
+:upload
+@rem Skip upload if not requested
+if not defined upload goto run
+if not defined SSHCONFIG (
+  echo SSHCONFIG is not set for upload
+  exit /b 1
+)
+if not defined STAGINGSERVER set STAGINGSERVER=node-www
+if "%target_arch%"=="x64" set staging_dir=nodejs/%DISTTYPEDIR%/v%FULLVERSION%/x64
+if "%target_arch%"=="x86" set staging_dir=nodejs/%DISTTYPEDIR%/v%FULLVERSION%/
+echo Uploading to %STAGINGSERVER%:%staging_dir%
+ssh -F %SSHCONFIG% %STAGINGSERVER% "mkdir -p %staging_dir%"
+scp -F %SSHCONFIG% Release\node.exe %STAGINGSERVER%:%staging_dir%/node.exe
+scp -F %SSHCONFIG% Release\node.lib %STAGINGSERVER%:%staging_dir%/node.lib
+scp -F %SSHCONFIG% Release\node.pdb %STAGINGSERVER%:%staging_dir%/node.pdb
+scp -F %SSHCONFIG% Release\node.exp %STAGINGSERVER%:%staging_dir%/node.exp
+scp -F %SSHCONFIG% Release\openssl-cli.exe %STAGINGSERVER%:%staging_dir%/openssl-cli.exe
+scp -F %SSHCONFIG% Release\openssl-cli.pdb %STAGINGSERVER%:%staging_dir%/openssl-cli.pdb
+scp -F %SSHCONFIG% node-v%FULLVERSION%-%target_arch%.msi %STAGINGSERVER%:%staging_dir%/
+if "%target_arch%"=="x64" (
+  ssh -F %SSHCONFIG% %STAGINGSERVER% "touch %staging_dir%.done && chmod -R ug=rw-x+X,o=r+X %staging_dir%*"
+)
+if "%target_arch%"=="x86" (
+  ssh -F %SSHCONFIG% %STAGINGSERVER% "touch %staging_dir%/node-v%FULLVERSION%-%target_arch%.msi.done %staging_dir%/node.exe.done %staging_dir%/node.lib.done %staging_dir%/node.pdb.done %staging_dir%/node.exp.done %staging_dir%/openssl-cli.exe.done %staging_dir%/openssl-cli.pdb.done && chmod -R ug=rw-x+X,o=r+X %staging_dir%/node.* %staging_dir%/openssl-cli.* %staging_dir%/node-v%FULLVERSION%-%target_arch%.msi* && chmod -R ug=rw-x+X,o=r+X %staging_dir%"
+)
 
 :run
 @rem Run tests if requested.
@@ -258,17 +281,6 @@ goto jslint
 echo Failed to create vc project files. 
 goto exit
 
-:upload
-echo uploading .exe .msi .pdb to nodejs.org
-call :getnodeversion
-@echo on
-ssh node@nodejs.org mkdir -p web/nodejs.org/dist/v%NODE_VERSION%
-scp Release\node.msi node@nodejs.org:~/web/nodejs.org/dist/v%NODE_VERSION%/node-v%NODE_VERSION%.msi
-scp Release\node.exe node@nodejs.org:~/web/nodejs.org/dist/v%NODE_VERSION%/node.exe
-scp Release\node.pdb node@nodejs.org:~/web/nodejs.org/dist/v%NODE_VERSION%/node.pdb
-@echo off
-goto exit
-
 :jslint
 if not defined jslint goto exit
 echo running jslint
@@ -295,6 +307,46 @@ rem ***************
 
 :getnodeversion
 set NODE_VERSION=
+set TAG=
+set FULLVERSION=
+
 for /F "usebackq tokens=*" %%i in (`python "%~dp0tools\getnodeversion.py"`) do set NODE_VERSION=%%i
-if not defined NODE_VERSION echo Cannot determine current version of node.js & exit /b 1
+if not defined NODE_VERSION (
+  echo Cannot determine current version of Node.js
+  exit /b 1
+)
+
+if not defined DISTTYPE set DISTTYPE=release
+if "%DISTTYPE%"=="release" (
+  set FULLVERSION=%NODE_VERSION%
+  goto exit
+)
+if "%DISTTYPE%"=="custom" (
+  if not defined CUSTOMTAG (
+    echo "CUSTOMTAG is not set for DISTTYPE=custom"
+    exit /b 1
+  )
+  set TAG=%CUSTOMTAG%
+)
+if not "%DISTTYPE%"=="custom" (
+  if not defined DATESTRING (
+    echo "DATESTRING is not set for nightly"
+    exit /b 1
+  )
+  if not defined COMMIT (
+    echo "COMMIT is not set for nightly"
+    exit /b 1
+  )
+  if not "%DISTTYPE%"=="nightly" (
+    if not "%DISTTYPE%"=="next-nightly" (
+      echo "DISTTYPE is not release, custom, nightly or next-nightly"
+      exit /b 1
+    )
+  )
+  set TAG=%DISTTYPE%%DATESTRING%%COMMIT%
+)
+set FULLVERSION=%NODE_VERSION%-%TAG%
+
+:exit
+if not defined DISTTYPEDIR set DISTTYPEDIR=%DISTTYPE%
 goto :EOF


### PR DESCRIPTION
Same as https://github.com/nodejs/node/pull/3642 but for v0.10. Almost the same code but ICU is not here so that all had to be ripped out. I also had to remove the `--download*` stuff from Jenkins when the Node version is `^0\.10`.

Test build is here: https://nodejs.org/download/nightly/v0.10.41-nightly20151122fe730a2943/

I believe this is ready for a review. In line with my comments in #3642, I think that any of the LICENSE or README stuff that already exists in `master` should be changed there first and backported to these branches rather than these older branches diverging.

I'll push a v0.10.41-rc.1 soon, would appreciate if I could get some +1's from tests of the binaries at the above URL though.