### PR TITLE
fs: refactor self=this to arrow

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1764,7 +1764,7 @@ function ReadStream(path, options) {
 fs.FileReadStream = fs.ReadStream; // support the legacy name
 
 ReadStream.prototype.open = function() {
-  
+
   fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
       if (this.autoClose) {
@@ -1868,7 +1868,6 @@ ReadStream.prototype.close = function(cb) {
   }
   this.closed = true;
   close();
-
   
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1848,7 +1848,7 @@ ReadStream.prototype.destroy = function() {
 ReadStream.prototype.close = function(cb) {
 
   const close = (fd) => {
-    fs.close(fd || this.fd, function(er) {
+    fs.close(fd || this.fd, (er) => {
       if (er)
         this.emit('error', er);
       else

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1300,18 +1300,17 @@ fs.appendFileSync = function(path, data, options) {
 function FSWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new FSEvent();
   this._handle.owner = this;
 
-  this._handle.onchange = function(status, event, filename) {
+  this._handle.onchange = (status, event, filename) => {
     if (status < 0) {
-      self._handle.close();
+      this._handle.close();
       const error = errnoException(status, `watch ${filename}`);
       error.filename = filename;
-      self.emit('error', error);
+      this.emit('error', error);
     } else {
-      self.emit('change', event, filename);
+      this.emit('change', event, filename);
     }
   };
 }
@@ -1367,24 +1366,23 @@ fs.watch = function(filename) {
 function StatWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new binding.StatWatcher();
 
   // uv_fs_poll is a little more powerful than ev_stat but we curb it for
   // the sake of backwards compatibility
   var oldStatus = -1;
 
-  this._handle.onchange = function(current, previous, newStatus) {
+  this._handle.onchange = (current, previous, newStatus) => {
     if (oldStatus === -1 &&
         newStatus === -1 &&
         current.nlink === previous.nlink) return;
 
     oldStatus = newStatus;
-    self.emit('change', current, previous);
+    this.emit('change', current, previous);
   };
 
-  this._handle.onstop = function() {
-    self.emit('stop');
+  this._handle.onstop = () => {
+    this.emit('stop');
   };
 }
 util.inherits(StatWatcher, EventEmitter);
@@ -1766,20 +1764,20 @@ function ReadStream(path, options) {
 fs.FileReadStream = fs.ReadStream; // support the legacy name
 
 ReadStream.prototype.open = function() {
-  var self = this;
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+  
+  fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
-      self.emit('error', er);
+      this.emit('error', er);
       return;
     }
 
-    self.fd = fd;
-    self.emit('open', fd);
+    this.fd = fd;
+    this.emit('open', fd);
     // start the flow of data.
-    self.read();
+    this.read();
   });
 };
 
@@ -1814,7 +1812,6 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
-  var self = this;
   fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
 
   // move the pool positions, and internal position for reading.
@@ -1822,6 +1819,7 @@ ReadStream.prototype._read = function(n) {
     this.pos += toRead;
   pool.used += toRead;
 
+  var self = this;
   function onread(er, bytesRead) {
     if (er) {
       if (self.autoClose) {
@@ -1848,7 +1846,17 @@ ReadStream.prototype.destroy = function() {
 
 
 ReadStream.prototype.close = function(cb) {
-  var self = this;
+
+  const close = (fd) => {
+    fs.close(fd || this.fd, function(er) {
+      if (er)
+        this.emit('error', er);
+      else
+        this.emit('close');
+    });
+    this.fd = null;
+  };
+
   if (cb)
     this.once('close', cb);
   if (this.closed || typeof this.fd !== 'number') {
@@ -1861,15 +1869,7 @@ ReadStream.prototype.close = function(cb) {
   this.closed = true;
   close();
 
-  function close(fd) {
-    fs.close(fd || self.fd, function(er) {
-      if (er)
-        self.emit('error', er);
-      else
-        self.emit('close');
-    });
-    self.fd = null;
-  }
+  
 };
 
 
@@ -1957,15 +1957,14 @@ WriteStream.prototype._write = function(data, encoding, cb) {
       this._write(data, encoding, cb);
     });
 
-  var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+  fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 
@@ -1992,7 +1991,6 @@ WriteStream.prototype._writev = function(data, cb) {
       this._writev(data, cb);
     });
 
-  const self = this;
   const len = data.length;
   const chunks = new Array(len);
   var size = 0;
@@ -2004,12 +2002,12 @@ WriteStream.prototype._writev = function(data, cb) {
     size += chunk.length;
   }
 
-  writev(this.fd, chunks, this.pos, function(er, bytes) {
+  writev(this.fd, chunks, this.pos, (er, bytes) => {
     if (er) {
-      self.destroy();
+      this.destroy();
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -59,10 +59,10 @@ function Client(port, host) {
 }
 util.inherits(Client, EventEmitter);
 Client.prototype.request = function(method, path, headers) {
-  var self = this;
+  
   var options = {};
-  options.host = self.host;
-  options.port = self.port;
+  options.host = this.host;
+  options.port = this.port;
   if (method[0] === '/') {
     headers = path;
     path = method;
@@ -71,22 +71,22 @@ Client.prototype.request = function(method, path, headers) {
   options.method = method;
   options.path = path;
   options.headers = headers;
-  options.agent = self.agent;
+  options.agent = this.agent;
   var c = new ClientRequest(options);
-  c.on('error', function(e) {
-    self.emit('error', e);
+  c.on('error', (e) => {
+    this.emit('error', e);
   });
   // The old Client interface emitted 'end' on socket end.
   // This doesn't map to how we want things to operate in the future
   // but it will get removed when we remove this legacy interface.
-  c.on('socket', function(s) {
-    s.on('end', function() {
-      if (self._decoder) {
-        var ret = self._decoder.end();
+  c.on('socket', (s) => {
+    s.on('end', () => {
+      if (this._decoder) {
+        var ret = this._decoder.end();
         if (ret)
-          self.emit('data', ret);
+          this.emit('data', ret);
       }
-      self.emit('end');
+      this.emit('end');
     });
   });
   return c;

--- a/lib/http.js
+++ b/lib/http.js
@@ -59,7 +59,7 @@ function Client(port, host) {
 }
 util.inherits(Client, EventEmitter);
 Client.prototype.request = function(method, path, headers) {
-  
+
   var options = {};
   options.host = this.host;
   options.port = this.port;

--- a/lib/https.js
+++ b/lib/https.js
@@ -77,12 +77,12 @@ function createConnection(port, host, options) {
     }
   }
 
-  const self = this;
-  const socket = tls.connect(options, function() {
+  
+  const socket = tls.connect(options, () => {
     if (!options._agentKey)
       return;
 
-    self._cacheSession(options._agentKey, socket.getSession());
+    this._cacheSession(options._agentKey, socket.getSession());
   });
   return socket;
 }

--- a/lib/https.js
+++ b/lib/https.js
@@ -77,7 +77,6 @@ function createConnection(port, host, options) {
     }
   }
 
-  
   const socket = tls.connect(options, () => {
     if (!options._agentKey)
       return;


### PR DESCRIPTION
This PR refactors `self = this` pattern usages to arrow functions in several places in the code.

In some places, arrow functions were already used and the `self = this` was simply redundant. 