### PR TITLE
License builder tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -51,19 +51,222 @@ maintained libraries.
 
 The externally maintained libraries used by Node.js are:
 
-- V8, located at deps/v8. V8's license follows:
+- c-ares, located at deps/cares, is licensed as follows:
+  """
+    Copyright 1998 by the Massachusetts Institute of Technology.
+    Copyright (C) 2007-2013 by Daniel Stenberg
+
+    Permission to use, copy, modify, and distribute this
+    software and its documentation for any purpose and without
+    fee is hereby granted, provided that the above copyright
+    notice appear in all copies and that both that copyright
+    notice and this permission notice appear in supporting
+    documentation, and that the name of M.I.T. not be used in
+    advertising or publicity pertaining to distribution of the
+    software without specific, written prior permission.
+    M.I.T. makes no representations about the suitability of
+    this software for any purpose.  It is provided "as is"
+    without express or implied warranty.
+  """
+
+- HTTP Parser, located at deps/http_parser, is licensed as follows:
+  """
+    http_parser.c is based on src/http/ngx_http_parse.c from NGINX copyright
+    Igor Sysoev.
+
+    Additional changes are licensed under the same terms as NGINX and
+    copyright Joyent, Inc. and other Node contributors. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+  """
+
+- ICU, located at deps/icu, is licensed as follows:
+  """
+    Copyright (c) 1995-2015 International Business Machines Corporation and others
+
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, and/or sell
+    copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, provided that the above
+    copyright notice(s) and this permission notice appear in all copies
+    of the Software and that both the above copyright notice(s) and this
+    permission notice appear in supporting documentation.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+    PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL
+    THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM,
+    OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+    RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+    NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+    USE OR PERFORMANCE OF THIS SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder shall not be
+    used in advertising or otherwise to promote the sale, use or other dealings in
+    this Software without prior written authorization of the copyright holder.
+  """
+
+- libuv, located at deps/uv, is licensed as follows:
+  """
+    libuv is part of the Node project: http://nodejs.org/
+    libuv may be distributed alone under Node's license:
+
+    ====
+
+    Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+
+    ====
+
+    This license applies to all parts of libuv that are not externally
+    maintained libraries.
+
+    The externally maintained libraries used by libuv are:
+
+      - tree.h (from FreeBSD), copyright Niels Provos. Two clause BSD license.
+
+      - inet_pton and inet_ntop implementations, contained in src/inet.c, are
+        copyright the Internet Systems Consortium, Inc., and licensed under the ISC
+        license.
+
+      - stdint-msvc2008.h (from msinttypes), copyright Alexander Chemeris. Three
+        clause BSD license.
+
+      - pthread-fixes.h, pthread-fixes.c, copyright Google Inc. and Sony Mobile
+        Communications AB. Three clause BSD license.
+
+      - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design
+        Inc, Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
+        n° 289016). Three clause BSD license.
+  """
+
+- OpenSSL, located at deps/openssl, is licensed as follows:
+  """
+    Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    3. All advertising materials mentioning features or use of this
+    software must display the following acknowledgment:
+    "This product includes software developed by the OpenSSL Project
+    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+    4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+    endorse or promote products derived from this software without
+    prior written permission. For written permission, please contact
+    openssl-core@openssl.org.
+
+    5. Products derived from this software may not be called "OpenSSL"
+    nor may "OpenSSL" appear in their names without prior written
+    permission of the OpenSSL Project.
+
+    6. Redistributions of any form whatsoever must retain the following
+    acknowledgment:
+    "This product includes software developed by the OpenSSL Project
+    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+    THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+    EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+    PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+    ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+    OF THE POSSIBILITY OF SUCH DAMAGE.
+    ====================================================================
+
+    This product includes cryptographic software written by Eric Young
+    (eay@cryptsoft.com).  This product includes software written by Tim
+    Hudson (tjh@cryptsoft.com).
+  """
+
+- Punycode.js, located at lib/punycode.js, is licensed as follows:
+  """
+    Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  """
+
+- V8, located at deps/v8, is licensed as follows:
   """
     This license applies to all parts of V8 that are not externally
     maintained libraries.  The externally maintained libraries used by V8
     are:
 
       - PCRE test suite, located in
-        test/mjsunit/third_party/regexp-pcre.js.  This is based on the
+        test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the
         test suite from PCRE-7.3, which is copyrighted by the University
         of Cambridge and Google, Inc.  The copyright notice and license
         are embedded in regexp-pcre.js.
 
-      - Layout tests, located in test/mjsunit/third_party.  These are
+      - Layout tests, located in test/mjsunit/third_party/object-keys.  These are
         based on layout tests from webkit.org which are copyrighted by
         Apple Computer, Inc. and released under a 3-clause BSD license.
 
@@ -81,7 +284,10 @@ The externally maintained libraries used by Node.js are:
     These libraries have their own licenses; we recommend you read them,
     as their terms may differ from the terms below.
 
-    Copyright 2006-2012, the V8 project authors. All rights reserved.
+    Further license information can be found in LICENSE files located in
+    sub-directories.
+
+    Copyright 2014, the V8 project authors. All rights reserved.
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are
     met:
@@ -109,244 +315,45 @@ The externally maintained libraries used by Node.js are:
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   """
 
