### PR TITLE
repl: remove unused function

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -14,12 +14,6 @@ module.exports.createInternalRepl = createRepl;
 // The debounce is to guard against code pasted into the REPL.
 const kDebounceHistoryMS = 15;
 
-// XXX(chrisdickinson): hack to make sure that the internal debugger
-// uses the original repl.
-function replStart() {
-  return REPL.start.apply(REPL, arguments);
-}
-
 function createRepl(env, opts, cb) {
   if (typeof opts === 'function') {
     cb = opts;


### PR DESCRIPTION
replStart() was defined but never used. The function has been removed.

R=@chrisdickinson (Presumably, the hack involved using the function at some point and not merely having the function exist...)