### PR TITLE
src: return UV_EAI_NODATA on empty lookup

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -983,6 +983,10 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
       address = address->ai_next;
     }
 
+    // No responses were found to return
+    if (n == 0) {
+      argv[0] = Integer::New(env->isolate(), UV_EAI_NODATA);
+    }
 
     argv[1] = results;
   }


### PR DESCRIPTION
`AfterGetAddrInfo()` can potentially return an empty array of results without setting an error value. The JavaScript layer expects the array to have at least one value if an error is not returned. This commit sets a `UV_EAI_NODATA` error when an empty result array is detected.

Fixes: https://github.com/nodejs/node/issues/4545

R= @evanlucas 