### PR TITLE
util: make inspect more reliable

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -290,7 +290,7 @@ function formatValue(ctx, value, recurseTimes) {
     }
     // Fast path for ArrayBuffer.  Can't do the same for DataView because it
     // has a non-primitive .buffer property that we need to recurse for.
-    if (value instanceof ArrayBuffer) {
+    if (binding.isArrayBuffer(value)) {
       return `${getConstructorOf(value).name}` +
              ` { byteLength: ${formatNumber(ctx, value.byteLength)} }`;
     }
@@ -328,18 +328,18 @@ function formatValue(ctx, value, recurseTimes) {
       keys.unshift('size');
     empty = value.size === 0;
     formatter = formatMap;
-  } else if (value instanceof ArrayBuffer) {
+  } else if (binding.isArrayBuffer(value)) {
     braces = ['{', '}'];
     keys.unshift('byteLength');
     visibleKeys.byteLength = true;
-  } else if (value instanceof DataView) {
+  } else if (binding.isDataView(value)) {
     braces = ['{', '}'];
     // .buffer goes last, it's not a primitive like the others.
     keys.unshift('byteLength', 'byteOffset', 'buffer');
     visibleKeys.byteLength = true;
     visibleKeys.byteOffset = true;
     visibleKeys.buffer = true;
-  } else if (isTypedArray(value)) {
+  } else if (binding.isTypedArray(value)) {
     braces = ['[', ']'];
     formatter = formatTypedArray;
     if (ctx.showHidden) {
@@ -676,19 +676,6 @@ function reduceToSingleString(output, base, braces) {
   }
 
   return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
-}
-
-
-function isTypedArray(value) {
-  return value instanceof Float32Array ||
-         value instanceof Float64Array ||
-         value instanceof Int16Array ||
-         value instanceof Int32Array ||
-         value instanceof Int8Array ||
-         value instanceof Uint16Array ||
-         value instanceof Uint32Array ||
-         value instanceof Uint8Array ||
-         value instanceof Uint8ClampedArray;
 }
 
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -30,6 +30,24 @@ static void IsPromise(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+static void IsTypedArray(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(args[0]->IsTypedArray());
+}
+
+
+static void IsArrayBuffer(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(args[0]->IsArrayBuffer());
+}
+
+
+static void IsDataView(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(args[0]->IsDataView());
+}
+
+
 static void GetHiddenValue(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -53,6 +71,9 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "isMapIterator", IsMapIterator);
   env->SetMethod(target, "isSetIterator", IsSetIterator);
   env->SetMethod(target, "isPromise", IsPromise);
+  env->SetMethod(target, "isTypedArray", IsTypedArray);
+  env->SetMethod(target, "isArrayBuffer", IsArrayBuffer);
+  env->SetMethod(target, "isDataView", IsDataView);
   env->SetMethod(target, "getHiddenValue", GetHiddenValue);
 }
 


### PR DESCRIPTION
34a35919e165cba6d5972e004e6b2cbdf2f4c65a added pretty printing for
TypedArray, ArrayBuffer, and DataView. This change allows inspecting
those across different contexts.

Since instanceof does not work across contexts, we can use
v8::Value::IsTypedArray, v8::Value::IsArrayBuffer, and
v8::Value::IsDataView

/cc @bnoordhuis 