### PR TITLE
async_wrap: add uid argument to all asyncWrap hooks

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -40,8 +40,8 @@ inline AsyncWrap::AsyncWrap(Environment* env,
   v8::HandleScope scope(env->isolate());
 
   v8::Local<v8::Value> argv[] = {
-    v8::Int32::New(env->isolate(), provider),
     v8::Integer::New(env->isolate(), get_uid()),
+    v8::Int32::New(env->isolate(), provider),
     Null(env->isolate())
   };
 

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -42,11 +42,14 @@ inline AsyncWrap::AsyncWrap(Environment* env,
   v8::Local<v8::Value> argv[] = {
     v8::Integer::New(env->isolate(), get_uid()),
     v8::Int32::New(env->isolate(), provider),
+    Null(env->isolate()),
     Null(env->isolate())
   };
 
-  if (parent != nullptr)
-    argv[2] = parent->object();
+  if (parent != nullptr) {
+    argv[2] = v8::Integer::New(env->isolate(), parent->get_uid());
+    argv[3] = parent->object();
+  }
 
   v8::MaybeLocal<v8::Value> ret =
       init_fn->Call(env->context(), object, ARRAY_SIZE(argv), argv);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -179,6 +179,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
   Local<Function> post_fn = env()->async_hooks_post_function();
+  Local<Value> uid = Integer::New(env()->isolate(), get_uid());
   Local<Object> context = object();
   Local<Object> process = env()->process_object();
   Local<Object> domain;
@@ -207,14 +208,14 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (ran_init_callback() && !pre_fn.IsEmpty()) {
-    if (pre_fn->Call(context, 0, nullptr).IsEmpty())
+    if (pre_fn->Call(context, 1, &uid).IsEmpty())
       FatalError("node::AsyncWrap::MakeCallback", "pre hook threw");
   }
 
   Local<Value> ret = cb->Call(context, argc, argv);
 
   if (ran_init_callback() && !post_fn.IsEmpty()) {
-    if (post_fn->Call(context, 0, nullptr).IsEmpty())
+    if (post_fn->Call(context, 1, &uid).IsEmpty())
       FatalError("node::AsyncWrap::MakeCallback", "post hook threw");
   }
 

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -19,8 +19,8 @@ let keyList = pkeys.slice();
 keyList.splice(0, 1);
 
 
-function init(id) {
-  keyList = keyList.filter((e) => e != pkeys[id]);
+function init(id, provider) {
+  keyList = keyList.filter((e) => e != pkeys[provider]);
 }
 
 function noop() { }

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -10,7 +10,7 @@ let cntr = 0;
 let server;
 let client;
 
-function init(type, id, parent) {
+function init(id, type, parent) {
   if (parent) {
     cntr++;
     // Cannot assert in init callback or will abort.

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -6,17 +6,24 @@ const net = require('net');
 const async_wrap = process.binding('async_wrap');
 const providers = Object.keys(async_wrap.Providers);
 
+const uidSymbol = Symbol('uid');
+
 let cntr = 0;
 let server;
 let client;
 
-function init(id, type, parent) {
-  if (parent) {
+function init(uid, type, parentUid, parentHandle) {
+  this[uidSymbol] = uid;
+
+  if (parentHandle) {
     cntr++;
     // Cannot assert in init callback or will abort.
     process.nextTick(() => {
       assert.equal(providers[type], 'TCPWRAP');
-      assert.equal(parent, server._handle, 'server doesn\'t match parent');
+      assert.equal(parentUid, server._handle[uidSymbol],
+                   'server uid doesn\'t match parent uid');
+      assert.equal(parentHandle, server._handle,
+                   'server handle doesn\'t match parent handle');
       assert.equal(this, client._handle, 'client doesn\'t match context');
     });
   }

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -9,7 +9,7 @@ let cntr = 0;
 let server;
 let client;
 
-function init(type, id, parent) {
+function init(id, type, parent) {
   if (parent) {
     cntr++;
     // Cannot assert in init callback or will abort.

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -4,17 +4,26 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const async_wrap = process.binding('async_wrap');
+const providers = Object.keys(async_wrap.Providers);
+
+const uidSymbol = Symbol('uid');
 
 let cntr = 0;
 let server;
 let client;
 
-function init(id, type, parent) {
-  if (parent) {
+function init(uid, type, parentUid, parentHandle) {
+  this[uidSymbol] = uid;
+
+  if (parentHandle) {
     cntr++;
     // Cannot assert in init callback or will abort.
     process.nextTick(() => {
-      assert.equal(parent, server._handle, 'server doesn\'t match parent');
+      assert.equal(providers[type], 'TCPWRAP');
+      assert.equal(parentUid, server._handle[uidSymbol],
+                   'server uid doesn\'t match parent uid');
+      assert.equal(parentHandle, server._handle,
+                   'server handle doesn\'t match parent handle');
       assert.equal(this, client._handle, 'client doesn\'t match context');
     });
   }

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -9,7 +9,7 @@ const storage = new Map();
 async_wrap.setupHooks(init, pre, post, destroy);
 async_wrap.enable();
 
-function init(provider, uid) {
+function init(uid) {
   storage.set(uid, {
     init: true,
     pre: false,

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -1,0 +1,57 @@
+'use strict';
+
+require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const async_wrap = process.binding('async_wrap');
+
+const storage = new Map();
+async_wrap.setupHooks(init, pre, post, destroy);
+async_wrap.enable();
+
+function init(provider, uid) {
+  storage.set(uid, {
+    init: true,
+    pre: false,
+    post: false,
+    destroy: false
+  });
+}
+
+function pre(uid) {
+  storage.get(uid).pre = true;
+}
+
+function post(uid) {
+  storage.get(uid).post = true;
+}
+
+function destroy(uid) {
+  storage.get(uid).destroy = true;
+}
+
+fs.access(__filename, function(err) {
+  assert.ifError(err);
+});
+
+fs.access(__filename, function(err) {
+  assert.ifError(err);
+});
+
+async_wrap.disable();
+
+process.once('exit', function() {
+  assert.strictEqual(storage.size, 2);
+
+  for (const item of storage) {
+    const uid = item[0];
+    const value = item[1];
+    assert.strictEqual(typeof uid, 'number');
+    assert.deepStrictEqual(value, {
+      init: true,
+      pre: true,
+      post: true,
+      destroy: true
+    });
+  }
+});


### PR DESCRIPTION
By doing this, users can use a Map object for storing information instead of modifying the handle object.

@trevnorris mentioned this was an "API deficiency" https://github.com/nodejs/tracing-wg/pull/37/files#r48493114

Also, could we make `uid` the first argument in the `init` hook, such that it consistent for all hooks?