### PR TITLE
doc: clarify v0.12.9 notable items

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,10 +2,10 @@
 
 Security Update
 
-Notable items:
+Notable changes:
 
-* http: Fix a bug where an HTTP socket may no longer have a socket but a pipelined request triggers a pause or resume, a potential denial-of-service vector. (Fedor Indutny)
-* openssl: Upgrade to 1.0.1q, containing fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
+* http: Fix CVE-2015-8027, a bug whereby an HTTP socket may no longer have a parser associated with it but a pipelined request attempts trigger a pause or resume on the non-existent parser, a potential denial-of-service vulnerability. (Fedor Indutny)
+* openssl: Upgrade to 1.0.1q, fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers using client certificate authentication; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
 
 Commits:
 


### PR DESCRIPTION
* Include reference to CVE-2015-8027
* Fix "socket may no longer have a socket" reference
* Expand on non-existent parser causing the error
* Clarify that CVE-2015-3194 affects TLS servers using _client
  certificate authentication_