### PR TITLE
doc: fix named anchors

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -1018,5 +1018,5 @@ Test in JavaScript by running:
 [Native Abstrations for Node.js]: https://github.com/nodejs/nan
 [examples]: https://github.com/nodejs/nan/tree/master/examples/
 [bindings]: https://github.com/TooTallNate/node-bindings
-[Linking to Node.js' own dependencies]: #linking-to-node-js-own-dependencies
+[Linking to Node.js' own dependencies]: #linking-to-nodejs-own-dependencies
 [installation instructions]: https://github.com/nodejs/node-gyp#installation

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -1112,7 +1112,7 @@ There are a few special headers that should be noted.
 [`http.Agent`]: #http_class_http_agent
 [`http.ClientRequest`]: #http_class_http_clientrequest
 [`http.globalAgent`]: #http_http_globalagent
-[`http.IncomingMessage`]: #http_http_incomingmessage
+[`http.IncomingMessage`]: #http_class_http_incomingmessage
 [`http.request()`]: #http_http_request_options_callback
 [`http.Server`]: #http_class_http_server
 [`http.ServerResponse`]: #http_class_http_serverresponse


### PR DESCRIPTION
This just fixes two references that weren't working in the docs.