### PR TITLE
net: refactor Server.prototype.listen

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -952,7 +952,7 @@ function SNICallback(servername, callback) {
 //
 //
 function normalizeConnectArgs(listArgs) {
-  var args = net._normalizeConnectArgs(listArgs);
+  var args = net._normalizeArgs(listArgs);
   var options = args[0];
   var cb = args[1];
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1363,9 +1363,11 @@ Server.prototype.listen = function() {
       // with net.connect().
       assertPort(options.port);
       if (options.host)
-        lookupAndListen(this, options.port | 0, options.host, backlog, options.exclusive);
+        lookupAndListen(this, options.port | 0, options.host, backlog,
+                        options.exclusive);
       else
-        listen(this, null, options.port | 0, 4, backlog, undefined, options.exclusive);
+        listen(this, null, options.port | 0, 4, backlog, undefined,
+               options.exclusive);
     } else if (options.path && isPipeName(options.path)) {
       // UNIX socket or Windows pipe.
       const pipeName = this._pipeName = options.path;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1355,8 +1355,7 @@ Server.prototype.listen = function() {
   } else if (typeof options.fd === 'number' && options.fd >= 0) {
     listen(this, null, null, null, backlog, options.fd);
   } else {
-    if (options.backlog)
-      backlog = options.backlog;
+    backlog = options.backlog || backlog;
 
     if (typeof options.port === 'number' || typeof options.port === 'string' ||
         (typeof options.port === 'undefined' && 'port' in options)) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1354,33 +1354,30 @@ Server.prototype.listen = function() {
     // Bind to a random port.
     listen(this, null, 0, null, backlog);
   } else if (arguments[0] !== null && typeof arguments[0] === 'object') {
-    var h = arguments[0];
-    h = h._handle || h.handle || h;
-
-    if (h instanceof TCP) {
-      this._handle = h;
+    if (options instanceof TCP) {
+      this._handle = options;
       listen(this, null, -1, -1, backlog);
-    } else if (typeof h.fd === 'number' && h.fd >= 0) {
-      listen(this, null, null, null, backlog, h.fd);
+    } else if (typeof options.fd === 'number' && options.fd >= 0) {
+      listen(this, null, null, null, backlog, options.fd);
     } else {
       // The first argument is a configuration object
-      if (h.backlog)
-        backlog = h.backlog;
+      if (options.backlog)
+        backlog = options.backlog;
 
-      if (typeof h.port === 'number' || typeof h.port === 'string' ||
-          (typeof h.port === 'undefined' && 'port' in h)) {
+      if (typeof options.port === 'number' || typeof options.port === 'string' ||
+          (typeof options.port === 'undefined' && 'port' in options)) {
         // Undefined is interpreted as zero (random port) for consistency
         // with net.connect().
-        assertPort(h.port);
-        if (h.host)
-          lookupAndListen(this, h.port | 0, h.host, backlog, h.exclusive);
+        assertPort(options.port);
+        if (options.host)
+          lookupAndListen(this, options.port | 0, options.host, backlog, options.exclusive);
         else
-          listen(this, null, h.port | 0, 4, backlog, undefined, h.exclusive);
-      } else if (h.path && isPipeName(h.path)) {
-        const pipeName = this._pipeName = h.path;
-        listen(this, pipeName, -1, -1, backlog, undefined, h.exclusive);
+          listen(this, null, options.port | 0, 4, backlog, undefined, options.exclusive);
+      } else if (options.path && isPipeName(options.path)) {
+        const pipeName = this._pipeName = options.path;
+        listen(this, pipeName, -1, -1, backlog, undefined, options.exclusive);
       } else {
-        throw new Error('Invalid listen argument: ' + h);
+        throw new Error('Invalid listen argument: ' + options);
       }
     }
   } else if (isPipeName(arguments[0])) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -64,7 +64,7 @@ exports.connect = exports.createConnection = function() {
   var args = new Array(argsLen);
   for (var i = 0; i < argsLen; i++)
     args[i] = arguments[i];
-  args = normalizeConnectArgs(args);
+  args = normalizeArgs(args);
   debug('createConnection', args);
   var s = new Socket(args[0]);
   return Socket.prototype.connect.apply(s, args);
@@ -72,7 +72,8 @@ exports.connect = exports.createConnection = function() {
 
 // Returns an array [options] or [options, cb]
 // It is the same as the argument of Socket.prototype.connect().
-function normalizeConnectArgs(args) {
+// This is also used by Server.prototype.listen().
+function normalizeArgs(args) {
   var options = {};
 
   if (args[0] !== null && typeof args[0] === 'object') {
@@ -92,7 +93,7 @@ function normalizeConnectArgs(args) {
   var cb = args[args.length - 1];
   return typeof cb === 'function' ? [options, cb] : [options];
 }
-exports._normalizeConnectArgs = normalizeConnectArgs;
+exports._normalizeArgs = normalizeArgs;
 
 
 // called when creating new Socket, or when re-using a closed Socket
@@ -889,7 +890,7 @@ Socket.prototype.connect = function(options, cb) {
     var args = new Array(argsLen);
     for (var i = 0; i < argsLen; i++)
       args[i] = arguments[i];
-    args = normalizeConnectArgs(args);
+    args = normalizeArgs(args);
     return Socket.prototype.connect.apply(this, args);
   }
 
@@ -1329,7 +1330,7 @@ Server.prototype.listen = function() {
   var args = new Array(arguments.length);
   for (var i = 0; i < arguments.length; i++)
     args[i] = arguments[i];
-  args = normalizeConnectArgs(args);
+  args = normalizeArgs(args);
 
   if (args[1]) {
     this.once('listening', args[1]);

--- a/lib/net.js
+++ b/lib/net.js
@@ -1326,11 +1326,9 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
 
 
 Server.prototype.listen = function() {
-  var self = this;
-
   var lastArg = arguments[arguments.length - 1];
   if (typeof lastArg === 'function') {
-    self.once('listening', lastArg);
+    this.once('listening', lastArg);
   }
 
   var port = toNumber(arguments[0]);
@@ -1341,16 +1339,16 @@ Server.prototype.listen = function() {
 
   if (arguments.length === 0 || typeof arguments[0] === 'function') {
     // Bind to a random port.
-    listen(self, null, 0, null, backlog);
+    listen(this, null, 0, null, backlog);
   } else if (arguments[0] !== null && typeof arguments[0] === 'object') {
     var h = arguments[0];
     h = h._handle || h.handle || h;
 
     if (h instanceof TCP) {
-      self._handle = h;
-      listen(self, null, -1, -1, backlog);
+      this._handle = h;
+      listen(this, null, -1, -1, backlog);
     } else if (typeof h.fd === 'number' && h.fd >= 0) {
-      listen(self, null, null, null, backlog, h.fd);
+      listen(this, null, null, null, backlog, h.fd);
     } else {
       // The first argument is a configuration object
       if (h.backlog)
@@ -1362,47 +1360,47 @@ Server.prototype.listen = function() {
         // with net.connect().
         assertPort(h.port);
         if (h.host)
-          listenAfterLookup(h.port | 0, h.host, backlog, h.exclusive);
+          lookupAndListen(this, h.port | 0, h.host, backlog, h.exclusive);
         else
-          listen(self, null, h.port | 0, 4, backlog, undefined, h.exclusive);
+          listen(this, null, h.port | 0, 4, backlog, undefined, h.exclusive);
       } else if (h.path && isPipeName(h.path)) {
-        const pipeName = self._pipeName = h.path;
-        listen(self, pipeName, -1, -1, backlog, undefined, h.exclusive);
+        const pipeName = this._pipeName = h.path;
+        listen(this, pipeName, -1, -1, backlog, undefined, h.exclusive);
       } else {
         throw new Error('Invalid listen argument: ' + h);
       }
     }
   } else if (isPipeName(arguments[0])) {
     // UNIX socket or Windows pipe.
-    const pipeName = self._pipeName = arguments[0];
-    listen(self, pipeName, -1, -1, backlog);
+    const pipeName = this._pipeName = arguments[0];
+    listen(this, pipeName, -1, -1, backlog);
 
   } else if (arguments[1] === undefined ||
              typeof arguments[1] === 'function' ||
              typeof arguments[1] === 'number') {
     // The first argument is the port, no IP given.
     assertPort(port);
-    listen(self, null, port, 4, backlog);
+    listen(this, null, port, 4, backlog);
 
   } else {
     // The first argument is the port, the second an IP.
     assertPort(port);
-    listenAfterLookup(port, arguments[1], backlog);
+    lookupAndListen(this, port, arguments[1], backlog);
   }
 
-  function listenAfterLookup(port, address, backlog, exclusive) {
-    require('dns').lookup(address, function(err, ip, addressType) {
-      if (err) {
-        self.emit('error', err);
-      } else {
-        addressType = ip ? addressType : 4;
-        listen(self, ip, port, addressType, backlog, undefined, exclusive);
-      }
-    });
-  }
-
-  return self;
+  return this;
 };
+
+function lookupAndListen(self, port, address, backlog, exclusive) {
+  require('dns').lookup(address, function(err, ip, addressType) {
+    if (err) {
+      self.emit('error', err);
+    } else {
+      addressType = ip ? addressType : 4;
+      listen(self, ip, port, addressType, backlog, undefined, exclusive);
+    }
+  });
+}
 
 Object.defineProperty(Server.prototype, 'listening', {
   get: function() {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1342,60 +1342,37 @@ Server.prototype.listen = function() {
     options.port = 0;
   }
 
-  var port = toNumber(arguments[0]);
-
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.
   var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
 
   options = options._handle || options.handle || options;
 
-  if (arguments.length === 0 || typeof arguments[0] === 'function') {
-    // Bind to a random port.
-    listen(this, null, 0, null, backlog);
-  } else if (arguments[0] !== null && typeof arguments[0] === 'object') {
-    if (options instanceof TCP) {
-      this._handle = options;
-      listen(this, null, -1, -1, backlog);
-    } else if (typeof options.fd === 'number' && options.fd >= 0) {
-      listen(this, null, null, null, backlog, options.fd);
-    } else {
-      // The first argument is a configuration object
-      if (options.backlog)
-        backlog = options.backlog;
-
-      if (typeof options.port === 'number' || typeof options.port === 'string' ||
-          (typeof options.port === 'undefined' && 'port' in options)) {
-        // Undefined is interpreted as zero (random port) for consistency
-        // with net.connect().
-        assertPort(options.port);
-        if (options.host)
-          lookupAndListen(this, options.port | 0, options.host, backlog, options.exclusive);
-        else
-          listen(this, null, options.port | 0, 4, backlog, undefined, options.exclusive);
-      } else if (options.path && isPipeName(options.path)) {
-        const pipeName = this._pipeName = options.path;
-        listen(this, pipeName, -1, -1, backlog, undefined, options.exclusive);
-      } else {
-        throw new Error('Invalid listen argument: ' + options);
-      }
-    }
-  } else if (isPipeName(arguments[0])) {
-    // UNIX socket or Windows pipe.
-    const pipeName = this._pipeName = arguments[0];
-    listen(this, pipeName, -1, -1, backlog);
-
-  } else if (arguments[1] === undefined ||
-             typeof arguments[1] === 'function' ||
-             typeof arguments[1] === 'number') {
-    // The first argument is the port, no IP given.
-    assertPort(port);
-    listen(this, null, port, 4, backlog);
-
+  if (options instanceof TCP) {
+    this._handle = options;
+    listen(this, null, -1, -1, backlog);
+  } else if (typeof options.fd === 'number' && options.fd >= 0) {
+    listen(this, null, null, null, backlog, options.fd);
   } else {
-    // The first argument is the port, the second an IP.
-    assertPort(port);
-    lookupAndListen(this, port, arguments[1], backlog);
+    if (options.backlog)
+      backlog = options.backlog;
+
+    if (typeof options.port === 'number' || typeof options.port === 'string' ||
+        (typeof options.port === 'undefined' && 'port' in options)) {
+      // Undefined is interpreted as zero (random port) for consistency
+      // with net.connect().
+      assertPort(options.port);
+      if (options.host)
+        lookupAndListen(this, options.port | 0, options.host, backlog, options.exclusive);
+      else
+        listen(this, null, options.port | 0, 4, backlog, undefined, options.exclusive);
+    } else if (options.path && isPipeName(options.path)) {
+      // UNIX socket or Windows pipe.
+      const pipeName = this._pipeName = options.path;
+      listen(this, pipeName, -1, -1, backlog, undefined, options.exclusive);
+    } else {
+      throw new Error('Invalid listen argument: ' + options);
+    }
   }
 
   return this;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1326,9 +1326,8 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
 
 
 Server.prototype.listen = function() {
-  const argsLen = arguments.length;
-  var args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
+  var args = new Array(arguments.length);
+  for (var i = 0; i < arguments.length; i++)
     args[i] = arguments[i];
   args = normalizeConnectArgs(args);
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1362,12 +1362,13 @@ Server.prototype.listen = function() {
       // Undefined is interpreted as zero (random port) for consistency
       // with net.connect().
       assertPort(options.port);
-      if (options.host)
+      if (options.host) {
         lookupAndListen(this, options.port | 0, options.host, backlog,
                         options.exclusive);
-      else
+      } else {
         listen(this, null, options.port | 0, 4, backlog, undefined,
                options.exclusive);
+      }
     } else if (options.path && isPipeName(options.path)) {
       // UNIX socket or Windows pipe.
       const pipeName = this._pipeName = options.path;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1345,7 +1345,7 @@ Server.prototype.listen = function() {
 
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.
-  var backlog = toNumber(args[1]) || toNumber(args[2]);
+  var backlog = toNumber(args.length > 1 && args[1]) || toNumber(args.length > 2 && args[2]);
 
   options = options._handle || options.handle || options;
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -70,7 +70,7 @@ exports.connect = exports.createConnection = function() {
   return Socket.prototype.connect.apply(s, args);
 };
 
-// Returns an array [options] or [options, cb]
+// Returns an array [options, cb], where cb can be null.
 // It is the same as the argument of Socket.prototype.connect().
 // This is also used by Server.prototype.listen().
 function normalizeArgs(args) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -91,7 +91,9 @@ function normalizeArgs(args) {
   }
 
   var cb = args[args.length - 1];
-  return typeof cb === 'function' ? [options, cb] : [options];
+  if (typeof cb !== 'function')
+    cb = null;
+  return [options, cb];
 }
 exports._normalizeArgs = normalizeArgs;
 
@@ -1330,21 +1332,20 @@ Server.prototype.listen = function() {
   var args = new Array(arguments.length);
   for (var i = 0; i < arguments.length; i++)
     args[i] = arguments[i];
-  args = normalizeArgs(args);
+  var [options, cb] = normalizeArgs(args);
 
-  if (args[1]) {
-    this.once('listening', args[1]);
+  if (typeof cb === 'function') {
+    this.once('listening', cb);
   }
 
-  var options = args[0];
-  if (arguments.length === 0 || typeof arguments[0] === 'function') {
+  if (args.length === 0 || typeof args[0] === 'function') {
     // Bind to a random port.
     options.port = 0;
   }
 
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.
-  var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
+  var backlog = toNumber(args[1]) || toNumber(args[2]);
 
   options = options._handle || options.handle || options;
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1326,9 +1326,20 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
 
 
 Server.prototype.listen = function() {
-  var lastArg = arguments[arguments.length - 1];
-  if (typeof lastArg === 'function') {
-    this.once('listening', lastArg);
+  const argsLen = arguments.length;
+  var args = new Array(argsLen);
+  for (var i = 0; i < argsLen; i++)
+    args[i] = arguments[i];
+  args = normalizeConnectArgs(args);
+
+  if (args[1]) {
+    this.once('listening', args[1]);
+  }
+
+  var options = args[0];
+  if (arguments.length === 0 || typeof arguments[0] === 'function') {
+    // Bind to a random port.
+    options.port = 0;
   }
 
   var port = toNumber(arguments[0]);
@@ -1336,6 +1347,8 @@ Server.prototype.listen = function() {
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.
   var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
+
+  options = options._handle || options.handle || options;
 
   if (arguments.length === 0 || typeof arguments[0] === 'function') {
     // Bind to a random port.

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -19,7 +19,7 @@ const listenVariants = [
 
 listenVariants.forEach((listenVariant, i) => {
   listenVariant(undefined, common.mustCall(close));
-  listenVariant('' + (common.PORT + i), common.mustCall(close));
+  listenVariant(`${common.PORT + i}`, common.mustCall(close));
 
   [
     'nan',

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -1,28 +1,45 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
 function close() { this.close(); }
-net.Server().listen({ port: undefined }, close);
-net.Server().listen({ port: '' + common.PORT }, close);
 
-[ 'nan',
-  -1,
-  123.456,
-  0x10000,
-  1 / 0,
-  -1 / 0,
-  '+Infinity',
-  '-Infinity'
-].forEach(function(port) {
-  assert.throws(function() {
-    net.Server().listen({ port: port }, common.fail);
-  }, /"port" argument must be >= 0 and < 65536/i);
-});
+// From lib/net.js
+function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
 
-[null, true, false].forEach(function(port) {
-  assert.throws(function() {
-    net.Server().listen({ port: port }, common.fail);
-  }, /invalid listen argument/i);
+function isPipeName(s) {
+  return typeof s === 'string' && toNumber(s) === false;
+}
+
+const listenVariants = [
+  (port, cb) => net.Server().listen({port}, cb),
+  (port, cb) => net.Server().listen(port, cb)
+];
+
+listenVariants.forEach((listenVariant, i) => {
+  listenVariant(undefined, common.mustCall(close));
+  listenVariant('' + (common.PORT + i), common.mustCall(close));
+
+  [
+    'nan',
+    -1,
+    123.456,
+    0x10000,
+    1 / 0,
+    -1 / 0,
+    '+Infinity',
+    '-Infinity'
+  ].forEach((port) => {
+    if (i === 1 && isPipeName(port)) {
+      // skip this, because listen(port) can also be listen(path)
+      return;
+    }
+    assert.throws(() => listenVariant(port, common.fail),
+                  /"port" argument must be >= 0 and < 65536/i);
+  });
+
+  [null, true, false].forEach((port) =>
+    assert.throws(() => listenVariant(port, common.fail),
+                  /invalid listen argument/i));
 });

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -19,7 +19,7 @@ const listenVariants = [
 
 listenVariants.forEach((listenVariant, i) => {
   listenVariant(undefined, common.mustCall(close));
-  listenVariant(`${common.PORT + i}`, common.mustCall(close));
+  listenVariant('0', common.mustCall(close));
 
   [
     'nan',


### PR DESCRIPTION
This PR simplifies `Server.prototype.listen`, removing some redundancy and inconsistency.

Because `listen` and `connect` have a similar function signature, `normalizeConnectArgs` can be reused for `listen`.

`listenAfterLookup` renamed to `lookupAndListen` for consistency with `lookupAndConnect`, and moved out of `Server.prototype.listen`.

## Functional differences

To improve consistency, I actually made some small functional changes:

- `port` was checked with this complicated code if set in a config object:
  ```
  if (typeof h.port === 'number' || typeof h.port === 'string' ||
      (typeof h.port === 'undefined' && 'port' in h)) {
    // Undefined is interpreted as zero (random port) for consistency
    // with net.connect().
    if (typeof h.port !== 'undefined' && !isLegalPort(h.port))
      throw new RangeError('"port" option should be >= 0 and < 65536: ' +
                           h.port);
    …
  ```
  But if set as first argument, it was only coerced to a number with `var port = toNumber(arguments[0]);`.
  Now, it is consistently using the first way, `toNumber` is not used anymore.
 
  However this is a breaking change, because before invalid ports resulted in using a random port instead of throwing.

- `addressType` was sometimes `null` and sometimes `4`, if no address is given.
  Now it is always `4`.

- `host` was checked like this:
  ```
  if (arguments[1] !== undefined &&
      typeof arguments[1] !== 'function' &&
      typeof arguments[1] !== 'number')
  ```
  Now it is checked with `if (typeof arguments[1] === 'string')`, this is consistent with `connect`.