### PR TITLE
test: remove unused variables form http tests

### DIFF
--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var net = require('net');
 

--- a/test/parallel/test-http-304.js
+++ b/test/parallel/test-http-304.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 var childProcess = require('child_process');

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -14,7 +14,7 @@ var server = http.Server(function(req, res) {
 var responseClose = false;
 
 server.listen(common.PORT, function() {
-  var client = http.get({
+  http.get({
     port: common.PORT,
     headers: { connection: 'keep-alive' }
 

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -45,7 +45,7 @@ server.listen(common.PORT, function() {
 });
 
 function doRequest(i) {
-  var req = http.get({
+  http.get({
     port: common.PORT,
     path: '/request' + i
   }, function(res) {

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var Agent = require('_http_agent').Agent;
-var EventEmitter = require('events').EventEmitter;
 
 var agent = new Agent({
   keepAlive: true,

--- a/test/parallel/test-http-agent-null.js
+++ b/test/parallel/test-http-agent-null.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var net = require('net');
 
 var request = 0;
 var response = 0;

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
 var http = require('http');
 
 var body = 'hello world\n';

--- a/test/parallel/test-http-client-abort2.js
+++ b/test/parallel/test-http-client-abort2.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-client-encoding.js
+++ b/test/parallel/test-http-client-encoding.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -2,7 +2,6 @@
 // see https://github.com/joyent/node/issues/3257
 
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -57,7 +57,7 @@ if (common.hasCrypto) {
     res.end('ok');
     this.close();
   }).listen(SSLPORT, function() {
-    var req = https.get({
+    https.get({
       host: 'localhost',
       rejectUnauthorized: false,
       headers: {

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -6,7 +6,6 @@ var assert = require('assert');
 // where the server has ended the socket.
 
 var http = require('http');
-var net = require('net');
 var server = http.createServer(function(req, res) {
   setImmediate(function() {
     res.destroy();

--- a/test/parallel/test-http-eof-on-connect.js
+++ b/test/parallel/test-http-eof-on-connect.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var net = require('net');
 var http = require('http');
 

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
@@ -11,9 +10,8 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req;
   for (var i = 0; i < 4; i += 1) {
-    req = http.get({ port: common.PORT, path: '/busy/' + i });
+    http.get({ port: common.PORT, path: '/busy/' + i });
   }
 });
 

--- a/test/parallel/test-http-flush.js
+++ b/test/parallel/test-http-flush.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 http.createServer(function(req, res) {

--- a/test/parallel/test-http-incoming-pipelined-socket-destroy.js
+++ b/test/parallel/test-http-incoming-pipelined-socket-destroy.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 var net = require('net');

--- a/test/parallel/test-http-keep-alive.js
+++ b/test/parallel/test-http-keep-alive.js
@@ -11,7 +11,6 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
-var connectCount = 0;
 var agent = new http.Agent({maxSockets: 1});
 var headers = {'connection': 'keep-alive'};
 var name = agent.getName({ port: common.PORT });

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -17,7 +17,7 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var req = http.request({
+  http.request({
     host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // no warnings should happen!
 var trace = console.trace;

--- a/test/parallel/test-http-no-content-length.js
+++ b/test/parallel/test-http-no-content-length.js
@@ -10,7 +10,7 @@ var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
 }).listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  http.get({port: common.PORT}, function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       body += chunk;

--- a/test/parallel/test-http-pipeline-regr-3508.js
+++ b/test/parallel/test-http-pipeline-regr-3508.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 const net = require('net');
 

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -25,7 +25,7 @@ var backend = http.createServer(function(req, res) {
 
 var proxy = http.createServer(function(req, res) {
   console.error('proxy req headers: ' + JSON.stringify(req.headers));
-  var proxy_req = http.get({
+  http.get({
     port: BACKEND_PORT,
     path: url.parse(req.url).pathname
   }, function(proxy_res) {
@@ -56,7 +56,7 @@ function startReq() {
   nlistening++;
   if (nlistening < 2) return;
 
-  var client = http.get({
+  http.get({
     port: PROXY_PORT,
     path: '/test'
   }, function(res) {

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -54,14 +54,6 @@ http.createServer(function(req, res) {
   ]);
   res.end('x f o o');
 }).listen(common.PORT, function() {
-  var expectRawHeaders = [
-    'Date',
-    'Tue, 06 Aug 2013 01:31:54 GMT',
-    'Connection',
-    'close',
-    'Transfer-Encoding',
-    'chunked'
-  ];
   var req = http.request({ port: common.PORT, path: '/' });
   req.addTrailers([
     ['x-bAr', 'yOyOyOy'],

--- a/test/parallel/test-http-regr-gh-2821.js
+++ b/test/parallel/test-http-regr-gh-2821.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -18,7 +18,7 @@ var server = http.Server(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  http.get({port: common.PORT}, function(res) {
     server.close();
   });
 });

--- a/test/parallel/test-http-server-stale-close.js
+++ b/test/parallel/test-http-server-stale-close.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var util = require('util');
 var fork = require('child_process').fork;

--- a/test/parallel/test-http-timeout.js
+++ b/test/parallel/test-http-timeout.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
 var http = require('http');
 
 var status_ok = false; // status code == 200?

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -10,7 +10,6 @@ var https = require('https');
 
 var url = require('url');
 var fs = require('fs');
-var clientRequest;
 
 // https options
 var httpsOptions = {


### PR DESCRIPTION
The http tests seem especially prone to including unused variables.
This change removes them.
