### PR TITLE
test: only include http module once

### DIFF
--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -18,7 +18,6 @@ var http  = require('http'),
 
 console.log('We should do ' + todo + ' requests');
 
-var http = require('http');
 var server = http.createServer(serverHandler);
 server.listen(PORT, getall);
 

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -20,7 +20,6 @@ var http  = require('http'),
 
 console.log('We should do ' + todo + ' requests');
 
-var http = require('http');
 var server = http.createServer(serverHandler);
 server.listen(PORT, runTest);
 

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -22,7 +22,6 @@ var http  = require('http'),
 
 console.log('We should do ' + todo + ' requests');
 
-var http = require('http');
 var server = http.createServer(serverHandler);
 server.listen(PORT, getall);
 

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -18,7 +18,6 @@ var http  = require('http'),
 
 console.log('We should do ' + todo + ' requests');
 
-var http = require('http');
 var server = http.createServer(serverHandler);
 server.listen(PORT, getall);
 


### PR DESCRIPTION
A few tests in test/gc include the http module twice. Remove duplicate
require().