### PR TITLE
net: remove hot path comment from connect

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -933,7 +933,6 @@ function lookupAndConnect(self, options) {
   port |= 0;
 
   // If host is an IP, skip performing a lookup
-  // TODO(evanlucas) should we hot path this for localhost?
   var addressType = exports.isIP(host);
   if (addressType) {
     process.nextTick(function() {


### PR DESCRIPTION
This comment was added with an assumption that we could determine the
IP address that localhost should resolve to without performing a
lookup. This was a false assumption and should be removed.

Ref: https://github.com/nodejs/node/issues/4642