### PR TITLE
fs: un-deprecate existsSync(), throw error on EPERM

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -367,10 +367,13 @@ non-existent.
 
 ## fs.existsSync(path)
 
-    Stability: 0 - Deprecated: Use [fs.statSync][] or [fs.accessSync][] instead.
-
 Synchronous version of [`fs.exists`][].
 Returns `true` if the file exists, `false` otherwise.
+
+Note: this function will throw on Windows if an EPERM error is returned by the
+underlying `fs.statSync()` call. However, it is not suggested to attempt to
+catch this error. Instead, the end user probably needs to fix the file's
+permissions by hand.
 
 ## fs.fchmod(fd, mode, callback)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -223,6 +223,9 @@ fs.existsSync = function(path) {
     binding.stat(pathModule._makeLong(path));
     return true;
   } catch (e) {
+    if (e.code === 'EPERM')
+      throw e; // EPERM means we no longer knows if it exists or not.
+
     return false;
   }
 };


### PR DESCRIPTION
This is my conclusion from https://github.com/nodejs/node/issues/1592#issuecomment-159143911.

A significant amount of people find specifically `existsSync()` useful (especially in simple CLI apps) and it seems unreasonable to require a module for this. Keep `exists()` deprecated as it breaks our errback API convention.

This commit makes `existsSync()` throw on `EPERM`. The technical problem with `existsSync()` (besides a race condition if used badly) is that you cannot know if a file does or doesn't exist under Windows with improper permissions.
Throwing in that case really isn't that bad of an idea, since the regular output will probably cause errors anyways down the line, and I don't think these errors can be remedied from Node.js. Instead, error so the end user can clean up their file permissions. Catching this error in user code isn't really worthwhile due to these reasons, so suggest against it.

Discuss. cc @nodejs/collaborators 