### PR TITLE
doc: Grammar/typo fix for https.Agent section

### DIFF
--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -195,7 +195,7 @@ Example:
       ...
     }
 
-Or does not use an `Agent`.
+Alternatively, opt out of connection pooling by not using an `Agent`.
 
 Example:
 


### PR DESCRIPTION
Changed to use imperative to be consistent with "use a custom `Agent`" above.