### PR TITLE
debugger: guard against call from non-node context

### DIFF
--- a/src/debug-agent.cc
+++ b/src/debug-agent.cc
@@ -321,6 +321,8 @@ void Agent::EnqueueMessage(AgentMessage* message) {
 void Agent::MessageHandler(const v8::Debug::Message& message) {
   Isolate* isolate = message.GetIsolate();
   Environment* env = Environment::GetCurrent(isolate);
+  if (env == nullptr)
+    return;  // Called from a non-node context.
   Agent* a = env->debugger_agent();
   CHECK_NE(a, nullptr);
   CHECK_EQ(isolate, a->parent_env()->isolate());

--- a/test/parallel/test-debug-no-context.js
+++ b/test/parallel/test-debug-no-context.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+const args = [`--debug`, `--debug-port=${common.PORT}`, `--interactive`];
+const proc = spawn(process.execPath, args, { stdio: 'pipe' });
+proc.stdin.write(`
+    util.inspect(Promise.resolve(42));
+    util.inspect(Promise.resolve(1337));
+    .exit
+`);
+proc.on('exit', common.mustCall((exitCode, signalCode) => {
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signalCode, null);
+}));
+let stdout = '';
+proc.stdout.setEncoding('utf8');
+proc.stdout.on('data', data => stdout += data);
+process.on('exit', () => {
+  assert(stdout.includes('Promise { 42 }'));
+  assert(stdout.includes('Promise { 1337 }'));
+});


### PR DESCRIPTION
Fix a segmentation fault when the debug message handler was called from
a context without an associated `node::Environment`.

Fixes: https://github.com/nodejs/node/issues/4261
Fixes: https://github.com/nodejs/node/issues/4322

R=@indutny?

CI: https://ci.nodejs.org/job/node-test-pull-request/1017/