### PR TITLE
build,src: add Intel Vtune profiling support

### DIFF
--- a/configure
+++ b/configure
@@ -86,6 +86,14 @@ parser.add_option("--fully-static",
     help="Generate an executable without external dynamic libraries. This "
          "will not work on OSX when using default compilation environment")
 
+parser.add_option("--enable-vtune-profiling",
+    action="store_true",
+    dest="enable_vtune_profiling",
+    help="Enable profiling support for Intel Vtune profiler to profile"
+         "JavaScript code executed in nodejs. This feature is only available "
+         "for ia32, x32 or x64 platform.")
+
+
 parser.add_option("--link-module",
     action="append",
     dest="linked_module",
@@ -673,6 +681,15 @@ def configure_node(o):
     configure_arm(o)
   elif target_arch in ('mips', 'mipsel'):
     configure_mips(o)
+
+  if target_arch in ('x86', 'x64', 'ia32', 'x32'):
+    o['variables']['node_enable_v8_vtunejit'] = b(options.enable_vtune_profiling)
+  elif options.enable_vtune_profiling:
+    raise Exception(
+       'vtune profiler for JavaScript is only supported on x86, x32 or x64 '
+       'platform.')
+  else:
+    o['variables']['node_enable_v8_vtunejit'] = 'false'
 
   if flavor in ('solaris', 'mac', 'linux', 'freebsd'):
     use_dtrace = not options.without_dtrace

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -30,10 +30,9 @@ encoding method.  Here are the different string encodings.
 
 * `'base64'` - Base64 string encoding.
 
-* `'binary'` - A way of encoding raw binary data into strings by using only
-  the first 8 bits of each character. This encoding method is deprecated and
-  should be avoided in favor of `Buffer` objects where possible. This encoding
-  will be removed in future versions of Node.js.
+* `'binary'` - A way of encoding the buffer into a one-byte (i.e. `latin-1`)
+  encoded string. The string `'latin-1'` is not supported. Instead simply pass
+  `'binary'` to use `'latin-1'` encoding.
 
 * `'hex'` - Encode each byte as two hexadecimal characters.
 

--- a/node.gyp
+++ b/node.gyp
@@ -12,6 +12,7 @@
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'node_v8_options%': '',
+    'node_enable_v8_vtunejit%': 'false',
     'node_target_type%': 'executable',
     'library_files': [
       'src/node.js',
@@ -217,6 +218,13 @@
             [ 'icu_small=="true"', {
               'defines': [ 'NODE_HAVE_SMALL_ICU=1' ],
           }]],
+        }],
+        [ 'node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
+           target_arch=="ia32" or target_arch=="x32")', {
+          'defines': [ 'NODE_ENABLE_VTUNE_PROFILING' ],
+          'dependencies': [
+            'deps/v8/src/third_party/vtune/v8vtune.gyp:v8_vtune'
+          ],
         }],
         [ 'node_use_openssl=="true"', {
           'defines': [ 'HAVE_OPENSSL=1' ],

--- a/src/node.cc
+++ b/src/node.cc
@@ -43,6 +43,10 @@
 #include "v8-profiler.h"
 #include "zlib.h"
 
+#ifdef NODE_ENABLE_VTUNE_PROFILING
+#include "../deps/v8/src/third_party/vtune/v8-vtune.h"
+#endif
+
 #include <errno.h>
 #include <limits.h>  // PATH_MAX
 #include <locale.h>
@@ -3946,6 +3950,9 @@ static void StartNodeInstance(void* arg) {
   Isolate::CreateParams params;
   ArrayBufferAllocator* array_buffer_allocator = new ArrayBufferAllocator();
   params.array_buffer_allocator = array_buffer_allocator;
+#ifdef NODE_ENABLE_VTUNE_PROFILING
+  params.code_event_handler = vTune::GetVtuneCodeEventHandler();
+#endif
   Isolate* isolate = Isolate::New(params);
   if (track_heap_objects) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -37,6 +37,7 @@ set i18n_arg=
 set download_arg=
 set release_urls_arg=
 set build_release=
+set enable_vtune_profiling=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -71,6 +72,7 @@ if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
 if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
+if /i "%1"=="enable-vtune"  set enable_vtune_profiling="--enable-vtune-profiling"&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -168,7 +170,7 @@ goto run
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
+python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% %enable_vtune_profiling% --dest-cpu=%target_arch% --tag=%TAG%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -259,13 +261,14 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all] [enable-vtune]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build
 echo   vcbuild.bat release msi    : builds release build and MSI installer package
 echo   vcbuild.bat test           : builds debug build and runs tests
 echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
+echo   vcbuild.bat enable-vtune   : builds nodejs with Intel Vtune profiling support to profile JavaScript
 goto exit
 
 :exit


### PR DESCRIPTION
    This feature supports the Intel Vtune profiling support for JITted
    JavaScript on IA32 / X64 / X32 platform. The advantage of this profiling
    is that the user / developer of NodeJS application can get the detailed
    profiling information for every line of the JavaScript source code.
    This information will be very useful for the owner to optimize their
    applications.

    This feature is a compile-time option. For windows platform, the user
    needs to pass the following parameter to vcbuild.bat: "enable-vtune"

    For other OS, the user needs to pass the following parameter to
    ./configure command: "--enable-vtune-profiling"

    cherry-pick https://github.com/nodejs/node/pull/3785
    Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
