### PR TITLE
test: fix flaky test-cluster-shared-leak

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-cluster-shared-leak             : PASS,FLAKY
 test-debug-no-context                : PASS,FLAKY
 test-tls-ticket-cluster              : PASS,FLAKY
 

--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -15,14 +15,16 @@ if (cluster.isMaster) {
   worker1 = cluster.fork();
   worker1.on('message', common.mustCall(function() {
     worker2 = cluster.fork();
-    conn = net.connect(common.PORT, common.mustCall(function() {
-      worker1.send('die');
-      worker2.send('die');
-    }));
-    conn.on('error', function(e) {
-      // ECONNRESET is OK
-      if (e.code !== 'ECONNRESET')
-        throw e;
+    worker2.on('online', function() {
+      conn = net.connect(common.PORT, common.mustCall(function() {
+        worker1.send('die');
+        worker2.send('die');
+      }));
+      conn.on('error', function(e) {
+        // ECONNRESET is OK
+        if (e.code !== 'ECONNRESET')
+          throw e;
+      });
     });
   }));
 


### PR DESCRIPTION
Wait for worker2 to come online before doing anything that might result
in an EPIPE. Fixes flakiness of test on Windows.

Fixes: https://github.com/nodejs/node/issues/3956