### PR TITLE
lib: remove unused modules

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -3,7 +3,6 @@
 const util = require('util');
 const net = require('net');
 const url = require('url');
-const EventEmitter = require('events');
 const HTTPParser = process.binding('http_parser').HTTPParser;
 const assert = require('assert').ok;
 const common = require('_http_common');

--- a/lib/os.js
+++ b/lib/os.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const binding = process.binding('os');
-const util = require('util');
 const internalUtil = require('internal/util');
 const isWindows = process.platform === 'win32';
 

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const util = require('util');
-const internalUtil = require('internal/util');
 const net = require('net');
 const TTY = process.binding('tty_wrap').TTY;
 const isTTY = process.binding('tty_wrap').isTTY;


### PR DESCRIPTION
Some files in `lib` were using `require` to load modules that were
subsequently not used in the file. This removes those `require`
statements.