### PR TITLE
test: remove duplicate fork module import

### DIFF
--- a/test/parallel/test-child-process-fork-close.js
+++ b/test/parallel/test-child-process-fork-close.js
@@ -1,7 +1,6 @@
 'use strict';
 var assert = require('assert'),
     common = require('../common'),
-    fork = require('child_process').fork,
     fork = require('child_process').fork;
 
 var cp = fork(common.fixturesDir + '/child-process-message-and-exit.js');


### PR DESCRIPTION
`fork` is imported twice in a row. Remove duplication.