### PR TITLE
test: fix flaky test-cluster-shared-leak.js

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-cluster-shared-leak             : PASS,FLAKY
 test-debug-no-context                : PASS,FLAKY
 test-tls-ticket-cluster              : PASS,FLAKY
 

--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -18,6 +18,7 @@ if (cluster.isMaster) {
     conn = net.connect(common.PORT, common.mustCall(function() {
       worker1.send('die');
       worker2.send('die');
+      worker2.on('error', function(e) {});
     }));
     conn.on('error', function(e) {
       // ECONNRESET is OK


### PR DESCRIPTION
test-cluster-shared-leak.js was flaky because a worker can emit EPIPE.
This error event is expected.

Fixes: https://github.com/nodejs/node/issues/3956