### PR TITLE
tools: fix setting path containing an ampersand

### DIFF
--- a/tools/msvs/nodevars.bat
+++ b/tools/msvs/nodevars.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem Ensure this Node.js and npm are first in the PATH
-set PATH=%APPDATA%\npm;%~dp0;%PATH%
+set "PATH=%APPDATA%\npm;%~dp0;%PATH%"
 
 setlocal enabledelayedexpansion
 pushd "%~dp0"


### PR DESCRIPTION
This commit fixes an issue with the Node.js command prompt on Windows where the PATH environment variable would not be set correctly if the existing PATH contained an '&'.

Fixes: https://github.com/nodejs/node/issues/4802