### PR TITLE
test: extend timeout in Debug mode

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -255,6 +255,9 @@ exports.spawnPwd = function(options) {
 };
 
 exports.platformTimeout = function(ms) {
+  if (process.config.target_defaults.default_configuration === 'Debug')
+    ms = 2 * ms;
+
   if (process.arch !== 'arm')
     return ms;
 

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // this test only fails with CentOS 6.3 using kernel version 2.6.32
 // On other linuxes and darwin, the `read` call gets an ECONNRESET in


### PR DESCRIPTION
Debug mode slows execution speed. There is work afoot to enable Debug
mode runs on the continuous integration infrastructure for the project.
Some tests are timing out, such as test-net-GH-5504.js.

This change doubles the timeout returned from `common.platformTimeout()`
when running in Debug mode. It also removes an unused variable from the
aforementioned test-net-GH-5504.js.

R=@jbergstroem who hopefully can run this through CI in debug mode to confirm that it fixes a few tests