### PR TITLE
dns: throw a TypeError in lookupService with invalid port

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -189,6 +189,9 @@ exports.lookupService = function(host, port, callback) {
   if (cares.isIP(host) === 0)
     throw new TypeError('"host" argument needs to be a valid IP address');
 
+  if (typeof port !== 'number')
+    throw new TypeError(`"port" argument must be a number, got "${port}"`);
+
   callback = makeAsync(callback);
 
   var req = new GetNameInfoReqWrap();

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -145,3 +145,19 @@ assert.doesNotThrow(function() {
     hints: dns.ADDRCONFIG | dns.V4MAPPED
   }, noop);
 });
+
+assert.throws(function() {
+  dns.lookupService('0.0.0.0');
+}, /Invalid arguments/);
+
+assert.throws(function() {
+  dns.lookupService('fasdfdsaf', 0, noop);
+}, /"host" argument needs to be a valid IP address/);
+
+assert.throws(function() {
+  dns.lookupService('0.0.0.0', '0', noop);
+}, /"port" argument must be a number, got "0"/);
+
+assert.doesNotThrow(function() {
+  dns.lookupService('0.0.0.0', 0, noop);
+});


### PR DESCRIPTION
Previously, port was assumed to be a number and would cause an abort in
cares_wrap. This change throws a TypeError if port is not a number
before we actually hit C++.

Fixes: https://github.com/nodejs/node/issues/4837