### PR TITLE
node: NativeModule should set lineOffset to -1

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -966,7 +966,7 @@
     var source = NativeModule.getSource(this.id);
     source = NativeModule.wrap(source);
 
-    var fn = runInThisContext(source, { filename: this.filename });
+    var fn = runInThisContext(source, { filename: this.filename, lineOffset: -1 });
     fn(this.exports, NativeModule.require, this, this.filename);
 
     this.loaded = true;


### PR DESCRIPTION
Because we basically wrap the NativeModule, this fixes the
error stack printed by native module like:

```
events.js:143
      throw er; // Unhandled 'error' event
```

But the correct line number should be here: https://github.com/nodejs/node/blob/master/lib/events.js#L142, that's because we used -1 as `lineOffset` in calling `ScriptContextify` but using the default 0 for natives.