### PR TITLE
doc: use same link color in linked code blocks as in regular text links

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -343,6 +343,10 @@ li code {
   padding: 0.2em 0.4em;
 }
 
+a code {
+  color: inherit;
+}
+
 span.type {
   color: #222;
 }


### PR DESCRIPTION
Currently there's no way in the docs to visually distinguish a link in a code block from a non-linked code block.

This is how linked code blocks are styled today...

<img width="267" alt="before" src="https://cloud.githubusercontent.com/assets/76098/11458942/c81d12e2-9698-11e5-9d54-ecfbd88277e2.png">

...and this is how linked code blocks are styled with this commit applied...

<img width="261" alt="after" src="https://cloud.githubusercontent.com/assets/76098/11458943/d6575ef8-9698-11e5-9ea6-5abe55c13e63.png">
