### PR TITLE
lib: fix basename comparison on windows

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -340,11 +340,12 @@ win32.basename = function(path, ext) {
   if (ext !== undefined && typeof ext !== 'string')
     throw new TypeError('"ext" argument must be a string');
 
-  var f = win32SplitPath(path)[2];
-  // TODO: make this comparison case-insensitive on windows?
-  if (ext && f.substr(-1 * ext.length) === ext) {
+  let f = win32SplitPath(path)[2];
+
+  if (ext && f.toLowerCase().endsWith(ext.toLowerCase())) {
     f = f.substr(0, f.length - ext.length);
   }
+
   return f;
 };
 

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -406,6 +406,13 @@ assert.equal(path.win32.delimiter, ';');
 // posix
 assert.equal(path.posix.delimiter, ':');
 
+// ensure ext comparison is case-insensitive on windows
+const upBaseName = path.win32.basename('same.txt', '.TXT');
+const loBaseName = path.win32.basename('SAME.TXT', '.txt');
+
+assert.strictEqual(upBaseName.length,
+                   loBaseName.length,
+                   'both should return "same"');
 
 if (common.isWindows)
   assert.deepEqual(path, path.win32, 'should be win32 path module');


### PR DESCRIPTION
Fixes TODO in lib/path.js ref'd here #4642

``` javascript
 var f = win32SplitPath(path)[2];
  // TODO: make this comparison case-insensitive on windows?
  if (ext && f.substr(-1 * ext.length) === ext) {
    f = f.substr(0, f.length - ext.length);
```
