### PR TITLE
Http(s) Agent: handle errors on idle sockets

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -282,6 +282,13 @@ function socketErrorListener(err) {
   socket.destroy();
 }
 
+function freeSocketErrorListener(err) {
+  var socket = this;
+  debug('SOCKET ERROR on FREE socket:', err.message, err.stack);
+  socket.destroy();
+  socket.emit('agentRemove');
+}
+
 function socketOnEnd() {
   var socket = this;
   var req = this._httpMessage;
@@ -448,6 +455,7 @@ function responseOnEnd() {
     }
     socket.removeListener('close', socketCloseListener);
     socket.removeListener('error', socketErrorListener);
+    socket.once('error', freeSocketErrorListener);
     // Mark this socket as available, AFTER user-added end
     // handlers have a chance to run.
     process.nextTick(emitFreeNT, socket);
@@ -483,6 +491,7 @@ function tickOnSocket(req, socket) {
   }
 
   parser.onIncoming = parserOnIncomingClient;
+  socket.removeListener('error', freeSocketErrorListener);
   socket.on('error', socketErrorListener);
   socket.on('data', socketOnData);
   socket.on('end', socketOnEnd);

--- a/test/parallel/test-http-agent-error-on-idle.js
+++ b/test/parallel/test-http-agent-error-on-idle.js
@@ -1,0 +1,56 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+var Agent = http.Agent;
+
+var agent = new Agent({
+  keepAlive: true,
+});
+
+var requestParams = {
+  host: 'localhost',
+  port: common.PORT,
+  agent: agent,
+  path: '/'
+};
+
+var socketKey = agent.getName(requestParams);
+
+function get(callback) {
+  return http.get(requestParams, callback);
+}
+
+var destroy_queue = {};
+var server = http.createServer(function(req, res) {
+  res.end('hello world');
+});
+
+server.listen(common.PORT, function() {
+  get(function(res) {
+    assert.equal(res.statusCode, 200);
+    res.resume();
+    res.on('end', function() {
+      process.nextTick(function() {
+        var freeSockets = agent.freeSockets[socketKey];
+        assert.equal(freeSockets.length, 1,
+                     'expect a free socket on ' + socketKey);
+
+        //generate a random error on the free socket
+        var freeSocket = freeSockets[0];
+        freeSocket.emit('error', new Error('ECONNRESET: test'));
+
+        get(done);
+      });
+    });
+  });
+});
+
+function done() {
+  assert.equal(Object.keys(agent.freeSockets).length, 0,
+              'expect the freeSockets pool to be empty');
+
+  agent.destroy();
+  server.close();
+  process.exit(0);
+}


### PR DESCRIPTION
This is my proposed fix for #3595.

This change adds a new error handler on every socket when the socket is *idle*.

If there is an error on the tcp connection, eg: the server abruptly close the connection while the socket is idle then we destroy the socket and remove it from the pool of free sockets.