### PR TITLE
test: share maxBuffer between stdout and stderr

### DIFF
--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -95,4 +95,11 @@ assert.ok(ret.error, 'maxBuffer should error');
 assert.strictEqual(ret.error.errno, 'ENOBUFS');
 // we can have buffers larger than maxBuffer because underneath we alloc 64k
 // that matches our read sizes
-assert.deepEqual(ret.stdout, msgOutBuf);
+
+// While we are writing to stdout first which is expected to
+// overflow the buffer and cause child to return, the actual
+// write order can be reversed based on how uv loop get them.
+// So expect either stdout or stderr to be holding the data
+assert.ok(ret.stdout.toString() === msgOutBuf.toString() ||
+          ret.stderr.toString() === msgErrBuf.toString(),
+          'expected at least one stream to write back.');


### PR DESCRIPTION
The last item in this test case - with maxBuffer set to 1 fails in AIX, with an assertion failure. Root cause is that the chid's stdout file is not populated as expected.

Given that:
a) While spawnSync() API is blocking, the code within the spawned child is still asynchronous.
b) While maxBuffer is the limit of data allowed for child's stdout + stderr together, and if exceeded child process is killed, there is no dictum as to who can consume this up.

It is evident that console.error() got processed first before console.log in the child. While the call was made in order, their descriptors became IO ready in the reverse order.
Consequently, stderr populated its data into the channel buffer, and crossed the maxBuffer (maxBuffer is lazy, overflow check performed post-write), and caused the child termination, short-circuiting stdout's event. Tracing at the readCallback() for the streams (the first interception point behind the uv loop), I clearly see the order reversal.

While this is not happening in Linux or Windows, no documented evidence exists for the order of event rediness in the event loop.

In summary, the test should not assume that the buffer would be consumed first by stdout.