### PR TITLE
test: fix tls-multi-key race condition

### DIFF
--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -35,8 +35,8 @@ var server = tls.createServer(options, function(conn) {
       rejectUnauthorized: false
     }, function() {
       ciphers.push(rsa.getCipher());
-      ecdsa.destroy();
-      rsa.destroy();
+      ecdsa.end();
+      rsa.end();
       server.close();
     });
   });


### PR DESCRIPTION
In some conditions it can happen that the client-side socket is destroyed
before the server-side socket has gracefully closed, thus causing a
'ECONNRESET' error in this socket. To solve this, wait in the client-side
socket for the 'end' event before closing it.

It tries to fix the following error I've observed a couple of times running the tests:
```
Path: parallel/test-tls-multi-key
events.js:142
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at exports._errnoException (util.js:873:11)
    at TLSWrap.onread (net.js:545:26)
Command: out/Release/node /Users/sgimeno/node/node/test/parallel/test-tls-multi-key.js
```
I've been able to reproduce it by increasing the data sent in the socket to around `10000` bytes