### PR TITLE
tools: add missing headers

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -153,7 +153,7 @@ NODE_EXTERN v8::Local<v8::Value> MakeCallback(
 }  // namespace node
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
-#include "node_internals.h"
+# error node internals are not available in add-ons
 #endif
 
 #include <assert.h>

--- a/tools/install.py
+++ b/tools/install.py
@@ -156,7 +156,6 @@ def headers(action):
     'config.gypi',
     'src/node.h',
     'src/node_buffer.h',
-    'src/node_internals.h',
     'src/node_object_wrap.h',
     'src/node_version.h',
   ], 'include/node/')


### PR DESCRIPTION
Two header files were missing when expose the include file.
These headers are used in "node_internals.h".