### PR TITLE
dgram: prevent disabled optimization of bind()

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -134,8 +134,9 @@ function replaceHandle(self, newHandle) {
   self._handle = newHandle;
 }
 
-Socket.prototype.bind = function(port /*, address, callback*/) {
+Socket.prototype.bind = function(port_ /*, address, callback*/) {
   var self = this;
+  let port = port_;
 
   self._healthCheck();
 


### PR DESCRIPTION
Reassigning a named parameter while also using the arguments object causes the entire function to never be optimized.