### PR TITLE
Code Style: make sure about function name

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -482,41 +482,41 @@ inline v8::Local<v8::FunctionTemplate>
 inline void Environment::SetMethod(v8::Local<v8::Object> that,
                                    const char* name,
                                    v8::FunctionCallback callback) {
-  v8::Local<v8::Function> function =
+  v8::Local<v8::Function> fn =
       NewFunctionTemplate(callback)->GetFunction();
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
-  v8::Local<v8::String> name_string =
+  v8::Local<v8::String> fn_name =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(name_string, function);
-  function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
+  that->Set(fn_name, fn);
+  fn->SetName(fn_name);  // NODE_SET_METHOD() compatibility.
 }
 
 inline void Environment::SetProtoMethod(v8::Local<v8::FunctionTemplate> that,
                                         const char* name,
                                         v8::FunctionCallback callback) {
   v8::Local<v8::Signature> signature = v8::Signature::New(isolate(), that);
-  v8::Local<v8::Function> function =
+  v8::Local<v8::Function> fn =
       NewFunctionTemplate(callback, signature)->GetFunction();
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
-  v8::Local<v8::String> name_string =
+  v8::Local<v8::String> fn_name =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->PrototypeTemplate()->Set(name_string, function);
-  function->SetName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
+  that->PrototypeTemplate()->Set(fn_name, fn);
+  fn->SetName(fn_name);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
 }
 
 inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
                                            const char* name,
                                            v8::FunctionCallback callback) {
-  v8::Local<v8::Function> function =
+  v8::Local<v8::Function> fn =
       NewFunctionTemplate(callback)->GetFunction();
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
-  v8::Local<v8::String> name_string =
+  v8::Local<v8::String> fn_name =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(name_string, function);
-  function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
+  that->Set(fn_name, fn);
+  fn->SetName(fn_name);  // NODE_SET_METHOD() compatibility.
 }
 
 inline v8::Local<v8::Object> Environment::NewInternalFieldObject() {


### PR DESCRIPTION
Change name of the variables. ``function`` -> ``fn``, ``name_string`` ->
``fn_name``.

In ``Environment::SetMethod, Environment::SetProtoMethod,
Environment::SetTemplateMethod`` name for new function
templates, ``name_string``, is similar with ``name`` variable which
receive from arguments.