### PR TITLE
test: fix tls-no-rsa-key flakiness

### DIFF
--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -23,9 +23,16 @@ var server = tls.createServer(options, function(conn) {
   var c = tls.connect(common.PORT, {
     rejectUnauthorized: false
   }, function() {
+    c.on('end', common.mustCall(function() {
+      c.end();
+      server.close();
+    }));
+
+    c.on('data', function(data) {
+      assert.equal(data, 'ok');
+    });
+
     cert = c.getPeerCertificate();
-    c.destroy();
-    server.close();
   });
 });
 


### PR DESCRIPTION
In some conditions it can happen that the client-side socket is destroyed
before the server-side socket has gracefully closed, thus causing a
'ECONNRESET' error in this socket. To solve this, wait in the client-side
socket for the 'end' event before closing it.

It tries to fix this error I've received several times in `OS X`:
```
=== release test-tls-no-rsa-key ===                                            
Path: parallel/test-tls-no-rsa-key
events.js:142
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at exports._errnoException (util.js:873:11)
    at TLSWrap.onread (net.js:545:26)

```

It's the same fix as in https://github.com/nodejs/node/pull/3966