### PR TITLE
doc: harmonize description of `ca` argument

### DIFF
--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -164,8 +164,9 @@ The following options from [`tls.connect()`][] can also be specified. However, a
 - `key`: Private key to use for SSL. Default `null`.
 - `passphrase`: A string of passphrase for the private key or pfx. Default `null`.
 - `cert`: Public x509 certificate to use. Default `null`.
-- `ca`: An authority certificate or array of authority certificates to check
-  the remote host against.
+- `ca`: A string, `Buffer` or array of strings or `Buffer`s of trusted
+  certificates in PEM format. If this is omitted several well known "root"
+  CAs will be used, like VeriSign. These are used to authorize connections.
 - `ciphers`: A string describing the ciphers to use or exclude. Consult
   <https://www.openssl.org/docs/apps/ciphers.html#CIPHER_LIST_FORMAT> for
   details on the format.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -564,9 +564,9 @@ Creates a new client connection to the given `port` and `host` (old API) or
   - `cert`: A string or `Buffer` containing the certificate key of the client in
     PEM format. (Could be an array of certs).
 
-  - `ca`: An array of strings or `Buffer`s of trusted certificates in PEM
-    format. If this is omitted several well known "root" CAs will be used,
-    like VeriSign. These are used to authorize connections.
+  - `ca`: A string, `Buffer` or array of strings or `Buffer`s of trusted
+    certificates in PEM format. If this is omitted several well known "root"
+    CAs will be used, like VeriSign. These are used to authorize connections.
 
   - `ciphers`: A string describing the ciphers to use or exclude, separated by
    `:`. Uses the same default cipher suite as `tls.createServer`.
@@ -674,8 +674,9 @@ dictionary with keys:
   objects in the format `{pem: key, passphrase: passphrase}`. (Required)
 * `passphrase` : A string of passphrase for the private key or pfx
 * `cert` : A string holding the PEM encoded certificate
-* `ca` : Either a string or list of strings of PEM encoded CA
-  certificates to trust.
+* `ca`: A string, `Buffer` or array of strings or `Buffer`s of trusted
+  certificates in PEM format. If this is omitted several well known "root"
+  CAs will be used, like VeriSign. These are used to authorize connections.
 * `crl` : Either a string or list of strings of PEM encoded CRLs
   (Certificate Revocation List)
 * `ciphers`: A string describing the ciphers to use or exclude.
@@ -736,9 +737,9 @@ automatically set as a listener for the [`'secureConnection'`][] event.  The
   - `cert`: A string or `Buffer` containing the certificate key of the server in
     PEM format. (Could be an array of certs). (Required)
 
-  - `ca`: An array of strings or `Buffer`s of trusted certificates in PEM
-    format. If this is omitted several well known "root" CAs will be used,
-    like VeriSign. These are used to authorize connections.
+  - `ca`: A string, `Buffer` or array of strings or `Buffer`s of trusted
+    certificates in PEM format. If this is omitted several well known "root"
+    CAs will be used, like VeriSign. These are used to authorize connections.
 
   - `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate
     Revocation List)


### PR DESCRIPTION
Different sections said different things about what the `ca` argument
should look like.  This commit harmonizes them.

Ref: https://github.com/nodejs/node/pull/4099

R=@rvagg