### PR TITLE
repl: Allow fn parenthesis across multiple lines

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -605,6 +605,8 @@ ArrayStream.prototype.write = function() {};
 const requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
 const simpleExpressionRE =
     /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
+const recoverableErrosRE =
+    /^(?:Unexpected (?:end of input|token)|missing \) after)/;
 
 function intFilter(item) {
   // filters out anything not starting with A-Z, a-z, $ or _
@@ -1140,7 +1142,7 @@ function isRecoverableError(e, self) {
       self._inTemplateLiteral = true;
       return true;
     }
-    return /^(Unexpected end of input|Unexpected token)/.test(message);
+    return recoverableErrosRE.test(message);
   }
   return false;
 }

--- a/test/parallel/test-repl-missing-parenthesis-recoverable.js
+++ b/test/parallel/test-repl-missing-parenthesis-recoverable.js
@@ -1,0 +1,27 @@
+'use strict';
+/*
+ * This is a regression test for https://github.com/nodejs/node/issues/4060
+ */
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+// use -i to force node into interactive mode, despite stdout not being a TTY
+const args = ['-i'];
+const child = spawn(process.execPath, args);
+
+const input = 'function a() {}; a({}\n)';
+// Match '...' as well since it marks a multi-line statement
+const expectOut = /^> ... undefined\n/;
+
+child.stderr.on('data', common.fail);
+
+let out = '';
+child.stdout.on('data', (c) => {
+  out += c;
+});
+
+child.stdout.on('end', common.mustCall(() => {
+  assert(expectOut.test(out));
+}));
+
+child.stdin.end(input);


### PR DESCRIPTION
This fixes #4060, which breaks due to the error: `missing ) after argument list` and is not treated as recoverable.