### PR TITLE
stream: be less eager with readable flag

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -385,7 +385,6 @@ function onEofChunk(stream, state) {
     }
   }
   state.ended = true;
-  stream.readable = false;
 
   // emit 'readable' now to make sure it gets picked up.
   emitReadable(stream);


### PR DESCRIPTION
As of 34b535f, test-child-process-flush-stdio was failing on CentOS 5 systems in CI due to the change in stream state checking in `child_process`.

This commit fixes those failures by making readable streams less eager in setting their readable flag on EOF.

Fixes: https://github.com/nodejs/node/issues/4125