### PR TITLE
test: fix flaky child-process-fork-regr-gh-2847

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-child-process-fork-regr-gh-2847 : PASS,FLAKY
 test-cluster-net-send                : PASS,FLAKY
 test-cluster-shared-leak             : PASS,FLAKY
 test-tls-ticket-cluster              : PASS,FLAKY

--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -18,6 +18,13 @@ if (!cluster.isMaster) {
 }
 
 var server = net.createServer(function(s) {
+  if (common.isWindows) {
+    s.on('error', function(err) {
+      // Prevent possible ECONNRESET errors from popping up
+      if (err.code !== 'ECONNRESET' || sendcount === 0)
+        throw err;
+    });
+  }
   setTimeout(function() {
     s.destroy();
   }, 100);


### PR DESCRIPTION
Windows would die with ECONNRESET most times when running this particular test. This commit makes handling these errors more tolerable.

I'm not sure if the error handling logic is 100% correct here. Is silencing ECONNRESET errors on server-side sockets ever acceptable, or are those particular errors relevant to this test?

/cc @mhdawson @jasnell @indutny @trevnorris