### PR TITLE
doc: fix improper http.get sample code in http.markdown

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -966,6 +966,8 @@ Example:
 
     http.get("http://www.google.com/index.html", function(res) {
       console.log("Got response: " + res.statusCode);
+      // consume response body
+      res.resume();
     }).on('error', function(e) {
       console.log("Got error: " + e.message);
     });


### PR DESCRIPTION
I fixed improper sample code that will potentially hang up around http agent.
This is equals to https://github.com/nodejs/node-v0.x-archive/pull/25471
Related issue is https://github.com/nodejs/node-v0.x-archive/issues/8443