### PR TITLE
test: mark test flaky on FreeBSD

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -19,3 +19,4 @@ test-child-process-exit-code      : PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
+test-net-socket-local-address     : PASS,FLAKY


### PR DESCRIPTION
Mark test-net-socket-local-address flaky on FreeBSD. It times out with
some frequency on CI.

Ref: https://github.com/nodejs/node/issues/2475