### PR TITLE
url: change scoping of variables with let

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -169,8 +169,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 
     // find the first instance of any hostEndingChars
     var hostEnd = -1;
-    for (var i = 0; i < hostEndingChars.length; i++) {
-      var hec = rest.indexOf(hostEndingChars[i]);
+    for (let i = 0; i < hostEndingChars.length; i++) {
+      const hec = rest.indexOf(hostEndingChars[i]);
       if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
         hostEnd = hec;
     }
@@ -197,8 +197,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 
     // the host is the remaining to the left of the first non-host char
     hostEnd = -1;
-    for (var i = 0; i < nonHostChars.length; i++) {
-      var hec = rest.indexOf(nonHostChars[i]);
+    for (let i = 0; i < nonHostChars.length; i++) {
+      const hec = rest.indexOf(nonHostChars[i]);
       if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
         hostEnd = hec;
     }
@@ -224,12 +224,12 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // validate a little.
     if (!ipv6Hostname) {
       var hostparts = this.hostname.split(/\./);
-      for (var i = 0, l = hostparts.length; i < l; i++) {
+      for (let i = 0, l = hostparts.length; i < l; i++) {
         var part = hostparts[i];
         if (!part) continue;
         if (!part.match(hostnamePartPattern)) {
           var newpart = '';
-          for (var j = 0, k = part.length; j < k; j++) {
+          for (let j = 0, k = part.length; j < k; j++) {
             if (part.charCodeAt(j) > 127) {
               // we replace non-ASCII char with a temporary placeholder
               // we need this to make sure size of hostname is not
@@ -294,7 +294,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // First, make 100% sure that any "autoEscape" chars get
     // escaped, even if encodeURIComponent doesn't think they
     // need to be.
-    for (var i = 0, l = autoEscape.length; i < l; i++) {
+    for (let i = 0, l = autoEscape.length; i < l; i++) {
       var ae = autoEscape[i];
       if (rest.indexOf(ae) === -1)
         continue;
@@ -335,8 +335,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 
   //to support http.request
   if (this.pathname || this.search) {
-    var p = this.pathname || '';
-    var s = this.search || '';
+    const p = this.pathname || '';
+    const s = this.search || '';
     this.path = p + s;
   }
 
@@ -498,7 +498,7 @@ Url.prototype.resolveObject = function(relative) {
     if (!relative.host &&
         !/^file:?$/.test(relative.protocol) &&
         !hostlessProtocol[relative.protocol]) {
-      var relPath = (relative.pathname || '').split('/');
+      const relPath = (relative.pathname || '').split('/');
       while (relPath.length && !(relative.host = relPath.shift()));
       if (!relative.host) relative.host = '';
       if (!relative.hostname) relative.hostname = '';
@@ -533,8 +533,8 @@ Url.prototype.resolveObject = function(relative) {
   var mustEndAbs = (isRelAbs || isSourceAbs ||
                     (result.host && relative.pathname));
   const removeAllDots = mustEndAbs;
-  var srcPath = result.pathname && result.pathname.split('/') || [];
-  var relPath = relative.pathname && relative.pathname.split('/') || [];
+  let srcPath = result.pathname && result.pathname.split('/') || [];
+  const relPath = relative.pathname && relative.pathname.split('/') || [];
   const psychotic = result.protocol && !slashedProtocol[result.protocol];
 
   // if the url is a non-slashed url, then relative
@@ -589,7 +589,7 @@ Url.prototype.resolveObject = function(relative) {
       //occasionally the auth can get stuck only in host
       //this especially happens in cases like
       //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-      var authInHost = result.host && result.host.indexOf('@') > 0 ?
+      const authInHost = result.host && result.host.indexOf('@') > 0 ?
                        result.host.split('@') : false;
       if (authInHost) {
         result.auth = authInHost.shift();
@@ -632,7 +632,7 @@ Url.prototype.resolveObject = function(relative) {
   // strip single dots, resolve double dots to parent dir
   // if the path tries to go above the root, `up` ends up > 0
   var up = 0;
-  for (var i = srcPath.length; i >= 0; i--) {
+  for (let i = srcPath.length; i >= 0; i--) {
     last = srcPath[i];
     if (last === '.') {
       spliceOne(srcPath, i);
@@ -671,7 +671,7 @@ Url.prototype.resolveObject = function(relative) {
     //occasionally the auth can get stuck only in host
     //this especially happens in cases like
     //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-    var authInHost = result.host && result.host.indexOf('@') > 0 ?
+    const authInHost = result.host && result.host.indexOf('@') > 0 ?
                      result.host.split('@') : false;
     if (authInHost) {
       result.auth = authInHost.shift();


### PR DESCRIPTION
This PR addresses variable redeclarations in `lib/url.js` by changing hoisted `var`s to `let`.
Also changes some `var`s to `const` as recommended by the linter.

@Trott points out in #4853 that the linter reports a lot of redeclarations. I believe addressing this incrementally is easier and less risky, hence this PR only fixes these issues in this one file.