-- C-Ares, an asynchronous DNS client, located at deps/cares. C-Ares license
-  follows:
+- zlib, located at deps/zlib, is licensed as follows:
   """
-    /* Copyright 1998 by the Massachusetts Institute of Technology.
-     *
-     * Permission to use, copy, modify, and distribute this
-     * software and its documentation for any purpose and without
-     * fee is hereby granted, provided that the above copyright
-     * notice appear in all copies and that both that copyright
-     * notice and this permission notice appear in supporting
-     * documentation, and that the name of M.I.T. not be used in
-     * advertising or publicity pertaining to distribution of the
-     * software without specific, written prior permission.
-     * M.I.T. makes no representations about the suitability of
-     * this software for any purpose.  It is provided "as is"
-     * without express or implied warranty.
-  """
+    zlib.h -- interface of the 'zlib' general purpose compression library
+    version 1.2.8, April 28th, 2013
 
-- OpenSSL located at deps/openssl. OpenSSL is cryptographic software written
-  by Eric Young (eay@cryptsoft.com) to provide SSL/TLS encryption. OpenSSL's
-  license follows:
-  """
-    /* ====================================================================
-     * Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved.
-     *
-     * Redistribution and use in source and binary forms, with or without
-     * modification, are permitted provided that the following conditions
-     * are met:
-     *
-     * 1. Redistributions of source code must retain the above copyright
-     *    notice, this list of conditions and the following disclaimer.
-     *
-     * 2. Redistributions in binary form must reproduce the above copyright
-     *    notice, this list of conditions and the following disclaimer in
-     *    the documentation and/or other materials provided with the
-     *    distribution.
-     *
-     * 3. All advertising materials mentioning features or use of this
-     *    software must display the following acknowledgment:
-     *    "This product includes software developed by the OpenSSL Project
-     *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
-     *
-     * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
-     *    endorse or promote products derived from this software without
-     *    prior written permission. For written permission, please contact
-     *    openssl-core@openssl.org.
-     *
-     * 5. Products derived from this software may not be called "OpenSSL"
-     *    nor may "OpenSSL" appear in their names without prior written
-     *    permission of the OpenSSL Project.
-     *
-     * 6. Redistributions of any form whatsoever must retain the following
-     *    acknowledgment:
-     *    "This product includes software developed by the OpenSSL Project
-     *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
-     *
-     * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
-     * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-     * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-     * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
-     * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-     * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-     * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-     * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-     * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-     * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-     * OF THE POSSIBILITY OF SUCH DAMAGE.
-     * ====================================================================
-     *
-     * This product includes cryptographic software written by Eric Young
-     * (eay@cryptsoft.com).  This product includes software written by Tim
-     * Hudson (tjh@cryptsoft.com).
-     *
-     */
+    Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source distribution.
+
+    Jean-loup Gailly        Mark Adler
+    jloup@gzip.org          madler@alumni.caltech.edu
   """
 
