### PR TITLE
crypto: clear error stack in ECDH::Initialize

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4678,6 +4678,8 @@ void ECDH::Initialize(Environment* env, Local<Object> target) {
 void ECDH::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
+  MarkPopErrorOnReturn mark_pop_error_on_return;
+
   // TODO(indutny): Support raw curves?
   CHECK(args[0]->IsString());
   node::Utf8Value curve(env->isolate(), args[0]);

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -159,6 +159,11 @@ secret2 = ecdh2.computeSecret(key1, 'binary', 'buffer');
 
 assert.equal(secret1, secret2.toString('base64'));
 
+// Oakley curves do not clean up ERR stack, it was causing unexpected failure
+// when accessing other OpenSSL APIs afterwards.
+crypto.createECDH('Oakley-EC2N-3');
+crypto.createHash('sha256');
+
 // Point formats
 assert.equal(ecdh1.getPublicKey('buffer', 'uncompressed')[0], 4);
 let firstByte = ecdh1.getPublicKey('buffer', 'compressed')[0];


### PR DESCRIPTION
Clean up OpenSSL error stack in `ECDH::Initialize`, some curves have
faulty implementations that are leaving dangling errors after
initializing the curve.

Fix: #4686