### PR TITLE
src: cares_wrap: only loop through once on lookup

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -928,7 +928,7 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
     char ip[INET6_ADDRSTRLEN];
     const char *addr;
 
-    // Iterate over the IPv4 responses again this time creating javascript
+    // Iterate over the IPv4/IPv6 responses again this time creating javascript
     // strings for each IP and filling the results array.
     address = res;
     while (address) {
@@ -950,20 +950,7 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
         Local<String> s = OneByteString(env->isolate(), ip);
         results->Set(n, s);
         n++;
-      }
-
-      // Increment
-      address = address->ai_next;
-    }
-
-    // Iterate over the IPv6 responses putting them in the array.
-    address = res;
-    while (address) {
-      CHECK_EQ(address->ai_socktype, SOCK_STREAM);
-
-      // Ignore random ai_family types.
-      if (address->ai_family == AF_INET6) {
-        // Juggle pointers
+      } else if (address->ai_family == AF_INET6) {
         addr = reinterpret_cast<char*>(&(reinterpret_cast<struct sockaddr_in6*>(
             address->ai_addr)->sin6_addr));
         int err = uv_inet_ntop(address->ai_family,


### PR DESCRIPTION
The results will already be sorted based on the implementation of
getaddrinfo(). There is no need to loop through the returned addresses
twice (once for IPv4, once for IPv6). We should return them in the
order in which they already are.

References: 

- https://support.microsoft.com/en-us/kb/2621067
- http://linux.die.net/man/3/getaddrinfo
- https://www.ietf.org/mail-archive/web/v6ops/current/msg09805.html

This may need to be marked as semver-major