### PR TITLE
http: fix non-string header value concatenation

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -165,7 +165,7 @@ IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
 
     default:
       // make comma-separated list
-      if (dest[field] !== undefined) {
+      if (typeof dest[field] === 'string') {
         dest[field] += ', ' + value;
       } else {
         dest[field] = value;

--- a/test/parallel/test-http-server-multiheaders.js
+++ b/test/parallel/test-http-server-multiheaders.js
@@ -16,6 +16,7 @@ var srv = http.createServer(function(req, res) {
   assert.equal(req.headers['x-bar'], 'banjo, bango');
   assert.equal(req.headers['sec-websocket-protocol'], 'chat, share');
   assert.equal(req.headers['sec-websocket-extensions'], 'foo; 1, bar; 2, baz');
+  assert.equal(req.headers['constructor'], 'foo, bar, baz');
 
   res.writeHead(200, {'Content-Type' : 'text/plain'});
   res.end('EOF');
@@ -48,7 +49,10 @@ srv.listen(common.PORT, function() {
       ['sec-websocket-protocol', 'share'],
       ['sec-websocket-extensions', 'foo; 1'],
       ['sec-websocket-extensions', 'bar; 2'],
-      ['sec-websocket-extensions', 'baz']
+      ['sec-websocket-extensions', 'baz'],
+      ['constructor', 'foo'],
+      ['constructor', 'bar'],
+      ['constructor', 'baz'],
     ]
   });
 });


### PR DESCRIPTION
Since headers are stored in an empty literal object (`{}`) instead of an object created with `Object.create(null)`, care must be taken with property names inherited from Object. Currently there are
only functions inherited, so we can safely check for existing strings instead.

Fixes: https://github.com/nodejs/node/issues/4456