### PR TITLE
fs: deprecate fs.read's string interface

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -35,6 +35,7 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
+const printDeprecation = require('internal/util').printDeprecationMessage;
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +
@@ -584,9 +585,14 @@ fs.openSync = function(path, flags, mode) {
   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
 };
 
+var readWarned = false;
 fs.read = function(fd, buffer, offset, length, position, callback) {
   if (!(buffer instanceof Buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
+    readWarned = printDeprecation('fs.read\'s legacy String interface ' +
+                                  'is deprecated. Use the Buffer API as ' +
+                                  'mentioned in the documentation instead.',
+                                  readWarned);
     const cb = arguments[4];
     const encoding = arguments[3];
 
@@ -636,12 +642,17 @@ function tryToStringWithEnd(buf, encoding, end, callback) {
   callback(e, buf, end);
 }
 
+var readSyncWarned = false;
 fs.readSync = function(fd, buffer, offset, length, position) {
   var legacy = false;
   var encoding;
 
   if (!(buffer instanceof Buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
+    readSyncWarned = printDeprecation('fs.readSync\'s legacy String interface' +
+                                      'is deprecated. Use the Buffer API as ' +
+                                      'mentioned in the documentation instead.',
+                                      readSyncWarned);
     legacy = true;
     encoding = arguments[3];
 


### PR DESCRIPTION
`fs.read` supports a deprecated string interface version, which is
not documented. It was intended to be deprecated in this commit in 2010
https://github.com/nodejs/node/commit/c93e0aaf062081db3ec40ac45b3e2c979d5759d6
This patch issues a deprecation message saying the usage of this
interface is deprecated.