### PR TITLE
deps: backport 066747e from upstream V8

### DIFF
--- a/deps/v8/src/elements.cc
+++ b/deps/v8/src/elements.cc
@@ -1071,13 +1071,18 @@ class FastElementsAccessor
       }
       int num_used = 0;
       for (int i = 0; i < backing_store->length(); ++i) {
-        if (!backing_store->is_the_hole(i)) ++num_used;
-        // Bail out early if more than 1/4 is used.
-        if (4 * num_used > backing_store->length()) break;
+        if (!backing_store->is_the_hole(i)) {
+          ++num_used;
+          // Bail out if a number dictionary wouldn't be able to save at least
+          // 75% space.
+          if (4 * SeededNumberDictionary::ComputeCapacity(num_used) *
+                  SeededNumberDictionary::kEntrySize >
+              backing_store->length()) {
+            return;
+          }
+        }
       }
-      if (4 * num_used <= backing_store->length()) {
-        JSObject::NormalizeElements(obj);
-      }
+      JSObject::NormalizeElements(obj);
     }
   }
 

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -12226,6 +12226,8 @@ static bool ShouldConvertToFastElements(JSObject* object,
 
   uint32_t dictionary_size = static_cast<uint32_t>(dictionary->Capacity()) *
                              SeededNumberDictionary::kEntrySize;
+
+  // Turn fast if the dictionary only saves 50% space.
   return 2 * dictionary_size >= *new_capacity;
 }
 


### PR DESCRIPTION
This backport fixes a performance pathology in how arrays grow/shrink. This was a regression introduced in V8 4.5. The V8 team has already backported this a far back as V8 4.7. We need to float the backport for `v5.x` (V8 4.6) and `v4.x` (V8 4.5).

Fixes: https://github.com/nodejs/node/issues/3538
V8-Commit: https://github.com/v8/v8/commit/066747ea053012a99e0cd3e20f36b8ed053b2124

Original commit message:
  Make sure that NormalizeElements and ShouldConvertToFastElements are …

  …based on the same values

  BUG=v8:4518
  LOG=n

  Review URL: https://codereview.chromium.org/1472293002

  Cr-Commit-Position: refs/heads/master@{#32265}