### PR TITLE
test: remove unnecessary assignments

### DIFF
--- a/test/internet/test-dns-txt-sigsegv.js
+++ b/test/internet/test-dns-txt-sigsegv.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dns = require('dns');
 

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),

--- a/test/internet/test-http-dns-fail.js
+++ b/test/internet/test-http-dns-fail.js
@@ -4,7 +4,7 @@
  * should trigger the error event after each attempt.
  */
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/internet/test-net-connect-timeout.js
+++ b/test/internet/test-net-connect-timeout.js
@@ -3,7 +3,7 @@
 // https://groups.google.com/forum/#!topic/nodejs/UE0ZbfLt6t8
 // https://groups.google.com/forum/#!topic/nodejs-dev/jR7-5UDqXkw
 
-var common = require('../common');
+require('../common');
 var net = require('net');
 var assert = require('assert');
 

--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/message/2100bytes.js
+++ b/test/message/2100bytes.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var util = require('util');
 

--- a/test/message/core_line_numbers.js
+++ b/test/message/core_line_numbers.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const punycode = require('punycode');
 
 // This test verifies that line numbers in core modules are reported correctly.

--- a/test/message/error_exit.js
+++ b/test/message/error_exit.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 process.on('exit', function(code) {

--- a/test/message/eval_messages.js
+++ b/test/message/eval_messages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/message/hello_world.js
+++ b/test/message/hello_world.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 console.log('hello world');

--- a/test/message/max_tick_depth.js
+++ b/test/message/max_tick_depth.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 process.maxTickDepth = 10;
 var i = 20;

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 process.nextTick(function() {

--- a/test/message/stack_overflow.js
+++ b/test/message/stack_overflow.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 Error.stackTraceLimit = 0;

--- a/test/message/stdin_messages.js
+++ b/test/message/stdin_messages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/message/throw_custom_error.js
+++ b/test/message/throw_custom_error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // custom error throwing

--- a/test/message/throw_in_line_with_tabs.js
+++ b/test/message/throw_in_line_with_tabs.js
@@ -1,6 +1,6 @@
 /* eslint-disable indent */
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 console.error('before');

--- a/test/message/throw_non_error.js
+++ b/test/message/throw_non_error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // custom error throwing

--- a/test/message/throw_null.js
+++ b/test/message/throw_null.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 throw null;

--- a/test/message/throw_undefined.js
+++ b/test/message/throw_undefined.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 throw undefined;

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 setTimeout(function() {

--- a/test/message/undefined_reference_in_new_context.js
+++ b/test/message/undefined_reference_in_new_context.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/message/vm_display_runtime_error.js
+++ b/test/message/vm_display_runtime_error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/message/vm_dont_display_syntax_error.js
+++ b/test/message/vm_dont_display_syntax_error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-async-wrap-throw-no-init.js
+++ b/test/parallel/test-async-wrap-throw-no-init.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
 

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const Buffer = require('buffer').Buffer;

--- a/test/parallel/test-buffer-ascii.js
+++ b/test/parallel/test-buffer-ascii.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // ASCII conversion in node.js simply masks off the high bits,

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Buffer = require('buffer').Buffer;
 

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var zero = [];

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const Buffer = require('buffer').Buffer;
 const Bp = Buffer.prototype;

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Buffer = require('buffer').Buffer;

--- a/test/parallel/test-buffer-inheritance.js
+++ b/test/parallel/test-buffer-inheritance.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var util = require('util');

--- a/test/parallel/test-buffer-iterator.js
+++ b/test/parallel/test-buffer-iterator.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var buffer = new Buffer([1, 2, 3, 4, 5]);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const buffer = require('buffer');
 const Buffer = buffer.Buffer;

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -1,7 +1,7 @@
 'use strict';
 
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 var child_process = require('child_process');
 var ChildProcess = child_process.ChildProcess;
 assert.equal(typeof ChildProcess, 'function');

--- a/test/parallel/test-child-process-detached.js
+++ b/test/parallel/test-child-process-detached.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var path = require('path');
 

--- a/test/parallel/test-child-process-fork-and-spawn.js
+++ b/test/parallel/test-child-process-fork-and-spawn.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var fork = require('child_process').fork;

--- a/test/parallel/test-child-process-fork-ref.js
+++ b/test/parallel/test-child-process-fork-ref.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fork = require('child_process').fork;
 

--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fork = require('child_process').fork;
 

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 //messages

--- a/test/parallel/test-child-process-set-blocking.js
+++ b/test/parallel/test-child-process-set-blocking.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var ch = require('child_process');
 

--- a/test/parallel/test-child-process-silent.js
+++ b/test/parallel/test-child-process-silent.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var childProcess = require('child_process');
 

--- a/test/parallel/test-child-process-spawnsync-env.js
+++ b/test/parallel/test-child-process-spawnsync-env.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cp = require('child_process');
 

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawnSync = require('child_process').spawnSync;

--- a/test/parallel/test-child-process-stdin-ipc.js
+++ b/test/parallel/test-child-process-stdin-ipc.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var BUFSIZE = 1024;
 

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -1,8 +1,8 @@
 'use strict';
 // Flags: --expose_internals
 
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 var _validateStdio = require('internal/child_process')._validateStdio;
 
 // should throw if string and not ignore, pipe, or inherit

--- a/test/parallel/test-cluster-debug-port.js
+++ b/test/parallel/test-cluster-debug-port.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master-cumulative.js
+++ b/test/parallel/test-cluster-setup-master-cumulative.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master-emit.js
+++ b/test/parallel/test-cluster-setup-master-emit.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master-multiple.js
+++ b/test/parallel/test-cluster-setup-master-multiple.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -3,7 +3,7 @@
 // one that the cluster module installs.
 // https://github.com/joyent/node/issues/2556
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var fork = require('child_process').fork;

--- a/test/parallel/test-cluster-worker-constructor.js
+++ b/test/parallel/test-cluster-worker-constructor.js
@@ -2,7 +2,7 @@
 // test-cluster-worker-constructor.js
 // validates correct behavior of the cluster.Worker constructor
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var worker;

--- a/test/parallel/test-cluster-worker-death.js
+++ b/test/parallel/test-cluster-worker-death.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -3,7 +3,7 @@
 // verifies that, when a child process is forked, the cluster.worker
 // object can receive messages as expected
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var msg = 'foo';

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Stream = require('stream');
 var Console = require('console').Console;

--- a/test/parallel/test-console-not-call-toString.js
+++ b/test/parallel/test-console-not-call-toString.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var func = function() {};

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 assert.ok(process.stdout.writable);

--- a/test/parallel/test-delayed-require.js
+++ b/test/parallel/test-delayed-require.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var a;

--- a/test/parallel/test-dgram-bind.js
+++ b/test/parallel/test-dgram-bind.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-bytes-length.js
+++ b/test/parallel/test-dgram-bytes-length.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-listen-after-bind.js
+++ b/test/parallel/test-dgram-listen-after-bind.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-ref.js
+++ b/test/parallel/test-dgram-ref.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var dgram = require('dgram');
 
 // should not hang, see #1282

--- a/test/parallel/test-dgram-regress-4496.js
+++ b/test/parallel/test-dgram-regress-4496.js
@@ -1,7 +1,7 @@
 'use strict';
 // Remove this test once we support sending strings.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/parallel/test-dgram-send-bad-arguments.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 

--- a/test/parallel/test-dgram-unref.js
+++ b/test/parallel/test-dgram-unref.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var dgram = require('dgram');

--- a/test/parallel/test-dh-padding.js
+++ b/test/parallel/test-dh-padding.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 try {

--- a/test/parallel/test-dns-cares-domains.js
+++ b/test/parallel/test-dns-cares-domains.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dns = require('dns');
 var domain = require('domain');

--- a/test/parallel/test-dns-lookup-cb-error.js
+++ b/test/parallel/test-dns-lookup-cb-error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cares = process.binding('cares_wrap');
 

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dns = require('dns');
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var dns = require('dns');

--- a/test/parallel/test-domain-exit-dispose.js
+++ b/test/parallel/test-domain-exit-dispose.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var disposalFailed = false;

--- a/test/parallel/test-domain-from-timer.js
+++ b/test/parallel/test-domain-from-timer.js
@@ -1,7 +1,7 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // timeouts call the callback directly from cc, so need to make sure the

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -1,7 +1,7 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var events = require('events');

--- a/test/parallel/test-domain-nested-throw.js
+++ b/test/parallel/test-domain-nested-throw.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var domain = require('domain');

--- a/test/parallel/test-domain-stack.js
+++ b/test/parallel/test-domain-stack.js
@@ -1,7 +1,7 @@
 'use strict';
 // Make sure that the domain stack doesn't get out of hand.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var events = require('events');

--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -1,7 +1,7 @@
 'use strict';
+require('../common');
 var domain = require('domain');
 var assert = require('assert');
-var common = require('../common');
 
 var timeout_err, timeout, immediate_err;
 

--- a/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -7,7 +7,7 @@
  * top-level error handler, not the one from the previous error.
  */
 
-const common = require('../common');
+require('../common');
 
 const domainErrHandlerExMessage = 'exception from domain error handler';
 const internalExMessage = 'You should NOT see me';

--- a/test/parallel/test-domain.js
+++ b/test/parallel/test-domain.js
@@ -1,7 +1,7 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var events = require('events');

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var EventEmitter = require('events');
 

--- a/test/parallel/test-event-emitter-listener-count.js
+++ b/test/parallel/test-event-emitter-listener-count.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-method-names.js
+++ b/test/parallel/test-event-emitter-method-names.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-modify-in-emit.js
+++ b/test/parallel/test-event-emitter-modify-in-emit.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
+++ b/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 var domain = require('domain');

--- a/test/parallel/test-event-emitter-num-args.js
+++ b/test/parallel/test-event-emitter-num-args.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-set-max-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-set-max-listeners-side-effects.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var events = require('events');
 

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');

--- a/test/parallel/test-exception-handler.js
+++ b/test/parallel/test-exception-handler.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var MESSAGE = 'catch me if you can';

--- a/test/parallel/test-exception-handler2.js
+++ b/test/parallel/test-exception-handler2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 process.on('uncaughtException', function(err) {

--- a/test/parallel/test-exec-max-buffer.js
+++ b/test/parallel/test-exec-max-buffer.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var exec = require('child_process').exec;
 var assert = require('assert');
 

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var f = __filename;

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var constants = require('constants');

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var constants = require('constants');
-var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-read-file-sync-hostname.js
+++ b/test/parallel/test-fs-read-file-sync-hostname.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-readfile-zero-byte-liar.js
+++ b/test/parallel/test-fs-readfile-zero-byte-liar.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -1,5 +1,5 @@
 /* eslint-disable strict */
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var got_error = false;

--- a/test/parallel/test-fs-sync-fd-leak.js
+++ b/test/parallel/test-fs-sync-fd-leak.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-write-no-fd.js
+++ b/test/parallel/test-fs-write-no-fd.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const assert = require('assert');
 

--- a/test/parallel/test-handle-wrap-close-abort.js
+++ b/test/parallel/test-handle-wrap-close-abort.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 process.on('uncaughtException', function() { });
 

--- a/test/parallel/test-http-agent-false.js
+++ b/test/parallel/test-http-agent-false.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -1,8 +1,8 @@
 'use strict';
 
+require('../common');
 var assert = require('assert');
 var http = require('http');
-var common = require('../common');
 
 var agent = new http.Agent();
 

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var util = require('util');

--- a/test/parallel/test-http-methods.js
+++ b/test/parallel/test-http-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var util = require('util');

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -4,7 +4,7 @@
 
 // Flags: --expose_gc
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var HTTPParser = process.binding('http_parser').HTTPParser;
 

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var HTTPParser = process.binding('http_parser').HTTPParser;

--- a/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
+++ b/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');

--- a/test/parallel/test-internal-modules-expose.js
+++ b/test/parallel/test-internal-modules-expose.js
@@ -1,7 +1,7 @@
 'use strict';
 // Flags: --expose_internals
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 assert.equal(typeof require('internal/freelist').FreeList, 'function');

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 assert.throws(function() {

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // does node think that i18n was enabled?

--- a/test/parallel/test-js-stream-call-properties.js
+++ b/test/parallel/test-js-stream-call-properties.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const util = require('util');
 const JSStream = process.binding('js_stream').JSStream;
 

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var r = process.memoryUsage();

--- a/test/parallel/test-microtask-queue-integration-domain.js
+++ b/test/parallel/test-microtask-queue-integration-domain.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 

--- a/test/parallel/test-microtask-queue-integration.js
+++ b/test/parallel/test-microtask-queue-integration.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var implementations = [

--- a/test/parallel/test-microtask-queue-run-domain.js
+++ b/test/parallel/test-microtask-queue-run-domain.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 

--- a/test/parallel/test-microtask-queue-run-immediate-domain.js
+++ b/test/parallel/test-microtask-queue-run-immediate-domain.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 

--- a/test/parallel/test-microtask-queue-run-immediate.js
+++ b/test/parallel/test-microtask-queue-run-immediate.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 function enqueueMicrotask(fn) {

--- a/test/parallel/test-microtask-queue-run.js
+++ b/test/parallel/test-microtask-queue-run.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 function enqueueMicrotask(fn) {

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 console.error('load test-module-loading-error.js');

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var net = require('net');

--- a/test/parallel/test-net-end-without-connect.js
+++ b/test/parallel/test-net-end-without-connect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var net = require('net');
 
 var sock = new net.Socket();

--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var gotError = false;

--- a/test/parallel/test-net-server-connections.js
+++ b/test/parallel/test-net-server-connections.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var net = require('net');

--- a/test/parallel/test-net-server-unref-persistent.js
+++ b/test/parallel/test-net-server-unref-persistent.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var closed = false;

--- a/test/parallel/test-next-tick-domain.js
+++ b/test/parallel/test-next-tick-domain.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var origNextTick = process.nextTick;

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var order = [],

--- a/test/parallel/test-next-tick-intentional-starvation.js
+++ b/test/parallel/test-next-tick-intentional-starvation.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // this is the inverse of test-next-tick-starvation.

--- a/test/parallel/test-next-tick-ordering.js
+++ b/test/parallel/test-next-tick-ordering.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var i;
 

--- a/test/parallel/test-next-tick-ordering2.js
+++ b/test/parallel/test-next-tick-ordering2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var order = [];

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var complete = 0;

--- a/test/parallel/test-path-zero-length-strings.js
+++ b/test/parallel/test-path-zero-length-strings.js
@@ -5,7 +5,7 @@
 // directory. This test makes sure that the behaviour is intact between commits.
 // See: https://github.com/nodejs/node/pull/2106
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const pwd = process.cwd();

--- a/test/parallel/test-pipe-return-val.js
+++ b/test/parallel/test-pipe-return-val.js
@@ -1,7 +1,7 @@
 'use strict';
 // This test ensures SourceStream.pipe(DestStream) returns DestStream
 
-var common = require('../common');
+require('../common');
 var Stream = require('stream').Stream;
 var assert = require('assert');
 var util = require('util');

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
+require('../common');
+var assert = require('assert'),
     path = require('path'),
     child_process = require('child_process');
 

--- a/test/parallel/test-process-before-exit.js
+++ b/test/parallel/test-process-before-exit.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 
 var N = 5;
 var n = 0;

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -4,7 +4,7 @@
 // first things first, set the timezone; see tzset(3)
 process.env.TZ = 'Europe/Amsterdam';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 switch (process.argv[2]) {

--- a/test/parallel/test-process-exit.js
+++ b/test/parallel/test-process-exit.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // calling .exit() from within "exit" should not overflow the call stack

--- a/test/parallel/test-process-getgroups.js
+++ b/test/parallel/test-process-getgroups.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // the default behavior, return an Array "tuple" of numbers

--- a/test/parallel/test-process-kill-null.js
+++ b/test/parallel/test-process-kill-null.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // test variants of pid

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var N = 2;
 var tickCount = 0;

--- a/test/parallel/test-process-raw-debug.js
+++ b/test/parallel/test-process-raw-debug.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var os = require('os');
 

--- a/test/parallel/test-process-wrap.js
+++ b/test/parallel/test-process-wrap.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Process = process.binding('process_wrap').Process;
 var Pipe = process.binding('pipe_wrap').Pipe;

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var punycode = require('punycode');
 var assert = require('assert');
 

--- a/test/parallel/test-querystring-multichar-separator.js
+++ b/test/parallel/test-querystring-multichar-separator.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const qs = require('querystring');
 

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // test using assert

--- a/test/parallel/test-readdouble.js
+++ b/test/parallel/test-readdouble.js
@@ -2,7 +2,7 @@
 /*
  * Tests to verify we're reading in doubles correctly
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-readfloat.js
+++ b/test/parallel/test-readfloat.js
@@ -2,7 +2,7 @@
 /*
  * Tests to verify we're reading in floats correctly
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-readint.js
+++ b/test/parallel/test-readint.js
@@ -2,7 +2,7 @@
 /*
  * Tests to verify we're reading in signed integers correctly
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-readuint.js
+++ b/test/parallel/test-readuint.js
@@ -3,7 +3,7 @@
  * A battery of tests to help us read a series of uints
  */
 
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-ref-unref-return.js
+++ b/test/parallel/test-ref-unref-return.js
@@ -1,8 +1,8 @@
 'use strict';
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var dgram = require('dgram');
-var common = require('../common');
 
 assert.ok((new net.Server()).ref() instanceof net.Server);
 assert.ok((new net.Server()).unref() instanceof net.Server);

--- a/test/parallel/test-regress-GH-6235.js
+++ b/test/parallel/test-regress-GH-6235.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 assert.doesNotThrow(function() {

--- a/test/parallel/test-regress-GH-7511.js
+++ b/test/parallel/test-regress-GH-7511.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
+require('../common');
+var assert = require('assert'),
     vm     = require('vm');
 
 assert.doesNotThrow(function() {

--- a/test/parallel/test-regress-GH-897.js
+++ b/test/parallel/test-regress-GH-897.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var t = Date.now();

--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -2,7 +2,7 @@
 
 // Flags: --expose-internals
 
-const common = require('../common');
+require('../common');
 const stream = require('stream');
 const REPL = require('internal/repl');
 const assert = require('assert');

--- a/test/parallel/test-repl-harmony.js
+++ b/test/parallel/test-repl-harmony.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/parallel/test-repl-require-cache.js
+++ b/test/parallel/test-repl-require-cache.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common'),
-    assert = require('assert'),
+require('../common');
+var assert = require('assert'),
     repl = require('repl');
 
 // https://github.com/joyent/node/issues/3226

--- a/test/parallel/test-repl-setprompt.js
+++ b/test/parallel/test-repl-setprompt.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 const os = require('os');

--- a/test/parallel/test-repl-syntax-error-handling.js
+++ b/test/parallel/test-repl-syntax-error-handling.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 switch (process.argv[2]) {

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -2,7 +2,7 @@
 /*
  * This is a regression test for https://github.com/joyent/node/issues/8874.
  */
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/parallel/test-require-cache.js
+++ b/test/parallel/test-require-cache.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 (function testInjectFakeModule() {

--- a/test/parallel/test-signal-safety.js
+++ b/test/parallel/test-signal-safety.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Signal = process.binding('signal_wrap').Signal;
 

--- a/test/parallel/test-stdin-hang.js
+++ b/test/parallel/test-stdin-hang.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 // This test *only* verifies that invoking the stdin getter does not
 // cause node to hang indefinitely.

--- a/test/parallel/test-stdio-readable-writable.js
+++ b/test/parallel/test-stdio-readable-writable.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 assert(process.stdout.writable);

--- a/test/parallel/test-stdout-close-unref.js
+++ b/test/parallel/test-stdout-close-unref.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 
 var errs = 0;
 

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var util = require('util');
 var stream = require('stream');

--- a/test/parallel/test-stream-big-push.js
+++ b/test/parallel/test-stream-big-push.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var stream = require('stream');
 var str = 'asdfasdfasdfasdfasdf';

--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Duplex = require('stream').Transform;

--- a/test/parallel/test-stream-end-paused.js
+++ b/test/parallel/test-stream-end-paused.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var gotEnd = false;
 

--- a/test/parallel/test-stream-ispaused.js
+++ b/test/parallel/test-stream-ispaused.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 
 var stream = require('stream');
 

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('_stream_readable');

--- a/test/parallel/test-stream-pipe-cleanup.js
+++ b/test/parallel/test-stream-pipe-cleanup.js
@@ -2,7 +2,7 @@
 // This test asserts that Stream.prototype.pipe does not leave listeners
 // hanging on the source or dest.
 
-var common = require('../common');
+require('../common');
 var stream = require('stream');
 var assert = require('assert');
 var util = require('util');

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Stream = require('stream').Stream;
 

--- a/test/parallel/test-stream-pipe-event.js
+++ b/test/parallel/test-stream-pipe-event.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var stream = require('stream');
 var assert = require('assert');
 var util = require('util');

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var Readable = require('stream').Readable;
 var assert = require('assert');
 

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream-readable-constructor-set-methods.js
+++ b/test/parallel/test-stream-readable-constructor-set-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream-readable-flow-recursion.js
+++ b/test/parallel/test-stream-readable-flow-recursion.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // this test verifies that passing a huge number to read(size)

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Transform = require('stream').Transform;

--- a/test/parallel/test-stream-transform-objectmode-falsey-value.js
+++ b/test/parallel/test-stream-transform-objectmode-falsey-value.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream-transform-split-objectmode.js
+++ b/test/parallel/test-stream-transform-split-objectmode.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Transform = require('stream').Transform;

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // This test verifies that stream.unshift(Buffer(0)) or

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // This test verifies that:

--- a/test/parallel/test-stream-wrap.js
+++ b/test/parallel/test-stream-wrap.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const StreamWrap = require('_stream_wrap');

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Writable = require('stream').Writable;

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var R = require('_stream_readable');
 var W = require('_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var stream = require('stream');
 var Buffer = require('buffer').Buffer;
 

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // If everything aligns so that you do a read(n) of exactly the

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var Readable = require('_stream_readable');
 var Writable = require('_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-pipe-error-handling.js
+++ b/test/parallel/test-stream2-pipe-error-handling.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var stream = require('stream');
 

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var util = require('util');

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var stream = require('stream');
 var Readable = stream.Readable;
 var Writable = stream.Writable;

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Readable = require('stream').Readable;
 var r = new Readable();

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('stream').Readable;

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 var fromList = require('_stream_readable')._fromList;
 
 // tiny node-tap lookalike.

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Stream = require('stream');

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 var Readable = require('_stream_readable');
 
 var len = 0;

--- a/test/parallel/test-stream2-readable-wrap-empty.js
+++ b/test/parallel/test-stream2-readable-wrap-empty.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('_stream_readable');

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var Readable = require('_stream_readable');

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var R = require('_stream_readable');
 var util = require('util');

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 var PassThrough = require('_stream_passthrough');
 var Transform = require('_stream_transform');
 

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var stream = require('stream');
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var W = require('_stream_writable');
 var D = require('_stream_duplex');
 var assert = require('assert');

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var stream = require('stream');

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var StringDecoder = require('string_decoder').StringDecoder;
 

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 // minimum string size to overflow into external string space
 var EXTERN_APEX = 0xFBEE9;

--- a/test/parallel/test-timers-active.js
+++ b/test/parallel/test-timers-active.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const active = require('timers').active;
 

--- a/test/parallel/test-timers-args.js
+++ b/test/parallel/test-timers-args.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 function range(n) {

--- a/test/parallel/test-timers-immediate-queue.js
+++ b/test/parallel/test-timers-immediate-queue.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // setImmediate should run clear its queued cbs once per event loop turn

--- a/test/parallel/test-timers-immediate.js
+++ b/test/parallel/test-timers-immediate.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var immediateA = false,

--- a/test/parallel/test-timers-linked-list.js
+++ b/test/parallel/test-timers-linked-list.js
@@ -1,8 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var L = require('_linklist');
-
+require('../common');
+const assert = require('assert');
+const L = require('_linklist');
 
 var list = { name: 'list' };
 var A = { name: 'A' };

--- a/test/parallel/test-timers-now.js
+++ b/test/parallel/test-timers-now.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 // Return value of Timer.now() should easily fit in a SMI right after start-up.

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Timer = process.binding('timer_wrap').Timer;
 

--- a/test/parallel/test-timers-uncaught-exception.js
+++ b/test/parallel/test-timers-uncaught-exception.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var exceptions = 0;

--- a/test/parallel/test-timers-unref-active.js
+++ b/test/parallel/test-timers-unref-active.js
@@ -15,7 +15,7 @@
  * all 10 timeouts had the time to expire.
  */
 
-const common = require('../common');
+require('../common');
 const timers = require('timers');
 const assert = require('assert');
 

--- a/test/parallel/test-timers-unref-call.js
+++ b/test/parallel/test-timers-unref-call.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 var Timer = process.binding('timer_wrap').Timer;
 Timer.now = function() { return ++Timer.now.ticks; };

--- a/test/parallel/test-timers-unref-remove-other-unref-timers-only-one-fires.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers-only-one-fires.js
@@ -10,7 +10,7 @@
  * This behavior is a private implementation detail and should not be
  * considered public interface.
  */
-const common = require('../common');
+require('../common');
 const timers = require('timers');
 const assert = require('assert');
 

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var interval_fired = false,

--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // https://github.com/joyent/node/issues/2079 - zero timeout drops extra args

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var inputs = [

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const tls = require('tls');
 

--- a/test/parallel/test-tty-stdout-end.js
+++ b/test/parallel/test-tty-stdout-end.js
@@ -1,6 +1,6 @@
 'use strict';
 // Can't test this when 'make test' doesn't assign a tty to the stdout.
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const shouldThrow = function() {

--- a/test/parallel/test-tty-wrap.js
+++ b/test/parallel/test-tty-wrap.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var TTY = process.binding('tty_wrap').TTY;

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var url = require('url'),

--- a/test/parallel/test-utf8-scripts.js
+++ b/test/parallel/test-utf8-scripts.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // üäö

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var util = require('util');
 var symbol = Symbol('foo');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var util = require('util');
 

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var util = require('util');
 var context = require('vm').runInNewContext;

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 

--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 var vm = require('vm');

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-context-async-script.js
+++ b/test/parallel/test-vm-context-async-script.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-context-property-forwarding.js
+++ b/test/parallel/test-vm-context-property-forwarding.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-create-context-accessors.js
+++ b/test/parallel/test-vm-create-context-accessors.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-create-context-circular-reference.js
+++ b/test/parallel/test-vm-create-context-circular-reference.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-cross-context.js
+++ b/test/parallel/test-vm-cross-context.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-function-declaration.js
+++ b/test/parallel/test-vm-function-declaration.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-global-define-property.js
+++ b/test/parallel/test-vm-global-define-property.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-global-identity.js
+++ b/test/parallel/test-vm-global-identity.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-harmony-proxies.js
+++ b/test/parallel/test-vm-harmony-proxies.js
@@ -1,7 +1,7 @@
 'use strict';
 // Flags: --harmony_proxies
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-harmony-symbols.js
+++ b/test/parallel/test-vm-harmony-symbols.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-is-context.js
+++ b/test/parallel/test-vm-is-context.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-vm-preserves-property.js
+++ b/test/parallel/test-vm-preserves-property.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-symbols.js
+++ b/test/parallel/test-vm-symbols.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var vm = require('vm');

--- a/test/parallel/test-vm-syntax-error-message.js
+++ b/test/parallel/test-vm-syntax-error-message.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var child_process = require('child_process');
 

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var vm = require('vm');
 

--- a/test/parallel/test-writedouble.js
+++ b/test/parallel/test-writedouble.js
@@ -2,7 +2,7 @@
 /*
  * Tests to verify we're writing doubles correctly
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 function test(clazz) {

--- a/test/parallel/test-writefloat.js
+++ b/test/parallel/test-writefloat.js
@@ -2,7 +2,7 @@
 /*
  * Tests to verify we're writing floats correctly
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 function test(clazz) {

--- a/test/parallel/test-writeint.js
+++ b/test/parallel/test-writeint.js
@@ -2,7 +2,7 @@
 /*
  * Tests to verify we're writing signed integers correctly
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 function test8(clazz) {

--- a/test/parallel/test-writeuint.js
+++ b/test/parallel/test-writeuint.js
@@ -2,7 +2,7 @@
 /*
  * A battery of tests to help us read a series of uints
  */
-var common = require('../common');
+require('../common');
 var ASSERT = require('assert');
 
 /*

--- a/test/parallel/test-zlib-close-after-write.js
+++ b/test/parallel/test-zlib-close-after-write.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -1,5 +1,5 @@
 /* eslint-disable strict */
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var zlib = require('zlib');

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -1,7 +1,7 @@
 'use strict';
 // test convenience methods with and without options supplied
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -1,10 +1,10 @@
 'use strict';
 // test compression/decompression with dictionary
 
-var common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
-var path = require('path');
+require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const path = require('path');
 
 var spdyDict = new Buffer([
   'optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-',

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 const path = require('path');

--- a/test/parallel/test-zlib-from-string.js
+++ b/test/parallel/test-zlib-from-string.js
@@ -1,7 +1,7 @@
 'use strict';
 // test compressing and uncompressing a string with zlib
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -1,8 +1,8 @@
 'use strict';
 // test uncompressing invalid input
 
-var common = require('../common'),
-    assert = require('assert'),
+require('../common');
+var assert = require('assert'),
     zlib = require('zlib');
 
 var nonStringInputs = [1, true, {a: 1}, ['a']];

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 var fs = require('fs');

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var zlib = require('zlib');

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var os = require('os');
 var util = require('util');

--- a/test/pummel/test-next-tick-infinite-calls.js
+++ b/test/pummel/test-next-tick-infinite-calls.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var complete = 0;

--- a/test/pummel/test-process-hrtime.js
+++ b/test/pummel/test-process-hrtime.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var start = process.hrtime();

--- a/test/pummel/test-process-uptime.js
+++ b/test/pummel/test-process-uptime.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 console.error(process.uptime());

--- a/test/pummel/test-stream-pipe-multi.js
+++ b/test/pummel/test-stream-pipe-multi.js
@@ -2,7 +2,7 @@
 // Test that having a bunch of streams piping in parallel
 // doesn't break anything.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var Stream = require('stream').Stream;
 var rr = [];

--- a/test/pummel/test-stream2-basic.js
+++ b/test/pummel/test-stream2-basic.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 

--- a/test/pummel/test-timer-wrap.js
+++ b/test/pummel/test-timer-wrap.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var timeouts = 0;

--- a/test/pummel/test-timer-wrap2.js
+++ b/test/pummel/test-timer-wrap2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // Test that allocating a timer does not increase the loop's reference

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var WINDOW = 200; // why is does this need to be so big?

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -1,8 +1,8 @@
 'use strict';
 // Flags: --max_old_space_size=32
 
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 
 var start = Date.now();
 var maxMem = 0;

--- a/test/sequential/test-debug-args.js
+++ b/test/sequential/test-debug-args.js
@@ -1,7 +1,7 @@
 'use strict';
 // Flags: --debugger
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 assert.notEqual(process.execArgv.indexOf('--debugger'), -1);

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var execFile = require('child_process').execFile;
 var depmod = require.resolve('../fixtures/deprecated.js');

--- a/test/sequential/test-memory-usage-emfile.js
+++ b/test/sequential/test-memory-usage-emfile.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var fs = require('fs');

--- a/test/sequential/test-net-listen-exclusive-random-ports.js
+++ b/test/sequential/test-net-listen-exclusive-random-ports.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var net = require('net');

--- a/test/sequential/test-regress-GH-1726.js
+++ b/test/sequential/test-regress-GH-1726.js
@@ -4,7 +4,7 @@
 // exit when its child exits.
 // https://github.com/joyent/node/issues/1726
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var ch = require('child_process');
 

--- a/test/sequential/test-regress-GH-819.js
+++ b/test/sequential/test-regress-GH-819.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var net = require('net');
 var assert = require('assert');
 

--- a/test/sequential/test-setproctitle.js
+++ b/test/sequential/test-setproctitle.js
@@ -7,7 +7,7 @@ if ('linux freebsd darwin'.indexOf(process.platform) === -1) {
   return;
 }
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 var path = require('path');

--- a/test/sequential/test-sigint-infinite-loop.js
+++ b/test/sequential/test-sigint-infinite-loop.js
@@ -2,7 +2,7 @@
 // This test is to assert that we can SIGINT a script which loops forever.
 // Ref(http):
 // groups.google.com/group/nodejs-dev/browse_thread/thread/e20f2f8df0296d3f
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 

--- a/test/sequential/test-stdin-child-proc.js
+++ b/test/sequential/test-stdin-child-proc.js
@@ -1,7 +1,7 @@
 'use strict';
 // This tests that pausing and resuming stdin does not hang and timeout
 // when done in a child process.  See test/simple/test-stdin-pause-resume.js
-var common = require('../common');
+require('../common');
 var child_process = require('child_process');
 var path = require('path');
 child_process.spawn(process.execPath,

--- a/test/sequential/test-stdin-pipe-resume.js
+++ b/test/sequential/test-stdin-pipe-resume.js
@@ -1,6 +1,6 @@
 'use strict';
 // This tests that piping stdin will cause it to resume() as well.
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child') {

--- a/test/sequential/test-stdin-script-child.js
+++ b/test/sequential/test-stdin-script-child.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;

--- a/test/sequential/test-stdout-cannot-be-closed-child-process-pipe.js
+++ b/test/sequential/test-stdout-cannot-be-closed-child-process-pipe.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child')

--- a/test/sequential/test-stdout-stderr-reading.js
+++ b/test/sequential/test-stdout-stderr-reading.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 // verify that stdout is never read from.

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -1,7 +1,7 @@
 'use strict';
 // Make sure that sync writes to stderr get processed before exiting.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var util = require('util');
 

--- a/test/sequential/test-sync-fileread.js
+++ b/test/sequential/test-sync-fileread.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child')

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -1,7 +1,7 @@
 'use strict';
 // FaketimeFlags: --exclude-monotonic -f '2014-07-21 09:00:00'
 
-var common = require('../common');
+require('../common');
 
 var Timer  = process.binding('timer_wrap').Timer;
 var assert = require('assert');


### PR DESCRIPTION
#4408 backported for LTS.

common.js needs to be loaded in all tests so that there is checking
for variable leaks and possibly other things. However, it does not
need to be assigned to a variable if nothing in common.js is referred
to elsewhere in the test.

The main tradeoff for this bit of code churn is that it gets the code
base most of the way to being able to enable the no-unused-vars rule in
eslint.

(The non-tooling benefit is that it lessens cognitive load when reading
tests as it is an immediate indication that none of the functions or
properties in common.js will be used by the test.)