### PR TITLE
Skip the long path tests when not on Windows

### DIFF
--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -4,6 +4,11 @@ var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 
+if (!common.isWindows) {
+  console.log('1..0 # Skipped: this test is Windows-specific.');
+  return;
+}
+
 var successes = 0;
 
 // make a path that will be at least 260 chars long.

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -3,6 +3,11 @@ const common = require('../common');
 const fs = require('fs');
 const path = require('path');
 
+if (!common.isWindows) {
+  console.log('1..0 # Skipped: this test is Windows-specific.');
+  return;
+}
+
 // make a path that is more than 260 chars long.
 const dirNameLen = Math.max(260 - common.tmpDir.length, 1);
 const dirName = path.join(common.tmpDir, 'x'.repeat(dirNameLen));


### PR DESCRIPTION
This is another attempt to fix the tests failing on Ubuntu (see issue #2255)
This time by skipping the tests when not on Windows (as [advised](https://github.com/nodejs/node/pull/3929#issuecomment-161072622) by @bnoordhuis)

Other PRs that solve the same issue:
* #3925 runs the tests under os.tmpdir() on Linux if it is readable/writable (my first idea)
* #3929 retries the tests on Linux under os.tmpdir() only when they fail (as [advised](https://github.com/nodejs/node/pull/3925#issuecomment-158204979) by @rvagg)
* #4116 (this one) skips the test when not on Windows (as [advised](https://github.com/nodejs/node/pull/3929#issuecomment-161072622) by @bnoordhuis)

See also comments to PRs #3925 and #3929 for more context.