### PR TITLE
http: remove reference to onParserExecute

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -170,6 +170,7 @@ var parsers = new FreeList('parsers', 1000, function() {
   parser[kOnHeadersComplete] = parserOnHeadersComplete;
   parser[kOnBody] = parserOnBody;
   parser[kOnMessageComplete] = parserOnMessageComplete;
+  parser[kOnExecute] = null;
 
   return parser;
 });

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -20,6 +20,7 @@ const kOnHeaders = HTTPParser.kOnHeaders | 0;
 const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
 const kOnBody = HTTPParser.kOnBody | 0;
 const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
+const kOnExecute = HTTPParser.kOnExecute | 0;
 
 // Only called in the slow case where slow means
 // that the request headers were either fragmented
@@ -194,6 +195,7 @@ function freeParser(parser, req, socket) {
     parser.socket = null;
     parser.incoming = null;
     parser.outgoing = null;
+    parser[kOnExecute] = null;
     if (parsers.free(parser) === false)
       parser.close();
     parser = null;


### PR DESCRIPTION
Parsers hold a reference to the socket associated with the request
through onParserExecute. This must be removed when the parser is
freed so that the socket can be garbage collected when destroyed.

Not removing this causes the last 1000 sockets used for inbound http requests to go uncollected after being destroyed.

Code was introduced in 59b91f1.