### PR TITLE
src: use GetCurrentProcessId() for process.pid

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -68,9 +68,8 @@
 #if defined(_MSC_VER)
 #include <direct.h>
 #include <io.h>
-#include <process.h>
 #define strcasecmp _stricmp
-#define getpid _getpid
+#define getpid GetCurrentProcessId
 #define umask _umask
 typedef int mode_t;
 #else


### PR DESCRIPTION
Commit a9c0c65 ("src: define getpid() based on OS") made src/env.cc
use `GetCurrentProcessId()` on Windows for the PID in log messages.
`GetCurrentProcessId()` is also what is used by libuv, OpenSSL and V8.

This commit makes `process.pid` use `GetCurrentProcessId()` instead of
`_getpid()` for consistency.

R=@cjihrig?

CI: https://ci.nodejs.org/job/node-test-pull-request/930/