### PR TITLE
test: address flaky test-http-client-timeout-event

### DIFF
--- a/test/parallel/test-http-client-timeout-event.js
+++ b/test/parallel/test-http-client-timeout-event.js
@@ -33,8 +33,8 @@ server.listen(options.port, options.host, function() {
   setTimeout(function() {
     req.destroy();
     assert.equal(timeout_events, 1);
-  }, 100);
+  }, common.platformTimeout(100));
   setTimeout(function() {
     req.end();
-  }, 50);
+  }, common.platformTimeout(50));
 });


### PR DESCRIPTION
Use common.platformTimeout() to make test more reliable on Raspberry Pi.

Fixes: https://github.com/nodejs/node/issues/2555