### PR TITLE
Support resolving plain DNS PTR records

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -151,7 +151,7 @@ Valid values for `rrtype` are:
  * `'MX'` - mail exchange records
  * `'TXT'` - text records
  * `'SRV'` - SRV records
- * `'PTR'` - used for reverse IP lookups
+ * `'PTR'` - PTR records
  * `'NS'` - name server records
  * `'CNAME'` - canonical name records
  * `'SOA'` - start of authority record
@@ -243,6 +243,12 @@ be an array of objects with the following properties:
   name: 'service.example.com'
 }
 ```
+
+## dns.resolvePtr(hostname, callback)
+
+Uses the DNS protocol to resolve pointer records (`PTR` records) for the
+`hostname`. The `addresses` argument passed to the `callback` function will
+be an array of strings containing the reply records.
 
 ## dns.resolveTxt(hostname, callback)
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -248,9 +248,10 @@ exports.resolveMx = resolveMap.MX = resolver('queryMx');
 exports.resolveNs = resolveMap.NS = resolver('queryNs');
 exports.resolveTxt = resolveMap.TXT = resolver('queryTxt');
 exports.resolveSrv = resolveMap.SRV = resolver('querySrv');
+exports.resolvePtr = resolveMap.PTR = resolver('queryPtr');
 exports.resolveNaptr = resolveMap.NAPTR = resolver('queryNaptr');
 exports.resolveSoa = resolveMap.SOA = resolver('querySoa');
-exports.reverse = resolveMap.PTR = resolver('getHostByAddr');
+exports.reverse = resolver('getHostByAddr');
 
 
 exports.resolve = function(hostname, type_, callback_) {

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -166,6 +166,37 @@ TEST(function test_resolveSrv_failure(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolvePtr(done) {
+  var req = dns.resolvePtr('8.8.8.8.in-addr.arpa', function(err, result) {
+    if (err) throw err;
+
+    assert.ok(result.length > 0);
+
+    for (var i = 0; i < result.length; i++) {
+      var item = result[i];
+      assert.ok(item);
+      assert.ok(typeof item === 'string');
+    }
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+TEST(function test_resolvePtr_failure(done) {
+  var req = dns.resolvePtr('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
 TEST(function test_resolveNaptr(done) {
   var req = dns.resolveNaptr('sip2sip.info', function(err, result) {
     if (err) throw err;

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -84,6 +84,18 @@ TEST(function test_resolveMx(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolveMx_failure(done) {
+  var req = dns.resolveMx('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
+    done();
+  });
+
+  checkWrap(req);
+});
 
 TEST(function test_resolveNs(done) {
   var req = dns.resolveNs('rackspace.com', function(err, names) {
@@ -103,6 +115,18 @@ TEST(function test_resolveNs(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolveNs_failure(done) {
+  var req = dns.resolveNs('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
+    done();
+  });
+
+  checkWrap(req);
+});
 
 TEST(function test_resolveSrv(done) {
   var req = dns.resolveSrv('_jabber._tcp.google.com', function(err, result) {
@@ -129,6 +153,19 @@ TEST(function test_resolveSrv(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolveSrv_failure(done) {
+  var req = dns.resolveSrv('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
 TEST(function test_resolveNaptr(done) {
   var req = dns.resolveNaptr('sip2sip.info', function(err, result) {
     if (err) throw err;
@@ -147,6 +184,19 @@ TEST(function test_resolveNaptr(done) {
       assert.ok(typeof item.order === 'number');
       assert.ok(typeof item.preference === 'number');
     }
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
+TEST(function test_resolveNaptr_failure(done) {
+  var req = dns.resolveNaptr('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
 
     done();
   });
@@ -188,6 +238,19 @@ TEST(function test_resolveSoa(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolveSoa_failure(done) {
+  var req = dns.resolveSoa('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
 TEST(function test_resolveCname(done) {
   var req = dns.resolveCname('www.microsoft.com', function(err, names) {
     if (err) throw err;
@@ -206,6 +269,19 @@ TEST(function test_resolveCname(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolveCname_failure(done) {
+  var req = dns.resolveCname('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
 
 TEST(function test_resolveTxt(done) {
   var req = dns.resolveTxt('google.com', function(err, records) {
@@ -213,6 +289,19 @@ TEST(function test_resolveTxt(done) {
     assert.equal(records.length, 1);
     assert.ok(util.isArray(records[0]));
     assert.equal(records[0][0].indexOf('v=spf1'), 0);
+    done();
+  });
+
+  checkWrap(req);
+});
+
+TEST(function test_resolveTxt_failure(done) {
+  var req = dns.resolveTxt('something.invalid', function(err, result) {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errno, 'ENOTFOUND');
+
+    assert.ok(result == undefined);
+
     done();
   });
 

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -31,7 +31,7 @@ assert.throws(function() {
 // C:\Windows\System32\drivers\etc\hosts
 // so we disable this test on Windows.
 if (!common.isWindows) {
-  dns.resolve('127.0.0.1', 'PTR', function(error, domains) {
+  dns.reverse('127.0.0.1', function(error, domains) {
     if (error) throw error;
     assert.ok(Array.isArray(domains));
   });

--- a/test/parallel/test-dns-cares-domains.js
+++ b/test/parallel/test-dns-cares-domains.js
@@ -12,6 +12,7 @@ var methods = [
   'resolveNs',
   'resolveTxt',
   'resolveSrv',
+  'resolvePtr',
   'resolveNaptr',
   'resolveSoa'
 ];


### PR DESCRIPTION
Node's DNS module currently supports reverse IP lookup with dns.reverse(), which internally uses c-ares' gethostbyaddr(). It works great to look up the registered hostname for IP addresses ("Reverse DNS").

In DNS-SD ([RFC6763](https://tools.ietf.org/html/rfc6763)), PTR records are used for listing service instance names for a domain (see [Section 4.1](https://tools.ietf.org/html/rfc6763#section-4.1)), and there might be other uses of PTR records outside of Reverse DNS or DNS-SD.

c-ares supports querying and parsing PTR records, and ares_gethostbyaddr() uses ares_parse_ptr_reply internally. It's just not wrapped in the current version of node.

I took on the straightforward work of copying the glue code that wraps ares_query/ares_parse_srv_reply into dns.resolveSrv (SRV record lookup), and use ares_parse_ptr_reply to implement dns.resolvePtr, as seen in this pull request. It returns a simple array of strings containing the returned PTR records.

for example,
```
> dns.resolvePtr("8.8.8.8.in-addr.arpa",console.log);
null [ 'google-public-dns-a.google.com' ]
```

if i have registered a number of DNS-SD service instances, it can look like:
```
> dns.resolvePtr("_http._tcp.lan",console.log);
null [ 'Public_Message_Board._http._tcp.lan',
  'New_Employee_Information_Page._http._tcp.lan',
  'Company_Website._http._tcp.lan' ]
```


One caveat: this clears up the use of rrtype in dns.resolve() with rrtype="PTR", but changes the behaviour of resolve(hostname,"PTR",cb). Before, this was using dns.reverse(), so to lookup the hostname for 8.8.4.4, you would do:
`dns.resolve("8.8.4.4","PTR",console.log);`
Now, you would have to:
`dns.resolve("4.4.8.8.in-addr.arpa","PTR",console.log);`
Or, better, you can still do:
`dns.reverse("8.8.4.4",console.log)`
