### PR TITLE
http: Remove an unnecessary assignment

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -572,7 +572,7 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   var ret;
   if (data) {
     // Normal body write.
-    ret = this.write(data, encoding);
+    this.write(data, encoding);
   }
 
   if (this._hasBody && this.chunkedEncoding) {


### PR DESCRIPTION
This just removes an assignment to `ret` of a value that's not used before
it's overwritten.  Immediately following the assigment is an `if/else` in
which both branches assign to `ret` without using it.