### PR TITLE
doc, test: Symbols as event names

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -10,7 +10,8 @@ is opened. All objects which emit events are instances of `events.EventEmitter`.
 You can access this module by doing: `require("events");`
 
 Typically, event names are represented by a camel-cased string, however,
-there aren't any strict restrictions on that, as any string will be accepted.
+there aren't any strict restrictions on that, as any valid property key will be
+accepted.
 
 Functions can then be attached to objects, to be executed when an event
 is emitted. These functions are called _listeners_. Inside a listener
@@ -59,7 +60,7 @@ Returns the number of listeners for a given event.
 
 ### Event: 'newListener'
 
-* `event` {String} The event name
+* `event` {String|Symbol} The event name
 * `listener` {Function} The event handler function
 
 This event is emitted *before* a listener is added. When this event is
@@ -70,7 +71,7 @@ added.
 
 ### Event: 'removeListener'
 
-* `event` {String} The event name
+* `event` {String|Symbol} The event name
 * `listener` {Function} The event handler function
 
 This event is emitted *after* a listener is removed.  When this event is

--- a/test/parallel/test-event-emitter-symbols.js
+++ b/test/parallel/test-event-emitter-symbols.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const EventEmitter = require('events');
+const assert = require('assert');
+
+const ee = new EventEmitter();
+const foo = Symbol('foo');
+const listener = common.mustCall(function() {});
+
+ee.on(foo, listener);
+assert.deepEqual(ee.listeners(foo), [listener]);
+
+ee.emit(foo);
+
+ee.removeAllListeners();
+assert.deepEqual(ee.listeners(foo), []);
+
+ee.on(foo, listener);
+assert.deepEqual(ee.listeners(foo), [listener]);
+
+ee.removeListener(foo, listener);
+assert.deepEqual(ee.listeners(foo), []);


### PR DESCRIPTION
As a result of the new support for Symbols in V8, along with the implementation of EventEmitter in Node, it turns out that Symbols are usable as event names. This adds the possibility of Symbol event names to the docs, and adds an EventEmitter test specific to Symbols so as to ensure that this doesn't break due to any potential future alternative implementations.