### PR TITLE
deps: backport b444da41 from V8's upstream

### DIFF
--- a/deps/v8/src/preparser.h
+++ b/deps/v8/src/preparser.h
@@ -2602,7 +2602,9 @@ ParserBase<Traits>::ParsePropertyDefinition(
     // static MethodDefinition
     return ParsePropertyDefinition(checker, true, has_extends, true,
                                    is_computed_name, nullptr, classifier, ok);
-  } else if (is_get || is_set) {
+  } else if ((is_get || is_set) &&
+             (in_class || (peek() != Token::RBRACE && peek() != Token::COMMA &&
+                           peek() != Token::ASSIGN))) {
     // Accessor
     name = this->EmptyIdentifier();
     bool dont_care = false;

--- a/deps/v8/test/cctest/test-parsing.cc
+++ b/deps/v8/test/cctest/test-parsing.cc
@@ -6458,6 +6458,8 @@ TEST(DestructuringPositiveTests) {
     "a",
     "{ x : y }",
     "{ x : y = 1 }",
+    "{ get, set }",
+    "{ get = 1, set = 2 }",
     "[a]",
     "[a = 1]",
     "[a,b,c]",

--- a/deps/v8/test/mjsunit/es6/object-literals-property-shorthand.js
+++ b/deps/v8/test/mjsunit/es6/object-literals-property-shorthand.js
@@ -10,6 +10,14 @@
 })();
 
 
+(function TestBasicsGetSet() {
+  var get = 1, set = 2;
+  var object = {get, set};
+  assertEquals(1, object.get);
+  assertEquals(2, object.set);
+})();
+
+
 (function TestDescriptor() {
   var x = 1;
   var object = {x};

--- a/deps/v8/test/mjsunit/harmony/destructuring.js
+++ b/deps/v8/test/mjsunit/harmony/destructuring.js
@@ -6,9 +6,11 @@
 // Flags: --harmony-default-parameters --harmony-rest-parameters
 
 (function TestObjectLiteralPattern() {
-  var { x : x, y : y } = { x : 1, y : 2 };
+  var { x : x, y : y, get, set } = { x : 1, y : 2, get: 3, set: 4 };
   assertEquals(1, x);
   assertEquals(2, y);
+  assertEquals(3, get);
+  assertEquals(4, set);
 
   var {z} = { z : 3 };
   assertEquals(3, z);


### PR DESCRIPTION
Original commit message:

    [es6] support `get` and `set` in shorthand properties

    Add support for `get` and `set` as shorthand properties. Also
    supports them for CoverInitializedName in BindingPatterns and (once implemented)
    AssignmentPatterns.

    BUG=v8:4412, v8:3584
    LOG=N
    R=adamk, aperez, wingo, rossberg

    Review URL: https://codereview.chromium.org/1328083002

    Cr-Commit-Position: refs/heads/master@{#30769}

Fixes: https://github.com/nodejs/node/issues/4237

cc @nodejs/v8 @mscdex 