### PR TITLE
build: Add option to select environment for msbuild (vc2015 or vc2013)

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -15,6 +15,7 @@ if /i "%1"=="/?" goto help
 set config=Release
 set target=Build
 set target_arch=x86
+set target_env=
 set noprojgen=
 set nobuild=
 set nosign=
@@ -44,6 +45,8 @@ if /i "%1"=="clean"         set target=Clean&goto arg-ok
 if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
+if /i "%1"=="vc2013"        set target_env=vc2013&goto arg-ok
+if /i "%1"=="vc2015"        set target_env=vc2015&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
 if /i "%1"=="nosign"        set nosign=1&goto arg-ok
@@ -109,6 +112,10 @@ call :getnodeversion || exit /b 1
 
 @rem Set environment for msbuild
 
+if "%target_env%"=="vc2015" goto vc-set-2015
+if "%target_env%"=="vc2013" goto vc-set-2013
+
+:vc-set-2015
 @rem Look for Visual Studio 2015
 echo Looking for Visual Studio 2015
 if not defined VS140COMNTOOLS goto vc-set-2013
@@ -261,7 +268,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all] [enable-vtune]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [vc2013/vc2015] [download-all] [enable-vtune]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -112,10 +112,7 @@ call :getnodeversion || exit /b 1
 
 @rem Set environment for msbuild
 
-if "%target_env%"=="vc2015" goto vc-set-2015
-if "%target_env%"=="vc2013" goto vc-set-2013
-
-:vc-set-2015
+if defined target_env if "%target_env%" NEQ "vc2015" goto vc-set-2013
 @rem Look for Visual Studio 2015
 echo Looking for Visual Studio 2015
 if not defined VS140COMNTOOLS goto vc-set-2013
@@ -139,6 +136,7 @@ set PLATFORM_TOOLSET=v140
 goto msbuild-found
 
 :vc-set-2013
+if defined target_env if "%target_env%" NEQ "vc2013" goto msbuild-not-found
 @rem Look for Visual Studio 2013
 echo Looking for Visual Studio 2013
 if not defined VS120COMNTOOLS goto msbuild-not-found


### PR DESCRIPTION
Add option in vcbuild.bat script to select Visual Studio environment to build Node on Windows.
- vc2013 to select Visual Studio 2013 environment
- vc2015 to select Visual Studio 2015 environment