### PR TITLE
doc: improvements to cluster.markdown copy

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -2,12 +2,40 @@
 
     Stability: 2 - Stable
 
-A single instance of Node.js runs in a single thread. To take advantage of
-multi-core systems the user will sometimes want to launch a cluster of Node.js
-processes to handle the load.
+Node.js executes JavaScript code within the context of an event loop. Under the 
+hood, non-blocking socket I/O runs on the main event loop thread while blocking 
+DNS and filesystem I/O runs on a secondary thread that notifies the main thread 
+when it's finished. This concurrency model allows a blocking 
+[I/O bound](https://en.wikipedia.org/wiki/I/O_bound) application to easily 
+distribute work across multiple CPU cores. For more details, see the 
+[libuv](http://docs.libuv.org/en/v1.x/design.html) project.
 
-The cluster module allows you to easily create child processes that
-all share server ports.
+The `cluster` API allows a non-blocking I/O bound application to distribute 
+work across multiple CPU cores. A Node.js cluster is created when a **master 
+process** forks one or more **worker processes**. By design, workers use the 
+same application code as the master. Conveniently, the `cluster.isMaster` 
+property determines if a running process is the master or a worker.
+
+```js
+const cluster = require('cluster');
+if (cluster.isMaster) {
+  for (var i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
+} else {
+  // Non-blocking I/O work
+}
+```
+
+The implementation itself is built directly on top of the
+[`child_process.fork()`][] API, The master communicates with, and manages,
+each of the workers through an IPC channel.
+
+## Distributing server workload
+
+One of the primary use cases for the cluster API is allowing a developer to
+easily distribute request processing over multiple worker processes that all
+share a single common server port:
 
 ```js
 const cluster = require('cluster');
@@ -33,7 +61,7 @@ if (cluster.isMaster) {
 }
 ```
 
-Running Node.js will now share port 8000 between the workers:
+Running this example will now share port 8000 between the workers:
 
 ```
 $ NODE_DEBUG=cluster node server.js
@@ -46,26 +74,25 @@ $ NODE_DEBUG=cluster node server.js
 Please note that, on Windows, it is not yet possible to set up a named pipe
 server in a worker.
 
-## How It Works
+### How It Works
 
-<!--type=misc-->
+The implementation of the `cluster` API in Node.js includes the built-in ability
+to share TCP server connections automatically across multiple worker forks.
+Whenever a worker starts and begins listening on a port, the master
+is actually directed to open and listen to that port, distributing incoming
+connections among the various children.
 
-The worker processes are spawned using the [`child_process.fork()`][] method,
-so that they can communicate with the parent via IPC and pass server
-handles back and forth.
+The cluster module supports two methods of distributing incoming connections:
 
-The cluster module supports two methods of distributing incoming
-connections.
+1. The first is a round-robin model where the master process listens on a
+   port, accepts new connections, and distributes them across all workers
+   in a round-robin fashion, with some built-in intelligence to avoid
+   overloading any single worker process. This is the default on all platforms
+   except Windows),
 
-The first one (and the default one on all platforms except Windows),
-is the round-robin approach, where the master process listens on a
-port, accepts new connections and distributes them across the workers
-in a round-robin fashion, with some built-in smarts to avoid
-overloading a worker process.
-
-The second approach is where the master process creates the listen
-socket and sends it to interested workers. The workers then accept
-incoming connections directly.
+2. The second approach is where the master process creates the listen
+   socket and sends it to interested workers. The workers then accept
+   incoming connections directly.
 
 The second approach should, in theory, give the best performance.
 In practice however, distribution tends to be very unbalanced due
@@ -73,9 +100,9 @@ to operating system scheduler vagaries. Loads have been observed
 where over 70% of all connections ended up in just two processes,
 out of a total of eight.
 
-Because `server.listen()` hands off most of the work to the master
-process, there are three cases where the behavior between a normal
-Node.js process and a cluster worker differs:
+When running within a worker process, `server.listen()` hands off most of
+its work to the master process. There are three cases where the behavior
+between a normal Node.js process and a cluster worker differs:
 
 1. `server.listen({fd: 7})` Because the message is passed to the master,
    file descriptor 7 **in the parent** will be listened on, and the
@@ -92,30 +119,374 @@ Node.js process and a cluster worker differs:
    want to listen on a unique port, generate a port number based on the
    cluster worker ID.
 
-There is no routing logic in Node.js, or in your program, and no shared
-state between the workers.  Therefore, it is important to design your
-program such that it does not rely too heavily on in-memory data objects
-for things like sessions and login.
+It is important to keep in mind that worker processes do not share state or
+memory with each other, or with the master, beyond the shared socket handles
+used for distributing connection workload. Applications using cluster must be
+written in such a way that they do not rely too heavily on in-memory data
+objects for things like sessions and login.
 
-Because workers are all separate processes, they can be killed or
-re-spawned depending on your program's needs, without affecting other
-workers.  As long as there are some workers still alive, the server will
-continue to accept connections.  If no workers are alive, existing connections
-will be dropped and new connections will be refused.  Node.js does not
-automatically manage the number of workers for you, however.  It is your
-responsibility to manage the worker pool for your application's needs.
+Because workers are all separate processes, it is safe to terminate and
+re-spawn individual workers depending on the program's needs, without
+affecting any of the other workers. As long as there are some workers still
+alive, the server will continue to accept connections.  If no workers are
+alive, existing connections will be dropped and new connections will be
+refused.  Node.js does not automatically manage the number of workers for you,
+however.  It is your responsibility to manage the worker pool for your
+application's needs.
 
+## The `cluster` module
 
+The `cluster` module is loaded using `require('custer')`:
 
-## Class: Worker
+```js
+const cluster = require('cluster');
+```
 
-A Worker object contains all public information and method about a worker.
-In the master it can be obtained using `cluster.workers`. In a worker
-it can be obtained using `cluster.worker`.
+The `cluster` module itself is an instance of `'EventEmitter'` and exposes a
+number of properties and methods whose values and functions will vary depending
+on if the current process is the master or a worker.
 
 ### Event: 'disconnect'
 
-Similar to the `cluster.on('disconnect')` event, but specific to this worker.
+* `worker` {cluster.Worker}
+
+Emitted within the master process after a worker IPC channel has disconnected.
+This can occur when a worker exits gracefully, is killed, or is disconnected
+manually (such as when using `worker.disconnect()`).
+
+There can be a delay between the `'disconnect'` and `'exit'` events.  These
+events can be used, for instance, to detect when a working process is stuck in
+a cleanup process or if there are long-living connections.
+
+When triggered, the callback function will be passed the `Worker` instance
+representing the worker that has disconnected:
+
+```js
+cluster.on('disconnect', (worker) => {
+  console.log(`The worker #${worker.id} has disconnected`);
+});
+```
+
+### Event: 'exit'
+
+* `worker` {cluster.Worker}
+* `code` {Number} the exit code if the child exited on its own.
+* `signal` {String} the signal by which the child process was terminated.
+
+When any worker processes exits or is terminated for any reason, the cluster
+module will emit the `'exit'` event within the master process.
+
+This can be used, for instance, to restart a failing worker by calling
+`cluster.fork()` again.
+
+```js
+cluster.on('exit', (worker, code, signal) => {
+  console.log('worker %d died (%s). restarting...',
+    worker.process.pid, signal || code);
+  cluster.fork();
+});
+```
+
+See [child_process event: 'exit'][].
+
+### Event: 'fork'
+
+* `worker` {cluster.Worker}
+
+When a new worker is forked the cluster module will emit a `'fork'` event
+within the master process.
+
+This can be used, for instance, to log worker activity or to create timeouts
+for managing worker lifetime:
+
+```js
+const timeouts = [];
+function errorMsg() {
+  console.error('Something must be wrong with the connection ...');
+}
+
+cluster.on('fork', (worker) => {
+  timeouts[worker.id] = setTimeout(errorMsg, 2000);
+});
+cluster.on('listening', (worker, address) => {
+  clearTimeout(timeouts[worker.id]);
+});
+cluster.on('exit', (worker, code, signal) => {
+  clearTimeout(timeouts[worker.id]);
+  errorMsg();
+});
+```
+
+### Event: 'listening'
+
+* `worker` {cluster.Worker}
+* `address` {Object}
+
+After calling the `listen()` event on a TCP server inside a worker, whenever
+the `'listening'` event is emitted by the server object, a corresponding
+`'listening'` event will also be emitted by the `cluster` module in the
+master process.
+
+The event handler is passed two arguments when invoked: `worker` and `address`.
+The `worker` argument is a reference to the `Worker` object, and the `address`
+argument is an object containing the properties `address`, `port`, and
+`addressType`. These are particularly useful if the worker is listening
+on more than one address.
+
+```js
+cluster.on('listening', (worker, address) => {
+  console.log(
+    `Worker ${worker.id} is now connected to ` +
+    `${address.address}:${address.port}`);
+});
+```
+
+The `addressType` is one of:
+
+* `4` (TCPv4)
+* `6` (TCPv6)
+* `-1` (local domain)
+* `"udp4"` or `"udp6"` (UDP v4 or v6)
+
+### Event: 'message'
+
+* `worker` {cluster.Worker}
+* `message` {Object}
+* `handle` {undefined|Object}
+
+Emitted when any worker receives a message.
+
+See [child_process event: 'message'][].
+
+Before Node.js v6.0, this event emitted only the message and the handle,
+but not the worker object, contrary to what the documentation stated.
+
+If you need to support older versions and don't need the worker object,
+you can work around the discrepancy by checking the number of arguments:
+
+```js
+cluster.on('message', function(worker, message, handle) {
+  if (arguments.length === 2) {
+    handle = message;
+    message = worker;
+    worker = undefined;
+  }
+  // ...
+});
+```
+
+### Event: 'online'
+
+* `worker` {cluster.Worker}
+
+The `'online'` event will be emitted in the master process whenever a
+worker has fully started and is ready to begin accepting messages from the
+master.
+
+The difference between `'fork'` and `'online'` is that `'fork'` is emitted when
+the master spawns a worker, while `'online'` is emitted only when the worker is
+running.
+
+```js
+cluster.on('online', (worker) => {
+  console.log('Yay, the worker responded after it was spawned');
+});
+```
+
+### Event: 'setup'
+
+* `settings` {Object}
+
+The `'setup'` event is emitted  in the master process whenever
+`cluster.setupMaster()` is called.
+
+The event handler is passed a `settings` argument that is set to the value of
+the `cluster.settings` property at the time `cluster.setupMaster()` was called
+and is advisory only since multiple calls to `cluster.setupMaster()` can
+occur within a single tick. If accuracy is important, use `cluster.settings`.
+
+### cluster.disconnect([callback])
+
+* `callback` {Function} called when all workers are disconnected and handles are
+  closed
+
+Calling the `cluster.disconnect()` method will sequentially call the
+`worker.disconnect()` method on each `Worker` instance in `cluster.workers`.
+
+Once the workers are disconnected, all internal handles will be closed,
+allowing the master process to exit gracefully if there is no other pending
+work.
+
+The method takes an optional `callback` argument which will be called when
+all workers have been disconnected.
+
+The `cluster.disconnect()` method can only be called from the master process.
+
+### cluster.fork([env])
+
+* `env` {Object} Key/value pairs to add to worker process environment.
+* return {Worker object}
+
+Spawn a new worker process.
+
+The `cluster.fork()` method can only be called from the master process.
+
+### cluster.isMaster
+
+* {Boolean}
+
+Returns `true` only if the process is a master.
+
+This state is determined by checking the value of `process.env.NODE_UNIQUE_ID`.
+If `process.env.NODE_UNIQUE_ID` is `undefined`, then `cluster.isMaster` is
+`true`.
+
+### cluster.isWorker
+
+* {Boolean}
+
+Returns `true` only if the process is not a master (e.g. `cluster.isMaster`
+is `false`);
+
+### cluster.schedulingPolicy
+
+Identifies the scheduling policy. This will either be `cluster.SCHED_RR` for
+round-robin or `cluster.SCHED_NONE` for the operating system default. This is a
+global setting that cannot be modified once either the first worker is spawned
+or `cluster.setupMaster()` is called (whichever comes first).
+
+`SCHED_RR` is the default on all operating systems except Windows.
+Windows will change to `SCHED_RR` once libuv is able to effectively
+distribute IOCP handles without incurring a large performance hit.
+
+It is possible to set the value of `cluster.schedulingPolicy` using the
+`NODE_CLUSTER_SCHED_POLICY` environment variable. Valid values are `"rr"`
+and `"none"`.
+
+### cluster.settings
+
+* {Object}
+  * `execArgv` {Array} list of string arguments passed to the Node.js
+    executable. (Default=`process.execArgv`)
+  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `args` {Array} string arguments passed to worker.
+    (Default=`process.argv.slice(2)`)
+  * `silent` {Boolean} whether or not to send output to parent's stdio.
+    (Default=`false`)
+  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+
+The `cluster.settings` property contains the default spawn settings for all
+workers. Its value is set for the first time after calling either
+`cluster.setupMaster()` or `cluster.fork()` (whichever comes first).
+
+While the object is not read-only, it's properties must only be modified
+through use of the `cluster.setupMaster()` method.
+
+### cluster.setupMaster([settings])
+
+* `settings` {Object}
+  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `args` {Array} string arguments passed to worker.
+    (Default=`process.argv.slice(2)`)
+  * `silent` {Boolean} whether or not to send output to parent's stdio.
+    (Default=`false`)
+
+The `cluster.setupMaster()` method is used to modify the default spawn settings
+for each fork. Once called, the settings will be present in `cluster.settings`.
+
+Note that:
+
+* any settings changes only affect future calls to `.fork()` and have no
+  effect on workers that are already running
+* The *only* attribute of a worker that cannot be set via `.setupMaster()` is
+  the `env` passed to `.fork()`
+* the defaults above apply to the first call only, the defaults for later
+  calls is the current value at the time of `cluster.setupMaster()` is called
+
+Example:
+
+```js
+const cluster = require('cluster');
+cluster.setupMaster({
+  exec: 'worker.js',
+  args: ['--use', 'https'],
+  silent: true
+});
+cluster.fork(); // https worker
+cluster.setupMaster({
+  args: ['--use', 'http']
+});
+cluster.fork(); // http worker
+```
+
+The `cluster.setupMaster()` method can only be called from the master process.
+
+### cluster.worker
+
+* {Object}
+
+A reference to the current worker object. Not available in the master process.
+
+```js
+const cluster = require('cluster');
+
+if (cluster.isMaster) {
+  console.log('I am master');
+  cluster.fork();
+  cluster.fork();
+} else if (cluster.isWorker) {
+  console.log(`I am worker #${cluster.worker.id}`);
+}
+```
+
+### cluster.workers
+
+* {Object}
+
+A hash that stores the active worker objects, keyed by `id` field, making it
+possible to loop through all available workers.
+
+The `cluster.workers` property is available only in the master process.
+
+A worker is removed from cluster.workers after the worker has disconnected _and_
+exited. The ordering of these events cannot be determined in advance. However,
+it is guaranteed that the removal from the cluster.workers list happens
+before the final `'disconnect'` or `'exit'` event is emitted.
+
+```js
+// Go through all workers
+function eachWorker(callback) {
+  for (var id in cluster.workers) {
+    callback(cluster.workers[id]);
+  }
+}
+eachWorker((worker) => {
+  worker.send('big announcement to all workers');
+});
+```
+
+The worker's unique id is the easiest way to find a worker:
+
+```js
+socket.on('data', (id) => {
+  var worker = cluster.workers[id];
+});
+```
+
+## Class: Worker
+
+Instances of the `Worker` class are [`EventEmitters`] that provide information
+about a worker and methods for interacting with, or controlling, the worker.
+
+Master processes maintain a record of all spawned worker processes using the
+`cluster.workers` property. Worker processes have access only to the one
+`Worker` object representing that process (using the `cluster.worker` property).
+
+### Event: 'disconnect'
+
+Emitted by the `Worker` object when the worker process has disconnected from
+the master.
 
 ```js
 cluster.fork().on('disconnect', () => {
@@ -125,17 +496,19 @@ cluster.fork().on('disconnect', () => {
 
 ### Event: 'error'
 
-This event is the same as the one provided by [`child_process.fork()`][].
+Emitted by the `Worker` object when an error has occurred. This event is the
+same as that provided by [`child_process.fork()`][].
 
-In a worker you can also use `process.on('error')`.
+Because the `cluster` API is built on top of the `child_process` module and
+worker processes are spawned using [`child_process.fork()`][], it is also
+possible to use `process.on('error')` to listen to and handle `'error'` events.
 
 ### Event: 'exit'
 
-* `code` {Number} the exit code, if it exited normally.
-* `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
-  the process to be killed.
+* `code` {Number} the exit code if the child exited on its own.
+* `signal` {String} the signal by which the child process was terminated.
 
-Similar to the `cluster.on('exit')` event, but specific to this worker.
+Emitted by the `Worker` object when the worker process exits.
 
 ```js
 const worker = cluster.fork();
@@ -154,7 +527,10 @@ worker.on('exit', (code, signal) => {
 
 * `address` {Object}
 
-Similar to the `cluster.on('listening')` event, but specific to this worker.
+Emitted only within the master process whenever the specific worker process
+is listening on a server port. The callback function is passed a single
+`address` object that includes the `address`, `port`, and `addressType`
+properties.
 
 ```js
 cluster.fork().on('listening', (address) => {
@@ -162,19 +538,19 @@ cluster.fork().on('listening', (address) => {
 });
 ```
 
-It is not emitted in the worker.
-
 ### Event: 'message'
 
 * `message` {Object}
 
-Similar to the `cluster.on('message')` event, but specific to this worker.
+Because the `cluster` module is built on top of the `child_process` module, and
+because workers are launched using [`child_process.fork()`][], it is possible to
+pass messages between the master and worker processes. The `'message'` event
+is triggered on the `Worker` object whenever a message is received.
 
-This event is the same as the one provided by [`child_process.fork()`][].
+Within the worker process, you can also use `process.on('message')` to receive
+messages sent from the master process.
 
-In a worker you can also use `process.on('message')`.
-
-As an example, here is a cluster that keeps count of the number of requests
+For example, following is a cluster that keeps a count of the number of requests
 in the master process using the message system:
 
 ```js
@@ -221,7 +597,8 @@ if (cluster.isMaster) {
 
 ### Event: 'online'
 
-Similar to the `cluster.on('online')` event, but specific to this worker.
+Triggered only within the master process when a specific worker is online
+and ready to receive messages.
 
 ```js
 cluster.fork().on('online', () => {
@@ -229,34 +606,37 @@ cluster.fork().on('online', () => {
 });
 ```
 
-It is not emitted in the worker.
-
 ### worker.disconnect()
 
-In a worker, this function will close all servers, wait for the `'close'` event on
-those servers, and then disconnect the IPC channel.
+When called from within a worker process, the `worker.disconnect()` method
+will close all listening servers, wait for the `'close'` event on those servers
+to be triggered, and will then disconnect the IPC channel with the master
+process.
 
-In the master, an internal message is sent to the worker causing it to call
-`.disconnect()` on itself.
+When called on the master process, an internal control message is sent to
+the worker instructing it to call the `worker.disconnect()` message itself.
 
-Causes `.suicide` to be set.
+When called, the `worker.suicide` flag will be set to `true`.
 
-Note that after a server is closed, it will no longer accept new connections,
-but connections may be accepted by any other listening worker. Existing
-connections will be allowed to close as usual. When no more connections exist,
-see [`server.close()`][], the IPC channel to the worker will close allowing it to
-die gracefully.
+Note that after a server is closed, new connections will no longer be accepted
+by that worker, but connections may be accepted by any other listening worker.
+Existing connections will be allowed to close as usual. When no more
+connections exist (see [`server.close()`][]) the IPC channel to the worker will
+close allowing it to exit gracefully.
 
-The above applies *only* to server connections, client connections are not
-automatically closed by workers, and disconnect does not wait for them to close
-before exiting.
+Client connections, on the other hand, are not automatically closed by workers,
+and disconnect does not wait for client connections to close before exiting.
 
-Note that in a worker, `process.disconnect` exists, but it is not this function,
-it is [`disconnect`][].
+Note that in a worker process, the `worker.disconnect()` and
+`process.disconnect()` methods are *not* equivalent to one another
+(`process.disconnect()` simply disconnects the IPC channel, while
+`worker.disconnect()` closes all servers then disconnects the IPC channel).
+Worker processes should always use the `worker.disconnect()` method.
 
 Because long living server connections may block workers from disconnecting, it
-may be useful to send a message, so application specific actions may be taken to
-close them. It also may be useful to implement a timeout, killing a worker if
+may be useful to have the master process send a shutdown message to the
+workers, so that application specific actions may be taken to close them.
+It also may be useful to implement a timeout, killing a worker if
 the `'disconnect'` event has not been emitted after some time.
 
 ```js
@@ -296,21 +676,18 @@ if (cluster.isMaster) {
 
 * {Number}
 
-Each new worker is given its own unique id, this id is stored in the
-`id`.
-
-While a worker is alive, this is the key that indexes it in
-cluster.workers
+Returns the unique identifier of the worker process. While a worker is alive,
+this is the key used to index it in `cluster.workers`.
 
 ### worker.isConnected()
 
-This function returns `true` if the worker is connected to its master via its IPC
-channel, `false` otherwise. A worker is connected to its master after it's been
-created. It is disconnected after the `'disconnect'` event is emitted.
+Returns `true` if the worker is connected to its master via its IPC
+channel, `false` otherwise. A worker is connected to its master after it has
+been created. It is disconnected after the `'disconnect'` event is emitted.
 
 ### worker.isDead()
 
-This function returns `true` if the worker's process has terminated (either
+Returns `true` if the worker's process has terminated (either
 because of exiting or being signaled). Otherwise, it returns `false`.
 
 ### worker.kill([signal='SIGTERM'])
@@ -318,30 +695,70 @@ because of exiting or being signaled). Otherwise, it returns `false`.
 * `signal` {String} Name of the kill signal to send to the worker
   process.
 
-This function will kill the worker. In the master, it does this by disconnecting
-the `worker.process`, and once disconnected, killing with `signal`. In the
-worker, it does it by disconnecting the channel, and then exiting with code `0`.
+This function will, by default, signal the worker process to terminate. In the
+master process, this is done by first disconnecting the worker process, then
+sending the `signal` (which defaults to `SIGTERM`). Within the worker, the IPC
+channel is disconnected and the process exits with code `0`.
 
-Causes `.suicide` to be set.
+Note that once the `worker.kill()` is called, all open server connections
+will be closed and the worker process will normally exit before the `signal`
+can be delivered. Sending the `signal` is only a backup in case the worker
+process fails to exit on its own and code should not be written to expect the
+signal to be delivered. Applications that wish to send `signals` reliably
+should use `process.kill()` instead.
+
+When called, the `worker.suicide` property will be set to `true`.
 
 This method is aliased as `worker.destroy()` for backwards compatibility.
 
-Note that in a worker, `process.kill()` exists, but it is not this function,
-it is [`kill`][].
+Note that in a worker process, the `worker.kill()` and `process.kill()` methods
+are *not* equivalent to one another.
 
 ### worker.process
 
 * {ChildProcess}
 
-All workers are created using [`child_process.fork()`][], the returned object
-from this function is stored as `.process`. In a worker, the global `process`
-is stored.
+Within the master process, `worker.process` returns the [`ChildProcess`][]
+object returned by [`child_process.fork()`][] when the worker was spawned.
 
-See: [Child Process module][]
+Within the worker process, `worker.process` returns the global `process`.
 
-Note that workers will call `process.exit(0)` if the `'disconnect'` event occurs
-on `process` and `.suicide` is not `true`. This protects against accidental
-disconnection.
+Note that a worker will exit with exit code `0` and `worker.suicide` set to
+`false` if `process.disconnect()` is called.
+
+For instance:
+
+```js
+const cluster = require('cluster');
+
+if (cluster.isMaster) {  
+  var worker = cluster.fork();
+  worker.on('exit', (code,sig)=>{
+    console.log(
+      `${worker.id} exited: ${code}, ${sig}, ${worker.suicide}`);
+      // Prints: 1 exited: 0, null, false
+  });
+} else {
+  process.disconnect();
+}
+```
+
+In contrast:
+
+```js
+const cluster = require('cluster');
+
+if (cluster.isMaster) {  
+  var worker = cluster.fork();
+  worker.on('exit', (code,sig)=>{
+    console.log(
+      `${worker.id} exited: ${code}, ${sig}, ${worker.suicide}`);
+      // Prints: 1 exited: 0, null, true
+  });
+} else {
+  cluster.worker.disconnect();
+}
+```
 
 ### worker.send(message[, sendHandle][, callback])
 
@@ -350,13 +767,11 @@ disconnection.
 * `callback` {Function}
 * Return: Boolean
 
-Send a message to a worker or master, optionally with a handle.
+Within the master process, `worker.send` sends a message to worker. It is
+identical to [`ChildProcess.send()`][].
 
-In the master this sends a message to a specific worker. It is identical to
-[`ChildProcess.send()`][].
-
-In a worker this sends a message to the master. It is identical to
-`process.send()`.
+Within the worker process, `worker.send` sends a message to the master. It is
+identical to `process.send()`.
 
 This example will echo back all messages from the master:
 
@@ -376,15 +791,17 @@ if (cluster.isMaster) {
 
 * {Boolean}
 
-Set by calling `.kill()` or `.disconnect()`, until then it is `undefined`.
+Returns `true` if either the `worker.kill()` or `worker.disconnect()` methods
+have been called, until then it is `undefined`.
 
-The boolean `worker.suicide` lets you distinguish between voluntary and accidental
-exit, the master may choose not to respawn a worker based on this value.
+The `worker.suicide` property makes is possible to distinguish between
+voluntary and accidental exit of a worker. The master can choose whether to
+respawn a worker based on this value.
 
 ```js
 cluster.on('exit', (worker, code, signal) => {
   if (worker.suicide === true) {
-    console.log('Oh, it was just suicide\' – no need to worry').
+    console.log('The worker meant to exit. No need to worry.').
   }
 });
 
@@ -392,321 +809,11 @@ cluster.on('exit', (worker, code, signal) => {
 worker.kill();
 ```
 
-## Event: 'disconnect'
-
-* `worker` {cluster.Worker}
-
-Emitted after the worker IPC channel has disconnected. This can occur when a
-worker exits gracefully, is killed, or is disconnected manually (such as with
-worker.disconnect()).
-
-There may be a delay between the `'disconnect'` and `'exit'` events.  These events
-can be used to detect if the process is stuck in a cleanup or if there are
-long-living connections.
-
-```js
-cluster.on('disconnect', (worker) => {
-  console.log(`The worker #${worker.id} has disconnected`);
-});
-```
-
-## Event: 'exit'
-
-* `worker` {cluster.Worker}
-* `code` {Number} the exit code, if it exited normally.
-* `signal` {String} the name of the signal (eg. `'SIGHUP'`) that caused
-  the process to be killed.
-
-When any of the workers die the cluster module will emit the `'exit'` event.
-
-This can be used to restart the worker by calling `.fork()` again.
-
-```js
-cluster.on('exit', (worker, code, signal) => {
-  console.log('worker %d died (%s). restarting...',
-    worker.process.pid, signal || code);
-  cluster.fork();
-});
-```
-
-See [child_process event: 'exit'][].
-
-## Event: 'fork'
-
-* `worker` {cluster.Worker}
-
-When a new worker is forked the cluster module will emit a `'fork'` event.
-This can be used to log worker activity, and create your own timeout.
-
-```js
-var timeouts = [];
-function errorMsg() {
-  console.error('Something must be wrong with the connection ...');
-}
-
-cluster.on('fork', (worker) => {
-  timeouts[worker.id] = setTimeout(errorMsg, 2000);
-});
-cluster.on('listening', (worker, address) => {
-  clearTimeout(timeouts[worker.id]);
-});
-cluster.on('exit', (worker, code, signal) => {
-  clearTimeout(timeouts[worker.id]);
-  errorMsg();
-});
-```
-
-## Event: 'listening'
-
-* `worker` {cluster.Worker}
-* `address` {Object}
-
-After calling `listen()` from a worker, when the `'listening'` event is emitted on
-the server, a `'listening'` event will also be emitted on `cluster` in the master.
-
-The event handler is executed with two arguments, the `worker` contains the worker
-object and the `address` object contains the following connection properties:
-`address`, `port` and `addressType`. This is very useful if the worker is listening
-on more than one address.
-
-```js
-cluster.on('listening', (worker, address) => {
-  console.log(
-    `A worker is now connected to ${address.address}:${address.port}`);
-});
-```
-
-The `addressType` is one of:
-
-* `4` (TCPv4)
-* `6` (TCPv6)
-* `-1` (unix domain socket)
-* `"udp4"` or `"udp6"` (UDP v4 or v6)
-
-## Event: 'message'
-
-* `worker` {cluster.Worker}
-* `message` {Object}
-* `handle` {undefined|Object}
-
-Emitted when any worker receives a message.
-
-See [child_process event: 'message'][].
-
-Before Node.js v6.0, this event emitted only the message and the handle,
-but not the worker object, contrary to what the documentation stated.
-
-If you need to support older versions and don't need the worker object,
-you can work around the discrepancy by checking the number of arguments:
-
-```js
-cluster.on('message', function(worker, message, handle) {
-  if (arguments.length === 2) {
-    handle = message;
-    message = worker;
-    worker = undefined;
-  }
-  // ...
-});
-```
-
-## Event: 'online'
-
-* `worker` {cluster.Worker}
-
-After forking a new worker, the worker should respond with an online message.
-When the master receives an online message it will emit this event.
-The difference between `'fork'` and `'online'` is that fork is emitted when the
-master forks a worker, and 'online' is emitted when the worker is running.
-
-```js
-cluster.on('online', (worker) => {
-  console.log('Yay, the worker responded after it was forked');
-});
-```
-
-## Event: 'setup'
-
-* `settings` {Object}
-
-Emitted every time `.setupMaster()` is called.
-
-The `settings` object is the `cluster.settings` object at the time
-`.setupMaster()` was called and is advisory only, since multiple calls to
-`.setupMaster()` can be made in a single tick.
-
-If accuracy is important, use `cluster.settings`.
-
-## cluster.disconnect([callback])
-
-* `callback` {Function} called when all workers are disconnected and handles are
-  closed
-
-Calls `.disconnect()` on each worker in `cluster.workers`.
-
-When they are disconnected all internal handles will be closed, allowing the
-master process to die gracefully if no other event is waiting.
-
-The method takes an optional callback argument which will be called when finished.
-
-This can only be called from the master process.
-
-## cluster.fork([env])
-
-* `env` {Object} Key/value pairs to add to worker process environment.
-* return {cluster.Worker}
-
-Spawn a new worker process.
-
-This can only be called from the master process.
-
-## cluster.isMaster
-
-* {Boolean}
-
-True if the process is a master. This is determined
-by the `process.env.NODE_UNIQUE_ID`. If `process.env.NODE_UNIQUE_ID` is
-undefined, then `isMaster` is `true`.
-
-## cluster.isWorker
-
-* {Boolean}
-
-True if the process is not a master (it is the negation of `cluster.isMaster`).
-
-## cluster.schedulingPolicy
-
-The scheduling policy, either `cluster.SCHED_RR` for round-robin or
-`cluster.SCHED_NONE` to leave it to the operating system. This is a
-global setting and effectively frozen once you spawn the first worker
-or call `cluster.setupMaster()`, whatever comes first.
-
-`SCHED_RR` is the default on all operating systems except Windows.
-Windows will change to `SCHED_RR` once libuv is able to effectively
-distribute IOCP handles without incurring a large performance hit.
-
-`cluster.schedulingPolicy` can also be set through the
-`NODE_CLUSTER_SCHED_POLICY` environment variable. Valid
-values are `"rr"` and `"none"`.
-
-## cluster.settings
-
-* {Object}
-  * `execArgv` {Array} list of string arguments passed to the Node.js
-    executable. (Default=`process.execArgv`)
-  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
-  * `args` {Array} string arguments passed to worker.
-    (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
-    (Default=`false`)
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-
-After calling `.setupMaster()` (or `.fork()`) this settings object will contain
-the settings, including the default values.
-
-It is effectively frozen after being set, because `.setupMaster()` can
-only be called once.
-
-This object is not supposed to be changed or set manually, by you.
-
-## cluster.setupMaster([settings])
-
-* `settings` {Object}
-  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
-  * `args` {Array} string arguments passed to worker.
-    (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
-    (Default=`false`)
-
-`setupMaster` is used to change the default 'fork' behavior. Once called,
-the settings will be present in `cluster.settings`.
-
-Note that:
-
-* any settings changes only affect future calls to `.fork()` and have no
-  effect on workers that are already running
-* The *only* attribute of a worker that cannot be set via `.setupMaster()` is
-  the `env` passed to `.fork()`
-* the defaults above apply to the first call only, the defaults for later
-  calls is the current value at the time of `cluster.setupMaster()` is called
-
-Example:
-
-```js
-const cluster = require('cluster');
-cluster.setupMaster({
-  exec: 'worker.js',
-  args: ['--use', 'https'],
-  silent: true
-});
-cluster.fork(); // https worker
-cluster.setupMaster({
-  exec: 'worker.js',
-  args: ['--use', 'http']
-});
-cluster.fork(); // http worker
-```
-
-This can only be called from the master process.
-
-## cluster.worker
-
-* {Object}
-
-A reference to the current worker object. Not available in the master process.
-
-```js
-const cluster = require('cluster');
-
-if (cluster.isMaster) {
-  console.log('I am master');
-  cluster.fork();
-  cluster.fork();
-} else if (cluster.isWorker) {
-  console.log(`I am worker #${cluster.worker.id}`);
-}
-```
-
-## cluster.workers
-
-* {Object}
-
-A hash that stores the active worker objects, keyed by `id` field. Makes it
-easy to loop through all the workers. It is only available in the master
-process.
-
-A worker is removed from cluster.workers after the worker has disconnected _and_
-exited. The order between these two events cannot be determined in advance.
-However, it is guaranteed that the removal from the cluster.workers list happens
-before last `'disconnect'` or `'exit'` event is emitted.
-
-```js
-// Go through all workers
-function eachWorker(callback) {
-  for (var id in cluster.workers) {
-    callback(cluster.workers[id]);
-  }
-}
-eachWorker((worker) => {
-  worker.send('big announcement to all workers');
-});
-```
-
-Should you wish to reference a worker over a communication channel, using
-the worker's unique id is the easiest way to find the worker.
-
-```js
-socket.on('data', (id) => {
-  var worker = cluster.workers[id];
-});
-```
-
 [`child_process.fork()`]: child_process.html#child_process_child_process_fork_modulepath_args_options
 [`ChildProcess.send()`]: child_process.html#child_process_child_send_message_sendhandle_callback
 [`disconnect`]: child_process.html#child_process_child_disconnect
 [`kill`]: process.html#process_process_kill_pid_signal
 [`server.close()`]: net.html#net_event_close
-[Child Process module]: child_process.html#child_process_child_process_fork_modulepath_args_options
+[`ChildProcess`]: child_process.html#childprocess
 [child_process event: 'exit']: child_process.html#child_process_event_exit
 [child_process event: 'message']: child_process.html#child_process_event_message


### PR DESCRIPTION
A number of general improvements to cluster.markdown including
copyedits and revised examples