### PR TITLE
repl: attach location info to syntax errors

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -274,6 +274,7 @@ function REPLServer(prompt,
   self._domain.on('error', function(e) {
     debug('domain error');
     const top = replMap.get(self);
+    util.decorateErrorStack(e);
     top.outputStream.write((e.stack || e) + '\n');
     top.lineParser.reset();
     top.bufferedCommand = '';

--- a/lib/util.js
+++ b/lib/util.js
@@ -899,3 +899,14 @@ exports._exceptionWithHostPort = function(err,
   }
   return ex;
 };
+
+
+exports.decorateErrorStack = function(err) {
+  if (!(isError(err) && err.stack))
+    return;
+
+  const arrow = internalUtil.getHiddenValue(err, 'arrowMessage');
+
+  if (arrow)
+    err.stack = arrow + err.stack;
+};

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const repl = require('repl');
+const util = require('util');
+let found = false;
+
+process.on('exit', () => {
+  assert.strictEqual(found, true);
+});
+
+// A stream to push an array into a REPL
+function ArrayStream() {
+  this.run = function(data) {
+    data.forEach(line => {
+      this.emit('data', line + '\n');
+    });
+  };
+}
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function() {};
+ArrayStream.prototype.write = function(output) {
+  if (/var foo bar;/.test(output))
+    found = true;
+};
+
+const putIn = new ArrayStream();
+const testMe = repl.start('', putIn);
+let file = path.resolve(__dirname, '../fixtures/syntax/bad_syntax');
+
+if (common.isWindows)
+  file = file.replace(/\\/g, '\\\\');
+
+putIn.run(['.clear']);
+putIn.run([`require('${file}');`]);

--- a/test/parallel/test-util-decorate-error-stack.js
+++ b/test/parallel/test-util-decorate-error-stack.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const util = require('util');
+
+assert.doesNotThrow(function() {
+  util.decorateErrorStack();
+  util.decorateErrorStack(null);
+  util.decorateErrorStack(1);
+  util.decorateErrorStack(true);
+});
+
+// Verify that a stack property is not added to non-Errors
+const obj = {};
+util.decorateErrorStack(obj);
+assert.strictEqual(obj.stack, undefined);
+
+// Verify that the stack is decorated when possible
+let err;
+
+try {
+  require('../fixtures/syntax/bad_syntax');
+} catch (e) {
+  err = e;
+  assert(!/var foo bar;/.test(err.stack));
+  util.decorateErrorStack(err);
+}
+
+assert(/var foo bar;/.test(err.stack));
+
+// Verify that the stack is unchanged when there is no arrow message
+err = new Error('foo');
+const originalStack = err.stack;
+util.decorateErrorStack(err);
+assert.strictEqual(originalStack, err.stack);


### PR DESCRIPTION
Currently, when a file with a syntax error is imported in the REPL, no information is provided on the error's location. This commit adds the error's location to the stack trace.

Refs #3784