### PR TITLE
configure: respect CC_host in host arch detection

### DIFF
--- a/configure
+++ b/configure
@@ -589,7 +589,7 @@ def host_arch_cc():
     # would be xlc so hard code gcc
     k = cc_macros('gcc')
   else:
-    k = cc_macros()
+    k = cc_macros(os.environ.get('CC_host'))
 
   matchup = {
     '__aarch64__' : 'arm64',


### PR DESCRIPTION
When cross compiling, GYP uses the variables CC_host and CXX_host to find the host compiler, if they are defined. This ensures that variable is used, if defined, when detecting the host architecture.

This is necessary to be able to cross compile for ARM, unblocking https://github.com/nodejs/node/pull/3962 and https://github.com/nodejs/build/issues/266 . Snapshots can be re-enabled for ARM on CI when this lands.

cc @nodejs/build 