### PR TITLE
crypto: use SSL_CTX_clear_extra_chain_certs.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -517,10 +517,7 @@ int SSL_CTX_use_certificate_chain(SSL_CTX* ctx,
     // the CA certificates.
     int r;
 
-    if (ctx->extra_certs != nullptr) {
-      sk_X509_pop_free(ctx->extra_certs, X509_free);
-      ctx->extra_certs = nullptr;
-    }
+    SSL_CTX_clear_extra_chain_certs(ctx);
 
     for (int i = 0; i < sk_X509_num(extra_certs); i++) {
       X509* ca = sk_X509_value(extra_certs, i);


### PR DESCRIPTION
The SSL_CTX_clear_extra_chain_certs function clears the extra
certificates associated with an SSL_CTX without reaching into the
SSL_CTX structure itself (which will become impossible in OpenSSL
1.1.0). The underlying implementation in OpenSSL[1] is the same what the
code was doing and OpenSSL has provided this function since 0.9.8 so
this change should be fully compatible.

[1] https://github.com/nodejs/node/blob/master/deps/openssl/openssl/ssl/s3_lib.c#L3899