### PR TITLE
doc: update and modernize examples in api docs

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -99,7 +99,7 @@ You can now use the binary addon in a Node.js project `hello.js` by pointing
 `require` to the recently built `hello.node` module:
 
     // hello.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     console.log(addon.hello()); // 'world'
 
@@ -189,7 +189,7 @@ function calls and return a result. This is the main and only needed source
 You can test it with the following JavaScript snippet:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     console.log( 'This should be eight:', addon.add(3,5) );
 
@@ -237,7 +237,7 @@ adding the function as a property of `exports`.
 To test it, run the following JavaScript snippet:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     addon(function(msg){
       console.log(msg); // 'hello world'
@@ -282,7 +282,7 @@ the string passed to `createObject()`:
 To test it in JavaScript:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     var obj1 = addon('hello');
     var obj2 = addon('world');
@@ -336,7 +336,7 @@ wraps a C++ function:
 To test:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     var fn = addon();
     console.log(fn()); // 'hello world'
@@ -470,7 +470,7 @@ prototype:
 Test it with:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     var obj = new addon.MyObject(10);
     console.log( obj.plusOne() ); // 11
@@ -630,7 +630,7 @@ The implementation is similar to the above in `myobject.cc`:
 Test it with:
 
     // test.js
-    var createObject = require('./build/Release/addon');
+    const createObject = require('./build/Release/addon');
 
     var obj = createObject(10);
     console.log( obj.plusOne() ); // 11
@@ -792,7 +792,7 @@ The implementation of `myobject.cc` is similar to before:
 Test it with:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
     var obj1 = addon.createObject(10);
     var obj2 = addon.createObject(20);
@@ -866,7 +866,7 @@ The file `addon.cc` implements AtExit below:
 Test in JavaScript by running:
 
     // test.js
-    var addon = require('./build/Release/addon');
+    const addon = require('./build/Release/addon');
 
 [online]: https://v8docs.nodesource.com/
 [libuv]: https://github.com/libuv/libuv

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -41,7 +41,7 @@ assertion.
 
     assert.doesNotThrow(
       function() {
-        throw new TypeError("Wrong value");
+        throw new TypeError('Wrong value');
       },
       SyntaxError
     );
@@ -51,7 +51,7 @@ is thrown instead.
 
     assert.doesNotThrow(
       function() {
-        throw new TypeError("Wrong value");
+        throw new TypeError('Wrong value');
       },
       TypeError
     );
@@ -102,7 +102,7 @@ Validate instanceof using constructor:
 
     assert.throws(
       function() {
-        throw new Error("Wrong value");
+        throw new Error('Wrong value');
       },
       Error
     );
@@ -111,7 +111,7 @@ Validate error message using [`RegExp`][]:
 
     assert.throws(
       function() {
-        throw new Error("Wrong value");
+        throw new Error('Wrong value');
       },
       /value/
     );
@@ -120,14 +120,14 @@ Custom error validation:
 
     assert.throws(
       function() {
-        throw new Error("Wrong value");
+        throw new Error('Wrong value');
       },
       function(err) {
         if ( (err instanceof Error) && /value/.test(err) ) {
           return true;
         }
       },
-      "unexpected error"
+      'unexpected error'
     );
 
 [`assert.deepEqual`]: #assert_assert_deepequal_actual_expected_message

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -104,8 +104,8 @@ Example:
 
     str = '\u00bd + \u00bc = \u00be';
 
-    console.log(str + ": " + str.length + " characters, " +
-      Buffer.byteLength(str, 'utf8') + " bytes");
+    console.log(`${str}: ${str.length} characters, ` +
+                `${Buffer.byteLength(str, 'utf8')} bytes`);
 
     // ½ + ¼ = ¾: 9 characters, 12 bytes
 
@@ -277,7 +277,7 @@ and `end` (defaults to `buffer.length`) are not given it will fill the entire
 buffer.
 
     var b = new Buffer(50);
-    b.fill("h");
+    b.fill('h');
 
 ### buf.indexOf(value[, byteOffset])
 
@@ -314,7 +314,7 @@ buffer object.  It does not change when the contents of the buffer are changed.
     buf = new Buffer(1234);
 
     console.log(buf.length);
-    buf.write("some string", 0, "ascii");
+    buf.write('some string', 0, 'ascii');
     console.log(buf.length);
 
     // 1234
@@ -326,7 +326,7 @@ modify the length of a buffer should therefore treat `length` as read-only and
 use [`buf.slice`][] to create a new buffer.
 
     buf = new Buffer(10);
-    buf.write("abcdefghj", 0, "ascii");
+    buf.write('abcdefghj', 0, 'ascii');
     console.log(buf.length); // 10
     buf = buf.slice(0,5);
     console.log(buf.length); // 5
@@ -652,7 +652,7 @@ The method will not write partial characters.
 
     buf = new Buffer(256);
     len = buf.write('\u00bd + \u00bc = \u00be', 0);
-    console.log(len + " bytes: " + buf.toString('utf8', 0, len));
+    console.log(`${len} bytes: ${buf.toString('utf8', 0, len)}`);
 
 ### buf.writeDoubleBE(value, offset[, noAssert])
 ### buf.writeDoubleLE(value, offset[, noAssert])

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -115,11 +115,12 @@ child process has any open IPC channels with the parent (i.e [`fork()`][]).
 Send a signal to the child process. If no argument is given, the process will
 be sent `'SIGTERM'`. See `signal(7)` for a list of available signals.
 
-    var spawn = require('child_process').spawn,
-        grep  = spawn('grep', ['ssh']);
+    const spawn = require('child_process').spawn;
+    const grep = spawn('grep', ['ssh']);
 
-    grep.on('close', function (code, signal) {
-      console.log('child process terminated due to receipt of signal ' + signal);
+    grep.on('close', (code, signal) => {
+      console.log(
+        `child process terminated due to receipt of signal ${signal}`);
     });
 
     // send SIGHUP to process
@@ -145,10 +146,10 @@ The process identifier (PID) of the child process.
 
 Example:
 
-    var spawn = require('child_process').spawn,
-        grep  = spawn('grep', ['ssh']);
+    const spawn = require('child_process').spawn;
+    const grep = spawn('grep', ['ssh']);
 
-    console.log('Spawned child pid: ' + grep.pid);
+    console.log(`Spawned child pid: ${grep.pid}`);
     grep.stdin.end();
 
 ### child.send(message[, sendHandle][, callback])
@@ -164,11 +165,11 @@ a `'message'` event on the child.
 
 For example:
 
-    var cp = require('child_process');
+    const cp = require('child_process');
 
-    var n = cp.fork(__dirname + '/sub.js');
+    var n = cp.fork(`${__dirname}/sub.js`);
 
-    n.on('message', function(m) {
+    n.on('message', (m) => {
       console.log('PARENT got message:', m);
     });
 
@@ -176,7 +177,7 @@ For example:
 
 And then the child script, `'sub.js'` might look like this:
 
-    process.on('message', function(m) {
+    process.on('message', (m) => {
       console.log('CHILD got message:', m);
     });
 
@@ -211,22 +212,22 @@ control.
 
 Here is an example of sending a server:
 
-    var child = require('child_process').fork('child.js');
+    const child = require('child_process').fork('child.js');
 
     // Open up the server object and send the handle.
     var server = require('net').createServer();
-    server.on('connection', function (socket) {
+    server.on('connection', (socket) => {
       socket.end('handled by parent');
     });
-    server.listen(1337, function() {
+    server.listen(1337, () => {
       child.send('server', server);
     });
 
 And the child would then receive the server object as:
 
-    process.on('message', function(m, server) {
+    process.on('message', (m, server) => {
       if (m === 'server') {
-        server.on('connection', function (socket) {
+        server.on('connection', (socket) => {
           socket.end('handled by child');
         });
       }
@@ -246,12 +247,12 @@ connections with the remote address `74.125.127.100` as VIP by sending the
 socket to a "special" child process. Other sockets will go to a "normal"
 process.
 
-    var normal = require('child_process').fork('child.js', ['normal']);
-    var special = require('child_process').fork('child.js', ['special']);
+    const normal = require('child_process').fork('child.js', ['normal']);
+    const special = require('child_process').fork('child.js', ['special']);
 
     // Open up the server and send sockets to child
     var server = require('net').createServer();
-    server.on('connection', function (socket) {
+    server.on('connection', (socket) => {
 
       // if this is a VIP
       if (socket.remoteAddress === '74.125.127.100') {
@@ -265,9 +266,9 @@ process.
 
 The `child.js` could look like this:
 
-    process.on('message', function(m, socket) {
+    process.on('message', (m, socket) => {
       if (m === 'socket') {
-        socket.end('You were handled as a ' + process.argv[2] + ' person');
+        socket.end(`You were handled as a ${process.argv[2]} person`);
       }
     });
 
@@ -315,9 +316,9 @@ In the following example, only the child's fd `1` is setup as a pipe, so only
 the parent's `child.stdio[1]` is a stream, all other values in the array are
 `null`.
 
-    var assert = require('assert');
-    var fs = require('fs');
-    var child_process = require('child_process');
+    const assert = require('assert');
+    const fs = require('fs');
+    const child_process = require('child_process');
 
     child = child_process.spawn('ls', {
         stdio: [
@@ -378,15 +379,13 @@ callback or returning an EventEmitter).
 
 Runs a command in a shell and buffers the output.
 
-    var exec = require('child_process').exec,
-        child;
-
-    child = exec('cat *.js bad_file | wc -l',
-      function (error, stdout, stderr) {
-        console.log('stdout: ' + stdout);
-        console.log('stderr: ' + stderr);
+    const exec = require('child_process').exec;
+    var child = exec('cat *.js bad_file | wc -l',
+      (error, stdout, stderr) => {
+        console.log(`stdout: ${stdout}`);
+        console.log(`stderr: ${stderr}`);
         if (error !== null) {
-          console.log('exec error: ' + error);
+          console.log(`exec error: ${error}`);
         }
     });
 
@@ -508,64 +507,64 @@ process, the default is `process.env`.
 
 Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit code:
 
-    var spawn = require('child_process').spawn,
-        ls    = spawn('ls', ['-lh', '/usr']);
+    const spawn = require('child_process').spawn;
+    var ls = spawn('ls', ['-lh', '/usr']);
 
-    ls.stdout.on('data', function (data) {
-      console.log('stdout: ' + data);
+    ls.stdout.on('data', (data) => {
+      console.log(`stdout: ${data}`);
     });
 
-    ls.stderr.on('data', function (data) {
-      console.log('stderr: ' + data);
+    ls.stderr.on('data', (data) => {
+      console.log(`stderr: ${data}`);
     });
 
-    ls.on('close', function (code) {
-      console.log('child process exited with code ' + code);
+    ls.on('close', (code) => {
+      console.log(`child process exited with code ${code}`);
     });
 
 
 Example: A very elaborate way to run 'ps ax | grep ssh'
 
-    var spawn = require('child_process').spawn,
-        ps    = spawn('ps', ['ax']),
-        grep  = spawn('grep', ['ssh']);
+    const spawn = require('child_process').spawn;
+    var ps = spawn('ps', ['ax']);
+    var grep = spawn('grep', ['ssh']);
 
-    ps.stdout.on('data', function (data) {
+    ps.stdout.on('data', (data) => {
       grep.stdin.write(data);
     });
 
-    ps.stderr.on('data', function (data) {
-      console.log('ps stderr: ' + data);
+    ps.stderr.on('data', (data) => {
+      console.log(`ps stderr: ${data}`);
     });
 
-    ps.on('close', function (code) {
+    ps.on('close', (code) => {
       if (code !== 0) {
-        console.log('ps process exited with code ' + code);
+        console.log(`ps process exited with code ${code}`);
       }
       grep.stdin.end();
     });
 
-    grep.stdout.on('data', function (data) {
-      console.log('' + data);
+    grep.stdout.on('data', (data) => {
+      console.log(`${data}`);
     });
 
-    grep.stderr.on('data', function (data) {
-      console.log('grep stderr: ' + data);
+    grep.stderr.on('data', (data) => {
+      console.log(`grep stderr: ${data}`);
     });
 
-    grep.on('close', function (code) {
+    grep.on('close', (code) => {
       if (code !== 0) {
-        console.log('grep process exited with code ' + code);
+        console.log(`grep process exited with code ${code}`);
       }
     });
 
 
 Example of checking for failed exec:
 
-    var spawn = require('child_process').spawn,
-        child = spawn('bad_command');
+    const spawn = require('child_process').spawn;
+    var child = spawn('bad_command');
 
-    child.on('error', function (err) {
+    child.on('error', (err) => {
       console.log('Failed to start child process.');
     });
 
@@ -587,10 +586,10 @@ and the parent's event loop will not include the child in its reference count.
 Example of detaching a long-running process and redirecting its output to a
 file:
 
-     var fs = require('fs'),
-         spawn = require('child_process').spawn,
-         out = fs.openSync('./out.log', 'a'),
-         err = fs.openSync('./out.log', 'a');
+     const fs = require('fs');
+     const spawn = require('child_process').spawn;
+     var out = fs.openSync('./out.log', 'a');
+     var err = fs.openSync('./out.log', 'a');
 
      var child = spawn('prg', [], {
        detached: true,
@@ -646,7 +645,7 @@ index corresponds to a fd in the child.  The value is one of the following:
 
 Example:
 
-    var spawn = require('child_process').spawn;
+    const spawn = require('child_process').spawn;
 
     // Child will use parent's stdios
     spawn('prg', [], { stdio: 'inherit' });

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -166,8 +166,7 @@ a `'message'` event on the child.
 For example:
 
     const cp = require('child_process');
-
-    var n = cp.fork(`${__dirname}/sub.js`);
+    const n = cp.fork(`${__dirname}/sub.js`);
 
     n.on('message', (m) => {
       console.log('PARENT got message:', m);
@@ -215,7 +214,7 @@ Here is an example of sending a server:
     const child = require('child_process').fork('child.js');
 
     // Open up the server object and send the handle.
-    var server = require('net').createServer();
+    const server = require('net').createServer();
     server.on('connection', (socket) => {
       socket.end('handled by parent');
     });
@@ -251,7 +250,7 @@ process.
     const special = require('child_process').fork('child.js', ['special']);
 
     // Open up the server and send sockets to child
-    var server = require('net').createServer();
+    const server = require('net').createServer();
     server.on('connection', (socket) => {
 
       // if this is a VIP
@@ -320,7 +319,7 @@ the parent's `child.stdio[1]` is a stream, all other values in the array are
     const fs = require('fs');
     const child_process = require('child_process');
 
-    child = child_process.spawn('ls', {
+    const child = child_process.spawn('ls', {
         stdio: [
           0, // use parents stdin for child
           'pipe', // pipe child's stdout to parent
@@ -380,7 +379,7 @@ callback or returning an EventEmitter).
 Runs a command in a shell and buffers the output.
 
     const exec = require('child_process').exec;
-    var child = exec('cat *.js bad_file | wc -l',
+    const child = exec('cat *.js bad_file | wc -l',
       (error, stdout, stderr) => {
         console.log(`stdout: ${stdout}`);
         console.log(`stderr: ${stderr}`);
@@ -508,7 +507,7 @@ process, the default is `process.env`.
 Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit code:
 
     const spawn = require('child_process').spawn;
-    var ls = spawn('ls', ['-lh', '/usr']);
+    const ls = spawn('ls', ['-lh', '/usr']);
 
     ls.stdout.on('data', (data) => {
       console.log(`stdout: ${data}`);
@@ -526,8 +525,8 @@ Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the exit cod
 Example: A very elaborate way to run 'ps ax | grep ssh'
 
     const spawn = require('child_process').spawn;
-    var ps = spawn('ps', ['ax']);
-    var grep = spawn('grep', ['ssh']);
+    const ps = spawn('ps', ['ax']);
+    const grep = spawn('grep', ['ssh']);
 
     ps.stdout.on('data', (data) => {
       grep.stdin.write(data);
@@ -562,7 +561,7 @@ Example: A very elaborate way to run 'ps ax | grep ssh'
 Example of checking for failed exec:
 
     const spawn = require('child_process').spawn;
-    var child = spawn('bad_command');
+    const child = spawn('bad_command');
 
     child.on('error', (err) => {
       console.log('Failed to start child process.');
@@ -588,10 +587,10 @@ file:
 
      const fs = require('fs');
      const spawn = require('child_process').spawn;
-     var out = fs.openSync('./out.log', 'a');
-     var err = fs.openSync('./out.log', 'a');
+     const out = fs.openSync('./out.log', 'a');
+     const err = fs.openSync('./out.log', 'a');
 
-     var child = spawn('prg', [], {
+     const child = spawn('prg', [], {
        detached: true,
        stdio: [ 'ignore', out, err ]
      });

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -131,7 +131,7 @@ In a worker you can also use `process.on('error')`.
 
 Similar to the `cluster.on('exit')` event, but specific to this worker.
 
-    var worker = cluster.fork();
+    const worker = cluster.fork();
     worker.on('exit', (code, signal) => {
       if( signal ) {
         console.log(`worker was killed by signal: ${signal}`);
@@ -612,7 +612,7 @@ A reference to the current worker object. Not available in the master process.
       cluster.fork();
       cluster.fork();
     } else if (cluster.isWorker) {
-      console.log('I am worker #' + cluster.worker.id);
+      console.log(`I am worker #${cluster.worker.id}`);
     }
 
 ## cluster.workers

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -9,9 +9,9 @@ processes to handle the load.
 The cluster module allows you to easily create child processes that
 all share server ports.
 
-    var cluster = require('cluster');
-    var http = require('http');
-    var numCPUs = require('os').cpus().length;
+    const cluster = require('cluster');
+    const http = require('http');
+    const numCPUs = require('os').cpus().length;
 
     if (cluster.isMaster) {
       // Fork workers.
@@ -19,15 +19,15 @@ all share server ports.
         cluster.fork();
       }
 
-      cluster.on('exit', function(worker, code, signal) {
-        console.log('worker ' + worker.process.pid + ' died');
+      cluster.on('exit', (worker, code, signal) => {
+        console.log(`worker ${worker.process.pid} died`);
       });
     } else {
       // Workers can share any TCP connection
       // In this case it is an HTTP server
-      http.createServer(function(req, res) {
+      http.createServer((req, res) => {
         res.writeHead(200);
-        res.end("hello world\n");
+        res.end('hello world\n');
       }).listen(8000);
     }
 
@@ -113,7 +113,7 @@ it can be obtained using `cluster.worker`.
 
 Similar to the `cluster.on('disconnect')` event, but specific to this worker.
 
-    cluster.fork().on('disconnect', function() {
+    cluster.fork().on('disconnect', () => {
       // Worker has disconnected
     });
 
@@ -132,13 +132,13 @@ In a worker you can also use `process.on('error')`.
 Similar to the `cluster.on('exit')` event, but specific to this worker.
 
     var worker = cluster.fork();
-    worker.on('exit', function(code, signal) {
+    worker.on('exit', (code, signal) => {
       if( signal ) {
-        console.log("worker was killed by signal: "+signal);
+        console.log(`worker was killed by signal: ${signal}`);
       } else if( code !== 0 ) {
-        console.log("worker exited with error code: "+code);
+        console.log(`worker exited with error code: ${code}`);
       } else {
-        console.log("worker success!");
+        console.log('worker success!');
       }
     });
 
@@ -148,7 +148,7 @@ Similar to the `cluster.on('exit')` event, but specific to this worker.
 
 Similar to the `cluster.on('listening')` event, but specific to this worker.
 
-    cluster.fork().on('listening', function(address) {
+    cluster.fork().on('listening', (address) => {
       // Worker is listening
     });
 
@@ -167,15 +167,15 @@ In a worker you can also use `process.on('message')`.
 As an example, here is a cluster that keeps count of the number of requests
 in the master process using the message system:
 
-    var cluster = require('cluster');
-    var http = require('http');
+    const cluster = require('cluster');
+    const http = require('http');
 
     if (cluster.isMaster) {
 
       // Keep track of http requests
       var numReqs = 0;
-      setInterval(function() {
-        console.log("numReqs =", numReqs);
+      setInterval(() => {
+        console.log('numReqs =', numReqs);
       }, 1000);
 
       // Count requests
@@ -186,21 +186,21 @@ in the master process using the message system:
       }
 
       // Start workers and listen for messages containing notifyRequest
-      var numCPUs = require('os').cpus().length;
+      const numCPUs = require('os').cpus().length;
       for (var i = 0; i < numCPUs; i++) {
         cluster.fork();
       }
 
-      Object.keys(cluster.workers).forEach(function(id) {
+      Object.keys(cluster.workers).forEach((id) => {
         cluster.workers[id].on('message', messageHandler);
       });
 
     } else {
 
       // Worker processes have a http server.
-      http.Server(function(req, res) {
+      http.Server((req, res) => {
         res.writeHead(200);
-        res.end("hello world\n");
+        res.end('hello world\n');
 
         // notify master about the request
         process.send({ cmd: 'notifyRequest' });
@@ -211,7 +211,7 @@ in the master process using the message system:
 
 Similar to the `cluster.on('online')` event, but specific to this worker.
 
-    cluster.fork().on('online', function() {
+    cluster.fork().on('online', () => {
       // Worker is online
     });
 
@@ -249,27 +249,27 @@ the `'disconnect'` event has not been emitted after some time.
       var worker = cluster.fork();
       var timeout;
 
-      worker.on('listening', function(address) {
+      worker.on('listening', (address) => {
         worker.send('shutdown');
         worker.disconnect();
-        timeout = setTimeout(function() {
+        timeout = setTimeout(() => {
           worker.kill();
         }, 2000);
       });
 
-      worker.on('disconnect', function() {
+      worker.on('disconnect', () => {
         clearTimeout(timeout);
       });
 
     } else if (cluster.isWorker) {
-      var net = require('net');
-      var server = net.createServer(function(socket) {
+      const net = require('net');
+      var server = net.createServer((socket) => {
         // connections never end
       });
 
       server.listen(8000);
 
-      process.on('message', function(msg) {
+      process.on('message', (msg) => {
         if(msg === 'shutdown') {
           // initiate graceful close of any connections to server
         }
@@ -349,7 +349,7 @@ This example will echo back all messages from the master:
       worker.send('hi there');
 
     } else if (cluster.isWorker) {
-      process.on('message', function(msg) {
+      process.on('message', (msg) => {
         process.send(msg);
       });
     }
@@ -363,7 +363,7 @@ Set by calling `.kill()` or `.disconnect()`, until then it is `undefined`.
 The boolean `worker.suicide` lets you distinguish between voluntary and accidental
 exit, the master may choose not to respawn a worker based on this value.
 
-    cluster.on('exit', function(worker, code, signal) {
+    cluster.on('exit', (worker, code, signal) => {
       if (worker.suicide === true) {
         console.log('Oh, it was just suicide\' – no need to worry').
       }
@@ -384,8 +384,8 @@ There may be a delay between the `'disconnect'` and `'exit'` events.  These even
 can be used to detect if the process is stuck in a cleanup or if there are
 long-living connections.
 
-    cluster.on('disconnect', function(worker) {
-      console.log('The worker #' + worker.id + ' has disconnected');
+    cluster.on('disconnect', (worker) => {
+      console.log(`The worker #${worker.id} has disconnected`);
     });
 
 ## Event: 'exit'
@@ -399,7 +399,7 @@ When any of the workers die the cluster module will emit the `'exit'` event.
 
 This can be used to restart the worker by calling `.fork()` again.
 
-    cluster.on('exit', function(worker, code, signal) {
+    cluster.on('exit', (worker, code, signal) => {
       console.log('worker %d died (%s). restarting...',
         worker.process.pid, signal || code);
       cluster.fork();
@@ -416,16 +416,16 @@ This can be used to log worker activity, and create your own timeout.
 
     var timeouts = [];
     function errorMsg() {
-      console.error("Something must be wrong with the connection ...");
+      console.error('Something must be wrong with the connection ...');
     }
 
-    cluster.on('fork', function(worker) {
+    cluster.on('fork', (worker) => {
       timeouts[worker.id] = setTimeout(errorMsg, 2000);
     });
-    cluster.on('listening', function(worker, address) {
+    cluster.on('listening', (worker, address) => {
       clearTimeout(timeouts[worker.id]);
     });
-    cluster.on('exit', function(worker, code, signal) {
+    cluster.on('exit', (worker, code, signal) => {
       clearTimeout(timeouts[worker.id]);
       errorMsg();
     });
@@ -443,8 +443,9 @@ object and the `address` object contains the following connection properties:
 `address`, `port` and `addressType`. This is very useful if the worker is listening
 on more than one address.
 
-    cluster.on('listening', function(worker, address) {
-      console.log("A worker is now connected to " + address.address + ":" + address.port);
+    cluster.on('listening', (worker, address) => {
+      console.log(
+        `A worker is now connected to ${address.address}:${address.port}`);
     });
 
 The `addressType` is one of:
@@ -472,8 +473,8 @@ When the master receives an online message it will emit this event.
 The difference between `'fork'` and `'online'` is that fork is emitted when the
 master forks a worker, and 'online' is emitted when the worker is running.
 
-    cluster.on('online', function(worker) {
-      console.log("Yay, the worker responded after it was forked");
+    cluster.on('online', (worker) => {
+      console.log('Yay, the worker responded after it was forked');
     });
 
 ## Event: 'setup'
@@ -584,7 +585,7 @@ Note that:
 
 Example:
 
-    var cluster = require('cluster');
+    const cluster = require('cluster');
     cluster.setupMaster({
       exec: 'worker.js',
       args: ['--use', 'https'],
@@ -604,7 +605,7 @@ This can only be called from the master process.
 
 A reference to the current worker object. Not available in the master process.
 
-    var cluster = require('cluster');
+    const cluster = require('cluster');
 
     if (cluster.isMaster) {
       console.log('I am master');
@@ -633,14 +634,14 @@ before last `'disconnect'` or `'exit'` event is emitted.
         callback(cluster.workers[id]);
       }
     }
-    eachWorker(function(worker) {
+    eachWorker((worker) => {
       worker.send('big announcement to all workers');
     });
 
 Should you wish to reference a worker over a communication channel, using
 the worker's unique id is the easiest way to find the worker.
 
-    socket.on('data', function(id) {
+    socket.on('data', (id) => {
       var worker = cluster.workers[id];
     });
 

--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -16,8 +16,8 @@ directly without `require`.
 
 Use `require('console').Console` or `console.Console` to access this class.
 
-    var Console = require('console').Console;
-    var Console = console.Console;
+    const Console = require('console').Console;
+    const Console = console.Console;
 
 You can use the `Console` class to create a simple logger like `console` but
 with different output streams.
@@ -29,10 +29,10 @@ Create a new `Console` by passing one or two writable stream instances.
 is used for warning or error output. If `stderr` isn't passed, the warning
 and error output will be sent to the `stdout`.
 
-    var output = fs.createWriteStream('./stdout.log');
-    var errorOutput = fs.createWriteStream('./stderr.log');
+    const output = fs.createWriteStream('./stdout.log');
+    const errorOutput = fs.createWriteStream('./stderr.log');
     // custom simple logger
-    var logger = new Console(output, errorOutput);
+    const logger = new Console(output, errorOutput);
     // use it like console
     var count = 5;
     logger.log('count: %d', count);

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -280,7 +280,7 @@ associated with the private key being set.
 
 Example (obtaining a shared secret):
 
-    var crypto = require('crypto');
+    const crypto = require('crypto');
     var alice = crypto.createECDH('secp256k1');
     var bob = crypto.createECDH('secp256k1');
 
@@ -536,19 +536,19 @@ algorithms.
 Example: this program that takes the sha256 sum of a file
 
     var filename = process.argv[2];
-    var crypto = require('crypto');
-    var fs = require('fs');
+    const crypto = require('crypto');
+    const fs = require('fs');
 
     var shasum = crypto.createHash('sha256');
 
     var s = fs.ReadStream(filename);
-    s.on('data', function(d) {
+    s.on('data', (d) => {
       shasum.update(d);
     });
 
-    s.on('end', function() {
+    s.on('end', () => {
       var d = shasum.digest('hex');
-      console.log(d + '  ' + filename);
+      console.log(`${d}  ${filename}`);
     });
 
 ## crypto.createHmac(algorithm, key)
@@ -608,7 +608,7 @@ and communication time.
 
 Example (obtaining a shared secret):
 
-    var crypto = require('crypto');
+    const crypto = require('crypto');
     var alice = crypto.getDiffieHellman('modp14');
     var bob = crypto.getDiffieHellman('modp14');
 
@@ -711,7 +711,7 @@ NOTE: All paddings are defined in `constants` module.
 Generates cryptographically strong pseudo-random data. Usage:
 
     // async
-    crypto.randomBytes(256, function(ex, buf) {
+    crypto.randomBytes(256, (ex, buf) => {
       if (ex) throw ex;
       console.log('Have %d bytes of random data: %s', buf.length, buf);
     });

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -281,8 +281,8 @@ associated with the private key being set.
 Example (obtaining a shared secret):
 
     const crypto = require('crypto');
-    var alice = crypto.createECDH('secp256k1');
-    var bob = crypto.createECDH('secp256k1');
+    const alice = crypto.createECDH('secp256k1');
+    const bob = crypto.createECDH('secp256k1');
 
     // Note: This is a shortcut way to specify one of Alice's previous private
     // keys. It would be unwise to use such a predictable private key in a real
@@ -294,8 +294,8 @@ Example (obtaining a shared secret):
     // Bob uses a newly generated cryptographically strong pseudorandom key pair
     bob.generateKeys();
 
-    var alice_secret = alice.computeSecret(bob.getPublicKey(), null, 'hex');
-    var bob_secret = bob.computeSecret(alice.getPublicKey(), null, 'hex');
+    const alice_secret = alice.computeSecret(bob.getPublicKey(), null, 'hex');
+    const bob_secret = bob.computeSecret(alice.getPublicKey(), null, 'hex');
 
     // alice_secret and bob_secret should be the same shared secret value
     console.log(alice_secret === bob_secret);
@@ -535,13 +535,13 @@ algorithms.
 
 Example: this program that takes the sha256 sum of a file
 
-    var filename = process.argv[2];
+    const filename = process.argv[2];
     const crypto = require('crypto');
     const fs = require('fs');
 
-    var shasum = crypto.createHash('sha256');
+    const shasum = crypto.createHash('sha256');
 
-    var s = fs.ReadStream(filename);
+    const s = fs.ReadStream(filename);
     s.on('data', (d) => {
       shasum.update(d);
     });
@@ -581,7 +581,7 @@ Returns an array with the names of the supported ciphers.
 
 Example:
 
-    var ciphers = crypto.getCiphers();
+    const ciphers = crypto.getCiphers();
     console.log(ciphers); // ['aes-128-cbc', 'aes-128-ccm', ...]
 
 ## crypto.getCurves()
@@ -590,7 +590,7 @@ Returns an array with the names of the supported elliptic curves.
 
 Example:
 
-    var curves = crypto.getCurves();
+    const curves = crypto.getCurves();
     console.log(curves); // ['secp256k1', 'secp384r1', ...]
 
 ## crypto.getDiffieHellman(group_name)
@@ -609,14 +609,14 @@ and communication time.
 Example (obtaining a shared secret):
 
     const crypto = require('crypto');
-    var alice = crypto.getDiffieHellman('modp14');
-    var bob = crypto.getDiffieHellman('modp14');
+    const alice = crypto.getDiffieHellman('modp14');
+    const bob = crypto.getDiffieHellman('modp14');
 
     alice.generateKeys();
     bob.generateKeys();
 
-    var alice_secret = alice.computeSecret(bob.getPublicKey(), null, 'hex');
-    var bob_secret = bob.computeSecret(alice.getPublicKey(), null, 'hex');
+    const alice_secret = alice.computeSecret(bob.getPublicKey(), null, 'hex');
+    const bob_secret = bob.computeSecret(alice.getPublicKey(), null, 'hex');
 
     /* alice_secret and bob_secret should be the same */
     console.log(alice_secret == bob_secret);
@@ -627,7 +627,7 @@ Returns an array with the names of the supported hash algorithms.
 
 Example:
 
-    var hashes = crypto.getHashes();
+    const hashes = crypto.getHashes();
     console.log(hashes); // ['sha', 'sha1', 'sha1WithRSAEncryption', ...]
 
 ## crypto.pbkdf2(password, salt, iterations, keylen[, digest], callback)

--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -27,9 +27,9 @@ For example, suppose `myscript.js` looked like this:
     x = 5;
     setTimeout(function () {
       debugger;
-      console.log("world");
+      console.log('world');
     }, 1000);
-    console.log("hello");
+    console.log('hello');
 
 Then once the debugger is run, it will break on line 4.
 
@@ -46,15 +46,15 @@ Then once the debugger is run, it will break on line 4.
       1 x = 5;
       2 setTimeout(function () {
       3   debugger;
-      4   console.log("world");
+      4   console.log('world');
       5 }, 1000);
     debug> next
     break in /home/indutny/Code/git/indutny/myscript.js:4
       2 setTimeout(function () {
       3   debugger;
-      4   console.log("world");
+      4   console.log('world');
       5 }, 1000);
-      6 console.log("hello");
+      6 console.log('hello');
     debug> repl
     Press Ctrl + C to leave debug repl
     > x
@@ -65,9 +65,9 @@ Then once the debugger is run, it will break on line 4.
     < world
     break in /home/indutny/Code/git/indutny/myscript.js:5
       3   debugger;
-      4   console.log("world");
+      4   console.log('world');
       5 }, 1000);
-      6 console.log("hello");
+      6 console.log('hello');
       7
     debug> quit
     %

--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -9,13 +9,13 @@ Datagram sockets are available through `require('dgram')`.
 Important note: the behavior of [`dgram.Socket#bind()`][] has changed in v0.10
 and is always asynchronous now.  If you have code that looks like this:
 
-    var s = dgram.createSocket('udp4');
+    const s = dgram.createSocket('udp4');
     s.bind(1234);
     s.addMembership('224.0.0.114');
 
 You have to change it to this:
 
-    var s = dgram.createSocket('udp4');
+    const s = dgram.createSocket('udp4');
     s.bind(1234, () => {
       s.addMembership('224.0.0.114');
     });
@@ -94,7 +94,7 @@ Example of a UDP server listening on port 41234:
 
     const dgram = require('dgram');
 
-    var server = dgram.createSocket('udp4');
+    const server = dgram.createSocket('udp4');
 
     server.on('error', (err) => {
       console.log(`server error:\n${err.stack}`);
@@ -188,8 +188,8 @@ be calculated with respect to [byte length][] and not the character position.
 Example of sending a UDP packet to a random port on `localhost`;
 
     const dgram = require('dgram');
-    var message = new Buffer('Some bytes');
-    var client = dgram.createSocket('udp4');
+    const message = new Buffer('Some bytes');
+    const client = dgram.createSocket('udp4');
     client.send(message, 0, message.length, 41234, 'localhost', (err) => {
       client.close();
     });

--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -16,7 +16,7 @@ and is always asynchronous now.  If you have code that looks like this:
 You have to change it to this:
 
     var s = dgram.createSocket('udp4');
-    s.bind(1234, function() {
+    s.bind(1234, () => {
       s.addMembership('224.0.0.114');
     });
 
@@ -49,7 +49,7 @@ are created.
 Emitted when a new datagram is available on a socket.  `msg` is a `Buffer` and
 `rinfo` is an object with the sender's address information:
 
-    socket.on('message', function(msg, rinfo) {
+    socket.on('message', (msg, rinfo) => {
       console.log('Received %d bytes from %s:%d\n',
                   msg.length, rinfo.address, rinfo.port);
     });
@@ -92,24 +92,22 @@ binding a closed socket), an [`Error`][] may be thrown by this method.
 
 Example of a UDP server listening on port 41234:
 
-    var dgram = require("dgram");
+    const dgram = require('dgram');
 
-    var server = dgram.createSocket("udp4");
+    var server = dgram.createSocket('udp4');
 
-    server.on("error", function (err) {
-      console.log("server error:\n" + err.stack);
+    server.on('error', (err) => {
+      console.log(`server error:\n${err.stack}`);
       server.close();
     });
 
-    server.on("message", function (msg, rinfo) {
-      console.log("server got: " + msg + " from " +
-        rinfo.address + ":" + rinfo.port);
+    server.on('message', (msg, rinfo) => {
+      console.log(`server got: ${msg} from ${rinfo.address}:${rinfo.port}`);
     });
 
-    server.on("listening", function () {
+    server.on('listening', () => {
       var address = server.address();
-      console.log("server listening " +
-          address.address + ":" + address.port);
+      console.log(`server listening ${address.address}:${address.port}`);
     });
 
     server.bind(41234);
@@ -189,10 +187,10 @@ be calculated with respect to [byte length][] and not the character position.
 
 Example of sending a UDP packet to a random port on `localhost`;
 
-    var dgram = require('dgram');
-    var message = new Buffer("Some bytes");
-    var client = dgram.createSocket("udp4");
-    client.send(message, 0, message.length, 41234, "localhost", function(err) {
+    const dgram = require('dgram');
+    var message = new Buffer('Some bytes');
+    var client = dgram.createSocket('udp4');
+    client.send(message, 0, message.length, 41234, 'localhost', (err) => {
       client.close();
     });
 

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -8,13 +8,13 @@ This module contains functions that belong to two different categories:
 
 1) Functions that use the underlying operating system facilities to perform
 name resolution, and that do not necessarily do any network communication.
-This category contains only one function: [`dns.lookup()`][]. __Developers looking
-to perform name resolution in the same way that other applications on the same
-operating system behave should use [`dns.lookup()`][].__
+This category contains only one function: [`dns.lookup()`][]. __Developers
+looking to perform name resolution in the same way that other applications on
+the same operating system behave should use [`dns.lookup()`][].__
 
 Here is an example that does a lookup of `www.google.com`.
 
-    var dns = require('dns');
+    const dns = require('dns');
 
     dns.lookup('www.google.com', function onLookup(err, addresses, family) {
       console.log('addresses:', addresses);
@@ -22,30 +22,29 @@ Here is an example that does a lookup of `www.google.com`.
 
 2) Functions that connect to an actual DNS server to perform name resolution,
 and that _always_ use the network to perform DNS queries. This category
-contains all functions in the `dns` module but [`dns.lookup()`][]. These functions
-do not use the same set of configuration files than what [`dns.lookup()`][] uses.
-For instance, _they do not use the configuration from `/etc/hosts`_. These
-functions should be used by developers who do not want to use the underlying
-operating system's facilities for name resolution, and instead want to
-_always_ perform DNS queries.
+contains all functions in the `dns` module but [`dns.lookup()`][]. These
+functions do not use the same set of configuration files than what
+[`dns.lookup()`][] uses. For instance, _they do not use the configuration from
+`/etc/hosts`_. These functions should be used by developers who do not want to
+use the underlying operating system's facilities for name resolution, and
+instead want to _always_ perform DNS queries.
 
 Here is an example which resolves `'www.google.com'` then reverse
 resolves the IP addresses which are returned.
 
-    var dns = require('dns');
+    const dns = require('dns');
 
-    dns.resolve4('www.google.com', function (err, addresses) {
+    dns.resolve4('www.google.com', (err, addresses) => {
       if (err) throw err;
 
-      console.log('addresses: ' + JSON.stringify(addresses));
+      console.log(`addresses: ${JSON.stringify(addresses)}`);
 
-      addresses.forEach(function (a) {
-        dns.reverse(a, function (err, hostnames) {
+      addresses.forEach((a) => {
+        dns.reverse(a, (err, hostnames) => {
           if (err) {
             throw err;
           }
-
-          console.log('reverse for ' + a + ': ' + JSON.stringify(hostnames));
+          console.log(`reverse for ${a}: ${JSON.stringify(hostnames)}`);
         });
       });
     });
@@ -164,16 +163,17 @@ records). `addresses` is an array of the canonical name records available for
 
 ## dns.resolveMx(hostname, callback)
 
-The same as [`dns.resolve()`][], but only for mail exchange queries (`MX` records).
+The same as [`dns.resolve()`][], but only for mail exchange queries
+(`MX` records).
 
 `addresses` is an array of MX records, each with a priority and an exchange
 attribute (e.g. `[{'priority': 10, 'exchange': 'mx.example.com'},...]`).
 
 ## dns.resolveNs(hostname, callback)
 
-The same as [`dns.resolve()`][], but only for name server records (`NS` records).
-`addresses` is an array of the name server records available for `hostname`
-(e.g., `['ns1.example.com', 'ns2.example.com']`).
+The same as [`dns.resolve()`][], but only for name server records
+(`NS` records). `addresses` is an array of the name server records available
+for `hostname` (e.g., `['ns1.example.com', 'ns2.example.com']`).
 
 ## dns.resolveSoa(hostname, callback)
 
@@ -271,20 +271,20 @@ on some operating systems (e.g FreeBSD 10.1).
 
 ## Implementation considerations
 
-Although [`dns.lookup()`][] and `dns.resolve*()/dns.reverse()` functions have the same
-goal of associating a network name with a network address (or vice versa),
-their behavior is quite different. These differences can have subtle but
+Although [`dns.lookup()`][] and `dns.resolve*()/dns.reverse()` functions have
+the same goal of associating a network name with a network address (or vice
+versa), their behavior is quite different. These differences can have subtle but
 significant consequences on the behavior of Node.js programs.
 
 ### dns.lookup
 
-Under the hood, [`dns.lookup()`][] uses the same operating system facilities as most
-other programs. For instance, [`dns.lookup()`][] will almost always resolve a given
-name the same way as the `ping` command. On most POSIX-like operating systems,
-the behavior of the [`dns.lookup()`][] function can be tweaked by changing settings
-in `nsswitch.conf(5)` and/or `resolv.conf(5)`, but be careful that changing
-these files will change the behavior of all other programs running on the same
-operating system.
+Under the hood, [`dns.lookup()`][] uses the same operating system facilities
+as most other programs. For instance, [`dns.lookup()`][] will almost always
+resolve a given name the same way as the `ping` command. On most POSIX-like
+operating systems, the behavior of the [`dns.lookup()`][] function can be
+tweaked by changing settings in `nsswitch.conf(5)` and/or `resolv.conf(5)`, but
+be careful that changing these files will change the behavior of all other
+programs running on the same operating system.
 
 Though the call will be asynchronous from JavaScript's perspective, it is
 implemented as a synchronous call to `getaddrinfo(3)` that runs on libuv's
@@ -299,10 +299,10 @@ setting the 'UV_THREADPOOL_SIZE' environment variable to a value greater than
 
 ### dns.resolve, functions starting with dns.resolve and dns.reverse
 
-These functions are implemented quite differently than [`dns.lookup()`][]. They do
-not use `getaddrinfo(3)` and they _always_ perform a DNS query on the network.
-This network communication is always done asynchronously, and does not use
-libuv's threadpool.
+These functions are implemented quite differently than [`dns.lookup()`][]. They
+do not use `getaddrinfo(3)` and they _always_ perform a DNS query on the
+network. This network communication is always done asynchronously, and does not
+use libuv's threadpool.
 
 As a result, these functions cannot have the same negative impact on other
 processing that happens on libuv's threadpool that [`dns.lookup()`][] can have.

--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -55,8 +55,8 @@ d.on('error', function(er) {
   // This is no better than process.on('uncaughtException')!
   console.log('error, but oh well', er.message);
 });
-d.run(function() {
-  require('http').createServer(function(req, res) {
+d.run(() => {
+  require('http').createServer((req, res) => {
     handleRequest(req, res);
   }).listen(PORT);
 });
@@ -69,8 +69,8 @@ appropriately, and handle errors with much greater safety.
 ```javascript
 // Much better!
 
-var cluster = require('cluster');
-var PORT = +process.env.PORT || 1337;
+const cluster = require('cluster');
+const PORT = +process.env.PORT || 1337;
 
 if (cluster.isMaster) {
   // In real life, you'd probably use more than just 2 workers,
@@ -88,7 +88,7 @@ if (cluster.isMaster) {
   cluster.fork();
   cluster.fork();
 
-  cluster.on('disconnect', function(worker) {
+  cluster.on('disconnect', (worker) => {
     console.error('disconnect!');
     cluster.fork();
   });
@@ -98,14 +98,14 @@ if (cluster.isMaster) {
   //
   // This is where we put our bugs!
 
-  var domain = require('domain');
+  const domain = require('domain');
 
   // See the cluster documentation for more details about using
   // worker processes to serve requests.  How it works, caveats, etc.
 
-  var server = require('http').createServer(function(req, res) {
+  var server = require('http').createServer((req, res) => {
     var d = domain.create();
-    d.on('error', function(er) {
+    d.on('error', (er) => {
       console.error('error', er.stack);
 
       // Note: we're in dangerous territory!
@@ -115,7 +115,7 @@ if (cluster.isMaster) {
 
       try {
         // make sure we close down within 30 seconds
-        var killtimer = setTimeout(function() {
+        var killtimer = setTimeout(() => {
           process.exit(1);
         }, 30000);
         // But don't keep the process open just for that!
@@ -146,7 +146,7 @@ if (cluster.isMaster) {
     d.add(res);
 
     // Now run the handler function in the domain.
-    d.run(function() {
+    d.run(() => {
       handleRequest(req, res);
     });
   });
@@ -159,7 +159,7 @@ function handleRequest(req, res) {
   switch(req.url) {
     case '/error':
       // We do some async stuff, and then...
-      setTimeout(function() {
+      setTimeout(() => {
         // Whoops!
         flerb.bark();
       });
@@ -231,16 +231,16 @@ For example:
 // create a top-level domain for the server
 var serverDomain = domain.create();
 
-serverDomain.run(function() {
+serverDomain.run(() => {
   // server is created in the scope of serverDomain
-  http.createServer(function(req, res) {
+  http.createServer((req, res) => {
     // req and res are also created in the scope of serverDomain
     // however, we'd prefer to have a separate domain for each request.
     // create it first thing, and add req and res to it.
     var reqd = domain.create();
     reqd.add(req);
     reqd.add(res);
-    reqd.on('error', function(er) {
+    reqd.on('error', (er) => {
       console.error('Error', er, req.url);
       try {
         res.writeHead(500);
@@ -282,13 +282,13 @@ Example:
 
 ```
 var d = domain.create();
-d.on('error', function(er) {
+d.on('error', (er) => {
   console.error('Caught error!', er);
 });
-d.run(function() {
-  process.nextTick(function() {
-    setTimeout(function() { // simulating some various async stuff
-      fs.open('non-existent file', 'r', function(er, fd) {
+d.run(() => {
+  process.nextTick(() => {
+    setTimeout(() => { // simulating some various async stuff
+      fs.open('non-existent file', 'r', (er, fd) => {
         if (er) throw er;
         // proceed...
       });
@@ -350,7 +350,7 @@ thrown will be routed to the domain's `'error'` event.
       }));
     }
 
-    d.on('error', function(er) {
+    d.on('error', (er) => {
       // an error occurred somewhere.
       // if we throw it now, it will crash the program
       // with the normal line number and stack message.
@@ -386,7 +386,7 @@ with a single error handler in a single place.
       }));
     }
 
-    d.on('error', function(er) {
+    d.on('error', (er) => {
       // an error occurred somewhere.
       // if we throw it now, it will crash the program
       // with the normal line number and stack message.

--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -48,7 +48,7 @@ For example, this is not a good idea:
 // XXX WARNING!  BAD IDEA!
 
 var d = require('domain').create();
-d.on('error', function(er) {
+d.on('error', (er) => {
   // The error won't crash the process, but what it does is worse!
   // Though we've prevented abrupt process restarting, we are leaking
   // resources like crazy if this ever happens.
@@ -103,7 +103,7 @@ if (cluster.isMaster) {
   // See the cluster documentation for more details about using
   // worker processes to serve requests.  How it works, caveats, etc.
 
-  var server = require('http').createServer((req, res) => {
+  const server = require('http').createServer((req, res) => {
     var d = domain.create();
     d.on('error', (er) => {
       console.error('error', er.stack);
@@ -229,7 +229,9 @@ For example:
 
 ```
 // create a top-level domain for the server
-var serverDomain = domain.create();
+const domain = require('domain');
+const http = require('http');
+const serverDomain = domain.create();
 
 serverDomain.run(() => {
   // server is created in the scope of serverDomain
@@ -281,7 +283,9 @@ This is the most basic way to use a domain.
 Example:
 
 ```
-var d = domain.create();
+const domain = require('domain');
+const fs = require('fs');
+const d = domain.create();
 d.on('error', (er) => {
   console.error('Caught error!', er);
 });
@@ -341,7 +345,7 @@ thrown will be routed to the domain's `'error'` event.
 
 #### Example
 
-    var d = domain.create();
+    const d = domain.create();
 
     function readSomeFile(filename, cb) {
       fs.readFile(filename, 'utf8', d.bind(function(er, data) {
@@ -370,7 +374,7 @@ with a single error handler in a single place.
 
 #### Example
 
-    var d = domain.create();
+    const d = domain.create();
 
     function readSomeFile(filename, cb) {
       fs.readFile(filename, 'utf8', d.intercept(function(data) {

--- a/doc/api/errors.markdown
+++ b/doc/api/errors.markdown
@@ -47,12 +47,12 @@ it will crash the process as an unhandled exception unless [domains][] are
 employed appropriately or [`process.on('uncaughtException')`][] has a handler.
 
 ```javascript
-var net = require('net');
+const net = require('net');
 
 var connection = net.connect('localhost');
 
 // adding an 'error' event handler to a stream:
-connection.on('error', function(err) {
+connection.on('error', (err) => {
   // if the connection is reset by the server, or if it can't
   // connect at all, or on any sort of error encountered by
   // the connection, the error will be sent here.
@@ -67,11 +67,11 @@ provided by Node.js -- even user created event emitters and streams will throw
 errors when no error handlers are attached. An example:
 
 ```javascript
-var EventEmitter = require('events');
+const EventEmitter = require('events');
 
 var ee = new EventEmitter();
 
-setImmediate(function() {
+setImmediate(() => {
   // this will crash the process because no 'error' event
   // handler has been added.
   ee.emit('error', new Error('This will crash'));
@@ -92,14 +92,14 @@ at least **one** argument -- `error` -- that will either be `null` (if no error
 was encountered) or an `Error` instance.  For instance:
 
 ```javascript
-var fs = require('fs');
+const fs = require('fs');
 
 fs.readFile('/some/file/that/does-not-exist', function nodeStyleCallback(err, data) {
   console.log(err)  // Error: ENOENT
   console.log(data) // undefined / null
 });
 
-fs.readFile('/some/file/that/does-exist', function(err, data) {
+fs.readFile('/some/file/that/does-exist', (err, data) => {
   console.log(err)  // null
   console.log(data) // <Buffer: ba dd ca fe>
 })
@@ -111,10 +111,10 @@ inside their node style callback:
 
 ```javascript
 // THIS WILL NOT WORK:
-var fs = require('fs');
+const fs = require('fs');
 
 try {
-  fs.readFile('/some/file/that/does-not-exist', function(err, data) {
+  fs.readFile('/some/file/that/does-not-exist', (err, data) => {
     // mistaken assumption: throwing here...
     if (err) {
       throw err;
@@ -240,7 +240,7 @@ calls a JavaScript function, the frame representing the `cheetahify` call will *
 be present in stacktraces:
 
 ```javascript
-var cheetahify = require('./native-binding.node');
+const cheetahify = require('./native-binding.node');
 
 function makeFaster() {
   // cheetahify *synchronously* calls speedy.
@@ -331,7 +331,7 @@ program.
 
 ```javascript
 try {
-  require("vm").runInThisContext("binary ! isNotOk");
+  require('vm').runInThisContext('binary ! isNotOk');
 } catch(err) {
   // err will be a SyntaxError
 }

--- a/doc/api/errors.markdown
+++ b/doc/api/errors.markdown
@@ -49,7 +49,7 @@ employed appropriately or [`process.on('uncaughtException')`][] has a handler.
 ```javascript
 const net = require('net');
 
-var connection = net.connect('localhost');
+const connection = net.connect('localhost');
 
 // adding an 'error' event handler to a stream:
 connection.on('error', (err) => {
@@ -69,7 +69,7 @@ errors when no error handlers are attached. An example:
 ```javascript
 const EventEmitter = require('events');
 
-var ee = new EventEmitter();
+const ee = new EventEmitter();
 
 setImmediate(() => {
   // this will crash the process because no 'error' event

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -24,7 +24,7 @@ attached to.
 Use `require('events')` to access the EventEmitter class.
 
 ```javascript
-var EventEmitter = require('events');
+const EventEmitter = require('events');
 ```
 
 When an `EventEmitter` instance experiences an error, the typical action is
@@ -107,7 +107,7 @@ This can be useful to increment/decrement max listeners to avoid the warning
 while not being irresponsible and setting a too big number.
 
     emitter.setMaxListeners(emitter.getMaxListeners() + 1);
-    emitter.once('event', function () {
+    emitter.once('event', () => {
       // do stuff
       emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
     });
@@ -122,7 +122,7 @@ Returns the number of listeners listening to the `type` of event.
 
 Returns a copy of the array of listeners for the specified event.
 
-    server.on('connection', function (stream) {
+    server.on('connection', (stream) => {
       console.log('someone connected!');
     });
     console.log(util.inspect(server.listeners('connection'))); // [ [Function] ]
@@ -134,7 +134,7 @@ No checks are made to see if the `listener` has already been added. Multiple
 calls passing the same combination of `event` and `listener` will result in the
 `listener` being added multiple times.
 
-    server.on('connection', function (stream) {
+    server.on('connection', (stream) => {
       console.log('someone connected!');
     });
 
@@ -146,7 +146,7 @@ Adds a **one time** listener for the event. This listener is
 invoked only the next time the event is fired, after which
 it is removed.
 
-    server.once('connection', function (stream) {
+    server.once('connection', (stream) => {
       console.log('Ah, we have our first user!');
     });
 

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -18,16 +18,16 @@ You can use try/catch to handle exceptions or allow them to bubble up.
 
 Here is an example of the asynchronous version:
 
-    var fs = require('fs');
+    const fs = require('fs');
 
-    fs.unlink('/tmp/hello', function (err) {
+    fs.unlink('/tmp/hello', (err) => {
       if (err) throw err;
       console.log('successfully deleted /tmp/hello');
     });
 
 Here is the synchronous version:
 
-    var fs = require('fs');
+    const fs = require('fs');
 
     fs.unlinkSync('/tmp/hello');
     console.log('successfully deleted /tmp/hello');
@@ -35,23 +35,23 @@ Here is the synchronous version:
 With the asynchronous methods there is no guaranteed ordering. So the
 following is prone to error:
 
-    fs.rename('/tmp/hello', '/tmp/world', function (err) {
+    fs.rename('/tmp/hello', '/tmp/world', (err) => {
       if (err) throw err;
       console.log('renamed complete');
     });
-    fs.stat('/tmp/world', function (err, stats) {
+    fs.stat('/tmp/world', (err, stats) => {
       if (err) throw err;
-      console.log('stats: ' + JSON.stringify(stats));
+      console.log(`stats: ${JSON.stringify(stats)}`);
     });
 
 It could be that `fs.stat` is executed before `fs.rename`.
 The correct way to do this is to chain the callbacks.
 
-    fs.rename('/tmp/hello', '/tmp/world', function (err) {
+    fs.rename('/tmp/hello', '/tmp/world', (err) => {
       if (err) throw err;
-      fs.stat('/tmp/world', function (err, stats) {
+      fs.stat('/tmp/world', (err, stats) => {
         if (err) throw err;
-        console.log('stats: ' + JSON.stringify(stats));
+        console.log(`stats: ${JSON.stringify(stats)}`);
       });
     });
 
@@ -240,7 +240,7 @@ Asynchronously append data to a file, creating the file if it does not yet exist
 
 Example:
 
-    fs.appendFile('message.txt', 'data to append', function (err) {
+    fs.appendFile('message.txt', 'data to append', (err) => {
       if (err) throw err;
       console.log('The "data to append" was appended to file!');
     });
@@ -355,8 +355,8 @@ If `options` is a string, then it specifies the encoding.
 Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
 
-    fs.exists('/etc/passwd', function (exists) {
-      console.log(exists ? "it's there" : 'no passwd!');
+    fs.exists('/etc/passwd', (exists) => {
+      console.log(exists ? 'it\'s there' : 'no passwd!');
     });
 
 `fs.exists()` should not be used to check if a file exists before calling
@@ -579,7 +579,7 @@ Synchronous readdir(3). Returns an array of filenames excluding `'.'` and
 
 Asynchronously reads the entire contents of a file. Example:
 
-    fs.readFile('/etc/passwd', function (err, data) {
+    fs.readFile('/etc/passwd', (err, data) => {
       if (err) throw err;
       console.log(data);
     });
@@ -623,7 +623,7 @@ resolution or avoid additional `fs.stat` calls for known real paths.
 Example:
 
     var cache = {'/etc':'/private/etc'};
-    fs.realpath('/etc/passwd', cache, function (err, resolvedPath) {
+    fs.realpath('/etc/passwd', cache, (err, resolvedPath) => {
       if (err) throw err;
       console.log(resolvedPath);
     });
@@ -790,10 +790,10 @@ Windows.  Even on supported platforms, `filename` is not always guaranteed to
 be provided. Therefore, don't assume that `filename` argument is always
 provided in the callback, and have some fallback logic if it is null.
 
-    fs.watch('somedir', function (event, filename) {
-      console.log('event is: ' + event);
+    fs.watch('somedir', (event, filename) => {
+      console.log(`event is: ${event}`);
       if (filename) {
-        console.log('filename provided: ' + filename);
+        console.log(`filename provided: ${filename}`);
       } else {
         console.log('filename not provided');
       }
@@ -814,9 +814,9 @@ target should be polled in milliseconds. The default is
 The `listener` gets two arguments the current stat object and the previous
 stat object:
 
-    fs.watchFile('message.text', function (curr, prev) {
-      console.log('the current mtime is: ' + curr.mtime);
-      console.log('the previous mtime was: ' + prev.mtime);
+    fs.watchFile('message.text', (curr, prev) => {
+      console.log(`the current mtime is: ${curr.mtime}`);
+      console.log(`the previous mtime was: ${prev.mtime}`);
     });
 
 These stat objects are instances of `fs.Stat`.
@@ -900,7 +900,7 @@ to `'utf8'`.
 
 Example:
 
-    fs.writeFile('message.txt', 'Hello Node.js', function (err) {
+    fs.writeFile('message.txt', 'Hello Node.js', (err) => {
       if (err) throw err;
       console.log('It\'s saved!');
     });

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -64,10 +64,10 @@ a `'close'` event or a special `'agentRemove'` event. This means that if
 you intend to keep one HTTP request open for a long time and don't
 want it to stay in the pool you can do something along the lines of:
 
-    http.get(options, function(res) {
+    http.get(options, (res)=> {
       // Do stuff
-    }).on("socket", function (socket) {
-      socket.emit("agentRemove");
+    }).on('socket', (socket)=> {
+      socket.emit('agentRemove');
     });
 
 Alternatively, you could just opt out of pooling entirely using
@@ -78,7 +78,7 @@ Alternatively, you could just opt out of pooling entirely using
       port: 80,
       path: '/',
       agent: false  // create a new agent just for this one request
-    }, function (res) {
+    }, (res)=> {
       // Do stuff with response
     })
 
@@ -103,7 +103,7 @@ of these values set to their respective defaults.
 To configure any of them, you must create your own [`http.Agent`][] object.
 
 ```javascript
-var http = require('http');
+const http = require('http');
 var keepAliveAgent = new http.Agent({ keepAlive: true });
 options.agent = keepAliveAgent;
 http.request(options, onResponseCallback);
@@ -202,19 +202,19 @@ their connections closed.
 
 A client server pair that show you how to listen for the `'connect'` event.
 
-    var http = require('http');
-    var net = require('net');
-    var url = require('url');
+    const http = require('http');
+    const net = require('net');
+    const url = require('url');
 
     // Create an HTTP tunneling proxy
-    var proxy = http.createServer(function (req, res) {
+    var proxy = http.createServer( (req, res)=> {
       res.writeHead(200, {'Content-Type': 'text/plain'});
       res.end('okay');
     });
-    proxy.on('connect', function(req, cltSocket, head) {
+    proxy.on('connect', (req, cltSocket, head)=> {
       // connect to an origin server
-      var srvUrl = url.parse('http://' + req.url);
-      var srvSocket = net.connect(srvUrl.port, srvUrl.hostname, function() {
+      var srvUrl = url.parse(`http://${req.url}`);
+      var srvSocket = net.connect(srvUrl.port, srvUrl.hostname, ()=> {
         cltSocket.write('HTTP/1.1 200 Connection Established\r\n' +
                         'Proxy-agent: Node.js-Proxy\r\n' +
                         '\r\n');
@@ -225,7 +225,7 @@ A client server pair that show you how to listen for the `'connect'` event.
     });
 
     // now that proxy is running
-    proxy.listen(1337, '127.0.0.1', function() {
+    proxy.listen(1337, '127.0.0.1', ()=> {
 
       // make a request to a tunneling proxy
       var options = {
@@ -238,7 +238,7 @@ A client server pair that show you how to listen for the `'connect'` event.
       var req = http.request(options);
       req.end();
 
-      req.on('connect', function(res, socket, head) {
+      req.on('connect', (res, socket, head)=> {
         console.log('got connected!');
 
         // make a request over an HTTP tunnel
@@ -246,10 +246,10 @@ A client server pair that show you how to listen for the `'connect'` event.
                      'Host: www.google.com:80\r\n' +
                      'Connection: close\r\n' +
                      '\r\n');
-        socket.on('data', function(chunk) {
+        socket.on('data', (chunk)=> {
           console.log(chunk.toString());
         });
-        socket.on('end', function() {
+        socket.on('end', ()=> {
           proxy.close();
         });
       });
@@ -292,14 +292,14 @@ their connections closed.
 
 A client server pair that show you how to listen for the `'upgrade'` event.
 
-    var http = require('http');
+    const http = require('http');
 
     // Create an HTTP server
-    var srv = http.createServer(function (req, res) {
+    var srv = http.createServer( (req, res)=> {
       res.writeHead(200, {'Content-Type': 'text/plain'});
       res.end('okay');
     });
-    srv.on('upgrade', function(req, socket, head) {
+    srv.on('upgrade', (req, socket, head)=> {
       socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
                    'Upgrade: WebSocket\r\n' +
                    'Connection: Upgrade\r\n' +
@@ -309,7 +309,7 @@ A client server pair that show you how to listen for the `'upgrade'` event.
     });
 
     // now that server is running
-    srv.listen(1337, '127.0.0.1', function() {
+    srv.listen(1337, '127.0.0.1', ()=> {
 
       // make a request
       var options = {
@@ -324,7 +324,7 @@ A client server pair that show you how to listen for the `'upgrade'` event.
       var req = http.request(options);
       req.end();
 
-      req.on('upgrade', function(res, socket, upgradeHead) {
+      req.on('upgrade', (res, socket, upgradeHead)=> {
         console.log('got upgraded!');
         socket.end();
         process.exit(0);
@@ -606,7 +606,7 @@ emit trailers, with a list of the header fields in its value. E.g.,
     response.writeHead(200, { 'Content-Type': 'text/plain',
                               'Trailer': 'Content-MD5' });
     response.write(fileData);
-    response.addTrailers({'Content-MD5': "7895bf4b8828b55ceaf47747b4bca667"});
+    response.addTrailers({'Content-MD5': '7895bf4b8828b55ceaf47747b4bca667'});
     response.end();
 
 Attempting to set a trailer field name that contains invalid characters will
@@ -649,7 +649,7 @@ Removes a header that's queued for implicit sending.
 
 Example:
 
-    response.removeHeader("Content-Encoding");
+    response.removeHeader('Content-Encoding');
 
 ### response.sendDate
 
@@ -667,11 +667,11 @@ here if you need to send multiple headers with the same name.
 
 Example:
 
-    response.setHeader("Content-Type", "text/html");
+    response.setHeader('Content-Type', 'text/html');
 
 or
 
-    response.setHeader("Set-Cookie", ["type=ninja", "language=javascript"]);
+    response.setHeader('Set-Cookie', ['type=ninja', 'language=javascript']);
 
 Attempting to set a header field name that contains invalid characters will
 result in a [`TypeError`][] being thrown.
@@ -964,12 +964,12 @@ is that it sets the method to GET and calls `req.end()` automatically.
 
 Example:
 
-    http.get("http://www.google.com/index.html", function(res) {
-      console.log("Got response: " + res.statusCode);
+    http.get('http://www.google.com/index.html', (res)=> {
+      console.log(`Got response: ${res.statusCode}`);
       // consume response body
       res.resume();
-    }).on('error', function(e) {
-      console.log("Got error: " + e.message);
+    }).on('error', (e)=> {
+      console.log(`Got error: ${e.message}`);
     });
 
 ## http.globalAgent
@@ -1037,20 +1037,20 @@ Example:
       }
     };
 
-    var req = http.request(options, function(res) {
-      console.log('STATUS: ' + res.statusCode);
-      console.log('HEADERS: ' + JSON.stringify(res.headers));
+    var req = http.request(options, (res)=> {
+      console.log(`STATUS: ${res.statusCode}`);
+      console.log(`HEADERS: ${JSON.stringify(res.headers)}`);
       res.setEncoding('utf8');
-      res.on('data', function (chunk) {
-        console.log('BODY: ' + chunk);
+      res.on('data', (chunk)=> {
+        console.log(`BODY: ${chunk}`);
       });
-      res.on('end', function() {
+      res.on('end', ()=> {
         console.log('No more data in response.')
       })
     });
 
-    req.on('error', function(e) {
-      console.log('problem with request: ' + e.message);
+    req.on('error', (e)=> {
+      console.log(`problem with request: ${e.message}`);
     });
 
     // write data to request body

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -64,9 +64,9 @@ a `'close'` event or a special `'agentRemove'` event. This means that if
 you intend to keep one HTTP request open for a long time and don't
 want it to stay in the pool you can do something along the lines of:
 
-    http.get(options, (res)=> {
+    http.get(options, (res) => {
       // Do stuff
-    }).on('socket', (socket)=> {
+    }).on('socket', (socket) => {
       socket.emit('agentRemove');
     });
 
@@ -78,7 +78,7 @@ Alternatively, you could just opt out of pooling entirely using
       port: 80,
       path: '/',
       agent: false  // create a new agent just for this one request
-    }, (res)=> {
+    }, (res) => {
       // Do stuff with response
     })
 
@@ -207,14 +207,14 @@ A client server pair that show you how to listen for the `'connect'` event.
     const url = require('url');
 
     // Create an HTTP tunneling proxy
-    var proxy = http.createServer( (req, res)=> {
+    var proxy = http.createServer( (req, res) => {
       res.writeHead(200, {'Content-Type': 'text/plain'});
       res.end('okay');
     });
-    proxy.on('connect', (req, cltSocket, head)=> {
+    proxy.on('connect', (req, cltSocket, head) => {
       // connect to an origin server
       var srvUrl = url.parse(`http://${req.url}`);
-      var srvSocket = net.connect(srvUrl.port, srvUrl.hostname, ()=> {
+      var srvSocket = net.connect(srvUrl.port, srvUrl.hostname, () => {
         cltSocket.write('HTTP/1.1 200 Connection Established\r\n' +
                         'Proxy-agent: Node.js-Proxy\r\n' +
                         '\r\n');
@@ -225,7 +225,7 @@ A client server pair that show you how to listen for the `'connect'` event.
     });
 
     // now that proxy is running
-    proxy.listen(1337, '127.0.0.1', ()=> {
+    proxy.listen(1337, '127.0.0.1', () => {
 
       // make a request to a tunneling proxy
       var options = {
@@ -238,7 +238,7 @@ A client server pair that show you how to listen for the `'connect'` event.
       var req = http.request(options);
       req.end();
 
-      req.on('connect', (res, socket, head)=> {
+      req.on('connect', (res, socket, head) => {
         console.log('got connected!');
 
         // make a request over an HTTP tunnel
@@ -246,10 +246,10 @@ A client server pair that show you how to listen for the `'connect'` event.
                      'Host: www.google.com:80\r\n' +
                      'Connection: close\r\n' +
                      '\r\n');
-        socket.on('data', (chunk)=> {
+        socket.on('data', (chunk) => {
           console.log(chunk.toString());
         });
-        socket.on('end', ()=> {
+        socket.on('end', () => {
           proxy.close();
         });
       });
@@ -295,11 +295,11 @@ A client server pair that show you how to listen for the `'upgrade'` event.
     const http = require('http');
 
     // Create an HTTP server
-    var srv = http.createServer( (req, res)=> {
+    var srv = http.createServer( (req, res) => {
       res.writeHead(200, {'Content-Type': 'text/plain'});
       res.end('okay');
     });
-    srv.on('upgrade', (req, socket, head)=> {
+    srv.on('upgrade', (req, socket, head) => {
       socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
                    'Upgrade: WebSocket\r\n' +
                    'Connection: Upgrade\r\n' +
@@ -309,7 +309,7 @@ A client server pair that show you how to listen for the `'upgrade'` event.
     });
 
     // now that server is running
-    srv.listen(1337, '127.0.0.1', ()=> {
+    srv.listen(1337, '127.0.0.1', () => {
 
       // make a request
       var options = {
@@ -324,7 +324,7 @@ A client server pair that show you how to listen for the `'upgrade'` event.
       var req = http.request(options);
       req.end();
 
-      req.on('upgrade', (res, socket, upgradeHead)=> {
+      req.on('upgrade', (res, socket, upgradeHead) => {
         console.log('got upgraded!');
         socket.end();
         process.exit(0);
@@ -964,11 +964,11 @@ is that it sets the method to GET and calls `req.end()` automatically.
 
 Example:
 
-    http.get('http://www.google.com/index.html', (res)=> {
+    http.get('http://www.google.com/index.html', (res) => {
       console.log(`Got response: ${res.statusCode}`);
       // consume response body
       res.resume();
-    }).on('error', (e)=> {
+    }).on('error', (e) => {
       console.log(`Got error: ${e.message}`);
     });
 
@@ -1037,19 +1037,19 @@ Example:
       }
     };
 
-    var req = http.request(options, (res)=> {
+    var req = http.request(options, (res) => {
       console.log(`STATUS: ${res.statusCode}`);
       console.log(`HEADERS: ${JSON.stringify(res.headers)}`);
       res.setEncoding('utf8');
-      res.on('data', (chunk)=> {
+      res.on('data', (chunk) => {
         console.log(`BODY: ${chunk}`);
       });
-      res.on('end', ()=> {
+      res.on('end', () => {
         console.log('No more data in response.')
       })
     });
 
-    req.on('error', (e)=> {
+    req.on('error', (e) => {
       console.log(`problem with request: ${e.message}`);
     });
 

--- a/doc/api/https.markdown
+++ b/doc/api/https.markdown
@@ -32,31 +32,31 @@ automatically added to the `'request'` event.
 Example:
 
     // curl -k https://localhost:8000/
-    var https = require('https');
-    var fs = require('fs');
+    const https = require('https');
+    const fs = require('fs');
 
-    var options = {
+    const options = {
       key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
       cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
     };
 
-    https.createServer(options, function (req, res) {
+    https.createServer(options, (req, res) => {
       res.writeHead(200);
-      res.end("hello world\n");
+      res.end('hello world\n');
     }).listen(8000);
 
 Or
 
-    var https = require('https');
-    var fs = require('fs');
+    const https = require('https');
+    const fs = require('fs');
 
-    var options = {
+    const options = {
       pfx: fs.readFileSync('server.pfx')
     };
 
-    https.createServer(options, function (req, res) {
+    https.createServer(options, (req, res) => {
       res.writeHead(200);
-      res.end("hello world\n");
+      res.end('hello world\n');
     }).listen(8000);
 
 ### server.close([callback])
@@ -78,17 +78,17 @@ automatically parsed with [`url.parse()`][].
 
 Example:
 
-    var https = require('https');
+    const https = require('https');
 
-    https.get('https://encrypted.google.com/', function(res) {
-      console.log("statusCode: ", res.statusCode);
-      console.log("headers: ", res.headers);
+    https.get('https://encrypted.google.com/', (res) => {
+      console.log('statusCode: ', res.statusCode);
+      console.log('headers: ', res.headers);
 
-      res.on('data', function(d) {
+      res.on('data', (d) => {
         process.stdout.write(d);
       });
 
-    }).on('error', function(e) {
+    }).on('error', (e) => {
       console.error(e);
     });
 
@@ -107,7 +107,7 @@ All options from [`http.request()`][] are valid.
 
 Example:
 
-    var https = require('https');
+    const https = require('https');
 
     var options = {
       hostname: 'encrypted.google.com',
@@ -116,17 +116,17 @@ Example:
       method: 'GET'
     };
 
-    var req = https.request(options, function(res) {
-      console.log("statusCode: ", res.statusCode);
-      console.log("headers: ", res.headers);
+    var req = https.request(options, (res) => {
+      console.log('statusCode: ', res.statusCode);
+      console.log('headers: ', res.headers);
 
-      res.on('data', function(d) {
+      res.on('data', (d) => {
         process.stdout.write(d);
       });
     });
     req.end();
 
-    req.on('error', function(e) {
+    req.on('error', (e) => {
       console.error(e);
     });
 
@@ -192,7 +192,7 @@ Example:
     };
     options.agent = new https.Agent(options);
 
-    var req = https.request(options, function(res) {
+    var req = https.request(options, (res) => {
       ...
     }
 
@@ -210,7 +210,7 @@ Example:
       agent: false
     };
 
-    var req = https.request(options, function(res) {
+    var req = https.request(options, (res) => {
       ...
     }
 

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -10,13 +10,12 @@ in one-to-one correspondence.  As an example, `foo.js` loads the module
 
 The contents of `foo.js`:
 
-    var circle = require('./circle.js');
-    console.log( 'The area of a circle of radius 4 is '
-               + circle.area(4));
+    const circle = require('./circle.js');
+    console.log( `The area of a circle of radius 4 is ${circle.area(4)}`);
 
 The contents of `circle.js`:
 
-    var PI = Math.PI;
+    const PI = Math.PI;
 
     exports.area = function (r) {
       return PI * r * r;
@@ -40,9 +39,9 @@ instead of `exports`.
 
 Below, `bar.js` makes use of the `square` module, which exports a constructor:
 
-    var square = require('./square.js');
+    const square = require('./square.js');
     var mySquare = square(2);
-    console.log('The area of my square is ' + mySquare.area());
+    console.log(`The area of my square is ${mySquare.area()}`);
 
 The `square` module is defined in `square.js`:
 
@@ -233,7 +232,7 @@ Consider this situation:
 
     console.log('a starting');
     exports.done = false;
-    var b = require('./b.js');
+    const b = require('./b.js');
     console.log('in a, b.done = %j', b.done);
     exports.done = true;
     console.log('a done');
@@ -242,7 +241,7 @@ Consider this situation:
 
     console.log('b starting');
     exports.done = false;
-    var a = require('./a.js');
+    const a = require('./a.js');
     console.log('in b, a.done = %j', a.done);
     exports.done = true;
     console.log('b done');
@@ -250,8 +249,8 @@ Consider this situation:
 `main.js`:
 
     console.log('main starting');
-    var a = require('./a.js');
-    var b = require('./b.js');
+    const a = require('./a.js');
+    const b = require('./b.js');
     console.log('in main, a.done=%j, b.done=%j', a.done, b.done);
 
 When `main.js` loads `a.js`, then `a.js` in turn loads `b.js`.  At that
@@ -425,20 +424,20 @@ which is probably not what you want to do.
 
 For example suppose we were making a module called `a.js`
 
-    var EventEmitter = require('events');
+    const EventEmitter = require('events');
 
     module.exports = new EventEmitter();
 
     // Do some work, and after some time emit
     // the 'ready' event from the module itself.
-    setTimeout(function() {
+    setTimeout(() => {
       module.exports.emit('ready');
     }, 1000);
 
 Then in another file we could do
 
-    var a = require('./a');
-    a.on('ready', function() {
+    const a = require('./a');
+    a.on('ready', () => {
       console.log('module a is ready');
     });
 
@@ -448,13 +447,13 @@ done in any callbacks.  This does not work:
 
 x.js:
 
-    setTimeout(function() {
-      module.exports = { a: "hello" };
+    setTimeout(() => {
+      module.exports = { a: 'hello' };
     }, 0);
 
 y.js:
 
-    var x = require('./x');
+    const x = require('./x');
     console.log(x.a);
 
 #### exports alias

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -45,14 +45,14 @@ Returns an object with three properties, e.g.
 
 Example:
 
-    var server = net.createServer(function (socket) {
-      socket.end("goodbye\n");
+    var server = net.createServer((socket) => {
+      socket.end('goodbye\n');
     });
 
     // grab a random port.
-    server.listen(function() {
+    server.listen(() => {
       address = server.address();
-      console.log("opened server on %j", address);
+      console.log('opened server on %j', address);
     });
 
 Don't call `server.address()` until the `'listening'` event has been emitted.
@@ -184,10 +184,10 @@ One issue some users run into is getting `EADDRINUSE` errors. This means that
 another server is already running on the requested port. One way of handling this
 would be to wait a second and then try again. This can be done with
 
-    server.on('error', function (e) {
+    server.on('error', (e) => {
       if (e.code == 'EADDRINUSE') {
         console.log('Address in use, retrying...');
-        setTimeout(function () {
+        setTimeout(() => {
           server.close();
           server.listen(PORT, HOST);
         }, 1000);
@@ -512,17 +512,17 @@ The `connectListener` parameter will be added as a listener for the
 
 Here is an example of a client of the previously described echo server:
 
-    var net = require('net');
+    const net = require('net');
     var client = net.connect({port: 8124},
-        function() { //'connect' listener
+        () => { //'connect' listener
       console.log('connected to server!');
       client.write('world!\r\n');
     });
-    client.on('data', function(data) {
+    client.on('data', (data) => {
       console.log(data.toString());
       client.end();
     });
-    client.on('end', function() {
+    client.on('end', () => {
       console.log('disconnected from server');
     });
 
@@ -562,17 +562,17 @@ The `connectListener` parameter will be added as a listener for the
 
 Here is an example of a client of the previously described echo server:
 
-    var net = require('net');
+    const net = require('net');
     var client = net.connect({port: 8124},
-        function() { //'connect' listener
+        () => { //'connect' listener
       console.log('connected to server!');
       client.write('world!\r\n');
     });
-    client.on('data', function(data) {
+    client.on('data', (data) => {
       console.log(data.toString());
       client.end();
     });
-    client.on('end', function() {
+    client.on('end', () => {
       console.log('disconnected from server');
     });
 
@@ -624,16 +624,16 @@ original process. To begin reading data from a paused socket, call [`resume()`][
 Here is an example of an echo server which listens for connections
 on port 8124:
 
-    var net = require('net');
-    var server = net.createServer(function(c) { //'connection' listener
+    const net = require('net');
+    var server = net.createServer((c) => { //'connection' listener
       console.log('client connected');
-      c.on('end', function() {
+      c.on('end', () => {
         console.log('client disconnected');
       });
       c.write('hello\r\n');
       c.pipe(c);
     });
-    server.listen(8124, function() { //'listening' listener
+    server.listen(8124, () => { //'listening' listener
       console.log('server bound');
     });
 
@@ -644,7 +644,7 @@ Test this by using `telnet`:
 To listen on the socket `/tmp/echo.sock` the third line from the last would
 just be changed to
 
-    server.listen('/tmp/echo.sock', function() { //'listening' listener
+    server.listen('/tmp/echo.sock', () => { //'listening' listener
 
 Use `nc` to connect to a UNIX domain socket server:
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -513,8 +513,7 @@ The `connectListener` parameter will be added as a listener for the
 Here is an example of a client of the previously described echo server:
 
     const net = require('net');
-    var client = net.connect({port: 8124},
-        () => { //'connect' listener
+    const client = net.connect({port: 8124}, () => { //'connect' listener
       console.log('connected to server!');
       client.write('world!\r\n');
     });
@@ -529,7 +528,7 @@ Here is an example of a client of the previously described echo server:
 To connect on the socket `/tmp/echo.sock` the second line would just be
 changed to
 
-    var client = net.connect({path: '/tmp/echo.sock'});
+    const client = net.connect({path: '/tmp/echo.sock'});
 
 ## net.connect(path[, connectListener])
 
@@ -563,7 +562,7 @@ The `connectListener` parameter will be added as a listener for the
 Here is an example of a client of the previously described echo server:
 
     const net = require('net');
-    var client = net.connect({port: 8124},
+    const client = net.connect({port: 8124},
         () => { //'connect' listener
       console.log('connected to server!');
       client.write('world!\r\n');
@@ -579,7 +578,7 @@ Here is an example of a client of the previously described echo server:
 To connect on the socket `/tmp/echo.sock` the second line would just be
 changed to
 
-    var client = net.connect({path: '/tmp/echo.sock'});
+    const client = net.connect({path: '/tmp/echo.sock'});
 
 ## net.createConnection(path[, connectListener])
 
@@ -625,7 +624,7 @@ Here is an example of an echo server which listens for connections
 on port 8124:
 
     const net = require('net');
-    var server = net.createServer((c) => { //'connection' listener
+    const server = net.createServer((c) => { //'connection' listener
       console.log('client connected');
       c.on('end', () => {
         console.log('client disconnected');

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -909,7 +909,7 @@ Sets or reads the process's file mode creation mask. Child processes inherit
 the mask from the parent process. Returns the old mask if `mask` argument is
 given, otherwise returns the current mask.
 
-    const newmask = 0022;
+    const newmask = 0o022;
     const oldmask = process.umask(newmask);
     console.log(
       `Changed umask from ${oldmask.toString(8)} to ${newmask.toString(8)}`

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -71,7 +71,7 @@ event tells you when the list of unhandled rejections shrinks.
 For example using the rejection detection hooks in order to keep a map of all
 the rejected promise reasons at a given time:
 
-    var unhandledRejections = new Map();
+    const unhandledRejections = new Map();
     process.on('unhandledRejection', (reason, p) => {
       unhandledRejections.set(p, reason);
     });
@@ -909,11 +909,11 @@ Sets or reads the process's file mode creation mask. Child processes inherit
 the mask from the parent process. Returns the old mask if `mask` argument is
 given, otherwise returns the current mask.
 
-    var oldmask, newmask = 0022;
-
-    oldmask = process.umask(newmask);
-    console.log('Changed umask from: ' + oldmask.toString(8) +
-                ' to ' + newmask.toString(8));
+    const newmask = 0022;
+    const oldmask = process.umask(newmask);
+    console.log(
+      `Changed umask from ${oldmask.toString(8)} to ${newmask.toString(8)}`
+    );
 
 
 ## process.uptime()

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -29,9 +29,9 @@ implicitly by the event loop draining.
 
 Example of listening for `'exit'`:
 
-    process.on('exit', function(code) {
+    process.on('exit', (code) => {
       // do *NOT* do this
-      setTimeout(function() {
+      setTimeout(() => {
         console.log('This will not run');
       }, 0);
       console.log('About to exit with code:', code);
@@ -72,10 +72,10 @@ For example using the rejection detection hooks in order to keep a map of all
 the rejected promise reasons at a given time:
 
     var unhandledRejections = new Map();
-    process.on('unhandledRejection', function(reason, p) {
+    process.on('unhandledRejection', (reason, p) => {
       unhandledRejections.set(p, reason);
     });
-    process.on('rejectionHandled', function(p) {
+    process.on('rejectionHandled', (p) => {
       unhandledRejections.delete(p);
     });
 
@@ -93,11 +93,11 @@ a stack trace and exit) will not occur.
 
 Example of listening for `'uncaughtException'`:
 
-    process.on('uncaughtException', function(err) {
-      console.log('Caught exception: ' + err);
+    process.on('uncaughtException', (err) => {
+      console.log(`Caught exception: ${err}`);
     });
 
-    setTimeout(function() {
+    setTimeout(() => {
       console.log('This will still run.');
     }, 500);
 
@@ -138,7 +138,7 @@ instance).
 
 Here is an example that logs every unhandled rejection to the console
 
-    process.on('unhandledRejection', function(reason, p) {
+    process.on('unhandledRejection', (reason, p) => {
         console.log("Unhandled Rejection at: Promise ", p, " reason: ", reason);
         // application specific logging, throwing an error, or other logic here
     });
@@ -146,8 +146,8 @@ Here is an example that logs every unhandled rejection to the console
 For example, here is a rejection that will trigger the `'unhandledRejection'`
 event:
 
-    somePromise.then(function(res) {
-      return reportToUser(JSON.pasre(res)); // note the typo
+    somePromise.then((res) => {
+      return reportToUser(JSON.parse(res)); // note the typo
     }); // no `.catch` or `.then`
 
 Here is an example of a coding pattern that will also trigger
@@ -226,7 +226,7 @@ Example of listening for `SIGINT`:
     // Start reading from stdin so we don't exit.
     process.stdin.resume();
 
-    process.on('SIGINT', function() {
+    process.on('SIGINT', () => {
       console.log('Got SIGINT.  Press Control-D to exit.');
     });
 
@@ -285,8 +285,8 @@ An array containing the command line arguments.  The first element will be
 next elements will be any additional command line arguments.
 
     // print process.argv
-    process.argv.forEach(function(val, index, array) {
-      console.log(index + ': ' + val);
+    process.argv.forEach((val, index, array) => {
+      console.log(`${index}: ${val}`);
     });
 
 This will generate:
@@ -302,13 +302,13 @@ This will generate:
 
 Changes the current working directory of the process or throws an exception if that fails.
 
-    console.log('Starting directory: ' + process.cwd());
+    console.log(`Starting directory: ${process.cwd()}`);
     try {
       process.chdir('/tmp');
-      console.log('New directory: ' + process.cwd());
+      console.log(`New directory: ${process.cwd()}`);
     }
     catch (err) {
-      console.log('chdir: ' + err);
+      console.log(`chdir: ${err}`);
     }
 
 ## process.config
@@ -350,7 +350,7 @@ If `process.connected` is false, it is no longer possible to send messages.
 
 Returns the current working directory of the process.
 
-    console.log('Current directory: ' + process.cwd());
+    console.log(`Current directory: ${process.cwd()}`);
 
 ## process.disconnect()
 
@@ -450,7 +450,7 @@ Gets the effective group identity of the process. (See getegid(2).)
 This is the numerical group id, not the group name.
 
     if (process.getegid) {
-      console.log('Current gid: ' + process.getegid());
+      console.log(`Current gid: ${process.getegid()}`);
     }
 
 
@@ -463,7 +463,7 @@ Gets the effective user identity of the process. (See geteuid(2).)
 This is the numerical userid, not the username.
 
     if (process.geteuid) {
-      console.log('Current uid: ' + process.geteuid());
+      console.log(`Current uid: ${process.geteuid()}`);
     }
 
 ## process.getgid()
@@ -475,7 +475,7 @@ Gets the group identity of the process. (See getgid(2).)
 This is the numerical group id, not the group name.
 
     if (process.getgid) {
-      console.log('Current gid: ' + process.getgid());
+      console.log(`Current gid: ${process.getgid()}`);
     }
 
 ## process.getgroups()
@@ -495,7 +495,7 @@ Gets the user identity of the process. (See getuid(2).)
 This is the numerical userid, not the username.
 
     if (process.getuid) {
-      console.log('Current uid: ' + process.getuid());
+      console.log(`Current uid: ${process.getuid()}`);
     }
 
 ## process.hrtime()
@@ -511,7 +511,7 @@ a diff reading, useful for benchmarks and measuring intervals:
     var time = process.hrtime();
     // [ 1800216, 25 ]
 
-    setTimeout(function() {
+    setTimeout(() => {
       var diff = process.hrtime(time);
       // [ 1, 552 ]
 
@@ -556,11 +556,11 @@ something other than kill the target process.
 
 Example of sending a signal to yourself:
 
-    process.on('SIGHUP', function() {
+    process.on('SIGHUP', () => {
       console.log('Got SIGHUP signal.');
     });
 
-    setTimeout(function() {
+    setTimeout(() => {
       console.log('Exiting.');
       process.exit(0);
     }, 100);
@@ -584,7 +584,7 @@ As with `require.main`, it will be `undefined` if there was no entry script.
 Returns an object describing the memory usage of the Node.js process
 measured in bytes.
 
-    var util = require('util');
+    const util = require('util');
 
     console.log(util.inspect(process.memoryUsage()));
 
@@ -609,7 +609,7 @@ efficient.  It runs before any additional I/O events (including
 timers) fire in subsequent ticks of the event loop.
 
     console.log('start');
-    process.nextTick(function() {
+    process.nextTick(() => {
       console.log('nextTick callback');
     });
     console.log('scheduled');
@@ -625,7 +625,7 @@ but before any I/O has occurred.
     function MyThing(options) {
       this.setupOptions(options);
 
-      process.nextTick(function() {
+      process.nextTick(() => {
         this.startDoingStuff();
       }.bind(this));
     }
@@ -677,14 +677,14 @@ happening, just like a `while(true);` loop.
 
 The PID of the process.
 
-    console.log('This process is pid ' + process.pid);
+    console.log(`This process is pid ${process.pid}`);
 
 ## process.platform
 
 What platform you're running on:
 `'darwin'`, `'freebsd'`, `'linux'`, `'sunos'` or `'win32'`
 
-    console.log('This platform is ' + process.platform);
+    console.log(`This platform is ${process.platform}`);
 
 ## process.release
 
@@ -738,13 +738,13 @@ This accepts either a numerical ID or a groupname string. If a groupname
 is specified, this method blocks while resolving it to a numerical ID.
 
     if (process.getegid && process.setegid) {
-      console.log('Current gid: ' + process.getegid());
+      console.log(`Current gid: ${process.getegid()}`);
       try {
         process.setegid(501);
-        console.log('New gid: ' + process.getegid());
+        console.log(`New gid: ${process.getegid()}`);
       }
       catch (err) {
-        console.log('Failed to set gid: ' + err);
+        console.log(`Failed to set gid: ${err}`);
       }
     }
 
@@ -758,13 +758,13 @@ This accepts either a numerical ID or a username string.  If a username
 is specified, this method blocks while resolving it to a numerical ID.
 
     if (process.geteuid && process.seteuid) {
-      console.log('Current uid: ' + process.geteuid());
+      console.log(`Current uid: ${process.geteuid()}`);
       try {
         process.seteuid(501);
-        console.log('New uid: ' + process.geteuid());
+        console.log(`New uid: ${process.geteuid()}`);
       }
       catch (err) {
-        console.log('Failed to set uid: ' + err);
+        console.log(`Failed to set uid: ${err}`);
       }
     }
 
@@ -778,13 +778,13 @@ a numerical ID or a groupname string. If a groupname is specified, this method
 blocks while resolving it to a numerical ID.
 
     if (process.getgid && process.setgid) {
-      console.log('Current gid: ' + process.getgid());
+      console.log(`Current gid: ${process.getgid()}`);
       try {
         process.setgid(501);
-        console.log('New gid: ' + process.getgid());
+        console.log(`New gid: ${process.getgid()}`);
       }
       catch (err) {
-        console.log('Failed to set gid: ' + err);
+        console.log(`Failed to set gid: ${err}`);
       }
     }
 
@@ -808,13 +808,13 @@ a numerical ID or a username string.  If a username is specified, this method
 blocks while resolving it to a numerical ID.
 
     if (process.getuid && process.setuid) {
-      console.log('Current uid: ' + process.getuid());
+      console.log(`Current uid: ${process.getuid()}`);
       try {
         process.setuid(501);
-        console.log('New uid: ' + process.getuid());
+        console.log(`New uid: ${process.getuid()}`);
       }
       catch (err) {
-        console.log('Failed to set uid: ' + err);
+        console.log(`Failed to set uid: ${err}`);
       }
     }
 
@@ -836,14 +836,14 @@ Example of opening standard input and listening for both events:
 
     process.stdin.setEncoding('utf8');
 
-    process.stdin.on('readable', function() {
+    process.stdin.on('readable', () => {
       var chunk = process.stdin.read();
       if (chunk !== null) {
-        process.stdout.write('data: ' + chunk);
+        process.stdout.write(`data: ${chunk}`);
       }
     });
 
-    process.stdin.on('end', function() {
+    process.stdin.on('end', () => {
       process.stdout.write('end');
     });
 
@@ -865,7 +865,7 @@ A `Writable Stream` to `stdout` (on fd `1`).
 For example, a `console.log` equivalent could look like this:
 
     console.log = function(msg) {
-      process.stdout.write(msg + '\n');
+      process.stdout.write(`${msg}\n`);
     };
 
 `process.stderr` and `process.stdout` are unlike other streams in Node.js in
@@ -924,7 +924,7 @@ Number of seconds Node.js has been running.
 
 A compiled-in property that exposes `NODE_VERSION`.
 
-    console.log('Version: ' + process.version);
+    console.log(`Version: ${process.version}`);
 
 ## process.versions
 

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -11,7 +11,7 @@ program to gracefully exit:
 
     const readline = require('readline');
 
-    var rl = readline.createInterface({
+    const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout
     });
@@ -211,8 +211,8 @@ Example of listening for `SIGTSTP`:
 Here's an example of how to use all these together to craft a tiny command
 line interface:
 
-    const readline = require('readline'),
-        rl = readline.createInterface(process.stdin, process.stdout);
+    const readline = require('readline');
+    const rl = readline.createInterface(process.stdin, process.stdout);
 
     rl.setPrompt('OHAI> ');
     rl.prompt();
@@ -292,7 +292,7 @@ Also `completer` can be run in async mode if it accepts two arguments:
 [`process.stdout`][] in order to accept user input:
 
     const readline = require('readline');
-    var rl = readline.createInterface({
+    const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout
     });

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -9,16 +9,16 @@ Note that once you've invoked this module, your Node.js program will not
 terminate until you've closed the interface. Here's how to allow your
 program to gracefully exit:
 
-    var readline = require('readline');
+    const readline = require('readline');
 
     var rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout
     });
 
-    rl.question("What do you think of Node.js? ", function(answer) {
+    rl.question('What do you think of Node.js? ', (answer) => {
       // TODO: Log the answer in a database
-      console.log("Thank you for your valuable feedback:", answer);
+      console.log('Thank you for your valuable feedback:', answer);
 
       rl.close();
     });
@@ -66,8 +66,8 @@ nothing is displayed.
 
 Example usage:
 
-    interface.question('What is your favorite food?', function(answer) {
-      console.log('Oh, so your favorite food is ' + answer);
+    interface.question('What is your favorite food?', (answer) => {
+      console.log(`Oh, so your favorite food is ${answer}`);
     });
 
 ### rl.resume()
@@ -117,8 +117,8 @@ user hits enter, or return. This is a good hook to listen for user input.
 
 Example of listening for `'line'`:
 
-    rl.on('line', function (cmd) {
-      console.log('You just typed: '+cmd);
+    rl.on('line', (cmd) => {
+      console.log(`You just typed: ${cmd}`);
     });
 
 ### Event: 'pause'
@@ -132,7 +132,7 @@ Also emitted whenever the `input` stream is not paused and receives the
 
 Example of listening for `'pause'`:
 
-    rl.on('pause', function() {
+    rl.on('pause', () => {
       console.log('Readline paused.');
     });
 
@@ -144,7 +144,7 @@ Emitted whenever the `input` stream is resumed.
 
 Example of listening for `'resume'`:
 
-    rl.on('resume', function() {
+    rl.on('resume', () => {
       console.log('Readline resumed.');
     });
 
@@ -161,7 +161,7 @@ background.
 
 Example of listening for `SIGCONT`:
 
-    rl.on('SIGCONT', function() {
+    rl.on('SIGCONT', () => {
       // `prompt` will automatically resume the stream
       rl.prompt();
     });
@@ -176,8 +176,8 @@ stream receives a `SIGINT`, `pause` will be triggered.
 
 Example of listening for `SIGINT`:
 
-    rl.on('SIGINT', function() {
-      rl.question('Are you sure you want to exit?', function(answer) {
+    rl.on('SIGINT', () => {
+      rl.question('Are you sure you want to exit?', (answer) => {
         if (answer.match(/^y(es)?$/i)) rl.pause();
       });
     });
@@ -200,7 +200,7 @@ before the program was sent to the background.
 
 Example of listening for `SIGTSTP`:
 
-    rl.on('SIGTSTP', function() {
+    rl.on('SIGTSTP', () => {
       // This will override SIGTSTP and prevent the program from going to the
       // background.
       console.log('Caught SIGTSTP.');
@@ -211,13 +211,13 @@ Example of listening for `SIGTSTP`:
 Here's an example of how to use all these together to craft a tiny command
 line interface:
 
-    var readline = require('readline'),
+    const readline = require('readline'),
         rl = readline.createInterface(process.stdin, process.stdout);
 
     rl.setPrompt('OHAI> ');
     rl.prompt();
 
-    rl.on('line', function(line) {
+    rl.on('line', (line) => {
       switch(line.trim()) {
         case 'hello':
           console.log('world!');
@@ -227,7 +227,7 @@ line interface:
           break;
       }
       rl.prompt();
-    }).on('close', function() {
+    }).on('close', () => {
       console.log('Have a great day!');
       process.exit(0);
     });
@@ -277,7 +277,7 @@ Example:
 
     function completer(line) {
       var completions = '.help .error .exit .quit .q'.split(' ')
-      var hits = completions.filter(function(c) { return c.indexOf(line) == 0 })
+      var hits = completions.filter((c) => { return c.indexOf(line) == 0 })
       // show all completions if none found
       return [hits.length ? hits : completions, line]
     }
@@ -291,7 +291,7 @@ Also `completer` can be run in async mode if it accepts two arguments:
 `createInterface` is commonly used with [`process.stdin`][] and
 [`process.stdout`][] in order to accept user input:
 
-    var readline = require('readline');
+    const readline = require('readline');
     var rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -85,8 +85,8 @@ a variable to the REPL explicitly by assigning it to the `context` object
 associated with each `REPLServer`.  For example:
 
     // repl_test.js
-    var repl = require('repl'),
-        msg = 'message';
+    const repl = require('repl');
+    var msg = 'message';
 
     repl.start('> ').context.m = msg;
 
@@ -152,7 +152,7 @@ to signal `'end'` on the `input` stream.
 
 Example of listening for `exit`:
 
-    replServer.on('exit', function () {
+    replServer.on('exit', () => {
       console.log('Got "exit" event from repl!');
       process.exit();
     });
@@ -173,7 +173,7 @@ Example of listening for `reset`:
     someExtension.extend(r.context);
 
     // When a new context is created extend it as well.
-    replServer.on('reset', function (context) {
+    replServer.on('reset', (context) => {
       console.log('repl has a new context');
       someExtension.extend(context);
     });
@@ -196,13 +196,13 @@ If a function is provided instead of an object for `cmd`, it is treated as the
 Example of defining a command:
 
     // repl_test.js
-    var repl = require('repl');
+    const repl = require('repl');
 
     var replServer = repl.start();
     replServer.defineCommand('sayhello', {
       help: 'Say hello',
       action: function(name) {
-        this.write('Hello, ' + name + '!\n');
+        this.write(`Hello, ${name}!\n');
         this.displayPrompt();
       }
     });
@@ -277,9 +277,9 @@ will share the same global object but will have unique I/O.
 
 Here is an example that starts a REPL on stdin, a Unix socket, and a TCP socket:
 
-    var net = require('net'),
-        repl = require('repl'),
-        connections = 0;
+    const net = require('net');
+    const repl = require('repl');
+    var connections = 0;
 
     repl.start({
       prompt: 'Node.js via stdin> ',
@@ -287,24 +287,24 @@ Here is an example that starts a REPL on stdin, a Unix socket, and a TCP socket:
       output: process.stdout
     });
 
-    net.createServer(function (socket) {
+    net.createServer((socket) => {
       connections += 1;
       repl.start({
         prompt: 'Node.js via Unix socket> ',
         input: socket,
         output: socket
-      }).on('exit', function() {
+      }).on('exit', () => {
         socket.end();
       })
     }).listen('/tmp/node-repl-sock');
 
-    net.createServer(function (socket) {
+    net.createServer((socket) => {
       connections += 1;
       repl.start({
         prompt: 'Node.js via TCP socket> ',
         input: socket,
         output: socket
-      }).on('exit', function() {
+      }).on('exit', () => {
         socket.end();
       });
     }).listen(5001);

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -50,9 +50,9 @@ Almost all Node.js programs, no matter how simple, use Streams in some
 way. Here is an example of using Streams in an Node.js program:
 
 ```javascript
-var http = require('http');
+const http = require('http');
 
-var server = http.createServer(function (req, res) {
+var server = http.createServer( (req, res) => {
   // req is an http.IncomingMessage, which is a Readable Stream
   // res is an http.ServerResponse, which is a Writable Stream
 
@@ -62,18 +62,18 @@ var server = http.createServer(function (req, res) {
   req.setEncoding('utf8');
 
   // Readable streams emit 'data' events once a listener is added
-  req.on('data', function (chunk) {
+  req.on('data', (chunk) => {
     body += chunk;
   });
 
   // the end event tells you that you have entire body
-  req.on('end', function () {
+  req.on('end', () => {
     try {
       var data = JSON.parse(body);
     } catch (er) {
       // uh oh!  bad json!
       res.statusCode = 400;
-      return res.end('error: ' + er.message);
+      return res.end(`error: ${er.message}`);
     }
 
     // write back something interesting to the user:
@@ -176,7 +176,7 @@ possible, this is the best way to do so.
 
 ```javascript
 var readable = getReadableStreamSomehow();
-readable.on('data', function(chunk) {
+readable.on('data', (chunk) => {
   console.log('got %d bytes of data', chunk.length);
 });
 ```
@@ -191,10 +191,10 @@ or by calling `read()` repeatedly until you get to the end.
 
 ```javascript
 var readable = getReadableStreamSomehow();
-readable.on('data', function(chunk) {
+readable.on('data', (chunk) => {
   console.log('got %d bytes of data', chunk.length);
 });
-readable.on('end', function() {
+readable.on('end', () => {
   console.log('there will be no more data.');
 });
 ```
@@ -216,7 +216,7 @@ hadn't already.
 
 ```javascript
 var readable = getReadableStreamSomehow();
-readable.on('readable', function() {
+readable.on('readable', () => {
   // there is some data to read now
 });
 ```
@@ -234,12 +234,12 @@ In the former case, `.read()` will return that data. In the latter case,
 is an empty file:
 
 ```javascript
-var fs = require('fs');
+const fs = require('fs');
 var rr = fs.createReadStream('foo.txt');
-rr.on('readable', function() {
+rr.on('readable', () => {
   console.log('readable:', rr.read());
 });
-rr.on('end', function() {
+rr.on('end', () => {
   console.log('end');
 });
 ```
@@ -280,11 +280,11 @@ available will remain in the internal buffer.
 
 ```javascript
 var readable = getReadableStreamSomehow();
-readable.on('data', function(chunk) {
+readable.on('data', (chunk) => {
   console.log('got %d bytes of data', chunk.length);
   readable.pause();
   console.log('there will be no more data for 1 second');
-  setTimeout(function() {
+  setTimeout(() => {
     console.log('now data will start flowing again');
     readable.resume();
   }, 1000);
@@ -335,7 +335,7 @@ end.
 
 ```javascript
 reader.pipe(writer, { end: false });
-reader.on('end', function() {
+reader.on('end', () => {
   writer.end('Goodbye\n');
 });
 ```
@@ -366,7 +366,7 @@ drained.
 
 ```javascript
 var readable = getReadableStreamSomehow();
-readable.on('readable', function() {
+readable.on('readable', () => {
   var chunk;
   while (null !== (chunk = readable.read())) {
     console.log('got %d bytes of data', chunk.length);
@@ -395,7 +395,7 @@ data.
 ```javascript
 var readable = getReadableStreamSomehow();
 readable.resume();
-readable.on('end', function() {
+readable.on('end', () => {
   console.log('got to the end, but did not read anything');
 });
 ```
@@ -420,7 +420,7 @@ as strings, always use this method.
 ```javascript
 var readable = getReadableStreamSomehow();
 readable.setEncoding('utf8');
-readable.on('data', function(chunk) {
+readable.on('data', (chunk) => {
   assert.equal(typeof chunk, 'string');
   console.log('got %d characters of string data', chunk.length);
 });
@@ -443,7 +443,7 @@ var writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt',
 // but only for the first second
 readable.pipe(writable);
-setTimeout(function() {
+setTimeout(() => {
   console.log('stop writing to file.txt');
   readable.unpipe(writable);
   console.log('manually close the file stream');
@@ -471,7 +471,7 @@ for Stream Implementors, below.)
 // Pull off a header delimited by \n\n
 // use unshift() if we get too much
 // Call the callback with (error, header, stream)
-var StringDecoder = require('string_decoder').StringDecoder;
+const StringDecoder = require('string_decoder').StringDecoder;
 function parseHeader(stream, callback) {
   stream.on('error', callback);
   stream.on('readable', onReadable);
@@ -528,12 +528,12 @@ as a convenience for interacting with old Node.js programs and libraries.
 For example:
 
 ```javascript
-var OldReader = require('./old-api-module.js').OldReader;
+const OldReader = require('./old-api-module.js').OldReader;
 var oreader = new OldReader;
-var Readable = require('stream').Readable;
+const Readable = require('stream').Readable;
 var myReader = new Readable().wrap(oreader);
 
-myReader.on('readable', function() {
+myReader.on('readable', () => {
   myReader.read(); // etc.
 });
 ```
@@ -615,10 +615,10 @@ to the underlying system, this event is emitted.
 ```javascript
 var writer = getWritableStreamSomehow();
 for (var i = 0; i < 100; i ++) {
-  writer.write('hello, #' + i + '!\n');
+  writer.write('hello, #${i}!\n');
 }
 writer.end('this is the end\n');
-writer.on('finish', function() {
+writer.on('finish', () => {
   console.error('all writes are now complete.');
 });
 ```
@@ -633,7 +633,7 @@ stream, adding this writable to its set of destinations.
 ```javascript
 var writer = getWritableStreamSomehow();
 var reader = getReadableStreamSomehow();
-writer.on('pipe', function(src) {
+writer.on('pipe', (src) => {
   console.error('something is piping into the writer');
   assert.equal(src, reader);
 });
@@ -650,7 +650,7 @@ readable stream, removing this writable from its set of destinations.
 ```javascript
 var writer = getWritableStreamSomehow();
 var reader = getReadableStreamSomehow();
-writer.on('unpipe', function(src) {
+writer.on('unpipe', (src) => {
   console.error('something has stopped piping into the writer');
   assert.equal(src, reader);
 });
@@ -955,8 +955,8 @@ This is a basic example of a Readable stream.  It emits the numerals
 from 1 to 1,000,000 in ascending order, and then ends.
 
 ```javascript
-var Readable = require('stream').Readable;
-var util = require('util');
+const Readable = require('stream').Readable;
+const util = require('util');
 util.inherits(Counter, Readable);
 
 function Counter(opt) {
@@ -995,8 +995,8 @@ below for a better implementation.
 // Using Readable directly for this is sub-optimal.  See the
 // alternative example below under the Transform section.
 
-var Readable = require('stream').Readable;
-var util = require('util');
+const Readable = require('stream').Readable;
+const util = require('util');
 
 util.inherits(SimpleProtocol, Readable);
 
@@ -1012,13 +1012,13 @@ function SimpleProtocol(source, options) {
   this._source = source;
 
   var self = this;
-  source.on('end', function() {
+  source.on('end', () => {
     self.push(null);
   });
 
   // give it a kick whenever the source is readable
   // read(0) will not consume any bytes
-  source.on('readable', function() {
+  source.on('readable', () => {
     self.read(0);
   });
 
@@ -1210,8 +1210,8 @@ would be piped into the parser, which is a more idiomatic Node.js stream
 approach.
 
 ```javascript
-var util = require('util');
-var Transform = require('stream').Transform;
+const util = require('util');
+const Transform = require('stream').Transform;
 util.inherits(SimpleProtocol, Transform);
 
 function SimpleProtocol(options) {
@@ -1518,10 +1518,10 @@ For example, consider the following code:
 
 ```javascript
 // WARNING!  BROKEN!
-net.createServer(function(socket) {
+net.createServer((socket) => {
 
   // we add an 'end' method, but never consume the data
-  socket.on('end', function() {
+  socket.on('end', () => {
     // It will never get here.
     socket.end('I got your message (but didnt read it)\n');
   });
@@ -1538,9 +1538,9 @@ start the flow of data:
 
 ```javascript
 // Workaround
-net.createServer(function(socket) {
+net.createServer((socket) => {
 
-  socket.on('end', function() {
+  socket.on('end', () => {
     socket.end('I got your message (but didnt read it)\n');
   });
 
@@ -1589,9 +1589,9 @@ respectively. These options can be used to implement parsers and
 serializers with Transform streams.
 
 ```javascript
-var util = require('util');
-var StringDecoder = require('string_decoder').StringDecoder;
-var Transform = require('stream').Transform;
+const util = require('util');
+const StringDecoder = require('string_decoder').StringDecoder;
+const Transform = require('stream').Transform;
 util.inherits(JSONParseStream, Transform);
 
 // Gets \n-delimited JSON string data, and emits the parsed objects

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -529,9 +529,9 @@ For example:
 
 ```javascript
 const OldReader = require('./old-api-module.js').OldReader;
-var oreader = new OldReader;
 const Readable = require('stream').Readable;
-var myReader = new Readable().wrap(oreader);
+const oreader = new OldReader;
+const myReader = new Readable().wrap(oreader);
 
 myReader.on('readable', () => {
   myReader.read(); // etc.

--- a/doc/api/string_decoder.markdown
+++ b/doc/api/string_decoder.markdown
@@ -7,12 +7,12 @@ buffer to a string. It is a simple interface to `buffer.toString()` but provides
 additional support for utf8.
 
     const StringDecoder = require('string_decoder').StringDecoder;
-    var decoder = new StringDecoder('utf8');
+    const decoder = new StringDecoder('utf8');
 
-    var cent = new Buffer([0xC2, 0xA2]);
+    const cent = new Buffer([0xC2, 0xA2]);
     console.log(decoder.write(cent));
 
-    var euro = new Buffer([0xE2, 0x82, 0xAC]);
+    const euro = new Buffer([0xE2, 0x82, 0xAC]);
     console.log(decoder.write(euro));
 
 ## Class: StringDecoder

--- a/doc/api/string_decoder.markdown
+++ b/doc/api/string_decoder.markdown
@@ -6,7 +6,7 @@ To use this module, do `require('string_decoder')`. StringDecoder decodes a
 buffer to a string. It is a simple interface to `buffer.toString()` but provides
 additional support for utf8.
 
-    var StringDecoder = require('string_decoder').StringDecoder;
+    const StringDecoder = require('string_decoder').StringDecoder;
     var decoder = new StringDecoder('utf8');
 
     var cent = new Buffer([0xC2, 0xA2]);

--- a/doc/api/synopsis.markdown
+++ b/doc/api/synopsis.markdown
@@ -5,9 +5,9 @@
 An example of a [web server][] written with Node.js which responds with
 `'Hello World'`:
 
-    var http = require('http');
+    const http = require('http');
 
-    http.createServer(function (request, response) {
+    http.createServer( (request, response) => {
       response.writeHead(200, {'Content-Type': 'text/plain'});
       response.end('Hello World\n');
     }).listen(8124);

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -243,11 +243,11 @@ established after addition of event listener.
 Here's an example for using TLS session resumption:
 
     var tlsSessionStore = {};
-    server.on('newSession', function(id, data, cb) {
+    server.on('newSession', (id, data, cb) => {
       tlsSessionStore[id.toString('hex')] = data;
       cb();
     });
-    server.on('resumeSession', function(id, cb) {
+    server.on('resumeSession', (id, cb) => {
       cb(null, tlsSessionStore[id.toString('hex')] || null);
     });
 
@@ -615,10 +615,10 @@ The `callback` parameter will be added as a listener for the
 
 Here is an example of a client of echo server as described previously:
 
-    var tls = require('tls');
-    var fs = require('fs');
+    const tls = require('tls');
+    const fs = require('fs');
 
-    var options = {
+    const options = {
       // These are necessary only if using the client certificate authentication
       key: fs.readFileSync('client-key.pem'),
       cert: fs.readFileSync('client-cert.pem'),
@@ -627,40 +627,40 @@ Here is an example of a client of echo server as described previously:
       ca: [ fs.readFileSync('server-cert.pem') ]
     };
 
-    var socket = tls.connect(8000, options, function() {
+    var socket = tls.connect(8000, options, () => {
       console.log('client connected',
                   socket.authorized ? 'authorized' : 'unauthorized');
       process.stdin.pipe(socket);
       process.stdin.resume();
     });
     socket.setEncoding('utf8');
-    socket.on('data', function(data) {
+    socket.on('data', (data) => {
       console.log(data);
     });
-    socket.on('end', function() {
+    socket.on('end', () => {
       server.close();
     });
 
 Or
 
-    var tls = require('tls');
-    var fs = require('fs');
+    const tls = require('tls');
+    const fs = require('fs');
 
-    var options = {
+    const options = {
       pfx: fs.readFileSync('client.pfx')
     };
 
-    var socket = tls.connect(8000, options, function() {
+    var socket = tls.connect(8000, options, () => {
       console.log('client connected',
                   socket.authorized ? 'authorized' : 'unauthorized');
       process.stdin.pipe(socket);
       process.stdin.resume();
     });
     socket.setEncoding('utf8');
-    socket.on('data', function(data) {
+    socket.on('data', (data) => {
       console.log(data);
     });
-    socket.on('end', function() {
+    socket.on('end', () => {
       server.close();
     });
 
@@ -856,10 +856,10 @@ automatically set as a listener for the [`'secureConnection'`][] event.  The
 
 Here is a simple example echo server:
 
-    var tls = require('tls');
-    var fs = require('fs');
+    const tls = require('tls');
+    const fs = require('fs');
 
-    var options = {
+    const options = {
       key: fs.readFileSync('server-key.pem'),
       cert: fs.readFileSync('server-cert.pem'),
 
@@ -870,23 +870,23 @@ Here is a simple example echo server:
       ca: [ fs.readFileSync('client-cert.pem') ]
     };
 
-    var server = tls.createServer(options, function(socket) {
+    var server = tls.createServer(options, (socket) => {
       console.log('server connected',
                   socket.authorized ? 'authorized' : 'unauthorized');
-      socket.write("welcome!\n");
+      socket.write('welcome!\n');
       socket.setEncoding('utf8');
       socket.pipe(socket);
     });
-    server.listen(8000, function() {
+    server.listen(8000, () => {
       console.log('server bound');
     });
 
 Or
 
-    var tls = require('tls');
-    var fs = require('fs');
+    const tls = require('tls');
+    const fs = require('fs');
 
-    var options = {
+    const options = {
       pfx: fs.readFileSync('server.pfx'),
 
       // This is necessary only if using the client certificate authentication.
@@ -894,14 +894,14 @@ Or
 
     };
 
-    var server = tls.createServer(options, function(socket) {
+    var server = tls.createServer(options, (socket) => {
       console.log('server connected',
                   socket.authorized ? 'authorized' : 'unauthorized');
-      socket.write("welcome!\n");
+      socket.write('welcome!\n');
       socket.setEncoding('utf8');
       socket.pipe(socket);
     });
-    server.listen(8000, function() {
+    server.listen(8000, () => {
       console.log('server bound');
     });
 You can test this server by connecting to it with `openssl s_client`:

--- a/doc/api/tty.markdown
+++ b/doc/api/tty.markdown
@@ -45,9 +45,9 @@ ever created (and only when `isatty(1)` is true).
 Emitted by `refreshSize()` when either of the `columns` or `rows` properties
 has changed.
 
-    process.stdout.on('resize', function() {
+    process.stdout.on('resize', () => {
       console.log('screen size has changed!');
-      console.log(process.stdout.columns + 'x' + process.stdout.rows);
+      console.log(`${process.stdout.columns}x${process.stdout.rows}`);
     });
 
 ### ws.columns

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -53,7 +53,7 @@ comma.  For example, `NODE_DEBUG=fs,net,tls`.
 
 Marks that a method should not be used any more.
 
-    var util = require('util');
+    const util = require('util');
 
     exports.puts = util.deprecate(function() {
       for (var i = 0, len = arguments.length; i < len; ++i) {
@@ -123,8 +123,8 @@ prototype of `constructor` will be set to a new object created from
 As an additional convenience, `superConstructor` will be accessible
 through the `constructor.super_` property.
 
-    var util = require("util");
-    var EventEmitter = require("events");
+    const util = require('util');
+    const EventEmitter = require('events');
 
     function MyStream() {
         EventEmitter.call(this);
@@ -133,7 +133,7 @@ through the `constructor.super_` property.
     util.inherits(MyStream, EventEmitter);
 
     MyStream.prototype.write = function(data) {
-        this.emit("data", data);
+        this.emit('data', data);
     }
 
     var stream = new MyStream();
@@ -141,10 +141,10 @@ through the `constructor.super_` property.
     console.log(stream instanceof EventEmitter); // true
     console.log(MyStream.super_ === EventEmitter); // true
 
-    stream.on("data", function(data) {
-        console.log('Received data: "' + data + '"');
+    stream.on('data', (data) => {
+      console.log(`Received data: "${data}"`);
     })
-    stream.write("It works!"); // Received data: "It works!"
+    stream.write('It works!'); // Received data: "It works!"
 
 ## util.inspect(object[, options])
 
@@ -168,7 +168,7 @@ formatted string:
 
 Example of inspecting all properties of the `util` object:
 
-    var util = require('util');
+    const util = require('util');
 
     console.log(util.inspect(util, { showHidden: true, depth: null }));
 
@@ -207,11 +207,11 @@ There are also `bold`, `italic`, `underline` and `inverse` codes.
 Objects also may define their own `inspect(depth)` function which `util.inspect()`
 will invoke and use the result of when inspecting the object:
 
-    var util = require('util');
+    const util = require('util');
 
     var obj = { name: 'nate' };
     obj.inspect = function(depth) {
-      return '{' + this.name + '}';
+      return `{${this.name}}`;
     };
 
     util.inspect(obj);
@@ -237,7 +237,7 @@ Internal alias for [`Array.isArray`][].
 
 Returns `true` if the given "object" is an `Array`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isArray([])
       // true
@@ -252,7 +252,7 @@ Returns `true` if the given "object" is an `Array`. `false` otherwise.
 
 Returns `true` if the given "object" is a `Boolean`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isBoolean(1)
       // false
@@ -269,7 +269,7 @@ Use `Buffer.isBuffer()` instead.
 
 Returns `true` if the given "object" is a `Buffer`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isBuffer({ length: 0 })
       // false
@@ -284,7 +284,7 @@ Returns `true` if the given "object" is a `Buffer`. `false` otherwise.
 
 Returns `true` if the given "object" is a `Date`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isDate(new Date())
       // true
@@ -299,7 +299,7 @@ Returns `true` if the given "object" is a `Date`. `false` otherwise.
 
 Returns `true` if the given "object" is an [`Error`][]. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isError(new Error())
       // true
@@ -314,7 +314,7 @@ Returns `true` if the given "object" is an [`Error`][]. `false` otherwise.
 
 Returns `true` if the given "object" is a `Function`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     function Foo() {}
     var Bar = function() {};
@@ -332,7 +332,7 @@ Returns `true` if the given "object" is a `Function`. `false` otherwise.
 
 Returns `true` if the given "object" is strictly `null`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isNull(0)
       // false
@@ -347,7 +347,7 @@ Returns `true` if the given "object" is strictly `null`. `false` otherwise.
 
 Returns `true` if the given "object" is `null` or `undefined`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isNullOrUndefined(0)
       // false
@@ -362,7 +362,7 @@ Returns `true` if the given "object" is `null` or `undefined`. `false` otherwise
 
 Returns `true` if the given "object" is a `Number`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isNumber(false)
       // false
@@ -380,7 +380,7 @@ Returns `true` if the given "object" is a `Number`. `false` otherwise.
 Returns `true` if the given "object" is strictly an `Object` __and__ not a
 `Function`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isObject(5)
       // false
@@ -397,7 +397,7 @@ Returns `true` if the given "object" is strictly an `Object` __and__ not a
 
 Returns `true` if the given "object" is a primitive type. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isPrimitive(5)
       // true
@@ -424,7 +424,7 @@ Returns `true` if the given "object" is a primitive type. `false` otherwise.
 
 Returns `true` if the given "object" is a `RegExp`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isRegExp(/some regexp/)
       // true
@@ -439,7 +439,7 @@ Returns `true` if the given "object" is a `RegExp`. `false` otherwise.
 
 Returns `true` if the given "object" is a `String`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isString('')
       // true
@@ -456,7 +456,7 @@ Returns `true` if the given "object" is a `String`. `false` otherwise.
 
 Returns `true` if the given "object" is a `Symbol`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     util.isSymbol(5)
       // false
@@ -471,7 +471,7 @@ Returns `true` if the given "object" is a `Symbol`. `false` otherwise.
 
 Returns `true` if the given "object" is `undefined`. `false` otherwise.
 
-    var util = require('util');
+    const util = require('util');
 
     var foo;
     util.isUndefined(5)

--- a/doc/api/v8.markdown
+++ b/doc/api/v8.markdown
@@ -35,7 +35,7 @@ Usage:
 
 ```
 // Print GC events to stdout for one minute.
-var v8 = require('v8');
+const v8 = require('v8');
 v8.setFlagsFromString('--trace_gc');
 setTimeout(function() { v8.setFlagsFromString('--notrace_gc'); }, 60e3);
 ```

--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -6,7 +6,7 @@
 
 You can access this module with:
 
-    var vm = require('vm');
+    const vm = require('vm');
 
 JavaScript code can be compiled and run immediately or compiled, saved, and run
 later.
@@ -48,8 +48,8 @@ and returns the result. Running code does not have access to local scope.
 Example: compile code that increments a global variable and sets one, then
 execute the code multiple times. These globals are contained in the sandbox.
 
-    var util = require('util');
-    var vm = require('vm');
+    const util = require('util');
+    const vm = require('vm');
 
     var sandbox = {
       animal: 'cat',
@@ -85,14 +85,14 @@ Example: compile code that sets a global variable, then execute the code
 multiple times in different contexts. These globals are set on and contained in
 the sandboxes.
 
-    var util = require('util');
-    var vm = require('vm');
+    const util = require('util');
+    const vm = require('vm');
 
     var sandboxes = [{}, {}, {}];
 
     var script = new vm.Script('globalVar = "set"');
 
-    sandboxes.forEach(function (sandbox) {
+    sandboxes.forEach((sandbox) => {
       script.runInNewContext(sandbox);
     });
 
@@ -114,7 +114,7 @@ current `global` object.
 Example of using `script.runInThisContext` to compile code once and run it
 multiple times:
 
-    var vm = require('vm');
+    const vm = require('vm');
 
     global.globalVar = 0;
 
@@ -176,8 +176,8 @@ returns the result. Running code does not have access to local scope. The
 
 Example: compile and execute different scripts in a single existing context.
 
-    var util = require('util');
-    var vm = require('vm');
+    const util = require('util');
+    const vm = require('vm');
 
     var sandbox = { globalVar: 1 };
     vm.createContext(sandbox);
@@ -217,8 +217,8 @@ the sandbox as the global object and returns the result.
 Example: compile and execute code that increments a global variable and sets a
 new one. These globals are contained in the sandbox.
 
-    var util = require('util');
-    var vm = require('vm');
+    const util = require('util');
+    const vm = require('vm');
 
     var sandbox = {
       animal: 'cat',
@@ -242,7 +242,7 @@ code does not have access to local scope, but does have access to the current
 
 Example of using `vm.runInThisContext` and `eval` to run the same code:
 
-    var vm = require('vm');
+    const vm = require('vm');
     var localVar = 'initial value';
 
     var vmResult = vm.runInThisContext('localVar = "vm";');

--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -88,9 +88,9 @@ the sandboxes.
     const util = require('util');
     const vm = require('vm');
 
-    var sandboxes = [{}, {}, {}];
+    const sandboxes = [{}, {}, {}];
 
-    var script = new vm.Script('globalVar = "set"');
+    const script = new vm.Script('globalVar = "set"');
 
     sandboxes.forEach((sandbox) => {
       script.runInNewContext(sandbox);
@@ -118,7 +118,7 @@ multiple times:
 
     global.globalVar = 0;
 
-    var script = new vm.Script('globalVar += 1', { filename: 'myfile.vm' });
+    const script = new vm.Script('globalVar += 1', { filename: 'myfile.vm' });
 
     for (var i = 0; i < 1000; ++i) {
       script.runInThisContext();
@@ -179,7 +179,7 @@ Example: compile and execute different scripts in a single existing context.
     const util = require('util');
     const vm = require('vm');
 
-    var sandbox = { globalVar: 1 };
+    const sandbox = { globalVar: 1 };
     vm.createContext(sandbox);
 
     for (var i = 0; i < 10; ++i) {
@@ -198,7 +198,7 @@ separate process.
 `vm.runInDebugContext` compiles and executes `code` inside the V8 debug context.
 The primary use case is to get access to the V8 debug object:
 
-    var Debug = vm.runInDebugContext('Debug');
+    const Debug = vm.runInDebugContext('Debug');
     Debug.scripts().forEach(function(script) { console.log(script.name); });
 
 Note that the debug context and object are intrinsically tied to V8's debugger
@@ -220,7 +220,7 @@ new one. These globals are contained in the sandbox.
     const util = require('util');
     const vm = require('vm');
 
-    var sandbox = {
+    const sandbox = {
       animal: 'cat',
       count: 2
     };
@@ -245,11 +245,11 @@ Example of using `vm.runInThisContext` and `eval` to run the same code:
     const vm = require('vm');
     var localVar = 'initial value';
 
-    var vmResult = vm.runInThisContext('localVar = "vm";');
+    const vmResult = vm.runInThisContext('localVar = "vm";');
     console.log('vmResult: ', vmResult);
     console.log('localVar: ', localVar);
 
-    var evalResult = eval('localVar = "eval";');
+    const evalResult = eval('localVar = "eval";');
     console.log('evalResult: ', evalResult);
     console.log('localVar: ', localVar);
 

--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -15,24 +15,24 @@ is a readable/writable Stream.
 Compressing or decompressing a file can be done by piping an
 fs.ReadStream into a zlib stream, then into an fs.WriteStream.
 
-    var gzip = zlib.createGzip();
+    const gzip = zlib.createGzip();
     const fs = require('fs');
-    var inp = fs.createReadStream('input.txt');
-    var out = fs.createWriteStream('input.txt.gz');
+    const inp = fs.createReadStream('input.txt');
+    const out = fs.createWriteStream('input.txt.gz');
 
     inp.pipe(gzip).pipe(out);
 
 Compressing or decompressing data in one step can be done by using
 the convenience methods.
 
-    var input = '.................................';
+    const input = '.................................';
     zlib.deflate(input, function(err, buffer) {
       if (!err) {
         console.log(buffer.toString('base64'));
       }
     });
 
-    var buffer = new Buffer('eJzT0yMAAGTvBe8=', 'base64');
+    const buffer = new Buffer('eJzT0yMAAGTvBe8=', 'base64');
     zlib.unzip(buffer, function(err, buffer) {
       if (!err) {
         console.log(buffer.toString());
@@ -51,11 +51,11 @@ on the speed/memory/compression tradeoffs involved in zlib usage.
     const zlib = require('zlib');
     const http = require('http');
     const fs = require('fs');
-    var request = http.get({ host: 'izs.me',
+    const request = http.get({ host: 'izs.me',
                              path: '/',
                              port: 80,
                              headers: { 'accept-encoding': 'gzip,deflate' } });
-    request.on('response', function(response) {
+    request.on('response', (response) => {
       var output = fs.createWriteStream('izs.me_index.html');
 
       switch (response.headers['content-encoding']) {
@@ -78,7 +78,7 @@ on the speed/memory/compression tradeoffs involved in zlib usage.
     const zlib = require('zlib');
     const http = require('http');
     const fs = require('fs');
-    http.createServer(function(request, response) {
+    http.createServer((request, response) => {
       var raw = fs.createReadStream('index.html');
       var acceptEncoding = request.headers['accept-encoding'];
       if (!acceptEncoding) {

--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -4,7 +4,7 @@
 
 You can access this module with:
 
-    var zlib = require('zlib');
+    const zlib = require('zlib');
 
 This provides bindings to Gzip/Gunzip, Deflate/Inflate, and
 DeflateRaw/InflateRaw classes.  Each class takes the same options, and
@@ -16,7 +16,7 @@ Compressing or decompressing a file can be done by piping an
 fs.ReadStream into a zlib stream, then into an fs.WriteStream.
 
     var gzip = zlib.createGzip();
-    var fs = require('fs');
+    const fs = require('fs');
     var inp = fs.createReadStream('input.txt');
     var out = fs.createWriteStream('input.txt.gz');
 
@@ -48,9 +48,9 @@ ought to be cached.  See [Memory Usage Tuning][] below for more information
 on the speed/memory/compression tradeoffs involved in zlib usage.
 
     // client request example
-    var zlib = require('zlib');
-    var http = require('http');
-    var fs = require('fs');
+    const zlib = require('zlib');
+    const http = require('http');
+    const fs = require('fs');
     var request = http.get({ host: 'izs.me',
                              path: '/',
                              port: 80,
@@ -75,9 +75,9 @@ on the speed/memory/compression tradeoffs involved in zlib usage.
     // server example
     // Running a gzip operation on every request is quite expensive.
     // It would be much more efficient to cache the compressed buffer.
-    var zlib = require('zlib');
-    var http = require('http');
-    var fs = require('fs');
+    const zlib = require('zlib');
+    const http = require('http');
+    const fs = require('fs');
     http.createServer(function(request, response) {
       var raw = fs.createReadStream('index.html');
       var acceptEncoding = request.headers['accept-encoding'];


### PR DESCRIPTION
* Use single quotes consistently
* Modernize examples to use template strings and arrow funcs
* Fix typos
* Fix a few line wrap issues

/cc @nodejs/http 