### PR TITLE
v8 remote debug: export BreakEvent, BreakPoint and CompileEvent

### DIFF
--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -96,6 +96,7 @@ Seo Sanghyeon <sanxiyn@gmail.com>
 Tobias Burnus <burnus@net-b.de>
 Victor Costan <costan@gmail.com>
 Vlad Burlik <vladbph@gmail.com>
+Vladimir Krivosheev <develar@gmail.com>
 Vladimir Shutoff <vovan@shutoff.ru>
 Yu Yin <xwafish@gmail.com>
 Zhongping Wang <kewpie.w.zp@gmail.com>

--- a/deps/v8/src/debug/debug.js
+++ b/deps/v8/src/debug/debug.js
@@ -2607,6 +2607,9 @@ function ValueToProtocolValue_(value, mirror_serializer) {
 utils.InstallConstants(global, [
   "Debug", Debug,
   "DebugCommandProcessor", DebugCommandProcessor,
+  "BreakEvent", BreakEvent,
+  "CompileEvent", CompileEvent,
+  "BreakPoint", BreakPoint,
 ]);
 
 // Functions needed by the debugger runtime.


### PR DESCRIPTION
JetBrains debugger overrides BreakEvent/CompileEvent.toJSONProtocol implementation and it works in the previous version of V8 (nodejs v4).

Corresponding V8 review: https://codereview.chromium.org/1477233002/

V8 team will accept my patch, but unlikely that V8 will be updated in Nodejs 5.x, right? So, I created this pull request. It is required to fix https://youtrack.jetbrains.com/issue/WEB-16397 not only for Nodejs 0.12.x and 4.x, but for 5.x too.