### PR TITLE
Clarify error events on HTTP module documentation

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -1061,7 +1061,8 @@ even if there is no data being written to the request body.
 
 If any error is encountered during the request (be that with DNS resolution,
 TCP level errors, or actual HTTP parse errors) an `'error'` event is emitted
-on the returned request object.
+on the returned request object. If no `'error'` listeners are registered
+the error will be thrown.
 
 There are a few special headers that should be noted.
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -1061,7 +1061,7 @@ even if there is no data being written to the request body.
 
 If any error is encountered during the request (be that with DNS resolution,
 TCP level errors, or actual HTTP parse errors) an `'error'` event is emitted
-on the returned request object. If no `'error'` listeners are registered
+on the returned request object. As with all `'error'` events, if no listeners are registered
 the error will be thrown.
 
 There are a few special headers that should be noted.


### PR DESCRIPTION
Minor clarification on how errors surface on the HTTP module.
It's not clear that if a listener is not registered, the error will be thrown.
Bumped against it this weekend.