### PR TITLE
test: fix test-cluster-disconnect-leak.js for AIX

### DIFF
--- a/test/sequential/test-cluster-disconnect-leak.js
+++ b/test/sequential/test-cluster-disconnect-leak.js
@@ -16,8 +16,9 @@ if (common.isWindows) {
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 if (cluster.isMaster) {
+  const largeTries = common.isAix ? 112 : 128; 
   const cpus = os.cpus().length;
-  const tries = cpus > 8 ? 128 : cpus * 16;
+  const tries = cpus > 8 ? largeTries : cpus * 16;
 
   const worker1 = cluster.fork();
   worker1.on('message', common.mustCall(() => {


### PR DESCRIPTION
lowered the number of spawned workers as EAGAIN errors were
being thrown.