### PR TITLE
docs: Fixing broken links to the v8 wiki

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -169,4 +169,4 @@ debugger. The syntax is:
 * `node debug -p <pid>` - Connects to the process via the `pid`
 * `node debug <URI>` - Connects to the process via the URI such as localhost:5858
 
-[TCP protocol]: http://code.google.com/p/v8/wiki/DebuggerProtocol
+[TCP protocol]: https://github.com/v8/v8/wiki/Debugging-Protocol

--- a/doc/api/errors.markdown
+++ b/doc/api/errors.markdown
@@ -486,5 +486,5 @@ often a sign that a connected socket was not `.end()`'d appropriately.
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html
-[V8's stack trace API]: https://code.google.com/p/v8-wiki/wiki/JavaScriptStackTraceApi
+[V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
 [vm]: vm.html

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -46,7 +46,7 @@ exports.port = 5858;
 
 //
 // Parser/Serializer for V8 debugger protocol
-// http://code.google.com/p/v8/wiki/DebuggerProtocol
+// https://github.com/v8/v8/wiki/Debugging-Protocol
 //
 // Usage:
 //    p = new Protocol();


### PR DESCRIPTION
The docs and `_debugger.js` are currently linking to the now non-existing v8 wiki on the v8 issue tracker; Instead it has now been moved to https://github.com/v8/v8/wiki