### PR TITLE
VTune config and vcbuild fixups

### DIFF
--- a/configure
+++ b/configure
@@ -95,9 +95,9 @@ parser.add_option("--partly-static",
 parser.add_option("--enable-vtune-profiling",
     action="store_true",
     dest="enable_vtune_profiling",
-    help="Enable profiling support for Intel Vtune profiler to profile"
+    help="Enable profiling support for Intel VTune profiler to profile"
          "JavaScript code executed in nodejs. This feature is only available "
-         "for ia32, x32 or x64 platform.")
+         "for x32, x86 and x64 architectures.")
 
 
 parser.add_option("--link-module",
@@ -692,8 +692,8 @@ def configure_node(o):
     o['variables']['node_enable_v8_vtunejit'] = b(options.enable_vtune_profiling)
   elif options.enable_vtune_profiling:
     raise Exception(
-       'vtune profiler for JavaScript is only supported on x86, x32 or x64 '
-       'platform.')
+       'The VTune profiler for JavaScript is only supported on x32, x86 and x64 '
+       'architectures.')
   else:
     o['variables']['node_enable_v8_vtunejit'] = 'false'
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -33,7 +33,7 @@ set i18n_arg=
 set download_arg=
 set release_urls_arg=
 set build_release=
-set enable_vtune_profiling=
+set enable_vtune_arg=
 set configure_flags=
 
 :next-arg
@@ -68,7 +68,7 @@ if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
 if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
-if /i "%1"=="enable-vtune"  set enable_vtune_profiling="--enable-vtune-profiling"&goto arg-ok
+if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -93,6 +93,7 @@ if defined noetw set configure_flags=%configure_flags% --without-etw& set noetw_
 if defined noperfctr set configure_flags=%configure_flags% --without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
 if defined release_urlbase set release_urlbase_arg=--release-urlbase=%release_urlbase%
 if defined download_arg set configure_flags=%configure_flags% %download_arg%
+if defined enable_vtune_arg set configure_flags=%configure_flags% --enable-vtune-profiling
 
 if "%i18n_arg%"=="full-icu" set configure_flags=%configure_flags% --with-intl=full-icu
 if "%i18n_arg%"=="small-icu" set configure_flags=%configure_flags% --with-intl=small-icu
@@ -169,8 +170,8 @@ goto run
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-echo configure %configure_flags% %enable_vtune_profiling% --dest-cpu=%target_arch% --tag=%TAG%
-python configure %configure_flags% %enable_vtune_profiling% --dest-cpu=%target_arch% --tag=%TAG%
+echo configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
+python configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -268,7 +269,7 @@ echo   vcbuild.bat debug          : builds debug build
 echo   vcbuild.bat release msi    : builds release build and MSI installer package
 echo   vcbuild.bat test           : builds debug build and runs tests
 echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
-echo   vcbuild.bat enable-vtune   : builds nodejs with Intel Vtune profiling support to profile JavaScript
+echo   vcbuild.bat enable-vtune   : builds nodejs with Intel VTune profiling support to profile JavaScript
 goto exit
 
 :exit


### PR DESCRIPTION
* s/Vtune/VTune
* consistency in architecture types reported by `configure`, banish `ia32` in favour of `x86` there, also, do we actually support `x32` compiles? Does anyone know if this is _actual_ Linux x32 or if it's a synonym for x86? @bnoordhuis?
* refactor vcbuild.bat to use the new `configure_flags` for `enable-vtune`

/cc @cdai2