### PR TITLE
node_javascript: use V8's code cache for core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,8 @@ CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard \
 	test/addons/*/*.h \
 	tools/icu/*.cc \
 	tools/icu/*.h \
+	tools/*.cc \
+	tools/*.h \
 	))
 
 cpplint:

--- a/node.gyp
+++ b/node.gyp
@@ -502,6 +502,13 @@
     {
       'target_name': 'node_js2c',
       'type': 'none',
+      'conditions': [
+        [ 'target_arch == host_arch', {
+          'dependencies': [
+            'js2c-cache#target',
+          ],
+        }],
+      ],
       'toolsets': ['host'],
       'actions': [
         {
@@ -522,7 +529,10 @@
             }],
             [ 'node_use_perfctr=="false"', {
               'inputs': [ 'src/perfctr_macros.py' ]
-            }]
+            }],
+            [ 'target_arch == host_arch', {
+              'inputs': [ '<(PRODUCT_DIR)/js2c-cache' ],
+            }],
           ],
           'action': [
             '<(python)',
@@ -533,6 +543,21 @@
         },
       ],
     }, # end node_js2c
+    {
+      'target_name': 'js2c-cache',
+      'type': 'executable',
+      'dependencies': [
+        'deps/v8/tools/gyp/v8.gyp:v8',
+        'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
+      ],
+      'include_dirs': [
+        'tools',
+        'deps/v8/include',
+      ],
+      'sources': [
+        'tools/js2c-cache.cc',
+      ],
+    }, # end js2c-cache
     {
       'target_name': 'node_dtrace_header',
       'type': 'none',
@@ -694,7 +719,7 @@
       'sources': [
         'test/cctest/util.cc',
       ],
-    }
+    },
   ], # end targets
 
   'conditions': [

--- a/src/node.js
+++ b/src/node.js
@@ -973,6 +973,10 @@
     return NativeModule._source[id];
   };
 
+  NativeModule.getSourceCachedData = function(id) {
+    return NativeModule._source[id + '__cached_data'];
+  };
+
   NativeModule.wrap = function(script) {
     return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];
   };
