### PR TITLE
Add NODE_RTLD_GLOBAL to control library loading

### DIFF
--- a/deps/uv/docs/src/dll.rst
+++ b/deps/uv/docs/src/dll.rst
@@ -25,7 +25,7 @@ N/A
 API
 ---
 
-.. c:function:: int uv_dlopen(const char* filename, uv_lib_t* lib)
+.. c:function:: int uv_dlopen(const char* filename, uv_lib_t* lib, int glob)
 
     Opens a shared library. The filename is in utf-8. Returns 0 on success and
     -1 on error. Call :c:func:`uv_dlerror` to get the error message.

--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -1367,7 +1367,7 @@ UV_EXTERN extern uint64_t uv_hrtime(void);
 
 UV_EXTERN void uv_disable_stdio_inheritance(void);
 
-UV_EXTERN int uv_dlopen(const char* filename, uv_lib_t* lib);
+UV_EXTERN int uv_dlopen(const char* filename, uv_lib_t* lib, int glob);
 UV_EXTERN void uv_dlclose(uv_lib_t* lib);
 UV_EXTERN int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr);
 UV_EXTERN const char* uv_dlerror(const uv_lib_t* lib);

--- a/deps/uv/src/unix/dl.c
+++ b/deps/uv/src/unix/dl.c
@@ -30,10 +30,18 @@
 static int uv__dlerror(uv_lib_t* lib);
 
 
-int uv_dlopen(const char* filename, uv_lib_t* lib) {
+int uv_dlopen(const char* filename, uv_lib_t* lib, int glob) {
+  int flag;
+
   dlerror(); /* Reset error status. */
   lib->errmsg = NULL;
-  lib->handle = dlopen(filename, RTLD_LAZY);
+
+  flag = RTLD_LAZY;
+  if (glob) {
+    flag |= RTLD_GLOBAL;
+  }
+
+  lib->handle = dlopen(filename, flag);
   return lib->handle ? 0 : uv__dlerror(lib);
 }
 

--- a/deps/uv/src/win/dl.c
+++ b/deps/uv/src/win/dl.c
@@ -25,7 +25,7 @@
 static int uv__dlerror(uv_lib_t* lib, int errorno);
 
 
-int uv_dlopen(const char* filename, uv_lib_t* lib) {
+int uv_dlopen(const char* filename, uv_lib_t* lib, int glob) {
   WCHAR filename_w[32768];
 
   lib->handle = NULL;

--- a/deps/uv/test/test-dlerror.c
+++ b/deps/uv/test/test-dlerror.c
@@ -37,7 +37,7 @@ TEST_IMPL(dlerror) {
   ASSERT(msg != NULL);
   ASSERT(strstr(msg, dlerror_no_error) != NULL);
 
-  r = uv_dlopen(path, &lib);
+  r = uv_dlopen(path, &lib, false);
   ASSERT(r == -1);
 
   msg = uv_dlerror(&lib);

--- a/lib/module.js
+++ b/lib/module.js
@@ -420,7 +420,8 @@ Module._extensions['.json'] = function(module, filename) {
 
 //Native extension for .node
 Module._extensions['.node'] = function(module, filename) {
-  return process.dlopen(module, path._makeLong(filename));
+  const dlOpenFlag = process.env.NODE_RTLD_GLOBAL === "true";
+  return process.dlopen(module, path._makeLong(filename), dlOpenFlag);
 };
 
 


### PR DESCRIPTION
Setting the environment variable `NODE_RTLD_GLOBAL` to `true` set `RTLD_GLOBAL` flag when loading module.

This pull request is motivated by the fact that `dlopen` does not have the same behavior on MacOS X and Linux (cf. `dlopen` man page) :

* On MacOS X / BSD :
```
If neither RTLD_GLOBAL nor RTLD_LOCAL is specified, the default is RTLD_GLOBAL.
```

* On Linux :
```
  RTLD_LOCAL
    This is the converse of RTLD_GLOBAL, and the default if neither flag is specified.
```

I was not sure what name would be the best to use for this purpose, so this is a first suggestion, but I'd be happy to change them. Also, I've implemented that as an opt-in mode, with as few changes as I could, but I'd be also happy to extend the idea and provide more flexibility.

Note : I'm no Windows expert, so I was not sure how what to do for this implementation.

Many thanks in advance for considering this patch.