### PR TITLE
module: Remove unused code

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -470,11 +470,6 @@ Module._initPaths = function() {
   Module.globalPaths = modulePaths.slice(0);
 };
 
-// TODO(bnoordhuis) Unused, remove in the future.
-Module.requireRepl = internalUtil.deprecate(function() {
-  return NativeModule.require('internal/repl');
-}, 'Module.requireRepl is deprecated.');
-
 Module._preloadModules = function(requests) {
   if (!Array.isArray(requests))
     return;


### PR DESCRIPTION
Remove unused `requireRepl` code.
It was deprecated after 5.1.x.

This is with reference to #4642.