### PR TITLE
buffer: couple indexOf fixes

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -477,10 +477,14 @@ function slowIndexOf(buffer, val, byteOffset, encoding) {
 }
 
 Buffer.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
-  if (byteOffset > 0x7fffffff)
+  if (typeof byteOffset === 'string') {
+    encoding = byteOffset;
+    byteOffset = 0;
+  } else if (byteOffset > 0x7fffffff) {
     byteOffset = 0x7fffffff;
-  else if (byteOffset < -0x80000000)
+  } else if (byteOffset < -0x80000000) {
     byteOffset = -0x80000000;
+  }
   byteOffset >>= 0;
 
   if (typeof val === 'string') {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -849,7 +849,9 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   Local<String> needle = args[1].As<String>();
   const char* haystack = ts_obj_data;
   const size_t haystack_length = ts_obj_length;
-  const size_t needle_length = needle->Utf8Length();
+  // Extended latin-1 characters are 2 bytes in Utf8.
+  const size_t needle_length =
+      enc == BINARY ? needle->Length() : needle->Utf8Length();
 
 
   if (needle_length == 0 || haystack_length == 0) {

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -111,6 +111,11 @@ assert.equal(
     .indexOf(Buffer('d', 'binary'), 0, 'binary'), 3);
 
 
+// test optional offset with passed encoding
+assert.equal(new Buffer('aaaa0').indexOf('30', 'hex'), 4);
+assert.equal(new Buffer('aaaa00a').indexOf('3030', 'hex'), 4);
+
+
 // test usc2 encoding
 var twoByteString = new Buffer('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
 

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -109,6 +109,15 @@ assert.equal(
 assert.equal(
     Buffer(b.toString('binary'), 'binary')
     .indexOf(Buffer('d', 'binary'), 0, 'binary'), 3);
+assert.equal(
+    Buffer('aa\u00e8aa', 'binary')
+    .indexOf('\u00e8', 'binary'), 2);
+assert.equal(
+    Buffer('\u00e8', 'binary')
+    .indexOf('\u00e8', 'binary'), 0);
+assert.equal(
+    Buffer('\u00e8', 'binary')
+    .indexOf(Buffer('\u00e8', 'binary'), 'binary'), 0);
 
 
 // test optional offset with passed encoding


### PR DESCRIPTION
1) Fix arguments to allow `indexOf(val[, byteOffset][, encoding])` instead of forcing
`indexOf(val[, byteOffset[, encoding]])` as it does today. This works in conjunction with https://github.com/nodejs/node/pull/3373 which adds a documentation update.

2) Fix binary encoding. Currently the `needle` is always decoded as `utf8`, which means extended `latin-1` characters will increase the size by too many bytes and fail the search.

Tests have been added for both.

R= @bnoordhuis 

CI: https://ci.nodejs.org/job/node-test-pull-request/1349/