### PR TITLE
test: mark cluster-net-send test flaky on windows

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,8 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-tls-ticket-cluster           : PASS,FLAKY
+test-cluster-net-send                : PASS,FLAKY
+test-tls-ticket-cluster              : PASS,FLAKY
 
 [$system==linux]
 test-cluster-worker-forced-exit   : PASS,FLAKY


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/3957 for details and examples
failures.

Ref: https://github.com/nodejs/node/issues/3957