### PR TITLE
udp: remove a needless instanceof Buffer check

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -252,8 +252,7 @@ Socket.prototype.send = function(buffer,
 
   if (typeof buffer === 'string')
     buffer = new Buffer(buffer);
-
-  if (!(buffer instanceof Buffer))
+  else if (!(buffer instanceof Buffer))
     throw new TypeError('First argument must be a buffer or string');
 
   offset = offset | 0;


### PR DESCRIPTION
When a string is passed to udpsock.send, it is automatically converted to a Buffer. In that case, it is no longer needed to test whether or not the argument is a Buffer.