### PR TITLE
doc: refactor function expressions to arrow functions

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -44,7 +44,9 @@ be used as a starting-point for your own Addon.
 This "Hello world" example is a simple Addon, written in C++, that is the
 equivalent of the following JavaScript code:
 
-    module.exports.hello = function() { return 'world'; };
+```js
+module.exports.hello = () => 'world';
+```
 
 First, create the file `hello.cc`:
 
@@ -368,7 +370,7 @@ To test it, run the following JavaScript:
 // test.js
 const addon = require('./build/Release/addon');
 
-addon(function(msg){
+addon((msg) => {
   console.log(msg); // 'hello world'
 });
 ```

--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -139,7 +139,7 @@ matching error type in the assertion:
 
 ```js
 assert.doesNotThrow(
-  function() {
+  () => {
     throw new TypeError('Wrong value');
   },
   SyntaxError
@@ -151,7 +151,7 @@ However, the following will result in an `AssertionError` with the message
 
 ```js
 assert.doesNotThrow(
-  function() {
+  () => {
     throw new TypeError('Wrong value');
   },
   TypeError
@@ -164,7 +164,7 @@ message:
 
 ```js
 assert.doesNotThrow(
-  function() {
+  () => {
     throw new TypeError('Wrong value');
   },
   TypeError,
@@ -359,7 +359,7 @@ Validate instanceof using constructor:
 
 ```js
 assert.throws(
-  function() {
+  () => {
     throw new Error('Wrong value');
   },
   Error
@@ -370,7 +370,7 @@ Validate error message using [`RegExp`][]:
 
 ```js
 assert.throws(
-  function() {
+  () => {
     throw new Error('Wrong value');
   },
   /value/
@@ -381,7 +381,7 @@ Custom error validation:
 
 ```js
 assert.throws(
-  function() {
+  () => {
     throw new Error('Wrong value');
   },
   function(err) {

--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -15,7 +15,7 @@ $ node debug myscript.js
 connecting... ok
 break in /home/indutny/Code/git/indutny/myscript.js:1
   1 x = 5;
-  2 setTimeout(function () {
+  2 setTimeout(() => {
   3   debugger;
 debug>
 ```
@@ -31,7 +31,7 @@ For example, suppose `myscript.js` is written as:
 ```js
 // myscript.js
 x = 5;
-setTimeout(function () {
+setTimeout(() => {
   debugger;
   console.log('world');
 }, 1000);
@@ -46,19 +46,19 @@ $ node debug myscript.js
 connecting... ok
 break in /home/indutny/Code/git/indutny/myscript.js:1
   1 x = 5;
-  2 setTimeout(function () {
+  2 setTimeout(() => {
   3   debugger;
 debug> cont
 < hello
 break in /home/indutny/Code/git/indutny/myscript.js:3
   1 x = 5;
-  2 setTimeout(function () {
+  2 setTimeout(() => {
   3   debugger;
   4   console.log('world');
   5 }, 1000);
 debug> next
 break in /home/indutny/Code/git/indutny/myscript.js:4
-  2 setTimeout(function () {
+  2 setTimeout(() => {
   3   debugger;
   4   console.log('world');
   5 }, 1000);
@@ -135,7 +135,7 @@ Warning: script 'mod.js' was not loaded yet.
 debug> c
 break in test/fixtures/break-in-module/mod.js:23
  21
- 22 exports.hello = function() {
+ 22 exports.hello = () => {
  23   return 'hello from module';
  24 };
  25

--- a/doc/api/domain.markdown
+++ b/doc/api/domain.markdown
@@ -349,7 +349,7 @@ thrown will be routed to the domain's `'error'` event.
 const d = domain.create();
 
 function readSomeFile(filename, cb) {
-  fs.readFile(filename, 'utf8', d.bind(function(er, data) {
+  fs.readFile(filename, 'utf8', d.bind((er, data) => {
     // if this throws, it will also be passed to the domain
     return cb(er, data ? JSON.parse(data) : null);
   }));
@@ -380,7 +380,7 @@ with a single error handler in a single place.
 const d = domain.create();
 
 function readSomeFile(filename, cb) {
-  fs.readFile(filename, 'utf8', d.intercept(function(data) {
+  fs.readFile(filename, 'utf8', d.intercept((data) => {
     // note, the first argument is never passed to the
     // callback since it is assumed to be the 'Error' argument
     // and thus intercepted by the domain.

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -37,7 +37,7 @@ function MyEmitter() {
 util.inherits(MyEmitter, EventEmitter);
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 myEmitter.emit('event');
@@ -54,7 +54,7 @@ const EventEmitter = require('events');
 class MyEmitter extends EventEmitter {}
 
 const myEmitter = new MyEmitter();
-myEmitter.on('event', function() {
+myEmitter.on('event', () => {
   console.log('an event occurred!');
 });
 myEmitter.emit('event');
@@ -364,7 +364,7 @@ Removes the specified `listener` from the listener array for the specified
 `event`.
 
 ```js
-var callback = function(stream) {
+var callback = (stream) => {
   console.log('someone connected!');
 };
 server.on('connection', callback);

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -239,7 +239,7 @@ argument will be populated. The following example checks if the file
 `/etc/passwd` can be read and written by the current process.
 
 ```js
-fs.access('/etc/passwd', fs.R_OK | fs.W_OK, function (err) {
+fs.access('/etc/passwd', fs.R_OK | fs.W_OK, (err) => {
   console.log(err ? 'no access!' : 'can read/write');
 });
 ```

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -20,13 +20,10 @@ The contents of `circle.js`:
 ```js
 const PI = Math.PI;
 
-exports.area = function (r) {
-  return PI * r * r;
-};
+exports.area = (r) => PI * r * r;
 
-exports.circumference = function (r) {
-  return 2 * PI * r;
-};
+exports.circumference = (r) => 2 * PI * r;
+
 ```
 
 The module `circle.js` has exported the functions `area()` and
@@ -53,11 +50,9 @@ The `square` module is defined in `square.js`:
 
 ```js
 // assigning to exports will not modify module, must use module.exports
-module.exports = function(width) {
+module.exports = (width) => {
   return {
-    area: function() {
-      return width * width;
-    }
+    area: () => width * width
   };
 }
 ```
@@ -498,12 +493,12 @@ To illustrate the behavior, imagine this hypothetical implementation of
 ```js
 function require(...) {
   // ...
-  function (module, exports) {
+  ((module, exports) => {
     // Your module code here
     exports = some_func;        // re-assigns exports, exports is no longer
                                 // a shortcut, and nothing is exported.
     module.exports = some_func; // makes your module export 0
-  } (module, module.exports);
+  })(module, module.exports);
   return module;
 }
 ```

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -175,7 +175,7 @@ var resource = new SomeResource();
 
 In cases like this, you may not want to track the rejection as a developer
 error like you would for other `'unhandledRejection'` events. To address
-this, you can either attach a dummy `.catch(function() { })` handler to
+this, you can either attach a dummy `.catch(() => { })` handler to
 `resource.loaded`, preventing the `'unhandledRejection'` event from being
 emitted, or you can use the [`'rejectionHandled'`][] event.
 
@@ -720,7 +720,7 @@ function maybeSync(arg, cb) {
 This API is hazardous.  If you do this:
 
 ```js
-maybeSync(true, function() {
+maybeSync(true, () => {
   foo();
 });
 bar();
@@ -954,7 +954,7 @@ A `Writable Stream` to `stdout` (on fd `1`).
 For example, a `console.log` equivalent could look like this:
 
 ```js
-console.log = function(msg) {
+console.log = (msg) => {
   process.stdout.write(`${msg}\n`);
 };
 ```

--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -265,7 +265,7 @@ const rl = readline.createInterface({
   input: fs.createReadStream('sample.txt')
 });
 
-rl.on('line', function (line) {
+rl.on('line', (line) => {
   console.log('Line from file:', line);
 });
 ```

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -15,7 +15,7 @@ $ node
 Type '.help' for options.
 > a = [ 1, 2, 3];
 [ 1, 2, 3 ]
-> a.forEach(function (v){
+> a.forEach((v) => {
 ...   console.log(v);
 ...   });
 1
@@ -139,7 +139,7 @@ For example, if you have defined an `inspect()` function on an object, like this
 ```
 > var obj = {foo: 'this will not show up in the inspect() output'};
 undefined
-> obj.inspect = function() {
+> obj.inspect = () => {
 ...   return {bar: 'baz'};
 ... };
 [Function]

--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -925,18 +925,17 @@ function SourceWrapper(options) {
   Readable.call(this, options);
 
   this._source = getLowlevelSourceObject();
-  var self = this;
 
   // Every time there's data, we push it into the internal buffer.
-  this._source.ondata = function(chunk) {
+  this._source.ondata = (chunk) => {
     // if push() returns false, then we need to stop reading from source
-    if (!self.push(chunk))
-      self._source.readStop();
+    if (!this.push(chunk))
+      this._source.readStop();
   };
 
   // When the source ends, we push the EOF-signaling `null` chunk
-  this._source.onend = function() {
-    self.push(null);
+  this._source.onend = () => {
+    this.push(null);
   };
 }
 

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -58,7 +58,7 @@ Marks that a method should not be used any more.
 ```js
 const util = require('util');
 
-exports.puts = util.deprecate(function() {
+exports.puts = util.deprecate(() => {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(arguments[i] + '\n');
   }

--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -29,16 +29,20 @@ the convenience methods.
 
 ```js
 const input = '.................................';
-zlib.deflate(input, function(err, buffer) {
+zlib.deflate(input, (err, buffer) => {
   if (!err) {
     console.log(buffer.toString('base64'));
+  } else {
+    // handle error
   }
 });
 
 const buffer = new Buffer('eJzT0yMAAGTvBe8=', 'base64');
-zlib.unzip(buffer, function(err, buffer) {
+zlib.unzip(buffer, (err, buffer) => {
   if (!err) {
     console.log(buffer.toString());
+  } else {
+    // handle error
   }
 });
 ```


### PR DESCRIPTION
All the docs use arrow functions - looks like one was missed here in the fs docs.

(This is a tiny PR, I figured it's a good idea to break PRs down to a size where they're trivial to review - if bigger PRs are preferred I can do that instead)