### PR TITLE
buffer: make byteLength work with Buffer correctly

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -262,6 +262,9 @@ function base64ByteLength(str, bytes) {
 
 
 function byteLength(string, encoding) {
+  if (string instanceof Buffer)
+    return string.length;
+
   if (typeof string !== 'string')
     string = '' + string;
 

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -10,6 +10,12 @@ assert.equal(Buffer.byteLength(NaN, 'utf8'), 3);
 assert.equal(Buffer.byteLength({}, 'binary'), 15);
 assert.equal(Buffer.byteLength(), 9);
 
+// buffer
+var incomplete = new Buffer([0xe4, 0xb8, 0xad, 0xe6, 0x96]);
+assert.equal(Buffer.byteLength(incomplete), 5);
+var ascii = new Buffer('abc');
+assert.equal(Buffer.byteLength(ascii), 3);
+
 // special case: zero length string
 assert.equal(Buffer.byteLength('', 'ascii'), 0);
 assert.equal(Buffer.byteLength('', 'HeX'), 0);


### PR DESCRIPTION
Make the byteLength work correctly when input is Buffer.

e.g:

```js
// The incomplete unicode string
Buffer.byteLength(new Buffer([0xe4, 0xb8, 0xad, 0xe6, 0x96]))
```
The old output: 9
The new output: 5