### PR TITLE
stream: refactor redeclared variables

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -130,10 +130,10 @@ function readableAddChunk(stream, state, chunk, encoding, addToFront) {
     onEofChunk(stream, state);
   } else if (state.objectMode || chunk && chunk.length > 0) {
     if (state.ended && !addToFront) {
-      var e = new Error('stream.push() after EOF');
+      const e = new Error('stream.push() after EOF');
       stream.emit('error', e);
     } else if (state.endEmitted && addToFront) {
-      var e = new Error('stream.unshift() after end event');
+      const e = new Error('stream.unshift() after end event');
       stream.emit('error', e);
     } else {
       if (state.decoder && !addToFront && !encoding)
@@ -640,13 +640,13 @@ Readable.prototype.unpipe = function(dest) {
     state.pipesCount = 0;
     state.flowing = false;
 
-    for (var i = 0; i < len; i++)
+    for (let i = 0; i < len; i++)
       dests[i].emit('unpipe', this);
     return this;
   }
 
   // try to find the right one.
-  var i = state.pipes.indexOf(dest);
+  const i = state.pipes.indexOf(dest);
   if (i === -1)
     return this;
 
@@ -847,7 +847,7 @@ function fromList(n, state) {
     if (n < list[0].length) {
       // just take a part of the first list item.
       // slice is the same for buffers and strings.
-      var buf = list[0];
+      const buf = list[0];
       ret = buf.slice(0, n);
       list[0] = buf.slice(n);
     } else if (n === list[0].length) {
@@ -863,7 +863,7 @@ function fromList(n, state) {
 
       var c = 0;
       for (var i = 0, l = list.length; i < l && c < n; i++) {
-        var buf = list[0];
+        const buf = list[0];
         var cpy = Math.min(n - c, buf.length);
 
         if (stringMode)


### PR DESCRIPTION
`lib/_stream_readable.js` contained three instances of `var`
declarations occurring twice in the same scope. Refactored to `const` or
`let` as appropriate.