### PR TITLE
v4.x-staging: assert: accommodate ES6 classes that extend Error

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -283,6 +283,10 @@ function expectedException(actual, expected) {
     // Ignore.  The instanceof check doesn't work for arrow functions.
   }
 
+  if (Error.isPrototypeOf(expected)) {
+    return false;
+  }
+
   return expected.call({}, actual) === true;
 }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -342,9 +342,28 @@ a.throws(makeBlock(thrower, TypeError), function(err) {
   }
 });
 
+// https://github.com/nodejs/node/issues/3188
+threw = false;
+
+try {
+  var ES6Error = class extends Error {};
+
+  var AnotherErrorType = class extends Error {};
+
+  const functionThatThrows = function() {
+    throw new AnotherErrorType('foo');
+  };
+
+  assert.throws(functionThatThrows, ES6Error);
+} catch (e) {
+  threw = true;
+  assert(e instanceof AnotherErrorType,
+    `expected AnotherErrorType, received ${e}`);
+}
+
+assert.ok(threw);
 
 // GH-207. Make sure deepEqual doesn't loop forever on circular refs
-
 var b = {};
 b.b = b;
 


### PR DESCRIPTION
`assert.throws()` and `assert.doesNotThrow()` blow up with a `TypeError`
if used with an ES6 class that extends Error.

Fixes: https://github.com/nodejs/node/issues/3188
PR-URL: https://github.com/nodejs/node/pull/4166
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>