### PR TITLE
doc: add added

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -1,4 +1,7 @@
 # Assert
+<!-- YAML
+added: v0.1.21
+-->
 
     Stability: 3 - Locked
 
@@ -12,7 +15,14 @@ The API for the `assert` module is [Locked][]. This means that there will be no
 additions or changes to any of the methods implemented and exposed by
 the module.
 
-## assert(value[, message]), assert.ok(value[, message])
+## assert(value[, message])
+<!-- YAML
+added: v0.5.9
+-->
+## assert.ok(value[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests if `value` is truthy. It is equivalent to
 `assert.equal(!!value, true, message)`.
@@ -44,6 +54,9 @@ assert.ok(false, 'it\'s false');
 ```
 
 ## assert.deepEqual(actual, expected[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests for deep equality between the `actual` and `expected` parameters.
 Primitive values are compared with the equal comparison operator ( `==` ).
@@ -102,6 +115,9 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
 ## assert.deepStrictEqual(actual, expected[, message])
+<!-- YAML
+added: v1.2.0
+-->
 
 Generally identical to `assert.deepEqual` with the exception that primitive
 values are compared using the strict equality operator ( `===` ).
@@ -122,6 +138,9 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
 ## assert.doesNotThrow(block[, error][, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Asserts that the function `block` does not throw an error. See
 [`assert.throws()`][] for more details.
@@ -174,6 +193,9 @@ assert.doesNotThrow(
 ```
 
 ## assert.equal(actual, expected[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests shallow, coercive equality between the `actual` and `expected` parameters
 using the equal comparison operator ( `==` ).
@@ -197,6 +219,9 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
 ## assert.fail(actual, expected, message, operator)
+<!-- YAML
+added: v0.1.21
+-->
 
 Throws an `AssertionError`. If `message` is falsy, the error message is set as
 the values of `actual` and `expected` separated by the provided `operator`.
@@ -213,6 +238,9 @@ assert.fail(1, 2, 'whoops', '>');
 ```
 
 ## assert.ifError(value)
+<!-- YAML
+added: v0.1.97
+-->
 
 Throws `value` if `value` is truthy. This is useful when testing the `error`
 argument in callbacks.
@@ -227,6 +255,9 @@ assert.ifError(new Error()); // Throws Error
 ```
 
 ## assert.notDeepEqual(actual, expected[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests for any deep inequality. Opposite of [`assert.deepEqual`][].
 
@@ -268,6 +299,9 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
 ## assert.notDeepStrictEqual(actual, expected[, message])
+<!-- YAML
+added: v1.2.0
+-->
 
 Tests for deep strict inequality. Opposite of [`assert.deepStrictEqual`][].
 
@@ -286,6 +320,9 @@ with a `message` property set equal to the value of the `message` parameter. If
 the `message` parameter is undefined, a default error message is assigned.
 
 ## assert.notEqual(actual, expected[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests shallow, coercive inequality with the not equal comparison operator
 ( `!=` ).
@@ -308,6 +345,9 @@ property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
 ## assert.notStrictEqual(actual, expected[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests strict inequality as determined by the strict not equal operator
 ( `!==` ).
@@ -330,6 +370,9 @@ If the values are strictly equal, an `AssertionError` is thrown with a
 `message` parameter is undefined, a default error message is assigned.
 
 ## assert.strictEqual(actual, expected[, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Tests strict equality as determined by the strict equality operator ( `===` ).
 
@@ -351,6 +394,9 @@ If the values are not strictly equal, an `AssertionError` is thrown with a
 `message` parameter is undefined, a default error message is assigned.
 
 ## assert.throws(block[, error][, message])
+<!-- YAML
+added: v0.1.21
+-->
 
 Expects the function `block` to throw an error. If specified, `error` can be a
 constructor, [`RegExp`][], or validation function.

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -153,10 +153,16 @@ and try to print `obj` in REPL, it will invoke the custom `inspect()` function:
 ```
 
 ## Class: REPLServer
+<!-- YAML
+added: v0.1.92
+-->
 
 This inherits from [Readline Interface][] with the following events:
 
 ### Event: 'exit'
+<!-- YAML
+added: v0.9.1
+-->
 
 `function () {}`
 
@@ -175,6 +181,9 @@ replServer.on('exit', () => {
 
 
 ### Event: 'reset'
+<!-- YAML
+added: v0.11.8
+-->
 
 `function (context) {}`
 
@@ -197,6 +206,9 @@ replServer.on('reset', (context) => {
 ```
 
 ### replServer.defineCommand(keyword, cmd)
