### PR TITLE
test: require common module only once

### DIFF
--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -10,8 +10,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var common = require('../common');
-
 var requests = 0;
 
 var server = tls.createServer({

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -10,8 +10,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var common = require('../common');
-
 var buf = new Buffer(10000);
 var received = 0;
 var ended = 0;


### PR DESCRIPTION
Two tests were requiring the common module twice. This removes the
duplicate require statement in the tests.