### PR TITLE
test: fix race condition in test-http-client-onerror

### DIFF
--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -22,7 +22,7 @@ console.log('We should do ' + todo + ' requests');
 
 var http = require('http');
 var server = http.createServer(serverHandler);
-server.listen(PORT, getall);
+server.listen(PORT, runTest);
 
 function getall() {
   if (count >= todo)
@@ -51,8 +51,10 @@ function getall() {
   setImmediate(getall);
 }
 
-for (var i = 0; i < 10; i++)
-  getall();
+function runTest() {
+  for (var i = 0; i < 10; i++)
+    getall();
+}
 
 function afterGC() {
   countGC ++;


### PR DESCRIPTION
I've noticed an error pop up very rarely in test-http-client-onerror, where the test fails whith a refused connection. Tracking it down I believe the issue is that the test is written such that connections could be attempted before the socket is listening