### PR TITLE
src: fix negative values in process.hrtime()

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -193,10 +193,9 @@
 
       if (typeof ar !== 'undefined') {
         if (Array.isArray(ar)) {
-          return [
-            (hrValues[0] * 0x100000000 + hrValues[1]) - ar[0],
-            hrValues[2] - ar[1]
-          ];
+          const sec = (hrValues[0] * 0x100000000 + hrValues[1]) - ar[0];
+          const nsec = hrValues[2] - ar[1];
+          return [nsec < 0 ? sec - 1 : sec, nsec < 0 ? nsec + 1e9 : nsec];
         }
 
         throw new TypeError('process.hrtime() only accepts an Array tuple');

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -25,5 +25,5 @@ function validateTuple(tuple) {
   });
 }
 
-const diff = process.hrtime([0, 1e9-1]);
+const diff = process.hrtime([0, 1e9 - 1]);
 assert(diff[1] >= 0);  // https://github.com/nodejs/node/issues/4751

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -24,3 +24,6 @@ function validateTuple(tuple) {
     assert(isFinite(v));
   });
 }
+
+const diff = process.hrtime([0, 1e9-1]);
+assert(diff[1] >= 0);  // https://github.com/nodejs/node/issues/4751


### PR DESCRIPTION
Fix a regression introduced in commit 89f056b ("node: improve
performance of hrtime()") where the nanosecond field sometimes
had a negative value when calculating the difference between two
timestamps.

Fixes: https://github.com/nodejs/node/issues/4751

R=@trevnorris

[Can't run the CI - https://ci.nodejs.org/ times out.]