### PR TITLE
buffer: workaround for v8 buffer.toString failure. fixes #4266

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,10 +2,10 @@
 
 Security Update
 
-Notable items:
+Notable changes:
 
-* http: Fix a bug where an HTTP socket may no longer have a socket but a pipelined request triggers a pause or resume, a potential denial-of-service vector. (Fedor Indutny)
-* openssl: Upgrade to 1.0.1q, containing fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
+* http: Fix CVE-2015-8027, a bug whereby an HTTP socket may no longer have a parser associated with it but a pipelined request attempts to trigger a pause or resume on the non-existent parser, a potential denial-of-service vulnerability. (Fedor Indutny)
+* openssl: Upgrade to 1.0.1q, fixes CVE-2015-3194 "Certificate verify crash with missing PSS parameter", a potential denial-of-service vector for Node.js TLS servers using client certificate authentication; TLS clients are also impacted. Details are available at <http://openssl.org/news/secadv/20151203.txt>. (Ben Noordhuis) https://github.com/nodejs/node/pull/4133
 
 Commits:
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -944,6 +944,27 @@ class ScriptOrigin {
 };
 
 
+class V8_EXPORT SealHandleScope {
+ public:
+  SealHandleScope(Isolate* isolate);
+  ~SealHandleScope();
+
+ private:
+  // Make it hard to create heap-allocated or illegal handle scopes by
+  // disallowing certain operations.
+  SealHandleScope(const SealHandleScope&);
+  void operator=(const SealHandleScope&);
+  void* operator new(size_t size);
+  void operator delete(void*, size_t);
+
+  internal::Isolate* isolate_;
+  int prev_level_;
+  internal::Object** prev_limit_;
+};
+
+
+
+
 /**
  * A compiled JavaScript script, not yet tied to a Context.
  */

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -637,6 +637,27 @@ i::Object** EscapableHandleScope::Escape(i::Object** escape_value) {
 }
 
 
