### PR TITLE
src: remove forwards for v8::GC*logueCallback

### DIFF
--- a/src/node_counters.cc
+++ b/src/node_counters.cc
@@ -11,8 +11,6 @@ namespace node {
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::GCCallbackFlags;
-using v8::GCEpilogueCallback;
-using v8::GCPrologueCallback;
 using v8::GCType;
 using v8::HandleScope;
 using v8::Isolate;

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -34,8 +34,6 @@ namespace node {
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::GCCallbackFlags;
-using v8::GCEpilogueCallback;
-using v8::GCPrologueCallback;
 using v8::GCType;
 using v8::HandleScope;
 using v8::Isolate;

--- a/src/node_lttng.cc
+++ b/src/node_lttng.cc
@@ -29,8 +29,6 @@ namespace node {
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::GCCallbackFlags;
-using v8::GCEpilogueCallback;
-using v8::GCPrologueCallback;
 using v8::GCType;
 using v8::HandleScope;
 using v8::Isolate;


### PR DESCRIPTION
These types are no longer used in the file and V8 4.9 no longer defines these
types anymore.

R=@bnoordhuis 