### PR TITLE
src: fix line numbers on core errors

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -966,7 +966,10 @@
     var source = NativeModule.getSource(this.id);
     source = NativeModule.wrap(source);
 
-    var fn = runInThisContext(source, { filename: this.filename });
+    var fn = runInThisContext(source, {
+      filename: this.filename,
+      lineOffset: -1
+    });
     fn(this.exports, NativeModule.require, this, this.filename);
 
     this.loaded = true;

--- a/test/message/core_line_numbers.js
+++ b/test/message/core_line_numbers.js
@@ -1,0 +1,11 @@
+'use strict';
+const common = require('../common');
+const punycode = require('punycode');
+
+// This test verifies that line numbers in core modules are reported correctly.
+// The punycode module was chosen for testing because it changes infrequently.
+// If this test begins failing, it is likely due to a punycode update, and the
+// test's assertions simply need to be updated to reflect the changes. If a
+// punycode update was not made, and this test begins failing, then line numbers
+// are probably actually broken.
+punycode.decode('x');

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -1,0 +1,15 @@
+punycode.js:67
+		throw new RangeError(errors[type]);
+		^
+
+RangeError: Invalid input
+    at error (punycode.js:67:*)
+    at Object.decode (punycode.js:*:*)
+    at Object.<anonymous> (*test*message*core_line_numbers.js:*:*)
+    at Module._compile (module.js:*:*)
+    at Object.Module._extensions..js (module.js:*:*)
+    at Module.load (module.js:*:*)
+    at Function.Module._load (module.js:*:*)
+    at Function.Module.runMain (module.js:*:*)
+    at startup (node.js:*:*)
+    at node.js:*:*


### PR DESCRIPTION
In dfee4e3712ac4673b5fc472a8f77ac65bdc65f87, the module wrapper and line offset used when wrapping module code was changed to better report errors on the first line of modules. However, that commit did not update the `runInThisContext()` call used to execute the core modules, so their error line numbers have been off by one. This commit provides the correct `lineOffset` for core modules.

Refs: https://github.com/nodejs/node/pull/2867