### PR TITLE
buffer: fix range checking for slowToString

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -327,13 +327,34 @@ Object.defineProperty(Buffer.prototype, 'offset', {
 function slowToString(encoding, start, end) {
   var loweredCase = false;
 
-  start = start >>> 0;
-  end = end === undefined || end === Infinity ? this.length : end >>> 0;
+  // No need to verify that "this.length <= MAX_UINT32" since it's a read-only
+  // property of a typed array.
+
+  // This behaves neither like String nor Uint8Array in that we set start/end
+  // to their upper/lower bounds if the value passed is out of range.
+  // undefined is handled specially as per ECMA-262 6th Edition,
+  // Section 13.3.3.7 Runtime Semantics: KeyedBindingInitialization.
+  if (start === undefined || start < 0)
+    start = 0;
+  // Return early if start > this.length. Done here to prevent potential uint32
+  // coercion fail below.
+  if (start > this.length)
+    return '';
+
+  if (end === undefined || end > this.length)
+    end = this.length;
+
+  if (end <= 0)
+    return '';
+
+  // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
+  end >>>= 0;
+  start >>>= 0;
+
+  if (end <= start)
+    return '';
 
   if (!encoding) encoding = 'utf8';
-  if (start < 0) start = 0;
-  if (end > this.length) end = this.length;
-  if (end <= start) return '';
 
   while (true) {
     switch (encoding) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -172,7 +172,7 @@ inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
     return true;
   }
 
-  int32_t tmp_i = arg->Int32Value();
+  int32_t tmp_i = arg->Uint32Value();
 
   if (tmp_i < 0)
     return false;

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -248,14 +248,83 @@ b.copy(new Buffer(1), 1, 1, 1);
 // try to copy 0 bytes from past the end of the source buffer
 b.copy(new Buffer(1), 0, 2048, 2048);
 
-// try to toString() a 0-length slice of a buffer, both within and without the
-// valid buffer range
-assert.equal(new Buffer('abc').toString('ascii', 0, 0), '');
-assert.equal(new Buffer('abc').toString('ascii', -100, -100), '');
-assert.equal(new Buffer('abc').toString('ascii', 100, 100), '');
+const rangeBuffer = new Buffer('abc');
+
+// if start >= buffer's length, empty string will be returned
+assert.equal(rangeBuffer.toString('ascii', 3), '');
+assert.equal(rangeBuffer.toString('ascii', +Infinity), '');
+assert.equal(rangeBuffer.toString('ascii', 3.14, 3), '');
+assert.equal(rangeBuffer.toString('ascii', 'Infinity', 3), '');
+
+// if end <= 0, empty string will be returned
+assert.equal(rangeBuffer.toString('ascii', 1, 0), '');
+assert.equal(rangeBuffer.toString('ascii', 1, -1.2), '');
+assert.equal(rangeBuffer.toString('ascii', 1, -100), '');
+assert.equal(rangeBuffer.toString('ascii', 1, -Infinity), '');
+
+// if start < 0, start will be taken as zero
+assert.equal(rangeBuffer.toString('ascii', -1, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', -1.99, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', -Infinity, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '-1', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '-1.99', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
+
+// if start is an invalid integer, start will be taken as zero
+assert.equal(rangeBuffer.toString('ascii', 'node.js', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', {}, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', [], 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', NaN, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', null, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', undefined, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', false, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '', 3), 'abc');
+
+// but, if start is an integer when coerced, then it will be coerced and used.
+assert.equal(rangeBuffer.toString('ascii', '-1', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '1', 3), 'bc');
+assert.equal(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '3', 3), '');
+assert.equal(rangeBuffer.toString('ascii', Number(3), 3), '');
+assert.equal(rangeBuffer.toString('ascii', '3.14', 3), '');
+assert.equal(rangeBuffer.toString('ascii', '1.99', 3), 'bc');
+assert.equal(rangeBuffer.toString('ascii', '-1.99', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 1.99, 3), 'bc');
+assert.equal(rangeBuffer.toString('ascii', true, 3), 'bc');
+
+// if end > buffer's length, end will be taken as buffer's length
+assert.equal(rangeBuffer.toString('ascii', 0, 5), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, 6.99), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, Infinity), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '5'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '6.99'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, 'Infinity'), 'abc');
+
+// if end is an invalid integer, end will be taken as buffer's length
+assert.equal(rangeBuffer.toString('ascii', 0, 'node.js'), '');
+assert.equal(rangeBuffer.toString('ascii', 0, {}), '');
+assert.equal(rangeBuffer.toString('ascii', 0, NaN), '');
+assert.equal(rangeBuffer.toString('ascii', 0, undefined), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, null), '');
+assert.equal(rangeBuffer.toString('ascii', 0, []), '');
+assert.equal(rangeBuffer.toString('ascii', 0, false), '');
+assert.equal(rangeBuffer.toString('ascii', 0, ''), '');
+
+// but, if end is an integer when coerced, then it will be coerced and used.
+assert.equal(rangeBuffer.toString('ascii', 0, '-1'), '');
+assert.equal(rangeBuffer.toString('ascii', 0, '1'), 'a');
+assert.equal(rangeBuffer.toString('ascii', 0, '-Infinity'), '');
+assert.equal(rangeBuffer.toString('ascii', 0, '3'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, Number(3)), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '3.14'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '1.99'), 'a');
+assert.equal(rangeBuffer.toString('ascii', 0, '-1.99'), '');
+assert.equal(rangeBuffer.toString('ascii', 0, 1.99), 'a');
+assert.equal(rangeBuffer.toString('ascii', 0, true), 'a');
 
 // try toString() with a object as a encoding
-assert.equal(new Buffer('abc').toString({toString: function() {
+assert.equal(rangeBuffer.toString({toString: function() {
   return 'ascii';
 }}), 'abc');
 


### PR DESCRIPTION
If `start` is not a valid number in the range, then the default value
zero will be used. Same way, if `end` is not a valid number in the
accepted range, then, by default, the length of the buffer is assumed.

Ref: https://github.com/nodejs/node/issues/2668

PR-URL: https://github.com/nodejs/node/pull/2919