### PR TITLE
docs: Adds usage of readline line-by-line parsing

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -232,6 +232,22 @@ line interface:
       process.exit(0);
     });
 
+## Example: Read File Stream Line-by-Line
+
+Also a common case for `readline`'s `input` option is passing a file system
+readable Stream to it. This is how one could craft line-by-line parsing:
+
+    const readline = require('readline');
+    const fs = require('fs');
+
+    const rl = readline.createInterface({
+      input: fs.createReadStream('sample.txt')
+    });
+
+    rl.on('line', function (line) {
+      console.log('Line from file:', line);
+    });
+
 ## readline.clearLine(stream, dir)
 
 Clears current line of given TTY stream in a specified direction.

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -234,8 +234,8 @@ line interface:
 
 ## Example: Read File Stream Line-by-Line
 
-Also a common case for `readline`'s `input` option is passing a file system
-readable Stream to it. This is how one could craft line-by-line parsing:
+A common case for `readline`'s `input` option is to pass a filesystem readable
+stream to it. This is how one could craft line-by-line parsing of a file:
 
     const readline = require('readline');
     const fs = require('fs');


### PR DESCRIPTION
In order to make developers aware of node-core built-in
functionality, which might replace module APIs, we should
add an example of readline`s interface usage.
SEO will eventually aid this goal, since it is well searched
on Q&A sites.

PR-URL: #4609
Reviewed-By: