### PR TITLE
repl: make sure historyPath is trimmed

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -37,7 +37,7 @@ via the following environment variables:
  - `NODE_REPL_HISTORY` - When a valid path is given, persistent REPL history
    will be saved to the specified file rather than `.node_repl_history` in the
    user's home directory. Setting this value to `""` will disable persistent
-   REPL history.
+   REPL history. Whitespace will be trimmed from the value.
  - `NODE_REPL_HISTORY_SIZE` - defaults to `1000`. Controls how many lines of
    history will be persisted if history is available. Must be a positive number.
  - `NODE_REPL_MODE` - may be any of `sloppy`, `strict`, or `magic`. Defaults

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -55,15 +55,26 @@ function createRepl(env, opts, cb) {
   }
 
   const repl = REPL.start(opts);
-  if (opts.terminal && env.NODE_REPL_HISTORY !== '') {
+  if (opts.terminal) {
     return setupHistory(repl, env.NODE_REPL_HISTORY,
                         env.NODE_REPL_HISTORY_FILE, cb);
   }
+
   repl._historyPrev = _replHistoryMessage;
   cb(null, repl);
 }
 
 function setupHistory(repl, historyPath, oldHistoryPath, ready) {
+  // Empty string disables persistent history.
+
+  if (typeof historyPath === 'string')
+    historyPath = historyPath.trim();
+
+  if (historyPath === '') {
+    repl._historyPrev = _replHistoryMessage;
+    return ready(null, repl);
+  }
+
   if (!historyPath) {
     try {
       historyPath = path.join(os.homedir(), '.node_repl_history');

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -86,6 +86,11 @@ const tests = [
     expected: [prompt, replDisabled, prompt]
   },
   {
+    env: { NODE_REPL_HISTORY: ' ' },
+    test: [UP],
+    expected: [prompt, replDisabled, prompt]
+  },
+  {
     env: { NODE_REPL_HISTORY: '',
            NODE_REPL_HISTORY_FILE: enoentHistoryPath },
     test: [UP],


### PR DESCRIPTION
If one were to set NODE_REPL_HISTORY to a string that contains only a
space (" "), then the history file would be created with that name
which can cause problems are certain systems.

Related: https://github.com/nodejs/node/issues/4522

R= @Fishrock123?