### PR TITLE
doc: change references from node to Node.js

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -77,7 +77,7 @@ Resumes the readline `input` stream.
 ### rl.setPrompt(prompt)
 
 Sets the prompt, for example when you run `node` on the command line, you see
-`> `, which is node.js's prompt.
+`> `, which is Node.js's prompt.
 
 ### rl.write(data[, key])
 

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -5,12 +5,12 @@
 These functions are in the module `'util'`. Use `require('util')` to
 access them.
 
-The `util` module is primarily designed to support the needs of node.js's
+The `util` module is primarily designed to support the needs of Node.js's
 internal APIs.  Many of these utilities are useful for your own
 programs.  If you find that these functions are lacking for your
 purposes, however, you are encouraged to write your own utilities.  We
 are not interested in any future additions to the `util` module that
-are unnecessary for node.js's internal functionality.
+are unnecessary for Node.js's internal functionality.
 
 ## util.debug(string)
 
@@ -260,7 +260,7 @@ Returns `true` if the given "object" is a `Boolean`. `false` otherwise.
       // false
     util.isBoolean(false)
       // true
-      
+
 ## util.isBuffer(object)
 
     Stability: 0 - Deprecated

--- a/doc/api/v8.markdown
+++ b/doc/api/v8.markdown
@@ -3,7 +3,7 @@
     Stability: 2 - Stable
 
 This module exposes events and interfaces specific to the version of [V8][]
-built with node.js.  These interfaces are subject to change by upstream and are
+built with Node.js.  These interfaces are subject to change by upstream and are
 therefore not covered under the stability index.
 
 ## getHeapStatistics()
@@ -27,7 +27,7 @@ Set additional V8 command line flags.  Use with care; changing settings
 after the VM has started may result in unpredictable behavior, including
 crashes and data loss.  Or it may simply do nothing.
 
-The V8 options available for a version of node.js may be determined by running
+The V8 options available for a version of Node.js may be determined by running
 `node --v8-options`.  An unofficial, community-maintained list of options
 and their effects is available [here][].
 


### PR DESCRIPTION
Some API doc referenced Node.js with "node" or "node.js". This commit replaces these references.