### PR TITLE
child_process.flushStdio: resume _consuming streams

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -217,7 +217,7 @@ util.inherits(ChildProcess, EventEmitter);
 function flushStdio(subprocess) {
   if (subprocess.stdio == null) return;
   subprocess.stdio.forEach(function(stream, fd, stdio) {
-    if (!stream || !stream.readable || stream._consuming)
+    if (!stream || !stream.readable)
       return;
     stream.resume();
   });

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -6,8 +6,8 @@ const assert = require('assert');
 const p = cp.spawn('echo');
 
 p.on('close', common.mustCall(function(code, signal) {
-    assert.strictEqual(code, 0);
-    assert.strictEqual(signal, null);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
 }));
 
 p.stdout.read();

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -1,10 +1,14 @@
 'use strict';
 const cp = require('child_process');
 const common = require('../common');
+const assert = require('assert');
 
-var p = cp.spawn('echo');
+const p = cp.spawn('echo');
 
-p.on('close', common.mustCall(function() {}));
+p.on('close', common.mustCall(function(code, signal) {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+}));
 
 p.stdout.read();
 

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -2,7 +2,7 @@
 const cp = require('child_process');
 const common = require('../common');
 
-var p = cp.spawn('yes');
+var p = cp.spawn('echo');
 
 p.on('close', common.mustCall(function() {}));
 

--- a/test/sequential/test-child-process-flush-stdio.js
+++ b/test/sequential/test-child-process-flush-stdio.js
@@ -1,0 +1,13 @@
+'use strict';
+const cp = require('child_process');
+const common = require('../common');
+
+var p = cp.spawn('yes');
+
+p.on('close', common.mustCall(function() {}));
+
+p.stdout.read();
+
+setTimeout(function() {
+  p.kill();
+}, 100);


### PR DESCRIPTION
Hey! I'm new here. Tried to follow all the guidelines. Thanks for your attention!

When a client calls read() with a nonzero argument
on a Socket, that Socket sets this._consuming to true.
It never sets this._consuming back to false.
child_process.flushStdio currently doesn't flush
any streams where _consuming is truthy. But that means
that it never flushes any stream that has ever been read from.
This prevents a child process from ever closing if one of
its streams has been read from, causing issue #4049.

child_process.flushStdio should flush streams even if their
_consuming is set to true. Then it will close even after a read.
