### PR TITLE
doc: close backtick in process.title description

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -891,7 +891,7 @@ See [the tty docs][] for more information.
 
 ## process.title
 
-Getter/setter to set what is displayed in `ps.
+Getter/setter to set what is displayed in `ps`.
 
 When used as a setter, the maximum length is platform-specific and probably
 short.


### PR DESCRIPTION
https://nodejs.org/api/process.html#process_process_title is just rendering this unclosed backtick, which probably isn't the intention.