### PR TITLE
dns: pass err to callback instead of throwing

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -230,7 +230,8 @@ function resolver(bindingName) {
     req.hostname = name;
     req.oncomplete = onresolve;
     var err = binding(req, name);
-    if (err) throw errnoException(err, bindingName);
+    if (err)
+      return callback(errnoException(err, bindingName));
     callback.immediately = true;
     return req;
   };

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -90,6 +90,11 @@ assert.doesNotThrow(function() {
   dns.lookup(NaN, noop);
 });
 
+// Make sure that dns.reverse does not throw if ip is invalid
+assert.doesNotThrow(function() {
+  dns.reverse('foo', noop)
+});
+
 /*
  * Make sure that dns.lookup throws if hints does not represent a valid flag.
  * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:


### PR DESCRIPTION
Previously, if invalid input is passed to dns methods like dns.reverse,
an error would be thrown. This change instead passes the error to the
callback.

Fixes: https://github.com/nodejs/node/issues/3882
Fixes: https://github.com/nodejs/node/issues/3112

I wanted to mainly open this for discussion. I know @ChALkeR has a strong opinion on not changing this behavior, and that is fine with me, but this issue has come up more than once now. If we are not going to change this behavior, then we should at least update the documentation to state that invalid input will throw on the functions affected.

I will open an alternative PR that simply updates the documentation.