### PR TITLE
tls_wrap: slice buffer properly in `ClearOut`

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -409,6 +409,7 @@ void TLSWrap::ClearOut() {
     if (read <= 0)
       break;
 
+    char* current = out;
     while (read > 0) {
       int avail = read;
 
@@ -416,10 +417,11 @@ void TLSWrap::ClearOut() {
       OnAlloc(avail, &buf);
       if (static_cast<int>(buf.len) < avail)
         avail = buf.len;
-      memcpy(buf.base, out, avail);
+      memcpy(buf.base, current, avail);
       OnRead(avail, &buf);
 
       read -= avail;
+      current += avail;
     }
   }
 

--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -15,6 +15,8 @@ var net = require('net');
 var options, a, b, portA, portB;
 var gotHello = false;
 
+var body = new Buffer(4000).fill('A');
+
 options = {
   key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem')),
   cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
@@ -38,7 +40,7 @@ a = tls.createServer(options, function(socket) {
 
 // the "target" server
 b = tls.createServer(options, function(socket) {
-  socket.end('hello');
+  socket.end(body);
 });
 
 process.on('exit', function() {
@@ -60,7 +62,7 @@ a.listen(common.PORT, function() {
     });
     ssl.setEncoding('utf8');
     ssl.once('data', function(data) {
-      assert.equal('hello', data);
+      assert.equal(body.toString(), data);
       gotHello = true;
     });
     ssl.on('end', function() {

--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -61,11 +61,13 @@ a.listen(common.PORT, function() {
       rejectUnauthorized: false
     });
     ssl.setEncoding('utf8');
+    var buf = '';
     ssl.once('data', function(data) {
-      assert.equal(body.toString(), data);
+      buf += data;
       gotHello = true;
     });
     ssl.on('end', function() {
+      assert.equal(buf, body);
       ssl.end();
       a.close();
       b.close();


### PR DESCRIPTION
Fix incorrect slicing of cleartext buffer in `TLSWrap::ClearOut`.

Fix: https://github.com/nodejs/node/issues/4161