### PR TITLE
events: make sure console functions exist

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -240,7 +240,8 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
                            'leak detected. %d %s listeners added. ' +
                            'Use emitter.setMaxListeners() to increase limit.',
                            existing.length, type);
-        console.trace();
+        if (console.trace)
+          console.trace();
       }
     }
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -19,7 +19,20 @@ EventEmitter.prototype._maxListeners = undefined;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
 // added to it. This is a useful default which helps finding memory leaks.
-EventEmitter.defaultMaxListeners = 10;
+var defaultMaxListeners = 10;
+
+Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
+  enumerable: true,
+  get: function() {
+    return defaultMaxListeners;
+  },
+  set: function(arg) {
+    // force global console to be compiled.
+    // see https://github.com/nodejs/node/issues/4467
+    console;
+    defaultMaxListeners = arg;
+  }
+});
 
 EventEmitter.init = function() {
   this.domain = null;
@@ -240,8 +253,7 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
                            'leak detected. %d %s listeners added. ' +
                            'Use emitter.setMaxListeners() to increase limit.',
                            existing.length, type);
-        if (console.trace)
-          console.trace();
+        console.trace();
       }
     }
   }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -25,7 +25,8 @@ exports.error = function(msg) {
     args[0] = fmt;
     for (let i = 1; i < arguments.length; ++i)
       args[i] = arguments[i];
-    console.error.apply(console, args);
+    if (console.error)
+      console.error.apply(console, args);
   } else {
     console.error(fmt);
   }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -25,8 +25,7 @@ exports.error = function(msg) {
     args[0] = fmt;
     for (let i = 1; i < arguments.length; ++i)
       args[i] = arguments[i];
-    if (console.error)
-      console.error.apply(console, args);
+    console.error.apply(console, args);
   } else {
     console.error(fmt);
   }

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const events = require('events');
+
+const old_default = events.defaultMaxListeners;
+events.defaultMaxListeners = 1;
+
+const e = new events.EventEmitter();
+e.on('hello', function() {});
+
+assert.ok(!e._events['hello'].hasOwnProperty('warned'));
+
+e.on('hello', function() {});
+
+assert.ok(e._events['hello'].hasOwnProperty('warned'));
+
+events.defaultMaxListeners = old_default;
+
+// this caches console, so place it after the test just to appease the linter
+require('../common');

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const assert = require('assert');
-const events = require('events');
+const EventEmitter = require('events');
 const leak_warning = /EventEmitter memory leak detected\. 2 hello listeners/;
 
 var write_calls = 0;
@@ -20,13 +20,13 @@ process.stderr.write = function(data) {
   write_calls++;
 };
 
-const old_default = events.defaultMaxListeners;
-events.defaultMaxListeners = 1;
+const old_default = EventEmitter.defaultMaxListeners;
+EventEmitter.defaultMaxListeners = 1;
 
-const e = new events.EventEmitter();
+const e = new EventEmitter();
 e.on('hello', function() {});
 e.on('hello', function() {});
 
 assert.equal(write_calls, 2);
 
-events.defaultMaxListeners = old_default;
+EventEmitter.defaultMaxListeners = old_default;

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -2,18 +2,28 @@
 
 const assert = require('assert');
 const events = require('events');
+const leak_warning = /EventEmitter memory leak detected. 2 hello listeners/;
+
+var write_calls = 0;
+process.stderr.write = function(data) {
+  if (write_calls === 0)
+    assert.ok(data.match(leak_warning));
+  else if (write_calls === 1)
+    assert.ok(data.match(/Trace/));
+  else
+    assert.ok(false, 'stderr.write should be called only twice');
+
+  write_calls++;
+};
 
 const old_default = events.defaultMaxListeners;
 events.defaultMaxListeners = 1;
 
 const e = new events.EventEmitter();
 e.on('hello', function() {});
-
-assert.ok(!e._events['hello'].hasOwnProperty('warned'));
-
 e.on('hello', function() {});
 
-assert.ok(e._events['hello'].hasOwnProperty('warned'));
+assert.equal(write_calls, 2);
 
 events.defaultMaxListeners = old_default;
 

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -1,8 +1,12 @@
+/* eslint-disable required-modules */
+// ordinarily test files must require('common') but that action causes
+// the global console to be compiled, defeating the purpose of this test
+
 'use strict';
 
 const assert = require('assert');
 const events = require('events');
-const leak_warning = /EventEmitter memory leak detected. 2 hello listeners/;
+const leak_warning = /EventEmitter memory leak detected\. 2 hello listeners/;
 
 var write_calls = 0;
 process.stderr.write = function(data) {
@@ -26,6 +30,3 @@ e.on('hello', function() {});
 assert.equal(write_calls, 2);
 
 events.defaultMaxListeners = old_default;
-
-// this caches console, so place it after the test just to appease the linter
-require('../common');

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -27,6 +27,7 @@ const e = new EventEmitter();
 e.on('hello', function() {});
 e.on('hello', function() {});
 
+// TODO validate console
 assert.equal(write_calls, 2);
 
 EventEmitter.defaultMaxListeners = old_default;


### PR DESCRIPTION
If there's no global console cached, these calls will initialize it,
which in some cases can cause a circular dependency, making the console
received here an empty object. The program shouldn't crash in this case.

Fixes https://github.com/nodejs/node/issues/4467