+<!-- YAML
+added: v0.3.0
+-->
 
 * `keyword` {String}
 * `cmd` {Object|Function}
@@ -235,6 +247,9 @@ Hello, Node.js User!
 ```
 
 ### replServer.displayPrompt([preserveCursor])
+<!-- YAML
+added: v0.1.92
+-->
 
 * `preserveCursor` {Boolean}
 
@@ -244,6 +259,9 @@ used primarily with `defineCommand`. It's also used internally to render each
 prompt line.
 
 ## repl.start(options)
+<!-- YAML
+added: v0.1.92
+-->
 
 Returns and starts a `REPLServer` instance, that inherits from
 [Readline Interface][]. Accepts an "options" Object that takes

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -1,4 +1,7 @@
 # Timers
+<!-- YAML
+added: v0.0.1
+-->
 
     Stability: 3 - Locked
 
@@ -6,18 +9,30 @@ All of the timer functions are globals.  You do not need to `require()`
 this module in order to use them.
 
 ## clearImmediate(immediateObject)
+<!-- YAML
+added: v0.9.1
+-->
 
 Stops an immediate from triggering.
 
 ## clearInterval(intervalObject)
+<!-- YAML
+added: v0.0.1
+-->
 
 Stops an interval from triggering.
 
 ## clearTimeout(timeoutObject)
+<!-- YAML
+added: v0.0.1
+-->
 
 Prevents a timeout from triggering.
 
 ## ref()
+<!-- YAML
+added: v0.9.1
+-->
 
 If you had previously `unref()`d a timer you can call `ref()` to explicitly
 request the timer hold the program open. If the timer is already `ref`d calling
@@ -26,6 +41,9 @@ request the timer hold the program open. If the timer is already `ref`d calling
 Returns the timer.
 
 ## setImmediate(callback[, arg][, ...])
+<!-- YAML
+added: v0.9.1
+-->
 
 To schedule the "immediate" execution of `callback` after I/O events
 callbacks and before [`setTimeout`][] and [`setInterval`][]. Returns an
@@ -40,6 +58,9 @@ until the next event loop iteration.
 If `callback` is not a function `setImmediate()` will throw immediately.
 
 ## setInterval(callback, delay[, arg][, ...])
+<!-- YAML
+added: v0.0.1
+-->
 
 To schedule the repeated execution of `callback` every `delay` milliseconds.
 Returns a `intervalObject` for possible use with `clearInterval()`. Optionally
@@ -52,6 +73,9 @@ milliseconds (approximately 25 days) or less than 1, Node.js will use 1 as the
 If `callback` is not a function `setInterval()` will throw immediately.
 
 ## setTimeout(callback, delay[, arg][, ...])
+<!-- YAML
+added: v0.0.1
+-->
 
 To schedule execution of a one-time `callback` after `delay` milliseconds.
 Returns a `timeoutObject` for possible use with `clearTimeout()`. Optionally you
@@ -69,6 +93,9 @@ immediately, as if the `delay` was set to 1.
 If `callback` is not a function `setTimeout()` will throw immediately.
 
 ## unref()
+<!-- YAML
+added: v0.9.1
+-->
 
 The opaque value returned by [`setTimeout`][] and [`setInterval`][] also has the
 method `timer.unref()` which will allow you to create a timer that is active but

--- a/doc/api/zlib.markdown
+++ b/doc/api/zlib.markdown
@@ -1,4 +1,7 @@
 # Zlib
+<!-- YAML
+added: v0.5.8
+-->
 
     Stability: 2 - Stable
 
@@ -242,30 +245,51 @@ See the description of `deflateInit2` and `inflateInit2` at
 <http://zlib.net/manual.html#Advanced> for more information on these.
 
 ## Class: zlib.Deflate
+<!-- YAML
+added: v0.5.8
+-->
 
 Compress data using deflate.
 
 ## Class: zlib.DeflateRaw
+<!-- YAML
+added: v0.5.8
+-->
 
 Compress data using deflate, and do not append a zlib header.
 
 ## Class: zlib.Gunzip
+<!-- YAML
+added: v0.5.8
+-->
 
 Decompress a gzip stream.
 
 ## Class: zlib.Gzip
+<!-- YAML
+added: v0.5.8
+-->
 
 Compress data using gzip.
 
 ## Class: zlib.Inflate
+<!-- YAML
+added: v0.5.8
+-->
 
 Decompress a deflate stream.
 
 ## Class: zlib.InflateRaw
+<!-- YAML
+added: v0.5.8
+-->
 
 Decompress a raw deflate stream.
 
 ## Class: zlib.Unzip
+<!-- YAML
+added: v0.5.8
+-->
 
 Decompress either a Gzip- or Deflate-compressed stream by auto-detecting
 the header.
@@ -276,6 +300,9 @@ Not exported by the `zlib` module. It is documented here because it is the base
 class of the compressor/decompressor classes.
 
 ### zlib.flush([kind], callback)
+<!-- YAML
+added: v0.5.8
+-->
 
 `kind` defaults to `zlib.Z_FULL_FLUSH`.
 
@@ -293,30 +320,51 @@ Reset the compressor/decompressor to factory defaults. Only applicable to
 the inflate and deflate algorithms.
 
 ## zlib.createDeflate([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [Deflate][] object with an [options][].
 
 ## zlib.createDeflateRaw([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [DeflateRaw][] object with an [options][].
 
 ## zlib.createGunzip([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [Gunzip][] object with an [options][].
 
 ## zlib.createGzip([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [Gzip][] object with an [options][].
 
 ## zlib.createInflate([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [Inflate][] object with an [options][].
 
 ## zlib.createInflateRaw([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [InflateRaw][] object with an [options][].
 
 ## zlib.createUnzip([options])
+<!-- YAML
+added: v0.5.8
+-->
 
 Returns a new [Unzip][] object with an [options][].
 


### PR DESCRIPTION
This is still a work in progress, as this will be a lot of changes, I figure the longer eyes can see it, the better.

This requires #3867

---
Introduces the YAML metadata concept and the "Added" property to the
documentation.

---
- [x] assert.markdown
```
v0.1.21 530328f12b4a00dfbc8ea57bafb1f9344912f0db
	ok, fail, equal, notEqual, deepEqual, notDeepEqual, strictEqual, notStrictEqual, throws

