### PR TITLE
test: use regular timeout times for ARMv8

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -245,10 +245,15 @@ exports.platformTimeout = function(ms) {
   if (process.arch !== 'arm')
     return ms;
 
-  if (process.config.variables.arm_version === '6')
+  const armv = process.config.variables.arm_version;
+
+  if (armv === '6')
     return 7 * ms;  // ARMv6
 
-  return 2 * ms;  // ARMv7 and up.
+  if (armv === '7')
+    return 2 * ms;  // ARMv7
+
+  return ms; // ARMv8+
 };
 
 var knownGlobals = [setTimeout,


### PR DESCRIPTION
ARMv8 machines are typically quite fast and likely may not need extended timeout times.

I don't have data on this but I figure it is worth a shot.

cc @nodejs/build