### PR TITLE
repl: Fixed node repl history edge case. Fixes #4102.

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -120,7 +120,15 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
 
     if (data) {
       repl.history = data.split(/[\n\r]+/, repl.historySize);
-    } else if (oldHistoryPath) {
+    } else if (oldHistoryPath === historyPath) {
+      // If pre-v3.0, the user had set NODE_REPL_HISTORY_FILE to
+      // ~/.node_repl_history. Warn the user about it and proceed.
+      repl._writeToOutput(
+          '\nThe old repl history file has the same name and location as ' +
+          `the new one i.e., ${historyPath} and is empty.\nUsing it as is.\n`);
+      repl._refreshLine();
+
+    }  else if (oldHistoryPath) {
       // Grab data from the older pre-v3.0 JSON NODE_REPL_HISTORY_FILE format.
       repl._writeToOutput(
           '\nConverting old JSON repl history to line-separated history.\n' +
@@ -128,7 +136,13 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
       repl._refreshLine();
 
       try {
-        repl.history = JSON.parse(fs.readFileSync(oldHistoryPath, 'utf8'));
+        // Pre-v3.0, repl history was stored as JSON. Try and convert it
+        // to line separated history.
+        var oldReplJSONHistory = fs.readFileSync(oldHistoryPath, 'utf8');
+
+        // If there is NO old history, set repl history to an empty array.
+        if (oldReplJSONHistory) repl.history = JSON.parse(oldReplJSONHistory);
+
         if (!Array.isArray(repl.history)) {
           throw new Error('Expected array, got ' + typeof repl.history);
         }

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -73,8 +73,13 @@ const historyPath = path.join(common.tmpDir, '.fixture_copy_repl_history');
 const historyPathFail = path.join(common.tmpDir, '.node_repl\u0000_history');
 const oldHistoryPath = path.join(fixtures, 'old-repl-history-file.json');
 const enoentHistoryPath = path.join(fixtures, 'enoent-repl-history-file.json');
+const emptyHistoryPath = path.join(fixtures, '.empty-repl-history-file');
 const defaultHistoryPath = path.join(common.tmpDir, '.node_repl_history');
 
+const sameHistoryFilePaths = '\nThe old repl history file has the same name ' +
+                             'and location as the new one i.e., ' +
+                             path.join(common.tmpDir, '.node_repl_history') +
+                             ' and is empty.\nUsing it as is.\n';
 
 const tests = [{
   env: { NODE_REPL_HISTORY: '' },
@@ -92,6 +97,16 @@ const tests = [{
          NODE_REPL_HISTORY_FILE: oldHistoryPath },
   test: [UP],
   expected: [prompt, replDisabled, prompt]
+},
+{
+  env: { NODE_REPL_HISTORY_FILE: emptyHistoryPath },
+  test: [UP],
+  expected: [prompt, convertMsg, prompt]
+},
+{
+  env: { NODE_REPL_HISTORY_FILE: defaultHistoryPath },
+  test: [UP],
+  expected: [prompt, sameHistoryFilePaths, prompt]
 },
 {
   env: { NODE_REPL_HISTORY: historyPath },


### PR DESCRIPTION
If the deprecated NODE_REPL_HISTORY_FILE is set to default
node history file path ($HOME/.node_repl_history) and the file
doesn't exist, then node creates the file and then crashes when
it tries to parse that file as JSON thinking that it's an older
JSON formatted history file. This fixes that bug.

This patch also prevents node repl from throwing if the old
history file is empty or if $HOME/.node_repl_history is empty.

Also, in the test file, I moved the file paths above common
messages to make it easier to shift to template strings in the
future to build the messages.