### PR TITLE
test: remove unused modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -84,6 +84,8 @@ rules:
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#variables
   ## disallow use of undefined variables (globals)
   no-undef: 2
+  ## disallow declaration of variables that are not used in the code
+  no-unused-vars: [2, {"args": "none"}]
 
   # Custom rules in tools/eslint-rules
   require-buffer: 2

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Binaries, installers, and source tarballs are available at
 <https://nodejs.org/download/release/>, listed under their version strings.
 The [latest](https://nodejs.org/download/release/latest/) directory is an
 alias for the latest Stable release. The latest LTS release from an LTS
-line is available in the form: latest-lts-_codename_. For example:
-<https://nodejs.org/download/release/latest-lts-argon>
+line is available in the form: latest-_codename_. For example:
+<https://nodejs.org/download/release/latest-argon>
 
 **Nightly** builds are available at
 <https://nodejs.org/download/nightly/>, listed under their version

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Releases of Node.js and io.js will be signed with one of the following GPG keys:
 * **James M Snell** &lt;jasnell@keybase.io&gt; `71DCFD284A79C3B38668286BC97EC7A07EDE3FC1`
 * **Rod Vagg** &lt;rod@vagg.org&gt; `DD8F2338BAE7501E3DD5AC78C273792F7D83545D`
 * **Myles Borins** &lt;thealphanerd@keybase.io&gt; `792807C150954BF0299B289A38CE40DEEE898E15`
+* **Evan Lucas** &lt;evanlucas@me.com&gt; `B9AE9905FFD7803F25714661B63B535A4C206CA9`
 
 The full set of trusted release keys can be imported by running:
 
@@ -456,6 +457,7 @@ gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE
 gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1
 gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 gpg --keyserver pool.sks-keyservers.net --recv-keys 792807C150954BF0299B289A38CE40DEEE898E15
+gpg --keyserver pool.sks-keyservers.net --recv-keys B9AE9905FFD7803F25714661B63B535A4C206CA9
 ```
 
 See the section above on [Verifying Binaries](#verifying-binaries) for

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Releases of Node.js and io.js will be signed with one of the following GPG keys:
 * **Jeremiah Senkpiel** &lt;fishrock@keybase.io&gt; `FD3A5288F042B6850C66B31F09FE44734EB7990E`
 * **James M Snell** &lt;jasnell@keybase.io&gt; `71DCFD284A79C3B38668286BC97EC7A07EDE3FC1`
 * **Rod Vagg** &lt;rod@vagg.org&gt; `DD8F2338BAE7501E3DD5AC78C273792F7D83545D`
+* **Myles Borins** &lt;thealphanerd@keybase.io&gt; `792807C150954BF0299B289A38CE40DEEE898E15`
 
 The full set of trusted release keys can be imported by running:
 
@@ -454,6 +455,7 @@ gpg --keyserver pool.sks-keyservers.net --recv-keys 0034A06D9D9B0064CE8ADF6BF174
 gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E
 gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1
 gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
+gpg --keyserver pool.sks-keyservers.net --recv-keys 792807C150954BF0299B289A38CE40DEEE898E15
 ```
 
 See the section above on [Verifying Binaries](#verifying-binaries) for

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Releases of Node.js and io.js will be signed with one of the following GPG keys:
 * **Jeremiah Senkpiel** &lt;fishrock@keybase.io&gt; `FD3A5288F042B6850C66B31F09FE44734EB7990E`
 * **James M Snell** &lt;jasnell@keybase.io&gt; `71DCFD284A79C3B38668286BC97EC7A07EDE3FC1`
 * **Rod Vagg** &lt;rod@vagg.org&gt; `DD8F2338BAE7501E3DD5AC78C273792F7D83545D`
-* **Myles Borins** &lt;thealphanerd@keybase.io&gt; `792807C150954BF0299B289A38CE40DEEE898E15`
+* **Myles Borins** &lt;myles.borins@gmail.com&gt; `C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8`
 * **Evan Lucas** &lt;evanlucas@me.com&gt; `B9AE9905FFD7803F25714661B63B535A4C206CA9`
 
 The full set of trusted release keys can be imported by running:
@@ -456,7 +456,7 @@ gpg --keyserver pool.sks-keyservers.net --recv-keys 0034A06D9D9B0064CE8ADF6BF174
 gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E
 gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1
 gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
-gpg --keyserver pool.sks-keyservers.net --recv-keys 792807C150954BF0299B289A38CE40DEEE898E15
+gpg --keyserver pool.sks-keyservers.net --recv-keys C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8
 gpg --keyserver pool.sks-keyservers.net --recv-keys B9AE9905FFD7803F25714661B63B535A4C206CA9
 ```
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -781,7 +781,7 @@ should be used to determine the number of bytes in a given encoding.
 And Node.js does not check whether Content-Length and the length of the body
 which has been transmitted are equal or not.
 
-## http.IncomingMessage
+## Class: http.IncomingMessage
 
 An `IncomingMessage` object is created by [`http.Server`][] or
 [`http.ClientRequest`][] and passed as the first argument to the `'request'`

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -506,6 +506,8 @@ Listening on a file descriptor is not supported on Windows.
 This function is asynchronous. The last parameter `callback` will be added as
 a listener for the `'listening'` event. See also [`net.Server.listen()`][].
 
+Returns `server`.
+
 ### server.listen(path[, callback])
 
 Start a UNIX socket server listening for connections on the given `path`.

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -247,7 +247,7 @@ Clears the screen from the current position of the cursor down.
 
 ## readline.createInterface(options)
 
-Creates a readline `Interface` instance. Accepts an `options Object that takes
+Creates a readline `Interface` instance. Accepts an `options` Object that takes
 the following values:
 
  - `input` - the readable stream to listen to (Required).

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -232,6 +232,22 @@ line interface:
       process.exit(0);
     });
 
