### PR TITLE
http: optimize OutgoingMessage._renderHeaders()

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -395,17 +395,16 @@ OutgoingMessage.prototype._renderHeaders = function() {
     throw new Error('Can\'t render headers after they are sent to the client');
   }
 
-  var headersMap = this._headers;
+  const headersMap = this._headers;
   if (!headersMap) return {};
 
-  var headers = {};
-  var keys = Object.keys(headersMap);
-  var headerNames = this._headerNames;
+  const headers = {};
+  const headerNames = this._headerNames;
 
-  for (var i = 0, l = keys.length; i < l; i++) {
-    var key = keys[i];
+  for (var key in headersMap) {
     headers[headerNames[key]] = headersMap[key];
   }
+
   return headers;
 };
 


### PR DESCRIPTION
Iterating object property names directly rather than Object.keys() is ~3x faster.

See http://jsperf.com/renderheaders
