### PR TITLE
test: fs.link() on same device

### DIFF
--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -8,13 +8,16 @@ common.refreshTmpDir();
 
 // test creating and reading hard link
 const srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
+const tmpSrcPath = path.join(common.tmpDir, 'root.js');
 const dstPath = path.join(common.tmpDir, 'link1.js');
+const srcContent = fs.readFileSync(srcPath, 'utf8');
 
 const callback = function(err) {
   if (err) throw err;
-  const srcContent = fs.readFileSync(srcPath, 'utf8');
   const dstContent = fs.readFileSync(dstPath, 'utf8');
   assert.strictEqual(srcContent, dstContent);
 };
 
-fs.link(srcPath, dstPath, common.mustCall(callback));
+// copy to same directory to avoid cross-filesystem issues
+fs.writeFileSync(tmpSrcPath, srcContent, 'utf8');
+fs.link(tmpSrcPath, dstPath, common.mustCall(callback));


### PR DESCRIPTION
If `NODE_TEST_DIR` is set to a device different than the location of the test
files (where this repo is checked out), then the parallel/test-fs-link.js
test will fail with `EXDEV: cross-device link not permitted`. The code works
fine (and is in fact throwing an error as desired) but the test fails.

This commit first copies the "source" file to the same directory as the
"destination" (where the hardlink will be created).