### PR TITLE
doc: copyedit setTimeout() documentation

### DIFF
--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -49,14 +49,14 @@ milliseconds (approximately 25 days) or less than 1, Node.js will use 1 as the
 
 ## setTimeout(callback, delay[, arg][, ...])
 
-To schedule execution of a one-time `callback` after `delay` milliseconds. Returns a
-`timeoutObject` for possible use with `clearTimeout()`. Optionally you can
-also pass arguments to the callback.
+To schedule execution of a one-time `callback` after `delay` milliseconds.
+Returns a `timeoutObject` for possible use with `clearTimeout()`. Optionally you
+can also pass arguments to the callback.
 
-It is important to note that your callback will probably not be called in exactly
-`delay` milliseconds - Node.js makes no guarantees about the exact timing of when
-the callback will fire, nor of the ordering things will fire in. The callback will
-be called as close as possible to the time specified.
+The callback will likely not be invoked in precisely `delay` milliseconds.
+Node.js makes no guarantees about the exact timing of when callbacks will fire,
+nor of their ordering. The callback will be called as close as possible to the
+time specified.
 
 To follow browser behavior, when using delays larger than 2147483647
 milliseconds (approximately 25 days) or less than 1, the timeout is executed
@@ -64,10 +64,11 @@ immediately, as if the `delay` was set to 1.
 
 ## unref()
 
-The opaque value returned by [`setTimeout`][] and [`setInterval`][] also has the method
-`timer.unref()` which will allow you to create a timer that is active but if
-it is the only item left in the event loop, it won't keep the program running.
-If the timer is already `unref`d calling `unref` again will have no effect.
+The opaque value returned by [`setTimeout`][] and [`setInterval`][] also has the
+method `timer.unref()` which will allow you to create a timer that is active but
+if it is the only item left in the event loop, it won't keep the program
+running. If the timer is already `unref`d calling `unref` again will have no
+effect.
 
 In the case of `setTimeout` when you `unref` you create a separate timer that
 will wakeup the event loop, creating too many of these may adversely effect


### PR DESCRIPTION
Copyedit the documentation for setTimeout() and enforce wrapping at 80
characters in the markdown file for nearby text.