### PR TITLE
test: fix race in test-net-socket-local-address

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,4 +21,3 @@ test-child-process-exit-code         : PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
-test-net-socket-local-address     : PASS,FLAKY


### PR DESCRIPTION
test-net-socket-local-address had a race condition that resulted in
unreliability on FreeBSD. This changes fixes the issue.

Fixes: https://github.com/nodejs/node/issues/2475