+SealHandleScope::SealHandleScope(Isolate* isolate) {
+  i::Isolate* internal_isolate = reinterpret_cast<i::Isolate*>(isolate);
+
+  isolate_ = internal_isolate;
+  i::HandleScopeData* current = internal_isolate->handle_scope_data();
+  prev_limit_ = current->limit;
+  current->limit = current->next;
+  prev_level_ = current->level;
+  current->level = 0;
+}
+
+
+SealHandleScope::~SealHandleScope() {
+  i::HandleScopeData* current = isolate_->handle_scope_data();
+  DCHECK_EQ(0, current->level);
+  current->level = prev_level_;
+  DCHECK_EQ(current->next, current->limit);
+  current->limit = prev_limit_;
+}
+
+
 void Context::Enter() {
   i::Handle<i::Context> env = Utils::OpenHandle(this);
   i::Isolate* isolate = env->GetIsolate();

--- a/deps/v8/src/api.h
+++ b/deps/v8/src/api.h
@@ -642,7 +642,7 @@ void HandleScopeImplementer::DeleteExtensions(internal::Object** prev_limit) {
   while (!blocks_.is_empty()) {
     internal::Object** block_start = blocks_.last();
     internal::Object** block_limit = block_start + kHandleBlockSize;
-#ifdef DEBUG
+
     // SealHandleScope may make the prev_limit to point inside the block.
     if (block_start <= prev_limit && prev_limit <= block_limit) {
 #ifdef ENABLE_HANDLE_ZAPPING
@@ -650,9 +650,6 @@ void HandleScopeImplementer::DeleteExtensions(internal::Object** prev_limit) {
 #endif
       break;
     }
-#else
-    if (prev_limit == block_limit) break;
-#endif
 
     blocks_.RemoveLast();
 #ifdef ENABLE_HANDLE_ZAPPING

--- a/deps/v8/test/cctest/cctest.status
+++ b/deps/v8/test/cctest/cctest.status
@@ -43,6 +43,7 @@
   # they don't fail then test.py has failed.
   'test-serialize/TestThatAlwaysFails': [FAIL],
   'test-serialize/DependentTestThatAlwaysFails': [FAIL],
+  'test-api/SealHandleScope': [FAIL],
 
   # This test always fails.  It tests that LiveEdit causes abort when turned off.
   'test-debug/LiveEditDisabled': [FAIL],

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -20625,6 +20625,38 @@ void CallCompletedCallbackException() {
 }
 
 
+TEST(SealHandleScope) {
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope handle_scope(isolate);
+  LocalContext env;
+
+  v8::SealHandleScope seal(isolate);
+
+  // Should fail
+  v8::Local<v8::Object> obj = v8::Object::New(isolate);
+
+  USE(obj);
+}
+
+
+TEST(SealHandleScopeNested) {
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope handle_scope(isolate);
+  LocalContext env;
+
+  v8::SealHandleScope seal(isolate);
+
+  {
+    v8::HandleScope handle_scope(isolate);
+
+    // Should work
+    v8::Local<v8::Object> obj = v8::Object::New(isolate);
+
+    USE(obj);
+  }
+}
+
+
 TEST(CallCompletedCallbackOneException) {
   LocalContext env;
   v8::HandleScope scope(env->GetIsolate());

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -45,8 +45,13 @@ Object.defineProperty(process, 'domain', {
 // between js and c++ w/o much overhead
 var _domain_flag = {};
 
+// it's possible to enter one domain while already inside
+// another one.  the stack is each entered domain.
+var stack = [];
+exports._stack = stack;
+
 // let the process know we're using domains
-process._setupDomainUse(_domain, _domain_flag);
+process._setupDomainUse(_domain, _domain_flag, stack);
 
 exports.Domain = Domain;
 
@@ -54,10 +59,6 @@ exports.create = exports.createDomain = function() {
   return new Domain();
 };
 
-// it's possible to enter one domain while already inside
-// another one.  the stack is each entered domain.
-var stack = [];
-exports._stack = stack;
 // the active domain is always the one that we're currently in.
 exports.active = null;
 
@@ -114,14 +115,20 @@ Domain.prototype._errorHandler = function errorHandler(er) {
   // that these exceptions are caught, and thus would prevent it from
   // aborting in these cases.
   if (stack.length === 1) {
-    try {
-      // Set the _emittingTopLevelDomainError so that we know that, even
-      // if technically the top-level domain is still active, it would
-      // be ok to abort on an uncaught exception at this point
-      process._emittingTopLevelDomainError = true;
-      caught = emitError();
-    } finally {
-      process._emittingTopLevelDomainError = false;
+    // If there's no error handler, do not emit an 'error' event
+    // as this would throw an error, make the process exit, and thus
+    // prevent the process 'uncaughtException' event from being emitted
+    // if a listener is set.
+    if (EventEmitter.listenerCount(self, 'error') > 0) {
+      try {
+        // Set the _emittingTopLevelDomainError so that we know that, even
+        // if technically the top-level domain is still active, it would
+        // be ok to abort on an uncaught exception at this point
+        process._emittingTopLevelDomainError = true;
+        caught = emitError();
+      } finally {
+        process._emittingTopLevelDomainError = false;
+      }
     }
   } else {
     // wrap this in a try/catch so we don't get infinite throwing

--- a/src/env.h
+++ b/src/env.h
@@ -258,6 +258,7 @@ namespace node {
   V(buffer_constructor_function, v8::Function)                                \
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
+  V(domains_stack_array, v8::Array)                                           \
   V(fs_stats_constructor_function, v8::Function)                              \
   V(gc_info_callback_function, v8::Function)                                  \
   V(module_load_list_array, v8::Array)                                        \

--- a/src/node.cc
+++ b/src/node.cc
@@ -115,6 +115,7 @@ using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::PropertyCallbackInfo;
+using v8::SealHandleScope;
 using v8::String;
 using v8::TryCatch;
 using v8::Uint32;
@@ -3755,19 +3756,23 @@ int Start(int argc, char** argv) {
     if (use_debug_agent)
       EnableDebug(env);
 
-    bool more;
-    do {
-      more = uv_run(env->event_loop(), UV_RUN_ONCE);
-      if (more == false) {
-        EmitBeforeExit(env);
+    {
+      SealHandleScope seal(node_isolate);
+      bool more;
+      do {
+        more = uv_run(env->event_loop(), UV_RUN_ONCE);
+        if (more == false) {
+          EmitBeforeExit(env);
 
-        // Emit `beforeExit` if the loop became alive either after emitting
-        // event, or after running some callbacks.
-        more = uv_loop_alive(env->event_loop());
-        if (uv_run(env->event_loop(), UV_RUN_NOWAIT) != 0)
-          more = true;
-      }
-    } while (more == true);
+          // Emit `beforeExit` if the loop became alive either after emitting
+          // event, or after running some callbacks.
+          more = uv_loop_alive(env->event_loop());
+          if (uv_run(env->event_loop(), UV_RUN_NOWAIT) != 0)
+            more = true;
+        }
+      } while (more == true);
+    }
+
     code = EmitExit(env);
     RunAtExit(env);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3163,6 +3163,7 @@ static void EnableDebug(Environment* env) {
 
 // Called from the main thread.
 static void DispatchDebugMessagesAsyncCallback(uv_async_t* handle) {
+  HandleScope scope(node_isolate);
   if (debugger_running == false) {
     fprintf(stderr, "Starting debugger agent.\n");
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3043,7 +3043,9 @@ static void ParseArgs(int* argc,
       SSL3_ENABLE = true;
 #endif
     } else if (strcmp(arg, "--allow-insecure-server-dhparam") == 0) {
+#if HAVE_OPENSSL
       ALLOW_INSECURE_SERVER_DHPARAM = true;
+#endif
     } else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
       PrintHelp();
       exit(0);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -62,6 +62,10 @@ class ExternString: public ResourceType {
       return length_;
     }
 
+    // Maximum length in bytes that V8 can handle. 
+    // This equals to 268435440 bytes = (256 * 1024 * 1024) - 16
+    static const size_t kMaxLength = (1 << 28) - 16;
+    
     static Local<String> NewFromCopy(Isolate* isolate,
                                      const TypeName* data,
                                      size_t length) {
@@ -69,6 +73,10 @@ class ExternString: public ResourceType {
 
       if (length == 0)
         return scope.Escape(String::Empty(isolate));
+
+      // V8 aborts if we try to allocate a string that is too large.
+      if (length > kMaxLength)
+        return Local<String>();
 
       TypeName* new_data = new TypeName[length];
       memcpy(new_data, data, length * sizeof(*new_data));
@@ -87,6 +95,10 @@ class ExternString: public ResourceType {
       if (length == 0)
         return scope.Escape(String::Empty(isolate));
 
+      // V8 aborts if we try to allocate a string that is too large.
+      if (length > kMaxLength)
+        return Local<String>();
+        
       ExternString* h_str = new ExternString<ResourceType, TypeName>(isolate,
                                                                      data,
                                                                      length);

--- a/test/common.js
+++ b/test/common.js
@@ -347,3 +347,37 @@ exports.busyLoop = function busyLoop(time) {
     ;
   }
 };
+
+// Returns true if the exit code "exitCode" and/or signal name "signal"
+// represent the exit code and/or signal name of a node process that aborted,
+// false otherwise.
+exports.nodeProcessAborted = function nodeProcessAborted(exitCode, signal) {
+  // Depending on the compiler used, node will exit with either
+  // exit code 132 (SIGILL), 133 (SIGTRAP) or 134 (SIGABRT).
+  var expectedExitCodes = [132, 133, 134];
+
+  // On platforms using KSH as the default shell (like SmartOS),
+  // when a process aborts, KSH exits with an exit code that is
+  // greater than 256, and thus the exit code emitted with the 'exit'
+  // event is null and the signal is set to either SIGILL, SIGTRAP,
+  // or SIGABRT (depending on the compiler).
+  var expectedSignals = ['SIGILL', 'SIGTRAP', 'SIGABRT'];
+
+  // On Windows, v8's base::OS::Abort triggers an access violation,
+  // which corresponds to exit code 3221225477 (0xC0000005)
+  if (process.platform === 'win32')
+    expectedExitCodes = [3221225477];
+
+  // When using --abort-on-uncaught-exception, V8 will use
+  // base::OS::Abort to terminate the process.
+  // Depending on the compiler used, the shell or other aspects of
+  // the platform used to build the node binary, this will actually
+  // make V8 exit by aborting or by raising a signal. In any case,
+  // one of them (exit code or signal) needs to be set to one of
+  // the expected exit codes or signals.
+  if (signal !== null) {
+    return expectedSignals.indexOf(signal) > -1;
+  } else {
+    return expectedExitCodes.indexOf(exitCode) > -1;
+  }
+};

--- a/test/common.js
+++ b/test/common.js
@@ -381,3 +381,7 @@ exports.nodeProcessAborted = function nodeProcessAborted(exitCode, signal) {
     return expectedExitCodes.indexOf(exitCode) > -1;
   }
 };
+
+// Skip test instead of fail when memory constrained
+exports.enoughTestMem = os.totalmem() > 0x20000000; /* 512MB */
+

--- a/test/parallel/test-buffer-tostring-ascii.js
+++ b/test/parallel/test-buffer-tostring-ascii.js
@@ -1,0 +1,37 @@
+'use strict';
+// Flags: --expose-gc
+
+const common = require('../common');
+const assert = require('assert');
+
+// Maximum length in bytes that V8 can handle.
+// This equals to 268435440 bytes = (256 * 1024 * 1024) - 16
+const kMaxLength = (1 << 28) - 16;
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
+
+try {
+  var buf = new Buffer(kMaxLength + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kMaxLength);
+  gc();
+} catch(e) {
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ignore first byte. This should be successful.
+var maxString = buf.toString('ascii', 1);
+assert.equal(maxString.length, kMaxLength);
+
+// This should fail and return undefined.
+maxString = buf.toString('ascii');
+assert.equal(maxString, undefined);

--- a/test/parallel/test-buffer-tostring-base64.js
+++ b/test/parallel/test-buffer-tostring-base64.js
@@ -1,0 +1,37 @@
+'use strict';
+// Flags: --expose-gc
+
+const common = require('../common');
+const assert = require('assert');
+
+// Maximum length in bytes that V8 can handle.
+// This equals to 268435440 bytes = (256 * 1024 * 1024) - 16
+const kMaxLength = (1 << 28) - 16;
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
+
+try {
+  var buf = new Buffer(kMaxLength * 0.75 + 1); /* Max length for base64 */
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kMaxLength);
+  gc();
+} catch(e) {
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ignore first byte. This should be successful.
+var maxString = buf.toString('base64', 1);
+assert.equal(maxString.length, kMaxLength);
+
+// This should fail and return undefined.
+maxString = buf.toString('base64');
+assert.equal(maxString, undefined);

--- a/test/parallel/test-buffer-tostring-binary.js
+++ b/test/parallel/test-buffer-tostring-binary.js
@@ -1,0 +1,37 @@
+'use strict';
+// Flags: --expose-gc
+
+const common = require('../common');
+const assert = require('assert');
+
+// Maximum length in bytes that V8 can handle.
+// This equals to 268435440 bytes = (256 * 1024 * 1024) - 16
+const kMaxLength = (1 << 28) - 16;
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
+
+try {
+  var buf = new Buffer(kMaxLength + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kMaxLength);
+  gc();
+} catch(e) {
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ignore first byte. This should be successful.
+var maxString = buf.toString('binary', 1);
+assert.equal(maxString.length, kMaxLength);
+
+// This should fail and return undefined.
+maxString = buf.toString('binary');
+assert.equal(maxString, undefined);

--- a/test/parallel/test-buffer-tostring-hex.js
+++ b/test/parallel/test-buffer-tostring-hex.js
@@ -1,0 +1,37 @@
+'use strict';
+// Flags: --expose-gc
+
+const common = require('../common');
+const assert = require('assert');
+
+// Maximum length in bytes that V8 can handle.
+// This equals to 268435440 bytes = (256 * 1024 * 1024) - 16
+const kMaxLength = (1 << 28) - 16;
+
+const skipMessage =
+  '1..0 # Skipped: intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  console.log(skipMessage);
+  return;
+}
+assert(typeof gc === 'function', 'Run this test with --expose-gc');
+
+try {
+  var buf = new Buffer(kMaxLength / 2 + 1);
+  // Try to allocate memory first then force gc so future allocations succeed.
+  new Buffer(2 * kMaxLength);
+  gc();
+} catch(e) {
+  // If the exception is not due to memory confinement then rethrow it.
+  if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ignore first byte. This should be successful.
+var maxString = buf.toString('hex', 1);
+assert.equal(maxString.length, kMaxLength);
+
+// This should fail and return undefined.
+maxString = buf.toString('hex');
+assert.equal(maxString, undefined);

--- a/test/simple/test-domain-abort-on-uncaught.js
+++ b/test/simple/test-domain-abort-on-uncaught.js
@@ -1,0 +1,243 @@
+'use strict';
+
+// This test makes sure that when using --abort-on-uncaught-exception and
+// when throwing an error from within a domain that has an error handler
+// setup, the process _does not_ abort.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var child_process = require('child_process');
+
+var errorHandlerCalled = false;
+
+var tests = [
+  function nextTick() {
+    var d = domain.create();
+
+    d.once('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      process.nextTick(function() {
+        throw new Error('exceptional!');
+      });
+    });
+  },
+
+  function timer() {
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      setTimeout(function() {
+        throw new Error('exceptional!');
+      }, 33);
+    });
+  },
+
+  function immediate() {
+    console.log('starting test');
+    var d = domain.create();
+
+    d.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      setImmediate(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function timerPlusNextTick() {
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      setTimeout(function() {
+        process.nextTick(function() {
+          throw new Error('exceptional!');
+        });
+      }, 33);
+    });
+  },
+
+  function firstRun() {
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      throw new Error('exceptional!');
+    });
+  },
+
+  function fsAsync() {
+    var d = domain.create();
+
+    d.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      var fs = require('fs');
+      fs.exists('/non/existing/file', function onExists(exists) {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function netServer() {
+    var net = require('net');
+    var d = domain.create();
+
+    d.on('error', function(err) {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      var server = net.createServer(function(conn) {
+        conn.pipe(conn);
+      });
+      server.listen(common.PORT, '0.0.0.0', function() {
+        var conn = net.connect(common.PORT, '0.0.0.0');
+        conn.once('data', function() {
+          throw new Error('ok');
+        });
+        conn.end('ok');
+        server.close();
+      });
+    });
+  },
+
+  function firstRunNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function timeoutNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setTimeout(function() {
+          console.log('foo');
+          throw new Error('boom!');
+        }, 33);
+      });
+    });
+  },
+
+  function setImmediateNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setImmediate(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function nextTickNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        process.nextTick(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function fsAsyncNestedWithErrorHandler() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d2.on('error', function errorHandler() {
+      errorHandlerCalled = true;
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        var fs = require('fs');
+        fs.exists('/non/existing/file', function onExists(exists) {
+          throw new Error('boom!');
+        });
+      });
+    });
+  }
+];
+
+if (process.argv[2] === 'child') {
+  var testIndex = +process.argv[3];
+
+  tests[testIndex]();
+
+  process.on('exit', function onExit() {
+    assert.equal(errorHandlerCalled, true);
+  });
+} else {
+
+  tests.forEach(function(test, testIndex) {
+    var testCmd = '';
+    if (process.platform !== 'win32') {
+      // Do not create core files, as it can take a lot of disk space on
+      // continuous testing and developers' machines
+      testCmd += 'ulimit -c 0 && ';
+    }
+
+    testCmd +=  process.argv[0];
+    testCmd += ' ' + '--abort-on-uncaught-exception';
+    testCmd += ' ' + process.argv[1];
+    testCmd += ' ' + 'child';
+    testCmd += ' ' + testIndex;
+
+    var child = child_process.exec(testCmd);
+
+    child.on('exit', function onExit(code, signal) {
+      assert.equal(code, 0, 'Test at index ' + testIndex +
+        ' should have exited with exit code 0 but instead exited with code ' +
+        code + ' and signal ' + signal);
+    });
+
+  });
+}

--- a/test/simple/test-domain-exit-dispose-again.js
+++ b/test/simple/test-domain-exit-dispose-again.js
@@ -19,58 +19,41 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var disposalFailed = false;
 
-// no matter what happens, we should increment a 10 times.
-var a = 0;
-log();
-function log(){
-  console.log(a++, process.domain);
-  if (a < 10) setTimeout(log, 20);
-}
-
-var secondTimerRan = false;
-
-// in 50ms we'll throw an error.
+// Use the same timeout value so that both timers' callbacks are called during
+// the same invocation of the underlying native timer's callback (listOnTimeout
+// in lib/timers.js).
 setTimeout(err, 50);
-setTimeout(secondTimer, 50);
-function err(){
+setTimeout(common.mustCall(secondTimer), 50);
+
+function err() {
   var d = domain.create();
-  d.on('error', handle);
+  d.on('error', handleDomainError);
   d.run(err2);
 
   function err2() {
-    // this timeout should never be called, since the domain gets
-    // disposed when the error happens.
-    setTimeout(function() {
-      console.error('This should not happen.');
-      disposalFailed = true;
-      process.exit(1);
-    });
-
     // this function doesn't exist, and throws an error as a result.
     err3();
   }
 
-  function handle(e) {
-    // this should clean up everything properly.
-    d.dispose();
-    console.error(e);
-    console.error('in handler', process.domain, process.domain === d);
+  function handleDomainError(e) {
+    // In the domain's error handler, the current active domain should be the
+    // domain within which the error was thrown.
+    assert.equal(process.domain, d);
   }
 }
 
 function secondTimer() {
-  console.log('In second timer');
-  secondTimerRan = true;
+  // secondTimer was scheduled before any domain had been created, so its
+  // callback should not have any active domain set when it runs.
+  // Do not use assert here, as it throws errors and if a domain with an error
+  // handler is active, then asserting wouldn't make the test fail.
+  if (process.domain !== null) {
+    console.log('process.domain should be null, but instead is:',
+      process.domain);
+    process.exit(1);
+  }
 }
-
-process.on('exit', function() {
-  assert.equal(a, 10);
-  assert.equal(disposalFailed, false);
-  assert(secondTimerRan);
-  console.log('ok');
-});

--- a/test/simple/test-domain-exit-dispose-again.js
+++ b/test/simple/test-domain-exit-dispose-again.js
@@ -19,41 +19,74 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var common = require('../common');
+// This test makes sure that when a domain is disposed, timers that are
+// attached to that domain are not fired, but timers that are _not_ attached
+// to that domain, including those whose callbacks are called from within
+// the same invocation of listOnTimeout, _are_ called.
+
+var common = require('../common.js');
 var assert = require('assert');
 var domain = require('domain');
+var disposalFailed = false;
 
-// Use the same timeout value so that both timers' callbacks are called during
-// the same invocation of the underlying native timer's callback (listOnTimeout
-// in lib/timers.js).
-setTimeout(err, 50);
-setTimeout(common.mustCall(secondTimer), 50);
+// Repeatedly schedule a timer with a delay different than the timers attached
+// to a domain that will eventually be disposed to make sure that they are
+// called, regardless of what happens with those timers attached to domains
+// that will eventually be disposed.
+var a = 0;
+log();
+function log(){
+  console.log(a++, process.domain);
+  if (a < 10) setTimeout(log, 20);
+}
 
-function err() {
+var secondTimerRan = false;
+
+// Use the same timeout duration for both "firstTimer" and "secondTimer"
+// callbacks so that they are called during the same invocation of the
+// underlying native timer's callback (listOnTimeout in lib/timers.js).
+var TIMEOUT_DURATION = 50;
+
+setTimeout(function firstTimer() {
   var d = domain.create();
-  d.on('error', handleDomainError);
-  d.run(err2);
+  d.on('error', function handleError(err) {
+    // Dispose the domain on purpose, so that we can test that nestedTimer
+    // is not called since it's associated to this domain and a timer whose
+    // domain is diposed should not run.
+    d.dispose();
+    console.error(err);
+    console.error('in handler', process.domain, process.domain === d);
+  });
+  d.run(function() {
+    // Create another nested timer that is by definition associated to the
+    // domain "d". Because an error is thrown before the timer's callback
+    // is called, and because the domain's error handler disposes the domain,
+    // this timer's callback should never run.
+    setTimeout(function nestedTimer() {
+      console.error('Nested timer should not run, because it is attached to ' +
+          'a domain that should be disposed.');
+      disposalFailed = true;
+      process.exit(1);
+    });
 
-  function err2() {
-    // this function doesn't exist, and throws an error as a result.
+    // Make V8 throw an unreferenced error. As a result, the domain's error
+    // handler is called, which disposes the domain "d" and should prevent the
+    // nested timer that is attached to it from running.
     err3();
-  }
+  });
+}, TIMEOUT_DURATION);
 
-  function handleDomainError(e) {
-    // In the domain's error handler, the current active domain should be the
-    // domain within which the error was thrown.
-    assert.equal(process.domain, d);
-  }
-}
+// This timer expires in the same invocation of listOnTimeout than firstTimer,
+// but because it's not attached to any domain, it must run regardless of
+// domain "d" being disposed.
+setTimeout(function secondTimer() {
+  console.log('In second timer');
+  secondTimerRan = true;
+}, TIMEOUT_DURATION);
 
-function secondTimer() {
-  // secondTimer was scheduled before any domain had been created, so its
-  // callback should not have any active domain set when it runs.
-  // Do not use assert here, as it throws errors and if a domain with an error
-  // handler is active, then asserting wouldn't make the test fail.
-  if (process.domain !== null) {
-    console.log('process.domain should be null, but instead is:',
-      process.domain);
-    process.exit(1);
-  }
-}
+process.on('exit', function() {
+  assert.equal(a, 10);
+  assert.equal(disposalFailed, false);
+  assert(secondTimerRan);
+  console.log('ok');
+});

--- a/test/simple/test-domain-no-error-handler-abort-on-uncaught.js
+++ b/test/simple/test-domain-no-error-handler-abort-on-uncaught.js
@@ -1,0 +1,190 @@
+'use strict';
+
+/*
+ * This test makes sure that when using --abort-on-uncaught-exception and
+ * when throwing an error from within a domain that does not have an error
+ * handler setup, the process aborts.
+ */
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var child_process = require('child_process');
+
+var tests = [
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      throw new Error('boom!');
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.run(function() {
+      d2.run(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  /*
+   * In this case, only the domain at the top of the stack "d" has an error
+   * handler, but the domain from which the error is thrown doesn't have an
+   * error handler. To be consistent with the way domains bubble up errors,
+   * this test case _should not_ make the process abort. However it was
+   * determined that making such a change in v0.12.x might be a breaking
+   * change, so instead this test case makes sure the process aborts.
+   */
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      setTimeout(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      setImmediate(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      process.nextTick(function() {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+
+    d.run(function() {
+      var fs = require('fs');
+      fs.exists('/non/existing/file', function onExists(exists) {
+        throw new Error('boom!');
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setTimeout(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        setImmediate(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        process.nextTick(function() {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+
+  function() {
+    var d = domain.create();
+    var d2 = domain.create();
+
+    d.on('error', function errorHandler() {
+    });
+
+    d.run(function() {
+      d2.run(function() {
+        var fs = require('fs');
+        fs.exists('/non/existing/file', function onExists(exists) {
+          throw new Error('boom!');
+        });
+      });
+    });
+  },
+];
+
+if (process.argv[2] === 'child') {
+  var testIndex = +process.argv[3];
+  tests[testIndex]();
+} else {
+
+  tests.forEach(function(test, testIndex) {
+    var testCmd = '';
+    if (process.platform !== 'win32') {
+      // Do not create core files, as it can take a lot of disk space on
+      // continuous testing and developers' machines
+      testCmd += 'ulimit -c 0 && ';
+    }
+
+    testCmd +=  process.argv[0];
+    testCmd += ' ' + '--abort-on-uncaught-exception';
+    testCmd += ' ' + process.argv[1];
+    testCmd += ' ' + 'child';
+    testCmd += ' ' + testIndex;
+
+    var child = child_process.exec(testCmd);
+
+    child.on('exit', function onExit(exitCode, signal) {
+      var errMsg = 'Test at index ' + testIndex + ' should have aborted ' +
+          'but instead exited with exit code ' + exitCode + ' and signal ' +
+          signal;
+      assert(common.nodeProcessAborted(exitCode, signal), errMsg);
+    });
+  });
+}

--- a/test/simple/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/simple/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// This test makes sure that when throwing an error from a domain, and then
+// handling that error in an uncaughtException handler by throwing an error
+// again, the exit code, signal and error messages are the ones we expect with
+// and without using --abort-on-uncaught-exception.
+
+var common = require('../common');
+var assert = require('assert');
+var child_process = require('child_process');
+var domain = require('domain');
+
+var uncaughtExceptionHandlerErrMsg = 'boom from uncaughtException handler';
+var domainErrMsg = 'boom from domain';
+
+var RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE = 42;
+var d;
+
+if (process.argv[2] === 'child') {
+  process.on('uncaughtException', common.mustCall(function onUncaught() {
+    if (process.execArgv.indexOf('--abort-on-uncaught-exception') !== -1) {
+      // When passing --abort-on-uncaught-exception to the child process,
+      // we want to make sure that this handler (the process' uncaughtException
+      // event handler) wasn't called. Unfortunately we can't parse the child
+      // process' output to do that, since on Windows the standard error output
+      // is not properly flushed in V8's Isolate::Throw right before the
+      // process aborts due to an uncaught exception, and thus the error
+      // message representing the error that was thrown cannot be read by the
+      // parent process. So instead of parsing the child process' stdandard
+      // error, the parent process will check that in the case
+      // --abort-on-uncaught-exception was passed, the process did not exit
+      // with exit code RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE.
+      process.exit(RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE);
+    } else {
+      // On the other hand, when not passing --abort-on-uncaught-exception to
+      // the node process, we want to throw in this event handler to make sure
+      // that the proper error message, exit code and signal are the ones we
+      // expect.
+      throw new Error(uncaughtExceptionHandlerErrMsg);
+    }
+  }));
+
+  d = domain.create();
+  d.run(common.mustCall(function() {
+    throw new Error(domainErrMsg);
+  }));
+} else {
+  runTestWithoutAbortOnUncaughtException();
+  runTestWithAbortOnUncaughtException();
+}
+
+function runTestWithoutAbortOnUncaughtException() {
+  child_process.exec(createTestCmdLine(),
+      function onTestDone(err, stdout, stderr) {
+        // When _not_ passing --abort-on-uncaught-exception, the process'
+        // uncaughtException handler _must_ be called, and thus the error
+        // message must include only the message of the error thrown from the
+        // process' uncaughtException handler.
+        assert(stderr.indexOf(uncaughtExceptionHandlerErrMsg) !== -1,
+            'stderr output must include proper uncaughtException handler\'s ' +
+            'error\'s message');
+        assert(stderr.indexOf(domainErrMsg) === -1, 'stderr output must not ' +
+          'include domain\'s error\'s message');
+
+        assert.notEqual(err.code, 0,
+            'child process should have exited with a non-zero exit code, ' +
+            'but did not');
+      });
+}
+
+function runTestWithAbortOnUncaughtException() {
+  child_process.exec(createTestCmdLine({
+    withAbortOnUncaughtException: true
+  }), function onTestDone(err, stdout, stderr) {
+    assert.notEqual(err.code, RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE,
+        'child process should not have run its uncaughtException event ' +
+        'handler');
+    assert(common.nodeProcessAborted(err.code, err.signal),
+        'process should have aborted, but did not');
+  });
+}
+
+function createTestCmdLine(options) {
+  var testCmd = '';
+
+  if (process.platform !== 'win32') {
+    // Do not create core files, as it can take a lot of disk space on
+    // continuous testing and developers' machines
+    testCmd += 'ulimit -c 0 && ';
+  }
+
+  testCmd += process.argv[0];
+
+  if (options && options.withAbortOnUncaughtException) {
+    testCmd += ' ' + '--abort-on-uncaught-exception';
+  }
+
+  testCmd += ' ' + process.argv[1];
+  testCmd += ' ' + 'child';
+
+  return testCmd;
+}

--- a/test/simple/test-domain-uncaught-exception.js
+++ b/test/simple/test-domain-uncaught-exception.js
@@ -1,0 +1,205 @@
+'use strict';
+
+/*
+ * The goal of this test is to make sure that errors thrown within domains
+ * are handled correctly. It checks that the process' 'uncaughtException' event
+ * is emitted when appropriate, and not emitted when it shouldn't. It also
+ * checks that the proper domain error handlers are called when they should
+ * be called, and not called when they shouldn't.
+ */
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+var child_process = require('child_process');
+
+var uncaughtExceptions = {};
+
+var tests = [];
+
+function test1() {
+  /*
+   * Throwing from an async callback from within a domain that doesn't have
+   * an error handler must result in emitting the process' uncaughtException
+   * event.
+   */
+  var d = domain.create();
+  d.run(function() {
+    setTimeout(function onTimeout() {
+      throw new Error('boom!');
+   });
+  });
+}
+
+tests.push({
+  fn: test1,
+  expectedMessages: ['uncaughtException']
+});
+
+function test2() {
+  /*
+   * Throwing from from within a domain that doesn't have an error handler must
+   * result in emitting the process' uncaughtException event.
+   */
+  var d2 = domain.create();
+  d2.run(function() {
+    throw new Error('boom!');
+  });
+}
+
+tests.push({
+  fn: test2,
+  expectedMessages: ['uncaughtException']
+});
+
+function test3() {
+  /*
+   * This test creates two nested domains: d3 and d4. d4 doesn't register an
+   * error handler, but d3 does. The error is handled by the d3 domain and thus
+   * an 'uncaughtException' event should _not_ be emitted.
+   */
+  var d3 = domain.create();
+  var d4 = domain.create();
+
+  d3.on('error', function onErrorInD3Domain(err) {
+    process.send('errorHandledByDomain');
+  });
+
+  d3.run(function() {
+    d4.run(function() {
+      throw new Error('boom!');
+    });
+  });
+}
+
+tests.push({
+  fn: test3,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+function test4() {
+  /*
+   * This test creates two nested domains: d5 and d6. d6 doesn't register an
+   * error handler. When the timer's callback is called, because async
+   * operations like timer callbacks are bound to the domain that was active
+   * at the time of their creation, and because both d5 and d6 domains have
+   * exited by the time the timer's callback is called, its callback runs with
+   * only d6 on the domains stack. Since d6 doesn't register an error handler,
+   * the process' uncaughtException event should be emitted.
+   */
+  var d5 = domain.create();
+  var d6 = domain.create();
+
+  d5.on('error', function onErrorInD2Domain(err) {
+    process.send('errorHandledByDomain');
+  });
+
+  d5.run(function () {
+    d6.run(function() {
+      setTimeout(function onTimeout() {
+        throw new Error('boom!');
+      });
+    });
+  });
+}
+
+tests.push({
+  fn: test4,
+  expectedMessages: ['uncaughtException']
+});
+
+function test5() {
+  /*
+   * This test creates two nested domains: d7 and d8. d8 _does_ register an
+   * error handler, so throwing within that domain should not emit an uncaught
+   * exception.
+   */
+  var d7 = domain.create();
+  var d8 = domain.create();
+
+  d8.on('error', function onErrorInD3Domain(err) {
+    process.send('errorHandledByDomain')
+  });
+
+  d7.run(function() {
+    d8.run(function() {
+      throw new Error('boom!');
+    });
+  });
+}
+tests.push({
+  fn: test5,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+function test6() {
+  /*
+   * This test creates two nested domains: d9 and d10. d10 _does_ register an
+   * error handler, so throwing within that domain in an async callback should
+   * _not_ emit an uncaught exception.
+   */
+  var d9 = domain.create();
+  var d10 = domain.create();
+
+  d10.on('error', function onErrorInD2Domain(err) {
+    process.send('errorHandledByDomain');
+  });
+
+  d9.run(function () {
+    d10.run(function() {
+      setTimeout(function onTimeout() {
+        throw new Error('boom!');
+      });
+    });
+  });
+}
+
+tests.push({
+  fn: test6,
+  expectedMessages: ['errorHandledByDomain']
+});
+
+if (process.argv[2] === 'child') {
+  var testIndex = process.argv[3];
+  process.on('uncaughtException', function onUncaughtException() {
+    process.send('uncaughtException');
+  });
+
+  tests[testIndex].fn();
+} else {
+  // Run each test's function in a child process. Listen on
+  // messages sent by each child process and compare expected
+  // messages defined for each test with the actual received messages.
+  tests.forEach(function doTest(test, testIndex) {
+    var testProcess = child_process.fork(__filename, ['child', testIndex]);
+
+    testProcess.on('message', function onMsg(msg) {
+      if (test.messagesReceived === undefined)
+        test.messagesReceived = [];
+
+      test.messagesReceived.push(msg);
+    });
+
+    testProcess.on('disconnect', common.mustCall(function onExit() {
+      // Make sure that all expected messages were sent from the
+      // child process
+      test.expectedMessages.forEach(function(expectedMessage) {
+        if (test.messagesReceived === undefined ||
+          test.messagesReceived.indexOf(expectedMessage) === -1)
+          assert(false, 'test ' + test.fn.name +
+              ' should have sent message: ' + expectedMessage +
+              ' but didn\'t');
+      });
+
+      if (test.messagesReceived) {
+        test.messagesReceived.forEach(function(receivedMessage) {
+          if (test.expectedMessages.indexOf(receivedMessage) === -1) {
+            assert(false, 'test ' + test.fn.name +
+              ' should not have sent message: ' + receivedMessage +
+              ' but did');
+          }
+        });
+      }
+    }));
+  });
+}

--- a/test/simple/test-timers-reset-process-domain-on-throw.js
+++ b/test/simple/test-timers-reset-process-domain-on-throw.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var domain = require('domain');
+
+// Use the same timeout value so that both timers' callbacks are called during
+// the same invocation of the underlying native timer's callback (listOnTimeout
+// in lib/timers.js).
+setTimeout(err, 50);
+setTimeout(common.mustCall(secondTimer), 50);
+
+function err() {
+  var d = domain.create();
+  d.on('error', handleDomainError);
+  d.run(err2);
+
+  function err2() {
+    // this function doesn't exist, and throws an error as a result.
+    err3();
+  }
+
+  function handleDomainError(e) {
+    // In the domain's error handler, the current active domain should be the
+    // domain within which the error was thrown.
+    assert.equal(process.domain, d);
+  }
+}
+
+function secondTimer() {
+  // secondTimer was scheduled before any domain had been created, so its
+  // callback should not have any active domain set when it runs.
+  // Do not use assert here, as it throws errors and if a domain with an error
+  // handler is active, then asserting wouldn't make the test fail.
+  if (process.domain !== null) {
+    console.log('process.domain should be null, but instead is:',
+      process.domain);
+    process.exit(1);
+  }
+}

--- a/tools/install.py
+++ b/tools/install.py
@@ -142,6 +142,9 @@ def files(action):
 
   if 'true' == variables.get('node_install_npm'): npm_files(action)
 
+  headers(action)
+
+def headers(action):
   action([
     'common.gypi',
     'config.gypi',
@@ -194,8 +197,13 @@ def run(args):
   install_path = dst_dir + node_prefix + '/'
 
   cmd = args[1] if len(args) > 1 else 'install'
-  if cmd == 'install': return files(install)
-  if cmd == 'uninstall': return files(uninstall)
+  if os.environ.get('HEADERS_ONLY'):
+    if cmd == 'install': return headers(install)
+    if cmd == 'uninstall': return headers(uninstall)
+  else:
+    if cmd == 'install': return files(install)
+    if cmd == 'uninstall': return files(uninstall)
+
   raise RuntimeError('Bad command: %s\n' % cmd)
 
 if __name__ == '__main__':


### PR DESCRIPTION
A workaround to return `undefined` when `Buffer.toString` fails because of exceeding the maximum supported length in V8.
@bnoordhuis Please review.
