### PR TITLE
test: clarify role of domains in microtask queue tests

### DIFF
--- a/test/parallel/test-microtask-queue-integration-domain.js
+++ b/test/parallel/test-microtask-queue-integration-domain.js
@@ -1,7 +1,13 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-var domain = require('domain');
+
+// Requiring the domain module here changes the function that is used by node to
+// call process.nextTick's callbacks to a variant that specifically handles
+// domains. We want to test this specific variant in this test, and so even if
+// the domain module is not used, this require call is needed and must not be
+// removed.
+require('domain');
 
 var implementations = [
   function(fn) {

--- a/test/parallel/test-microtask-queue-run-domain.js
+++ b/test/parallel/test-microtask-queue-run-domain.js
@@ -1,7 +1,13 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-var domain = require('domain');
+
+// Requiring the domain module here changes the function that is used by node to
+// call process.nextTick's callbacks to a variant that specifically handles
+// domains. We want to test this specific variant in this test, and so even if
+// the domain module is not used, this require call is needed and must not be
+// removed.
+require('domain');
 
 function enqueueMicrotask(fn) {
   Promise.resolve().then(fn);

--- a/test/parallel/test-microtask-queue-run-immediate-domain.js
+++ b/test/parallel/test-microtask-queue-run-immediate-domain.js
@@ -1,7 +1,13 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-var domain = require('domain');
+
+// Requiring the domain module here changes the function that is used by node to
+// call process.nextTick's callbacks to a variant that specifically handles
+// domains. We want to test this specific variant in this test, and so even if
+// the domain module is not used, this require call is needed and must not be
+// removed.
+require('domain');
 
 function enqueueMicrotask(fn) {
   Promise.resolve().then(fn);


### PR DESCRIPTION
   Add this comment:
    
    > Requiring domain calls _setupDomainUse which in turns changes the
    > tickCallback function that is used to call callbacks scheduled with
    > process.nextTick.
    >
    > So requiring domain tests the _tickDomainCallback function, whereas
    > the tests equivalent tests without domain test the _tickCallback
    > function.
    
Also removes unnecessary assignment of domain module to a variable.

R: @misterdjules 
R: @jasnell