### PR TITLE
Fix debugger and profiler functionality

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -372,7 +372,7 @@ Module.prototype._compile = function(content, filename) {
   var wrapper = Module.wrap(content);
 
   var compiledWrapper = runInThisContext(wrapper,
-                                      { filename: filename, lineOffset: -1 });
+                                      { filename: filename, lineOffset: 0 });
   if (global.v8debug) {
     if (!resolvedArgv) {
       // we enter the repl if we're not given a filename argument.

--- a/src/node.js
+++ b/src/node.js
@@ -958,7 +958,7 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname) {\n',
+    '(function (exports, require, module, __filename, __dirname) { ',
     '\n});'
   ];
 
@@ -968,7 +968,7 @@
 
     var fn = runInThisContext(source, {
       filename: this.filename,
-      lineOffset: -1
+      lineOffset: 0
     });
     fn(this.exports, NativeModule.require, this, this.filename);
 

--- a/test/fixtures/exports-function-with-param.js
+++ b/test/fixtures/exports-function-with-param.js
@@ -1,0 +1,1 @@
+module.exports = function foo(arg) { return arg; }

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -53,6 +53,24 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
   assert.equal(breaks, 1);
 })();
 
+// Can set listeners and breakpoints on a single line file
+(function() {
+  const Debug = vm.runInDebugContext('Debug');
+  const fn = require(common.fixturesDir + '/exports-function-with-param');
+  let called = false;
+
+  Debug.setListener(function(event, state, data) {
+    if (data.constructor.name === 'BreakEvent') {
+      called = true;
+    }
+  });
+
+  Debug.setBreakPoint(fn);
+  fn('foo');
+  assert.strictEqual(Debug.showBreakPoints(fn), '(arg) { [B0]return arg; }');
+  assert.strictEqual(called, true);
+})();
+
 // See https://github.com/nodejs/node/issues/1190, fatal errors should not
 // crash the process.
 var script = common.fixturesDir + '/vm-run-in-debug-context.js';

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -281,9 +281,9 @@ assert.equal(42, require('../fixtures/utf8-bom.js'));
 assert.equal(42, require('../fixtures/utf8-bom.json'));
 
 // Error on the first line of a module should
-// have the correct line and column number
+// have the correct line number
 assert.throws(function() {
   require('../fixtures/test-error-first-line-offset.js');
 }, function(err) {
-  return /test-error-first-line-offset.js:1:1/.test(err.stack);
+  return /test-error-first-line-offset.js:1:/.test(err.stack);
 }, 'Expected appearance of proper offset in Error stack');


### PR DESCRIPTION
This PR contains two commits. The first is a fix for #4297, which restores the old module wrapping behavior. It is my hope that this commit can be reverted in the not so distant future. The second commit is a regression test for #4297.