### PR TITLE
test: remove time check

### DIFF
--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -117,47 +117,29 @@ if (process.argv[2] === 'child') {
   });
 
   var closeEmitted = false;
-  server.on('close', function() {
-    console.error('[m] server close');
+  server.on('close', common.mustCall(function() {
     closeEmitted = true;
 
-    console.error('[m] killing child processes');
     child1.kill();
     child2.kill();
     child3.kill();
-  });
+  }));
 
   server.listen(common.PORT, '127.0.0.1');
 
-  var timeElapsed = 0;
   var closeServer = function() {
-    console.error('[m] closeServer');
-    var startTime = Date.now();
-    server.on('close', function() {
-      console.error('[m] emit(close)');
-      timeElapsed = Date.now() - startTime;
-    });
-
-    console.error('[m] calling server.close');
     server.close();
 
     setTimeout(function() {
       assert(!closeEmitted);
-      console.error('[m] sending close to children');
       child1.send('close');
       child2.send('close');
       child3.disconnect();
     }, 200);
   };
 
-  var min = 190;
-  var max = common.platformTimeout(2000);
   process.on('exit', function() {
     assert.equal(disconnected, count);
     assert.equal(connected, count);
-    assert.ok(closeEmitted);
-    assert.ok(timeElapsed >= min && timeElapsed <= max,
-              `timeElapsed was not between ${min} and ${max} ms:` +
-              `${timeElapsed}`);
   });
 }


### PR DESCRIPTION
test-child-process-fork-net2.js checks that things happen within
certain time constraints, thus doubling as a benchmark test in addition
to a functionality test.

This change removes the time check, as it was causing the test to fail
on SmartOS and Windows (and possibly elsewhere) when the tests were
run in parallel on CI. There is no guarantee that other tests won't
consume enough resources to slow this test down, so don't check the time
constraints (beyond the generous timeout that the test is given by
test.py in the first place, of course).

If we want to do benchmark/performance tests, we should keep them
separate from pure functionality tests. The time check may have been a
remnant of the distant past when Node.js was much slower. It predates
io.js

Ref: https://github.com/nodejs/node/pull/4476

R=@jbergstroem ?