### PR TITLE
Use `self.keepAlive` instead of `self.options.keepAlive` in http agent

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -58,7 +58,7 @@ function Agent(options) {
       if (req &&
           req.shouldKeepAlive &&
           !socket.destroyed &&
-          self.options.keepAlive) {
+          self.keepAlive) {
         var freeSockets = self.freeSockets[name];
         var freeLen = freeSockets ? freeSockets.length : 0;
         var count = freeLen;


### PR DESCRIPTION
All other options are directly accessed through `self.` not `self.options`, so this looks like the odd one out.