### PR TITLE
assert: handle class constructors in throws()

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -278,7 +278,13 @@ function expectedException(actual, expected) {
     // Ignore.  The instanceof check doesn't work for arrow functions.
   }
 
-  return expected.call({}, actual) === true;
+  try {
+    return expected.call({}, actual) === true;
+  } catch (e) {
+    // Ignore. If expected is a class constructor, an error will be thrown
+  }
+
+  return false;
 }
 
 function _throws(shouldThrow, block, expected, message) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -334,6 +334,22 @@ try {
 }
 assert.ok(threw, 'wrong constructor validation');
 
+// Validate that a class constructor works with throws()
+threw = false;
+
+try {
+  const ClassError = class {};
+
+  assert.throws(() => {
+    throw new RangeError();
+  }, ClassError);
+} catch (e) {
+  assert(e instanceof RangeError);
+  threw = true;
+}
+
+assert.ok(threw, 'wrong constructor validation');
+
 // use a RegExp to validate error message
 a.throws(makeBlock(thrower, TypeError), /test/);
 


### PR DESCRIPTION
Currently, if a class constructor is passed as the expected value to `throws()`, and a match is not received, the code falls through to the validation function case, which uses `fn.prototype.call()`. Class constructors must be called with `new`, so this throws a `TypeError`. This commit adds a `try...catch`, which handles the thrown error.

I'm proposing this as an alternative to #4166. The drawback I see with #4166 is that it only handles classes which extend `Error`. In general, it might be a good thing to wrap user defined validation functions in a `try...catch` anyway. Closes #3188.