### PR TITLE
test: fix cluster-disconnect-handles flakiness

### DIFF
--- a/test/parallel/test-cluster-disconnect-handles.js
+++ b/test/parallel/test-cluster-disconnect-handles.js
@@ -33,6 +33,7 @@ if (cluster.isMaster) {
   worker.on('message', common.mustCall(message => {
     assert.strictEqual(Array.isArray(message), true);
     assert.strictEqual(message[0], 'listening');
+    let continueRecv = false;
     const address = message[1];
     const host = address.address;
     const debugClient = net.connect({ host, port: common.PORT });
@@ -41,13 +42,26 @@ if (cluster.isMaster) {
     debugClient.on('data', data => protocol.execute(data));
     debugClient.once('connect', common.mustCall(() => {
       protocol.onResponse = common.mustCall(res => {
-        protocol.onResponse = () => {};
+        protocol.onResponse = (res) => {
+          // It can happen that the first continue was sent before the break
+          // event was received. If that's the case, send also a continue from
+          // here so the worker exits
+          if (res.body.command === 'continue') {
+            continueRecv = true;
+          } else if ((res.body.event === 'break') && continueRecv) {
+            const req = protocol.serialize({ command: 'continue' });
+            debugClient.write(req);
+          }
+        };
+
         const conn = net.connect({ host, port: address.port });
         conn.once('connect', common.mustCall(() => {
           conn.destroy();
           assert.notDeepStrictEqual(handles, {});
           worker.disconnect();
           assert.deepStrictEqual(handles, {});
+          // Always send the continue, as the break event might have already
+          // been received
           const req = protocol.serialize({ command: 'continue' });
           debugClient.write(req);
         }));


### PR DESCRIPTION
Sometimes the test was timing out because the worker process remained stuck in
the breakpoint and didn't exit. This could happen because the continue was sent
before the breakpoint was set. If that's the case, with this change, a new
continue command is sent so the worker process can end.

It fixes for me the following error I was receiving in a `Jessie 64bit` box:
```
Path: parallel/test-cluster-disconnect-handles
Debugger listening on port 12446
Command: out/Release/node --expose_internals /home/sgimeno/node/node/test/parallel/test-cluster-disconnect-handles.js
--- TIMEOUT ---
```