-- HTTP Parser, located at deps/http_parser. HTTP Parser's license follows:
+- npm, located at deps/npm, is licensed as follows:
   """
-    http_parser.c is based on src/http/ngx_http_parse.c from NGINX copyright
-    Igor Sysoev.
-
-    Additional changes are licensed under the same terms as NGINX and
-    copyright Joyent, Inc. and other Node contributors. All rights reserved.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to
-    deal in the Software without restriction, including without limitation the
-    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-    sell copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-    IN THE SOFTWARE.
-  """
-
-- ESLint is located at tools/eslint. ESLint's license follows:
-  """
-    ESLint
-    Copyright (c) 2013 Nicholas C. Zakas. All rights reserved.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-  """
-
-- tools/cpplint.py is a C++ linter. Its license follows:
-  """
-    # Copyright (c) 2009 Google Inc. All rights reserved.
-    #
-    # Redistribution and use in source and binary forms, with or without
-    # modification, are permitted provided that the following conditions are
-    # met:
-    #
-    #    * Redistributions of source code must retain the above copyright
-    # notice, this list of conditions and the following disclaimer.
-    #    * Redistributions in binary form must reproduce the above
-    # copyright notice, this list of conditions and the following disclaimer
-    # in the documentation and/or other materials provided with the
-    # distribution.
-    #    * Neither the name of Google Inc. nor the names of its
-    # contributors may be used to endorse or promote products derived from
-    # this software without specific prior written permission.
-    #
-    # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    # A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    # OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    # LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  """
-
-- lib/punycode.js is copyright 2011 Mathias Bynens <http://mathiasbynens.be/>
-  and released under the MIT license.
-  """
-    * Punycode.js <http://mths.be/punycode>
-    * Copyright 2011 Mathias Bynens <http://mathiasbynens.be/>
-    * Available under MIT license <http://mths.be/mit>
-  """
-
-- tools/gyp. GYP is a meta-build system. GYP's license follows:
-  """
-    Copyright (c) 2009 Google Inc. All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are
-    met:
-
-       * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-       * Redistributions in binary form must reproduce the above
-    copyright notice, this list of conditions and the following disclaimer
-    in the documentation and/or other materials provided with the
-    distribution.
-       * Neither the name of Google Inc. nor the names of its
-    contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  """
-
-- Zlib at deps/zlib. zlib's license follows:
-  """
-    /* zlib.h -- interface of the 'zlib' general purpose compression library
-      version 1.2.8, April 28th, 2013
-
-      Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
-
-      This software is provided 'as-is', without any express or implied
-      warranty.  In no event will the authors be held liable for any damages
-      arising from the use of this software.
-
-      Permission is granted to anyone to use this software for any purpose,
-      including commercial applications, and to alter it and redistribute it
-      freely, subject to the following restrictions:
-
-      1. The origin of this software must not be misrepresented; you must not
-         claim that you wrote the original software. If you use this software
-         in a product, an acknowledgment in the product documentation would be
-         appreciated but is not required.
-      2. Altered source versions must be plainly marked as such, and must not be
-         misrepresented as being the original software.
-      3. This notice may not be removed or altered from any source distribution.
-
-      Jean-loup Gailly        Mark Adler
-      jloup@gzip.org          madler@alumni.caltech.edu
-    */
-  """
-
-- npm is a package manager program located at deps/npm.
-  npm's license follows:
-  """
-    Copyright (c) Isaac Z. Schlueter
+    Copyright (c) npm, Inc. and Contributors
     All rights reserved.
 
-    npm is released under the Artistic 2.0 License.
-    The text of the License follows:
+    npm is released under the Artistic License 2.0, subject to additional terms
+    that are listed below.
 
+    The text of the npm License follows and the text of the additional terms
+    follows the Artistic License 2.0 terms:
 
     --------
-
 
     The Artistic License 2.0
 
@@ -413,13 +420,11 @@ The externally maintained libraries used by Node.js are:
         or any other form resulting from mechanical transformation or
         translation of the Source form.
 
-
     Permission for Use and Modification Without Distribution
 
     (1)  You are permitted to use the Standard Version and create and use
     Modified Versions for any purpose without restriction, provided that
     you do not Distribute the Modified Version.
-
 
     Permissions for Redistribution of the Standard Version
 
@@ -434,7 +439,6 @@ The externally maintained libraries used by Node.js are:
     modifications made available from the Copyright Holder.  The resulting
     Package will still be considered the Standard Version, and as such
     will be subject to the Original License.
-
 
     Distribution of Modified Versions of the Package as Source
 
@@ -469,7 +473,6 @@ The externally maintained libraries used by Node.js are:
             available in that license fees are prohibited but Distributor
             Fees are allowed.
 
-
     Distribution of Compiled Forms of the Standard Version
     or Modified Versions without the Source
 
@@ -487,7 +490,6 @@ The externally maintained libraries used by Node.js are:
     the Source, provided that you comply with Section 4 with respect to
     the Source of the Modified Version.
 
-
     Aggregating or Linking the Package
 
     (7)  You may aggregate the Package (either the Standard Version or
@@ -504,7 +506,6 @@ The externally maintained libraries used by Node.js are:
     include the Package, and Distribute the result without restriction,
     provided the result does not expose a direct interface to the Package.
 
-
     Items That are Not Considered Part of a Modified Version
 
     (9) Works (including, but not limited to, modules and scripts) that
@@ -512,7 +513,6 @@ The externally maintained libraries used by Node.js are:
     the Package to be a Modified Version.  In addition, such works are not
     considered parts of the Package itself, and are not subject to the
     terms of this license.
-
 
     General Provisions
 
@@ -550,33 +550,86 @@ The externally maintained libraries used by Node.js are:
     DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
     ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
     --------
 
+    The following additional terms shall apply to use of the npm software, the npm
+    website, the npm repository and any other services or products offered by npm,
+    Inc.:
 
-    "Node.js" and "node" trademark Joyent, Inc. npm is not officially
-    part of the Node.js project, and is neither owned by nor
-    officially affiliated with Joyent, Inc.
+    "Node.js" trademark Joyent, Inc.  npm is not officially part of the Node.js
+    project, and is neither owned by nor affiliated with Joyent, Inc.
 
-    Packages published in the npm registry (other than the Software and
-    its included dependencies) are not part of npm itself, are the sole
-    property of their respective maintainers, and are not covered by
-    this license.
+    "npm" and "The npm Registry" are owned by npm, Inc. All rights reserved.
 
-    "npm Logo" created by Mathias Pettersson and Brian Hammond,
-    used with permission.
+    Modules published on the npm registry are not officially endorsed by npm, Inc.
+    or the Node.js project.
+
+    Data published to the npm registry is not part of npm itself, and is the sole
+    property of the publisher. While every effort is made to ensure accountability,
+    there is absolutely no guarantee, warrantee, or assertion expressed or implied
+    as to the quality, fitness for a specific purpose, or lack of malice in any
+    given npm package.  Packages downloaded through the npm registry are
+    independently licensed and are not covered by this license.
+
+    Additional policies relating to, and restrictions on use of, npm products and
+    services are available on the npm website.  All such policies and restrictions,
+    as updated from time to time, are hereby incorporated into this license
+    agreement.  By using npm, you acknowledge your agreement to all such policies
+    and restrictions.
+
+    If you have a complaint about a package in the public npm registry, and cannot
+    resolve it with the package owner, please email support@npmjs.com and explain
+    the situation.  See the [npm Dispute Resolution
+    policy](https://github.com/npm/policies/blob/master/disputes.md) for more
+    details.
+
+    Any data published to The npm Registry (including user account information) may
+    be removed or modified at the sole discretion of the npm server administrators.
+
+    "npm Logo" contributed by Mathias Pettersson and Brian Hammond,
+    use is subject to https://www.npmjs.com/policies/trademark
 
     "Gubblebum Blocky" font
-    Copyright (c) by Tjarda Koster, http://jelloween.deviantart.com
+    Copyright (c) by Tjarda Koster, https://jelloween.deviantart.com
     included for use in the npm website and documentation,
     used with permission.
 
-    This program uses several Node.js modules contained in the node_modules/
+    This program uses several Node modules contained in the node_modules/
     subdirectory, according to the terms of their respective licenses.
   """
 
