### PR TITLE
test: refactor flaky net-error-twice

### DIFF
--- a/test/parallel/test-net-error-twice.js
+++ b/test/parallel/test-net-error-twice.js
@@ -1,33 +1,32 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
-var buf = new Buffer(10 * 1024 * 1024);
+const buf = new Buffer(10 * 1024 * 1024);
 
 buf.fill(0x62);
 
 var errs = [];
 
-var srv = net.createServer(function onConnection(conn) {
-  conn.write(buf);
+const srv = net.createServer(function onConnection(conn) {
+  setImmediate(() => {
+    conn.write(buf);
+  });
+
   conn.on('error', function(err) {
     errs.push(err);
-    if (errs.length > 1 && errs[0] === errs[1])
-      assert(false, 'We should not be emitting the same error twice');
+    if (errs.length > 1)
+      assert(errs[0] !== errs[1], 'Should not get the same error twice');
   });
   conn.on('close', function() {
     srv.unref();
   });
 }).listen(common.PORT, function() {
-  var client = net.connect({ port: common.PORT });
-
-  client.on('connect', function() {
-    client.destroy();
-  });
+  const client = net.connect({ port: common.PORT });
+  client.on('connect', client.destroy);
 });
 
 process.on('exit', function() {
-  console.log(errs);
   assert.equal(errs.length, 1);
 });

--- a/test/parallel/test-net-error-twice.js
+++ b/test/parallel/test-net-error-twice.js
@@ -10,9 +10,14 @@ buf.fill(0x62);
 var errs = [];
 
 const srv = net.createServer(function onConnection(conn) {
-  setImmediate(() => {
+  if (common.isWindows) {
+    // Windows-specific handling. See:
+    //   * https://github.com/nodejs/node/pull/4062
+    //   * https://github.com/nodejs/node/issues/4057
+    setTimeout(() => { conn.write(buf); }, 100);
+  } else {
     conn.write(buf);
-  });
+  }
 
   conn.on('error', function(err) {
     errs.push(err);


### PR DESCRIPTION
The test was not reliably creating the error event on Windows 2012.

This makes the test more robust by using setTimeout() to delay the
server writing to the socket to give time for socket.destroy() to take
effect.

Fixes: https://github.com/nodejs/node/issues/4057