### PR TITLE
test: fix flaky test-net-socket-local-address

### DIFF
--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -12,35 +12,29 @@ if (common.inFreeBSDJail) {
 var conns = 0;
 var clientLocalPorts = [];
 var serverRemotePorts = [];
-
-const server = net.createServer(function(socket) {
+const client = new net.Socket();
+const server = net.createServer(socket => {
   serverRemotePorts.push(socket.remotePort);
-  testConnect();
+  socket.end();
 });
 
-const client = new net.Socket();
-
-server.on('close', common.mustCall(function() {
+server.on('close', common.mustCall(() => {
   assert.deepEqual(clientLocalPorts, serverRemotePorts,
                    'client and server should agree on the ports used');
-  assert.equal(2, conns);
+  assert.strictEqual(2, conns);
 }));
 
-server.listen(common.PORT, common.localhostIPv4, testConnect);
+server.listen(common.PORT, common.localhostIPv4, connect);
 
-function testConnect() {
-  if (conns > serverRemotePorts.length || conns > clientLocalPorts.length) {
-    // We're waiting for a callback to fire.
+function connect() {
+  if (conns === 2) {
+    server.close();
     return;
   }
 
-  if (conns === 2) {
-    return server.close();
-  }
-  client.connect(common.PORT, common.localhostIPv4, function() {
-    clientLocalPorts.push(this.localPort);
-    this.once('close', testConnect);
-    this.destroy();
-  });
   conns++;
+  client.once('close', connect);
+  client.connect(common.PORT, common.localhostIPv4, () => {
+    clientLocalPorts.push(client.localPort);
+  });
 }


### PR DESCRIPTION
Prior to this commit, the test was flaky because it was executing the majority of its logic in a function called from the client and multiple events on the server. This commit simplifies the test by separating the server's connection and listening events, and isolating the client logic.

Refs: #4476 and #4644
R= @Trott 