### PR TITLE
test: fix domain-top-level-error-handler-throw

### DIFF
--- a/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -36,10 +36,12 @@ if (process.argv[2] === 'child') {
       stderrOutput += data.toString();
     });
 
-    child.on('exit', function onChildExited(exitCode, signal) {
+    child.on('close', function onChildClosed() {
       assert(stderrOutput.indexOf(domainErrHandlerExMessage) !== -1);
       assert(stderrOutput.indexOf(internalExMessage) === -1);
+    });
 
+    child.on('exit', function onChildExited(exitCode, signal) {
       var expectedExitCode = 7;
       var expectedSignal = null;
 


### PR DESCRIPTION
Check the stderr output in the `close` event as it's not guaranteed to be fully
available when the `exit` event is fired.
It tries to fix https://github.com/nodejs/node/issues/4206.