### PR TITLE
lib: copy arguments object instead of leaking it

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -608,10 +608,18 @@ ClientRequest.prototype.setTimeout = function(msecs, callback) {
 };
 
 ClientRequest.prototype.setNoDelay = function() {
-  this._deferToConnect('setNoDelay', arguments);
+  const argsLen = arguments.length;
+  const args = new Array(argsLen);
+  for (var i = 0; i < argsLen; i++)
+    args[i] = arguments[i];
+  this._deferToConnect('setNoDelay', args);
 };
 ClientRequest.prototype.setSocketKeepAlive = function() {
-  this._deferToConnect('setKeepAlive', arguments);
+  const argsLen = arguments.length;
+  const args = new Array(argsLen);
+  for (var i = 0; i < argsLen; i++)
+    args[i] = arguments[i];
+  this._deferToConnect('setKeepAlive', args);
 };
 
 ClientRequest.prototype.clearTimeout = function(cb) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -960,7 +960,11 @@ function normalizeConnectArgs(listArgs) {
 }
 
 exports.connect = function(/* [port, host], options, cb */) {
-  var args = normalizeConnectArgs(arguments);
+  const argsLen = arguments.length;
+  var args = new Array(argsLen);
+  for (var i = 0; i < argsLen; i++)
+    args[i] = arguments[i];
+  args = normalizeConnectArgs(args);
   var options = args[0];
   var cb = args[1];
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -290,6 +290,16 @@ function expectedException(actual, expected) {
   return expected.call({}, actual) === true;
 }
 
+function _tryBlock(block) {
+  var error;
+  try {
+    block();
+  } catch (e) {
+    error = e;
+  }
+  return error;
+}
+
 function _throws(shouldThrow, block, expected, message) {
   var actual;
 
@@ -302,11 +312,7 @@ function _throws(shouldThrow, block, expected, message) {
     expected = null;
   }
 
-  try {
-    block();
-  } catch (e) {
-    actual = e;
-  }
+  actual = _tryBlock(block);
 
   message = (expected && expected.name ? ' (' + expected.name + ').' : '.') +
             (message ? ' ' + message : '.');
@@ -329,12 +335,12 @@ function _throws(shouldThrow, block, expected, message) {
 // assert.throws(block, Error_opt, message_opt);
 
 assert.throws = function(block, /*optional*/error, /*optional*/message) {
-  _throws.apply(this, [true].concat(pSlice.call(arguments)));
+  _throws(true, block, error, message);
 };
 
 // EXTENSION! This is annoying to write outside this module.
-assert.doesNotThrow = function(block, /*optional*/message) {
-  _throws.apply(this, [false].concat(pSlice.call(arguments)));
+assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
+  _throws(false, block, error, message);
 };
 
 assert.ifError = function(err) { if (err) throw err; };

--- a/lib/console.js
+++ b/lib/console.js
@@ -85,7 +85,10 @@ Console.prototype.trace = function trace() {
 
 Console.prototype.assert = function(expression) {
   if (!expression) {
-    var arr = Array.prototype.slice.call(arguments, 1);
+    const argsLen = arguments.length || 1;
+    const arr = new Array(argsLen - 1);
+    for (var i = 1; i < argsLen; i++)
+      arr[i - 1] = arguments[i];
     require('assert').ok(false, util.format.apply(null, arr));
   }
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -59,7 +59,11 @@ exports.createServer = function(options, connectionListener) {
 // connect(path, [cb]);
 //
 exports.connect = exports.createConnection = function() {
-  var args = normalizeConnectArgs(arguments);
+  const argsLen = arguments.length;
+  var args = new Array(argsLen);
+  for (var i = 0; i < argsLen; i++)
+    args[i] = arguments[i];
+  args = normalizeConnectArgs(args);
   debug('createConnection', args);
   var s = new Socket(args[0]);
   return Socket.prototype.connect.apply(s, args);
@@ -858,7 +862,11 @@ Socket.prototype.connect = function(options, cb) {
     // Old API:
     // connect(port, [host], [cb])
     // connect(path, [cb]);
-    var args = normalizeConnectArgs(arguments);
+    const argsLen = arguments.length;
+    var args = new Array(argsLen);
+    for (var i = 0; i < argsLen; i++)
+      args[i] = arguments[i];
+    args = normalizeConnectArgs(args);
     return Socket.prototype.connect.apply(this, args);
   }
 


### PR DESCRIPTION
Instead of leaking the arguments object by passing it as an argument to a function, copy it's contents to a new array, then pass the array. This allows V8 to optimize the function that contains this code, improving performance.

### Benchmarks

Using [benchmark.js](http://benchmarkjs.com/)

#### ClientRequest.setNoDelay / ClientRequest.setSocketKeepAlive

before: 15,286,485 ops/sec
after: 20,160,118 ops/sec
~33% faster

#### net.connect / tls.connect

before: 315,000 ops/sec
after: 345,000 ops/sec
~10% faster

code:
```js
net.connect({port: 80, host: 'google.com'}, () => {});
// same for tls
```

#### assert.throws

before: ~~98,403 ops/sec~~ 89,592 ops/sec
after: ~~145,609 ops/sec~~ 146,464 ops/sec
~~~48% faster~~ ~63% faster

code:
```js
function throws() {
  throw Error('error message');
}
// in test:
assert.throws(throws);
```

#### assert.doesNotThrow

before: ~~495,686 ops/sec~~ 424,867 ops/sec
after: ~~7,807,355 ops/sec~~ 14,513,552 ops/sec
~~~1475% faster~~ ~3316% faster

code:
```js
function doesNotThrow() {
  return 1 + 3;
}
// in test:
assert.doesNotThrow(doesNotThrow);
```

#### console.assert

before: 2,498,701 ops/sec
after: 4,163,156 ops/sec
~67% faster

code:
```js
console.assert(true);
```