### PR TITLE
src: remove __builtin_bswap16 call

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -109,12 +109,6 @@ inline static int snprintf(char *buffer, size_t n, const char *format, ...) {
 #endif
 #endif
 
-#if defined(__x86_64__)
-# define BITS_PER_LONG 64
-#else
-# define BITS_PER_LONG 32
-#endif
-
 #ifndef ARRAY_SIZE
 # define ARRAY_SIZE(a) (sizeof((a)) / sizeof((a)[0]))
 #endif

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -199,15 +199,8 @@ TypeName* Unwrap(v8::Local<v8::Object> object) {
 }
 
 void SwapBytes(uint16_t* dst, const uint16_t* src, size_t buflen) {
-  for (size_t i = 0; i < buflen; i++) {
-    // __builtin_bswap16 generates more efficient code with
-    // g++ 4.8 on PowerPC and other big-endian archs
-#ifdef __GNUC__
-    dst[i] = __builtin_bswap16(src[i]);
-#else
+  for (size_t i = 0; i < buflen; i += 1)
     dst[i] = (src[i] << 8) | (src[i] >> 8);
-#endif
-  }
 }
 
 


### PR DESCRIPTION
Not supported by apple-gcc and I'm not convinced it's worth adding more
preprocessor hacks when it should be easy as pie for the compiler to
to optimize the byteswap.  If it doesn't, fix the compiler.

Fixes: #4284

CI: https://ci.nodejs.org/job/node-test-pull-request/1002/