### PR TITLE
doc: clarify protocol default in http.request()

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -1008,7 +1008,7 @@ automatically parsed with [`url.parse()`][].
 
 Options:
 
-- `protocol`: Protocol to use. Defaults to `'http'`.
+- `protocol`: Protocol to use. Defaults to `'http:'`.
 - `host`: A domain name or IP address of the server to issue the request to.
   Defaults to `'localhost'`.
 - `hostname`: Alias for `host`. To support [`url.parse()`][] `hostname` is


### PR DESCRIPTION
The previously listed default of `'http'` is incorrect, and causes an error to be thrown. This commit changes it to the correct value of `'http:'`.

Fixes: https://github.com/nodejs/node/issues/4712