### PR TITLE
Fix crash in GetInterfaceAddresses

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -200,7 +200,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   ret = Object::New(env->isolate());
 
   if (err == UV_ENOSYS) {
-    args.GetReturnValue().Set(ret);
+    return args.GetReturnValue().Set(ret);
   } else if (err) {
     return env->ThrowUVException(err, "uv_interface_addresses");
   }


### PR DESCRIPTION
If uv_interface_addresses() returns UV_ENOSYS then interfaces and count are
uninitialised. This can cause a segmentation fault inside
GetInterfaceAddresses when it tries to use the invalid interfaces[]. Fix
the issue by returning from GetInterfaceAddresses on the UV_ENOSYS error.

This issue was observed when using uCLibc-ng version 1.0.9 because
uv_interface_addresses() in deps/uv/src/unix/linux-core.c incorrectly
undefines HAVE_IFADDRS_H.

I have submitted a pull request to libuv to fix uClibc-ng support, see https://github.com/libuv/libuv/pull/653.

Also, see https://bugs.busybox.net/show_bug.cgi?id=8296 for further details on
the origins of this bug.