### PR TITLE
Fix DNS lookup on Android

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -953,12 +953,12 @@ function lookupAndConnect(self, options) {
 
   if (dnsopts.family !== 4 && dnsopts.family !== 6) {
     dnsopts.hints = dns.ADDRCONFIG;
-    // The AI_V4MAPPED hint is not supported on FreeBSD, and getaddrinfo
+    // The AI_V4MAPPED hint is not supported on FreeBSD or Android, and getaddrinfo
     // returns EAI_BADFLAGS. However, it seems to be supported on most other
     // systems. See
     // http://lists.freebsd.org/pipermail/freebsd-bugs/2008-February/028260.html
     // for more information on the lack of support for FreeBSD.
-    if (process.platform !== 'freebsd')
+    if (process.platform !== 'freebsd' && process.platform !== 'android')
       dnsopts.hints |= dns.V4MAPPED;
   }
 


### PR DESCRIPTION
`V4MAPPED` isn't supported by Android either (as of 6.0).

Fixes #3771.