### PR TITLE
tools: add preinstall script for npm on OS X

### DIFF
--- a/tools/osx-pkg-preinstall.sh
+++ b/tools/osx-pkg-preinstall.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# TODO Can this be done inside the .pmdoc?
+# TODO Can we extract $PREFIX from the installer?
+
+set -e
+
+rm -rf /usr/local/lib/node_modules/npm

--- a/tools/osx-pkg.pmdoc/02npm.xml
+++ b/tools/osx-pkg.pmdoc/02npm.xml
@@ -19,6 +19,7 @@
     <mod>installTo.isAbsoluteType</mod>
   </config>
   <scripts>
+    <preinstall relative="true" mod="true">osx-pkg-preinstall.sh</preinstall>
     <postinstall relative="true" mod="true">osx-pkg-postinstall.sh</postinstall>
   </scripts>
 </pkgref>


### PR DESCRIPTION
Make sure we cleanly remove npm before installing on OS X

Related: https://github.com/nodejs/node/issues/3606

This is working for me locally, but would be great to have some others test. 