### PR TITLE
test: improve assert message

### DIFF
--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -42,7 +42,8 @@ var notSocketClient = net.createConnection(emptyTxt, function() {
 });
 
 notSocketClient.on('error', function(err) {
-  assert(err.code === 'ENOTSOCK' || err.code === 'ECONNREFUSED');
+  assert(err.code === 'ENOTSOCK' || err.code === 'ECONNREFUSED',
+    `received ${err.code} instead of ENOTSOCK or ECONNREFUSED`);
   notSocketErrorFired = true;
 });
 


### PR DESCRIPTION
Improves the message when an assertion fires in the
test-net-pipe-connect-errors so that it indicates the incorrect value
received rather than merely reporting that the value is incorrect.