### PR TITLE
test: fix race in test-net-server-pause-on-connect

### DIFF
--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -1,13 +1,16 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
-var msg = 'test';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const msg = 'test';
 var stopped = true;
-var server1 = net.createServer({pauseOnConnect: true}, function(socket) {
+var server1Sock;
+
+
+const server1ConnHandler = function(socket) {
   socket.on('data', function(data) {
     if (stopped) {
-      assert(false, 'data event should not have happened yet');
+      common.fail('data event should not have happened yet');
     }
 
     assert.equal(data.toString(), msg, 'invalid data received');
@@ -15,38 +18,34 @@ var server1 = net.createServer({pauseOnConnect: true}, function(socket) {
     server1.close();
   });
 
-  setTimeout(function() {
-    // After 50(ish) ms, the other socket should have already read the data.
-    assert.equal(read, true);
-    assert.equal(socket.bytesRead, 0, 'no data should have been read yet');
+  server1Sock = socket;
+};
 
-    socket.resume();
-    stopped = false;
-  }, common.platformTimeout(50));
-});
+const server1 = net.createServer({pauseOnConnect: true}, server1ConnHandler);
 
-// read is a timing check, as server1's timer should fire after server2's
-// connection receives the data. Note that this could be race-y.
-var read = false;
-var server2 = net.createServer({pauseOnConnect: false}, function(socket) {
+const server2ConnHandler = function(socket) {
   socket.on('data', function(data) {
-    read = true;
-
     assert.equal(data.toString(), msg, 'invalid data received');
     socket.end();
     server2.close();
+
+    assert.equal(server1Sock.bytesRead, 0, 'no data should have been read yet');
+    server1Sock.resume();
+    stopped = false;
   });
-});
+};
+
+const server2 = net.createServer({pauseOnConnect: false}, server2ConnHandler);
 
 server1.listen(common.PORT, function() {
-  net.createConnection({port: common.PORT}).write(msg);
-});
-
-server2.listen(common.PORT + 1, function() {
-  net.createConnection({port: common.PORT + 1}).write(msg);
+  const clientHandler = common.mustCall(function() {
+    server2.listen(common.PORT + 1, function() {
+      net.createConnection({port: common.PORT + 1}).write(msg);
+    });
+  });
+  net.createConnection({port: common.PORT}).write(msg, clientHandler);
 });
 
 process.on('exit', function() {
   assert.equal(stopped, false);
-  assert.equal(read, true);
 });


### PR DESCRIPTION
A 50ms timeout results in a race condition. Instead, enforce expected
order through callbacks. This has the side effect of speeding up the
test in most situations.

Ref: https://github.com/nodejs/node/pull/4476

R=@jbergstroem
R=@brendanashworth 