### PR TITLE
configure: Delete config_fips.gypi when not needed

### DIFF
--- a/configure
+++ b/configure
@@ -1142,6 +1142,8 @@ if 'make_fips_settings' in output:
   del output['make_fips_settings']
   write('config_fips.gypi', do_not_edit +
         pprint.pformat(config_fips, indent=2) + '\n')
+else:
+  os.remove('config_fips.gypi')
 
 # make_global_settings should be a root level element too
 if 'make_global_settings' in output:


### PR DESCRIPTION
If reconfiguring without fips, do not leave stale config_fips.gypi on disk. It will be recreated if needed by re-running configure.