### PR TITLE
test: fs.link() test runs on same device

### DIFF
--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -8,14 +8,18 @@ common.refreshTmpDir();
 
 // test creating and reading hard link
 const srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
+const srcContent = fs.readFileSync(srcPath, 'utf8');
+const tmpSrcPath = path.join(common.tmpDir, 'root.js');
 const dstPath = path.join(common.tmpDir, 'link1.js');
 
 const callback = function(err) {
   if (err) throw err;
-  const srcContent = fs.readFileSync(srcPath, 'utf8');
   const dstContent = fs.readFileSync(dstPath, 'utf8');
   assert.strictEqual(srcContent, dstContent);
 };
+
+// copy source file to same directory to avoid cross-filesystem issues
+fs.writeFileSync(tmpSrcPath, srcContent, 'utf8');
 
 fs.link(srcPath, dstPath, common.mustCall(callback));
 

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -7,19 +7,15 @@ const fs = require('fs');
 common.refreshTmpDir();
 
 // test creating and reading hard link
-const srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
-const srcContent = fs.readFileSync(srcPath, 'utf8');
-const tmpSrcPath = path.join(common.tmpDir, 'root.js');
+const srcPath = path.join(common.tmpDir, 'hardlink-target.txt');
 const dstPath = path.join(common.tmpDir, 'link1.js');
+fs.writeFileSync(srcPath, 'hello world');
 
 const callback = function(err) {
   if (err) throw err;
   const dstContent = fs.readFileSync(dstPath, 'utf8');
-  assert.strictEqual(srcContent, dstContent);
+  assert.strictEqual('hello world', dstContent);
 };
-
-// copy source file to same directory to avoid cross-filesystem issues
-fs.writeFileSync(tmpSrcPath, srcContent, 'utf8');
 
 fs.link(srcPath, dstPath, common.mustCall(callback));
 


### PR DESCRIPTION
When running the tests if `NODE_TEST_DIR` is set to a device different
than the location of the test files (where this repo is checked out),
then the parallel/test-fs-link.js test will fail with
`EXDEV: cross-device link not permitted`. The code works fine (and is in
fact throwing an error as desired) but the test fails.

This commit first copies the "source" file to the same directory as the
"destination" (where the hardlink will be created).