### PR TITLE
test: inherit JOBS from environment

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1339,7 +1339,10 @@ def ProcessOptions(options):
       print "The test group to run (n) must be smaller than number of groups (m)."
       return False
   if options.J:
-    options.j = multiprocessing.cpu_count()
+    # inherit JOBS from environment if provided. some virtualised systems
+    # tends to exaggerate the number of available cpus/cores.
+    cores = os.environ.get('JOBS')
+    options.j = int(cores) if cores is not None else multiprocessing.cpu_count()
   if options.flaky_tests not in ["run", "skip", "dontcare"]:
     print "Unknown flaky-tests mode %s" % options.flaky_tests
     return False


### PR DESCRIPTION
In some virtualized environments the amount of available resources are misleading; for instance `multiprocessing.cpu_count()` on our current 4-core smartos vm's returns `48`. This is not a bug, merely how the vm host provides information about available hardware.

Avoid running into issues by overriding `cpu_count()` with `JOBS`.

Refs #4494.