### PR TITLE
cluster: fix race condition setting suicide prop

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -434,7 +434,7 @@ function masterInit() {
     else if (message.act === 'listening')
       listening(worker, message);
     else if (message.act === 'suicide')
-      worker.suicide = true;
+      suicide(worker, message);
     else if (message.act === 'close')
       close(worker, message);
   }
@@ -443,6 +443,11 @@ function masterInit() {
     worker.state = 'online';
     worker.emit('online');
     cluster.emit('online', worker);
+  }
+
+  function suicide(worker, message) {
+    worker.suicide = true;
+    send(worker, { ack: message.seq });
   }
 
   function queryServer(worker, message) {
@@ -541,7 +546,7 @@ function workerInit() {
       if (message.act === 'newconn')
         onconnection(message, handle);
       else if (message.act === 'disconnect')
-        worker.disconnect();
+        _disconnect.call(worker, true);
     }
   };
 
@@ -662,14 +667,36 @@ function workerInit() {
   }
 
   Worker.prototype.disconnect = function() {
+    _disconnect.call(this);
+  };
+
+  Worker.prototype.destroy = function() {
+    this.suicide = true;
+    if (!this.isConnected()) process.exit(0);
+    var exit = process.exit.bind(null, 0);
+    send({ act: 'suicide' }, () => process.disconnect());
+    process.once('disconnect', exit);
+  };
+
+  function send(message, cb) {
+    sendHelper(process, message, null, cb);
+  }
+
+  function _disconnect(masterInitiated) {
     this.suicide = true;
     let waitingCount = 1;
 
     function checkWaitingCount() {
       waitingCount--;
       if (waitingCount === 0) {
-        send({ act: 'suicide' });
-        process.disconnect();
+        // If disconnect is worker initiated, wait for ack to be sure suicide
+        // is properly set in the master, otherwise, if it's master initiated
+        // there's no need to send the suicide message
+        if (masterInitiated) {
+          process.disconnect();
+        } else {
+          send({ act: 'suicide' }, () => process.disconnect());
+        }
       }
     }
 
@@ -681,19 +708,6 @@ function workerInit() {
     }
 
     checkWaitingCount();
-  };
-
-  Worker.prototype.destroy = function() {
-    this.suicide = true;
-    if (!this.isConnected()) process.exit(0);
-    var exit = process.exit.bind(null, 0);
-    send({ act: 'suicide' }, exit);
-    process.once('disconnect', exit);
-    process.disconnect();
-  };
-
-  function send(message, cb) {
-    sendHelper(process, message, null, cb);
   }
 }
 

--- a/test/sequential/test-cluster-disconnect-suicide-race.js
+++ b/test/sequential/test-cluster-disconnect-suicide-race.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
+const os = require('os');
 
 if (cluster.isMaster) {
   function forkWorker(action) {
@@ -15,8 +16,17 @@ if (cluster.isMaster) {
     }));
   }
 
-  forkWorker('disconnect');
-  forkWorker('kill');
+  const cpus = os.cpus().length;
+  const tries = cpus > 8 ? 64 : cpus * 8;
+
+  cluster.on('exit', common.mustCall((worker, code) => {
+    assert.strictEqual(code, 0, 'worker exited with error');
+  }, tries * 2));
+
+  for (let i = 0; i < tries; ++i) {
+    forkWorker('disconnect');
+    forkWorker('kill');
+  }
 } else {
   cluster.worker[process.env.action]();
 }


### PR DESCRIPTION
There is no guarantee that the `suicide` property of a worker in the master
process is going to be set when the `disconnect` and `exit` events are emitted.
To fix it, wait for the ACK of the suicide message from the master before
disconnecting the worker.
Modify `test-regress-GH-3238` so it checks both the `kill` and `disconnect`
cases. Also take into account that the `disconnect` event may be received after
the `exit` event.

I discovered this because I was sometimes getting this error:
```
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: false === true
    at Worker.<anonymous> (/Users/sgimeno/node/node/test/parallel/test-regress-GH-3238.js:17:12)
    at Worker.<anonymous> (/Users/sgimeno/node/node/test/common.js:401:15)
    at emitTwo (events.js:88:13)
    at Worker.emit (events.js:173:7)
    at ChildProcess.<anonymous> (cluster.js:361:14)
    at ChildProcess.g (events.js:264:16)
    at emitTwo (events.js:88:13)
    at ChildProcess.emit (events.js:173:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
```
I don't know if it's the proper fix though