### PR TITLE
readline: refactor construct Interface

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -23,22 +23,13 @@ const stripVTControlCharacters = internalReadline.stripVTControlCharacters;
 
 
 exports.createInterface = function(input, output, completer, terminal) {
-  var rl;
-  if (arguments.length === 1) {
-    rl = new Interface(input);
-  } else {
-    rl = new Interface(input, output, completer, terminal);
-  }
-  return rl;
+  return new Interface(input, output, completer, terminal);
 };
 
 
 function Interface(input, output, completer, terminal) {
   if (!(this instanceof Interface)) {
-    // call the constructor preserving original number of arguments
-    const self = Object.create(Interface.prototype);
-    Interface.apply(self, arguments);
-    return self;
+    return new Interface(input, output, completer, terminal);
   }
 
   this._sawReturnAt = 0;
@@ -51,7 +42,7 @@ function Interface(input, output, completer, terminal) {
   let crlfDelay;
   let prompt = '> ';
 
-  if (arguments.length === 1) {
+  if (input && input.input) {
     // an options object was given
     output = input.output;
     completer = input.completer;


### PR DESCRIPTION
Remove the dependency on the arguments.length.
