### PR TITLE
test: mark test-tick-processor flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -9,8 +9,10 @@ prefix parallel
 [$system==win32]
 test-debug-no-context                : PASS,FLAKY
 test-tls-ticket-cluster              : PASS,FLAKY
+test-tick-processor                  : PASS,FLAKY
 
 [$system==linux]
+test-tick-processor                  : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/4427

Recent sample failures:

* [win2008r2](https://ci.nodejs.org/job/node-test-binary-windows/395/RUN_SUBSET=1,VS_VERSION=vs2013,label=win2008r2/tapTestReport/test.tap-189/)
* [pi1-raspbian-wheezy](https://ci.nodejs.org/job/node-test-binary-arm/709/RUN_SUBSET=3,nodes=pi1-raspbian-wheezy/tapTestReport/test.tap-108/)