### PR TITLE
buffer: Default to UTF8 in JS rather than C++

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -272,6 +272,7 @@ function byteLength(string, encoding) {
 
       case 'utf8':
       case 'utf-8':
+      case undefined:
         return binding.byteLengthUtf8(string);
 
       case 'ucs2':


### PR DESCRIPTION
This will cause a minor speedup as previously with
undefined values we would always cast to a string and
then proceed to call .toLowerCase()

![screenshot from 2015-11-24 22-37-39](https://cloud.githubusercontent.com/assets/524382/11382824/13825b20-92fc-11e5-8a96-1edc1b8cb217.png)
![screenshot from 2015-11-24 22-38-04](https://cloud.githubusercontent.com/assets/524382/11382827/175b0fda-92fc-11e5-91ca-bf954b7ad71a.png)

First flame-graph is before, second is after; calls to ToLowerCase() are highlighted in purple.

Tests seems to pass, but wanted to make sure that this is a safe change.