### PR TITLE
test: fix flaky cluster-net-send

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-cluster-net-send                : PASS,FLAKY
 test-cluster-shared-leak             : PASS,FLAKY
 test-debug-no-context                : PASS,FLAKY
 test-tls-ticket-cluster              : PASS,FLAKY

--- a/test/parallel/test-cluster-net-send.js
+++ b/test/parallel/test-cluster-net-send.js
@@ -31,16 +31,22 @@ if (process.argv[2] !== 'child') {
 } else {
   console.error('[%d] worker', process.pid);
 
+  var socket;
+  var cbcalls = 0;
+  function socketConnected() {
+    if (++cbcalls === 2)
+      process.send('handle', socket);
+  }
+
   var server = net.createServer(function(c) {
     process.once('message', function(msg) {
       assert.equal(msg, 'got');
       c.end('hello');
     });
+    socketConnected();
   });
   server.listen(common.PORT, function() {
-    var socket = net.connect(common.PORT, '127.0.0.1', function() {
-      process.send('handle', socket);
-    });
+    socket = net.connect(common.PORT, '127.0.0.1', socketConnected);
   });
 
   process.on('disconnect', function() {


### PR DESCRIPTION
Before this commit, it was possible on Windows for the server's 'connection' handler to be called *after* the client socket's 'connect' handler. This caused the 'message' event to be missed and the test would never end (timing out in CI). This problem was more easily reproducible on a low resource (slow CPU) Windows (2012r2) installation.

This commit waits until both handlers have been called before sending the handle to the master process.