### PR TITLE
test: remove unused var from test-assert.js

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -271,8 +271,6 @@ assert.throws(makeBlock(a.deepStrictEqual, new Boolean(true), {}),
 function thrower(errorConstructor) {
   throw new errorConstructor('test');
 }
-var aethrow = makeBlock(thrower, a.AssertionError);
-aethrow = makeBlock(thrower, a.AssertionError);
 
 // the basic calls work
 assert.throws(makeBlock(thrower, a.AssertionError),


### PR DESCRIPTION
`aethrow` is defined as a function returned from `makeBlock()` but the function is never used and the call to `makeBlock()` does not run any tests.