### PR TITLE
test: refactor test-fs-empty-readStream

### DIFF
--- a/test/parallel/test-fs-empty-readStream.js
+++ b/test/parallel/test-fs-empty-readStream.js
@@ -15,15 +15,7 @@ fs.open(emptyFile, 'r', function(error, fd) {
     throw new Error('data event should not emit');
   });
 
-  var readEmit = false;
-  read.once('end', function() {
-    readEmit = true;
-    console.error('end event 1');
-  });
-
-  setTimeout(function() {
-    assert.equal(readEmit, true);
-  }, common.platformTimeout(50));
+  read.once('end', common.mustCall(function endEvent1() {}));
 });
 
 fs.open(emptyFile, 'r', function(error, fd) {
@@ -36,13 +28,11 @@ fs.open(emptyFile, 'r', function(error, fd) {
     throw new Error('data event should not emit');
   });
 
-  var readEmit = false;
-  read.once('end', function() {
-    readEmit = true;
-    console.error('end event 2');
+  read.once('end', function endEvent2() {
+    throw new Error('end event should not emit');
   });
 
   setTimeout(function() {
-    assert.equal(readEmit, false);
+    assert.equal(read.isPaused(), true);
   }, common.platformTimeout(50));
 });


### PR DESCRIPTION
Refactor test to remove unnecessary booleans and one unnecesary timer.
Instead, throw Error objects where appropriate and rely on
common.mustCall().

The timer seemed to be the source of an issue when parallelizing tests.
Ref: https://github.com/nodejs/node/pull/4476#issuecomment-168080875