### PR TITLE
doc: mention that http.Server inherits from net.Server

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -395,7 +395,7 @@ Returns `request`.
 
 ## Class: http.Server
 
-This is an [`EventEmitter`][] with the following events:
+This class inherits from [`net.Server`][] and has the following additional events:
 
 ### Event: 'checkContinue'
 
@@ -1096,6 +1096,7 @@ There are a few special headers that should be noted.
 [`http.Server`]: #http_class_http_server
 [`http.ServerResponse`]: #http_class_http_serverresponse
 [`message.headers`]: #http_message_headers
+[`net.Server`]: net.html#net_class_net_server
 [`net.Server.close()`]: net.html#net_server_close_callback
 [`net.Server.listen()`]: net.html#net_server_listen_handle_callback
 [`net.Server.listen(path)`]: net.html#net_server_listen_path_callback


### PR DESCRIPTION
As a Node beginner, it wasn't immediately obvious to me that `http.Server` inherits from `net.Server` until I read the source.