### PR TITLE
doc: clarify explanation of first stream section

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -11,19 +11,17 @@ You can load the Stream base classes by doing `require('stream')`.
 There are base classes provided for [Readable][] streams, [Writable][]
 streams, [Duplex][] streams, and [Transform][] streams.
 
-This document is split up into 3 sections.  The first explains the
-parts of the API that you need to be aware of to use streams in your
-programs.  If you never intend to implement a streaming API yourself,
-you can stop there.
+This document is split up into 3 sections:
 
-The second section explains the parts of the API that you need to use
-if you implement your own custom streams yourself.  The API is
-designed to make this easy for you to do.
-
-The third section goes into more depth about how streams work,
-including some of the internal mechanisms and functions that you
-should probably not modify unless you definitely know what you are
-doing.
+1. The first section explains the parts of the API that you need to be
+   aware of to use streams in your programs.
+2. The second section explains the parts of the API that you need to
+   use if you implement your own custom streams yourself.  The API is
+   designed to make this easy for you to do.
+3. The third section goes into more depth about how streams work,
+   including some of the internal mechanisms and functions that you
+   should probably not modify unless you definitely know what you are
+   doing.
 
 
 ## API for Stream Consumers

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -13,8 +13,8 @@ streams, [Duplex][] streams, and [Transform][] streams.
 
 This document is split up into 3 sections.  The first explains the
 parts of the API that you need to be aware of to use streams in your
-programs.  If you never implement a streaming API yourself, you can
-stop there.
+programs.  If you never intend to implement a streaming API yourself,
+you can stop there.
 
 The second section explains the parts of the API that you need to use
 if you implement your own custom streams yourself.  The API is


### PR DESCRIPTION
The last sentence of the explanation for the first stream section
seemed a bit confusing. I tried to change the sentence to clarify it.