### PR TITLE
src: don't print garbage errors

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1512,8 +1512,10 @@ static void ReportException(Environment* env,
         name.IsEmpty() ||
         name->IsUndefined()) {
       // Not an error object. Just print as-is.
-      node::Utf8Value message(env->isolate(), er);
-      PrintErrorString("%s\n", *message);
+      String::Utf8Value message(er);
+
+      PrintErrorString("%s\n", *message ? *message :
+                                          "<toString() threw exception>");
     } else {
       node::Utf8Value name_string(env->isolate(), name);
       node::Utf8Value message_string(env->isolate(), message);

--- a/test/fixtures/throws_error7.js
+++ b/test/fixtures/throws_error7.js
@@ -1,0 +1,5 @@
+throw {
+  toString: function() {
+    throw this;
+  }
+};

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -24,8 +24,6 @@ function errExec(script, callback) {
 
     // Count the tests
     exits++;
-
-    console.log('.');
   });
 }
 
@@ -64,6 +62,11 @@ errExec('throws_error6.js', function(err, stdout, stderr) {
   assert.ok(/SyntaxError/.test(stderr));
 });
 
+// Object that throws in toString() doesn't print garbage
+errExec('throws_error7.js', function(err, stdout, stderr) {
+  assert.ok(/<toString\(\) threw exception/.test(stderr));
+});
+
 process.on('exit', function() {
-  assert.equal(6, exits);
+  assert.equal(7, exits);
 });


### PR DESCRIPTION
If JS throws an object whose `toString()` method throws, then Node attempts to print an empty message, but actually prints garbage. This commit checks for this case, and prints a newline instead.

Closes #4079 