### PR TITLE
http: 451 status code "Unavailable For Legal Reasons"

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -65,6 +65,7 @@ const STATUS_CODES = exports.STATUS_CODES = {
   428 : 'Precondition Required',      // RFC 6585
   429 : 'Too Many Requests',          // RFC 6585
   431 : 'Request Header Fields Too Large',// RFC 6585
+  451 : 'Unavailable For Legal Reasons',
   500 : 'Internal Server Error',
   501 : 'Not Implemented',
   502 : 'Bad Gateway',

--- a/test/parallel/test-http-status-code.js
+++ b/test/parallel/test-http-status-code.js
@@ -7,7 +7,7 @@ var http = require('http');
 // ServerResponse.prototype.statusCode
 
 var testsComplete = 0;
-var tests = [200, 202, 300, 404, 500];
+var tests = [200, 202, 300, 404, 451, 500];
 var testIdx = 0;
 
 var s = http.createServer(function(req, res) {
@@ -42,6 +42,6 @@ function nextTest() {
 
 
 process.on('exit', function() {
-  assert.equal(4, testsComplete);
+  assert.equal(5, testsComplete);
 });
 


### PR DESCRIPTION
This http code allows us to provide a fair reason when we can't return some data to the client by legal issues.

IETF https://datatracker.ietf.org/doc/draft-ietf-httpbis-legally-restricted-status/

Fixes: #4376