### PR TITLE
test: remove 1 second delay from test

### DIFF
--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -13,8 +13,9 @@ if (cluster.isWorker) {
     });
   }).listen(common.PORT, common.localhostIPv4);
 } else if (cluster.isMaster) {
-
-  var ok;
+  // Although not typical, the worker process can exit before the disconnect
+  // event fires. Use this to keep the process open until the event has fired.
+  var keepOpen = setInterval(function() {}, 9999);
 
   // start worker
   var worker = cluster.fork();
@@ -37,10 +38,6 @@ if (cluster.isWorker) {
   worker.once('disconnect', function() {
     // disconnect should occur after socket close
     assert.equal(socket.readyState, 'closed');
-    ok = true;
-  });
-
-  process.once('exit', function() {
-    assert.ok(ok);
+    clearInterval(keepOpen);
   });
 }

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -24,14 +24,14 @@ if (cluster.isWorker) {
   worker.once('listening', function() {
     net.createConnection(common.PORT, common.localhostIPv4, function() {
       var socket = this;
+      this.on('end', function() {
+        connectionDone = true;
+      });
       this.on('data', function() {
         console.log('got data from client');
         // socket definitely connected to worker if we got data
         worker.disconnect();
-        setTimeout(function() {
-          socket.end();
-          connectionDone = true;
-        }, 1000);
+        socket.end();
       });
     });
   });

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -14,19 +14,16 @@ if (cluster.isWorker) {
   }).listen(common.PORT, common.localhostIPv4);
 } else if (cluster.isMaster) {
 
-  var connectionDone;
   var ok;
 
   // start worker
   var worker = cluster.fork();
 
+  var socket;
   // Disconnect worker when it is ready
   worker.once('listening', function() {
     net.createConnection(common.PORT, common.localhostIPv4, function() {
-      var socket = this;
-      this.on('end', function() {
-        connectionDone = true;
-      });
+      socket = this;
       this.on('data', function() {
         console.log('got data from client');
         // socket definitely connected to worker if we got data
@@ -38,7 +35,8 @@ if (cluster.isWorker) {
 
   // Check worker events and properties
   worker.once('disconnect', function() {
-    assert.ok(connectionDone, 'disconnect should occur after socket close');
+    // disconnect should occur after socket close
+    assert.equal(socket.readyState, 'closed');
     ok = true;
   });
 


### PR DESCRIPTION
Remove unnecessary 1-second delay from test. Confirmed that test (with changes to eliminate ES6-isms in common.js) still fails in v1.8.1 (which has the bug this test was written for) and passes in v2.3.4 (which contains the fix). 

R=@sam-github 