### PR TITLE
tools: fix type sniffing for properties in JSON generation

### DIFF
--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -248,7 +248,7 @@ function processList(section) {
       // copy the data up to the section.
       var value = values[0] || {};
       delete value.name;
-      section.typeof = value.type;
+      section.typeof = value.type || section.typeof;
       delete value.type;
       Object.keys(value).forEach(function(k) {
         section[k] = value[k];


### PR DESCRIPTION
Before:

```json
            {
              "textRaw": "`children` {Array} ",
              "name": "children",
              "desc": "<p>The module objects required by this one.\n\n</p>\n"
            },
```

(https://nodejs.org/api/modules.json)

After:

```json
            {
              "textRaw": "`children` {Array} ",
              "type": "Array",
              "name": "children",
              "desc": "<p>The module objects required by this one.\n\n</p>\n"
            },
```