### PR TITLE
test: fix `fs-watch-recursive` flakiness

### DIFF
--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -34,7 +34,13 @@ watcher.on('change', function(event, filename) {
   watcherClosed = true;
 });
 
-fs.writeFileSync(filepathOne, 'world');
+if (process.platform === 'darwin') {
+  setTimeout(function() {
+    fs.writeFileSync(filepathOne, 'world');
+  }, 100);
+} else {
+  fs.writeFileSync(filepathOne, 'world');
+}
 
 process.on('exit', function() {
   assert(watcherClosed, 'watcher Object was not closed');


### PR DESCRIPTION
The test is sometimes timing out because of a race condition between
the fs event generated on file creation and the event being registered
in the kqueue. To avoid this problem, create the file after 100 ms,
that is the value used in the libuv test:
https://github.com/libuv/libuv/blob/v1.x/test/test-fs-event.c#L411