### PR TITLE
doc: clarify when writable.end callback is called

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -700,7 +700,9 @@ Flush all data, buffered since `.cork()` call.
 * Returns: {Boolean} True if the data was handled completely.
 
 This method writes some data to the underlying system, and calls the
-supplied callback once the data has been fully handled.
+supplied callback once the data has been fully handled.  If an error
+occurs, the callback may or may not be called with the error as its
+first argument.  To detect write errors, listen for the `'error'` event.
 
 The return value indicates if you should continue writing right now.
 If the data had to be buffered internally, then it will return


### PR DESCRIPTION
The current documentation for `writable.end` only specifies that the callback is called "once the data has been fully handled".  It is ambiguous whether this means "successfully handled" and, if so, whether the callback is called if the data can not be successfully handled (i.e. an error occurred).

The ambiguity is not only in the documentation.  The stream class implementations differ on this point.  `stream.Writable` invokes the callback with any errors that occur during parameter checking or during calls to `_write`.  However, not all classes return all errors to `_write`. `zlib.Zlib` does pass argument and state errors to the `_write` (`_transform`) callback, but does not pass data errors.  `http.OutgoingMessage` passes argument type errors and some other types of errors, but not all.

This inconsistency is behind issue #1746 and, I suspect, other issues in client code which passes a callback to write.

This commit takes no position on whether the callback error behavior should changed, but simply attempts to document the current behavior in a way that is open to changes so that users are not caught by surprise.

Thanks for considering,
Kevin