### PR TITLE
doc: remove old description for compare method

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -208,9 +208,6 @@ Example: copy an ASCII string into a buffer, one byte at a time:
 
     // Node.js
 
-Returns a boolean indicating whether `this` and `otherBuffer` have the same
-bytes.
-
 ### buf.compare(otherBuffer)
 
 * `otherBuffer` {Buffer}
@@ -266,6 +263,8 @@ region in the same buffer
 ### buf.equals(otherBuffer)
 
 * `otherBuffer` {Buffer}
+
+Returns a boolean indicating whether `this` and `otherBuffer` have the same bytes.
 
 ### buf.fill(value[, offset][, end])
 


### PR DESCRIPTION
Above the buffer.compare(otherBuffer) method, there seems to
be a description from an older version of this method.

I have removed it.