### PR TITLE
test: fix flaky test-net-socket-local-address

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,4 +21,3 @@ test-child-process-exit-code         : PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
-test-net-socket-local-address     : PASS,FLAKY

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -29,17 +29,18 @@ server.on('close', common.mustCall(function() {
 server.listen(common.PORT, common.localhostIPv4, testConnect);
 
 function testConnect() {
-  // If we're not waiting for a server or client callback to fire...
   if (conns > serverRemotePorts.length || conns > clientLocalPorts.length) {
-    // ...then proceed.
-    if (conns === 2) {
-      return server.close();
-    }
-    client.connect(common.PORT, common.localhostIPv4, function() {
-      clientLocalPorts.push(this.localPort);
-      this.once('close', testConnect);
-      this.destroy();
-    });
-    conns++;
+    // We're waiting for a callback to fire.
+    return;
   }
+
+  if (conns === 2) {
+    return server.close();
+  }
+  client.connect(common.PORT, common.localhostIPv4, function() {
+    clientLocalPorts.push(this.localPort);
+    this.once('close', testConnect);
+    this.destroy();
+  });
+  conns++;
 }

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -30,7 +30,7 @@ server.listen(common.PORT, common.localhostIPv4, testConnect);
 
 function testConnect() {
   // If we're not waiting for a server or client callback to fire...
-  if (serverRemotePorts.length === clientLocalPorts.length) {
+  if (conns > serverRemotePorts.length || conns > clientLocalPorts.length) {
     // ...then proceed.
     if (conns === 2) {
       return server.close();

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -15,7 +15,7 @@ var serverRemotePorts = [];
 
 const server = net.createServer(function(socket) {
   serverRemotePorts.push(socket.remotePort);
-  conns++;
+  testConnect();
 });
 
 const client = new net.Socket();
@@ -29,12 +29,17 @@ server.on('close', common.mustCall(function() {
 server.listen(common.PORT, common.localhostIPv4, testConnect);
 
 function testConnect() {
-  if (conns == 2) {
+  if (conns === 2) {
     return server.close();
   }
-  client.connect(common.PORT, common.localhostIPv4, function() {
-    clientLocalPorts.push(this.localPort);
-    this.once('close', testConnect);
-    this.destroy();
-  });
+  // conns === clientLocalPorts.length means both server and client callbacks
+  // have fired
+  if (conns === clientLocalPorts.length) {
+    client.connect(common.PORT, common.localhostIPv4, function() {
+      clientLocalPorts.push(this.localPort);
+      this.once('close', testConnect);
+      this.destroy();
+    });
+  }
+  conns++;
 }

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -32,9 +32,9 @@ function testConnect() {
   if (conns === 2) {
     return server.close();
   }
-  // conns === clientLocalPorts.length means both server and client callbacks
-  // have fired
-  if (conns === clientLocalPorts.length) {
+  // If both server and client callbacks have fired...
+  if (serverRemotePorts.length === clientLocalPorts.length) {
+    // ...then proceed.
     client.connect(common.PORT, common.localhostIPv4, function() {
       clientLocalPorts.push(this.localPort);
       this.once('close', testConnect);

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -29,17 +29,17 @@ server.on('close', common.mustCall(function() {
 server.listen(common.PORT, common.localhostIPv4, testConnect);
 
 function testConnect() {
-  if (conns === 2) {
-    return server.close();
-  }
-  // If both server and client callbacks have fired...
+  // If we're not waiting for a server or client callback to fire...
   if (serverRemotePorts.length === clientLocalPorts.length) {
     // ...then proceed.
+    if (conns === 2) {
+      return server.close();
+    }
     client.connect(common.PORT, common.localhostIPv4, function() {
       clientLocalPorts.push(this.localPort);
       this.once('close', testConnect);
       this.destroy();
     });
+    conns++;
   }
-  conns++;
 }


### PR DESCRIPTION
test-net-socket-local-address had a race condition that resulted in
unreliability on FreeBSD and Windows. This changes fixes the issue.

Fixes: https://github.com/nodejs/node/issues/2475