### PR TITLE
Add listening method to net + tests

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -548,6 +548,11 @@ parameter is 511 (not 512).
 This function is asynchronous. The last parameter `callback` will be added as
 a listener for the `'listening'` event.  See also [`net.Server.listen(port)`][].
 
+### server.listening
+
+A Boolean indicating whether or not the server is listening for
+connections.
+
 ### server.maxHeadersCount
 
 Limits maximum incoming headers count, equal to 1000 by default. If set to 0 -

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -196,6 +196,11 @@ would be to wait a second and then try again. This can be done with
 
 (Note: All sockets in Node.js set `SO_REUSEADDR` already)
 
+### server.listening
+
+A Boolean indicating whether or not the server is listening for
+connections.
+
 ### server.maxConnections
 
 Set this property to reject connections when the server's connection count gets

--- a/lib/net.js
+++ b/lib/net.js
@@ -1384,6 +1384,14 @@ Server.prototype.listen = function() {
   return self;
 };
 
+Object.defineProperty(Server.prototype, 'listening', {
+  get: function() {
+    return !!this._handle;
+  },
+  configurable: true,
+  enumerable: true
+});
+
 Server.prototype.address = function() {
   if (this._handle && this._handle.getsockname) {
     var out = {};

--- a/test/parallel/test-http-listening.js
+++ b/test/parallel/test-http-listening.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer();
+
+assert.strictEqual(server.listening, false);
+
+server.listen(common.PORT, common.mustCall(() => {
+  assert.strictEqual(server.listening, true);
+
+  server.close(common.mustCall(() => {
+    assert.strictEqual(server.listening, false);
+  }));
+}));

--- a/test/parallel/test-net-listening.js
+++ b/test/parallel/test-net-listening.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const server = net.createServer();
+
+assert.strictEqual(server.listening, false);
+
+server.listen(common.PORT, common.mustCall(() => {
+  assert.strictEqual(server.listening, true);
+
+  server.close(common.mustCall(() => {
+    assert.strictEqual(server.listening, false);
+  }));
+}));


### PR DESCRIPTION
Added:
* `listening` method into `net`
* Added test for `net` module
* Added test for `http` module, since it inherits properties from `net`

closes #4735