### PR TITLE
Revert commits that cause failing tests on Windows CI

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1550,7 +1550,7 @@ fs.realpathSync = function realpathSync(p, cache) {
         }
       }
       if (linkTarget === null) {
-        fs.accessSync(base, fs.F_OK);  // Throws ELOOP on cyclic links.
+        fs.statSync(base);
         linkTarget = fs.readlinkSync(base);
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);

--- a/lib/module.js
+++ b/lib/module.js
@@ -428,14 +428,14 @@ Module.prototype._compile = function(content, filename) {
 
 // Native extension for .js
 Module._extensions['.js'] = function(module, filename) {
-  var content = internalModuleReadFile(filename);
+  var content = fs.readFileSync(filename, 'utf8');
   module._compile(internalModule.stripBOM(content), filename);
 };
 
 
 // Native extension for .json
 Module._extensions['.json'] = function(module, filename) {
-  var content = internalModuleReadFile(filename);
+  var content = fs.readFileSync(filename, 'utf8');
   try {
     module.exports = JSON.parse(internalModule.stripBOM(content));
   } catch (err) {


### PR DESCRIPTION
Two commits in this one:

```
Revert "module: optimize js and json file i/o"
    
    This reverts commit 7c603280024de60329d5da283fb8433420bc6716.
    
    It is causing CI failures on Windows.
```

And 

```
   Revert "fs: change statSync to accessSync in realpathSync"
    
    This reverts commit 809bf5e38cdb1fe304da9d413f07e9d7e66ce8f9.
    
    It was causing tests to fail on Windows CI.
```

Ref: #4575 

R=@cjihrig 