-- tools/doc/node_modules/marked. Marked is a Markdown parser. Marked's
-  license follows:
+- GYP, located at tools/gyp, is licensed as follows:
+  """
+    Copyright (c) 2009 Google Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- marked, located at tools/doc/node_modules/marked, is licensed as follows:
   """
     Copyright (c) 2011-2012, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -599,8 +652,94 @@ The externally maintained libraries used by Node.js are:
     THE SOFTWARE.
   """
 
-- test/gc/node_modules/weak. Node-weak is a node.js addon that provides garbage
-  collector notifications. Node-weak's license follows:
+- cpplint.py, located at tools/cpplint.py, is licensed as follows:
+  """
+    Copyright (c) 2009 Google Inc. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- ESLint, located at tools/eslint, is licensed as follows:
+  """
+    ESLint
+    Copyright (c) 2013 Nicholas C. Zakas. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """
+
+- gtest, located at deps/gtest, is licensed as follows:
+  """
+    Copyright 2008, Google Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """
+
+- node-weak, located at test/gc/node_modules/weak, is licensed as follows:
   """
     Copyright (c) 2011, Ben Noordhuis <info@bnoordhuis.nl>
 
@@ -615,389 +754,4 @@ The externally maintained libraries used by Node.js are:
     WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
     ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-  """
