### PR TITLE
src: fix MakeCallback error handling

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -207,25 +207,22 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (ran_init_callback() && !pre_fn.IsEmpty()) {
-    try_catch.SetVerbose(false);
     pre_fn->Call(context, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::AsyncWrap::MakeCallback", "pre hook threw");
-    try_catch.SetVerbose(true);
   }
 
   Local<Value> ret = cb->Call(context, argc, argv);
 
-  if (try_catch.HasCaught()) {
-    return Undefined(env()->isolate());
-  }
-
   if (ran_init_callback() && !post_fn.IsEmpty()) {
-    try_catch.SetVerbose(false);
     post_fn->Call(context, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::AsyncWrap::MakeCallback", "post hook threw");
-    try_catch.SetVerbose(true);
+  }
+
+  // If the return value is empty then the callback threw.
+  if (ret.IsEmpty()) {
+    return Undefined(env()->isolate());
   }
 
   if (has_domain) {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -173,8 +173,8 @@ void LoadAsyncWrapperInfo(Environment* env) {
 
 
 Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
-                                      int argc,
-                                      Local<Value>* argv) {
+                                     int argc,
+                                     Local<Value>* argv) {
   CHECK(env()->context() == env()->isolate()->GetCurrentContext());
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
@@ -254,7 +254,6 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   env()->tick_callback_function()->Call(process, 0, nullptr);
 
   if (try_catch.HasCaught()) {
-    tick_info->set_last_threw(true);
     return Undefined(env()->isolate());
   }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -131,7 +131,7 @@ inline uint32_t Environment::DomainFlag::count() const {
   return fields_[kCount];
 }
 
-inline Environment::TickInfo::TickInfo() : in_tick_(false) {
+inline Environment::TickInfo::TickInfo() {
   for (int i = 0; i < kFieldsCount; ++i)
     fields_[i] = 0;
 }
@@ -144,20 +144,12 @@ inline int Environment::TickInfo::fields_count() const {
   return kFieldsCount;
 }
 
-inline bool Environment::TickInfo::in_tick() const {
-  return in_tick_;
-}
-
 inline uint32_t Environment::TickInfo::index() const {
   return fields_[kIndex];
 }
 
 inline uint32_t Environment::TickInfo::length() const {
   return fields_[kLength];
-}
-
-inline void Environment::TickInfo::set_in_tick(bool value) {
-  in_tick_ = value;
 }
 
 inline void Environment::TickInfo::set_index(uint32_t value) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -131,7 +131,7 @@ inline uint32_t Environment::DomainFlag::count() const {
   return fields_[kCount];
 }
 
-inline Environment::TickInfo::TickInfo() : in_tick_(false), last_threw_(false) {
+inline Environment::TickInfo::TickInfo() : in_tick_(false) {
   for (int i = 0; i < kFieldsCount; ++i)
     fields_[i] = 0;
 }
@@ -152,10 +152,6 @@ inline uint32_t Environment::TickInfo::index() const {
   return fields_[kIndex];
 }
 
-inline bool Environment::TickInfo::last_threw() const {
-  return last_threw_;
-}
-
 inline uint32_t Environment::TickInfo::length() const {
   return fields_[kLength];
 }
@@ -166,10 +162,6 @@ inline void Environment::TickInfo::set_in_tick(bool value) {
 
 inline void Environment::TickInfo::set_index(uint32_t value) {
   fields_[kIndex] = value;
-}
-
-inline void Environment::TickInfo::set_last_threw(bool value) {
-  last_threw_ = value;
 }
 
 inline Environment::ArrayBufferAllocatorInfo::ArrayBufferAllocatorInfo() {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -101,6 +101,20 @@ inline void Environment::AsyncHooks::set_enable_callbacks(uint32_t flag) {
   fields_[kEnableCallbacks] = flag;
 }
 
+inline Environment::AsyncCallbackScope::AsyncCallbackScope(Environment* env)
+    : env_(env) {
+  env_->makecallback_cntr_++;
+}
+
+inline Environment::AsyncCallbackScope::~AsyncCallbackScope() {
+  env_->makecallback_cntr_--;
+  CHECK_GE(env_->makecallback_cntr_, 0);
+}
+
+inline bool Environment::AsyncCallbackScope::in_makecallback() {
+  return env_->makecallback_cntr_ > 1;
+}
+
 inline Environment::DomainFlag::DomainFlag() {
   for (int i = 0; i < kFieldsCount; ++i) fields_[i] = 0;
 }
@@ -223,6 +237,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       using_domains_(false),
       printed_error_(false),
       trace_sync_io_(false),
+      makecallback_cntr_(0),
       async_wrap_uid_(0),
       debugger_agent_(this),
       http_parser_buffer_(nullptr),

--- a/src/env.cc
+++ b/src/env.cc
@@ -18,6 +18,7 @@ using v8::Message;
 using v8::StackFrame;
 using v8::StackTrace;
 using v8::TryCatch;
+using v8::Value;
 
 void Environment::PrintSyncTrace() const {
   if (!trace_sync_io_)
@@ -80,16 +81,10 @@ bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
     return true;
   }
 
-  // process nextTicks after call
-  TryCatch try_catch(isolate());
-  try_catch.SetVerbose(true);
-  tick_callback_function()->Call(process_object(), 0, nullptr);
+  Local<Value> ret =
+    tick_callback_function()->Call(process_object(), 0, nullptr);
 
-  if (try_catch.HasCaught()) {
-    return false;
-  }
-
-  return true;
+  return !ret.IsEmpty();
 }
 
 }  // namespace node

--- a/src/env.cc
+++ b/src/env.cc
@@ -64,10 +64,10 @@ void Environment::PrintSyncTrace() const {
 }
 
 
-bool Environment::KickNextTick() {
+bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
   TickInfo* info = tick_info();
 
-  if (info->in_tick()) {
+  if (scope->in_makecallback()) {
     return true;
   }
 
@@ -80,14 +80,10 @@ bool Environment::KickNextTick() {
     return true;
   }
 
-  info->set_in_tick(true);
-
   // process nextTicks after call
   TryCatch try_catch;
   try_catch.SetVerbose(true);
   tick_callback_function()->Call(process_object(), 0, nullptr);
-
-  info->set_in_tick(false);
 
   if (try_catch.HasCaught()) {
     info->set_last_threw(true);

--- a/src/env.cc
+++ b/src/env.cc
@@ -81,12 +81,11 @@ bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
   }
 
   // process nextTicks after call
-  TryCatch try_catch;
+  TryCatch try_catch(isolate());
   try_catch.SetVerbose(true);
   tick_callback_function()->Call(process_object(), 0, nullptr);
 
   if (try_catch.HasCaught()) {
-    info->set_last_threw(true);
     return false;
   }
 

--- a/src/env.h
+++ b/src/env.h
@@ -352,12 +352,10 @@ class Environment {
     inline uint32_t* fields();
     inline int fields_count() const;
     inline bool in_tick() const;
-    inline bool last_threw() const;
     inline uint32_t index() const;
     inline uint32_t length() const;
     inline void set_in_tick(bool value);
     inline void set_index(uint32_t value);
-    inline void set_last_threw(bool value);
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -371,7 +369,6 @@ class Environment {
 
     uint32_t fields_[kFieldsCount];
     bool in_tick_;
-    bool last_threw_;
 
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };

--- a/src/env.h
+++ b/src/env.h
@@ -314,6 +314,19 @@ class Environment {
     DISALLOW_COPY_AND_ASSIGN(AsyncHooks);
   };
 
+  class AsyncCallbackScope {
+   public:
+    explicit AsyncCallbackScope(Environment* env);
+    ~AsyncCallbackScope();
+
+    inline bool in_makecallback();
+
+   private:
+    Environment* env_;
+
+    DISALLOW_COPY_AND_ASSIGN(AsyncCallbackScope);
+  };
+
   class DomainFlag {
    public:
     inline uint32_t* fields();
@@ -466,7 +479,7 @@ class Environment {
 
   inline int64_t get_async_wrap_uid();
 
-  bool KickNextTick();
+  bool KickNextTick(AsyncCallbackScope* scope);
 
   inline uint32_t* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(uint32_t* pointer);
@@ -569,6 +582,7 @@ class Environment {
   bool using_domains_;
   bool printed_error_;
   bool trace_sync_io_;
+  size_t makecallback_cntr_;
   int64_t async_wrap_uid_;
   debugger::Agent debugger_agent_;
 

--- a/src/env.h
+++ b/src/env.h
@@ -351,10 +351,8 @@ class Environment {
    public:
     inline uint32_t* fields();
     inline int fields_count() const;
-    inline bool in_tick() const;
     inline uint32_t index() const;
     inline uint32_t length() const;
-    inline void set_in_tick(bool value);
     inline void set_index(uint32_t value);
 
    private:
@@ -368,7 +366,6 @@ class Environment {
     };
 
     uint32_t fields_[kFieldsCount];
-    bool in_tick_;
 
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };

--- a/src/node.cc
+++ b/src/node.cc
@@ -1127,10 +1127,10 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 
 
 Local<Value> MakeCallback(Environment* env,
-                           Local<Value> recv,
-                           const Local<Function> callback,
-                           int argc,
-                           Local<Value> argv[]) {
+                          Local<Value> recv,
+                          const Local<Function> callback,
+                          int argc,
+                          Local<Value> argv[]) {
   // If you hit this assertion, you forgot to enter the v8::Context first.
   CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
@@ -1162,7 +1162,7 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  TryCatch try_catch;
+  TryCatch try_catch(env->isolate());
   try_catch.SetVerbose(true);
 
   if (has_domain) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1162,33 +1162,28 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  TryCatch try_catch(env->isolate());
-  try_catch.SetVerbose(true);
-
   if (has_domain) {
     Local<Value> enter_v = domain->Get(env->enter_string());
     if (enter_v->IsFunction()) {
-        enter_v.As<Function>()->Call(domain, 0, nullptr);
-      if (try_catch.HasCaught())
-        return Undefined(env->isolate());
+      if (enter_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
+        FatalError("node::MakeCallback",
+                   "domain enter callback threw, please report this");
+      }
     }
   }
 
   if (ran_init_callback && !pre_fn.IsEmpty()) {
-    pre_fn->Call(object, 0, nullptr);
-    if (try_catch.HasCaught())
+    if (pre_fn->Call(object, 0, nullptr).IsEmpty())
       FatalError("node::MakeCallback", "pre hook threw");
   }
 
   Local<Value> ret = callback->Call(recv, argc, argv);
 
   if (ran_init_callback && !post_fn.IsEmpty()) {
-    post_fn->Call(object, 0, nullptr);
-    if (try_catch.HasCaught())
+    if (post_fn->Call(object, 0, nullptr).IsEmpty())
       FatalError("node::MakeCallback", "post hook threw");
   }
 
-  // If the return value is empty then the callback threw.
   if (ret.IsEmpty()) {
     return Undefined(env->isolate());
   }
@@ -1196,14 +1191,16 @@ Local<Value> MakeCallback(Environment* env,
   if (has_domain) {
     Local<Value> exit_v = domain->Get(env->exit_string());
     if (exit_v->IsFunction()) {
-      exit_v.As<Function>()->Call(domain, 0, nullptr);
-      if (try_catch.HasCaught())
-        return Undefined(env->isolate());
+      if (exit_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
+        FatalError("node::MakeCallback",
+                   "domain exit callback threw, please report this");
+      }
     }
   }
 
-  if (!env->KickNextTick(&callback_scope))
+  if (!env->KickNextTick(&callback_scope)) {
     return Undefined(env->isolate());
+  }
 
   return ret;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1140,6 +1140,8 @@ Local<Value> MakeCallback(Environment* env,
   bool ran_init_callback = false;
   bool has_domain = false;
 
+  Environment::AsyncCallbackScope callback_scope(env);
+
   // TODO(trevnorris): Adding "_asyncQueue" to the "this" in the init callback
   // is a horrible way to detect usage. Rethink how detection should happen.
   if (recv->IsObject()) {
@@ -1200,7 +1202,7 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  if (!env->KickNextTick())
+  if (!env->KickNextTick(&callback_scope))
     return Undefined(env->isolate());
 
   return ret;
@@ -4151,7 +4153,10 @@ static void StartNodeInstance(void* arg) {
     if (instance_data->use_debug_agent())
       StartDebug(env, debug_wait_connect);
 
-    LoadEnvironment(env);
+    {
+      Environment::AsyncCallbackScope callback_scope(env);
+      LoadEnvironment(env);
+    }
 
     env->set_trace_sync_io(trace_sync_io);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1173,21 +1173,22 @@ Local<Value> MakeCallback(Environment* env,
   }
 
   if (ran_init_callback && !pre_fn.IsEmpty()) {
-    try_catch.SetVerbose(false);
     pre_fn->Call(object, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::MakeCallback", "pre hook threw");
-    try_catch.SetVerbose(true);
   }
 
   Local<Value> ret = callback->Call(recv, argc, argv);
 
   if (ran_init_callback && !post_fn.IsEmpty()) {
-    try_catch.SetVerbose(false);
     post_fn->Call(object, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::MakeCallback", "post hook threw");
-    try_catch.SetVerbose(true);
+  }
+
+  // If the return value is empty then the callback threw.
+  if (ret.IsEmpty()) {
+    return Undefined(env->isolate());
   }
 
   if (has_domain) {
@@ -1197,10 +1198,6 @@ Local<Value> MakeCallback(Environment* env,
       if (try_catch.HasCaught())
         return Undefined(env->isolate());
     }
-  }
-
-  if (try_catch.HasCaught()) {
-    return Undefined(env->isolate());
   }
 
   if (!env->KickNextTick())

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -578,6 +578,8 @@ class Parser : public BaseObject {
     if (!cb->IsFunction())
       return;
 
+    Environment::AsyncCallbackScope callback_scope(parser->env());
+
     // Hooks for GetCurrentBuffer
     parser->current_buffer_len_ = nread;
     parser->current_buffer_data_ = buf->base;
@@ -587,7 +589,7 @@ class Parser : public BaseObject {
     parser->current_buffer_len_ = 0;
     parser->current_buffer_data_ = nullptr;
 
-    parser->env()->KickNextTick();
+    parser->env()->KickNextTick(&callback_scope);
   }
 
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -69,8 +69,6 @@ v8::Local<v8::Value> MakeCallback(Environment* env,
                                    int argc = 0,
                                    v8::Local<v8::Value>* argv = nullptr);
 
-bool KickNextTick();
-
 // Convert a struct sockaddr to a { address: '1.2.3.4', port: 1234 } JS object.
 // Sets address and port properties on the info object and returns it.
 // If |info| is omitted, a new object is returned.

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -1,0 +1,31 @@
+#include "node.h"
+#include "v8.h"
+
+#include "../../../src/util.h"
+
+using v8::Function;
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+namespace {
+
+void MakeCallback(const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsObject());
+  CHECK(args[1]->IsFunction());
+  Isolate* isolate = args.GetIsolate();
+  Local<Object> recv = args[0].As<Object>();
+  Local<Function> method = args[1].As<Function>();
+
+  node::MakeCallback(isolate, recv, method, 0, nullptr);
+}
+
+void Initialize(Local<Object> target) {
+  NODE_SET_METHOD(target, "makeCallback", MakeCallback);
+}
+
+}  // namespace anonymous
+
+NODE_MODULE(binding, Initialize)

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const domain = require('domain');
+const binding = require('./build/Release/binding');
+const makeCallback = binding.makeCallback;
+
+// Make sure this is run in the future.
+const mustCallCheckDomains = common.mustCall(checkDomains);
+
+
+// Make sure that using MakeCallback allows the error to propagate.
+assert.throws(function() {
+  makeCallback({}, function() {
+    throw new Error('hi from domain error');
+  });
+});
+
+
+// Check the execution order of the nextTickQueue and MicrotaskQueue in
+// relation to running multiple MakeCallback's from bootstrap,
+// node::MakeCallback() and node::AsyncWrap::MakeCallback().
+// TODO(trevnorris): Is there a way to verify this is being run during
+// bootstrap?
+(function verifyExecutionOrder(arg) {
+  const results_arr = [];
+
+  // Processing of the MicrotaskQueue is manually handled by node. They are not
+  // processed until after the nextTickQueue has been processed.
+  Promise.resolve(1).then(common.mustCall(function() {
+    results_arr.push(7);
+  }));
+
+  // The nextTick should run after all immediately invoked calls.
+  process.nextTick(common.mustCall(function() {
+    results_arr.push(3);
+
+    // Run same test again but while processing the nextTickQueue to make sure
+    // the following MakeCallback call breaks in the middle of processing the
+    // queue and allows the script to run normally.
+    process.nextTick(common.mustCall(function() {
+      results_arr.push(6);
+    }));
+
+    makeCallback({}, common.mustCall(function() {
+      results_arr.push(4);
+    }));
+
+    results_arr.push(5);
+  }));
+
+  results_arr.push(0);
+
+  // MakeCallback is calling the function immediately, but should then detect
+  // that a script is already in the middle of execution and return before
+  // either the nextTickQueue or MicrotaskQueue are processed.
+  makeCallback({}, common.mustCall(function() {
+    results_arr.push(1);
+  }));
+
+  // This should run before either the nextTickQueue or MicrotaskQueue are
+  // processed. Previously MakeCallback would not detect this circumstance
+  // and process them immediately.
+  results_arr.push(2);
+
+  setImmediate(common.mustCall(function() {
+    for (var i = 0; i < results_arr.length; i++) {
+      assert.equal(results_arr[i],
+                   i,
+                   `verifyExecutionOrder(${arg}) results: ${results_arr}`);
+    }
+    if (arg === 1) {
+      // The tests are first run on bootstrap during LoadEnvironment() in
+      // src/node.cc. Now run the tests through node::MakeCallback().
+      setImmediate(function() {
+        makeCallback({}, common.mustCall(function() {
+          verifyExecutionOrder(2);
+        }));
+      });
+    } else if (arg === 2) {
+      // setTimeout runs via the TimerWrap, which runs through
+      // AsyncWrap::MakeCallback(). Make sure there are no conflicts using
+      // node::MakeCallback() within it.
+      setTimeout(common.mustCall(function() {
+        verifyExecutionOrder(3);
+      }), 10);
+    } else if (arg === 3) {
+      mustCallCheckDomains();
+    } else {
+      throw new Error('UNREACHABLE');
+    }
+  }));
+}(1));
+
+
+function checkDomains() {
+  // Check that domains are properly entered/exited when called in multiple
+  // levels from both node::MakeCallback() and AsyncWrap::MakeCallback
+  setImmediate(common.mustCall(function() {
+    const d1 = domain.create();
+    const d2 = domain.create();
+    const d3 = domain.create();
+
+    makeCallback({ domain: d1 }, common.mustCall(function() {
+      assert.equal(d1, process.domain);
+      makeCallback({ domain: d2 }, common.mustCall(function() {
+        assert.equal(d2, process.domain);
+        makeCallback({ domain: d3 }, common.mustCall(function() {
+          assert.equal(d3, process.domain);
+        }));
+        assert.equal(d2, process.domain);
+      }));
+      assert.equal(d1, process.domain);
+    }));
+  }));
+
+  setTimeout(common.mustCall(function() {
+    const d1 = domain.create();
+    const d2 = domain.create();
+    const d3 = domain.create();
+
+    makeCallback({ domain: d1 }, common.mustCall(function() {
+      assert.equal(d1, process.domain);
+      makeCallback({ domain: d2 }, common.mustCall(function() {
+        assert.equal(d2, process.domain);
+        makeCallback({ domain: d3 }, common.mustCall(function() {
+          assert.equal(d3, process.domain);
+        }));
+        assert.equal(d2, process.domain);
+      }));
+      assert.equal(d1, process.domain);
+    }));
+  }), 1);
+
+  // Make sure nextTick, setImmediate and setTimeout can all recover properly
+  // after a thrown makeCallback call.
+  process.nextTick(common.mustCall(function() {
+    const d = domain.create();
+    d.on('error', common.mustCall(function(e) {
+      assert.equal(e.message, 'throw from domain 3');
+    }));
+    makeCallback({ domain: d }, function() {
+      throw new Error('throw from domain 3');
+    });
+    throw new Error('UNREACHABLE');
+  }));
+
+  setImmediate(common.mustCall(function() {
+    const d = domain.create();
+    d.on('error', common.mustCall(function(e) {
+      assert.equal(e.message, 'throw from domain 2');
+    }));
+    makeCallback({ domain: d }, function() {
+      throw new Error('throw from domain 2');
+    });
+    throw new Error('UNREACHABLE');
+  }));
+
+  setTimeout(common.mustCall(function() {
+    const d = domain.create();
+    d.on('error', common.mustCall(function(e) {
+      assert.equal(e.message, 'throw from domain 1');
+    }));
+    makeCallback({ domain: d }, function() {
+      throw new Error('throw from domain 1');
+    });
+    throw new Error('UNREACHABLE');
+  }));
+}


### PR DESCRIPTION
The final goal of this PR is to allow `MakeCallback` (in both `node::` and `AsyncWrap::`) to be reentrant. Reason is because the `HTTPParser` may enter the JS call stack initially, or be called while already in a stack (see @indutny's PR https://github.com/nodejs/node/pull/4509). Also so native addon developers can always use `node::MakeCallback` without the worry of code being executed in the wrong order (specifically in relation to usage of `nextTick` or the `MicrotaskQueue`).

To do this I first made sure the two implementations of `MakeCallback` were the same. Previously they would return at different points in the case of caught exception.

Finally was the addition of `AsyncCallbackScope` (admittedly the concept was taken from Fedor's PR above) to allow `MakeCallback` to be called recursively without each subsequent call from processing the `nextTickQueue` or the `MicrotaskQueue`.

I am working with @misterdjules on the proper way of handling domains. So this PR is currently a WIP.

Ref: https://github.com/nodejs/node-v0.x-archive/issues/9245

R=@bnoordhuis 
R=@indutny 