### PR TITLE
doc: link and style parameter types

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -59,7 +59,7 @@ It can be constructed in a variety of ways.
 
 ### new Buffer(array)
 
-* `array` Array
+* `array` {Array}
 
 Allocates a new buffer using an `array` of octets.
 
@@ -71,7 +71,7 @@ Copies the passed `buffer` data onto a new `Buffer` instance.
 
 ### new Buffer(size)
 
-* `size` Number
+* `size` {Number}
 
 Allocates a new buffer of `size` bytes.  `size` must be less than
 1,073,741,824 bytes (1 GB) on 32 bits architectures or
@@ -84,17 +84,17 @@ sensitive data. Use `buf.fill(0)` to initialize a buffer to zeroes.
 
 ### new Buffer(str[, encoding])
 
-* `str` String - string to encode.
-* `encoding` String - encoding to use, Optional.
+* `str` {String} - string to encode.
+* `encoding` {String} - encoding to use, Optional.
 
 Allocates a new buffer containing the given `str`.
 `encoding` defaults to `'utf8'`.
 
 ### Class Method: Buffer.byteLength(string[, encoding])
 
-* `string` String
-* `encoding` String, Optional, Default: 'utf8'
-* Return: Number
+* `string` {String}
+* `encoding` {String} - Optional, Default: 'utf8'
+* Return: {Number}
 
 Gives the actual byte length of a string. `encoding` defaults to `'utf8'`.
 This is not the same as `String.prototype.length` since that returns the
@@ -162,8 +162,8 @@ Example: build a single buffer from a list of three buffers:
 
 ### Class Method: Buffer.isBuffer(obj)
 
-* `obj` Object
-* Return: Boolean
+* `obj` {Object}
+* Return: {Boolean}
 
 Tests if `obj` is a `Buffer`.
 
@@ -221,10 +221,10 @@ the same as the `otherBuffer` in sort order.
 
 ### buf.copy(targetBuffer[, targetStart][, sourceStart][, sourceEnd])
 
-* `targetBuffer` Buffer object - Buffer to copy into
-* `targetStart` Number, Optional, Default: 0
-* `sourceStart` Number, Optional, Default: 0
-* `sourceEnd` Number, Optional, Default: `buffer.length`
+* `targetBuffer` {Buffer} - Buffer to copy into
+* `targetStart` {Number} - Optional, Default: 0
+* `sourceStart` {Number} - Optional, Default: 0
+* `sourceEnd` {Number} - Optional, Default: `buffer.length`
 
 Copies data from a region of this buffer to a region in the target buffer even
 if the target memory region overlaps with the source. If `undefined` the
@@ -282,9 +282,9 @@ buffer.
 
 ### buf.indexOf(value[, byteOffset])
 
