### PR TITLE
test: fix cluster-dgram-2 flakiness

### DIFF
--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -44,9 +44,11 @@ function master() {
     }
   });
 
-  // Fork workers.
-  for (var i = 0; i < NUM_WORKERS; i++)
-    cluster.fork();
+  socket.on('listening', function() {
+    // Fork workers.
+    for (var i = 0; i < NUM_WORKERS; i++)
+      cluster.fork();
+  });
 }
 
 
@@ -55,13 +57,26 @@ function worker() {
   var socket = dgram.createSocket('udp4');
   var buf = new Buffer('hello world');
 
+  // Retry sending on EPERM error. An EPERM error indicates the kernel could
+  // not send the message because of the high transmission rate. In this case,
+  // retry. See:
+  // https://groups.google.com/forum/#!topic/comp.protocols.tcp-ip/Qou9Sfgr77E
+  function doSend(b, init, length, port, host) {
+    socket.send(b, init, b.length, port, host, function(err) {
+      if (err) {
+        assert.equal(err.code, 'EPERM');
+        doSend(b, init, b.length, port, host);
+      }
+    });
+  }
+
   // This test is intended to exercise the cluster binding of udp sockets, but
   // since sockets aren't clustered when implicitly bound by at first call of
   // send(), explicitly bind them to an ephemeral port.
   socket.bind(0);
 
   for (var i = 0; i < PACKETS_PER_WORKER; i++)
-    socket.send(buf, 0, buf.length, common.PORT, '127.0.0.1');
+    doSend(buf, 0, buf.length, common.PORT, '127.0.0.1');
 
   console.log('worker %d sent %d packets', cluster.worker.id,
               PACKETS_PER_WORKER);


### PR DESCRIPTION
Sometimes, in Linux, some of the first messages sent fail with EPERM because
of the high transmission rate, making the test to timeout. If that happens,
retry. In addition, don't start forking until the server is ready.