### PR TITLE
build: fix build when python path contains spaces

### DIFF
--- a/configure
+++ b/configure
@@ -1102,7 +1102,7 @@ def configure_intl(o):
   return  # end of configure_intl
 
 output = {
-  'variables': { 'python': sys.executable },
+  'variables': {},
   'include_dirs': [],
   'libraries': [],
   'defines': [],

--- a/node.gyp
+++ b/node.gyp
@@ -525,7 +525,7 @@
             }]
           ],
           'action': [
-            '<(python)',
+            'python',
             'tools/js2c.py',
             '<@(_outputs)',
             '<@(_inputs)',


### PR DESCRIPTION
Fixes #4840
This allows Python to be installed in a path with spaces, like `C:\Program Files`.