### PR TITLE
doc: fix website wg mislink

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -37,7 +37,7 @@ back in to the TSC.
 * [Starting a Working Group](#starting-a-wg)
 * [Bootstrap Governance](#bootstrap-governance)
 
-### [Website](https://github.com/nodejs/website)
+### [Website](https://github.com/nodejs/nodejs.org)
 
 The website working group's purpose is to build and maintain a public
 website for the `Node.js` project.


### PR DESCRIPTION
`nodejs/website` -> `nodejs/nodejs.org`