### PR TITLE
Remove unused branches from fs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1160,16 +1160,16 @@ function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
   fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
     if (writeErr) {
       if (isUserFd) {
-        if (callback) callback(writeErr);
+        callback(writeErr);
       } else {
         fs.close(fd, function() {
-          if (callback) callback(writeErr);
+          callback(writeErr);
         });
       }
     } else {
       if (written === length) {
         if (isUserFd) {
-          if (callback) callback(null);
+          callback(null);
         } else {
           fs.close(fd, callback);
         }
@@ -1207,7 +1207,7 @@ fs.writeFile = function(path, data, options, callback_) {
 
   fs.open(path, flag, options.mode, function(openErr, fd) {
     if (openErr) {
-      if (callback) callback(openErr);
+      callback(openErr);
     } else {
       writeFd(fd, false);
     }


### PR DESCRIPTION
In a few places the code was refactored to use `maybeCallback` which always returns a function. Checking for `if (callback)` always returns true anyway.