### PR TITLE
doc: undo move http.IncomingMessage.statusMessage

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -939,14 +939,14 @@ The 3-digit HTTP response status code. E.G. `404`.
 
 **Only valid for response obtained from [`http.ClientRequest`][].**
 
+The HTTP response status message (reason phrase). E.G. `OK` or `Internal Server Error`.
+
 ### message.socket
 
 The [`net.Socket`][] object associated with the connection.
 
 With HTTPS support, use [`request.socket.getPeerCertificate()`][] to obtain the
 client's authentication details.
-
-The HTTP response status message (reason phrase). E.G. `OK` or `Internal Server Error`.
 
 ### message.trailers
 


### PR DESCRIPTION
The description for `statusMessage` was accidentally moved under the
heading for `http.IncomingMessage.socket`.  This commit puts it back
in the correct place.

/CC @nodejs/http @nodejs/documentation 

Fixes: nodejs/node#4558