+## Example: Read File Stream Line-by-Line
+
+A common case for `readline`'s `input` option is to pass a filesystem readable
+stream to it. This is how one could craft line-by-line parsing of a file:
+
+    const readline = require('readline');
+    const fs = require('fs');
+
+    const rl = readline.createInterface({
+      input: fs.createReadStream('sample.txt')
+    });
+
+    rl.on('line', function (line) {
+      console.log('Line from file:', line);
+    });
+
 ## readline.clearLine(stream, dir)
 
 Clears current line of given TTY stream in a specified direction.

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -723,7 +723,7 @@ To implement any sort of stream, the pattern is the same:
    [`util.inherits`][] method is particularly helpful for this.)
 2. Call the appropriate parent class constructor in your constructor,
    to be sure that the internal mechanisms are set up properly.
-2. Implement one or more specific methods, as detailed below.
+3. Implement one or more specific methods, as detailed below.
 
 The class to extend and the method(s) to implement depend on the sort
 of stream class you are writing:

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -11,26 +11,28 @@ body {
   font-size: 62.5%;
   margin: 0;
   padding: 0;
-  color: #3a3a3a;
-  background: #fcfefa;
+  color: #333;
+  background: #fff;
 }
 
 #content {
   font-size: 1.8em;
 }
 
