### PR TITLE
test: fix `http-upgrade-client` flakiness

### DIFF
--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -40,9 +40,14 @@ srv.listen(common.PORT, '127.0.0.1', function() {
     }
   });
   req.on('upgrade', function(res, socket, upgradeHead) {
-    // XXX: This test isn't fantastic, as it assumes that the entire response
-    //      from the server will arrive in a single data callback
-    assert.equal(upgradeHead, 'nurtzo');
+    var recvData = upgradeHead;
+    socket.on('data', function(d) {
+      recvData += d;
+    });
+
+    socket.on('close', common.mustCall(function() {
+      assert.equal(recvData, 'nurtzo');
+    }));
 
     console.log(res.headers);
     var expectedHeaders = {'hello': 'world',


### PR DESCRIPTION
It's not guaranteed that the socket data is received in the same chunk
as the upgrade response. Listen for the `data` event to make sure all
the data is received.