### PR TITLE
deps: upgrade to V8 4.7.80.25

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 7
 #define V8_BUILD_NUMBER 80
-#define V8_PATCH_LEVEL 24
+#define V8_PATCH_LEVEL 25
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/ast-value-factory.cc
+++ b/deps/v8/src/ast-value-factory.cc
@@ -29,6 +29,7 @@
 
 #include "src/api.h"
 #include "src/objects.h"
+#include "src/utils.h"
 
 namespace v8 {
 namespace internal {
@@ -379,11 +380,32 @@ AstRawString* AstValueFactory::GetString(uint32_t hash, bool is_one_byte,
 bool AstValueFactory::AstRawStringCompare(void* a, void* b) {
   const AstRawString* lhs = static_cast<AstRawString*>(a);
   const AstRawString* rhs = static_cast<AstRawString*>(b);
-  if (lhs->is_one_byte() != rhs->is_one_byte()) return false;
+  if (lhs->length() != rhs->length()) return false;
   if (lhs->hash() != rhs->hash()) return false;
-  int len = lhs->byte_length();
-  if (rhs->byte_length() != len) return false;
-  return memcmp(lhs->raw_data(), rhs->raw_data(), len) == 0;
+  const unsigned char* l = lhs->raw_data();
+  const unsigned char* r = rhs->raw_data();
+  size_t length = rhs->length();
+  if (lhs->is_one_byte()) {
+    if (rhs->is_one_byte()) {
+      return CompareCharsUnsigned(reinterpret_cast<const uint8_t*>(l),
+                                  reinterpret_cast<const uint8_t*>(r),
+                                  length) == 0;
+    } else {
+      return CompareCharsUnsigned(reinterpret_cast<const uint8_t*>(l),
+                                  reinterpret_cast<const uint16_t*>(r),
+                                  length) == 0;
+    }
+  } else {
+    if (rhs->is_one_byte()) {
+      return CompareCharsUnsigned(reinterpret_cast<const uint16_t*>(l),
+                                  reinterpret_cast<const uint8_t*>(r),
+                                  length) == 0;
+    } else {
+      return CompareCharsUnsigned(reinterpret_cast<const uint16_t*>(l),
+                                  reinterpret_cast<const uint16_t*>(r),
+                                  length) == 0;
+    }
+  }
 }
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/test/mjsunit/regress/regress-4450.js
+++ b/deps/v8/test/mjsunit/regress/regress-4450.js
@@ -1,0 +1,8 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+({})['foobar\u2653'.slice(0, 6)] = null;
+var x;
+eval('x = function foobar() { return foobar };');
+x();


### PR DESCRIPTION
Pick up the latest patch-level from V8 stable. This includes the following fix:

* https://github.com/v8/v8/commit/c408ea72bff7e26cdf498e952133c4c191ecb30c
  Make AstRawString deduplication encoding-agnostic.

  BUG=v8:4450
  LOG=N
  R=hablich@chromium.org
  TBR=hablich@chromium.org

  Review URL: https://codereview.chromium.org/1494293003

See also: https://github.com/nodejs/node/pull/4128

R=@nodejs/v8
/cc @vkurchatkin 