### PR TITLE
src: fix build error without OpenSSL support

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3043,7 +3043,9 @@ static void ParseArgs(int* argc,
       SSL3_ENABLE = true;
 #endif
     } else if (strcmp(arg, "--allow-insecure-server-dhparam") == 0) {
+#if HAVE_OPENSSL
       ALLOW_INSECURE_SERVER_DHPARAM = true;
+#endif
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);


### PR DESCRIPTION
PR #3890 [1] introduced the variable `ALLOW_INSECURE_SERVER_DHPARAM` defined in src/node_crypto.cc. However, if node is built without OpenSSL support, the build fails:
```sh
 error: ‘ALLOW_INSECURE_SERVER_DHPARAM’ was not declared in this scope
       ALLOW_INSECURE_SERVER_DHPARAM = true;
```
Fix this by using the preprocessor macro HAVE_OPENSSL to opt-out the use of `ALLOW_INSECURE_SERVER_DHPARAM` in non-OpenSSL builds.

[1] https://github.com/nodejs/node/pull/3890