### PR TITLE
test: add test for tls.parseCertString

### DIFF
--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const tls = require('tls');
+
+const singles = 'C=US\nST=CA\nL=SF\nO=Node.js Foundation\nOU=Node.js\nCN=ca1\n'
+  + 'emailAddress=ry@clouds.org';
+const singlesOut = tls.parseCertString(singles);
+assert.deepEqual(singlesOut, {
+  C: 'US',
+  ST: 'CA',
+  L: 'SF',
+  O: 'Node.js Foundation',
+  OU: 'Node.js',
+  CN: 'ca1',
+  emailAddress: 'ry@clouds.org'
+});
+
+const doubles = 'OU=Domain Control Validated\nOU=PositiveSSL Wildcard\n' +
+  'CN=*.nodejs.org';
+const doublesOut = tls.parseCertString(doubles);
+assert.deepEqual(doublesOut, {
+  OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
+  CN: '*.nodejs.org'
+});


### PR DESCRIPTION
It does not currently have any explicit tests to verify the behavior.