-a {
-  color: #FE5210;
+a,
+a:link,
+a:active {
+  color: #80bd01;
   text-decoration: none;
-}
-
-a:visited {
-  color: #FE7110;
+  border-radius: 2px;
+  padding: .1em .2em;
+  margin: -.1em 0;
 }
 
 a:hover,
 a:focus {
-  color: #FFA158;
+  color: #fff;
+  background-color: #80bd01;
 }
 
 strong {
@@ -170,7 +172,6 @@ dd + dt.pre {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: #301004;
   text-rendering: optimizeLegibility;
   font-weight: 700;
   position: relative;
@@ -280,7 +281,7 @@ code.pre {
 }
 
 #intro a {
-  color: #333;
+  color: #ddd;
   font-size: 1.25em;
   font-weight: bold;
 }
@@ -296,7 +297,6 @@ hr {
 }
 
 #toc h2 {
-  color: #C73E09;
   margin-top: 0;
   font-size: 1.0em;
   line-height: 0;
@@ -339,12 +339,14 @@ p code,
 li code {
   font-size: 0.9em;
   color: #040404;
-  background-color: #f2f5f0;
-  padding: 0.2em 0.4em;
+  background-color: #f0f0f0;
+  padding: .1em .2em;
+  border-radius: 2px;
 }
 
 a code {
   color: inherit;
+  background: inherit;
 }
 
 span.type {
@@ -360,12 +362,13 @@ span.type {
 
 #column1.interior {
   width: 702px;
-  border-left: 234px solid #f2f5f0;
+  margin-left: 234px;
   padding-left: 2.0em;
 }
 
 #column2.interior {
   width: 234px;
+  background: #333;
   position: fixed;
   height: 100%;
   overflow-y: scroll;
@@ -377,8 +380,8 @@ span.type {
   bottom: 0;
   left: 0;
   width: 234px;
-  height: 5em;
-  background: linear-gradient(rgba(242,245,240, 0), rgba(242,245,240, 1));
+  height: 4em;
+  background: linear-gradient(rgba(242,245,240, 0), rgba(51, 51, 51, 1));
   pointer-events: none;
 }
 
@@ -386,9 +389,9 @@ span.type {
   list-style: none;
   margin-left: 0em;
   margin-top: 1.25em;
-  background: #f2f5f0;
+  background: #333;
   margin-bottom: 0;
-  padding-bottom: 4em;
+  padding-bottom: 3em;
 }
 
 #column2 ul li {
@@ -403,19 +406,24 @@ span.type {
 }
 
 #column2 ul li a {
-  color: #7a7a7a;
+  color: #ccc;
+  border-radius: 0;
 }
 
-#column2 ul li a.active {
-  color: #533;
-  border-bottom: 1px solid #533;
+#column2 ul li a.active,
+#column2 ul li a.active:hover,
+#column2 ul li a.active:focus {
+  color: #80bd01;
+  border-radius: 0;
+  border-bottom: 1px solid #80bd01;
+  background: none;
 }
 
-#footer {
-  padding: 0;
-  min-height: 24px;
-  background: #333;
-  color: white;
+#intro a:hover,
+#column2 ul li a:hover,
+#column2 ul li a:focus {
+  color: #fff;
+  background: none;
 }
 
 span > .mark,
@@ -455,7 +463,7 @@ td > *:last-child {
     font-size: 2.1em;
   }
   #column1.interior {
-    border-left: 0;
+    margin-left: 0;
     padding-left: 0.5em;
     padding-right: 0.5em;
     width: auto;
@@ -473,7 +481,7 @@ td > *:last-child {
     font-size: 2.4em;
   }
   #column1.interior {
-    border-left: 0;
+    margin-left: 0;
     padding-left: 0.5em;
     padding-right: 0.5em;
     width: auto;

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -254,7 +254,7 @@ Your release should be available at <https://nodejs.org/dist/vx.y.z/> and <https
 
 There is an automatic build that is kicked off when you promote new builds, so within a few minutes nodejs.org will be listing your new version as the latest release. However, the blog post is not yet fully automatic.
 