-* `value` String, Buffer or Number
-* `byteOffset` Number, Optional, Default: 0
-* Return: Number
+* `value` {String | Buffer | Number}
+* `byteOffset` {Number} - Optional, Default: 0
+* Return: {Number}
 
 Operates similar to [Array#indexOf()][]. Accepts a String, Buffer or Number.
 Strings are interpreted as UTF8. Buffers will use the entire buffer. So in order
@@ -293,7 +293,7 @@ to compare a partial Buffer use `Buffer#slice()`. Numbers can range from 0 to
 
 ### buf.length
 
-* Number
+* {Number}
 
 The size of the buffer in bytes.  Note that this is not necessarily the size
 of the contents. `length` refers to the amount of memory allocated for the
@@ -322,9 +322,9 @@ use `buf.slice` to create a new buffer.
 ### buf.readDoubleBE(offset[, noAssert])
 ### buf.readDoubleLE(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads a 64 bit double from the buffer at the specified offset with specified
 endian format.
@@ -352,9 +352,9 @@ Example:
 ### buf.readFloatBE(offset[, noAssert])
 ### buf.readFloatLE(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads a 32 bit float from the buffer at the specified offset with specified
 endian format.
@@ -377,9 +377,9 @@ Example:
 
 ### buf.readInt8(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads a signed 8 bit integer from the buffer at the specified offset.
 
@@ -392,9 +392,9 @@ complement signed values.
 ### buf.readInt16BE(offset[, noAssert])
 ### buf.readInt16LE(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads a signed 16 bit integer from the buffer at the specified offset with
 specified endian format.
@@ -408,9 +408,9 @@ complement signed values.
 ### buf.readInt32BE(offset[, noAssert])
 ### buf.readInt32LE(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads a signed 32 bit integer from the buffer at the specified offset with
 specified endian format.
@@ -443,9 +443,9 @@ may be beyond the end of the buffer. Defaults to `false`.
 
 ### buf.readUInt8(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads an unsigned 8 bit integer from the buffer at the specified offset.
 
@@ -473,9 +473,9 @@ Example:
 ### buf.readUInt16BE(offset[, noAssert])
 ### buf.readUInt16LE(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads an unsigned 16 bit integer from the buffer at the specified offset with
 specified endian format.
@@ -509,9 +509,9 @@ Example:
 ### buf.readUInt32BE(offset[, noAssert])
 ### buf.readUInt32LE(offset[, noAssert])
 
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
-* Return: Number
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
+* Return: {Number}
 
 Reads an unsigned 32 bit integer from the buffer at the specified offset with
 specified endian format.
@@ -581,9 +581,9 @@ byte from the original Buffer.
 
 ### buf.toString([encoding][, start][, end])
 
-* `encoding` String, Optional, Default: 'utf8'
-* `start` Number, Optional, Default: 0
-* `end` Number, Optional, Default: `buffer.length`
+* `encoding` {String} - Optional, Default: 'utf8'
+* `start` {Number} - Optional, Default: 0
+* `end` {Number} - Optional, Default: `buffer.length`
 
 Decodes and returns a string from buffer data encoded using the specified
 character set encoding. If `encoding` is `undefined` or `null`, then `encoding`
@@ -626,10 +626,10 @@ Example:
 
 ### buf.write(string[, offset][, length][, encoding])
 
-* `string` String - data to be written to buffer
-* `offset` Number, Optional, Default: 0
-* `length` Number, Optional, Default: `buffer.length - offset`
-* `encoding` String, Optional, Default: 'utf8'
+* `string` {String} - data to be written to buffer
+* `offset` {Number} - Optional, Default: 0
+* `length` {Number} - Optional, Default: `buffer.length - offset`
+* `encoding` {String} - Optional, Default: 'utf8'
 
 Writes `string` to the buffer at `offset` using the given encoding.
 `offset` defaults to `0`, `encoding` defaults to `'utf8'`. `length` is
@@ -645,9 +645,9 @@ The method will not write partial characters.
 ### buf.writeDoubleBE(value, offset[, noAssert])
 ### buf.writeDoubleLE(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset with specified endian
 format. Note, `value` must be a valid 64 bit double.
@@ -674,9 +674,9 @@ Example:
 ### buf.writeFloatBE(value, offset[, noAssert])
 ### buf.writeFloatLE(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset with specified endian
 format. Note, behavior is unspecified if `value` is not a 32 bit float.
@@ -702,9 +702,9 @@ Example:
 
 ### buf.writeInt8(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset. Note, `value` must be a
 valid signed 8 bit integer.
@@ -720,9 +720,9 @@ signed integer into `buffer`.
 ### buf.writeInt16BE(value, offset[, noAssert])
 ### buf.writeInt16LE(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset with specified endian
 format. Note, `value` must be a valid signed 16 bit integer.
@@ -738,9 +738,9 @@ complement signed integer into `buffer`.
 ### buf.writeInt32BE(value, offset[, noAssert])
 ### buf.writeInt32LE(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset with specified endian
 format. Note, `value` must be a valid signed 32 bit integer.
@@ -774,9 +774,9 @@ to `false`.
 
 ### buf.writeUInt8(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset. Note, `value` must be a
 valid unsigned 8 bit integer.
@@ -832,9 +832,9 @@ Example:
 ### buf.writeUInt32BE(value, offset[, noAssert])
 ### buf.writeUInt32LE(value, offset[, noAssert])
 
-* `value` Number
-* `offset` Number
-* `noAssert` Boolean, Optional, Default: false
+* `value` {Number}
+* `offset` {Number}
+* `noAssert` {Boolean} - Optional, Default: false
 
 Writes `value` to the buffer at the specified offset with specified endian
 format. Note, `value` must be a valid unsigned 32 bit integer.
@@ -879,7 +879,7 @@ to `false`.
 
 ## buffer.INSPECT_MAX_BYTES
 
-* Number, Default: 50
+* {Number} - Default: 50
 
 How many bytes will be returned when `buffer.inspect()` is called. This can
 be overridden by user modules. See [util.inspect()][] for more details on

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -48,7 +48,7 @@ and the `.connected` property is false.
 
 ### Event:  'error'
 
-* `err` {Error Object} the error.
+* `err` {Error} the error.
 
 Emitted when:
 
@@ -84,7 +84,7 @@ See `waitpid(2)`.
 ### Event: 'message'
 
 * `message` {Object} a parsed JSON object or primitive value.
-* `sendHandle` {Handle object} a [net.Socket][] or [net.Server][] object, or
+* `sendHandle` {Handle} a [net.Socket][] or [net.Server][] object, or
   undefined.
 
 Messages sent by `.send(message, [sendHandle])` are obtained using the
@@ -140,7 +140,7 @@ See `kill(2)`
 
 ### child.pid
 
-* {Integer}
+* {Number}
 
 The PID of the child process.
 
@@ -155,7 +155,7 @@ Example:
 ### child.send(message[, sendHandle][, callback])
 
 * `message` {Object}
-* `sendHandle` {Handle object}
+* `sendHandle` {Handle}
 * `callback` {Function}
 * Return: Boolean
 
@@ -279,7 +279,7 @@ It is also recommended not to use `.maxConnections` in this condition.
 
 ### child.stderr
 
-* {Stream object}
+* {Stream}
 
 A `Readable Stream` that represents the child process's `stderr`.
 
@@ -291,7 +291,7 @@ to the same object, or null.
 
 ### child.stdin
 
-* {Stream object}
+* {Stream}
 
 A `Writable Stream` that represents the child process's `stdin`.
 If the child is waiting to read all its input, it will not continue until this
@@ -339,7 +339,7 @@ the parent's `child.stdio[1]` is a stream, all other values in the array are
 
 ### child.stdout
 
-* {Stream object}
+* {Stream}
 
 A `Readable Stream` that represents the child process's `stdout`.
 
@@ -375,7 +375,7 @@ callback or returning an EventEmitter).
   * `error` {Error}
   * `stdout` {Buffer}
   * `stderr` {Buffer}