-
-- ICU's license follows:
-  From http://source.icu-project.org/repos/icu/icu/trunk/license.html
-  """
-  ICU License - ICU 1.8.1 and later
-
-    COPYRIGHT AND PERMISSION NOTICE
-
-    Copyright (c) 1995-2014 International Business Machines Corporation and others
-
-    All rights reserved.
-
-    Permission is hereby granted, free of charge, to any person
-    obtaining a copy of this software and associated documentation
-    files (the "Software"), to deal in the Software without
-    restriction, including without limitation the rights to use, copy,
-    modify, merge, publish, distribute, and/or sell copies of the
-    Software, and to permit persons to whom the Software is furnished
-    to do so, provided that the above copyright notice(s) and this
-    permission notice appear in all copies of the Software and that
-    both the above copyright notice(s) and this permission notice
-    appear in supporting documentation.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE
-    COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR
-    ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR
-    ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
-    PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-    TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-    PERFORMANCE OF THIS SOFTWARE.
-
-    Except as contained in this notice, the name of a copyright holder
-    shall not be used in advertising or otherwise to promote the sale,
-    use or other dealings in this Software without prior written
-    authorization of the copyright holder.
-
-    All trademarks and registered trademarks mentioned herein are the
-    property of their respective owners.
-
-  Third-Party Software Licenses
-
-    This section contains third-party software notices and/or
-    additional terms for licensed third-party software components
-    included within ICU libraries.
-
-  1. Unicode Data Files and Software
-    COPYRIGHT AND PERMISSION NOTICE
-
-    Copyright © 1991-2014 Unicode, Inc. All rights reserved.
-    Distributed under the Terms of Use in
-    http://www.unicode.org/copyright.html.
-
-    Permission is hereby granted, free of charge, to any person obtaining
-    a copy of the Unicode data files and any associated documentation
-    (the "Data Files") or Unicode software and any associated documentation
-    (the "Software") to deal in the Data Files or Software
-    without restriction, including without limitation the rights to use,
-    copy, modify, merge, publish, distribute, and/or sell copies of
-    the Data Files or Software, and to permit persons to whom the Data Files
-    or Software are furnished to do so, provided that
-    (a) this copyright and permission notice appear with all copies
-    of the Data Files or Software,
-    (b) this copyright and permission notice appear in associated
-    documentation, and
-    (c) there is clear notice in each modified Data File or in the Software
-    as well as in the documentation associated with the Data File(s) or
-    Software that the data or software has been modified.
-
-    THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
-    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT OF THIRD PARTY RIGHTS.
-    IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
-    NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
-    DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
-    DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-    TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-    PERFORMANCE OF THE DATA FILES OR SOFTWARE.
-
-    Except as contained in this notice, the name of a copyright holder
-    shall not be used in advertising or otherwise to promote the sale,
-    use or other dealings in these Data Files or Software without prior
-    written authorization of the copyright holder.
-
-  2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
-     #    The Google Chrome software developed by Google is licensed
-     #  under the BSD license. Other software included in this distribution
-     #  is provided under other licenses, as set forth below.
-     #
-     #	The BSD License
-     #	http://opensource.org/licenses/bsd-license.php
-     #	Copyright (C) 2006-2008, Google Inc.
-     #
-     #	All rights reserved.
-     #
-     #	Redistribution and use in source and binary forms, with or
-     #  without modification, are permitted provided that the following
-     #  conditions are met:
-     #
-     #	Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-     #	Redistributions in binary form must reproduce the above
-     #  copyright notice, this list of conditions and the following
-     #  disclaimer in the documentation and/or other materials provided with
-     #  the distribution.
-     #	Neither the name of  Google Inc. nor the names of its
-     #  contributors may be used to endorse or promote products derived from
-     #  this software without specific prior written permission.
-     #
-     #
-     #	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     #
-     #
-     #	The word list in cjdict.txt are generated by combining three
-  word lists listed
-     #	below with further processing for compound word breaking. The
-  frequency is generated
-     #	with an iterative training against Google web corpora.
-     #
-     #	* Libtabe (Chinese)
-     #	  - https://sourceforge.net/project/?group_id=1519
-     #	  - Its license terms and conditions are shown below.
-     #
-     #	* IPADIC (Japanese)
-     #	  - http://chasen.aist-nara.ac.jp/chasen/distribution.html
-     #	  - Its license terms and conditions are shown below.
-     #
-     #	---------COPYING.libtabe ---- BEGIN--------------------
-     #
-     #	/*
-     #	 * Copyrighy (c) 1999 TaBE Project.
-     #	 * Copyright (c) 1999 Pai-Hsiang Hsiao.
-     #	 * All rights reserved.
-     #	 *
-     #	 * Redistribution and use in source and binary forms, with or without
-     #	 * modification, are permitted provided that the following conditions
-     #	 * are met:
-     #	 *
-     #	 * . Redistributions of source code must retain the above copyright
-     #	 *   notice, this list of conditions and the following disclaimer.
-     #	 * . Redistributions in binary form must reproduce the above copyright
-     #	 *   notice, this list of conditions and the following disclaimer in
-     #	 *   the documentation and/or other materials provided with the
-     #	 *   distribution.
-     #	 * . Neither the name of the TaBE Project nor the names of its
-     #	 *   contributors may be used to endorse or promote products derived
-     #	 *   from this software without specific prior written permission.
-     #	 *
-     #	 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-     #	 * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-     #	 * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-     #	 * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-     #	 * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-     #	 * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-     #	 * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-     #	 * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-     #	 * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-     #	 * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-     #	 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-     #	 * OF THE POSSIBILITY OF SUCH DAMAGE.
-     #	 */
-     #
-     #	/*
-     #	 * Copyright (c) 1999 Computer Systems and Communication Lab,
-     #	 *                    Institute of Information Science, Academia Sinica.
-     #	 * All rights reserved.
-     #	 *
-     #	 * Redistribution and use in source and binary forms, with or without
-     #	 * modification, are permitted provided that the following conditions
-     #	 * are met:
-     #	 *
-     #	 * . Redistributions of source code must retain the above copyright
-     #	 *   notice, this list of conditions and the following disclaimer.
-     #	 * . Redistributions in binary form must reproduce the above copyright
-     #	 *   notice, this list of conditions and the following disclaimer in
-     #	 *   the documentation and/or other materials provided with the
-     #	 *   distribution.
-     #	 * . Neither the name of the Computer Systems and Communication Lab
-     #	 *   nor the names of its contributors may be used to endorse or
-     #	 *   promote products derived from this software without specific
-     #	 *   prior written permission.
-     #	 *
-     #	 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-     #	 * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-     #	 * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-     #	 * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-     #	 * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-     #	 * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-     #	 * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-     #	 * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-     #	 * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-     #	 * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-     #	 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-     #	 * OF THE POSSIBILITY OF SUCH DAMAGE.
-     #	 */
-     #
-     #	Copyright 1996 Chih-Hao Tsai @ Beckman Institute, University of Illinois
-     #	c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
-     #
-     #	---------------COPYING.libtabe-----END------------------------------------
-     #
-     #
-     #	---------------COPYING.ipadic-----BEGIN------------------------------------
-     #
-     #	Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
-     #	and Technology.  All Rights Reserved.
-     #
-     #	Use, reproduction, and distribution of this software is permitted.
-     #	Any copy of this software, whether in its original form or modified,
-     #	must include both the above copyright notice and the following
-     #	paragraphs.
-     #
-     #	Nara Institute of Science and Technology (NAIST),
-     #	the copyright holders, disclaims all warranties with regard to this
-     #	software, including all implied warranties of merchantability and
-     #	fitness, in no event shall NAIST be liable for
-     #	any special, indirect or consequential damages or any damages
-     #	whatsoever resulting from loss of use, data or profits, whether in an
-     #	action of contract, negligence or other tortuous action, arising out
-     #	of or in connection with the use or performance of this software.
-     #
-     #	A large portion of the dictionary entries
-     #	originate from ICOT Free Software.  The following conditions for ICOT
-     #	Free Software applies to the current dictionary as well.
-     #
-     #	Each User may also freely distribute the Program, whether in its
-     #	original form or modified, to any third party or parties, PROVIDED
-     #	that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
-     #	on, or be attached to, the Program, which is distributed substantially
-     #	in the same form as set out herein and that such intended
-     #	distribution, if actually made, will neither violate or otherwise
-     #	contravene any of the laws and regulations of the countries having
-     #	jurisdiction over the User or the intended distribution itself.
-     #
-     #	NO WARRANTY
-     #
-     #	The program was produced on an experimental basis in the course of the
-     #	research and development conducted during the project and is provided
-     #	to users as so produced on an experimental basis.  Accordingly, the
-     #	program is provided without any warranty whatsoever, whether express,
-     #	implied, statutory or otherwise.  The term "warranty" used herein
-     #	includes, but is not limited to, any warranty of the quality,
-     #	performance, merchantability and fitness for a particular purpose of
-     #	the program and the nonexistence of any infringement or violation of
-     #	any right of any third party.
-     #
-     #	Each user of the program will agree and understand, and be deemed to
-     #	have agreed and understood, that there is no warranty whatsoever for
-     #	the program and, accordingly, the entire risk arising from or
-     #	otherwise connected with the program is assumed by the user.
-     #
-     #	Therefore, neither ICOT, the copyright holder, or any other
-     #	organization that participated in or was otherwise related to the
-     #	development of the program and their respective officials, directors,
-     #	officers and other employees shall be held liable for any and all
-     #	damages, including, without limitation, general, special, incidental
-     #	and consequential damages, arising out of or otherwise in connection
-     #	with the use or inability to use the program or any product, material
-     #	or result produced or otherwise obtained by using the program,
-     #	regardless of whether they have been advised of, or otherwise had
-     #	knowledge of, the possibility of such damages at any time during the
-     #	project or thereafter.  Each user will be deemed to have agreed to the
-     #	foregoing by his or her commencement of use of the program.  The term
-     #	"use" as used herein includes, but is not limited to, the use,
-     #	modification, copying and distribution of the program and the
-     #	production of secondary products from the program.
-     #
-     #	In the case where the program, whether in its original form or
-     #	modified, was distributed or delivered to or received by a user from
-     #	any person, organization or entity other than ICOT, unless it makes or
-     #	grants independently of ICOT any specific warranty to the user in
-     #	writing, such person, organization or entity, will also be exempted
-     #	from and not be held liable to the user for any such damages as noted
-     #	above as far as the program is concerned.
-     #
-     #	---------------COPYING.ipadic-----END------------------------------------
-
-   3. Lao Word Break Dictionary Data (laodict.txt)
-     #	Copyright (c) 2013 International Business Machines Corporation
-     #	and others. All Rights Reserved.
-     #
-     #	Project:    http://code.google.com/p/lao-dictionary/
-     #	Dictionary: http://lao-dictionary.googlecode.com/git/Lao-Dictionary.txt
-     #	License:    http://lao-dictionary.googlecode.com/git/Lao-Dictionary-LICENSE.txt
-     #	            (copied below)
-     #
-     #	This file is derived from the above dictionary, with slight modifications.
-     #	--------------------------------------------------------------------------------
-     #	Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
-     #	All rights reserved.
-     #
-     #	Redistribution and use in source and binary forms, with or without modification,
-     #	are permitted provided that the following conditions are met:
-     #
-     #		Redistributions of source code must retain the above copyright notice, this
-     #		list of conditions and the following disclaimer. Redistributions in binary
-     #		form must reproduce the above copyright notice, this list of conditions and
-     #		the following disclaimer in the documentation and/or other materials
-     #		provided with the distribution.
-     #
-     #	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-     #	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-     #	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-     #	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-     #	ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-     #	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-     #	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-     #	ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-     #	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-     #	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     #	--------------------------------------------------------------------------------
-
-  4. Burmese Word Break Dictionary Data (burmesedict.txt)
-     #	Copyright (c) 2014 International Business Machines Corporation
-     #	and others. All Rights Reserved.
-     #
-     #	This list is part of a project hosted at:
-     #	  github.com/kanyawtech/myanmar-karen-word-lists
-     #
-     #	--------------------------------------------------------------------------------
-     #	Copyright (c) 2013, LeRoy Benjamin Sharon
-     #	All rights reserved.
-     #
-     #	Redistribution and use in source and binary forms, with or without modification,
-     #	are permitted provided that the following conditions are met:
-     #
-     #	  Redistributions of source code must retain the above copyright notice, this
-     #	  list of conditions and the following disclaimer.
-     #
-     #	  Redistributions in binary form must reproduce the above copyright notice, this
-     #	  list of conditions and the following disclaimer in the documentation and/or
-     #	  other materials provided with the distribution.
-     #
-     #	  Neither the name Myanmar Karen Word Lists, nor the names of its
-     #	  contributors may be used to endorse or promote products derived from
-     #	  this software without specific prior written permission.
-     #
-     #	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-     #	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-     #	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-     #	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-     #	ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-     #	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-     #	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-     #	ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-     #	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-     #	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     #	--------------------------------------------------------------------------------
-
-    5. Time Zone Database
-    ICU uses the public domain data and code derived from Time Zone
-    Database for its time zone support. The ownership of the TZ
-    database is explained in BCP 175: Procedure for Maintaining the
-    Time Zone Database section 7.
-
-        7.  Database Ownership
-
-       The TZ database itself is not an IETF Contribution or an IETF
-       document.  Rather it is a pre-existing and regularly updated work
-       that is in the public domain, and is intended to remain in the public
-       domain.  Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do not apply
-       to the TZ Database or contributions that individuals make to it.
-       Should any claims be made and substantiated against the TZ Database,
-       the organization that is providing the IANA Considerations defined in
-       this RFC, under the memorandum of understanding with the IETF,
-       currently ICANN, may act in accordance with all competent court
-       orders.  No ownership claims will be made by ICANN or the IETF Trust
-       on the database or the code.  Any person making a contribution to the
-       database or code waives all rights to future claims in that
-       contribution or in the TZ Database.
   """

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -e
+
+rootdir="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+licensefile="${rootdir}/LICENSE"
+licensehead="$(sed '/^- /,$d' ${licensefile})"
+tmplicense="${rootdir}/~LICENSE.$$"
+echo -e "$licensehead" > $tmplicense
+
+
+# addlicense <library> <location> <license text>
+function addlicense {
+
+  echo "
+- ${1}, located at ${2}, is licensed as follows:
+  \"\"\"
+$(echo -e "$3" | sed -e 's/^/    /' -e 's/^    $//' -e 's/ *$//' | sed -e '/./,$!d' | sed -e '/^$/N;/^\n$/D')
+  \"\"\"\
+" >> $tmplicense
+
+}
+
+
+if ! [ -f "${rootdir}/deps/icu/license.html" ]; then
+  echo "ICU not installed, run configure to download it, e.g. ./configure --with-intl=small-icu --download=icu"
+  exit 1
+fi
+
+
+# Dependencies bundled in distributions
+addlicense "c-ares" "deps/cares" \
+           "$(sed -e '/^ \*\/$/,$d' -e '/^$/d' -e 's/^[/ ]\* *//' ${rootdir}/deps/cares/src/ares_init.c)"
+addlicense "HTTP Parser" "deps/http_parser" "$(cat deps/http_parser/LICENSE-MIT)"
+addlicense "ICU" "deps/icu" \
+           "$(sed -e '1,/COPYRIGHT AND PERMISSION NOTICE/d' -e '/^<hr/,$d' -e 's/^<\/*p>$//' ${rootdir}/deps/icu/license.html)"
+addlicense "libuv" "deps/uv" "$(cat ${rootdir}/deps/uv/LICENSE)"
+addlicense "OpenSSL" "deps/openssl" \
+           "$(sed -e '/^ \*\/$/,$d' -e '/^ [^*].*$/d' -e '/\/\*.*$/d' -e '/^$/d' -e 's/^[/ ]\* *//' ${rootdir}/deps/openssl/openssl/LICENSE)"
+addlicense "Punycode.js" "lib/punycode.js" \
+           "$(curl -sL https://raw.githubusercontent.com/bestiejs/punycode.js/master/LICENSE-MIT.txt)"
+addlicense "V8" "deps/v8" "$(cat ${rootdir}/deps/v8/LICENSE)"
+addlicense "zlib" "deps/zlib" \
+           "$(sed -e '/The data format used by the zlib library/,$d' -e 's/^\/\* *//' -e 's/^ *//' ${rootdir}/deps/zlib/zlib.h)"
+
+# npm
+addlicense "npm" "deps/npm" "$(cat ${rootdir}/deps/npm/LICENSE)"
+
+# Build tools
+addlicense "GYP" "tools/gyp" "$(cat ${rootdir}/tools/gyp/LICENSE)"
+addlicense "marked" "tools/doc/node_modules/marked" \
+           "$(cat ${rootdir}/tools/doc/node_modules/marked/LICENSE)"
+
+# Testing tools
+addlicense "cpplint.py" "tools/cpplint.py" \
+           "$(sed -e '/^$/,$d' -e 's/^#$//' -e 's/^# //' ${rootdir}/tools/cpplint.py | tail +3)"
+addlicense "ESLint" "tools/eslint" "$(cat ${rootdir}/tools/eslint/LICENSE)"
+addlicense "gtest" "deps/gtest" "$(cat ${rootdir}/deps/gtest/LICENSE)"
+addlicense "node-weak" "test/gc/node_modules/weak" \
+           "$(cat ${rootdir}/test/gc/node_modules/weak/LICENSE)"
+
+
+mv $tmplicense $licensefile


### PR DESCRIPTION
Added `tools/license-builder.sh` to construct the LICENSE file from the licenses of all the dependencies used by Node.

Re-ordered the licenses alphabetically within dependency type groups:

* Dependencies bundled in Node.js
  - C-Ares
  - HTTP Parser
  - ICU
  - libuv
  - OpenSSL
  - Punycode.js
  - V8
  - libuv (newly included)
* npm
* Build tools
  - GYP
  - marked
* Test tools
  - cpplint.py
  - ESLint
  - gtest
  - node-weak

Additionally:

* Cleaned up naming to be consistent with what each of these projects appear to want to be called.
* Made the lead for each license consistent `NAME, located at LOCATION, is licensed as follows:`
* Stripped out comment syntax, HTML and other unnecessary guff from licenses that have them (e.g. where they are included in source files and need it to be in comments)

It's surprising how far out of sync we are with our dependency licenses cause we don't have a tool or procedure to keep them updated.

This probably needs to wait at least until we get results from #3979 but I'd like us to have a tool that keeps our rules consistent and lets us ensure our LICENSE is up to date.

/cc @mikeal 