### PR TITLE
test: remove unused `util` imports

### DIFF
--- a/test/parallel/test-beforeexit-event.js
+++ b/test/parallel/test-beforeexit-event.js
@@ -1,7 +1,6 @@
 'use strict';
 var assert = require('assert');
 var net = require('net');
-var util = require('util');
 var common = require('../common');
 var revivals = 0;
 var deaths = 0;

--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -5,7 +5,6 @@ const assert = require('assert');
 
 const cluster = require('cluster');
 const net = require('net');
-const util = require('util');
 
 var connectcount = 0;
 var sendcount = 0;

--- a/test/parallel/test-cluster-worker-isconnected.js
+++ b/test/parallel/test-cluster-worker-isconnected.js
@@ -2,7 +2,6 @@
 require('../common');
 var cluster = require('cluster');
 var assert = require('assert');
-var util = require('util');
 
 if (cluster.isMaster) {
   var worker = cluster.fork();

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 
 var path = require('path');
 var fs = require('fs');
-var util = require('util');
 
 
 var filepath = path.join(common.tmpDir, 'write.txt');

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -3,8 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 
 var path = require('path'),
-    fs = require('fs'),
-    util = require('util');
+    fs = require('fs');
 
 
 var filepath = path.join(common.tmpDir, 'write_pos.txt');

--- a/test/parallel/test-http-buffer-sanity.js
+++ b/test/parallel/test-http-buffer-sanity.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
 
 var bufferSize = 5 * 1024 * 1024;
 var measuredSize = 0;

--- a/test/parallel/test-http-head-request.js
+++ b/test/parallel/test-http-head-request.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
 
 
 var body = 'hello world\n';

--- a/test/parallel/test-http-keep-alive-close-on-header.js
+++ b/test/parallel/test-http-keep-alive-close-on-header.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
 
 var body = 'hello world\n';
 var headers = {'connection': 'keep-alive'};

--- a/test/parallel/test-pipe-return-val.js
+++ b/test/parallel/test-pipe-return-val.js
@@ -4,7 +4,6 @@
 var common = require('../common');
 var Stream = require('stream').Stream;
 var assert = require('assert');
-var util = require('util');
 
 var sourceStream = new Stream();
 var destStream = new Stream();

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var util = require('util');
 var join = require('path').join;
 var fs = require('fs');
 var common = require('../common');

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -2,7 +2,6 @@
 var assert = require('assert');
 var common = require('../common');
 
-var util   = require('util');
 var repl   = require('repl');
 
 const putIn = new common.ArrayStream();

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -7,7 +7,6 @@ const stream = require('stream');
 const REPL = require('internal/repl');
 const assert = require('assert');
 const fs = require('fs');
-const util = require('util');
 const path = require('path');
 const os = require('os');
 

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const repl = require('repl');
-const util = require('util');
 let found = false;
 
 process.on('exit', () => {

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const util = require('util');
 const repl = require('repl');
 
 var referenceErrorCount = 0;

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -4,7 +4,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var util = require('util');
 var repl = require('repl');
 var referenceErrors = 0;
 var expectedReferenceErrors = 0;

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -1,7 +1,6 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-var util = require('util');
 var repl = require('repl');
 var zlib = require('zlib');
 

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -5,7 +5,6 @@ var Readable = stream.Readable;
 var Writable = stream.Writable;
 var assert = require('assert');
 
-var util = require('util');
 var EE = require('events').EventEmitter;
 
 

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -3,8 +3,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var url = require('url'),
-    util = require('util');
+var url = require('url');
 
 // URLs to parse, and expected data
 // { url : parsed }


### PR DESCRIPTION
A number of tests in `test/parallel` were importing the `util` module
via `require()` but not using `util` for anything. This removes those
`require()` statements.