### PR TITLE
test: fix flaky test-net-socket-local-address

### DIFF
--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -20,12 +20,6 @@ const server = net.createServer(function(socket) {
 
 const client = new net.Socket();
 
-server.on('close', common.mustCall(function() {
-  assert.deepEqual(clientLocalPorts, serverRemotePorts,
-                   'client and server should agree on the ports used');
-  assert.equal(2, conns);
-}));
-
 server.listen(common.PORT, common.localhostIPv4, testConnect);
 
 function testConnect() {
@@ -44,3 +38,9 @@ function testConnect() {
   });
   conns++;
 }
+
+process.on('exit', function() {
+  assert.deepEqual(clientLocalPorts, serverRemotePorts,
+                   'client and server should agree on the ports used');
+  assert.equal(2, conns);
+});


### PR DESCRIPTION
The close event can fire twice if close is called twice. Move checks
to exit event for process instead.

Ref: https://github.com/nodejs/node/pull/4476