### PR TITLE
doc: fix formatting in process.markdown

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -340,7 +340,7 @@ An example of the possible output looks like:
          target_arch: 'x64',
          v8_use_snapshot: 'true' } }
 
-### process.connected
+## process.connected
 
 * {Boolean} Set to false after `process.disconnect()` is called
 


### PR DESCRIPTION
All the other properties get an h2/## but `process.connected` gets an h3/### for no discernible reason. Seems like a typo.