### PR TITLE
tools, test: enable space-in-parens ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,8 +67,10 @@ rules:
   eol-last: 2
   ## no trailing spaces
   no-trailing-spaces: 2
-  # require space after keywords, eg 'for (..)'
+  ## require space after keywords, eg 'for (..)'
   space-after-keywords: 2
+  ## no leading/trailing spaces in parens
+  space-in-parens: [2, "never"]
 
   # ECMAScript 6
   # list: http://eslint.org/docs/rules/#ecmascript-6

--- a/test/parallel/test-beforeexit-event.js
+++ b/test/parallel/test-beforeexit-event.js
@@ -5,7 +5,7 @@ var common = require('../common');
 var revivals = 0;
 var deaths = 0;
 
-process.on('beforeExit', function() { deaths++; } );
+process.on('beforeExit', function() { deaths++; });
 
 process.once('beforeExit', tryImmediate);
 

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -62,7 +62,7 @@ var wikipedia = [
 for (var i = 0, l = wikipedia.length; i < l; i++) {
   for (var hash in wikipedia[i]['hmac']) {
     // FIPS does not support MD5.
-    if (common.hasFipsCrypto && hash == 'md5' )
+    if (common.hasFipsCrypto && hash == 'md5')
       continue;
     var result = crypto.createHmac(hash, wikipedia[i]['key'])
                      .update(wikipedia[i]['data'])

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -17,7 +17,7 @@ var options = {
 var server = http.createServer(function(req, res) {
   const m = /\/(.*)/.exec(req.url);
   const reqid = parseInt(m[1], 10);
-  if ( reqid % 2 ) {
+  if (reqid % 2) {
     // do not reply the request
   } else {
     res.writeHead(200, {'Content-Type': 'text/plain'});

--- a/test/parallel/test-process-binding.js
+++ b/test/parallel/test-process-binding.js
@@ -12,7 +12,7 @@ assert.throws(
 assert.doesNotThrow(function() {
   process.binding('buffer');
 }, function(err) {
-  if ( (err instanceof Error) ) {
+  if (err instanceof Error) {
     return true;
   }
 }, 'unexpected error');

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -30,7 +30,7 @@ clearTimeout(id);
 
 setInterval(function() {
   interval_count += 1;
-  var endtime = new Date( );
+  var endtime = new Date();
 
   var diff = endtime - starttime;
   assert.ok(diff > 0);


### PR DESCRIPTION
This came up in https://github.com/nodejs/node/pull/4743#issuecomment-172690436. There were only 7 violations, all of them in `test`.