### PR TITLE
doc: make doctool support guides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,23 @@ test-timers:
 test-timers-clean:
 	$(MAKE) --directory=tools clean
 
+guidedoc_sources = $(wildcard doc/guides/*.md)
+guidedocs = $(addprefix out/,$(guidedoc_sources:.md=.html))
+
+guidedoc_dirs = out/doc out/doc/guides/ out/doc/guides/assets
+
+# TODO(qard): Lifted api assets for now, may want to separate those.
+guideassets = $(subst api_assets,guides/assets,$(addprefix out/,$(wildcard doc/api_assets/*)))
+
+$(guidedoc_dirs):
+	mkdir -p $@
+
+out/doc/guides/assets/%: doc/guides_assets/% out/doc/guides/assets/
+	cp $< $@
+
+out/doc/guides/%.html: doc/guides/%.md $(NODE_EXE)
+	$(NODE) tools/doc/generate.js --format=html-guides --template=doc/guide-template.html $< > $@
+
 apidoc_sources = $(wildcard doc/api/*.markdown)
 apidocs = $(addprefix out/,$(apidoc_sources:.markdown=.html)) \
 		$(addprefix out/,$(apidoc_sources:.markdown=.json))
@@ -192,7 +209,9 @@ apidoc_dirs = out/doc out/doc/api/ out/doc/api/assets
 
 apiassets = $(subst api_assets,api/assets,$(addprefix out/,$(wildcard doc/api_assets/*)))
 
-doc: $(apidoc_dirs) $(apiassets) $(apidocs) tools/doc/ $(NODE_EXE)
+guidedocs: $(guidedoc_dirs) $(guideassets) $(guidedocs) tools/doc/ $(NODE_EXE)
+
+doc: $(apidoc_dirs) $(apiassets) $(apidocs) $(guidedoc_dirs) $(guideassets) $(guidedocs) tools/doc/ $(NODE_EXE)
 
 $(apidoc_dirs):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ guideassets = $(subst api_assets,guides/assets,$(addprefix out/,$(wildcard doc/a
 $(guidedoc_dirs):
 	mkdir -p $@
 
-out/doc/guides/assets/%: doc/guides_assets/% out/doc/guides/assets/
+out/doc/guides/assets/%: doc/api_assets/% out/doc/guides/assets/
 	cp $< $@
 
 out/doc/guides/%.html: doc/guides/%.md $(NODE_EXE)

--- a/doc/guides/test.md
+++ b/doc/guides/test.md
@@ -1,0 +1,1 @@
+# Hello, world

--- a/doc/guides/test.md
+++ b/doc/guides/test.md
@@ -1,1 +1,3 @@
+# Table of Contents
+
 # Hello, world

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -54,6 +54,14 @@ function next(er, input) {
       });
       break;
 
+    // TODO: Merge guide and api html generators
+    case 'html-guides':
+      require('./guides.js')(input, inputFile, template, function(er, html) {
+        if (er) throw er;
+        console.log(html);
+      });
+      break;
+
     default:
       throw new Error('Invalid format: ' + format);
   }

--- a/tools/doc/guides.js
+++ b/tools/doc/guides.js
@@ -1,10 +1,48 @@
 var fs = require('fs');
-var remark = require('remark');
 var path = require('path');
-var preprocess = require('./preprocess.js');
+
+var VFile = require('vfile');
+var remark = require('remark');
+var remarkHtml = require('remark-html');
+var slug = require('remark-slug');
+var toc = require('remark-toc');
+// TODO(qard): includes get hijacked by preprocess in generate script
+// var include = require('remark-include');
 
 module.exports = toHTML;
 
-function toHTML(input, filename, template, cb) {
-  // TODO: Do stuff...
+function makeVFile (input, filepath) {
+  var dir = path.dirname(filepath);
+  var ext = path.extname(filepath);
+  var name = path.basename(filepath, ext).slice(1);
+  return new VFile({
+    directory: dir,
+    filename: name,
+    extension: ext,
+    contents: input
+  });
+}
+
+function render (template, content, cb) {
+  fs.readFile(template, function (err, res) {
+    if (err) return cb(err);
+    var body = res.toString();
+    body = body.replace(/__CONTENT__/g, content);
+    cb(null, body);
+  });
+}
+
+function toHTML(input, filepath, template, cb) {
+  var processor = remark();
+  processor.use(toc);
+  processor.use(slug);
+  processor.use(remarkHtml);
+  // TODO(qard): includes get hijacked by preprocess in generate script
+  // processor.use(include, {
+  //   cwd: 'doc/guides'
+  // });
+
+  var file = makeVFile(input, filepath);
+  var content = processor.process(file);
+  render(template, content, cb);
 }

--- a/tools/doc/guides.js
+++ b/tools/doc/guides.js
@@ -1,0 +1,10 @@
+var fs = require('fs');
+var remark = require('remark');
+var path = require('path');
+var preprocess = require('./preprocess.js');
+
+module.exports = toHTML;
+
+function toHTML(input, filename, template, cb) {
+  // TODO: Do stuff...
+}

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -7,7 +7,13 @@
     "node": ">=0.6.10"
   },
   "dependencies": {
-    "marked": "~0.1.9"
+    "marked": "~0.1.9",
+    "remark": "^3.2.2",
+    "remark-html": "^2.0.2",
+    "remark-include": "^1.0.1",
+    "remark-slug": "^4.0.0",
+    "remark-toc": "^2.0.1",
+    "vfile": "^1.3.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
*DO NOT MERGE*

This is in-progress work to generate guide html files using the existing doctool. It's not at all ready to merge yet. I just want to get @nodejs/documentation eyes on it to decide if this seems like a valid approach.