### PR TITLE
internal/child_process: call postSend on error

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -602,12 +602,18 @@ function setupChannel(target, channel) {
       } else {
         process.nextTick(function() { req.oncomplete(); });
       }
-    } else if (!swallowErrors) {
-      const ex = errnoException(err, 'write');
-      if (typeof callback === 'function') {
-        process.nextTick(callback, ex);
-      } else {
-        this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+    } else {
+      // Cleanup handle on error
+      if (obj && obj.postSend)
+        obj.postSend(handle);
+
+      if (!swallowErrors) {
+        const ex = errnoException(err, 'write');
+        if (typeof callback === 'function') {
+          process.nextTick(callback, ex);
+        } else {
+          this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+        }
       }
     }
 


### PR DESCRIPTION
Call `obj.postSend` in error case of `process.send()`. The
`net.Socket`'s handle should not be leaked.

-------------

Noticed this while looking through the code. I'm not sure if any reliable test case could be written for it, but the problem seems to be kind of obvious to me.

R = @bnoordhuis or @sam-github 

cc @nodejs/collaborators 