### PR TITLE
configure: use __ARM_ARCH to determine arm version

### DIFF
--- a/configure
+++ b/configure
@@ -557,18 +557,13 @@ def cc_macros(cc=None):
 def is_arch_armv7():
   """Check for ARMv7 instructions"""
   cc_macros_cache = cc_macros()
-  return ('__ARM_ARCH_7__' in cc_macros_cache or
-          '__ARM_ARCH_7A__' in cc_macros_cache or
-          '__ARM_ARCH_7R__' in cc_macros_cache or
-          '__ARM_ARCH_7M__' in cc_macros_cache or
-          '__ARM_ARCH_7S__' in cc_macros_cache)
+  return cc_macros_cache.get('__ARM_ARCH') == '7'
 
 
 def is_arch_armv6():
   """Check for ARMv6 instructions"""
   cc_macros_cache = cc_macros()
-  return ('__ARM_ARCH_6__' in cc_macros_cache or
-          '__ARM_ARCH_6M__' in cc_macros_cache)
+  return cc_macros_cache.get('__ARM_ARCH') == '6'
 
 
 def is_arm_hard_float_abi():


### PR DESCRIPTION
Before this change, configure used processor specific macro defines (like `__ARM_ARCH_6M__`) to detect the arm processor version. This changes configure to use `__ARM_ARCH`, that should be defined to the correct version.

This is useful because configure may not expect the flag for a specific processor. Currently, if trying to cross compile optimizing to the Raspberry Pi 1 processor with `-mcpu=arm1176jzf-s` the detected `arm_version` will be `default` (because it sets`__ARM_ARCH_6ZK__`), and the generated binaries useless in that processor.

@nodejs/platform-arm ARM processors currently on CI are ok with this change, but could there be some other processor or compiler that does not set `__ARM_ARCH` or sets it to something that we do not want? @mmalecki you authored the original function, do you know of any problem with this? (Thanks!)

cc @nodejs/build 

For reference:
```
$ echo | arm-linux-gnueabihf-gcc -dM -E - | grep ARM_ARCH
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_6__ 1
#define __ARM_ARCH_ISA_THUMB 1
#define __ARM_ARCH 6
$ echo | arm-linux-gnueabihf-gcc -mcpu=arm1176jzf-s -dM -E - | grep ARM_ARCH
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_ISA_THUMB 1
#define __ARM_ARCH 6
#define __ARM_ARCH_6ZK__ 1
$ echo | arm-linux-gnueabihf-gcc -mcpu=cortex-a7 -dM -E - | grep ARM_ARCH                                                    
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_PROFILE 65
#define __ARM_ARCH_ISA_THUMB 2
#define __ARM_ARCH 7
#define __ARM_ARCH_7A__ 1
#define __ARM_ARCH_EXT_IDIV__ 1
```
