### PR TITLE
test: refactor switch

### DIFF
--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -71,17 +71,17 @@ if (process.argv[2] === 'child') {
   server.on('connection', function(socket) {
     switch (connected % 6) {
       case 0:
-        child1.send('end', socket, { track: false }); break;
+        child1.send('end', socket); break;
       case 1:
-        child1.send('write', socket, { track: true }); break;
+        child1.send('write', socket); break;
       case 2:
-        child2.send('end', socket, { track: true }); break;
+        child2.send('end', socket); break;
       case 3:
-        child2.send('write', socket, { track: false }); break;
+        child2.send('write', socket); break;
       case 4:
-        child3.send('end', socket, { track: false }); break;
+        child3.send('end', socket); break;
       case 5:
-        child3.send('write', socket, { track: false }); break;
+        child3.send('write', socket); break;
     }
     connected += 1;
 


### PR DESCRIPTION
`test-child-process-fork-net2.js` has a switch statement with 6 cases.
Each case uses `child.send()`, passing an object for the callback.
`child.send()` ignores the callback because it is not a function.
Removing the unused argument.