### PR TITLE
async_wrap: properly cast when child isn't known

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -91,7 +91,7 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
   Local<Object> object = wrapper.As<Object>();
   CHECK_GT(object->InternalFieldCount(), 0);
 
-  AsyncWrap* wrap = Unwrap<AsyncWrap>(object);
+  AsyncWrap* wrap = Unwrap<AsyncWrap>(object)->async_wrap_cast();
   CHECK_NE(nullptr, wrap);
 
   return new RetainedAsyncInfo(class_id, wrap);
@@ -264,6 +264,11 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   return ret;
+}
+
+
+AsyncWrap* AsyncWrap::async_wrap_cast() {
+  return this;
 }
 
 }  // namespace node

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -70,6 +70,9 @@ class AsyncWrap : public BaseObject {
 
   virtual size_t self_size() const = 0;
 
+  // Implement for any class that has multiple inheritance.
+  virtual AsyncWrap* async_wrap_cast();
+
  private:
   inline AsyncWrap();
   inline bool ran_init_callback() const;

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -29,6 +29,9 @@ class JSStream : public StreamBase, public AsyncWrap {
               uv_stream_t* send_handle) override;
 
   size_t self_size() const override { return sizeof(*this); }
+  AsyncWrap* async_wrap_cast() override {
+    return static_cast<AsyncWrap*>(this);
+  }
 
  protected:
   JSStream(Environment* env, v8::Local<v8::Object> obj, AsyncWrap* parent);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -329,6 +329,9 @@ class Connection : public SSLWrap<Connection>, public AsyncWrap {
 #endif
 
   size_t self_size() const override { return sizeof(*this); }
+  AsyncWrap* async_wrap_cast() override {
+    return static_cast<AsyncWrap*>(this);
+  }
 
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -51,6 +51,9 @@ class TLSWrap : public AsyncWrap,
   void NewSessionDoneCb();
 
   size_t self_size() const override { return sizeof(*this); }
+  AsyncWrap* async_wrap_cast() override {
+    return static_cast<AsyncWrap*>(this);
+  }
 
  protected:
   static const int kClearOutChunkSize = 16384;


### PR DESCRIPTION
Have the child class perform the class cast to AsyncWrap in multiple
inheritance situations to prevent all sorts of UB.

R=@indutny 
R=@bnoordhuis 