### PR TITLE
Grab file name from file_info for accuracy

### DIFF
--- a/deps/uv/src/win/fs-event.c
+++ b/deps/uv/src/win/fs-event.c
@@ -459,9 +459,9 @@ void uv_process_fs_event_req(uv_loop_t* loop, uv_req_t* req,
               }
             }
           } else {
-            /* We already have the long name of the file, so just use it. */
-            filenamew = handle->filew;
-            sizew = -1;
+          /* Switched to using file_info->FileName for filename accuracy. handle->filew is a closest match not accurate path. */
+            filenamew = file_info->FileName;
+            sizew = file_info->FileNameLength / sizeof(WCHAR);
           }
 
           if (filenamew) {


### PR DESCRIPTION
The handle->filew out of ReadDirectoryChangesW grabs the closest match to the file but does not contain the actual file name

fs.watch('**/*.jsx');
ex. /path/to/file/filename.jsx will match /path/to/file/filename.js if you use handle->filew

Using file_info->FileName it will return an event for filename.jsx or one for filename.js but at least in this case you will be able to properly filter the value in node since you have the correct file name to match against.

There is probably more we can do in order to ensure that the event doesn't leave libuv if it doesn't match the watched file path but at least this way we can accurately do something about it.