### PR TITLE
node: s/doNTCallbackX/nextTickCallbackWithXArgs/

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -356,20 +356,20 @@
           // callback invocation with small numbers of arguments to avoid the
           // performance hit associated with using `fn.apply()`
           if (args === undefined) {
-            doNTCallback0(callback);
+            nextTickCallbackWith0Args(callback);
           } else {
             switch (args.length) {
               case 1:
-                doNTCallback1(callback, args[0]);
+                nextTickCallbackWith1Arg(callback, args[0]);
                 break;
               case 2:
-                doNTCallback2(callback, args[0], args[1]);
+                nextTickCallbackWith2Args(callback, args[0], args[1]);
                 break;
               case 3:
-                doNTCallback3(callback, args[0], args[1], args[2]);
+                nextTickCallbackWith3Args(callback, args[0], args[1], args[2]);
                 break;
               default:
-                doNTCallbackMany(callback, args);
+                nextTickCallbackWithManyArgs(callback, args);
             }
           }
           if (1e4 < tickInfo[kIndex])
@@ -397,20 +397,20 @@
           // callback invocation with small numbers of arguments to avoid the
           // performance hit associated with using `fn.apply()`
           if (args === undefined) {
-            doNTCallback0(callback);
+            nextTickCallbackWith0Args(callback);
           } else {
             switch (args.length) {
               case 1:
-                doNTCallback1(callback, args[0]);
+                nextTickCallbackWith1Arg(callback, args[0]);
                 break;
               case 2:
-                doNTCallback2(callback, args[0], args[1]);
+                nextTickCallbackWith2Args(callback, args[0], args[1]);
                 break;
               case 3:
-                doNTCallback3(callback, args[0], args[1], args[2]);
+                nextTickCallbackWith3Args(callback, args[0], args[1], args[2]);
                 break;
               default:
-                doNTCallbackMany(callback, args);
+                nextTickCallbackWithManyArgs(callback, args);
             }
           }
           if (1e4 < tickInfo[kIndex])
@@ -424,7 +424,7 @@
       } while (tickInfo[kLength] !== 0);
     }
 
-    function doNTCallback0(callback) {
+    function nextTickCallbackWith0Args(callback) {
       var threw = true;
       try {
         callback();
@@ -435,7 +435,7 @@
       }
     }
 
-    function doNTCallback1(callback, arg1) {
+    function nextTickCallbackWith1Arg(callback, arg1) {
       var threw = true;
       try {
         callback(arg1);
@@ -446,7 +446,7 @@
       }
     }
 
-    function doNTCallback2(callback, arg1, arg2) {
+    function nextTickCallbackWith2Args(callback, arg1, arg2) {
       var threw = true;
       try {
         callback(arg1, arg2);
@@ -457,7 +457,7 @@
       }
     }
 
-    function doNTCallback3(callback, arg1, arg2, arg3) {
+    function nextTickCallbackWith3Args(callback, arg1, arg2, arg3) {
       var threw = true;
       try {
         callback(arg1, arg2, arg3);
@@ -468,7 +468,7 @@
       }
     }
 
-    function doNTCallbackMany(callback, args) {
+    function nextTickCallbackWithManyArgs(callback, args) {
       var threw = true;
       try {
         callback.apply(null, args);

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -7,7 +7,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 42
 42
@@ -20,7 +20,7 @@ Error: hello
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 [eval]:1
 throw new Error("hello")
@@ -31,7 +31,7 @@ Error: hello
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 100
 [eval]:1
@@ -43,7 +43,7 @@ ReferenceError: y is not defined
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 [eval]:1
 var ______________________________________________; throw 10

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -4,7 +4,7 @@
         ^
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
     at Function.Module.runMain (module.js:*:*)
     at startup (node.js:*:*)

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -8,7 +8,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 42
 42
@@ -22,7 +22,7 @@ Error: hello
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 
 [stdin]:1
@@ -34,7 +34,7 @@ Error: hello
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 100
 
@@ -47,7 +47,7 @@ ReferenceError: y is not defined
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at doNTCallback0 (node.js:*:*)
+    at nextTickCallbackWith0Args (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 
 [stdin]:1


### PR DESCRIPTION
Rename doNTCallback functions for clarity when profiling, these make sense internally but the "NT" in particular is a bit obtuse to be immediately understandable by non-core developers.