### PR TITLE
module: always decorate thrown errors

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -4,6 +4,7 @@ const binding = process.binding('util');
 const prefix = `(${process.release.name}:${process.pid}) `;
 
 exports.getHiddenValue = binding.getHiddenValue;
+exports.setHiddenValue = binding.setHiddenValue;
 
 // All the internal deprecations have to use this function only, as this will
 // prepend the prefix to the actual message.
@@ -76,13 +77,16 @@ exports._deprecate = function(fn, msg) {
 };
 
 exports.decorateErrorStack = function decorateErrorStack(err) {
-  if (!(exports.isError(err) && err.stack))
+  if (!(exports.isError(err) && err.stack) ||
+      exports.getHiddenValue(err, 'node:decorated') === true)
     return;
 
-  const arrow = exports.getHiddenValue(err, 'arrowMessage');
+  const arrow = exports.getHiddenValue(err, 'node:arrowMessage');
 
-  if (arrow)
+  if (arrow) {
     err.stack = arrow + err.stack;
+    exports.setHiddenValue(err, 'node:decorated', true);
+  }
 };
 
 exports.isError = function isError(e) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -23,6 +23,16 @@ function hasOwnProperty(obj, prop) {
 }
 
 
+function tryWrapper(wrapper, opts) {
+  try {
+    return runInThisContext(wrapper, opts);
+  } catch (e) {
+    internalUtil.decorateErrorStack(e);
+    throw e;
+  }
+}
+
+
 function Module(id, parent) {
   this.id = id;
   this.exports = {};
@@ -371,8 +381,8 @@ Module.prototype._compile = function(content, filename) {
   // create wrapper function
   var wrapper = Module.wrap(content);
 
-  var compiledWrapper = runInThisContext(wrapper,
-                                      { filename: filename, lineOffset: 0 });
+  var compiledWrapper = tryWrapper(wrapper,
+                                   { filename: filename, lineOffset: 0 });
   if (global.v8debug) {
     if (!resolvedArgv) {
       // we enter the repl if we're not given a filename argument.

--- a/src/env.h
+++ b/src/env.h
@@ -45,7 +45,7 @@ namespace node {
   V(alpn_buffer_string, "alpnBuffer")                                         \
   V(args_string, "args")                                                      \
   V(argv_string, "argv")                                                      \
-  V(arrow_message_string, "arrowMessage")                                     \
+  V(arrow_message_string, "node:arrowMessage")                                \
   V(async, "async")                                                           \
   V(async_queue_string, "_asyncQueue")                                        \
   V(atime_string, "atime")                                                    \
@@ -65,6 +65,7 @@ namespace node {
   V(cwd_string, "cwd")                                                        \
   V(debug_port_string, "debugPort")                                           \
   V(debug_string, "debug")                                                    \
+  V(decorated_string, "node:decorated")                                       \
   V(dest_string, "dest")                                                      \
   V(detached_string, "detached")                                              \
   V(dev_string, "dev")                                                        \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -52,6 +52,21 @@ static void GetHiddenValue(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(obj->GetHiddenValue(name));
 }
 
+static void SetHiddenValue(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  if (!args[0]->IsObject())
+    return env->ThrowTypeError("obj must be an object");
+
+  if (!args[1]->IsString())
+    return env->ThrowTypeError("name must be a string");
+
+  Local<Object> obj = args[0].As<Object>();
+  Local<String> name = args[1].As<String>();
+
+  args.GetReturnValue().Set(obj->SetHiddenValue(name, args[2]));
+}
+
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -63,6 +78,7 @@ void Initialize(Local<Object> target,
 #undef V
 
   env->SetMethod(target, "getHiddenValue", GetHiddenValue);
+  env->SetMethod(target, "setHiddenValue", SetHiddenValue);
 }
 
 }  // namespace util

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -12,6 +12,12 @@ function getHiddenValue(obj, name) {
   };
 }
 
+function setHiddenValue(obj, name, val) {
+  return function() {
+    internalUtil.setHiddenValue(obj, name, val);
+  };
+}
+
 assert.throws(getHiddenValue(), /obj must be an object/);
 assert.throws(getHiddenValue(null, 'foo'), /obj must be an object/);
 assert.throws(getHiddenValue(undefined, 'foo'), /obj must be an object/);
@@ -22,12 +28,24 @@ assert.throws(getHiddenValue({}, null), /name must be a string/);
 assert.throws(getHiddenValue({}, []), /name must be a string/);
 assert.deepEqual(internalUtil.getHiddenValue({}, 'foo'), undefined);
 
+assert.throws(setHiddenValue(), /obj must be an object/);
+assert.throws(setHiddenValue(null, 'foo'), /obj must be an object/);
+assert.throws(setHiddenValue(undefined, 'foo'), /obj must be an object/);
+assert.throws(setHiddenValue('bar', 'foo'), /obj must be an object/);
+assert.throws(setHiddenValue(85, 'foo'), /obj must be an object/);
+assert.throws(setHiddenValue({}), /name must be a string/);
+assert.throws(setHiddenValue({}, null), /name must be a string/);
+assert.throws(setHiddenValue({}, []), /name must be a string/);
+const obj = {};
+assert.strictEqual(internalUtil.setHiddenValue(obj, 'foo', 'bar'), true);
+assert.strictEqual(internalUtil.getHiddenValue(obj, 'foo'), 'bar');
+
 let arrowMessage;
 
 try {
   require('../fixtures/syntax/bad_syntax');
 } catch (err) {
-  arrowMessage = internalUtil.getHiddenValue(err, 'arrowMessage');
+  arrowMessage = internalUtil.getHiddenValue(err, 'node:arrowMessage');
 }
 
 assert(/bad_syntax\.js:1/.test(arrowMessage));


### PR DESCRIPTION
This provides more information when encountering a syntax or similar error when executing a file with require().