### PR TITLE
tls: scope loop vars with let

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -48,7 +48,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // cert's issuer in C++ code.
   if (options.ca) {
     if (Array.isArray(options.ca)) {
-      for (var i = 0, len = options.ca.length; i < len; i++) {
+      for (let i = 0, len = options.ca.length; i < len; i++) {
         c.context.addCACert(options.ca[i]);
       }
     } else {
@@ -60,7 +60,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.cert) {
     if (Array.isArray(options.cert)) {
-      for (var i = 0; i < options.cert.length; i++)
+      for (let i = 0; i < options.cert.length; i++)
         c.context.setCert(options.cert[i]);
     } else {
       c.context.setCert(options.cert);
@@ -73,7 +73,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // which leads to the crash later on.
   if (options.key) {
     if (Array.isArray(options.key)) {
-      for (var i = 0; i < options.key.length; i++) {
+      for (let i = 0; i < options.key.length; i++) {
         var key = options.key[i];
 
         if (key.passphrase)
@@ -108,7 +108,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.crl) {
     if (Array.isArray(options.crl)) {
-      for (var i = 0, len = options.crl.length; i < len; i++) {
+      for (let i = 0, len = options.crl.length; i < len; i++) {
         c.context.addCRL(options.crl[i]);
       }
     } else {


### PR DESCRIPTION
`lib/_tls_common.js` had instances of `for` loops that defined variables
with `var` such that they were re-declared in the same scope. This
change scopes those variables with `let` so that they are not
re-declared.