### PR TITLE
test: shorten path for bogus socket

### DIFF
--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -19,10 +19,12 @@ if (common.isWindows) {
   // file instead
   emptyTxt = path.join(common.fixturesDir, 'empty.txt');
 } else {
-  // use common.PIPE to ensure we stay within POSIX socket path length
-  // restrictions, even on CI
   common.refreshTmpDir();
-  emptyTxt = common.PIPE + '.txt';
+  // Keep the file name very short so tht we don't exceed the 108 char limit
+  // on CI for a POSIX socket. Even though this isn't actually a socket file,
+  // the error will be different from the one we are expecting if we exceed the
+  // limit.
+  emptyTxt = common.tmpDir + '0.txt';
 
   function cleanup() {
     try {


### PR DESCRIPTION
This (hopefully) fixes CI failures for test-net-pipe-connect-errors on Raspberry Pi
devices.