### PR TITLE
buffer: throw if both length and enc are passed

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -47,6 +47,11 @@ function alignPool() {
 function Buffer(arg, encoding) {
   // Common case.
   if (typeof arg === 'number') {
+    if (typeof encoding === 'string') {
+      throw new Error(
+        'If encoding is specified then the first argument must be a string'
+      );
+    }
     // If less than zero, or NaN.
     if (arg < 0 || arg !== arg)
       arg = 0;

--- a/test/sequential/test-buffer-bad-overload.js
+++ b/test/sequential/test-buffer-bad-overload.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.doesNotThrow(function() {
+  new Buffer(10);
+});
+
+assert.throws(function() {
+  new Buffer(10, 'hex');
+});
+
+assert.doesNotThrow(function() {
+  new Buffer('deadbeaf', 'hex');
+});


### PR DESCRIPTION
We just fixed a security issue in the [bittorrent-dht](https://github.com/feross/bittorrent-dht) module that allowed a peer to craft a specific message that would make a remote peer disclose memory.

The root cause of the issue was this snippet:

``` js
var nodeId = new Buffer(nodeIdString, 'hex')
```

The `nodeIdString` was received over the network and by sending back a number instead of a string the `new Buffer` constructor would return a non-zeroed out buffer. We fixed it in our code base by type checking the argument (which we of course should have done from the beginning) but it would have been easier to catch if node had thrown an exception.

I'm sure that are other modules out there that have the same kind of vulnerability that would benefit from this PR as well.