### PR TITLE
Use a const SSL_CIPHER.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5370,7 +5370,7 @@ void GetSSLCiphers(const FunctionCallbackInfo<Value>& args) {
   STACK_OF(SSL_CIPHER)* ciphers = SSL_get_ciphers(ssl);
 
   for (int i = 0; i < sk_SSL_CIPHER_num(ciphers); ++i) {
-    SSL_CIPHER* cipher = sk_SSL_CIPHER_value(ciphers, i);
+    const SSL_CIPHER* cipher = sk_SSL_CIPHER_value(ciphers, i);
     arr->Set(i, OneByteString(args.GetIsolate(), SSL_CIPHER_get_name(cipher)));
   }
 


### PR DESCRIPTION
SSL_CIPHER objects are conceptually const in any case and this allows
STACK_OF(SSL_CIPHER) to return a const pointer, as is done in BoringSSL
and, perhaps, OpenSSL in the future.