### PR TITLE
test: remove Object.observe from tests

### DIFF
--- a/test/parallel/test-microtask-queue-integration-domain.js
+++ b/test/parallel/test-microtask-queue-integration-domain.js
@@ -12,13 +12,6 @@ require('domain');
 var implementations = [
   function(fn) {
     Promise.resolve().then(fn);
-  },
-  function(fn) {
-    var obj = {};
-
-    Object.observe(obj, fn);
-
-    obj.a = 1;
   }
 ];
 

--- a/test/parallel/test-microtask-queue-integration.js
+++ b/test/parallel/test-microtask-queue-integration.js
@@ -5,13 +5,6 @@ var assert = require('assert');
 var implementations = [
   function(fn) {
     Promise.resolve().then(fn);
-  },
-  function(fn) {
-    var obj = {};
-
-    Object.observe(obj, fn);
-
-    obj.a = 1;
   }
 ];
 


### PR DESCRIPTION
Testing this wasn't really useful, besides Object.observe is going to be deprecated.

Also this test fails with Chakra (https://github.com/nodejs/node/pull/4765) for obvious reason.