### PR TITLE
doc: update readline docs on EOL handling

### DIFF
--- a/doc/api/readline.markdown
+++ b/doc/api/readline.markdown
@@ -118,8 +118,9 @@ the `input` stream receives a `^C`, respectively known as `SIGINT`.
 
 `function (line) {}`
 
-Emitted whenever the `input` stream receives a `\n`, usually received when the
-user hits enter, or return. This is a good hook to listen for user input.
+Emitted whenever the `input` stream receives end of line (`\n`, `\r`, or `\r\n`),
+usually received when the user hits enter, or return.
+This is a good hook to listen for user input.
 
 Example of listening for `'line'`:
 


### PR DESCRIPTION
As raised in #4916 readline actually handles all the various forms of EOL (`\r`, `\r\n`, `\n`).