### PR TITLE
test: fix flaky test-http-pipeline-flood (again!)

### DIFF
--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -3,14 +3,14 @@ const common = require('../common');
 const assert = require('assert');
 
 // Here we are testing the HTTP server module's flood prevention mechanism.
-// When writeable.write returns false (ie the underlying send() indicated the
+// When writeable.write returns false (the underlying send() indicated the
 // native buffer is full), the HTTP server cork()s the readable part of the
-// stream. This means that new requests will not be read (however request which
-// have already been read, but are awaiting processing will still be
+// stream. This means that new requests will not be read (however requests which
+// have already been read but are awaiting processing will still be
 // processed).
 
-// Normally when the writable stream emits a 'drain' event, the server then
-// uncorks the readable stream, although we arent testing that part here.
+// Normally when the writable stream emits a `drain` event, the server then
+// uncorks the readable stream, although we aren't testing that part here.
 
 switch (process.argv[2]) {
   case undefined:
@@ -24,18 +24,14 @@ switch (process.argv[2]) {
 function parent() {
   const http = require('http');
   const bigResponse = new Buffer(10240).fill('x');
-  var gotTimeout = false;
-  var childClosed = false;
-  var requests = 0;
   var connections = 0;
   var backloggedReqs = 0;
 
   const server = http.createServer(function(req, res) {
-    requests++;
     res.setHeader('content-length', bigResponse.length);
     if (!res.write(bigResponse)) {
       if (backloggedReqs === 0) {
-        // Once the native buffer fills (ie write() returns false), the flood
+        // Once the native buffer fills (write() returns false), the flood
         // prevention should kick in.
         // This means the stream should emit no more 'data' events. However we
         // may still be asked to process more requests if they were read before
@@ -57,21 +53,14 @@ function parent() {
     const spawn = require('child_process').spawn;
     const args = [__filename, 'child'];
     const child = spawn(process.execPath, args, { stdio: 'inherit' });
-    child.on('close', function() {
-      childClosed = true;
+    child.on('close', common.mustCall(function() {
       server.close();
-    });
-
-    server.setTimeout(common.platformTimeout(200), function(conn) {
-      gotTimeout = true;
-      child.kill();
-    });
+    }));
   });
 
   process.on('exit', function() {
-    assert(gotTimeout);
-    assert(childClosed);
     assert.equal(connections, 1);
+    assert(backloggedReqs > 0);
   });
 }
 
@@ -85,13 +74,9 @@ function child() {
 
   req = new Array(10241).join(req);
 
-  conn.on('connect', function() {
-    // Terminate child after flooding.
-    setTimeout(function() { conn.destroy(); }, common.platformTimeout(1000));
-    write();
-  });
+  conn.on('connect', common.mustCall(write));
 
-  conn.on('drain', write);
+  conn.on('drain', common.mustCall(() => {}));
 
   function write() {
     while (false !== conn.write(req, 'ascii'));


### PR DESCRIPTION
test-http-pipeline-flood has a history of flakiness. We're eliminating
the flakiness by removing competing timeouts which were necessarily
race-y.