### PR TITLE
Remove deprecated buffer.get / buffer.set methods

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -523,24 +523,6 @@ Buffer.prototype.fill = function fill(val, start, end) {
 };
 
 
-// XXX remove in v0.13
-Buffer.prototype.get = internalUtil.deprecate(function get(offset) {
-  offset = ~~offset;
-  if (offset < 0 || offset >= this.length)
-    throw new RangeError('Index out of range');
-  return this[offset];
-}, 'Buffer.get is deprecated. Use array indexes instead.');
-
-
-// XXX remove in v0.13
-Buffer.prototype.set = internalUtil.deprecate(function set(offset, v) {
-  offset = ~~offset;
-  if (offset < 0 || offset >= this.length)
-    throw new RangeError('Index out of range');
-  return this[offset] = v;
-}, 'Buffer.set is deprecated. Use array indexes instead.');
-
-
 // TODO(trevnorris): fix these checks to follow new standard
 // write(string, offset = 0, length = buffer.length, encoding = 'utf8')
 var writeWarned = false;


### PR DESCRIPTION
Fixes #4587.

These have been deprecated since Apr 27, 2013, and the plan was to
remove them in "node v0.13”.

`buffer.get(index)` is superseded by `buffer[index]`.

`buffer.set(index, value)` is superseded by `buffer[index] = value`.

These have never been documented at any point in node's history.