### PR TITLE
doc: improvements to globals.markdown copy

### DIFF
--- a/doc/api/globals.markdown
+++ b/doc/api/globals.markdown
@@ -229,7 +229,7 @@ Because the Module system is Node.js is [Locked][], it is unlikely that this
 feature will be removed entirely. However, the mechanism is considered to be
 unsupported and should not be used.
 
-Note that files with the extension `*.sjs` and processed as `*.js` files.
+Note that files with the extension `*.sjs` are processed as `*.js` files.
 
     require.extensions['.sjs'] = require.extensions['.js'];
 

--- a/doc/api/globals.markdown
+++ b/doc/api/globals.markdown
@@ -2,18 +2,146 @@
 
 <!-- type=misc -->
 
-These objects are available in all modules. Some of these objects aren't
-actually in the global scope but in the module scope - this will be noted.
+Node.js provides a number of global and module scope variables that are
+generally accessible to all modules.
 
-## Class: Buffer
+## Global-scope Variables
+
+### `Buffer`
 
 <!-- type=global -->
 
 * {Function}
 
-Used to handle binary data. See the [buffer section][].
+The `Buffer` class is used to handle binary data. See the
+[`Buffer` documentation][] for information.
 
-## __dirname
+### `clearInterval(t)`
+
+<!--type=global-->
+
+Stops a timer that was previously created with [`setInterval()`][]. The timers
+callback function will not be called. See the [Timers documentation][] for
+information.
+
+### `clearTimeout(t)`
+
+<!-- type=global -->
+
+Stops a timer that was previously created with [`setTimeout()`][]. The timers
+callback function will not be called. See the [Timers documentation][] for
+information.
+
+### `console`
+
+<!-- type=global -->
+
+* {Object}
+
+A `Console` object used to print to log information to stdout and
+stderr. See the [`Console` documentation][] for information.
+
+### `global`
+
+<!-- type=global -->
+
+* {Object} The global namespace object.
+
+Unlike browsers, which use a single top-level global scope, Node.js modules
+have a global and module scope.
+
+Any JavaScript that is run from a `*.js` file is run within a module scope.
+This means that when a variable is defined using, for instance,
+`var something = 1`, the variable is defined only within the scope of that one
+`*.js` file.
+
+On the other hand, when running JavaScript directly from the Node.js command
+line REPL, variables are defined in the global scope.
+
+The `global` object provides access to all available globally defined variables.
+
+For example, given the following JavaScript file `myScript.js`:
+
+    // myScript.js
+    const something = 1;
+    console.log(something);
+    console.log(global.something);
+    
+When the `myScript.js` file is run directly from the command line using
+`node myScript.js`, the output is:
+
+    $ node myScript.js
+    1
+    undefined
+    
+However, when the same code is run from the Node.js REPL, the output changes:
+
+    $ node
+    > const something = 1;
+    undefined
+    > console.log(something);
+    1
+    undefined
+    > console.log(global.something);
+    1
+    undefined
+
+### `process`
+
+<!-- type=global -->
+
+* {Object}
+
+References the `Process` object representing the current running Node.js
+process. See the [`Process` documentation][] for information.
+
+### `setImmediate(callback)`
+
+the `setImmediate()` method schedules a `callback` function to be run on the
+immediate next tick of the Node.js event loop. See the [Timers documentation][]
+for more information.
+
+### `setInterval(callback, ms)`
+
+The `setInterval()` method creates a Timer that will call the `callback`
+function repeatedly every `ms` milliseconds. Note that the actual
+interval may vary, depending on external factors such as operating system
+timer granularity and system load. The `callback` will never be called in less
+than `ms` milliseconds but it may be longer.
+
+The interval must be in the range of 1-2,147,483,647 (inclusive). If the value
+is outside of that range, the value is changed to 1 millisecond. Broadly
+speaking, a timer cannot span more than 24.8 days.
+
+The method returns an object representing the timer than can be passed later
+to the `clearInterval()` method to halt further calling of the `callback`
+function.
+
+See the [Timers documentation][] for more information.
+
+### `setTimeout(callback, ms)`
+
+The `setTimeout()` method creates a Timer that will call the `callback`
+function after *at least* `ms` milliseconds. The actual delay depends
+on external factors such as the operating system timer granularity and system
+load.
+
+The timeout must be in the range of 1-2,147,483,647 (inclusive). If the value is
+outside that range, the value is changed to 1 millisecond. Broadly speaking, a
+timer cannot span more than 24.8 days.
+
+The method returns an object representing the timer than can be passed later
+to the `clearTimeout()` method to halt further calling of the `callback`
+function.
+
+See the [Timers documentation][] for more information.
+
+## Module-scope Variables
+
+Module-scoped variables are accessible to all modules but are not true
+globals.
+
+### `__dirname`
 
 <!-- type=var -->
 
@@ -24,11 +152,9 @@ The name of the directory that the currently executing script resides in.
 Example: running `node example.js` from `/Users/mjr`
 
     console.log(__dirname);
-    // /Users/mjr
+      // Prints: /Users/mjr
 
-`__dirname` isn't actually a global but rather local to each module.
-
-## __filename
+### `__filename`
 
 <!-- type=var -->
 
@@ -42,148 +168,84 @@ to that module file.
 Example: running `node example.js` from `/Users/mjr`
 
     console.log(__filename);
-    // /Users/mjr/example.js
+      // Prints: /Users/mjr/example.js
 
