### PR TITLE
src: Return on UV_ENOSYS in GetInterfaceAddresses.

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -200,7 +200,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   ret = Object::New(env->isolate());
 
   if (err == UV_ENOSYS) {
-    args.GetReturnValue().Set(ret);
+    return args.GetReturnValue().Set(ret);
   } else if (err) {
     return env->ThrowUVException(err, "uv_interface_addresses");
   }


### PR DESCRIPTION
When using SUNOS_NO_IFADDRS (on Solaris 10, for context) libuv returns `-ENOSYS`.

When that error is seen this method sets the response to the error code, but continues processing.

This leads to a segfault in `uv_free_interface_addresses`. Instead, just return as there is no need to process the rest of the function (afaict?)