### PR TITLE
test: fix `http-upgrade-agent` flakiness

### DIFF
--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -46,9 +46,14 @@ srv.listen(common.PORT, '127.0.0.1', function() {
   req.end();
 
   req.on('upgrade', function(res, socket, upgradeHead) {
-    // XXX: This test isn't fantastic, as it assumes that the entire response
-    //      from the server will arrive in a single data callback
-    assert.equal(upgradeHead, 'nurtzo');
+    var recvData = upgradeHead;
+    socket.on('data', function(d) {
+      recvData += d;
+    });
+
+    socket.on('close', common.mustCall(function() {
+      assert.equal(recvData, 'nurtzo');
+    }));
 
     console.log(res.headers);
     var expectedHeaders = { 'hello': 'world',


### PR DESCRIPTION
It's not guaranteed that the socket data is received in the same chunk
as the upgrade response. Listen for the `data` event to make sure all
the data is received. Modify the test so it does not pass without
applying this change.

I was getting this error from time to time on `OS X`:
```
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: <Buffer > == 'nurtzo'
    at ClientRequest.<anonymous> (/Users/sgimeno/node/node/test/parallel/test-http-upgrade-agent.js:51:12)
    at emitThree (events.js:98:13)
    at ClientRequest.emit (events.js:176:7)
    at Socket.socketOnData (_http_client.js:342:11)
    at emitOne (events.js:78:13)
    at Socket.emit (events.js:170:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at Socket.Readable.push (_stream_readable.js:110:10)
    at TCP.onread (net.js:523:20)
```