### PR TITLE
doc: emitter.removeListener within emit cycle clarification

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -339,7 +339,8 @@ Removes the specified `listener` from the listener array for the specified
 `removeListener` will remove, at most, one instance of a listener from the
 listener array. If any single listener has been added multiple times to the
 listener array for the specified `event`, then `removeListener` must be called
-multiple times to remove each instance.
+multiple times to remove each instance. Listeners removed from an event from
+within the emit cycle of that event will still be called in that emit cycle.  
 
 Because listeners are managed using an internal array, calling this will
 change the position indices of any listener registered *after* the listener


### PR DESCRIPTION
As discussed in [https://github.com/nodejs/node/issues/4759](https://github.com/nodejs/node/issues/4759), listeners removed from an event while the event's emit cycle is underway will still be called in that cycle and the new listener array will only be used in subsequent calls. This change updates the documentation to explicitly clarify this behaviour.