### PR TITLE
stream: remove useless if test in transform

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -75,8 +75,7 @@ function afterTransform(stream, er, data) {
   if (data !== null && data !== undefined)
     stream.push(data);
 
-  if (cb)
-    cb(er);
+  cb(er);
 
   var rs = stream._readableState;
   rs.reading = false;


### PR DESCRIPTION
Falsy `cb` has already been rejected in https://github.com/nodejs/node/blob/master/lib/_stream_transform.js#L69