### PR TITLE
tools, test: enable assorted ESLint error rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,16 @@ rules:
   no-unreachable: 2
   ## require valid typeof compared string like typeof foo === 'strnig'
   valid-typeof: 2
+  ## disallow controls characters in regular expressions
+  no-control-regex: 2
+  ## disallow extra boolean casts
+  no-extra-boolean-cast : 2
+  ## validate regular expressions
+  no-invalid-regexp: 2
+  ## forbid weird whitespace characters
+  no-irregular-whitespace: 2
+  ## avoid unexpected multiline expressions
+  no-unexpected-multiline: 2
 
   # Best Practices
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#best-practices

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -385,7 +385,7 @@ asyncTest('Catching the Promise.all() of a collection that includes a' +
           'rejected promise prevents unhandledRejection', function(done) {
   var e = new Error();
   onUnhandledFail(done);
-  Promise.all([Promise.reject(e)]).then(common.fail, function() {});
+  Promise.all([Promise.reject(e)]).then(common.fail, function() {});
 });
 
 asyncTest(
@@ -401,7 +401,7 @@ asyncTest(
     });
     p = Promise.all([p]);
     process.nextTick(function() {
-      p.then(common.fail, function() {});
+      p.then(common.fail, function() {});
     });
   }
 );
@@ -455,7 +455,7 @@ asyncTest('Waiting for some combination of process.nextTick + promise' +
     Promise.resolve().then(function() {
       process.nextTick(function() {
         Promise.resolve().then(function() {
-          a.catch(function() {});
+          a.catch(function() {});
         });
       });
     });
@@ -474,7 +474,7 @@ asyncTest('Waiting for some combination of process.nextTick + promise' +
       Promise.resolve().then(function() {
         process.nextTick(function() {
           Promise.resolve().then(function() {
-            a.catch(function() {});
+            a.catch(function() {});
           });
         });
       });
@@ -494,7 +494,7 @@ asyncTest('Waiting for some combination of process.nextTick + promise ' +
       Promise.resolve().then(function() {
         process.nextTick(function() {
           Promise.resolve().then(function() {
-            a.catch(function() {});
+            a.catch(function() {});
           });
         });
       });
@@ -514,7 +514,7 @@ asyncTest('Waiting for some combination of promise microtasks + ' +
     process.nextTick(function() {
       Promise.resolve().then(function() {
         process.nextTick(function() {
-          a.catch(function() {});
+          a.catch(function() {});
         });
       });
     });
@@ -535,7 +535,7 @@ asyncTest(
         process.nextTick(function() {
           Promise.resolve().then(function() {
             process.nextTick(function() {
-              a.catch(function() {});
+              a.catch(function() {});
             });
           });
         });
@@ -556,7 +556,7 @@ asyncTest('Waiting for some combination of promise microtasks +' +
       process.nextTick(function() {
         Promise.resolve().then(function() {
           process.nextTick(function() {
-            a.catch(function() {});
+            a.catch(function() {});
           });
         });
       });


### PR DESCRIPTION
This enables assorted ESLint rules from the `Possible Errors` category. I made sure to choose only rules which won't get in the way of whatever arcane trick someone might want to attempt.

- [`no-control-regex`](http://eslint.org/docs/rules/no-control-regex)
- [`no-extra-boolean-cast`](http://eslint.org/docs/rules/no-extra-boolean-cast)
- [`no-invalid-regexp`](http://eslint.org/docs/rules/no-invalid-regexp)
- [`no-irregular-whitespace`](http://eslint.org/docs/rules/no-irregular-whitespace)
- [`no-unexpected-multiline`](http://eslint.org/docs/rules/no-unexpected-multiline)

`test-promises-unhandled-rejections.js` had some `\u00a0` space characters which I fixed.