### PR TITLE
test: fix http-many-ended-pipelines flakiness

### DIFF
--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -13,15 +13,19 @@ var http = require('http');
 var net = require('net');
 
 var numRequests = 20;
-var done = 0;
+var first = false;
 
 var server = http.createServer(function(req, res) {
-  res.end('ok');
+  if (!first) {
+    first = true;
+    req.socket.on('close', function() {
+      server.close();
+    });
+  }
 
+  res.end('ok');
   // Oh no!  The connection died!
   req.socket.destroy();
-  if (++done == numRequests)
-    server.close();
 });
 
 server.listen(common.PORT);


### PR DESCRIPTION
It can happen that the HTTP connection is closed before the server has received
all the requests, thus the server close condition is never reached. To solve
this, close the server when the socket is fully closed.

It tries to fix the following failure I'm sometimes getting in `OS X`:
```
HTTP/1.1 200 OK
Date: Wed, 25 Nov 2015 22:24:23 GMT
Connection: keep-alive
Content-Length: 2

ok
Command: out/Release/node /Users/sgimeno/node/node/test/parallel/test-http-many-ended-pipelines.js
--- TIMEOUT ---
```