### PR TITLE
test: remove unused assert module imports

### DIFF
--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -2,7 +2,6 @@
 // Flags: --expose-gc
 
 require('../../common');
-var assert = require('assert');
 var binding = require('./build/Release/binding');
 
 function check(size) {

--- a/test/message/2100bytes.js
+++ b/test/message/2100bytes.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 var util = require('util');
 
 console.log([

--- a/test/message/eval_messages.js
+++ b/test/message/eval_messages.js
@@ -1,7 +1,6 @@
 'use strict';
 
 require('../common');
-var assert = require('assert');
 
 var spawn = require('child_process').spawn;
 

--- a/test/message/hello_world.js
+++ b/test/message/hello_world.js
@@ -1,5 +1,4 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 console.log('hello world');

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 process.nextTick(function() {
   process.nextTick(function() {

--- a/test/message/stack_overflow.js
+++ b/test/message/stack_overflow.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 Error.stackTraceLimit = 0;
 

--- a/test/message/stdin_messages.js
+++ b/test/message/stdin_messages.js
@@ -1,7 +1,6 @@
 'use strict';
 
 require('../common');
-var assert = require('assert');
 
 var spawn = require('child_process').spawn;
 

--- a/test/message/throw_custom_error.js
+++ b/test/message/throw_custom_error.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 // custom error throwing
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });

--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,4 +1,4 @@
-*test*message*throw_custom_error.js:6
+*test*message*throw_custom_error.js:5
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });
 ^
 MyCustomError: This is a custom message

--- a/test/message/throw_in_line_with_tabs.js
+++ b/test/message/throw_in_line_with_tabs.js
@@ -1,7 +1,6 @@
 /* eslint-disable indent */
 'use strict';
 require('../common');
-var assert = require('assert');
 
 console.error('before');
 

--- a/test/message/throw_in_line_with_tabs.out
+++ b/test/message/throw_in_line_with_tabs.out
@@ -1,5 +1,5 @@
 before
-*test*message*throw_in_line_with_tabs.js:10
+*test*message*throw_in_line_with_tabs.js:9
 	throw ({ foo: 'bar' });
 	^
 [object Object]

--- a/test/message/throw_non_error.js
+++ b/test/message/throw_non_error.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 // custom error throwing
 throw ({ foo: 'bar' });

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,4 +1,4 @@
-*test*message*throw_non_error.js:6
+*test*message*throw_non_error.js:5
 throw ({ foo: 'bar' });
 ^
 [object Object]

--- a/test/message/throw_null.js
+++ b/test/message/throw_null.js
@@ -1,5 +1,4 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 throw null;

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_null.js:5
+*test*message*throw_null.js:4
 throw null;
 ^
 null

--- a/test/message/throw_undefined.js
+++ b/test/message/throw_undefined.js
@@ -1,5 +1,4 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 throw undefined;

--- a/test/message/throw_undefined.out
+++ b/test/message/throw_undefined.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_undefined.js:5
+*test*message*throw_undefined.js:4
 throw undefined;
 ^
 undefined

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 setTimeout(function() {
   undefined_reference_error_maker;

--- a/test/message/undefined_reference_in_new_context.js
+++ b/test/message/undefined_reference_in_new_context.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('before');

--- a/test/message/vm_display_runtime_error.js
+++ b/test/message/vm_display_runtime_error.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/message/vm_display_syntax_error.js
+++ b/test/message/vm_display_syntax_error.js
@@ -1,6 +1,5 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+require('../common');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/message/vm_dont_display_runtime_error.js
+++ b/test/message/vm_dont_display_runtime_error.js
@@ -1,6 +1,5 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+require('../common');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/message/vm_dont_display_syntax_error.js
+++ b/test/message/vm_dont_display_syntax_error.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 var vm = require('vm');
 
 console.error('beginning');

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -2,7 +2,6 @@
 var NUM_WORKERS = 4;
 var PACKETS_PER_WORKER = 10;
 
-var assert = require('assert');
 var cluster = require('cluster');
 var common = require('../common');
 var dgram = require('dgram');

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
@@ -20,8 +19,6 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var canSend = true;
-
 var server = tls.Server(options, function(socket) {
   setImmediate(function() {
     console.log('sending');
@@ -32,17 +29,15 @@ var server = tls.Server(options, function(socket) {
   });
 });
 
-var client;
-
 function verify() {
   console.log('verify');
-  var verified = crypto.createVerify('RSA-SHA1')
-                     .update('Test')
-                     .verify(certPem, 'asdfasdfas', 'base64');
+  crypto.createVerify('RSA-SHA1')
+    .update('Test')
+    .verify(certPem, 'asdfasdfas', 'base64');
 }
 
 server.listen(common.PORT, function() {
-  client = tls.connect({
+  tls.connect({
     port: common.PORT,
     rejectUnauthorized: false
   }, function() {

--- a/test/parallel/test-dgram-empty-packet.js
+++ b/test/parallel/test-dgram-empty-packet.js
@@ -1,8 +1,6 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
-var fs = require('fs');
 var dgram = require('dgram');
 var callbacks = 0;
 var client;

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -1,10 +1,7 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
-var fs = require('fs');
 var dgram = require('dgram');
-var callbacks = 0;
 var client, timer, buf;
 
 if (process.platform === 'darwin') {

--- a/test/parallel/test-domain-stack.js
+++ b/test/parallel/test-domain-stack.js
@@ -2,9 +2,7 @@
 // Make sure that the domain stack doesn't get out of hand.
 
 require('../common');
-var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 
 var a = domain.create();
 a.name = 'a';

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -1,11 +1,10 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 
 var repl   = require('repl');
 
 const putIn = new common.ArrayStream();
-var testMe = repl.start('', putIn);
+repl.start('', putIn);
 
 putIn.write = function(data) {
   // Don't use assert for this because the domain might catch it, and

--- a/test/parallel/test-require-extensions-main.js
+++ b/test/parallel/test-require-extensions-main.js
@@ -1,5 +1,4 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 require(common.fixturesDir + '/require-bin/bin/req.js');

--- a/test/parallel/test-stream-pipe-cleanup-pause.js
+++ b/test/parallel/test-stream-pipe-cleanup-pause.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const stream = require('stream');
 
 const reader = new stream.Readable();

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 var util = require('util');
 var stream = require('stream');

--- a/test/parallel/test-timers-non-integer-delay.js
+++ b/test/parallel/test-timers-non-integer-delay.js
@@ -16,7 +16,6 @@
  */
 
 require('../common');
-var assert = require('assert');
 
 var TIMEOUT_DELAY = 1.1;
 var NB_TIMEOUTS_FIRED = 50;

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -5,7 +5,6 @@
  */
 
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 const clients = [];

--- a/test/parallel/test-timers-unref-remove-other-unref-timers.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers.js
@@ -7,7 +7,6 @@
  * considered public interface.
  */
 const common = require('../common');
-const assert = require('assert');
 const timers = require('timers');
 
 const foo = {

--- a/test/parallel/test-timers-unrefd-interval-still-fires.js
+++ b/test/parallel/test-timers-unrefd-interval-still-fires.js
@@ -3,7 +3,6 @@
  * This test is a regression test for joyent/node#8900.
  */
 const common = require('../common');
-const assert = require('assert');
 
 const TEST_DURATION = common.platformTimeout(100);
 const N = 5;

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 

--- a/test/pummel/test-http-upload-timeout.js
+++ b/test/pummel/test-http-upload-timeout.js
@@ -3,7 +3,6 @@
 // data in random intervals. Clients are also randomly disconnecting until there
 // are no more clients left. If no false timeout occurs, this test has passed.
 var common = require('../common'),
-    assert = require('assert'),
     http = require('http'),
     server = http.createServer(),
     connections = 0;

--- a/test/pummel/test-next-tick-infinite-calls.js
+++ b/test/pummel/test-next-tick-infinite-calls.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 var complete = 0;
 

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // this test only fails with CentOS 6.3 using kernel version 2.6.32
 // On other linuxes and darwin, the `read` call gets an ECONNRESET in

--- a/test/sequential/test-regress-GH-819.js
+++ b/test/sequential/test-regress-GH-819.js
@@ -1,7 +1,6 @@
 'use strict';
 require('../common');
 var net = require('net');
-var assert = require('assert');
 
 // Connect to something that we need to DNS resolve
 var c = net.createConnection(80, 'google.com');

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -2,10 +2,6 @@
 // Make sure that sync writes to stderr get processed before exiting.
 
 require('../common');
-var assert = require('assert');
-var util = require('util');
-
-var errnoException = util._errnoException;
 
 function parent() {
   var spawn = require('child_process').spawn;


### PR DESCRIPTION
Many test modules load assert but do not use it. This change removes
those instances.

It also removes a handful of other unused variables when they were
nearby.