### PR TITLE
repl: display error message when loading directory

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1082,6 +1082,9 @@ function defineDefaultCommands(repl) {
               self.write(line + '\n');
             }
           });
+        } else {
+          this.outputStream.write('Failed to load:' + file +
+                                  ' is not a valid file\n');
         }
       } catch (e) {
         this.outputStream.write('Failed to load:' + file + '\n');

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -61,6 +61,14 @@ putIn.write = function(data) {
 };
 putIn.run(['.load ' + loadFile]);
 
+// throw error on loading directory
+loadFile = common.tmpDir;
+putIn.write = function(data) {
+  assert.equal(data, 'Failed to load:' + loadFile + ' is not a valid file\n');
+  putIn.write = function() {};
+};
+putIn.run(['.load ' + loadFile]);
+
 // clear the REPL
 putIn.run(['.clear']);
 


### PR DESCRIPTION
When loading directory instead of file, no error message
is displayed. Its good to display error message for
this scenario.

Before:
  ```
  > .load /Users/princejohnwesley/Projects/Playground/Node
  >
 ```
After:
```
  > .load /Users/princejohnwesley/Projects/Playground/Node
    Failed to load:/Users/princejohnwesley/Projects/Playground/Node is not a file
  >
```