### PR TITLE
test: remove race condition in http flood test

### DIFF
--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -62,7 +62,7 @@ function parent() {
       server.close();
     }));
 
-    server.setTimeout(common.platformTimeout(10), common.mustCall(function() {
+    server.setTimeout(10, common.mustCall(function() {
       child.kill();
     }));
   });
@@ -82,13 +82,10 @@ function child() {
 
   req = new Array(10241).join(req);
 
-  conn.on('connect', function() {
-    // Terminate child after flooding.    
-    setTimeout(function() { conn.destroy(); }, 500);   
-    write();    
-  });
+  conn.on('connect', write);
 
-  conn.on('drain', write);
+  // `drain` should fire once and only once
+  conn.on('drain', common.mustCall(write));
 
   function write() {
     while (false !== conn.write(req, 'ascii'));

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -62,7 +62,7 @@ function parent() {
       server.close();
     }));
 
-    server.setTimeout(10, common.mustCall(function() {
+    server.setTimeout(200, common.mustCall(function() {
       child.kill();
     }));
   });

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -24,8 +24,6 @@ switch (process.argv[2]) {
 function parent() {
   const http = require('http');
   const bigResponse = new Buffer(10240).fill('x');
-  var gotTimeout = false;
-  var childClosed = false;
   var requests = 0;
   var connections = 0;
   var backloggedReqs = 0;
@@ -57,20 +55,16 @@ function parent() {
     const spawn = require('child_process').spawn;
     const args = [__filename, 'child'];
     const child = spawn(process.execPath, args, { stdio: 'inherit' });
-    child.on('close', function() {
-      childClosed = true;
+    child.on('close', common.mustCall(function() {
       server.close();
-    });
+    }));
 
-    server.setTimeout(common.platformTimeout(200), function(conn) {
-      gotTimeout = true;
+    server.setTimeout(common.platformTimeout(200), common.mustCall(function() {
       child.kill();
-    });
+    }));
   });
 
   process.on('exit', function() {
-    assert(gotTimeout);
-    assert(childClosed);
     assert.equal(connections, 1);
   });
 }
@@ -85,11 +79,7 @@ function child() {
 
   req = new Array(10241).join(req);
 
-  conn.on('connect', function() {
-    // Terminate child after flooding.
-    setTimeout(function() { conn.destroy(); }, common.platformTimeout(1000));
-    write();
-  });
+  conn.on('connect', write);
 
   conn.on('drain', write);
 


### PR DESCRIPTION
Timer race results in some flakiness on slower devices in CI.