### PR TITLE
process: support symbol events

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -821,7 +821,8 @@
     var signalWraps = {};
 
     function isSignal(event) {
-      return event.slice(0, 3) === 'SIG' &&
+      return typeof event === 'string' &&
+             event.slice(0, 3) === 'SIG' &&
              startup.lazyConstants().hasOwnProperty(event);
     }
 

--- a/test/parallel/test-process-emit.js
+++ b/test/parallel/test-process-emit.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const sym = Symbol();
+
+process.on('normal', common.mustCall(data => {
+  assert.strictEqual(data, 'normalData');
+}));
+
+process.on(sym, common.mustCall(data => {
+  assert.strictEqual(data, 'symbolData');
+}));
+
+process.on('SIGPIPE', common.mustCall(data => {
+  assert.strictEqual(data, 'signalData');
+}));
+
+process.emit('normal', 'normalData');
+process.emit(sym, 'symbolData');
+process.emit('SIGPIPE', 'signalData');


### PR DESCRIPTION
Event emitters support symbols as event names. The `process` object assumes that the event name is a string, and examines the first three characters to check for signals. This causes an exception if the event name is a symbol. This commit ensures that the event name is a string before trying to `slice()` it.