### PR TITLE
test: remove unused modules

### DIFF
--- a/test/addons/at-exit/test.js
+++ b/test/addons/at-exit/test.js
@@ -1,3 +1,3 @@
 'use strict';
 require('../../common');
-var binding = require('./build/Release/binding');
+require('./build/Release/binding');

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv4 = net.isIPv4;
-var util = require('util');
 
 var expected = 0,
     completed = 0,

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv6 = net.isIPv6;
-var util = require('util');
 
 var expected = 0,
     completed = 0,

--- a/test/message/2100bytes.js
+++ b/test/message/2100bytes.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var util = require('util');
 
 console.log([
   '_______________________________________________50',

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -5,7 +5,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var cluster = require('cluster');
 var fork = require('child_process').fork;
 var net = require('net');
 

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
-var net = require('net');
 
 var SENTINEL = 42;
 

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -11,7 +11,6 @@ var crypto = require('crypto');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 var fs = require('fs');
-var path = require('path');
 
 // Test Certificates
 var spkacValid = fs.readFileSync(common.fixturesDir + '/spkac.valid');

--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -2,9 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs');
 var dgram = require('dgram');
-var callbacks = 0;
 var client, timer, buf, len, offset;
 
 

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -2,8 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs'),
-    dgram = require('dgram'), server, client,
+var dgram = require('dgram'), server, client,
     server_port = common.PORT,
     message_to_send = 'A message to send',
     timer;

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -4,7 +4,6 @@
 var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 
 var caughtA = false;
 var caughtB = false;

--- a/test/parallel/test-eval-require.js
+++ b/test/parallel/test-eval-require.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
-var path = require('path');
-var fs = require('fs');
 
 var options = {
   cwd: common.fixturesDir

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -2,7 +2,6 @@
 
 require('../common');
 var assert = require('assert');
-var events = require('events');
 
 var EventEmitter = require('events').EventEmitter;
 var assert = require('assert');

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const readdirDir = common.tmpDir;

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 var cluster = require('cluster');
 
 console.error('Cluster listen fd test', process.argv[2] || 'runner');

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 
 if (common.isWindows) {
   console.log('1..0 # Skipped: This test is disabled on windows.');

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var EventEmitter = require('events').EventEmitter;
 var PassThrough = require('stream').PassThrough;
 var assert = require('assert');
 var inherits = require('util').inherits;
@@ -16,7 +15,7 @@ inherits(FakeInput, PassThrough);
 
 var fi = new FakeInput();
 var fo = new FakeInput();
-var rli = new Interface({ input: fi, output: fo, terminal: true });
+new Interface({ input: fi, output: fo, terminal: true });
 
 var keys = [];
 fi.on('keypress', function(s, k) {

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -1,7 +1,6 @@
 'use strict';
 var fs = require('fs');
 var assert = require('assert');
-var path = require('path');
 var cp = require('child_process');
 var common = require('../common');
 

--- a/test/parallel/test-tls-legacy-onselect.js
+++ b/test/parallel/test-tls-legacy-onselect.js
@@ -9,13 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 var net = require('net');
 
-var fs = require('fs');
-
 var success = false;
-
-function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
-}
 
 var server = net.Server(function(raw) {
   var pair = tls.createSecurePair(null, true, false, false);

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -4,7 +4,6 @@
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 
 const spdyDict = new Buffer([
   'optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-',

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -2,7 +2,6 @@
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 
 const bigData = new Buffer(10240).fill('x');
 

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
-var fs = require('fs');
 
 var gzip = zlib.createGzip();
 var gunz = zlib.createUnzip();

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var os = require('os');
-var util = require('util');
 
 if (os.type() != 'SunOS') {
   console.log('1..0 # Skipped: no DTRACE support');
@@ -13,7 +12,6 @@ if (os.type() != 'SunOS') {
  * Some functions to create a recognizable stack.
  */
 var frames = [ 'stalloogle', 'bagnoogle', 'doogle' ];
-var expected;
 
 var stalloogle = function(str) {
   expected = str;
@@ -35,7 +33,6 @@ var doogle = function() {
 
 var spawn = require('child_process').spawn;
 var prefix = '/var/tmp/node';
-var corefile = prefix + '.' + process.pid;
 
 /*
  * We're going to use DTrace to stop us, gcore us, and set us running again

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var net = require('net'),
-    util = require('util'),
     http = require('http');
 
 var errorCount = 0;

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -5,7 +5,6 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var http = require('http');
-var path = require('path');
 var url = require('url');
 
 if (common.isWindows) {

--- a/test/pummel/test-timer-wrap2.js
+++ b/test/pummel/test-timer-wrap2.js
@@ -1,9 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 // Test that allocating a timer does not increase the loop's reference
 // count.
 
 var Timer = process.binding('timer_wrap').Timer;
-var t = new Timer();
+new Timer();

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -17,9 +17,7 @@ var join = require('path').join;
 var net = require('net');
 var assert = require('assert');
 var fs = require('fs');
-var crypto = require('crypto');
 var tls = require('tls');
-var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 
 test1();
@@ -46,8 +44,6 @@ function test(keyfn, certfn, check, next) {
   // the openssl s_server thus causing many tests to fail with
   // EADDRINUSE.
   var PORT = common.PORT + 5;
-
-  var connections = 0;
 
   keyfn = join(common.fixturesDir, keyfn);
   var key = fs.readFileSync(keyfn).toString();

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var os = require('os');
 
 var execSync = require('child_process').execSync;
 var execFileSync = require('child_process').execFileSync;

--- a/test/sequential/test-regress-GH-1697.js
+++ b/test/sequential/test-regress-GH-1697.js
@@ -1,8 +1,7 @@
 'use strict';
 var common = require('../common');
 var net = require('net'),
-    cp = require('child_process'),
-    util = require('util');
+    cp = require('child_process');
 
 if (process.argv[2] === 'server') {
   // Server

--- a/test/sequential/test-stdout-close-catch.js
+++ b/test/sequential/test-stdout-close-catch.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var child_process = require('child_process');
-var fs = require('fs');
 
 var testScript = path.join(common.fixturesDir, 'catch-stdout-error.js');
 


### PR DESCRIPTION
Many tests use `require()` to import modules that subsequently never gets
used. This removes those imports and, in a few cases, removes other
unused variables from tests.

I'm especially looking for review on the tests in `test/pummel` as I'm not 100% clear on how those tests work. It seems like a number of them were failing already prior to these changes (judging from results running `make test-pummel` on OS X).