### PR TITLE
buffer: refactor redeclared variables

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -125,7 +125,7 @@ function fromString(string, encoding) {
 
 function fromObject(obj) {
   if (obj instanceof Buffer) {
-    var b = allocate(obj.length);
+    const b = allocate(obj.length);
 
     if (b.length === 0)
       return b;
@@ -135,9 +135,9 @@ function fromObject(obj) {
   }
 
   if (Array.isArray(obj)) {
-    var length = obj.length;
-    var b = allocate(length);
-    for (var i = 0; i < length; i++)
+    const length = obj.length;
+    const b = allocate(length);
+    for (let i = 0; i < length; i++)
       b[i] = obj[i] & 255;
     return b;
   }
@@ -151,13 +151,13 @@ function fromObject(obj) {
   }
 
   if (obj.buffer instanceof ArrayBuffer || obj.length) {
-    var length;
+    let length;
     if (typeof obj.length !== 'number' || obj.length !== obj.length)
       length = 0;
     else
       length = obj.length;
-    var b = allocate(length);
-    for (var i = 0; i < length; i++) {
+    const b = allocate(length);
+    for (let i = 0; i < length; i++) {
       b[i] = obj[i] & 255;
     }
     return b;
@@ -165,8 +165,8 @@ function fromObject(obj) {
 
   if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
     var array = obj.data;
-    var b = allocate(array.length);
-    for (var i = 0; i < array.length; i++)
+    const b = allocate(array.length);
+    for (let i = 0; i < array.length; i++)
       b[i] = array[i] & 255;
     return b;
   }
@@ -231,7 +231,7 @@ Buffer.concat = function(list, length) {
 
   if (length === undefined) {
     length = 0;
-    for (var i = 0; i < list.length; i++)
+    for (let i = 0; i < list.length; i++)
       length += list[i].length;
   } else {
     length = length >>> 0;
@@ -239,7 +239,7 @@ Buffer.concat = function(list, length) {
 
   var buffer = new Buffer(length);
   var pos = 0;
-  for (var i = 0; i < list.length; i++) {
+  for (let i = 0; i < list.length; i++) {
     var buf = list[i];
     buf.copy(buffer, pos);
     pos += buf.length;
@@ -401,10 +401,11 @@ function slowToString(encoding, start, end) {
 
 
 Buffer.prototype.toString = function() {
+  let result;
   if (arguments.length === 0) {
-    var result = this.utf8Slice(0, this.length);
+    result = this.utf8Slice(0, this.length);
   } else {
-    var result = slowToString.apply(this, arguments);
+    result = slowToString.apply(this, arguments);
   }
   if (result === undefined)
     throw new Error('"toString()" failed');


### PR DESCRIPTION
A handful of variable declarations in `lib/buffer.js` redeclare the same
variable in the same scope. This change removes each redeclaration by
switching to `const`, switching to `let`, or explicitly hoisting the
`var` declaration.