### PR TITLE
doc: don't use "interface" as a variable name

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -69,7 +69,7 @@ nothing is displayed.
 Example usage:
 
 ```js
-interface.question('What is your favorite food?', (answer) => {
+rl.question('What is your favorite food?', (answer) => {
   console.log(`Oh, so your favorite food is ${answer}`);
 });
 ```


### PR DESCRIPTION
In `readline.markdown`, don't use strict mode reserved keyword `interface` as a variable name.

This commit changes the name of one `readline.Interface` instance from `interface` to `rl`, as it is named in other places of the readline documentation.