### PR TITLE
test: test each block in addon.md contains js & cc

### DIFF
--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -51,6 +51,12 @@ function once(fn) {
 function verifyFiles(files, onprogress, ondone) {
   var dir = path.resolve(verifyDir, 'doc-' + id++);
 
+  // must have a .cc and a .js to be a valid test
+  if (!Object.keys(files).some((name) => /\.cc$/.test(name)) ||
+      !Object.keys(files).some((name) => /\.js$/.test(name))) {
+    return;
+  }
+
   files = Object.keys(files).map(function(name) {
     return {
       path: path.resolve(dir, name),
@@ -58,6 +64,7 @@ function verifyFiles(files, onprogress, ondone) {
       content: files[name]
     };
   });
+
   files.push({
     path: path.resolve(dir, 'binding.gyp'),
     content: JSON.stringify({


### PR DESCRIPTION
Allows more freedom in adding additional headings to addon.markdown,
otherwise it'll try and convert each block under a heading to a test
case. We need to have at least a .js and a .cc in order to have
something to test.

Fixes regression caused by adding a new 3rd-level heading in
d5863bc0f43a3778aa773d5f5f4ad08e1d7d7497 (breaking all CI)

/cc @nodejs/build @jasnell @TheAlphaNerd 