### PR TITLE
buffer: faster case for create Buffer from zero length buffer

### DIFF
--- a/benchmark/buffers/buffer_zero.js
+++ b/benchmark/buffers/buffer_zero.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1024]
+});
+
+const zero = new Buffer(0);
+
+function main(conf) {
+  var n = +conf.n;
+  bench.start();
+  for (let i = 0; i < n * 1024; i++) {
+    new Buffer(zero);
+  }
+  bench.end(n);
+}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -123,6 +123,10 @@ function fromString(string, encoding) {
 function fromObject(obj) {
   if (obj instanceof Buffer) {
     var b = allocate(obj.length);
+
+    if (b.length === 0)
+      return b;
+
     obj.copy(b, 0, 0, obj.length);
     return b;
   }


### PR DESCRIPTION
When create Buffer from a Buffer will copy data from old
to new even though length is zero.

This patch can improve edge case 4x faster.
following is benchmark results.

new: buffers/buffer_zero.js n=1024: 2463.53891
old: buffers/buffer_zero.js n=1024: 618.70801