### PR TITLE
test: remove flaky status for cluster test

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -10,7 +10,6 @@ prefix parallel
 test-tls-ticket-cluster           : PASS,FLAKY
 
 [$system==linux]
-test-cluster-worker-forced-exit   : PASS,FLAKY
 test-http-client-timeout-event    : PASS,FLAKY
 test-child-process-buffering      : PASS,FLAKY
 test-child-process-exit-code      : PASS,FLAKY


### PR DESCRIPTION
The test did not fail after 9999 runs in continuous integration. https://ci.nodejs.org/job/node-stress-single-test/28/nodes=armv7-wheezy/console

Remove it's flaky status.

Fixes: https://github.com/nodejs/node/issues/2557