### PR TITLE
node: improve performance of process.hrtime()

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2138,17 +2138,7 @@ void Kill(const FunctionCallbackInfo<Value>& args) {
 // and nanoseconds, to avoid any integer overflow possibility.
 // Pass in an Array from a previous hrtime() call to instead get a time diff.
 void Hrtime(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   uint64_t t = uv_hrtime();
-
-  if (!args[1]->IsUndefined()) {
-    if (!args[1]->IsArray()) {
-      return env->ThrowTypeError(
-          "process.hrtime() only accepts an Array tuple");
-    }
-    args.GetReturnValue().Set(true);
-  }
 
   Local<ArrayBuffer> ab = args[0].As<Uint32Array>()->Buffer();
   uint32_t* fields = static_cast<uint32_t*>(ab->GetContents().Data());

--- a/src/node.js
+++ b/src/node.js
@@ -192,15 +192,23 @@
     }
 
     process.hrtime = function hrtime(ar) {
-      const ret = [0, 0];
-      if (_hrtime(hrValues, ar)) {
-        ret[0] = (hrValues[0] * 0x100000000 + hrValues[1]) - ar[0];
-        ret[1] = hrValues[2] - ar[1];
-      } else {
-        ret[0] = hrValues[0] * 0x100000000 + hrValues[1];
-        ret[1] = hrValues[2];
+      _hrtime(hrValues);
+
+      if (typeof ar !== 'undefined') {
+        if (Array.isArray(ar)) {
+          return [
+            (hrValues[0] * 0x100000000 + hrValues[1]) - ar[0],
+            hrValues[2] - ar[1]
+          ];
+        }
+
+        throw new TypeError('process.hrtime() only accepts an Array tuple');
       }
-      return ret;
+
+      return [
+        hrValues[0] * 0x100000000 + hrValues[1],
+        hrValues[2]
+      ];
     };
   };
 


### PR DESCRIPTION
Move argument validation out of C++ and into JS. Improves performance
by about 15-20%.

Benchmark comparisons between current master and this branch are below:

```
$ node benchmark/compare.js ./node ./node_before  -- misc bench-hrtime
running ./node
misc/bench-hrtime.js
running ./node_before
misc/bench-hrtime.js

misc/bench-hrtime.js n=1000000: ./node: 13037000 ./node_before: 10677000 . 22.11%

   
$ node benchmark/compare.js ./node ./node_before  -- misc bench-hrtime
running ./node
misc/bench-hrtime.js
running ./node_before
misc/bench-hrtime.js

misc/bench-hrtime.js n=1000000: ./node: 12954000 ./node_before: 10642000 . 21.73%

   
$ node benchmark/compare.js ./node ./node_before  -- misc bench-hrtime
running ./node
misc/bench-hrtime.js
running ./node_before
misc/bench-hrtime.js

misc/bench-hrtime.js n=1000000: ./node: 13322000 ./node_before: 10770000 . 23.69%
```

R= @trevnorris 