### PR TITLE
Standardize references to Node.js in docs

### DIFF
--- a/doc/api/documentation.markdown
+++ b/doc/api/documentation.markdown
@@ -65,4 +65,4 @@ Please do not suggest API changes in this area; they will be refused.
 Every HTML file in the markdown has a corresponding JSON file with the
 same data.
 
-This feature was added in node v0.6.12.  It is experimental.
+This feature was added in Node.js v0.6.12.  It is experimental.

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -24,7 +24,7 @@ finished running the process will exit. Therefore you **must** only perform
 checks on the module's state (like for unit tests). The callback takes one
 argument, the code the process is exiting with.
 
-This event is only emitted when node exits explicitly by process.exit() or
+This event is only emitted when Node.js exits explicitly by process.exit() or
 implicitly by the event loop draining.
 
 Example of listening for `exit`:


### PR DESCRIPTION
Super trivial commit to fix a couple inconsistent references to the name of the project.