### PR TITLE
buffer: faster case for create buffer from empty string

### DIFF
--- a/benchmark/buffers/buffer_zero.js
+++ b/benchmark/buffers/buffer_zero.js
@@ -3,16 +3,21 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  n: [1024]
+  n: [1024],
+  type: ['buffer', 'string']
 });
 
-const zero = Buffer.alloc(0);
+const zeroBuffer = Buffer.alloc(0);
+const zeroString = '';
 
 function main(conf) {
   var n = +conf.n;
   bench.start();
-  for (let i = 0; i < n * 1024; i++) {
-    Buffer.from(zero);
-  }
+
+  if (conf.type === 'buffer')
+    for (let i = 0; i < n * 1024; i++) Buffer.from(zeroBuffer);
+  else if (conf.type === 'string')
+    for (let i = 0; i < n * 1024; i++) Buffer.from(zeroString);
+
   bench.end(n);
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -170,6 +170,10 @@ function fromString(string, encoding) {
     throw new TypeError('"encoding" must be a valid string encoding');
 
   var length = byteLength(string, encoding);
+
+  if (length === 0)
+    return Buffer.alloc(0);
+
   if (length >= (Buffer.poolSize >>> 1))
     return binding.createFromString(string, encoding);
 


### PR DESCRIPTION
When create Buffer from empty string will touch
C++ binding also.

This patch can improve edge case ~70% faster.
following is benchmark results.