### PR TITLE
Fix deprecation message for ErrnoException

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -96,7 +96,7 @@ NODE_EXTERN v8::Local<v8::Value> UVException(v8::Isolate* isolate,
                                              const char* path,
                                              const char* dest);
 
-NODE_DEPRECATED("Use UVException(isolate, ...)",
+NODE_DEPRECATED("Use ErrnoException(isolate, ...)",
                 inline v8::Local<v8::Value> ErrnoException(
       int errorno,
       const char* syscall = NULL,


### PR DESCRIPTION
It seems to me that 75adde07f9a2de7f38a67bec72bd377d450bdb52 did a copy & paste mistake here. It doesn't make much sense to me to internally forward to the isolate-aware version of `ErrnoException` but suggest callees use `UVException` instead.