### PR TITLE
doc: harmonize $ node command line notation

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -36,7 +36,7 @@ if (cluster.isMaster) {
 Running Node.js will now share port 8000 between the workers:
 
 ```
-% NODE_DEBUG=cluster node server.js
+$ NODE_DEBUG=cluster node server.js
 23521,Master Worker 23524 online
 23521,Master Worker 23526 online
 23521,Master Worker 23523 online

--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -10,7 +10,7 @@ start Node.js with the `debug` argument followed by the path to the script to
 debug; a prompt will be displayed indicating successful launch of the debugger:
 
 ```
-% node debug myscript.js
+$ node debug myscript.js
 < debugger listening on port 5858
 connecting... ok
 break in /home/indutny/Code/git/indutny/myscript.js:1
@@ -41,7 +41,7 @@ console.log('hello');
 Once the debugger is run, a breakpoint will occur at line 4:
 
 ```
-% node debug myscript.js
+$ node debug myscript.js
 < debugger listening on port 5858
 connecting... ok
 break in /home/indutny/Code/git/indutny/myscript.js:1
@@ -78,7 +78,6 @@ break in /home/indutny/Code/git/indutny/myscript.js:5
   6 console.log('hello');
   7
 debug> quit
-%
 ```
 
 The `repl` command allows code to be evaluated remotely. The `next` command
@@ -121,7 +120,7 @@ It is also possible to set a breakpoint in a file (module) that
 isn't loaded yet:
 
 ```
-% ./node debug test/fixtures/break-in-module/main.js
+$ ./node debug test/fixtures/break-in-module/main.js
 < debugger listening on port 5858
 connecting to port 5858... ok
 break in test/fixtures/break-in-module/main.js:1

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -970,7 +970,8 @@ If you would like to parse the URL into its parts, you can use
 `require('url').parse(request.url)`.  Example:
 
 ```
-node> require('url').parse('/status?name=ryan')
+$ node
+> require('url').parse('/status?name=ryan')
 {
   href: '/status?name=ryan',
   search: '?name=ryan',
@@ -984,7 +985,8 @@ you can use the `require('querystring').parse` function, or pass
 `true` as the second argument to `require('url').parse`.  Example:
 
 ```
-node> require('url').parse('/status?name=ryan', true)
+$ node
+> require('url').parse('/status?name=ryan', true)
 {
   href: '/status?name=ryan',
   search: '?name=ryan',

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -11,7 +11,7 @@ By executing `node` without any arguments from the command-line you will be
 dropped into the REPL. It has simplistic emacs line-editing.
 
 ```
-mjr:~$ node
+$ node
 Type '.help' for options.
 > a = [ 1, 2, 3];
 [ 1, 2, 3 ]
@@ -101,7 +101,7 @@ repl.start('> ').context.m = msg;
 Things in the `context` object appear as local within the REPL:
 
 ```
-mjr:~$ node repl_test.js
+$ node repl_test.js
 > m
 'message'
 ```

--- a/doc/api/synopsis.markdown
+++ b/doc/api/synopsis.markdown
@@ -20,7 +20,7 @@ To run the server, put the code into a file called `example.js` and execute
 it with the node program
 
 ```
-> node example.js
+$ node example.js
 Server running at http://127.0.0.1:8124/
 ```
 


### PR DESCRIPTION
continuation of #4733.

Harmonizes inconsistent `repl` and command-line notation usage e.g. `node>`, `% node`, `> node` 
to `$ node`