### PR TITLE
doc: url.format - true slash postfix behaviour

### DIFF
--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -87,12 +87,12 @@ Here's how the formatting process works:
 * `path` will be ignored.
 * `protocol` is treated the same with or without the trailing `:` (colon).
   * The protocols `http`, `https`, `ftp`, `gopher`, `file` will be
-    postfixed with `://` (colon-slash-slash).
+    postfixed with `://` (colon-slash-slash) as long as `host`/`hostname` are present.
   * All other protocols `mailto`, `xmpp`, `aim`, `sftp`, `foo`, etc will
     be postfixed with `:` (colon).
 * `slashes` set to `true` if the protocol requires `://` (colon-slash-slash)
   * Only needs to be set for protocols not previously listed as requiring
-    slashes, such as `mongodb://localhost:8000/`.
+    slashes, such as `mongodb://localhost:8000/`, or if `host`/`hostname` are absent.
 * `auth` will be used if present.
 * `hostname` will only be used if `host` is absent.
 * `port` will only be used if `host` is absent.


### PR DESCRIPTION
Change url.format's references to slash postfixing to reflect
true behaviour (it only automatically postfixes slashes to the
slashedProtocols when host is present).

Fixes: #3361 
Also ccing to #4101