### PR TITLE
dgram: scope redeclared variables

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -40,13 +40,13 @@ function lookup6(address, callback) {
 
 function newHandle(type) {
   if (type == 'udp4') {
-    var handle = new UDP();
+    const handle = new UDP();
     handle.lookup = lookup4;
     return handle;
   }
 
   if (type == 'udp6') {
-    var handle = new UDP();
+    const handle = new UDP();
     handle.lookup = lookup6;
     handle.bind = handle.bind6;
     handle.send = handle.send6;
@@ -209,7 +209,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
       if (!self._handle)
         return; // handle has been closed in the mean time
 
-      var err = self._handle.bind(ip, port || 0, flags);
+      const err = self._handle.bind(ip, port || 0, flags);
       if (err) {
         var ex = exceptionWithHostPort(err, 'bind', ip, port);
         self.emit('error', ex);
@@ -332,7 +332,7 @@ Socket.prototype.send = function(buffer,
                                   !!callback);
       if (err && callback) {
         // don't emit as error, dgram_legacy.js compatibility
-        var ex = exceptionWithHostPort(err, 'send', address, port);
+        const ex = exceptionWithHostPort(err, 'send', address, port);
         process.nextTick(callback, ex);
       }
     }


### PR DESCRIPTION
A few variables in `lib/dgram.js` are redeclared with `var` in a scope
where they have already been declared. These instances can be scoped
more narrowly with `const`, so that's what this change does.