### PR TITLE
tls_legacy: do not read on OpenSSL's stack

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -614,13 +614,15 @@ function onclienthello(hello) {
 
     if (err) return self.socket.destroy(err);
 
-    self.ssl.loadSession(session);
-    self.ssl.endParser();
+    setImmediate(function() {
+      self.ssl.loadSession(session);
+      self.ssl.endParser();
 
-    // Cycle data
-    self._resumingSession = false;
-    self.cleartext.read(0);
-    self.encrypted.read(0);
+      // Cycle data
+      self._resumingSession = false;
+      self.cleartext.read(0);
+      self.encrypted.read(0);
+    });
   }
 
   if (hello.sessionId.length <= 0 ||


### PR DESCRIPTION
Do not attempt to read data from the socket whilst on OpenSSL's stack,
weird things may happen, and this is most likely going to result in some
kind of error.

R=@trevnorris

Let's land this change anyway, so it will be easier to work on our AsyncWrap stuff.

Not really going to introduce a test here, because this thing will fail once https://github.com/nodejs/node/pull/4509 or any similar PR will land.
