### PR TITLE
crypto: fix native module compilation with FIPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ ipch/
 
 /config.mk
 /config.gypi
+/config_fips.gypi
 *-nodegyp*
 /gyp-mac-tool
 /dist-osx

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean:
 
 distclean:
 	-rm -rf out
-	-rm -f config.gypi icu_config.gypi
+	-rm -f config.gypi icu_config.gypi config_fips.gypi
 	-rm -f config.mk
 	-rm -rf $(NODE_EXE) $(NODE_G_EXE)
 	-rm -rf node_modules

--- a/configure
+++ b/configure
@@ -787,7 +787,7 @@ def configure_openssl(o):
     o['variables']['openssl_fips'] = options.openssl_fips
     fips_dir = os.path.join(root_dir, 'deps', 'openssl', 'fips')
     fips_ld = os.path.abspath(os.path.join(fips_dir, 'fipsld'))
-    o['make_global_settings'] = [
+    o['make_fips_settings'] = [
       ['LINK', fips_ld + ' <(openssl_fips)/bin/fipsld'],
     ]
   else:
@@ -1108,6 +1108,15 @@ configure_fullystatic(output)
 # move everything else to target_defaults
 variables = output['variables']
 del output['variables']
+
+# make_global_settings for special FIPS linking
+# should not be used to compile modules in node-gyp
+config_fips = { 'make_global_settings' : [] } 
+if 'make_fips_settings' in output:
+  config_fips['make_global_settings'] = output['make_fips_settings']
+  del output['make_fips_settings']
+  write('config_fips.gypi', do_not_edit +
+        pprint.pformat(config_fips, indent=2) + '\n')
 
 # make_global_settings should be a root level element too
 if 'make_global_settings' in output:

--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -30,16 +30,21 @@ if __name__ == '__main__':
     args.append(os.path.join(node_root, 'node.gyp'))
     common_fn  = os.path.join(node_root, 'common.gypi')
     options_fn = os.path.join(node_root, 'config.gypi')
+    options_fips_fn = os.path.join(node_root, 'config_fips.gypi')
   else:
     args.append(os.path.join(os.path.abspath(node_root), 'node.gyp'))
     common_fn  = os.path.join(os.path.abspath(node_root), 'common.gypi')
     options_fn = os.path.join(os.path.abspath(node_root), 'config.gypi')
+    options_fips_fn = os.path.join(os.path.abspath(node_root), 'config_fips.gypi')
 
   if os.path.exists(common_fn):
     args.extend(['-I', common_fn])
 
   if os.path.exists(options_fn):
     args.extend(['-I', options_fn])
+
+  if os.path.exists(options_fips_fn):
+    args.extend(['-I', options_fips_fn])
 
   args.append('--depth=' + node_root)
 


### PR DESCRIPTION
When using a FIPS build of Node.js we cannot build and install native npm modules unless the original OpenSSL source is available at the same location where it was present during the Node executable's build. This issue occurs because OpenSSL's FIPS capsule requires linking with a special 'fipsld' utility. When configuring with --openssl-fips a global LD override is used that is then propagated to config.gypi. This file (config.gypi) is encoded into the Node executable itself (see node_natives.h) and is accessible via process.config. Node-gyp then appends all of process.config to each module's configuration (see configure.js).

There are multiple ways to fix this problem, I've opted to simply separate out the special FIPS link flag so it's only used during the Node.js executable's compilation, and not propagated to modules. While it is not strictly 'correct' to exclude the LD flag from process.config, doing so avoids having node-gyp be aware of special FIPS configuration exceptions.

Resolves https://github.com/nodejs/node/issues/3815.