### PR TITLE
test: fix debug-port-cluster flakiness

### DIFF
--- a/test/parallel/test-debug-port-cluster.js
+++ b/test/parallel/test-debug-port-cluster.js
@@ -17,14 +17,15 @@ child.stderr.on('data', function(data) {
   var lines = data.toString().replace(/\r/g, '').trim().split('\n');
   var line = lines[0];
 
-  lines.forEach(function(ln) { console.log('> ' + ln); } );
-
-  if (line === 'all workers are running') {
-    assertOutputLines();
-    process.exit();
-  } else {
-    outputLines = outputLines.concat(lines);
-  }
+  lines.forEach((ln, i) => {
+    console.log(i + '> ' + ln);
+    if (ln === 'all workers are running') {
+      assertOutputLines();
+      process.exit();
+    } else {
+      outputLines.push(ln);
+    }
+  });
 });
 
 process.on('exit', function onExit() {


### PR DESCRIPTION
The test was assuming that the `all workers are running` text was received
by the parent process in a separate chunk from the other texts. This might
not always be the case, causing the test never reaches the exit condition.
Fix it by checking every line received.

This test was timing out from time to time in  `OS X`. To check what the problem was, I added the index
of the lines array into the log and could verify what I described before:
```
/usr/bin/python tools/test.py --mode=release message parallel sequential -J
=== release test-debug-port-cluster ===                                        
Path: parallel/test-debug-port-cluster
0> Debugger listening on port 13783
0> Debugger listening on port 13784
1> Debugger listening on port 13785
2> all workers are running
Command: out/Release/node /Users/sgimeno/node/node/test/parallel/test-debug-port-cluster.js
--- TIMEOUT ---
```