### PR TITLE
src: don't check failure with ERR_peek_error()

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3611,8 +3611,7 @@ bool Hash::HashInit(const char* hash_type) {
   if (md_ == nullptr)
     return false;
   EVP_MD_CTX_init(&mdctx_);
-  EVP_DigestInit_ex(&mdctx_, md_, nullptr);
-  if (0 != ERR_peek_error()) {
+  if (EVP_DigestInit_ex(&mdctx_, md_, nullptr) <= 0) {
     return false;
   }
   initialised_ = true;


### PR DESCRIPTION
It's possible there is already an existing error on OpenSSL's error
stack that is unrelated to the EVP_DigestInit_ex() operation we just
executed.

Fixes: https://github.com/nodejs/node/issues/4221

R=@indutny

CI: https://ci.nodejs.org/job/node-test-pull-request/1281/