### PR TITLE
doc: clarify v0.10.41 openssl tls security impact

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,11 +2,11 @@
 
 Security Update
 
-Notable items:
+Notable changes:
 
 * build: Add support for Microsoft Visual Studio 2015
 * npm: Upgrade to v1.4.29 from v1.4.28. A special one-off release as part of the strategy to get a version of npm into Node.js v0.10.x that works with the current registry (https://github.com/nodejs/LTS/issues/37). This version of npm prints out a banner each time it is run. The banner warns that the next standard release of Node.js v0.10.x will ship with a version of npm v2.
-* openssl: Upgrade to 1.0.1q, containing fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
+* openssl: Upgrade to 1.0.1q, containing fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers using client certificate authentication; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
 
 Commits:
 


### PR DESCRIPTION
Updated to match the amended description that went live on the release
announcement @ http://nodejs.org/en/blog/release/v0.10.41/