### PR TITLE
child_process: guard against race condition

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -675,6 +675,9 @@ function setupChannel(target, channel) {
 
 const INTERNAL_PREFIX = 'NODE_';
 function handleMessage(target, message, handle) {
+  if (!target._channel)
+    return;
+
   var eventName = 'message';
   if (message !== null &&
       typeof message === 'object' &&

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -4,6 +4,7 @@
 // Ref: https://github.com/nodejs/node/issues/4205
 
 const common = require('../common');
+const assert = require('assert');
 const net = require('net');
 const cluster = require('cluster');
 cluster.schedulingPolicy = cluster.SCHED_NONE;
@@ -17,6 +18,10 @@ if (cluster.isMaster) {
     worker1.disconnect();
     worker2.on('online', common.mustCall(worker2.disconnect));
   }));
+
+  cluster.on('exit', function(worker, code) {
+    assert.strictEqual(code, 0, 'worker exited with error');
+  });
 
   return;
 }

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// This code triggers an AssertionError on Linux in Node.js 5.3.0 and earlier.
 // Ref: https://github.com/nodejs/node/issues/4205
 
 const common = require('../common');

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Ref: https://github.com/nodejs/node/issues/4205
+
+const common = require('../common');
+const net = require('net');
+const cluster = require('cluster');
+cluster.schedulingPolicy = cluster.SCHED_NONE;
+
+if (cluster.isMaster) {
+  var worker1, worker2;
+
+  worker1 = cluster.fork();
+  worker1.on('message', common.mustCall(function() {
+    worker2 = cluster.fork();
+    worker1.disconnect();
+    worker2.on('online', common.mustCall(worker2.disconnect));
+  }));
+
+  return;
+}
+
+var server = net.createServer();
+
+server.listen(common.PORT, function() {
+  process.send('listening');
+});


### PR DESCRIPTION
It is possible that the internal handleMessage() might try to send to
a channel that has been closed. The result can be an AssertionError.
Guard against this.

Fixes: https://github.com/nodejs/node/issues/4205