-* Return: ChildProcess object
+* Return: {ChildProcess}
 
 Runs a command in a shell and buffers the output.
 
@@ -433,7 +433,7 @@ the existing process and uses a shell to execute the command.*
   * `error` {Error}
   * `stdout` {Buffer}
   * `stderr` {Buffer}
-* Return: ChildProcess object
+* Return: {ChildProcess}
 
 This is similar to [`child_process.exec()`][] except it does not execute a
 subshell but rather the specified file directly. This makes it slightly
@@ -456,7 +456,7 @@ leaner than [`child_process.exec()`][]. It has the same options.
     (default is false)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-* Return: ChildProcess object
+* Return: {ChildProcess}
 
 This is a special case of the [`child_process.spawn()`][] functionality for
 spawning Node.js processes. In addition to having all the methods in a normal
@@ -490,7 +490,7 @@ current process.*
     [below](#child_process_options_detached))
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-* return: {ChildProcess object}
+* return: {ChildProcess}
 
 Launches a new process with the given `command`, with  command line arguments in
 `args`. If omitted, `args` defaults to an empty Array.
@@ -676,7 +676,7 @@ configuration at startup.
 * `args` {Array} List of string arguments
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
-  * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
+  * `input` {String | Buffer} The value which will be passed as stdin to the spawned process
     - supplying this value will override `stdio[0]`
   * `stdio` {Array} Child's stdio configuration. (Default: 'pipe')
     - `stderr` by default will be output to the parent process' stderr unless

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -315,7 +315,7 @@ it is [kill][].
 
 ### worker.process
 
-* {ChildProcess object}
+* {ChildProcess}
 
 All workers are created using `child_process.fork()`, the returned object
 from this function is stored as `.process`. In a worker, the global `process`
@@ -330,9 +330,9 @@ disconnection.
 ### worker.send(message[, sendHandle][, callback])
 
 * `message` {Object}
-* `sendHandle` {Handle object}
+* `sendHandle` {Handle}
 * `callback` {Function}
-* Return: Boolean
+* Return: {Boolean}
 
 Send a message to a worker or master, optionally with a handle.
 
@@ -374,7 +374,7 @@ exit, the master may choose not to respawn a worker based on this value.
 
 ## Event: 'disconnect'
 
-* `worker` {Worker object}
+* `worker` {Worker}
 
 Emitted after the worker IPC channel has disconnected. This can occur when a
 worker exits gracefully, is killed, or is disconnected manually (such as with
@@ -390,7 +390,7 @@ long-living connections.
 
 ## Event: 'exit'
 
-* `worker` {Worker object}
+* `worker` {Worker}
 * `code` {Number} the exit code, if it exited normally.
 * `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
   the process to be killed.
@@ -409,7 +409,7 @@ See [child_process event: 'exit'][].
 
 ## Event: 'fork'
 
-* `worker` {Worker object}
+* `worker` {Worker}
 
 When a new worker is forked the cluster module will emit a 'fork' event.
 This can be used to log worker activity, and create your own timeout.
@@ -432,7 +432,7 @@ This can be used to log worker activity, and create your own timeout.
 
 ## Event: 'listening'
 
-* `worker` {Worker object}
+* `worker` {Worker}
 * `address` {Object}
 
 After calling `listen()` from a worker, when the 'listening' event is emitted on
@@ -465,7 +465,7 @@ See [child_process event: 'message'][].
 
 ## Event: 'online'
 
-* `worker` {Worker object}
+* `worker` {Worker}
 
 After forking a new worker, the worker should respond with an online message.
 When the master receives an online message it will emit this event.
@@ -505,7 +505,7 @@ This can only be called from the master process.
 ## cluster.fork([env])
 
 * `env` {Object} Key/value pairs to add to worker process environment.
-* return {Worker object}
+* return {Worker}
 
 Spawn a new worker process.
 

--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -32,7 +32,7 @@ on this socket.
 
 ### Event: 'error'
 
-* `exception` Error object
+* `exception` {Error}
 
 Emitted when an error occurs.
 
@@ -43,8 +43,8 @@ are created.
 
 ### Event: 'message'
 
-* `msg` Buffer object. The message
-* `rinfo` Object. Remote address information
+* `msg` {Buffer} The message
+* `rinfo` {Object} Remote address information
 
 Emitted when a new datagram is available on a socket.  `msg` is a `Buffer` and
 `rinfo` is an object with the sender's address information:
@@ -56,8 +56,8 @@ Emitted when a new datagram is available on a socket.  `msg` is a `Buffer` and
 
 ### socket.addMembership(multicastAddress[, multicastInterface])
 
-* `multicastAddress` String
-* `multicastInterface` String, Optional
+* `multicastAddress` {String}
+* `multicastInterface` {String} - Optional
 
 Tells the kernel to join a multicast group with `IP_ADD_MEMBERSHIP` socket option.
 
@@ -71,9 +71,9 @@ this object will contain `address` , `family` and `port`.
 
 ### socket.bind([port][, address][, callback])
 
-* `port` Integer, Optional
-* `address` String, Optional
-* `callback` Function with no parameters, Optional. Callback when
+* `port` {Number} integer - Optional
+* `address` {String} Optional
+* `callback` {Function} with no parameters, Optional. Callback when
   binding is done.
 
 For UDP sockets, listen for datagrams on a named `port` and optional
@@ -118,7 +118,7 @@ Example of a UDP server listening on port 41234:
 ### socket.bind(options[, callback])
 
 * `options` {Object} - Required. Supports the following properties:
-  * `port` {Number} - Required.
+  * `port` {Number} integer - Required.
   * `address` {String} - Optional.
   * `exclusive` {Boolean} - Optional.
 * `callback` {Function} - Optional.
@@ -147,8 +147,8 @@ provided, it is added as a listener for the ['close'][] event.
 
 ### socket.dropMembership(multicastAddress[, multicastInterface])
 
-* `multicastAddress` String
-* `multicastInterface` String, Optional
+* `multicastAddress` {String}
+* `multicastInterface` {String} - Optional
 
 Opposite of `addMembership` - tells the kernel to leave a multicast group with
 `IP_DROP_MEMBERSHIP` socket option. This is automatically called by the kernel
@@ -160,12 +160,12 @@ interfaces.
 
 ### socket.send(buf, offset, length, port, address[, callback])
 
-* `buf` Buffer object or string.  Message to be sent
-* `offset` Integer. Offset in the buffer where the message starts.
-* `length` Integer. Number of bytes in the message.
-* `port` Integer. Destination port.
-* `address` String. Destination hostname or IP address.
-* `callback` Function. Called when the message has been sent. Optional.
+* `buf` {Buffer|String} Message to be sent
+* `offset` {Number} Integer. Offset in the buffer where the message starts.
+* `length` {Number} Integer. Number of bytes in the message.
+* `port` {Number} Integer. Destination port.
+* `address` {String} Destination hostname or IP address.
+* `callback` {Function} Called when the message has been sent. Optional.
 
 For UDP sockets, the destination port and address must be specified.  A string
 may be supplied for the `address` parameter, and it will be resolved with DNS.
@@ -225,21 +225,21 @@ informing the source that the data did not reach its intended recipient).
 
 ### socket.setBroadcast(flag)
 
-* `flag` Boolean
+* `flag` {Boolean}
 
 Sets or clears the `SO_BROADCAST` socket option.  When this option is set, UDP packets
 may be sent to a local interface's broadcast address.
 
 ### socket.setMulticastLoopback(flag)
 
-* `flag` Boolean
+* `flag` {Boolean}
 
 Sets or clears the `IP_MULTICAST_LOOP` socket option.  When this option is set, multicast
 packets will also be received on the local interface.
 
 ### socket.setMulticastTTL(ttl)
 
-* `ttl` Integer
+* `ttl` {Number} Integer
 
 Sets the `IP_MULTICAST_TTL` socket option.  TTL stands for "Time to Live," but in this
 context it specifies the number of IP hops that a packet is allowed to go through,
@@ -251,7 +251,7 @@ systems is 1.
 
 ### socket.setTTL(ttl)
 
-* `ttl` Integer
+* `ttl` {Number} Integer
 
 Sets the `IP_TTL` socket option.  TTL stands for "Time to Live," but in this context it
 specifies the number of IP hops that a packet is allowed to go through.  Each router or
@@ -279,9 +279,9 @@ active socket in the event system. If the socket is already `unref`d calling
 Returns `socket`.
 
 ## dgram.createSocket(options[, callback])
-* `options` Object
-* `callback` Function. Attached as a listener to `message` events.
-* Returns: Socket object
+* `options` {Object}
+* `callback` {Function} Attached as a listener to `message` events.
+* Returns: {dgram.Socket}
 
 The `options` object should contain a `type` field of either `udp4` or `udp6`
 and an optional boolean `reuseAddr` field.
@@ -299,10 +299,10 @@ with `socket.address().address` and `socket.address().port`.
 
 ## dgram.createSocket(type[, callback])
 
-* `type` String. Either 'udp4' or 'udp6'
-* `callback` Function. Attached as a listener to `message` events.
+* `type` {String} Either 'udp4' or 'udp6'
+* `callback` {Function} Attached as a listener to `message` events.
   Optional
-* Returns: Socket object
+* Returns: {dgram.Socket}
 
 Creates a datagram Socket of the specified types.  Valid types are `udp4`
 and `udp6`.

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -98,7 +98,7 @@ See more details in [fs.watch][].
 
 ### Event: 'error'
 
-* `error` {Error object}
+* `error` {Error}
 
 Emitted when an error occurs.
 
@@ -112,7 +112,7 @@ Stop watching for changes on the given `fs.FSWatcher`.
 
 ### Event: 'open'
 
-* `fd` {Integer} file descriptor used by the ReadStream.
+* `fd` {Number} Integer file descriptor used by the ReadStream.
 
 Emitted when the ReadStream's file is opened.
 
@@ -187,7 +187,7 @@ on Unix systems, it never was.
 
 ### Event: 'open'
 
-* `fd` {Integer} file descriptor used by the WriteStream.
+* `fd` {Number} Integer file descriptor used by the WriteStream.
 
 Emitted when the WriteStream's file is opened.
 
@@ -227,7 +227,7 @@ fail, and does nothing otherwise.
 
 ## fs.appendFile(file, data[, options], callback)
 
-* `file` {String | Integer} filename or file descriptor
+* `file` {String | Number} filename or file descriptor
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`
@@ -876,7 +876,7 @@ the end of the file.
 
 ## fs.writeFile(file, data[, options], callback)
 
-* `file` {String | Integer} filename or file descriptor
+* `file` {String | Number} filename or file descriptor
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -88,7 +88,7 @@ Alternatively, you could just opt out of pooling entirely using
   Can have the following fields:
   * `keepAlive` {Boolean} Keep sockets around in a pool to be used by
     other requests in the future. Default = `false`
-  * `keepAliveMsecs` {Integer} When using HTTP KeepAlive, how often
+  * `keepAliveMsecs` {Number} When using HTTP KeepAlive, how often
     to send TCP KeepAlive packets over sockets being kept alive.
     Default = `1000`.  Only relevant if `keepAlive` is set to `true`.
   * `maxSockets` {Number} Maximum number of sockets to allow per

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -502,7 +502,7 @@ loading.
 
 ### module.parent
 
-* {Module Object}
+* {Object} Module
 
 The module that first required this one.
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -19,14 +19,14 @@ event is not emitted until all connections are ended.
 
 ### Event: 'connection'
 
-* {Socket object} The connection object
+* {net.Socket} The connection object
 
 Emitted when a new connection is made. `socket` is an instance of
 `net.Socket`.
 
 ### Event: 'error'
 
-* {Error Object}
+* {Error}
 
 Emitted when an error occurs.  The ['close'][] event will be called directly
 following this event.  See example in discussion of `server.listen`.
@@ -280,7 +280,7 @@ caveat that the user is required to `end()` their side now.
 
 ### Event: 'error'
 
-* {Error object}
+* {Error}
 
 Emitted when an error occurs.  The `'close'` event will be called directly
 following this event.

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -201,7 +201,7 @@ readable.on('end', function() {
 
 #### Event: 'error'
 
-* {Error Object}
+* {Error}
 
 Emitted if there was an error receiving data.
 
@@ -254,7 +254,7 @@ end
 
 #### readable.isPaused()
 
-* Return: `Boolean`
+* Return: {Boolean}
 
 This method returns whether or not the `readable` has been **explicitly**
 paused by client code (using `readable.pause()` without a corresponding
@@ -293,7 +293,7 @@ readable.on('data', function(chunk) {
 
 #### readable.pipe(destination[, options])
 
-* `destination` {[Writable][] Stream} The destination for writing data
+* `destination` {stream.Writable} The destination for writing data
 * `options` {Object} Pipe options
   * `end` {Boolean} End the writer when the reader ends. Default = `true`
 
@@ -346,7 +346,7 @@ the process exits, regardless of the specified options.
 #### readable.read([size])
 
 * `size` {Number} Optional argument to specify how much data to read.
-* Return {String | Buffer | null}
+* Return {String | Buffer | Null}
 
 The `read()` method pulls some data out of the internal buffer and
 returns it.  If there is no data available, then it will return
@@ -428,7 +428,7 @@ readable.on('data', function(chunk) {
 
 #### readable.unpipe([destination])
 
-* `destination` {[Writable][] Stream} Optional specific stream to unpipe
+* `destination` {stream.Writable} Optional specific stream to unpipe
 
 This method will remove the hooks set up for a previous `pipe()` call.
 
@@ -603,7 +603,7 @@ function writeOneMillionTimes(writer, data, encoding, callback) {
 
 #### Event: 'error'
 
-* {Error object}
+* {Error}
 
 Emitted if there was an error when writing or piping data.
 
@@ -625,7 +625,7 @@ writer.on('finish', function() {
 
 #### Event: 'pipe'
 
-* `src` {[Readable][] Stream} source stream that is piping to this writable
+* `src` {stream.Readable} source stream that is piping to this writable
 
 This is emitted whenever the `pipe()` method is called on a readable
 stream, adding this writable to its set of destinations.
@@ -642,7 +642,7 @@ reader.pipe(writer);
 
 #### Event: 'unpipe'
 
-* `src` {[Readable][] Stream} The source stream that [unpiped][] this writable
+* `src` {stream.Readable} The source stream that [unpiped][] this writable
 
 This is emitted whenever the [`unpipe()`][] method is called on a
 readable stream, removing this writable from its set of destinations.
@@ -893,7 +893,7 @@ becomes available.  There is no need, for example to "wait" until
 
 #### readable.push(chunk[, encoding])
 
-* `chunk` {Buffer | null | String} Chunk of data to push into the read queue
+* `chunk` {Buffer | Null | String} Chunk of data to push into the read queue
 * `encoding` {String} Encoding of String chunks.  Must be a valid
   Buffer encoding, such as `'utf8'` or `'ascii'`
 * return {Boolean} Whether or not more pushes should be performed
@@ -1467,7 +1467,7 @@ var writable = new stream.Writable({
 <!--type=misc-->
 
 Both Writable and Readable streams will buffer data on an internal
-object which can be retrieved from `_writableState.getBuffer()` or 
+object which can be retrieved from `_writableState.getBuffer()` or
 `_readableState.buffer`, respectively.
 
 The amount of data that will potentially be buffered depends on the

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -347,8 +347,12 @@ a code {
   color: inherit;
 }
 
-span.type {
-  color: #222;
+span.type, a.type {
+  font-size: 0.9em;
+  padding: 0.2em 0.4em;
+  line-height: 1.5em;
+  font-family: Monaco, Consolas, "Lucida Console", monospace;
+  margin: 0;
 }
 
 #content {

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -1,0 +1,53 @@
+'use strict';
+const nodeDocUrl = '';
+const jsDocUrl = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/' +
+  'Reference/Global_Objects/';
+const jsGlobalTypes = [
+  'Error', 'Number', 'Object', 'Boolean', 'String', 'Function', 'Symbol',
+  'Array', 'Uint8Array', 'Uint16Array', 'Uint32Array', 'Int8Array',
+  'Int16Array', 'Int32Array', 'Uint8ClampedArray', 'Float32Array',
+  'Float64Array', 'Date', 'RegExp', 'ArrayBuffer', 'DataView', 'Promise',
+  'Null'
+];
+const typeMap = {
+  'Buffer': 'buffer.html#buffer_class_buffer',
+  'Handle': 'net.html#net_server_listen_handle_callback',
+  'Stream': 'stream.html#stream_stream',
+  'stream.Writable': 'stream.html#stream_class_stream_writable',
+  'stream.Readable': 'stream.html#stream_class_stream_readable',
+  'ChildProcess': 'child_process.html#child_process_class_childprocess',
+  'Worker': 'cluster.html#cluster_class_worker',
+  'dgram.Socket': 'dgram.html#dgram_class_dgram_socket',
+  'net.Socket': 'net.html#net_class_net_socket',
+  'EventEmitter': 'events.html#events_class_events_eventemitter',
+  'Timer': 'timers.html#timers_timers'
+};
+
+module.exports = {
+  toLink: function (typeInput) {
+    let typeLinks = [];
+    typeInput = typeInput.replace('{', '').replace('}', '');
+    let typeTexts = typeInput.split('|');
+
+    typeTexts.forEach(function (typeText) {
+      typeText = typeText.trim();
+      if (typeText) {
+        let typeUrl = null;
+        if (jsGlobalTypes.indexOf(typeText) !== -1) {
+          typeUrl = jsDocUrl + typeText;
+        } else if (typeMap[typeText]) {
+          typeUrl = nodeDocUrl + typeMap[typeText];
+        }
+
+        if (typeUrl) {
+          typeLinks.push('<a href="' + typeUrl + '" class="type">&lt;' +
+            typeText + '&gt;</a>');
+        } else {
+          typeLinks.push('<span class="type">&lt;' + typeText + '&gt;</span>');
+        }
+      }
+    });
+
+    return typeLinks.length ? typeLinks.join(' | ') : typeInput;
+  }
+}


### PR DESCRIPTION
Changes the parsing of parameter types, links to MDN or
nodejs docs. See #4350
example: "* {Object}" -> "* <link to MDN><Object></link>"