-`__filename` isn't actually a global but rather local to each module.
-
-## clearInterval(t)
-
-Stop a timer that was previously created with [`setInterval()`][]. The callback
-will not execute.
-
-<!--type=global-->
-
-The timer functions are global variables. See the [timers][] section.
-
-## clearTimeout(t)
-
-Stop a timer that was previously created with [`setTimeout()`][]. The callback will
-not execute.
-
-## console
-
-<!-- type=global -->
-
-* {Object}
-
-Used to print to stdout and stderr. See the [`console`][] section.
-
-## exports
+### `exports`
 
 <!-- type=var -->
 
-A reference to the `module.exports` that is shorter to type.
-See [module system documentation][] for details on when to use `exports` and
-when to use `module.exports`.
+A reference to the `module.exports`. See the [Module system documentation][]
+for details on when to use `exports` and when to use `module.exports`.
 
-`exports` isn't actually a global but rather local to each module.
-
-See the [module system documentation][] for more information.
-
-## global
-
-<!-- type=global -->
-
-* {Object} The global namespace object.
-
-In browsers, the top-level scope is the global scope. That means that in
-browsers if you're in the global scope `var something` will define a global
-variable. In Node.js this is different. The top-level scope is not the global
-scope; `var something` inside an Node.js module will be local to that module.
-
-## module
+### `module`
 
 <!-- type=var -->
 
 * {Object}
 
-A reference to the current module. In particular
-`module.exports` is used for defining what a module exports and makes
-available through `require()`.
+A reference to the current module. In particular, `module.exports` is used to
+define what a module exports and makes available through `require()`.
 
-`module` isn't actually a global but rather local to each module.
+See the [Module system documentation][] for more information.
 
-See the [module system documentation][] for more information.
+## Global and Module Scope
 
-## process
+Certain variables are defined at *both* the global and module scopes. The
+specific operation of these can vary depending on the current scope in
+which JavaScript code is executing.
 
-<!-- type=global -->
-
-* {Object}
-
-The process object. See the [`process` object][] section.
-
-## require()
+### `require()`
 
 <!-- type=var -->
 
 * {Function}
 
-To require modules. See the [Modules][] section.  `require` isn't actually a
-global but rather local to each module.
+The `require()` method is the primary mechanism for importing the functionality
+of another module into the current module. See the
+[Module system documentation][] for more information.
 
-### require.cache
+### `require.cache`
 
 * {Object}
 
 Modules are cached in this object when they are required. By deleting a key
-value from this object, the next `require` will reload the module.
+value from this object, the next `require()` will reload the module.
 
-### require.extensions
+### `require.extensions`
 
     Stability: 0 - Deprecated
 
 * {Object}
 
-Instruct `require` on how to handle certain file extensions.
+Used to instruct `require` on how to handle certain file extensions.
 
-Process files with the extension `.sjs` as `.js`:
-
-    require.extensions['.sjs'] = require.extensions['.js'];
-
-**Deprecated**  In the past, this list has been used to load
+**Deprecated**: Historically, this list has been used to load
 non-JavaScript modules into Node.js by compiling them on-demand.
-However, in practice, there are much better ways to do this, such as
+In practice, however, there are much better ways to do this, such as
 loading modules via some other Node.js program, or compiling them to
 JavaScript ahead of time.
 
-Since the Module system is locked, this feature will probably never go
-away.  However, it may have subtle bugs and complexities that are best
-left untouched.
+Because the Module system is Node.js is [Locked][], it is unlikely that this
+feature will be removed entirely. However, the mechanism is considered to be
+unsupported and should not be used.
 
-### require.resolve()
+Note that files with the extension `*.sjs` and processed as `*.js` files.
 
-Use the internal `require()` machinery to look up the location of a module,
-but rather than loading the module, just return the resolved filename.
+    require.extensions['.sjs'] = require.extensions['.js'];
 
-## setInterval(cb, ms)
+### `require.resolve()`
 
-Run callback `cb` repeatedly every `ms` milliseconds. Note that the actual
-interval may vary, depending on external factors like OS timer granularity and
-system load. It's never less than `ms` but it may be longer.
+The `require.resolve()` method is part of the internal machinery that allows
+the `require()` method to resolve the location of a module in the file
+system. Rather than loading the module, however, the `require.resolve()`
+method simply returns the resolved filename.
 
-The interval must be in the range of 1-2,147,483,647 inclusive. If the value is
-outside that range, it's changed to 1 millisecond. Broadly speaking, a timer
-cannot span more than 24.8 days.
 
-Returns an opaque value that represents the timer.
-
-## setTimeout(cb, ms)
-
-Run callback `cb` after *at least* `ms` milliseconds. The actual delay depends
-on external factors like OS timer granularity and system load.
-
-The timeout must be in the range of 1-2,147,483,647 inclusive. If the value is
-outside that range, it's changed to 1 millisecond. Broadly speaking, a timer
-cannot span more than 24.8 days.
-
-Returns an opaque value that represents the timer.
-
-[`console`]: console.html
-[`process` object]: process.html#process_process
-[`setInterval()`]: #globals_setinterval_cb_ms
-[`setTimeout()`]: #globals_settimeout_cb_ms
-[buffer section]: buffer.html
-[module system documentation]: modules.html
-[Modules]: modules.html#modules_modules
-[timers]: timers.html
+[`Console` documentation]: console.html
+[`Process` documentation]: process.html#process_process
+[`setInterval()`]: #globals_setinterval_callback_ms
+[`setTimeout()`]: #globals_settimeout_callback_ms
+[`Buffer` documentation]: buffer.html
+[Module system documentation]: modules.html
+[Timers documentation]: timers.html
+[Locked]: documentation.html#documentation_stability_index


### PR DESCRIPTION
General improvements to the globals.markdown copy,
including restructuring, improving examples, and
adding `setImmediate()` which had oddly been omitted.