### PR TITLE
domain: fix clearing domains stack

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -62,18 +62,6 @@ Domain.prototype._errorHandler = function errorHandler(er) {
   var caught = false;
   var self = this;
 
-  function emitError() {
-    var handled = self.emit('error', er);
-
-    // Exit all domains on the stack.  Uncaught exceptions end the
-    // current tick and no domains should be left on the stack
-    // between ticks.
-    stack.length = 0;
-    exports.active = process.domain = null;
-
-    return handled;
-  }
-
   // ignore errors on disposed domains.
   //
   // XXX This is a bit stupid.  We should probably get rid of
@@ -107,7 +95,7 @@ Domain.prototype._errorHandler = function errorHandler(er) {
         // if technically the top-level domain is still active, it would
         // be ok to abort on an uncaught exception at this point
         process._emittingTopLevelDomainError = true;
-        caught = emitError();
+        caught = self.emit('error', er);
       } finally {
         process._emittingTopLevelDomainError = false;
       }
@@ -123,7 +111,7 @@ Domain.prototype._errorHandler = function errorHandler(er) {
       //
       // If caught is false after this, then there's no need to exit()
       // the domain, because we're going to crash the process anyway.
-      caught = emitError();
+      caught = self.emit('error', er);
     } catch (er2) {
       // The domain error handler threw!  oh no!
       // See if another domain can catch THIS error,
@@ -138,9 +126,15 @@ Domain.prototype._errorHandler = function errorHandler(er) {
       } else {
         caught = false;
       }
-      return caught;
     }
   }
+
+  // Exit all domains on the stack.  Uncaught exceptions end the
+  // current tick and no domains should be left on the stack
+  // between ticks.
+  stack.length = 0;
+  exports.active = process.domain = null;
+
   return caught;
 };
 

--- a/test/parallel/test-domain-stack-empty-in-process-uncaughtexception.js
+++ b/test/parallel/test-domain-stack-empty-in-process-uncaughtexception.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const domain = require('domain');
+const assert = require('assert');
+
+const d = domain.create();
+
+process.on('uncaughtException', common.mustCall(function onUncaught() {
+  assert.equal(process.domain, null,
+    'domains stack should be empty in uncaughtException handler');
+}));
+
+process.on('beforeExit', common.mustCall(function onBeforeExit() {
+  assert.equal(process.domain, null,
+    'domains stack should be empty in beforeExit handler');
+}));
+
+d.run(function() {
+  throw new Error('boom');
+});
+


### PR DESCRIPTION
Clear domains stack __even if no domain error handler is set__ so that
code running in the process' uncaughtException handler, or any code that
may be executed when an error is thrown and not caught, doesn't run in
the context of the domain within which the error was thrown.

I set the `semver-minor` label conservatively because although in my opinion it fixes an inconsistency in domains' error handling, it's a potentially breaking behavior change.

I have a similar change for the v0.12.x branch, but we may not want to back port the change to the v0.12.x branch for the same reason. And finally, this test could also be back ported to the v0.10.x branch (the change itself doesn't need to, as v0.10.x versions are not affected by the problem this change fixes), with the same reserve.