### PR TITLE
dns: coerce port to number in lookupService

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -126,6 +126,10 @@ on some operating systems (e.g FreeBSD 10.1).
 Resolves the given `address` and `port` into a hostname and service using
 the operating system's underlying `getnameinfo` implementation.
 
+If `address` is not a valid IP address, a `TypeError` will be thrown.
+The `port` will be coerced to a number. If it is not a legal port, a `TypeError`
+will be thrown.
+
 The callback has arguments `(err, hostname, service)`. The `hostname` and
 `service` arguments are strings (e.g. `'localhost'` and `'http'` respectively).
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -5,12 +5,14 @@ const util = require('util');
 
 const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
+const internalNet = require('internal/net');
 
 const GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
 const GetNameInfoReqWrap = cares.GetNameInfoReqWrap;
 const QueryReqWrap = cares.QueryReqWrap;
 
 const isIp = net.isIP;
+const isLegalPort = internalNet.isLegalPort;
 
 
 function errnoException(err, syscall, hostname) {
@@ -189,9 +191,10 @@ exports.lookupService = function(host, port, callback) {
   if (cares.isIP(host) === 0)
     throw new TypeError('"host" argument needs to be a valid IP address');
 
-  if (typeof port !== 'number')
-    throw new TypeError(`"port" argument must be a number, got "${port}"`);
+  if (port == null || !isLegalPort(port))
+    throw new TypeError(`"port" should be >= 0 and < 65536, got "${port}"`);
 
+  port = +port;
   callback = makeAsync(callback);
 
   var req = new GetNameInfoReqWrap();

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -154,10 +154,26 @@ assert.throws(function() {
   dns.lookupService('fasdfdsaf', 0, noop);
 }, /"host" argument needs to be a valid IP address/);
 
-assert.throws(function() {
+assert.doesNotThrow(function() {
   dns.lookupService('0.0.0.0', '0', noop);
-}, /"port" argument must be a number, got "0"/);
+});
 
 assert.doesNotThrow(function() {
   dns.lookupService('0.0.0.0', 0, noop);
 });
+
+assert.throws(function() {
+  dns.lookupService('0.0.0.0', null, noop);
+}, /"port" should be >= 0 and < 65536, got "null"/);
+
+assert.throws(function() {
+  dns.lookupService('0.0.0.0', undefined, noop);
+}, /"port" should be >= 0 and < 65536, got "undefined"/);
+
+assert.throws(function() {
+  dns.lookupService('0.0.0.0', 65538, noop);
+}, /"port" should be >= 0 and < 65536, got "65538"/);
+
+assert.throws(function() {
+  dns.lookupService('0.0.0.0', 'test', noop);
+}, /"port" should be >= 0 and < 65536, got "test"/);


### PR DESCRIPTION
Previously, port could be any number in dns.lookupService. This change
throws a TypeError if port is outside the range of 0-65535. It also
coerces the port to a number.

This includes the commit from https://github.com/nodejs/node/pull/4882 as it depends on it.

I have separated them into two PRs for the sake of cherry-picking to release branches though as this is semver-major.