@@ -984,10 +988,12 @@
 
   NativeModule.prototype.compile = function() {
     var source = NativeModule.getSource(this.id);
+    var cachedData = NativeModule.getSourceCachedData(this.id);
     source = NativeModule.wrap(source);
 
     var fn = runInThisContext(source, {
       filename: this.filename,
+      cachedData: cachedData,
       lineOffset: 0
     });
     fn(this.exports, NativeModule.require, this, this.filename);

--- a/src/node_javascript.cc
+++ b/src/node_javascript.cc
@@ -11,26 +11,57 @@
 
 namespace node {
 
+using v8::ArrayBuffer;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
+using v8::ScriptCompiler;
+using v8::ScriptOrigin;
 using v8::String;
+using v8::Uint8Array;
 
-Local<String> MainSource(Environment* env) {
-  return OneByteString(env->isolate(), node_native, sizeof(node_native) - 1);
+ScriptCompiler::Source* MainSource(Environment* env, Local<String> filename) {
+  Local<String> source_str =
+      OneByteString(env->isolate(), node_native, sizeof(node_native) - 1);
+
+  ScriptOrigin origin(filename);
+  ScriptCompiler::CachedData* cached_data = nullptr;
+
+  // NOTE: It is illegal to have empty arrays in C, so we use { 0 } for this
+  // purposes.
+  if (sizeof(node_native_cache) <= 1) {
+    cached_data = new ScriptCompiler::CachedData(node_native_cache,
+                                                 sizeof(node_native_cache));
+  }
+
+  return new ScriptCompiler::Source(source_str, origin, cached_data);
 }
 
 void DefineJavaScript(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
+  Local<String> cache_postfix =
+      String::NewFromUtf8(env->isolate(), "__cached_data");
+
   for (int i = 0; natives[i].name; i++) {
     if (natives[i].source != node_native) {
       Local<String> name = String::NewFromUtf8(env->isolate(), natives[i].name);
       Local<String> source = String::NewFromUtf8(env->isolate(),
-                                                  natives[i].source,
-                                                  String::kNormalString,
-                                                  natives[i].source_len);
+                                                 natives[i].source,
+                                                 String::kNormalString,
+                                                 natives[i].source_len);
       target->Set(name, source);
+
+      if (natives[i].cache_len <= 1)
+        continue;
+
+      Local<ArrayBuffer> cache_ab = ArrayBuffer::New(env->isolate(),
+          const_cast<unsigned char*>(natives[i].cache),
+          natives[i].cache_len);
+      Local<Uint8Array> cache =
+          Uint8Array::New(cache_ab, 0, natives[i].cache_len);
+
+      target->Set(String::Concat(name, cache_postfix), cache);
     }
   }
 }

--- a/src/node_javascript.h
+++ b/src/node_javascript.h
@@ -7,7 +7,8 @@
 namespace node {
 
 void DefineJavaScript(Environment* env, v8::Local<v8::Object> target);
-v8::Local<v8::String> MainSource(Environment* env);
+v8::ScriptCompiler::Source* MainSource(Environment* env,
+                                       v8::Local<v8::String> filename);
 
 }  // namespace node
 

--- a/tools/js2c-cache.cc
+++ b/tools/js2c-cache.cc
@@ -1,0 +1,177 @@
+#include "js2c-cache.h"
+#include "v8.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+namespace js2c_cache {
+
+using v8::Context;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Script;
+using v8::ScriptCompiler;
+using v8::ScriptOrigin;
+using v8::String;
+using v8::V8;
+
+static const char* wrap_lines[] = {
+  "(function (exports, require, module, __filename, __dirname) { ",
+  "\n});"
+};
+
+
+static char* ReadStdin(unsigned int* size, bool needs_wrap) {
+  char* res = nullptr;
+  unsigned int off = 0;
+
+  if (needs_wrap) {
+    int prefix_size = strlen(wrap_lines[0]);
+    res = new char[prefix_size];
+    memcpy(res + off, wrap_lines[0], prefix_size);
+    off += prefix_size;
+  }
+
+  for (;;) {
+    int nread;
+
+    char tmp[16 * 1024];
+    nread = fread(tmp, 1, sizeof(tmp), stdin);
+
+    if (nread == 0) {
+      if (!feof(stdin)) {
+        off = 0;
+      }
+      break;
+    }
+
+    // This is very inefficient, but who cares?
+    if (res == nullptr) {
+      res = new char[nread];
+    } else {
+      char* bigger = new char[off + nread];
+      memcpy(bigger, res, off);
+      delete[] res;
+      res = bigger;
+    }
+
+    memcpy(res + off, tmp, nread);
+    off += nread;
+  }
+
+  if (off == 0) {
+    delete[] res;
+    return nullptr;
+  }
+
+  if (needs_wrap) {
+    int postfix_size = strlen(wrap_lines[1]);
+
+    char* bigger = new char[off + postfix_size];
+    memcpy(bigger, res, off);
+    delete[] res;
+    res = bigger;
+
+    memcpy(res + off, wrap_lines[1], postfix_size);
+    off += postfix_size;
+  }
+
+  *size = off;
+  return res;
+}
+
+
+static int CompileCache(Isolate* isolate,
+                        Local<Context> context,
+                        const char* input,
+                        unsigned int input_size,
+                        const char* filename) {
+  Local<String> source_str =
+      String::NewFromUtf8(isolate, input, String::kNormalString, input_size);
+
+  ScriptOrigin origin(String::NewFromUtf8(isolate, filename));
+  ScriptCompiler::Source source(source_str, origin);
+
+  Local<Script> script = ScriptCompiler::Compile(
+      context,
+      &source,
+      ScriptCompiler::kProduceCodeCache).ToLocalChecked();
+
+  const ScriptCompiler::CachedData* data = source.GetCachedData();
+
+  if (data->length == 0)
+    return 0;
+
+  fprintf(stdout, "0x%02x", data->data[0]);
+  for (int i = 1; i < data->length; i++) {
+    fprintf(stdout, ", 0x%02x", data->data[i]);
+  }
+
+  script.Clear();
+
+  return 0;
+}
+
+
+static void FatalErrorHandler(const char* location, const char* message) {
+  fprintf(stderr, "Fatal error at \"%s\":\n%s\n", location, message);
+}
+
+
+static int Start(const char* filename) {
+  int err = 0;
+
+  // Duplicate node's flags
+  const char no_typed_array_heap[] = "--typed_array_max_size_in_heap=0";
+  V8::SetFlagsFromString(no_typed_array_heap, sizeof(no_typed_array_heap) - 1);
+
+  V8::Initialize();
+
+  Isolate::CreateParams params;
+  params.array_buffer_allocator = new ArrayBufferAllocator();
+  Isolate* isolate = Isolate::New(params);
+
+  isolate->SetFatalErrorHandler(FatalErrorHandler);
+
+  {
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope scope(isolate);
+
+    Local<Context> context = Context::New(isolate);
+    Context::Scope context_scope(context);
+
+    bool needs_wrap = strcmp(filename, "src/node.js") != 0;
+
+    unsigned int input_size;
+    char* input = ReadStdin(&input_size, needs_wrap);
+    if (input == nullptr) {
+      fprintf(stderr, "Failed to read stdin, or empty input\n");
+      err = -1;
+    } else {
+      err = CompileCache(isolate, context, input, input_size, filename);
+    }
+
+    delete[] input;
+  }
+
+  isolate->Dispose(),
+
+  V8::Dispose();
+
+  return err;
+}
+
+}  // namespace js2c_cache
+
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    fprintf(stderr, "Not enough arguments\n\n"
+                    "Correct usage: js2c-cache file-name.js\n");
+    return -1;
+  }
+
+  return js2c_cache::Start(argv[1]);
+}

--- a/tools/js2c-cache.h
+++ b/tools/js2c-cache.h
@@ -1,0 +1,23 @@
+#ifndef TOOLS_JS2C_CACHE_H_
+#define TOOLS_JS2C_CACHE_H_
+
+#include "v8.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+namespace js2c_cache {
+
+class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+ public:
+  virtual void* Allocate(size_t length) {
+    void* data = AllocateUninitialized(length);
+    return data == nullptr ? data : memset(data, 0, length);
+  }
+  virtual void* AllocateUninitialized(size_t length) { return malloc(length); }
+  virtual void Free(void* data, size_t) { free(data); }
+};
+
+}  // namespace js2c_cache
+
+#endif  // TOOLS_JS2C_CACHE_H_


### PR DESCRIPTION
Use V8's code cache for code modules.

Fix: #4766 

cc @nodejs/v8 @bnoordhuis 

See: https://github.com/nodejs/node/pull/4777