### PR TITLE
http: make path null in Agent#createSocket

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1279,6 +1279,8 @@ Agent.prototype.addRequest = function(req, host, port, localAddress) {
 Agent.prototype.createSocket = function(name, host, port, localAddress, req) {
   var self = this;
   var options = util._extend({}, self.options);
+  if (options.path)
+    options.path = null;
   options.port = port;
   options.host = host;
   options.localAddress = localAddress;

--- a/test/simple/test-http-agent-path.js
+++ b/test/simple/test-http-agent-path.js
@@ -1,0 +1,26 @@
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  res.end();
+}).listen(common.PORT, function() {
+  var opts = {
+    host: 'localhost',
+    port: common.PORT,
+    headers: {
+      'Host': 'localhost:' + common.PORT,
+      'Connection': 'close'
+    }
+  };
+
+  var agent = new http.Agent(opts);
+  opts.agent = agent;
+  opts.path = '/';
+  var req = http.request(opts, function(res) {
+    res.resume();
+    server.close();
+  });
+  req.on('error', assert.fail);
+  req.end();
+});


### PR DESCRIPTION
This prevents net.createConnection from thinking the request should be
made using a unix socket. Without this fix,
test/simple/test-http-agent-path.js will emit a ENOTSOCK error.