### PR TITLE
Refactor functions to arrows

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -27,9 +27,8 @@ exports.globalAgent = agent.globalAgent;
 const client = require('_http_client');
 const ClientRequest = exports.ClientRequest = client.ClientRequest;
 
-exports.request = function(options, cb) {
-  return new ClientRequest(options, cb);
-};
+exports.request = (options, cb) => new ClientRequest(options, cb);
+
 
 exports.get = function(options, cb) {
   var req = exports.request(options, cb);
@@ -40,10 +39,7 @@ exports.get = function(options, cb) {
 exports._connectionListener = server._connectionListener;
 const Server = exports.Server = server.Server;
 
-exports.createServer = function(requestListener) {
-  return new Server(requestListener);
-};
-
+exports.createServer = requestListener => new Server(requestListener);
 
 // Legacy Interface
 


### PR DESCRIPTION
Another really small one, refactor a bunch of `function(...){ return ... }` into `(...) => ...`. 

I considered also changing `Client` and removing the `self = this` but as it 
is a legacy interface I don't think it's worth the trouble.