### PR TITLE
Ensure ES2016 engines construct Uint8Array (not Buffer) from Buffer.p…

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -70,6 +70,11 @@ function Buffer(arg, encoding) {
 Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
 Object.setPrototypeOf(Buffer, Uint8Array);
 
+if (Symbol.species && Buffer[Symbol.species] === Buffer) {
+  Object.defineProperty(Buffer, Symbol.species,
+                       { value: null, configurable: true });
+}
+
 
 function SlowBuffer(length) {
   if (+length != length)


### PR DESCRIPTION
…rototype.slice

In the ES2016 draft specification, TypedArray methods like
`%TypedArray%.prototype.subarray()` call out to a constructor for the result
based on the receiver. Ordinarily, the constructor is instance.constructor,
but subclasses can override this using the Symbol.species property on the
constructor.

`Buffer.prototype.slice` calls out to `%TypedArray%.prototype.subarray`, which
calls this calculated constructor with three arguments. The argument pattern
doesn't correspond to a constructor for Buffer, so without setting
`Symbol.species` appropriately, the wrong kind of result is created.

This patch sets `Buffer[Symbol.species]` to Uint8Array when appropriate, to
address the issue.

This addresses issue #4701 