### PR TITLE
lib: fixme defer error to next tick

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -510,7 +510,7 @@ function setupChannel(target, channel) {
     if (typeof callback === 'function') {
       process.nextTick(callback, ex);
     } else {
-      this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+      process.nextTick(() => this.emit('error', ex));
     }
     return false;
   };
@@ -612,7 +612,7 @@ function setupChannel(target, channel) {
         if (typeof callback === 'function') {
           process.nextTick(callback, ex);
         } else {
-          this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+          process.nextTick(() => this.emit('error', ex));
         }
       }
     }


### PR DESCRIPTION
Fixes FIXMEs in lib/internal/child_process.js ref's #4642

``` javascript
...
      process.nextTick(callback, ex);
    } else {
      this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
    }
    return false;
...
        process.nextTick(callback, ex);
      } else {
        this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
      }
    }
```
