### PR TITLE
Fix error and waring in make doc

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -32,7 +32,7 @@ would need to ever use `require('buffer')`.
     const buf4 = new Buffer('tést', 'utf8');
       // creates a buffer containing UTF8 bytes [74, c3, a9, 73, 74]
 
-### Buffers and Character Encodings
+## Buffers and Character Encodings
 
 Buffers are commonly used to represent sequences of encoded characters
 such as UTF8, UCS2, Base64 or even Hex-encoded data. It is possible to
@@ -66,7 +66,7 @@ The character encodings currently supported by Node.js include:
 
 * `'hex'` - Encode each byte as two hexadecimal characters.
 
-### Buffers and TypedArray
+## Buffers and TypedArray
 
 Buffers are also `Uint8Array` TypedArray instances. However, there are subtle
 incompatibilities with the TypedArray specification in ECMAScript 2015. For
@@ -116,7 +116,7 @@ create a Buffer that uses only a part of the `ArrayBuffer`, use the
     console.log(buf.length);
       // Prints: 16
 
-### Buffers and ES6 iteration
+## Buffers and ES6 iteration
 
 Buffers can be iterated over using the ECMAScript 2015 (ES6) `for..of` syntax:
 

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -283,7 +283,7 @@ function parseSignature(text, sig) {
     // [foo] -> optional
     if (p.charAt(p.length - 1) === ']') {
       optional = true;
-      p = p.substr(0, p.length - 1);
+      p = p.replace(/\]/g, '');
       p = p.trim();
     }
     var eq = p.indexOf('=');


### PR DESCRIPTION
#4370 causes an error of checking the depth of heading level in buffer api doc during make doc as 
```js
/home/ohtsu/github/node/tools/doc/generate.js:52
        if (er) throw er;
                ^

Error: Inappropriate heading level
{"type":"heading","depth":3,"text":"Buffers and Character Encodings"}
    at /home/ohtsu/github/node/tools/doc/html.js:192:17
    at Array.forEach (native)
    at buildToc (/home/ohtsu/github/node/tools/doc/html.js:189:9)
    at render (/home/ohtsu/github/node/tools/doc/html.js:71:3)
    at /home/ohtsu/github/node/tools/doc/html.js:37:7
    at tryToString (fs.js:414:3)
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:401:12)
make: *** [out/doc/api/all.html] Error 1
````
This just changes error headings of the sections to the 2nd level. 

And I also found that warning was shown from json.js as 
```sh
Warning: invalid param "end]"
 > {"textRaw":"`end` Number, Optional, Default: `buffer.length` ","name":"end","desc":"Number, Optional, Default: `buffer.length`"}
 > buf.slice([start[, end]])
````
This is due to insufficient trimming of right square brackets and it is fixed.

R= @jasnell