### PR TITLE
util: pass on additional error() args

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -18,7 +18,16 @@ exports.printDeprecationMessage = function(msg, warned) {
 };
 
 exports.error = function(msg) {
-  console.error(`${prefix}${msg}`);
+  const fmt = `${prefix}${msg}`;
+  if (arguments.length > 1) {
+    const args = new Array(arguments.length);
+    args[0] = fmt;
+    for (let i = 1; i < arguments.length; ++i)
+      args[i] = arguments[i];
+    console.error.apply(console, args);
+  } else {
+    console.error(fmt);
+  }
 };
 
 exports.trace = function(msg) {

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 const assert = require('assert');
 const internalUtil = require('internal/util');
+const spawnSync = require('child_process').spawnSync;
 
 function getHiddenValue(obj, name) {
   return function() {
@@ -30,3 +31,12 @@ try {
 }
 
 assert(/bad_syntax\.js:1/.test(arrowMessage));
+
+const args = [
+  '--expose-internals',
+  '-e',
+  "require('internal/util').error('foo %d', 5)"
+];
+const result = spawnSync(process.argv[0], args, { encoding: 'utf8' });
+assert.strictEqual(result.stderr.indexOf('%'), -1);
+assert(/foo 5/.test(result.stderr));


### PR DESCRIPTION
This fixes breakage introduced in 94b9948d63 when writing the max EventEmitter listeners warning to stderr.