### PR TITLE
test: fix time resolution constrain

### DIFF
--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -23,7 +23,7 @@ function check_mtime(resource, mtime) {
   var real_mtime = fs._toUnixTimestamp(stats.mtime);
   // check up to single-second precision
   // sub-second precision is OS and fs dependant
-  return Math.floor(mtime) == Math.floor(real_mtime);
+  return mtime - real_mtime < 2;
 }
 
 function expect_errno(syscall, resource, err, errno) {


### PR DESCRIPTION
The test case in one of its tests, is trying to change the modification time of a file, and validate that the modification applied (through stat call) is indeed same as what was requested, at an accuracy level of seconds. The output indicates that this validation fails a few times when checked for 10000 times back-to-back.

utime manual says "The utime() system call allows specification of timestamps with a resolution of 1 second." My interpretation of this is that one should expect a deviation of at most one second for the actual modification time, from the requested time. This is reflected in the output of failed cases as well, as every pairs have exactly a difference of one.

However, the test case seems to assume that the actual and request time should match at the seconds level. Excepts from test case:

  // check up to single-second precision
  // sub-second precision is OS and fs dependant
  return Math.floor(mtime) == Math.floor(real_mtime);

While this works for small workloads (less file system activities), when the stress on fs APIs increases (for example, if I increase the depth level of runTest callbacks) then the failure rate increases, and starts affecting Linux as well. The small test case above is in fact a stressed version of the original test case.

with the proposed change, the test passes consistently.
