### PR TITLE
lib: Remove XXX comment in readline and change to output debuglog

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -9,6 +9,7 @@
 const kHistorySize = 30;
 
 const util = require('util');
+const debug = util.debuglog('readline');
 const internalUtil = require('internal/util');
 const inherits = util.inherits;
 const Buffer = require('buffer').Buffer;
@@ -380,7 +381,7 @@ Interface.prototype._tabComplete = function() {
     self.resume();
 
     if (err) {
-      // XXX Log it somewhere?
+      debug('tab completion error %j', err);
       return;
     }
 


### PR DESCRIPTION
refs #4642 
Remove a comment that has a word 'XXX'.
And add a line to output debuglog of error.