### PR TITLE
doc: add "Edit on GitHub" link

### DIFF
--- a/doc/template.html
+++ b/doc/template.html
@@ -27,6 +27,7 @@
             <a href="index.html" name="toc">Index</a> |
             <a href="all.html">View on single page</a> |
             <a href="__FILENAME__.json">View as JSON</a>
+            __GITHUB_LINK__
           </p>
         </div>
         <hr>

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -78,6 +78,7 @@ function render(lexed, filename, template, cb) {
     template = template.replace(/__SECTION__/g, section);
     template = template.replace(/__VERSION__/g, process.version);
     template = template.replace(/__TOC__/g, toc);
+    template = template.replace(/__GITHUB_LINK__/, getGithubLink(filename));
     template = template.replace(
       /__GTOC__/g,
       gtocData.replace('class="nav-' + id, 'class="nav-' + id + ' active')
@@ -220,3 +221,16 @@ function getId(text) {
   return text;
 }
 
+function getGithubLink(page) {
+  // pages that shouldn't have "Edit on Github" link
+  var ignoredPages = [
+    'all',
+    'index'
+  ];
+
+  if (ignoredPages.indexOf(page) >= 0) {
+    return '';
+  }
+
+  return `| <a href="https://github.com/nodejs/node/edit/master/doc/api/${page}.markdown">Edit on GitHub</a>`;
+}


### PR DESCRIPTION
Add "Edit on GitHub" link at the top of every page, that can be edited. Makes easier for people to
contribute improvements and find page source.

This PR was created as a result of working on https://github.com/nodejs/nodejs.org/issues/363.

Here's how it looks:

<img width="593" alt="screen shot 2015-12-03 at 2 51 39 pm" src="https://cloud.githubusercontent.com/assets/697676/11576266/b9e12e72-9a15-11e5-9e8c-2d03b7cfd24b.png">


