### PR TITLE
Clarify Buffer hex string error message

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -594,7 +594,8 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
       enc == UCS2 ? str_obj->Length() * sizeof(uint16_t) : str_obj->Length();
 
   if (enc == HEX && str_length  % 2 != 0)
-    return env->ThrowTypeError("Invalid hex string");
+    return env->ThrowTypeError("Hex strings must have an even number of "
+                               "characters");
 
   if (str_length == 0)
     return;
@@ -664,7 +665,8 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   Local<String> str = args[0]->ToString(env->isolate());
 
   if (encoding == HEX && str->Length() % 2 != 0)
-    return env->ThrowTypeError("Invalid hex string");
+    return env->ThrowTypeError("Hex strings must have an even number of "
+                               "characters");
 
   size_t offset;
   size_t max_length;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -517,6 +517,9 @@ assert.throws(() => Buffer.from('A', 'hex'), TypeError);
 // Test single base64 char encodes as 0
 assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 
+// Creating a buffer from odd-length hex string should fail.
+assert.throws(() => Buffer.from('zzz', 'hex'),
+              /Hex strings must have an even number of characters/);
 
 {
   // test an invalid slice end.

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -135,7 +135,7 @@ testBufs('61c8b462c8b563c8b6', 12, 1, 'hex');
 // Make sure this operation doesn't go on forever
 buf1.fill('yKJh', 'hex');
 assert.throws(() =>
-      buf1.fill('\u0222', 'hex'), /^TypeError: Invalid hex string$/);
+      buf1.fill('\u0222', 'hex'), /^TypeError:/);
 
 
 // BASE64


### PR DESCRIPTION
Taking a clue from https://github.com/nodejs/node/blob/master/src/string_bytes.cc#L503, provide more reason for why a hex string is invalid (namely that the issue is the length being odd rather than even).
