### PR TITLE
doc: proper markdown escaping -> \_\_, \*, \_

### DIFF
--- a/doc/api/globals.markdown
+++ b/doc/api/globals.markdown
@@ -13,7 +13,7 @@ actually in the global scope but in the module scope - this will be noted.
 
 Used to handle binary data. See the [buffer section][].
 
-## __dirname
+## \_\_dirname
 
 <!-- type=var -->
 
@@ -30,7 +30,7 @@ console.log(__dirname);
 
 `__dirname` isn't actually a global but rather local to each module.
 
-## __filename
+## \_\_filename
 
 <!-- type=var -->
 

--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -28,7 +28,7 @@ path.basename('/foo/bar/baz/asdf/quux.html', '.html')
 
 The platform-specific path delimiter, `;` or `':'`.
 
-An example on *nix:
+An example on \*nix:
 
 ```js
 console.log(process.env.PATH)
@@ -191,7 +191,7 @@ path.normalize('/foo/bar//baz/asdf/quux/..')
 
 Returns an object from a path string.
 
-An example on *nix:
+An example on \*nix:
 
 ```js
 path.parse('/home/user/dir/file.txt')
@@ -304,7 +304,7 @@ path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
 
 The platform-specific file separator. `'\\'` or `'/'`.
 
-An example on *nix:
+An example on \*nix:
 
 ```js
 'foo/bar/baz'.split(path.sep)

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -863,7 +863,7 @@ In classes that extend the Readable class, make sure to call the
 Readable constructor so that the buffering settings can be properly
 initialized.
 
-#### readable._read(size)
+#### readable.\_read(size)
 
 * `size` {Number} Number of bytes to read asynchronously
 
@@ -871,14 +871,14 @@ Note: **Implement this method, but do NOT call it directly.**
 
 This method is prefixed with an underscore because it is internal to the
 class that defines it and should only be called by the internal Readable
-class methods. All Readable stream implementations must provide a _read
+class methods. All Readable stream implementations must provide a \_read
 method to fetch data from the underlying resource.
 
-When _read is called, if data is available from the resource, `_read` should
+When \_read is called, if data is available from the resource, `_read` should
 start pushing that data into the read queue by calling `this.push(dataChunk)`.
 `_read` should continue reading from the resource and pushing data until push
 returns false, at which point it should stop reading from the resource. Only
-when _read is called again after it has stopped should it start reading
+when \_read is called again after it has stopped should it start reading
 more data from the resource and pushing that data onto the queue.
 
 Note: once the `_read()` method is called, it will not be called again until
@@ -1127,7 +1127,7 @@ and Readable classes respectively. The `'finish'` event is fired after
 `end` is fired after all data has been output which is after the callback
 in `_flush` has been called.
 
-#### transform._flush(callback)
+#### transform.\_flush(callback)
 
 * `callback` {Function} Call this function (optionally with an error
   argument) when you are done flushing any remaining data.
@@ -1154,7 +1154,7 @@ the class that defines it, and should not be called directly by user
 programs.  However, you **are** expected to override this method in
 your own extension classes.
 
-#### transform._transform(chunk, encoding, callback)
+#### transform.\_transform(chunk, encoding, callback)
 
 * `chunk` {Buffer | String} The chunk to be transformed. Will **always**
   be a buffer unless the `decodeStrings` option was set to `false`.
@@ -1309,7 +1309,7 @@ In classes that extend the Writable class, make sure to call the
 constructor so that the buffering settings can be properly
 initialized.
 
-#### writable._write(chunk, encoding, callback)
+#### writable.\_write(chunk, encoding, callback)
 
 * `chunk` {Buffer | String} The chunk to be written. Will **always**
   be a buffer unless the `decodeStrings` option was set to `false`.
@@ -1342,7 +1342,7 @@ the class that defines it, and should not be called directly by user
 programs.  However, you **are** expected to override this method in
 your own extension classes.
 
-#### writable._writev(chunks, callback)
+#### writable.\_writev(chunks, callback)
 
 * `chunks` {Array} The chunks to be written.  Each chunk has following
   format: `{ chunk: ..., encoding: ... }`.


### PR DESCRIPTION
Continuation of #4733:

Fixes wrong escaping.
Now more pleasant Editor experience.

Rendered HTML looked same to me.

<img width="554" alt="eingefugtes_bild_21_01_16__22_43" src="https://cloud.githubusercontent.com/assets/3899684/12496216/9af7c0f2-c094-11e5-92a9-5721e14ee9ef.png">
 