### PR TITLE
doc: add more details to process.env

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -424,6 +424,31 @@ process.env.foo = 'bar';
 console.log(process.env.foo);
 ```
 
+Assigning a property on `process.env` will implicitly convert the value
+to a string.
+
+Example:
+
+```js
+process.env.test = null;
+console.log(process.env.test);
+// => 'null'
+process.env.test = undefined;
+console.log(process.env.test);
+// => 'undefined'
+```
+
+Use `delete` to delete a property from `process.env`.
+
+Example:
+
+```js
+process.env.TEST = 1;
+delete process.env.TEST;
+console.log(process.env.TEST);
+// => undefined
+```
+
 ## process.execArgv
 
 This is the set of Node.js-specific command line options from the


### PR DESCRIPTION
process.env has a few quirks that deserve documenting.

The commit documents:

- How assigning to process.env will implicitly call `toString()`
- How to remove an environment variable from process.env

/cc @cjihrig 