### PR TITLE
streams: update .readable/.writable to false

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -385,6 +385,7 @@ function onEofChunk(stream, state) {
     }
   }
   state.ended = true;
+  stream.readable = false;
 
   // emit 'readable' now to make sure it gets picked up.
   emitReadable(stream);
@@ -670,7 +671,7 @@ Readable.prototype.on = function(ev, fn) {
     this.resume();
   }
 
-  if (ev === 'readable' && this.readable) {
+  if (ev === 'readable' && !this._readableState.endEmitted) {
     var state = this._readableState;
     if (!state.readableListening) {
       state.readableListening = true;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -483,4 +483,5 @@ function endWritable(stream, state, cb) {
       stream.once('finish', cb);
   }
   state.ended = true;
+  stream.writable = false;
 }

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -1,6 +1,7 @@
 'use strict';
 var common = require('../common');
 var R = require('_stream_readable');
+var W = require('_stream_writable');
 var assert = require('assert');
 
 var util = require('util');
@@ -28,5 +29,26 @@ TestReader.prototype._read = function(n) {
 var reader = new TestReader();
 setImmediate(function() {
   assert.equal(ondataCalled, 1);
+  console.log('ok');
+  reader.push(null);
+});
+
+function TestWriter() {
+  W.apply(this);
+  this.write('foo');
+  this.end();
+}
+
+util.inherits(TestWriter, W);
+
+TestWriter.prototype._write = function(chunk, enc, cb) {
+  cb();
+};
+
+var writer = new TestWriter();
+
+process.on('exit', function() {
+  assert.strictEqual(reader.readable, false);
+  assert.strictEqual(writer.writable, false);
   console.log('ok');
 });


### PR DESCRIPTION
These properties were initially used to determine stream status back in node v0.8 and earlier. Since streams2 however, these properties were *always* true, which can be misleading for example if you are trying to immediately determine whether a Writable stream is still writable or not (to avoid a "write after
end" exception).

This is #1217 targeting the master branch and with a couple of minor changes to fix a lint error and to help address a concern about `.on()`.