### PR TITLE
repl: fix require('3rdparty') regression

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -35,6 +35,7 @@ const Module = require('module');
 const domain = require('domain');
 const debug = util.debuglog('repl');
 
+const parentModule = module;
 const replMap = new WeakMap();
 
 try {
@@ -526,6 +527,8 @@ REPLServer.prototype.createContext = function() {
   }
 
   const module = new Module('<repl>');
+  module.paths = Module._resolveLookupPaths('<repl>', parentModule)[1];
+
   const require = internalModule.makeRequireFunction.call(module);
   context.module = module;
   context.require = require;

--- a/test/fixtures/node_modules/baz/index.js
+++ b/test/fixtures/node_modules/baz/index.js
@@ -6,3 +6,5 @@ assert.equal(require('bar'), require('../bar.js'));
 
 // this should work, and get the one in ./node_modules/asdf.js
 assert.equal(require('asdf'), require('./node_modules/asdf.js'));
+
+module.exports = 'eye catcher';

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+process.chdir(common.fixturesDir);
+const repl = require('repl');
+
+const server = net.createServer(conn => {
+  repl.start('', conn).on('exit', () => {
+    conn.destroy();
+    server.close();
+  });
+});
+
+const host = common.localhostIPv4;
+const port = common.PORT;
+const options = { host, port };
+
+var answer = '';
+server.listen(options, function() {
+  const conn = net.connect(options);
+  conn.setEncoding('utf8');
+  conn.on('data', data => answer += data);
+  conn.write('require("baz")\n.exit\n');
+});
+
+process.on('exit', function() {
+  assert.strictEqual(false, /Cannot find module/.test(answer));
+  assert.strictEqual(false, /Error/.test(answer));
+  assert.strictEqual(true, /eye catcher/.test(answer));
+});


### PR DESCRIPTION
Fix module loading of third-party modules in the REPL by inheriting
module.paths from the REPL's parent module.

Commit ee72ee7 ("module,repl: remove repl require() hack") introduced
a regression where require() of modules in node_modules directories
no longer worked in the REPL (and fortunately only in the REPL.)
It turns out we didn't have test coverage for that but we do now.

Fixes: https://github.com/nodejs/node/issues/4208

R=@silverwind?

CI: https://ci.nodejs.org/job/node-test-pull-request/969/