### PR TITLE
node: remove unused variables in AppendExceptionLine

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1482,8 +1482,6 @@ void AppendExceptionLine(Environment* env,
   arrow[off + 1] = '\0';
 
   Local<String> arrow_str = String::NewFromUtf8(env->isolate(), arrow);
-  Local<Value> msg;
-  Local<Value> stack;
 
   // Allocation failed, just print it out
   if (arrow_str.IsEmpty() || err_obj.IsEmpty() || !err_obj->IsNativeError())


### PR DESCRIPTION
These variables in node.cc seems not to be used, just help to clean them :-)