### PR TITLE
module: deprecate require('module').Module

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -8,8 +8,13 @@ function EventEmitter() {
 }
 module.exports = EventEmitter;
 
-// Backwards-compat with node 0.10.x
-EventEmitter.EventEmitter = EventEmitter;
+Object.defineProperty(EventEmitter, 'EventEmitter', {
+  get: internalUtil.deprecate(function() {
+    return EventEmitter;
+  },
+  `require('events').EventEmitter is deprecated.` +
+  `Use require('events') instead.`)
+});
 
 EventEmitter.usingDomains = false;
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -516,5 +516,9 @@ Module._preloadModules = function(requests) {
 
 Module._initPaths();
 
-// backwards compatibility
-Module.Module = Module;
+Object.defineProperty(Module, 'Module', {
+  get: internalUtil.deprecate(function() {
+    return Module;
+  },
+  `require('module').Module is deprecated. Use require('module') instead.`)
+});


### PR DESCRIPTION
recommend developers to use `require('module')`.