### PR TITLE
test: remove flaky designations for tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,9 +12,6 @@ test-debug-no-context                : PASS,FLAKY
 test-tls-ticket-cluster              : PASS,FLAKY
 
 [$system==linux]
-test-http-client-timeout-event       : PASS,FLAKY
-test-child-process-buffering         : PASS,FLAKY
-test-child-process-exit-code         : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
Three tests designated as flaky on Linux have not failed on the
continuous integration server in a long time. Removing flaky designation
for these tests.

Fixes: https://github.com/nodejs/node/issues/4446

R=@mscdex 