### PR TITLE
doc: add branch-diff example to releases.md

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -54,6 +54,12 @@ Notes:
 
 Create a new branch named _"vx.y.z-proposal"_, or something similar. Using `git cherry-pick`, bring the appropriate commits into your new branch. To determine the relevant commits, use [`branch-diff`](https://github.com/rvagg/branch-diff) and [`changelog-maker`](https://github.com/rvagg/changelog-maker/) (both are available on npm and should be installed globally). These tools depend on our commit metadata, as well as the `semver-minor` and `semver-major` GitHub labels. One drawback is that when the `PR-URL` metadata is accidentally omitted from a commit, the commit will show up because it's unsure if it's a duplicate or not.
 
+For a list of commits that could be landed in a patch release on v5.x
+
+```
+$ branch-diff v5.x master --exclude-label semver-major,semver-minor,dont-land-on-v5.x --simple
+```
+
 Carefully review the list of commits looking for errors (incorrect `PR-URL`, incorrect semver, etc.). Commits labeled as semver minor or semver major should only be cherry-picked when appropriate for the type of release being made. Previous release commits and version bumps do not need to be cherry-picked.
 
 ### 2. Update `src/node_version.h`


### PR DESCRIPTION
Useful to have for reference, especially for onboarding