### PR TITLE
Code style: always-parens for arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -76,6 +76,8 @@ rules:
   # list: http://eslint.org/docs/rules/#ecmascript-6
   ## Suggest using 'const' wherever possible
   prefer-const: 2
+  ## always require paren in arrow functions, even in the single-argument case
+  arrow-parens: [2, "always"]
 
   # Strict Mode
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode

--- a/test/common.js
+++ b/test/common.js
@@ -470,7 +470,7 @@ exports.fail = function(msg) {
 // A stream to push an array into a REPL
 function ArrayStream() {
   this.run = function(data) {
-    data.forEach(line => {
+    data.forEach((line) => {
       this.emit('data', line + '\n');
     });
   };

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -482,7 +482,7 @@ testBlockTypeError(assert.throws, undefined);
 testBlockTypeError(assert.doesNotThrow, undefined);
 
 // https://github.com/nodejs/node/issues/3275
-assert.throws(() => { throw 'error'; }, err => err === 'error');
-assert.throws(() => { throw new Error(); }, err => err instanceof Error);
+assert.throws(() => { throw 'error'; }, (err) => err === 'error');
+assert.throws(() => { throw new Error(); }, (err) => err instanceof Error);
 
 console.log('All OK');

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -20,7 +20,7 @@ keyList.splice(0, 1);
 
 
 function init(id) {
-  keyList = keyList.filter(e => e != pkeys[id]);
+  keyList = keyList.filter((e) => e != pkeys[id]);
 }
 
 function noop() { }

--- a/test/parallel/test-cluster-disconnect-handles.js
+++ b/test/parallel/test-cluster-disconnect-handles.js
@@ -31,7 +31,7 @@ if (cluster.isMaster) {
   // scanner but is ignored by atoi(3).  Heinous hack.
   cluster.setupMaster({ execArgv: [`--debug=${common.PORT}.`] });
   const worker = cluster.fork();
-  worker.on('message', common.mustCall(message => {
+  worker.on('message', common.mustCall((message) => {
     assert.strictEqual(Array.isArray(message), true);
     assert.strictEqual(message[0], 'listening');
     let continueRecv = false;
@@ -40,9 +40,9 @@ if (cluster.isMaster) {
     const debugClient = net.connect({ host, port: common.PORT });
     const protocol = new Protocol();
     debugClient.setEncoding('utf8');
-    debugClient.on('data', data => protocol.execute(data));
+    debugClient.on('data', (data) => protocol.execute(data));
     debugClient.once('connect', common.mustCall(() => {
-      protocol.onResponse = common.mustCall(res => {
+      protocol.onResponse = common.mustCall((res) => {
         protocol.onResponse = (res) => {
           // It can happen that the first continue was sent before the break
           // event was received. If that's the case, send also a continue from
@@ -85,7 +85,7 @@ if (cluster.isMaster) {
     throw ex;
   });
 } else {
-  const server = net.createServer(socket => socket.pipe(socket));
+  const server = net.createServer((socket) => socket.pipe(socket));
   const cb = () => {
     process.send(['listening', server.address()]);
     debugger;

--- a/test/parallel/test-debug-no-context.js
+++ b/test/parallel/test-debug-no-context.js
@@ -17,7 +17,7 @@ proc.on('exit', common.mustCall((exitCode, signalCode) => {
 }));
 let stdout = '';
 proc.stdout.setEncoding('utf8');
-proc.stdout.on('data', data => stdout += data);
+proc.stdout.on('data', (data) => stdout += data);
 process.on('exit', () => {
   assert(stdout.includes('Promise { 42 }'));
   assert(stdout.includes('Promise { 1337 }'));

--- a/test/parallel/test-debug-port-cluster.js
+++ b/test/parallel/test-debug-port-cluster.js
@@ -15,7 +15,7 @@ const child = spawn(process.execPath, args);
 child.stderr.setEncoding('utf8');
 
 let stderr = '';
-child.stderr.on('data', data => {
+child.stderr.on('data', (data) => {
   stderr += data;
   if (child.killed !== true && stderr.includes('all workers are running'))
     child.kill();

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -13,7 +13,7 @@ var conns = 0;
 var clientLocalPorts = [];
 var serverRemotePorts = [];
 const client = new net.Socket();
-const server = net.createServer(socket => {
+const server = net.createServer((socket) => {
   serverRemotePorts.push(socket.remotePort);
   socket.end();
 });

--- a/test/parallel/test-process-emit.js
+++ b/test/parallel/test-process-emit.js
@@ -3,15 +3,15 @@ const common = require('../common');
 const assert = require('assert');
 const sym = Symbol();
 
-process.on('normal', common.mustCall(data => {
+process.on('normal', common.mustCall((data) => {
   assert.strictEqual(data, 'normalData');
 }));
 
-process.on(sym, common.mustCall(data => {
+process.on(sym, common.mustCall((data) => {
   assert.strictEqual(data, 'symbolData');
 }));
 
-process.on('SIGPIPE', common.mustCall(data => {
+process.on('SIGPIPE', common.mustCall((data) => {
   assert.strictEqual(data, 'signalData');
 }));
 

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -7,7 +7,7 @@ const net = require('net');
 process.chdir(common.fixturesDir);
 const repl = require('repl');
 
-const server = net.createServer(conn => {
+const server = net.createServer((conn) => {
   repl.start('', conn).on('exit', () => {
     conn.destroy();
     server.close();
@@ -22,7 +22,7 @@ var answer = '';
 server.listen(options, function() {
   const conn = net.connect(options);
   conn.setEncoding('utf8');
-  conn.on('data', data => answer += data);
+  conn.on('data', (data) => answer += data);
   conn.write('require("baz")\n.exit\n');
 });
 

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -78,12 +78,12 @@ testDHE1024();
 assert.throws(() => test(512, true, assert.fail),
               /DH parameter is less than 1024 bits/);
 
-[0, -1, -Infinity, NaN].forEach(minDHSize => {
+[0, -1, -Infinity, NaN].forEach((minDHSize) => {
   assert.throws(() => tls.connect({ minDHSize }),
                 /minDHSize is not a positive number/);
 });
 
-[true, false, null, undefined, {}, [], '', '1'].forEach(minDHSize => {
+[true, false, null, undefined, {}, [], '', '1'].forEach((minDHSize) => {
   assert.throws(() => tls.connect({ minDHSize }), /minDHSize is not a number/);
 });
 

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -40,7 +40,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
   client.stdout.pipe(process.stdout);
   client.stderr.pipe(process.stderr);
   client.stderr.setEncoding('utf8');
-  client.stderr.on('data', data => stderr += data);
+  client.stderr.on('data', (data) => stderr += data);
 
   client.once('exit', common.mustCall(function(exitCode) {
     assert.equal(exitCode, 1);
@@ -48,7 +48,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
   }));
 });
 
-server.on('tlsClientError', err => errors.push(err));
+server.on('tlsClientError', (err) => errors.push(err));
 
 process.on('exit', function() {
   if (/unknown option -ssl3/.test(stderr)) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -106,7 +106,7 @@ for (const showHidden of [true, false]) {
   Uint16Array,
   Uint32Array,
   Uint8Array,
-  Uint8ClampedArray ].forEach(constructor => {
+  Uint8ClampedArray ].forEach((constructor) => {
     const length = 2;
     const byteLength = length * constructor.BYTES_PER_ELEMENT;
     const array = new constructor(new ArrayBuffer(byteLength), 0, length);
@@ -133,7 +133,7 @@ for (const showHidden of [true, false]) {
   Uint16Array,
   Uint32Array,
   Uint8Array,
-  Uint8ClampedArray ].forEach(constructor => {
+  Uint8ClampedArray ].forEach((constructor) => {
     const length = 2;
     const byteLength = length * constructor.BYTES_PER_ELEMENT;
     const array = vm.runInNewContext('new constructor(new ArrayBuffer(' +

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -25,9 +25,9 @@ const expectedHeapSpaces = [
   'large_object_space'
 ];
 const heapSpaceStatistics = v8.getHeapSpaceStatistics();
-const actualHeapSpaceNames = heapSpaceStatistics.map(s => s.space_name);
+const actualHeapSpaceNames = heapSpaceStatistics.map((s) => s.space_name);
 assert.deepEqual(actualHeapSpaceNames.sort(), expectedHeapSpaces.sort());
-heapSpaceStatistics.forEach(heapSpace => {
+heapSpaceStatistics.forEach((heapSpace) => {
   assert.strictEqual(typeof heapSpace.space_name, 'string');
   assert.strictEqual(typeof heapSpace.space_size, 'number');
   assert.strictEqual(typeof heapSpace.space_used_size, 'number');


### PR DESCRIPTION
Continuing on from [here](https://github.com/nodejs/node/pull/4796#discussion_r50502219). While single-argument arrow functions allow you to drop parens, it doesn't mean you should. Personally I find these too terse and make code harder to visually parse. I know I'm not alone on this but I'm happy to hear from others who feel strongly about dropping parens in this case.

Note our codebase isn't consistent on this, there's lots of single-arg arrow functions with parens already.

/cc @nodejs/collaborators cause of the impact