### PR TITLE
doc: Typo in buffer.markdown referencing buf.write()

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -611,7 +611,7 @@ defaults to `'utf8'`. The `start` and `end` parameters default to `0` and
     buf.toString('utf8',0,5); // outputs: abcde
     buf.toString(undefined,0,5); // encoding defaults to 'utf8', outputs abcde
 
-See `buffer.write()` example, above.
+See `buf.write()` example, below.
 
 
 ### buf.toJSON()


### PR DESCRIPTION
The buffer's write function is documented below the buffer.toString function.  The final sentence describing the toString function indicated that there was a buffer.write function documented above it.  Additionally, all of the docs for buffer now use "buf" so the code snippet was changed to "buf.write()".