### PR TITLE
debugger: remove variable redeclarations

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1353,7 +1353,7 @@ Interface.prototype.setBreakpoint = function(script, line,
     return;
   }
 
-  var req;
+  let req;
   if (/\(\)$/.test(script)) {
     // setBreakpoint('functionname()');
     req = {
@@ -1653,9 +1653,8 @@ Interface.prototype.trySpawn = function(cb) {
   assert(!this.child);
 
   var isRemote = false;
-  var match;
   if (this.args.length === 2) {
-    match = this.args[1].match(/^([^:]+):(\d+)$/);
+    const match = this.args[1].match(/^([^:]+):(\d+)$/);
 
     if (match) {
       // Connecting to remote debugger
@@ -1679,7 +1678,7 @@ Interface.prototype.trySpawn = function(cb) {
       }
       isRemote = true;
     } else {
-      match = this.args[1].match(/^--port=(\d+)$/);
+      const match = this.args[1].match(/^--port=(\d+)$/);
       if (match) {
         // Start debugger on custom port
         // `node debug --port=5858 app.js`

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -463,7 +463,7 @@ Client.prototype.setBreakpoint = function(req, cb) {
 };
 
 Client.prototype.clearBreakpoint = function(req, cb) {
-  var req = {
+  req = {
     command: 'clearbreakpoint',
     arguments: req
   };
@@ -1353,9 +1353,10 @@ Interface.prototype.setBreakpoint = function(script, line,
     return;
   }
 
+  var req;
   if (/\(\)$/.test(script)) {
     // setBreakpoint('functionname()');
-    var req = {
+    req = {
       type: 'function',
       target: script.replace(/\(\)$/, ''),
       condition: condition
@@ -1381,7 +1382,6 @@ Interface.prototype.setBreakpoint = function(script, line,
     if (ambiguous) return this.error('Script name is ambiguous');
     if (line <= 0) return this.error('Line should be a positive value');
 
-    var req;
     if (scriptId) {
       req = {
         type: 'scriptId',
@@ -1653,8 +1653,9 @@ Interface.prototype.trySpawn = function(cb) {
   assert(!this.child);
 
   var isRemote = false;
+  var match;
   if (this.args.length === 2) {
-    var match = this.args[1].match(/^([^:]+):(\d+)$/);
+    match = this.args[1].match(/^([^:]+):(\d+)$/);
 
     if (match) {
       // Connecting to remote debugger
@@ -1678,7 +1679,7 @@ Interface.prototype.trySpawn = function(cb) {
       }
       isRemote = true;
     } else {
-      var match = this.args[1].match(/^--port=(\d+)$/);
+      match = this.args[1].match(/^--port=(\d+)$/);
       if (match) {
         // Start debugger on custom port
         // `node debug --port=5858 app.js`


### PR DESCRIPTION
Some variables are declared with `var` more than once in the same scope. This change reduces the declarations to one per scope.