### PR TITLE
test: refactor test-http-exit-delay

### DIFF
--- a/test/parallel/test-http-exit-delay.js
+++ b/test/parallel/test-http-exit-delay.js
@@ -1,41 +1,30 @@
 'use strict';
-var assert = require('assert');
-var common = require('../common');
-var http = require('http');
+const assert = require('assert');
+const common = require('../common');
+const http = require('http');
 
 var start;
-var server = http.createServer(function(req, res) {
+const server = http.createServer(common.mustCall(function(req, res) {
   req.resume();
   req.on('end', function() {
     res.end('Success');
   });
 
   server.close();
-});
+}));
 
-server.listen(common.PORT, 'localhost', function() {
-  var interval_id = setInterval(function() {
-    start = new Date();
-    if (start.getMilliseconds() > 100)
-      return;
-
-    console.log(start.toISOString());
-    var req = http.request({
-      'host': 'localhost',
-      'port': common.PORT,
-      'agent': false,
-      'method': 'PUT'
-    });
-
-    req.end('Test');
-    clearInterval(interval_id);
-  }, 10);
-});
+server.listen(common.PORT, 'localhost', common.mustCall(function() {
+  start = new Date();
+  const req = http.request({
+    'host': 'localhost',
+    'port': common.PORT,
+    'agent': false,
+    'method': 'PUT'
+  });
+  req.end('Test');
+}));
 
 process.on('exit', function() {
-  var end = new Date();
-  console.log(end.toISOString());
-  assert.equal(start.getSeconds(), end.getSeconds());
-  assert(end.getMilliseconds() < 900);
-  console.log('ok');
+  const end = new Date();
+  assert(end - start < 1000, 'Entire test should take less than one second');
 });


### PR DESCRIPTION
test-http-exit-delay was introduced to confirm the removal of a 1 second
delay that used to occur when exiting node after an http request.

This change refactors the test for simplicity and also in the hopes of
either eliminating flakiness on CI or, if not that, at least making
the source of the flakiness easier to track down.

Ref: https://github.com/nodejs/node/commit/16b59cbc
Fixes: https://github.com/nodejs/node/issues/4045