### PR TITLE
net: move isLegalPort to internal/net

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = { isLegalPort };
+
+// Check that the port number is not NaN when coerced to a number,
+// is an integer and that it falls within the legal range of port numbers.
+function isLegalPort(port) {
+  if (typeof port === 'string' && port.trim() === '')
+    return false;
+  return +port === (port >>> 0) && port >= 0 && port <= 0xFFFF;
+}

--- a/lib/net.js
+++ b/lib/net.js
@@ -5,6 +5,7 @@ const stream = require('stream');
 const timers = require('timers');
 const util = require('util');
 const internalUtil = require('internal/util');
+const internalNet = require('internal/net');
 const assert = require('assert');
 const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
@@ -22,6 +23,7 @@ const WriteWrap = process.binding('stream_wrap').WriteWrap;
 var cluster;
 const errnoException = util._errnoException;
 const exceptionWithHostPort = util._exceptionWithHostPort;
+const isLegalPort = internalNet.isLegalPort;
 
 function noop() {}
 
@@ -843,15 +845,6 @@ function connect(self, address, port, addressType, localAddress, localPort) {
     var ex = exceptionWithHostPort(err, 'connect', address, port, details);
     self._destroy(ex);
   }
-}
-
-
-// Check that the port number is not NaN when coerced to a number,
-// is an integer and that it falls within the legal range of port numbers.
-function isLegalPort(port) {
-  if (typeof port === 'string' && port.trim() === '')
-    return false;
-  return +port === (port >>> 0) && port >= 0 && port <= 0xFFFF;
 }
 
 

--- a/node.gyp
+++ b/node.gyp
@@ -73,6 +73,7 @@
       'lib/internal/cluster.js',
       'lib/internal/freelist.js',
       'lib/internal/linkedlist.js',
+      'lib/internal/net.js',
       'lib/internal/module.js',
       'lib/internal/readline.js',
       'lib/internal/repl.js',

--- a/test/parallel/test-net-internal.js
+++ b/test/parallel/test-net-internal.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Flags: --expose-internals
+
+require('../common');
+const assert = require('assert');
+const net = require('internal/net');
+
+assert.strictEqual(net.isLegalPort(''), false);
+assert.strictEqual(net.isLegalPort('0'), true);
+assert.strictEqual(net.isLegalPort(0), true);
+assert.strictEqual(net.isLegalPort(65536), false);
+assert.strictEqual(net.isLegalPort('65535'), true);
+assert.strictEqual(net.isLegalPort(undefined), false);
+assert.strictEqual(net.isLegalPort(null), true);


### PR DESCRIPTION
isLegalPort can be used in more places than just net.js. This change
moves it to a new internal net module in preparation for using it in
the dns module.