### PR TITLE
lib: Remove unnecessary TODO comments

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -523,8 +523,6 @@ Buffer.prototype.fill = function fill(val, start, end) {
 };
 
 
-// TODO(trevnorris): fix these checks to follow new standard
-// write(string, offset = 0, length = buffer.length, encoding = 'utf8')
 var writeWarned = false;
 const writeMsg = 'Buffer.write(string, encoding, offset, length) is ' +
                  'deprecated. Use write(string[, offset[, length]]' +
@@ -617,8 +615,6 @@ Buffer.prototype.toJSON = function() {
 };
 
 
-// TODO(trevnorris): currently works like Array.prototype.slice(), which
-// doesn't follow the new standard for throwing on out of range indexes.
 Buffer.prototype.slice = function slice(start, end) {
   const buffer = this.subarray(start, end);
   Object.setPrototypeOf(buffer, Buffer.prototype);


### PR DESCRIPTION
Original committer (@trevnorris) stated they were safe to remove in issue comments.
Ref: Issue #4642 

PS: I want to work more on the TODOs in 4642 (and, you know, actually fix things). I'm assuming I should direct questions if I have any there? It has a 'mentor-available' tag.