v0.1.21 4f679fd8d01c11c908bd5ca439a7aff956cda4ad
	doesNotThrow

v0.1.97 fe3d8f2411209b202b7fe74cb48b582ffc5cfc5f
	ifError

v0.5.9 8c8d51872361c0a30e56d2497daaf03a04c82849
	assert = assert.ok

v1.2.0 3f473ef141fdc7059928ebc4542b00e2f126ab07
	deepStrictEqual, notDeepStrictEqual
```

- [ ] modules.markdown

- [x] repl.markdown
```
v0.1.92 b7441040f87ff5e0e7b4575852996b6a64e0ea8f
	displayPrompt
	start

v0.3.0 56df0cbf93f78daf905eae7bd66daf0910650a72
	defineCommand

v0.7.0 3421f433519411c290c732c64dadbb6547e42235
	data

v0.9.1 659d449460d84c40fc5b3bf0e23575378d72d312
	exit

v0.11.8 eacdd4bf94edc8328f42e3591ba4dd79d347571
	reset
```

- [x] timers.markdown
```
v0.0.1 f213a276572a02fa9997c6e0375dc6de1a7333ba
	setTimeout, setInterval, clearTimeout, clearInterval

v0.9.1 cd6122edebe09a66a3a1a3fd0904ffda39d9007b
	ref, unref

v0.9.1 382f22f22959e686b10a5f42333c468e6654cb97
	setImmediate, clearImmediate
```

- [ ] zlib.markdown
```
v0.5.8 5b8e1dabbc117b38c56f874f4e6d5b7e537cd3c1
	Deflate, Inflate, Gzip, Gunzip, DeflateRaw, InflateRaw, Unzip
	createDeflate, createInflate, createDeflateRaw, createInflateRaw, createGzip, createGunzip, createUnzip
	flush, end, write, pause, resume
```

...adding to the list as I go