### PR TITLE
test: fix test-tls-zero-clear-in flakiness

### DIFF
--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -22,7 +22,7 @@ var server = tls.createServer({
 }, function(c) {
   // Nop
   setTimeout(function() {
-    c.destroy();
+    c.end();
     server.close();
   }, 20);
 }).listen(common.PORT, function() {


### PR DESCRIPTION
It can happen that the server-side socket is destroyed before the
client-side socket has gracefully closed, thus causing a 'ECONNRESET'
error in this socket. To solve this, also close gracefully in the server
side too.

It tries to solve the following error I'm getting from time to time in a `Debian Jessie 64` box:
```
=== release test-tls-zero-clear-in ===                                         
Path: parallel/test-tls-zero-clear-in
{ Error: read ECONNRESET
    at exports._errnoException (util.js:859:11)
    at TLSWrap.onread (net.js:544:26) code: 'ECONNRESET', errno: 'ECONNRESET', syscall: 'read' }
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: false == true
    at process.<anonymous> (/home/sgimeno/node/node/test/parallel/test-tls-zero-clear-in.js:51:10)
    at emitOne (events.js:96:20)
    at process.emit (events.js:183:7)
Command: out/Release/node /home/sgimeno/node/node/test/parallel/test-tls-zero-clear-in.js
```