### PR TITLE
tls: introduce `secureContext` for `tls.connect`

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -597,6 +597,10 @@ Creates a new client connection to the given `port` and `host` (old API) or
     SSL version 3. The possible values depend on your installation of
     OpenSSL and are defined in the constant [SSL_METHODS][].
 
+  - `secureContext`: An optional TLS context object from
+     `tls.createSecureContext( ... )`. Could it be used for caching client
+     certificates, key, and CA certificates.
+
   - `session`: A `Buffer` instance, containing TLS session.
 
   - `minDHSize`: Minimum size of DH parameter in bits to accept a TLS

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -984,7 +984,7 @@ exports.connect = function(/* [port, host], options, cb */) {
                  'localhost',
       NPN = {},
       ALPN = {},
-      context = tls.createSecureContext(options);
+      context = options.secureContext || tls.createSecureContext(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);
   tls.convertALPNProtocols(options.ALPNProtocols, ALPN);
 

--- a/test/parallel/test-tls-connect-secure-context.js
+++ b/test/parallel/test-tls-connect-secure-context.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+const tls = require('tls');
+
+const fs = require('fs');
+const path = require('path');
+
+const keysDir = path.join(common.fixturesDir, 'keys');
+
+const ca = fs.readFileSync(path.join(keysDir, 'ca1-cert.pem'));
+const cert = fs.readFileSync(path.join(keysDir, 'agent1-cert.pem'));
+const key = fs.readFileSync(path.join(keysDir, 'agent1-key.pem'));
+
+const server = tls.createServer({
+  cert: cert,
+  key: key
+}, function(c) {
+  c.end();
+}).listen(common.PORT, function() {
+  const secureContext = tls.createSecureContext({
+    ca: ca
+  });
+
+  const socket = tls.connect({
+    secureContext: secureContext,
+    servername: 'agent1',
+    port: common.PORT
+  }, common.mustCall(function() {
+    server.close();
+    socket.end();
+  }));
+});


### PR DESCRIPTION
Add `secureContext` option to `tls.connect`. It is useful for caching
client certificates, key, and CA certificates.

cc @nodejs/crypto 