### PR TITLE
test: try other ipv6 localhost alternatives

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -81,6 +81,19 @@ var opensslCli = null;
 var inFreeBSDJail = null;
 var localhostIPv4 = null;
 
+exports.localIPv6Hosts = [
+  // Debian/Ubuntu
+  'ip6-localhost',
+  'ip6-loopback',
+
+  // SUSE
+  'ipv6-localhost',
+  'ipv6-loopback',
+
+  // Typically universal
+  'localhost',
+];
+
 Object.defineProperty(exports, 'inFreeBSDJail', {
   get: function() {
     if (inFreeBSDJail !== null) return inFreeBSDJail;

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
-var dns = require('dns');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const dns = require('dns');
 
 if (!common.hasIPv6) {
   console.log('1..0 # Skipped: no IPv6 support');
@@ -12,46 +12,60 @@ if (!common.hasIPv6) {
 var serverGotEnd = false;
 var clientGotEnd = false;
 
-dns.lookup('localhost', 6, function(err) {
-  if (err) {
-    console.error('Looks like IPv6 is not really supported');
-    console.error(err);
-    return;
-  }
+const hosts = common.localIPv6Hosts;
+var hostIdx = 0;
+var host = hosts[hostIdx];
+var localhostTries = 10;
 
-  var server = net.createServer({allowHalfOpen: true}, function(socket) {
-    socket.resume();
-    socket.on('end', function() {
-      serverGotEnd = true;
-    });
-    socket.end();
+const server = net.createServer({allowHalfOpen: true}, function(socket) {
+  socket.resume();
+  socket.on('end', function() {
+    serverGotEnd = true;
   });
-
-  server.listen(common.PORT, '::1', function() {
-    var client = net.connect({
-      host: 'localhost',
-      port: common.PORT,
-      family: 6,
-      allowHalfOpen: true
-    }, function() {
-      console.error('client connect cb');
-      client.resume();
-      client.on('end', function() {
-        clientGotEnd = true;
-        setTimeout(function() {
-          assert(client.writable);
-          client.end();
-        }, 10);
-      });
-      client.on('close', function() {
-        server.close();
-      });
-    });
-  });
-
-  process.on('exit', function() {
-    console.error('exit', serverGotEnd, clientGotEnd);
-    assert(serverGotEnd);
-    assert(clientGotEnd);
-  });
+  socket.end();
 });
+
+server.listen(common.PORT, '::1', tryConnect);
+
+function tryConnect() {
+  const client = net.connect({
+    host: host,
+    port: common.PORT,
+    family: 6,
+    allowHalfOpen: true
+  }, function() {
+    console.error('client connect cb');
+    client.resume();
+    client.on('end', function() {
+      clientGotEnd = true;
+      setTimeout(function() {
+        assert(client.writable);
+        client.end();
+      }, 10);
+    });
+    client.on('close', function() {
+      server.close();
+    });
+  }).on('error', function(err) {
+    if (err.syscall === 'getaddrinfo' && err.code === 'ENOTFOUND') {
+      if (host !== 'localhost' || --localhostTries === 0)
+        host = hosts[++hostIdx];
+      if (host)
+        tryConnect();
+      else {
+        console.log('1..0 # Skipped: no IPv6 localhost support');
+        process.removeListener('exit', onExit);
+        server.close();
+      }
+      return;
+    }
+    throw err;
+  });
+}
+
+process.on('exit', onExit);
+function onExit() {
+  console.error('exit', serverGotEnd, clientGotEnd);
+  assert(serverGotEnd);
+  assert(clientGotEnd);
+}


### PR DESCRIPTION
`ubuntu1404-64` has been having issues with `test-net-connect-options-ipv6` fairly frequently. I'm not exactly sure why the IPv6 `localhost` resolving is flaky on that particular machine (it could be the way its network is configured?), but being an Ubuntu system it typically has other IPv6 localhost hostnames.

This change tries those special IPv6 hostnames first before trying `localhost`. If those special hostnames fail to resolve and if `localhost` should error with `ENOTFOUND`, it retries several times before giving up.

I'm hoping this is enough to fix things. I did perform a [stress test](https://ci.nodejs.org/job/node-stress-single-test/190/nodes=ubuntu1404-64/) on that particular node and it was ok on every run after this change.