### PR TITLE
src: use thread defaults provided by v8::platform

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4146,7 +4146,9 @@ int Start(int argc, char** argv) {
   V8::SetEntropySource(crypto::EntropySource);
 #endif
 
-  const int thread_pool_size = 4;
+  // The value zero chooses a suitable default based on the current number of
+  // processors online.
+  const int thread_pool_size = 0;
   default_platform = v8::platform::CreateDefaultPlatform(thread_pool_size);
   V8::InitializePlatform(default_platform);
   V8::Initialize();


### PR DESCRIPTION
By passing `const int thread_pool_size = 0` to `CreateDefaultPlatform`
we allow v8 to choose sensible defaults based on the currently online
processors.

Benchmarking on my local machine saw no performance regressions; however it is dual core and hyper-threaded and would of used the same thread count as previously - I assume that this will benefit machines with more online processors; however I am curious if this would affect machines with only one core.