### PR TITLE
test: add common.platformTimeout() to dgram test

### DIFF
--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -1,16 +1,13 @@
 'use strict';
-var common = require('../common');
-
-var dgram = require('dgram');
-var client, timer, buf;
+const common = require('../common');
+const dgram = require('dgram');
 
 if (process.platform === 'darwin') {
   console.log('1..0 # Skipped: because of 17894467 Apple bug');
   return;
 }
 
-
-client = dgram.createSocket('udp4');
+const client = dgram.createSocket('udp4');
 
 client.bind(common.PORT);
 
@@ -19,9 +16,9 @@ client.on('message', function(buffer, bytes) {
   client.close();
 });
 
-buf = new Buffer(0);
+const buf = new Buffer(0);
 client.send(buf, 0, 0, common.PORT, '127.0.0.1', function(err, len) { });
 
-timer = setTimeout(function() {
+const timer = setTimeout(function() {
   throw new Error('Timeout');
-}, 200);
+}, common.platformTimeout(200));


### PR DESCRIPTION
Use common.platformTimeout() to mitigate potential for CI to timeout
on slower devices.

Ref: https://github.com/nodejs/node/issues/4937