### PR TITLE
test: remove unused vars in ChildProcess tests

### DIFF
--- a/test/parallel/test-child-process-buffering.js
+++ b/test/parallel/test-child-process-buffering.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-var spawn = require('child_process').spawn;
-
 var pwd_called = false;
 var childClosed = false;
 var childExited = false;

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -1,8 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
-var path = require('path');
 
 var returns = 0;
 

--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -9,7 +9,7 @@ var success_count = 0;
 var str = 'hello';
 
 // default encoding
-var child = exec('echo ' + str, function(err, stdout, stderr) {
+exec('echo ' + str, function(err, stdout, stderr) {
   assert.ok('string', typeof(stdout), 'Expected stdout to be a string');
   assert.ok('string', typeof(stderr), 'Expected stderr to be a string');
   assert.equal(str + os.EOL, stdout);

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -16,7 +16,7 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-var child = exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
+exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
   if (err) {
     error_count++;
     console.log('error!: ' + err.code);

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -25,7 +25,6 @@ if (common.isWindows) {
 }
 
 if (process.argv[2] === 'child') {
-  var childCollected = 0;
   var server;
 
   process.on('message', function removeMe(msg, clusterServer) {

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var cp = require('child_process');
 var fs = require('fs');
 var path = require('path');
 var common = require('../common');

--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 var fork = require('child_process').fork;
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var fs = require('fs');
 var spawn = require('child_process').spawn;
 var assert = require('assert');
 

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -18,30 +18,20 @@ var response = '';
 var exitStatus = -1;
 var closed = false;
 
-var gotStdoutEOF = false;
-
 cat.stdout.setEncoding('utf8');
 cat.stdout.on('data', function(chunk) {
   console.log('stdout: ' + chunk);
   response += chunk;
 });
 
-cat.stdout.on('end', function() {
-  gotStdoutEOF = true;
-});
-
-
-var gotStderrEOF = false;
+cat.stdout.on('end', common.mustCall(function() {}));
 
 cat.stderr.on('data', function(chunk) {
   // shouldn't get any stderr output
   assert.ok(false);
 });
 
-cat.stderr.on('end', function(chunk) {
-  gotStderrEOF = true;
-});
-
+cat.stderr.on('end', common.mustCall(function() {}));
 
 cat.on('exit', function(status) {
   console.log('exit event');

--- a/test/parallel/test-child-process-stdio-inherit.js
+++ b/test/parallel/test-child-process-stdio-inherit.js
@@ -31,5 +31,5 @@ function grandparent() {
 
 function parent() {
   // should not immediately exit.
-  var child = common.spawnCat({ stdio: 'inherit' });
+  common.spawnCat({ stdio: 'inherit' });
 }

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
 
 var options = {stdio: ['pipe']};
 var child = common.spawnPwd(options);

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var path = require('path');
 
 // if child process output to console and exit
 if (process.argv[2] === 'child') {


### PR DESCRIPTION
In addition to removing unused vars, this also fixes an instance where
booleans were set presumably to check something but then never used.
This now confirms that the events that were setting the booleans are
fired.