### PR TITLE
test: fix parallel/test-net-socket-local-address

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,4 +21,3 @@ test-child-process-exit-code         : PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
-test-net-socket-local-address     : PASS,FLAKY

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -15,23 +15,21 @@ var serverRemotePorts = [];
 
 const server = net.createServer(function(socket) {
   serverRemotePorts.push(socket.remotePort);
-  conns++;
+  if (++conns === 2) this.close();
 });
 
 const client = new net.Socket();
 
-server.on('close', common.mustCall(function() {
+process.on('exit', function() {
   assert.deepEqual(clientLocalPorts, serverRemotePorts,
                    'client and server should agree on the ports used');
   assert.equal(2, conns);
-}));
+});
 
 server.listen(common.PORT, common.localhostIPv4, testConnect);
 
 function testConnect() {
-  if (conns == 2) {
-    return server.close();
-  }
+  if (conns >= 2) return;
   client.connect(common.PORT, common.localhostIPv4, function() {
     clientLocalPorts.push(this.localPort);
     this.once('close', testConnect);


### PR DESCRIPTION
Fix flakiness where the client sometimes closed the server before the
server had the chance to process the outstanding client connection.
Make the server close itself instead.

Fixes: https://github.com/nodejs/node/issues/2475

R=@Trott

CI: https://ci.nodejs.org/job/node-test-pull-request/885/
Stress test: https://ci.nodejs.org/job/node-stress-single-test/94/