### PR TITLE
LTS: backport no-unused-vars to v4.x-staging

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -84,6 +84,8 @@ rules:
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#variables
   ## disallow use of undefined variables (globals)
   no-undef: 2
+  ## disallow declaration of variables that are not used in the code
+  no-unused-vars: [2, {"args": "none"}]
 
   # Custom rules in tools/eslint-rules
   require-buffer: 2

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -3,7 +3,6 @@
 const util = require('util');
 const net = require('net');
 const url = require('url');
-const EventEmitter = require('events');
 const HTTPParser = process.binding('http_parser').HTTPParser;
 const assert = require('assert').ok;
 const common = require('_http_common');

--- a/lib/os.js
+++ b/lib/os.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const binding = process.binding('os');
-const util = require('util');
 const internalUtil = require('internal/util');
 const isWindows = process.platform === 'win32';
 

--- a/test/addons/at-exit/test.js
+++ b/test/addons/at-exit/test.js
@@ -1,3 +1,3 @@
 'use strict';
 require('../../common');
-var binding = require('./build/Release/binding');
+require('./build/Release/binding');

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -46,4 +46,4 @@ var options = {
 };
 
 // Run commands from fake REPL.
-var dummy = repl.start(options);
+repl.start(options);

--- a/test/common.js
+++ b/test/common.js
@@ -255,6 +255,9 @@ exports.spawnPwd = function(options) {
 };
 
 exports.platformTimeout = function(ms) {
+  if (process.config.target_defaults.default_configuration === 'Debug')
+    ms = 2 * ms;
+
   if (process.arch !== 'arm')
     return ms;
 

--- a/test/debugger/test-debugger-pid.js
+++ b/test/debugger/test-debugger-pid.js
@@ -1,16 +1,9 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 1337;
 var buffer = '';
-var expected = [];
-var scriptToDebug = common.fixturesDir + '/empty.js';
-
-function fail() {
-  assert(0); // `--debug-brk script.js` should not quit
-}
 
 // connect to debug agent
 var interfacer = spawn(process.execPath, ['debug', '-p', '655555']);

--- a/test/debugger/test-debugger-remote.js
+++ b/test/debugger/test-debugger-remote.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 1337;
 var buffer = '';
-var expected = [];
 var scriptToDebug = common.fixturesDir + '/empty.js';
 
 function fail() {

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv4 = net.isIPv4;
-var util = require('util');
 
 var expected = 0,
     completed = 0,

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -3,9 +3,7 @@ var common = require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv6 = net.isIPv6;
-var util = require('util');
 
 var expected = 0,
     completed = 0,

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -3,7 +3,6 @@ require('../common');
 var assert = require('assert'),
     dns = require('dns'),
     net = require('net'),
-    isIP = net.isIP,
     isIPv4 = net.isIPv4,
     isIPv6 = net.isIPv6;
 var util = require('util');
@@ -48,7 +47,7 @@ TEST(function test_reverse_bogus(done) {
   var error;
 
   try {
-    var req = dns.reverse('bogus ip', function() {
+    dns.reverse('bogus ip', function() {
       assert.ok(false);
     });
   } catch (e) {
@@ -369,7 +368,7 @@ console.log('looking up nodejs.org...');
 
 var cares = process.binding('cares_wrap');
 var req = new cares.GetAddrInfoReqWrap();
-var err = cares.getaddrinfo(req, 'nodejs.org', 4);
+cares.getaddrinfo(req, 'nodejs.org', 4);
 
 req.oncomplete = function(err, domains) {
   assert.strictEqual(err, 0);

--- a/test/message/2100bytes.js
+++ b/test/message/2100bytes.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var util = require('util');
 
 console.log([
   '_______________________________________________50',

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const a = require('assert');
 

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -3,7 +3,6 @@
 require('../common');
 const assert = require('assert');
 const Buffer = require('buffer').Buffer;
-const Bp = Buffer.prototype;
 
 function FakeBuffer() { }
 FakeBuffer.__proto__ = Buffer;

--- a/test/parallel/test-child-process-buffering.js
+++ b/test/parallel/test-child-process-buffering.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-var spawn = require('child_process').spawn;
-
 var pwd_called = false;
 var childClosed = false;
 var childExited = false;

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -1,8 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
-var path = require('path');
 
 var returns = 0;
 

--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -9,7 +9,7 @@ var success_count = 0;
 var str = 'hello';
 
 // default encoding
-var child = exec('echo ' + str, function(err, stdout, stderr) {
+exec('echo ' + str, function(err, stdout, stderr) {
   assert.ok('string', typeof(stdout), 'Expected stdout to be a string');
   assert.ok('string', typeof(stderr), 'Expected stderr to be a string');
   assert.equal(str + os.EOL, stdout);

--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -18,7 +18,7 @@ exec('echo ' + str, function(err, stdout, stderr) {
 });
 
 // no encoding (Buffers expected)
-var child = exec('echo ' + str, {
+exec('echo ' + str, {
   encoding: null
 }, function(err, stdout, stderr) {
   assert.ok(stdout instanceof Buffer, 'Expected stdout to be a Buffer');

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -16,7 +16,7 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-var child = exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
+exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
   if (err) {
     error_count++;
     console.log('error!: ' + err.code);

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -25,7 +25,6 @@ if (common.isWindows) {
 }
 
 if (process.argv[2] === 'child') {
-  var childCollected = 0;
   var server;
 
   process.on('message', function removeMe(msg, clusterServer) {

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var cp = require('child_process');
 var fs = require('fs');
 var path = require('path');
 var common = require('../common');

--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 var fork = require('child_process').fork;
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var fs = require('fs');
 var spawn = require('child_process').spawn;
 var assert = require('assert');
 

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -18,30 +18,20 @@ var response = '';
 var exitStatus = -1;
 var closed = false;
 
-var gotStdoutEOF = false;
-
 cat.stdout.setEncoding('utf8');
 cat.stdout.on('data', function(chunk) {
   console.log('stdout: ' + chunk);
   response += chunk;
 });
 
-cat.stdout.on('end', function() {
-  gotStdoutEOF = true;
-});
-
-
-var gotStderrEOF = false;
+cat.stdout.on('end', common.mustCall(function() {}));
 
 cat.stderr.on('data', function(chunk) {
   // shouldn't get any stderr output
   assert.ok(false);
 });
 
-cat.stderr.on('end', function(chunk) {
-  gotStderrEOF = true;
-});
-
+cat.stderr.on('end', common.mustCall(function() {}));
 
 cat.on('exit', function(status) {
   console.log('exit event');

--- a/test/parallel/test-child-process-stdio-inherit.js
+++ b/test/parallel/test-child-process-stdio-inherit.js
@@ -31,5 +31,5 @@ function grandparent() {
 
 function parent() {
   // should not immediately exit.
-  var child = common.spawnCat({ stdio: 'inherit' });
+  common.spawnCat({ stdio: 'inherit' });
 }

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var spawn = require('child_process').spawn;
 
 var options = {stdio: ['pipe']};
 var child = common.spawnPwd(options);

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var path = require('path');
 
 // if child process output to console and exit
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -5,7 +5,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var cluster = require('cluster');
 var fork = require('child_process').fork;
 var net = require('net');
 

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -34,7 +34,6 @@ http.createServer(function(req, res) {
   res.writeHead(200);
   res.end('OK');
 }).listen(common.PIPE, function() {
-  var self = this;
   http.get({ socketPath: common.PIPE, path: '/' }, function(res) {
     res.resume();
     res.on('end', function(err) {

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
-var net = require('net');
 
 var SENTINEL = 42;
 

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -20,7 +20,6 @@ var fs = require('fs');
 var path = require('path');
 
 // Test Certificates
-var caPem = fs.readFileSync(common.fixturesDir + '/test_ca.pem', 'ascii');
 var certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
 var certPfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
 var keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -11,7 +11,6 @@ var crypto = require('crypto');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 var fs = require('fs');
-var path = require('path');
 
 // Test Certificates
 var spkacValid = fs.readFileSync(common.fixturesDir + '/spkac.valid');

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -171,7 +171,7 @@ var ecdh3 = crypto.createECDH('secp256k1');
 var key3 = ecdh3.generateKeys();
 
 assert.throws(function() {
-  var secret3 = ecdh2.computeSecret(key3, 'binary', 'buffer');
+  ecdh2.computeSecret(key3, 'binary', 'buffer');
 });
 
 // ECDH should allow .setPrivateKey()/.setPublicKey()

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -10,7 +10,6 @@ var options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };
 var child = spawn(process.execPath, args, options);
 
 var outputLines = [];
-var outputTimerId;
 var waitingForDebuggers = false;
 
 var pids = null;

--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -20,7 +20,6 @@ socket_ipv4.bind(common.PORT, '1.1.1.1');
 
 // IPv6 Test
 var socket_ipv6 = dgram.createSocket('udp6');
-var family_ipv6 = 'IPv6';
 
 socket_ipv6.on('listening', common.fail);
 

--- a/test/parallel/test-dgram-pingpong.js
+++ b/test/parallel/test-dgram-pingpong.js
@@ -11,7 +11,6 @@ function pingPongTest(port, host) {
   var callbacks = 0;
   var N = 500;
   var count = 0;
-  var sent_final_ping = false;
 
   var server = dgram.createSocket('udp4', function(msg, rinfo) {
     if (debug) console.log('server got: ' + msg +
@@ -48,7 +47,6 @@ function pingPongTest(port, host) {
       if (count < N) {
         client.send(buf, 0, buf.length, port, 'localhost');
       } else {
-        sent_final_ping = true;
         client.send(buf, 0, buf.length, port, 'localhost', function() {
           client.close();
         });

--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -2,9 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs');
 var dgram = require('dgram');
-var callbacks = 0;
 var client, timer, buf, len, offset;
 
 

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -2,8 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs'),
-    dgram = require('dgram'), server, client,
+var dgram = require('dgram'), server, client,
     server_port = common.PORT,
     message_to_send = 'A message to send',
     timer;

--- a/test/parallel/test-domain-exit-dispose-again.js
+++ b/test/parallel/test-domain-exit-dispose-again.js
@@ -5,7 +5,7 @@
 // to that domain, including those whose callbacks are called from within
 // the same invocation of listOnTimeout, _are_ called.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var disposalFailed = false;

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -9,7 +9,6 @@ objects.baz.asdf = objects;
 
 var serverCaught = 0;
 var clientCaught = 0;
-var disposeEmit = 0;
 
 var server = http.createServer(function(req, res) {
   var dom = domain.create();

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -8,7 +8,6 @@ var caught = 0;
 var expectCaught = 1;
 
 var d = new domain.Domain();
-var e = new events.EventEmitter();
 
 d.on('error', function(er) {
   console.error('caught', er);

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -4,7 +4,6 @@
 require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 var caught = 0;
 var expectCaught = 1;
 

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -4,7 +4,6 @@
 var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var events = require('events');
 
 var caughtA = false;
 var caughtB = false;

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -13,8 +13,6 @@ const assert = require('assert');
 const domain = require('domain');
 const child_process = require('child_process');
 
-const uncaughtExceptions = {};
-
 const tests = [];
 
 function test1() {

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -31,7 +31,6 @@ const domainErrHandlerExMessage = 'exception from domain error handler';
 if (process.argv[2] === 'child') {
   var domain = require('domain');
   var d = domain.create();
-  var triggeredProcessUncaughtException = false;
 
   process.on('uncaughtException', function onUncaughtException() {
     // The process' uncaughtException event must not be emitted when
@@ -116,13 +115,6 @@ if (process.argv[2] === 'child') {
     var child = exec(cmdToExec);
 
     if (child) {
-      var childTriggeredOnUncaughtExceptionHandler = false;
-      child.on('message', function onChildMsg(msg) {
-        if (msg === 'triggeredProcessUncaughtEx') {
-          childTriggeredOnUncaughtExceptionHandler = true;
-        }
-      });
-
       child.on('exit', function onChildExited(exitCode, signal) {
         // When throwing errors from the top-level domain error handler
         // outside of a try/catch block, the process should not exit gracefully

--- a/test/parallel/test-dsa-fips-invalid-key.js
+++ b/test/parallel/test-dsa-fips-invalid-key.js
@@ -12,8 +12,6 @@ var fs = require('fs');
 
 var input = 'hello';
 
-var dsapub = fs.readFileSync(common.fixturesDir +
-                             '/keys/dsa_public_1025.pem');
 var dsapri = fs.readFileSync(common.fixturesDir +
                              '/keys/dsa_private_1025.pem');
 var sign = crypto.createSign('DSS1');

--- a/test/parallel/test-eval-require.js
+++ b/test/parallel/test-eval-require.js
@@ -2,8 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
-var path = require('path');
-var fs = require('fs');
 
 var options = {
   cwd: common.fixturesDir

--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -10,7 +10,7 @@ var error_count = 0;
 var cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
            'foo', 'bar'].join(' ');
 var expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
-var child = exec(cmd, function(err, stdout, stderr) {
+exec(cmd, function(err, stdout, stderr) {
   if (err) {
     console.log(err.toString());
     ++error_count;

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -2,7 +2,6 @@
 
 require('../common');
 var assert = require('assert');
-var events = require('events');
 
 var EventEmitter = require('events').EventEmitter;
 var assert = require('assert');

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -15,11 +15,6 @@ function listener2() {
   count++;
 }
 
-function listener3() {
-  console.log('listener3');
-  count++;
-}
-
 function remove1() {
   assert(0);
 }

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -124,7 +124,7 @@ function run_test_2() {
 
 
 function run_test_3() {
-  var file, buffer, options;
+  var file, options;
 
   var data = '\u2026\u2026',    // 3 bytes * 2 = 6 bytes in UTF-8
       fileData;
@@ -167,7 +167,7 @@ function run_test_3() {
 
 
 function run_test_4() {
-  var file, options;
+  var options;
 
   options = { start: -5,
               flags: 'r+' };

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -7,14 +7,9 @@ var fs = require('fs');
 
 var O_APPEND = constants.O_APPEND || 0;
 var O_CREAT = constants.O_CREAT || 0;
-var O_DIRECTORY = constants.O_DIRECTORY || 0;
 var O_EXCL = constants.O_EXCL || 0;
-var O_NOCTTY = constants.O_NOCTTY || 0;
-var O_NOFOLLOW = constants.O_NOFOLLOW || 0;
 var O_RDONLY = constants.O_RDONLY || 0;
 var O_RDWR = constants.O_RDWR || 0;
-var O_SYMLINK = constants.O_SYMLINK || 0;
-var O_SYNC = constants.O_SYNC || 0;
 var O_TRUNC = constants.O_TRUNC || 0;
 var O_WRONLY = constants.O_WRONLY || 0;
 

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var constants = require('constants');
 var assert = require('assert');
 var fs = require('fs');
 

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const readdirDir = common.tmpDir;

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -48,7 +48,7 @@ function expect_ok(syscall, resource, err, atime, mtime) {
 // would be even better though (node doesn't have such functionality yet)
 function runTest(atime, mtime, callback) {
 
-  var fd, err;
+  var fd;
   //
   // test synchronized code paths, these functions throw on failure
   //

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -15,7 +15,7 @@ fs._closeSync = fs.closeSync;
 fs.closeSync = closeSync;
 
 // Reset the umask for testing
-var mask = process.umask(0o000);
+process.umask(0o000);
 
 // On Windows chmod is only able to manipulate read-only bit. Test if creating
 // the file in read-only mode works.

--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var net = require('net');
 

--- a/test/parallel/test-http-304.js
+++ b/test/parallel/test-http-304.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 var childProcess = require('child_process');

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -14,7 +14,7 @@ var server = http.Server(function(req, res) {
 var responseClose = false;
 
 server.listen(common.PORT, function() {
-  var client = http.get({
+  http.get({
     port: common.PORT,
     headers: { connection: 'keep-alive' }
 

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -45,7 +45,7 @@ server.listen(common.PORT, function() {
 });
 
 function doRequest(i) {
-  var req = http.get({
+  http.get({
     port: common.PORT,
     path: '/request' + i
   }, function(res) {

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -3,7 +3,6 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 const Agent = require('_http_agent').Agent;
-const EventEmitter = require('events').EventEmitter;
 
 const agent = new Agent({
   keepAlive: true,

--- a/test/parallel/test-http-agent-null.js
+++ b/test/parallel/test-http-agent-null.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var net = require('net');
 
 var request = 0;
 var response = 0;

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
 var http = require('http');
 
 var body = 'hello world\n';

--- a/test/parallel/test-http-client-abort2.js
+++ b/test/parallel/test-http-client-abort2.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-client-encoding.js
+++ b/test/parallel/test-http-client-encoding.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -2,7 +2,6 @@
 // see https://github.com/joyent/node/issues/3257
 
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -57,7 +57,7 @@ if (common.hasCrypto) {
     res.end('ok');
     this.close();
   }).listen(SSLPORT, function() {
-    var req = https.get({
+    https.get({
       host: 'localhost',
       rejectUnauthorized: false,
       headers: {

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -6,7 +6,6 @@ var assert = require('assert');
 // where the server has ended the socket.
 
 var http = require('http');
-var net = require('net');
 var server = http.createServer(function(req, res) {
   setImmediate(function() {
     res.destroy();

--- a/test/parallel/test-http-eof-on-connect.js
+++ b/test/parallel/test-http-eof-on-connect.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var net = require('net');
 var http = require('http');
 

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
@@ -11,9 +10,8 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req;
   for (var i = 0; i < 4; i += 1) {
-    req = http.get({ port: common.PORT, path: '/busy/' + i });
+    http.get({ port: common.PORT, path: '/busy/' + i });
   }
 });
 

--- a/test/parallel/test-http-flush.js
+++ b/test/parallel/test-http-flush.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 http.createServer(function(req, res) {

--- a/test/parallel/test-http-incoming-pipelined-socket-destroy.js
+++ b/test/parallel/test-http-incoming-pipelined-socket-destroy.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 var net = require('net');

--- a/test/parallel/test-http-keep-alive.js
+++ b/test/parallel/test-http-keep-alive.js
@@ -11,7 +11,6 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
-var connectCount = 0;
 var agent = new http.Agent({maxSockets: 1});
 var headers = {'connection': 'keep-alive'};
 var name = agent.getName({ port: common.PORT });

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -17,7 +17,7 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var req = http.request({
+  http.request({
     host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // no warnings should happen!
 var trace = console.trace;

--- a/test/parallel/test-http-no-content-length.js
+++ b/test/parallel/test-http-no-content-length.js
@@ -10,7 +10,7 @@ var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
 }).listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  http.get({port: common.PORT}, function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       body += chunk;

--- a/test/parallel/test-http-pipeline-regr-3508.js
+++ b/test/parallel/test-http-pipeline-regr-3508.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 const net = require('net');
 

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -25,7 +25,7 @@ var backend = http.createServer(function(req, res) {
 
 var proxy = http.createServer(function(req, res) {
   console.error('proxy req headers: ' + JSON.stringify(req.headers));
-  var proxy_req = http.get({
+  http.get({
     port: BACKEND_PORT,
     path: url.parse(req.url).pathname
   }, function(proxy_res) {
@@ -56,7 +56,7 @@ function startReq() {
   nlistening++;
   if (nlistening < 2) return;
 
-  var client = http.get({
+  http.get({
     port: PROXY_PORT,
     path: '/test'
   }, function(res) {

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -54,14 +54,6 @@ http.createServer(function(req, res) {
   ]);
   res.end('x f o o');
 }).listen(common.PORT, function() {
-  var expectRawHeaders = [
-    'Date',
-    'Tue, 06 Aug 2013 01:31:54 GMT',
-    'Connection',
-    'close',
-    'Transfer-Encoding',
-    'chunked'
-  ];
   var req = http.request({ port: common.PORT, path: '/' });
   req.addTrailers([
     ['x-bAr', 'yOyOyOy'],

--- a/test/parallel/test-http-regr-gh-2821.js
+++ b/test/parallel/test-http-regr-gh-2821.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -18,7 +18,7 @@ var server = http.Server(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  http.get({port: common.PORT}, function(res) {
     server.close();
   });
 });

--- a/test/parallel/test-http-server-stale-close.js
+++ b/test/parallel/test-http-server-stale-close.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var util = require('util');
 var fork = require('child_process').fork;

--- a/test/parallel/test-http-timeout.js
+++ b/test/parallel/test-http-timeout.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 var http = require('http');
 

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
 var http = require('http');
 
 var status_ok = false; // status code == 200?

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -10,7 +10,6 @@ var https = require('https');
 
 var url = require('url');
 var fs = require('fs');
-var clientRequest;
 
 // https options
 var httpsOptions = {

--- a/test/parallel/test-https-agent-servername.js
+++ b/test/parallel/test-https-agent-servername.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
-var http = require('http');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -53,7 +53,7 @@ var bodyBuffer = '';
 
 server.listen(common.PORT, function() {
   console.log('1) Making Request');
-  var req = https.get({
+  https.get({
     port: common.PORT,
     rejectUnauthorized: false
   }, function(res) {

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -28,7 +28,7 @@ var server = https.createServer(options, function(req, res) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var req = https.request({
+  https.request({
     host: 'localhost',
     port: common.PORT,
     path: '/',

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
@@ -9,7 +8,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var fs = require('fs');
-var exec = require('child_process').exec;
 
 var http = require('http');
 

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -110,7 +110,7 @@ function makeReq(path, port, error, host, ca) {
     path: path,
     ca: ca
   };
-  var whichCa = 0;
+
   if (!ca) {
     options.agent = agent0;
   } else {

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 }
 var https = require('https');
 
-var net = require('net');
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var net = require('net');
-var tls = require('tls');
 var fs = require('fs');
 
 var clientErrors = 0;

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
@@ -9,7 +8,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var fs = require('fs');
-var exec = require('child_process').exec;
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var fs = require('fs');
-var path = require('path');
 
 var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 var cluster = require('cluster');
 
 console.error('Cluster listen fd test', process.argv[2] || 'runner');

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -4,7 +4,6 @@ var assert = require('assert');
 var http = require('http');
 var net = require('net');
 var PORT = common.PORT;
-var spawn = require('child_process').spawn;
 
 if (common.isWindows) {
   console.log('1..0 # Skipped: This test is disabled on windows.');

--- a/test/parallel/test-net-create-connection.js
+++ b/test/parallel/test-net-create-connection.js
@@ -22,7 +22,7 @@ server.listen(tcpPort, 'localhost', function() {
 
   function fail(opts, errtype, msg) {
     assert.throws(function() {
-      var client = net.createConnection(opts, cb);
+      net.createConnection(opts, cb);
     }, function(err) {
       return err instanceof errtype && msg === err.message;
     });

--- a/test/parallel/test-net-dns-custom-lookup.js
+++ b/test/parallel/test-net-dns-custom-lookup.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var dns = require('dns');
 var ok = false;
 
 function check(addressType, cb) {

--- a/test/parallel/test-net-dns-lookup-skip.js
+++ b/test/parallel/test-net-dns-lookup-skip.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var net = require('net');
 
 function check(addressType) {

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var gotError = false;
 
 var server = net.createServer(function(socket) {
 });

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var conns = 0, conns_closed = 0;
+var conns = 0;
 
 var server = net.createServer(function(socket) {
   conns++;

--- a/test/parallel/test-net-localerror.js
+++ b/test/parallel/test-net-localerror.js
@@ -17,6 +17,6 @@ connect({
 
 function connect(opts, msg) {
   assert.throws(function() {
-    var client = net.connect(opts);
+    net.connect(opts);
   }, msg);
 }

--- a/test/parallel/test-net-reconnect.js
+++ b/test/parallel/test-net-reconnect.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 var net = require('net');
 
 var N = 50;
-var c = 0;
 var client_recv_count = 0;
 var client_end_count = 0;
 var disconnect_count = 0;

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -82,7 +82,6 @@ child_process.exec(nodeBinary + ' '
   });
 
 // https://github.com/nodejs/node/issues/1691
-var originalCwd = process.cwd();
 process.chdir(path.join(__dirname, '../fixtures/'));
 child_process.exec(nodeBinary + ' '
   + '--expose_debug_as=v8debug '

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const versionParts = process.versions.node.split('.');
 

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -185,12 +185,11 @@ asyncTest('When re-throwing new errors in a promise catch, only the' +
 asyncTest('Test params of unhandledRejection for a synchronously-rejected' +
           'promise', function(done) {
   var e = new Error();
-  var e2 = new Error();
   onUnhandledSucceed(done, function(reason, promise) {
     assert.strictEqual(e, reason);
     assert.strictEqual(promise, promise);
   });
-  var promise = Promise.reject(e);
+  Promise.reject(e);
 });
 
 asyncTest('When re-throwing new errors in a promise catch, only the ' +
@@ -629,7 +628,7 @@ asyncTest('Promise unhandledRejection handler does not interfere with domain' +
       assert.strictEqual(domainReceivedError, domainError);
       d.dispose();
     });
-    var a = Promise.reject(e);
+    Promise.reject(e);
     process.nextTick(function() {
       throw domainError;
     });

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-var EventEmitter = require('events').EventEmitter;
 var PassThrough = require('stream').PassThrough;
 var assert = require('assert');
 var inherits = require('util').inherits;
@@ -16,7 +15,7 @@ inherits(FakeInput, PassThrough);
 
 var fi = new FakeInput();
 var fo = new FakeInput();
-var rli = new Interface({ input: fi, output: fo, terminal: true });
+new Interface({ input: fi, output: fo, terminal: true });
 
 var keys = [];
 fi.on('keypress', function(s, k) {

--- a/test/parallel/test-readline-undefined-columns.js
+++ b/test/parallel/test-readline-undefined-columns.js
@@ -11,7 +11,7 @@ const readline = require('readline');
 const iStream = new PassThrough();
 const oStream = new PassThrough();
 
-const rli = readline.createInterface({
+readline.createInterface({
   terminal: true,
   input: iStream,
   output: oStream,

--- a/test/parallel/test-regress-GH-4256.js
+++ b/test/parallel/test-regress-GH-4256.js
@@ -1,6 +1,6 @@
 'use strict';
 require('../common');
 process.domain = null;
-var timer = setTimeout(function() {
+setTimeout(function() {
   console.log('this console.log statement should not make node crash');
 }, 1);

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var util = require('util');
 var join = require('path').join;
 var fs = require('fs');
 var common = require('../common');

--- a/test/parallel/test-repl-autolibs.js
+++ b/test/parallel/test-repl-autolibs.js
@@ -8,7 +8,7 @@ var repl = require('repl');
 common.globalCheck = false;
 
 const putIn = new common.ArrayStream();
-var testMe = repl.start('', putIn, null, true);
+repl.start('', putIn, null, true);
 
 test1();
 

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 
-var util   = require('util');
 var repl   = require('repl');
 
 const putIn = new common.ArrayStream();

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const repl = require('repl');
-const util = require('util');
 let found = false;
 
 process.on('exit', () => {
@@ -17,7 +16,7 @@ common.ArrayStream.prototype.write = function(output) {
 };
 
 const putIn = new common.ArrayStream();
-const testMe = repl.start('', putIn);
+repl.start('', putIn);
 let file = path.resolve(__dirname, '../fixtures/syntax/bad_syntax');
 
 if (common.isWindows)

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const util = require('util');
 const repl = require('repl');
 
 var referenceErrorCount = 0;

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -4,7 +4,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var util = require('util');
 var repl = require('repl');
 var referenceErrors = 0;
 var expectedReferenceErrors = 0;

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -38,7 +38,6 @@ var Stream = require('stream').Stream;
 })();
 
 (function testErrorWithRemovedListenerThrows() {
-  var EE = require('events').EventEmitter;
   var R = Stream.Readable;
   var W = Stream.Writable;
 
@@ -73,7 +72,6 @@ var Stream = require('stream').Stream;
 })();
 
 (function testErrorWithRemovedListenerThrows() {
-  var EE = require('events').EventEmitter;
   var R = Stream.Readable;
   var W = Stream.Writable;
 

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -21,7 +21,7 @@ s._read = function(n) {
   }
 };
 
-var v = s.read(0);
+s.read(0);
 
 // ACTUALLY [1, 3, 5, 6, 4, 2]
 

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -13,7 +13,6 @@ var stream = require('stream');
 var hwm = 10;
 var r = stream.Readable({ highWaterMark: hwm });
 var chunks = 10;
-var t = (chunks * 5);
 
 var data = new Buffer(chunks * hwm + Math.ceil(hwm / 2));
 for (var i = 0; i < data.length; i++) {

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -30,11 +30,9 @@ function test(decode, uncork, multi, next) {
   function cnt(msg) {
     expectCount++;
     var expect = expectCount;
-    var called = false;
     return function(er) {
       if (er)
         throw er;
-      called = true;
       counter++;
       assert.equal(counter, expect);
     };

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -4,7 +4,6 @@ var R = require('_stream_readable');
 var assert = require('assert');
 
 var util = require('util');
-var EE = require('events').EventEmitter;
 
 var ondataCalled = 0;
 
@@ -25,7 +24,7 @@ TestReader.prototype._read = function(n) {
   this._buffer = new Buffer(0);
 };
 
-var reader = new TestReader();
+new TestReader();
 setImmediate(function() {
   assert.equal(ondataCalled, 1);
   console.log('ok');

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -53,9 +53,6 @@ function push() {
     setTimeout(push);
 }
 
-// start the flow
-var ret = r.read(0);
-
 process.on('exit', function() {
   assert.equal(pushes, PUSHCOUNT + 1);
   assert(endEmitted);

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -167,8 +167,6 @@ test('read(0) for object streams', function(t) {
   r.push('foobar');
   r.push(null);
 
-  var v = r.read(0);
-
   r.pipe(toArray(function(array) {
     assert.deepEqual(array, ['foobar']);
 

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -39,8 +39,6 @@ process.nextTick(run);
 
 
 test('buffers', function(t) {
-  // have a length
-  var len = 16;
   var list = [ new Buffer('foog'),
                new Buffer('bark'),
                new Buffer('bazy'),
@@ -69,8 +67,6 @@ test('buffers', function(t) {
 });
 
 test('strings', function(t) {
-  // have a length
-  var len = 16;
   var list = [ 'foog',
                'bark',
                'bazy',

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -303,12 +303,9 @@ test('passthrough event emission', function(t) {
   var pt = new PassThrough();
   var emits = 0;
   pt.on('readable', function() {
-    var state = pt._readableState;
     console.error('>>> emit readable %d', emits);
     emits++;
   });
-
-  var i = 0;
 
   pt.write(new Buffer('foog'));
 

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -3,13 +3,10 @@ require('../common');
 var assert = require('assert');
 var Timer = process.binding('timer_wrap').Timer;
 
-var i;
-
 var N = 30;
 
 var last_i = 0;
 var last_ts = 0;
-var start = Timer.now();
 
 var f = function(i) {
   if (i <= N) {

--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -7,7 +7,7 @@ var assert = require('assert');
   var ncalled = 0;
 
   setTimeout(f, 0, 'foo', 'bar', 'baz');
-  var timer = setTimeout(function() {}, 0);
+  setTimeout(function() {}, 0);
 
   function f(a, b, c) {
     assert.equal(a, 'foo');

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 var common = require('../common');
 

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -2,7 +2,6 @@
 
 var common = require('../common');
 
-var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 var constants = require('constants');

--- a/test/parallel/test-tls-client-default-ciphers.js
+++ b/test/parallel/test-tls-client-default-ciphers.js
@@ -19,7 +19,7 @@ function test1() {
   };
 
   try {
-    var s = tls.connect(common.PORT);
+    tls.connect(common.PORT);
   } catch (e) {
     assert(e instanceof Done);
   }

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -10,7 +10,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 var errorCount = 0;
 var closeCount = 0;

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 var ended = 0;
 

--- a/test/parallel/test-tls-destroy-whilst-write.js
+++ b/test/parallel/test-tls-destroy-whilst-write.js
@@ -1,5 +1,4 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 
 if (!common.hasCrypto) {

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -20,7 +20,7 @@ var server = tls.createServer(options, onconnection);
 var gotChunk = false;
 var gotDrain = false;
 
-var timer = setTimeout(function() {
+setTimeout(function() {
   console.log('not ok - timed out');
   process.exit(1);
 }, common.platformTimeout(500));

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -10,7 +10,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 var errorCount = 0;
 var closeCount = 0;

--- a/test/parallel/test-tls-handshake-nohang.js
+++ b/test/parallel/test-tls-handshake-nohang.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 
 var received = '';

--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -14,8 +14,6 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-var cert = null;
-
 assert.throws(function() {
   tls.createSecureContext(options);
 });

--- a/test/parallel/test-tls-legacy-onselect.js
+++ b/test/parallel/test-tls-legacy-onselect.js
@@ -9,17 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 var net = require('net');
 
-var fs = require('fs');
-
 var success = false;
-
-function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
-}
-
-function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
-}
 
 var server = net.Server(function(raw) {
   var pair = tls.createSecurePair(null, true, false, false);

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var net = require('net');
 
 var common = require('../common');
 

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -41,7 +41,6 @@ function test(testOptions, cb) {
   var clientSecure = 0;
   var ocspCount = 0;
   var ocspResponse;
-  var session;
 
   if (testOptions.pfx) {
     delete options.key;

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -11,7 +11,6 @@ var tls = require('tls');
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;
-var spawn = require('child_process').spawn;
 
 var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent5-key.pem')),

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -11,7 +11,6 @@ var tls = require('tls');
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;
-var spawn = require('child_process').spawn;
 
 var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'agent.key')),

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -11,7 +11,6 @@ var tls = require('tls');
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;
-var spawn = require('child_process').spawn;
 
 var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent1-key.pem')),

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -29,7 +29,7 @@ var server = tls.Server(options, function(socket) {
 });
 
 server.listen(common.PORT, function() {
-  var socket = tls.connect({
+  tls.connect({
     port: common.PORT,
     rejectUnauthorized: false
   });

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto) {
 const tls = require('tls');
 
 const fs = require('fs');
-const net = require('net');
 
 const sent = 'hello world';
 

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -42,7 +42,6 @@ if (cluster.isMaster) {
 
   function fork() {
     var worker = cluster.fork();
-    var workerReqCount = 0;
     worker.on('message', function(msg) {
       console.error('[master] got %j', msg);
       if (msg === 'reused') {

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1514,9 +1514,6 @@ relativeTests2.forEach(function(relativeTest) {
 //if format and parse are inverse operations then
 //resolveObject(parse(x), y) == parse(resolve(x, y))
 
-//host and hostname are special, in this case a '' value is important
-var emptyIsImportant = {'host': true, 'hostname': ''};
-
 //format: [from, path, expected]
 relativeTests.forEach(function(relativeTest) {
   var actual = url.resolveObject(url.parse(relativeTest[0]), relativeTest[1]),

--- a/test/parallel/test-util-decorate-error-stack.js
+++ b/test/parallel/test-util-decorate-error-stack.js
@@ -1,6 +1,6 @@
 // Flags: --expose_internals
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -1,7 +1,7 @@
 'use strict';
 // Flags: --expose_internals
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 

--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -4,12 +4,12 @@ var assert = require('assert');
 var vm = require('vm');
 
 assert.throws(function() {
-  var ctx = vm.createContext('string is not supported');
+  vm.createContext('string is not supported');
 }, TypeError);
 
 assert.doesNotThrow(function() {
-  var ctx = vm.createContext({ a: 1 });
-  ctx = vm.createContext([0, 1, 2, 3]);
+  vm.createContext({ a: 1 });
+  vm.createContext([0, 1, 2, 3]);
 });
 
 assert.doesNotThrow(function() {

--- a/test/parallel/test-vm-harmony-proxies.js
+++ b/test/parallel/test-vm-harmony-proxies.js
@@ -8,12 +8,12 @@ var vm = require('vm');
 // src/node_contextify.cc filters out the Proxy object from the parent
 // context.  Make sure that the new context has a Proxy object of its own.
 var sandbox = {};
-var result = vm.runInNewContext('this.Proxy = Proxy', sandbox);
+vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert(typeof sandbox.Proxy === 'object');
 assert(sandbox.Proxy !== Proxy);
 
 // Unless we copy the Proxy object explicitly, of course.
 var sandbox = { Proxy: Proxy };
-var result = vm.runInNewContext('this.Proxy = Proxy', sandbox);
+vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert(typeof sandbox.Proxy === 'object');
 assert(sandbox.Proxy === Proxy);

--- a/test/parallel/test-vm-harmony-symbols.js
+++ b/test/parallel/test-vm-harmony-symbols.js
@@ -5,12 +5,12 @@ var vm = require('vm');
 
 // The sandbox should have its own Symbol constructor.
 var sandbox = {};
-var result = vm.runInNewContext('this.Symbol = Symbol', sandbox);
+vm.runInNewContext('this.Symbol = Symbol', sandbox);
 assert(typeof sandbox.Symbol === 'function');
 assert(sandbox.Symbol !== Symbol);
 
 // Unless we copy the Symbol constructor explicitly, of course.
 var sandbox = { Symbol: Symbol };
-var result = vm.runInNewContext('this.Symbol = Symbol', sandbox);
+vm.runInNewContext('this.Symbol = Symbol', sandbox);
 assert(typeof sandbox.Symbol === 'function');
 assert(sandbox.Symbol === Symbol);

--- a/test/parallel/test-vm-new-script-new-context.js
+++ b/test/parallel/test-vm-new-script-new-context.js
@@ -21,7 +21,6 @@ assert.throws(function() {
 
 
 console.error('undefined reference');
-var error;
 script = new Script('foo.bar = 5;');
 assert.throws(function() {
   script.runInNewContext();
@@ -41,7 +40,9 @@ code = 'foo = 1;' +
 foo = 2;
 obj = { foo: 0, baz: 3 };
 script = new Script(code);
+/* eslint-disable no-unused-vars */
 var baz = script.runInNewContext(obj);
+/* eslint-enable no-unused-vars */
 assert.equal(1, obj.foo);
 assert.equal(2, obj.bar);
 assert.equal(2, foo);

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -29,7 +29,9 @@ code = 'foo = 1;' +
        'if (baz !== 3) throw new Error(\'test fail\');';
 foo = 2;
 obj = { foo: 0, baz: 3 };
+/* eslint-disable no-unused-vars */
 var baz = vm.runInNewContext(code, obj);
+/* eslint-enable no-unused-vars */
 assert.equal(1, obj.foo);
 assert.equal(2, obj.bar);
 assert.equal(2, foo);

--- a/test/parallel/test-vm-static-this.js
+++ b/test/parallel/test-vm-static-this.js
@@ -25,7 +25,9 @@ code = 'foo = 1;' +
        'if (typeof baz !== \'undefined\') throw new Error(\'test fail\');';
 foo = 2;
 obj = { foo: 0, baz: 3 };
+/* eslint-disable no-unused-vars */
 var baz = vm.runInThisContext(code);
+/* eslint-enable no-unused-vars */
 assert.equal(0, obj.foo);
 assert.equal(2, bar);
 assert.equal(1, foo);

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -4,7 +4,6 @@
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 
 var spdyDict = new Buffer([
   'optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-',

--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -2,7 +2,6 @@
 require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 
 const bigData = new Buffer(10240).fill('x');
 

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
-var fs = require('fs');
 
 var gzip = zlib.createGzip();
 var gunz = zlib.createUnzip();

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -2,7 +2,6 @@
 require('../common');
 var assert = require('assert');
 var os = require('os');
-var util = require('util');
 
 if (os.type() != 'SunOS') {
   console.log('1..0 # Skipped: no DTRACE support');
@@ -13,7 +12,6 @@ if (os.type() != 'SunOS') {
  * Some functions to create a recognizable stack.
  */
 var frames = [ 'stalloogle', 'bagnoogle', 'doogle' ];
-var expected;
 
 var stalloogle = function(str) {
   expected = str;
@@ -35,7 +33,6 @@ var doogle = function() {
 
 var spawn = require('child_process').spawn;
 var prefix = '/var/tmp/node';
-var corefile = prefix + '.' + process.pid;
 
 /*
  * We're going to use DTrace to stop us, gcore us, and set us running again

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -32,7 +32,6 @@ var doogle = function() {
 };
 
 var spawn = require('child_process').spawn;
-var prefix = '/var/tmp/node';
 
 /*
  * We're going to use DTrace to stop us, gcore us, and set us running again

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -9,7 +9,6 @@ var watchSeenTwo = 0;
 var watchSeenThree = 0;
 var watchSeenFour = 0;
 
-var startDir = process.cwd();
 var testDir = common.tmpDir;
 
 var filenameOne = 'watch.txt';

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var net = require('net'),
-    util = require('util'),
     http = require('http');
 
 var errorCount = 0;

--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -18,8 +18,6 @@ var options = {
 };
 
 var buf = new Buffer(1024 * 1024);
-var sent = 0;
-var received = 0;
 
 var server = https.createServer(options, function(req, res) {
   res.writeHead(200);
@@ -30,7 +28,6 @@ var server = https.createServer(options, function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var resumed = false;
   var req = https.request({
     method: 'POST',
     port: common.PORT,

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -5,7 +5,6 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var http = require('http');
-var path = require('path');
 var url = require('url');
 
 if (common.isWindows) {

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -17,11 +17,7 @@ var https = require('https');
 
 var fs = require('fs');
 
-var PORT = 8000;
-
-
 var bytesExpected = 1024 * 1024 * 32;
-var gotResponse = false;
 
 var started = false;
 

--- a/test/pummel/test-stream2-basic.js
+++ b/test/pummel/test-stream2-basic.js
@@ -157,7 +157,6 @@ test('pipe', function(t) {
                  'xxxxx' ];
 
   var w = new TestWriter();
-  var flush = true;
 
   w.on('end', function(received) {
     t.same(received, expect);
@@ -439,7 +438,6 @@ test('adding readable triggers data flow', function(t) {
       r.push(new Buffer('asdf'));
   };
 
-  var called = false;
   r.on('readable', function() {
     onReadable = true;
     r.read();

--- a/test/pummel/test-timer-wrap2.js
+++ b/test/pummel/test-timer-wrap2.js
@@ -1,9 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
 
 // Test that allocating a timer does not increase the loop's reference
 // count.
 
 var Timer = process.binding('timer_wrap').Timer;
-var t = new Timer();
+new Timer();

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -91,12 +91,12 @@ function t() {
   expectedTimeouts--;
 }
 
-var w = setTimeout(t, 200);
-var x = setTimeout(t, 200);
+setTimeout(t, 200);
+setTimeout(t, 200);
 var y = setTimeout(t, 200);
 
 clearTimeout(y);
-var z = setTimeout(t, 200);
+setTimeout(t, 200);
 clearTimeout(y);
 
 

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -17,9 +17,7 @@ var join = require('path').join;
 var net = require('net');
 var assert = require('assert');
 var fs = require('fs');
-var crypto = require('crypto');
 var tls = require('tls');
-var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 
 test1();
@@ -46,8 +44,6 @@ function test(keyfn, certfn, check, next) {
   // the openssl s_server thus causing many tests to fail with
   // EADDRINUSE.
   var PORT = common.PORT + 5;
-
-  var connections = 0;
 
   keyfn = join(common.fixturesDir, keyfn);
   var key = fs.readFileSync(keyfn).toString();

--- a/test/pummel/test-watch-file.js
+++ b/test/pummel/test-watch-file.js
@@ -6,7 +6,6 @@ var fs = require('fs');
 var path = require('path');
 
 var f = path.join(common.fixturesDir, 'x.txt');
-var f2 = path.join(common.fixturesDir, 'x2.txt');
 
 console.log('watching for changes of ' + f);
 

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-var os = require('os');
 
 var execSync = require('child_process').execSync;
 var execFileSync = require('child_process').execFileSync;

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 // this test only fails with CentOS 6.3 using kernel version 2.6.32
 // On other linuxes and darwin, the `read` call gets an ECONNRESET in

--- a/test/sequential/test-pump-file2tcp.js
+++ b/test/sequential/test-pump-file2tcp.js
@@ -28,7 +28,6 @@ server.listen(common.PORT, function() {
 });
 
 var buffer = '';
-var count = 0;
 
 server.on('listening', function() {
 });

--- a/test/sequential/test-regress-GH-1697.js
+++ b/test/sequential/test-regress-GH-1697.js
@@ -1,8 +1,7 @@
 'use strict';
 var common = require('../common');
 var net = require('net'),
-    cp = require('child_process'),
-    util = require('util');
+    cp = require('child_process');
 
 if (process.argv[2] === 'server') {
   // Server

--- a/test/sequential/test-stdout-close-catch.js
+++ b/test/sequential/test-stdout-close-catch.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var child_process = require('child_process');
-var fs = require('fs');
 
 var testScript = path.join(common.fixturesDir, 'catch-stdout-error.js');
 

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var R = require('_stream_readable');
 var assert = require('assert');
 
 var fs = require('fs');
@@ -41,7 +40,6 @@ var w = new TestWriter();
 w.on('results', function(res) {
   console.error(res, w.length);
   assert.equal(w.length, size);
-  var l = 0;
   assert.deepEqual(res.map(function(c) {
     return c.length;
   }), expectLengths);

--- a/test/sequential/test-tcp-wrap-listen.js
+++ b/test/sequential/test-tcp-wrap-listen.js
@@ -12,7 +12,7 @@ assert.equal(0, r);
 
 server.listen(128);
 
-var slice, sliceCount = 0, eofCount = 0;
+var sliceCount = 0, eofCount = 0;
 
 var writeCount = 0;
 var recvCount = 0;

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -44,7 +44,7 @@ monoTimer.ontimeout = function() {
 
 monoTimer.start(300, 0);
 
-var timer = setTimeout(function() {
+setTimeout(function() {
   timerFired = true;
 }, 200);
 


### PR DESCRIPTION
replaces: #4683  and #4684 

Backport all changes to get LTS v4.x-staging passing the linter with no-unused-vars enabled. This involved backporting commits from 10 different PRs':
 * #4422 
 * #4424 
 * #4425 
 * #4426
 * #4430 
 * #4431 
 * #4511 
 * #4536 
