### PR TITLE
http: remove variable redeclaration

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -121,8 +121,7 @@ function ClientRequest(options, cb) {
   if (self.socketPath) {
     self._last = true;
     self.shouldKeepAlive = false;
-    var conn = self.agent.createConnection({ path: self.socketPath });
-    self.onSocket(conn);
+    self.onSocket(self.agent.createConnection({ path: self.socketPath }));
   } else if (self.agent) {
     // If there is an agent we should default to Connection:keep-alive,
     // but only if the Agent will actually reuse the connection!
@@ -141,12 +140,11 @@ function ClientRequest(options, cb) {
     self._last = true;
     self.shouldKeepAlive = false;
     if (options.createConnection) {
-      var conn = options.createConnection(options);
+      self.onSocket(options.createConnection(options));
     } else {
       debug('CLIENT use net.createConnection', options);
-      var conn = net.createConnection(options);
+      self.onSocket(net.createConnection(options));
     }
-    self.onSocket(conn);
   }
 
   self._deferToConnect(null, null, function() {


### PR DESCRIPTION
In `lib/_http_client.js`, the variable `conn` was declared with the `var`
keyword three times in the same scope. This change eliminates the
variable entirely.