### PR TITLE
test: use platformTimeout() in more places

### DIFF
--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -52,4 +52,4 @@ server.bind(server_port);
 
 timer = setTimeout(function() {
   throw new Error('Timeout');
-}, 200);
+}, common.platformTimeout(200));

--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -19,7 +19,7 @@ function test(handler, request_generator, response_validator) {
     server.close();
     response_validator(server_response, client_got_eof, true);
   }
-  var timer = setTimeout(cleanup, 1000);
+  var timer = setTimeout(cleanup, common.platformTimeout(1000));
   process.on('exit', cleanup);
 
   server.listen(port);


### PR DESCRIPTION
Without these changes, the pi1-raspbian-wheezy CI node was timing out on these tests.