### PR TITLE
build: Add VARIATION variable to binary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,12 @@ endif
 
 TARNAME=node-$(FULLVERSION)
 TARBALL=$(TARNAME).tar
+# Custom user-specified variation, use it directly
+ifdef VARIATION
+BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)-$(VARIATION)
+else
 BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)
+endif
 BINARYTAR=$(BINARYNAME).tar
 # OSX doesn't have xz installed by default, http://macpkg.sourceforge.net/
 XZ=$(shell which xz > /dev/null 2>&1; echo $$?)


### PR DESCRIPTION
If the VARIATION variable is present, then "make binary" will produce archives named node-$(FULLVERSION)-$(PLATFORM)-$(ARCH)-$(VARIATION).

This capability is useful when building variations of Node.js for the same platform/architecture. For example, when building x64 Linux with FIPS compliant crypto provider, it is useful to have a "-fips" suffix to easily identify this functionality without having to examine the contents.

Contrast: node-v6.0.0-linux-x64.tar.gz vs node-v6.0.0-linux-x64-variation.tar.gz