### PR TITLE
stream_wrap: cast input to Buffer

### DIFF
--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const util = require('util');
 const Socket = require('net').Socket;
 const JSStream = process.binding('js_stream').JSStream;
+const Buffer = require('buffer').Buffer;
 const uv = process.binding('uv');
 const debug = util.debuglog('stream_wrap');
 
@@ -39,15 +40,24 @@ function StreamWrap(stream) {
   };
 
   this.stream.pause();
-  this.stream.on('error', function(err) {
+  this.stream.on('error', function onerror(err) {
     self.emit('error', err);
   });
-  this.stream.on('data', function(chunk) {
+  this.stream.on('data', function ondata(chunk) {
+    if (!(chunk instanceof Buffer)) {
+      // Make sure that no further `data` events will happen
+      this.pause();
+      this.removeListener('data', ondata);
+
+      self.emit('error', new Error('Stream has StringDecoder'));
+      return;
+    }
+
     debug('data', chunk.length);
     if (self._handle)
       self._handle.readBuffer(chunk);
   });
-  this.stream.once('end', function() {
+  this.stream.once('end', function onend() {
     debug('end');
     if (self._handle)
       self._handle.emitEOF();

--- a/test/parallel/test-stream-wrap-encoding.js
+++ b/test/parallel/test-stream-wrap-encoding.js
@@ -5,9 +5,7 @@ const assert = require('assert');
 const StreamWrap = require('_stream_wrap');
 const Duplex = require('stream').Duplex;
 
-var done = false;
-
-var stream = new Duplex({
+const stream = new Duplex({
   read: function() {
   },
   write: function() {
@@ -16,7 +14,7 @@ var stream = new Duplex({
 
 stream.setEncoding('ascii');
 
-var wrap = new StreamWrap(stream);
+const wrap = new StreamWrap(stream);
 
 wrap.on('error', common.mustCall(function(err) {
   assert(/StringDecoder/.test(err.message));

--- a/test/parallel/test-stream-wrap-encoding.js
+++ b/test/parallel/test-stream-wrap-encoding.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const StreamWrap = require('_stream_wrap');
+const Duplex = require('stream').Duplex;
+
+var done = false;
+
+var stream = new Duplex({
+  read: function() {
+  },
+  write: function() {
+  }
+});
+
+stream.setEncoding('ascii');
+
+var wrap = new StreamWrap(stream);
+
+wrap.on('error', common.mustCall(function(err) {
+  assert(/StringDecoder/.test(err.message));
+}));
+
+stream.push('ohai');


### PR DESCRIPTION
When wrapping stream - cast its input data to `Buffer` before using.
Someone may have called `.setEncoding()` on it, and we should not crash
if the input is a string.

Fix: https://github.com/nodejs/node/issues/3970