-Create a new blog post by running the [nodejs.org release-post.js script](https://github.com/nodejs/nodejs.org/blob/master/scripts/release-post.js). This script will use the promoted builds and changelog to generate the post. Run `npm serve` to preview the post locally before pushing to the [nodejs.org](https://github.com/nodejs/nodejs.org) repo.
+Create a new blog post by running the [nodejs.org release-post.js script](https://github.com/nodejs/nodejs.org/blob/master/scripts/release-post.js). This script will use the promoted builds and changelog to generate the post. Run `npm run serve` to preview the post locally before pushing to the [nodejs.org](https://github.com/nodejs/nodejs.org) repo.
 
 * You can add a short blurb just under the main heading if you want to say something important, otherwise the text should be publication ready.
 * The links to the download files won't be complete unless you waited for the ARMv6 builds. Any downloads that are missing will have `*Coming soon*` next to them. It's your responsibility to manually update these later when you have the outstanding builds.

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -54,6 +54,12 @@ Notes:
 
 Create a new branch named _"vx.y.z-proposal"_, or something similar. Using `git cherry-pick`, bring the appropriate commits into your new branch. To determine the relevant commits, use [`branch-diff`](https://github.com/rvagg/branch-diff) and [`changelog-maker`](https://github.com/rvagg/changelog-maker/) (both are available on npm and should be installed globally). These tools depend on our commit metadata, as well as the `semver-minor` and `semver-major` GitHub labels. One drawback is that when the `PR-URL` metadata is accidentally omitted from a commit, the commit will show up because it's unsure if it's a duplicate or not.
 
+For a list of commits that could be landed in a patch release on v5.x
+
+```
+$ branch-diff v5.x master --exclude-label semver-major,semver-minor,dont-land-on-v5.x --simple
+```
+
 Carefully review the list of commits looking for errors (incorrect `PR-URL`, incorrect semver, etc.). Commits labeled as semver minor or semver major should only be cherry-picked when appropriate for the type of release being made. Previous release commits and version bumps do not need to be cherry-picked.
 
 ### 2. Update `src/node_version.h`

--- a/doc/template.html
+++ b/doc/template.html
@@ -42,9 +42,6 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-  </div>
-
   <script src="assets/sh_main.js"></script>
   <script src="assets/sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>

--- a/test/addons/at-exit/test.js
+++ b/test/addons/at-exit/test.js
@@ -1,3 +1,3 @@
 'use strict';
 require('../../common');
-var binding = require('./build/Release/binding');
+require('./build/Release/binding');

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv4 = net.isIPv4;
-var util = require('util');
 
 var expected = 0,
     completed = 0,

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv6 = net.isIPv6;
-var util = require('util');
 
 var expected = 0,
     completed = 0,

--- a/test/message/2100bytes.js
+++ b/test/message/2100bytes.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var util = require('util');
 
 console.log([
   '_______________________________________________50',

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -5,7 +5,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var cluster = require('cluster');
 var fork = require('child_process').fork;
 var net = require('net');
 

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
-var net = require('net');
 
 var SENTINEL = 42;
 

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -11,7 +11,6 @@ var crypto = require('crypto');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 var fs = require('fs');
-var path = require('path');
 
 // Test Certificates
 var spkacValid = fs.readFileSync(common.fixturesDir + '/spkac.valid');

--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -2,9 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs');
 var dgram = require('dgram');
-var callbacks = 0;
 var client, timer, buf, len, offset;
 
 

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -2,8 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs'),
-    dgram = require('dgram'), server, client,
+var dgram = require('dgram'), server, client,
     server_port = common.PORT,
     message_to_send = 'A message to send',
     timer;

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -4,7 +4,6 @@
 var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 
 var caughtA = false;
 var caughtB = false;

--- a/test/parallel/test-eval-require.js
+++ b/test/parallel/test-eval-require.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
-var path = require('path');
-var fs = require('fs');
 
 var options = {
   cwd: common.fixturesDir

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -2,7 +2,6 @@
 
 require('../common');
 var assert = require('assert');
-var events = require('events');
 
 var EventEmitter = require('events').EventEmitter;
 var assert = require('assert');

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const readdirDir = common.tmpDir;

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 var cluster = require('cluster');
 
 console.error('Cluster listen fd test', process.argv[2] || 'runner');

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 
 if (common.isWindows) {
   console.log('1..0 # Skipped: This test is disabled on windows.');

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var EventEmitter = require('events').EventEmitter;
 var PassThrough = require('stream').PassThrough;
 var assert = require('assert');
 var inherits = require('util').inherits;
@@ -16,7 +15,7 @@ inherits(FakeInput, PassThrough);
 
 var fi = new FakeInput();
 var fo = new FakeInput();
-var rli = new Interface({ input: fi, output: fo, terminal: true });
+new Interface({ input: fi, output: fo, terminal: true });
 
 var keys = [];
 fi.on('keypress', function(s, k) {

--- a/test/parallel/test-tls-legacy-onselect.js
+++ b/test/parallel/test-tls-legacy-onselect.js
@@ -9,17 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 var net = require('net');
 
-var fs = require('fs');
-
 var success = false;
-
-function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
-}
-
-function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
-}
 
 var server = net.Server(function(raw) {
   var pair = tls.createSecurePair(null, true, false, false);

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -4,7 +4,6 @@
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 
 var spdyDict = new Buffer([
   'optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-',

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -2,7 +2,6 @@
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 
 const bigData = new Buffer(10240).fill('x');
 

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
-var fs = require('fs');
 
 var gzip = zlib.createGzip();
 var gunz = zlib.createUnzip();

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var os = require('os');
-var util = require('util');
 
 if (os.type() != 'SunOS') {
   console.log('1..0 # Skipped: no DTRACE support');
@@ -13,7 +12,6 @@ if (os.type() != 'SunOS') {
  * Some functions to create a recognizable stack.
  */
 var frames = [ 'stalloogle', 'bagnoogle', 'doogle' ];
-var expected;
 
 var stalloogle = function(str) {
   expected = str;
@@ -35,7 +33,6 @@ var doogle = function() {
 
 var spawn = require('child_process').spawn;
 var prefix = '/var/tmp/node';
-var corefile = prefix + '.' + process.pid;
 
 /*
  * We're going to use DTrace to stop us, gcore us, and set us running again

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var net = require('net'),
-    util = require('util'),
     http = require('http');
 
 var errorCount = 0;

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -5,7 +5,6 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var http = require('http');
-var path = require('path');
 var url = require('url');
 
 if (common.isWindows) {

--- a/test/pummel/test-timer-wrap2.js
+++ b/test/pummel/test-timer-wrap2.js
@@ -1,9 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 // Test that allocating a timer does not increase the loop's reference
 // count.
 
 var Timer = process.binding('timer_wrap').Timer;
-var t = new Timer();
+new Timer();

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -17,9 +17,7 @@ var join = require('path').join;
 var net = require('net');
 var assert = require('assert');
 var fs = require('fs');
-var crypto = require('crypto');
 var tls = require('tls');
-var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 
 test1();
@@ -46,8 +44,6 @@ function test(keyfn, certfn, check, next) {
   // the openssl s_server thus causing many tests to fail with
   // EADDRINUSE.
   var PORT = common.PORT + 5;
-
-  var connections = 0;
 
   keyfn = join(common.fixturesDir, keyfn);
   var key = fs.readFileSync(keyfn).toString();

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var os = require('os');
 
 var execSync = require('child_process').execSync;
 var execFileSync = require('child_process').execFileSync;

--- a/test/sequential/test-regress-GH-1697.js
+++ b/test/sequential/test-regress-GH-1697.js
@@ -1,8 +1,7 @@
 'use strict';
 var common = require('../common');
 var net = require('net'),
-    cp = require('child_process'),
-    util = require('util');
+    cp = require('child_process');
 
 if (process.argv[2] === 'server') {
   // Server

--- a/test/sequential/test-stdout-close-catch.js
+++ b/test/sequential/test-stdout-close-catch.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var child_process = require('child_process');
-var fs = require('fs');
 
 var testScript = path.join(common.fixturesDir, 'catch-stdout-error.js');
 


### PR DESCRIPTION
Many tests use require() to import modules that subsequently never gets
used. This removes those imports and, in a few cases, removes other
unused variables from tests.