### PR TITLE
test: scope redeclared vars in test-child-process*

### DIFF
--- a/test/parallel/test-child-process-default-options.js
+++ b/test/parallel/test-child-process-default-options.js
@@ -6,10 +6,11 @@ var spawn = require('child_process').spawn;
 
 process.env.HELLO = 'WORLD';
 
+var child;
 if (common.isWindows) {
-  var child = spawn('cmd.exe', ['/c', 'set'], {});
+  child = spawn('cmd.exe', ['/c', 'set'], {});
 } else {
-  var child = spawn('/usr/bin/env', [], {});
+  child = spawn('/usr/bin/env', [], {});
 }
 
 var response = '';

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -11,10 +11,11 @@ env.__proto__ = {
   'FOO': 'BAR'
 };
 
+var child;
 if (common.isWindows) {
-  var child = spawn('cmd.exe', ['/c', 'set'], {env: env});
+  child = spawn('cmd.exe', ['/c', 'set'], {env: env});
 } else {
-  var child = spawn('/usr/bin/env', [], {env: env});
+  child = spawn('/usr/bin/env', [], {env: env});
 }
 
 

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -24,9 +24,8 @@ if (common.isWindows) {
   return;
 }
 
+var server;
 if (process.argv[2] === 'child') {
-  var server;
-
   process.on('message', function removeMe(msg, clusterServer) {
     if (msg === 'server') {
       server = clusterServer;

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -42,7 +42,7 @@ if (process.argv[2] === 'child') {
   });
 
 } else {
-  var server = dgram.createSocket('udp4');
+  server = dgram.createSocket('udp4');
   var client = dgram.createSocket('udp4');
   var child = fork(__filename, ['child']);
 

--- a/test/parallel/test-child-process-silent.js
+++ b/test/parallel/test-child-process-silent.js
@@ -4,11 +4,11 @@ var assert = require('assert');
 var childProcess = require('child_process');
 
 // Child pipe test
-if (process.argv[2] === 'pipetest') {
+if (process.argv[2] === 'pipe') {
   process.stdout.write('stdout message');
   process.stderr.write('stderr message');
 
-} else if (process.argv[2] === 'ipctest') {
+} else if (process.argv[2] === 'ipc') {
   // Child IPC test
   process.send('message from child');
   process.on('message', function() {
@@ -18,7 +18,7 @@ if (process.argv[2] === 'pipetest') {
 } else if (process.argv[2] === 'parent') {
   // Parent | start child pipe test
 
-  var child = childProcess.fork(process.argv[1], ['pipetest'], {silent: true});
+  const child = childProcess.fork(process.argv[1], ['pipe'], {silent: true});
 
   // Allow child process to self terminate
   child._channel.close();
@@ -46,7 +46,7 @@ if (process.argv[2] === 'pipetest') {
   });
 
   // testing: do message system work when using silent
-  var child = childProcess.fork(process.argv[1], ['ipctest'], {silent: true});
+  const child = childProcess.fork(process.argv[1], ['ipc'], {silent: true});
 
   // Manual pipe so we will get errors
   child.stderr.pipe(process.stderr, {end: false});

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -36,7 +36,7 @@ function parent() {
 
   // then write a bunch more times.
   for (var i = 0; i < 100; i++) {
-    var buf = new Buffer(BUFSIZE);
+    const buf = new Buffer(BUFSIZE);
     buf.fill('.');
     sent += BUFSIZE;
     child.stdin.write(buf);

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -2,8 +2,8 @@
 // Flags: --expose_internals
 
 require('../common');
-var assert = require('assert');
-var _validateStdio = require('internal/child_process')._validateStdio;
+const assert = require('assert');
+const _validateStdio = require('internal/child_process')._validateStdio;
 
 // should throw if string and not ignore, pipe, or inherit
 assert.throws(function() {
@@ -16,27 +16,31 @@ assert.throws(function() {
 }, /Incorrect value of stdio option/);
 
 // should populate stdio with undefined if len < 3
-var stdio1 = [];
-var result = _validateStdio(stdio1, false);
-assert.equal(stdio1.length, 3);
-assert.equal(result.hasOwnProperty('stdio'), true);
-assert.equal(result.hasOwnProperty('ipc'), true);
-assert.equal(result.hasOwnProperty('ipcFd'), true);
+{
+  const stdio1 = [];
+  const result = _validateStdio(stdio1, false);
+  assert.equal(stdio1.length, 3);
+  assert.equal(result.hasOwnProperty('stdio'), true);
+  assert.equal(result.hasOwnProperty('ipc'), true);
+  assert.equal(result.hasOwnProperty('ipcFd'), true);
+}
 
 // should throw if stdio has ipc and sync is true
-var stdio2 = ['ipc', 'ipc', 'ipc'];
+const stdio2 = ['ipc', 'ipc', 'ipc'];
 assert.throws(function() {
   _validateStdio(stdio2, true);
 }, /You cannot use IPC with synchronous forks/);
 
-const stdio3 = [process.stdin, process.stdout, process.stderr];
-var result = _validateStdio(stdio3, false);
-assert.deepStrictEqual(result, {
-  stdio: [
-    { type: 'fd', fd: 0 },
-    { type: 'fd', fd: 1 },
-    { type: 'fd', fd: 2 }
-  ],
-  ipc: undefined,
-  ipcFd: undefined
-});
+{
+  const stdio3 = [process.stdin, process.stdout, process.stderr];
+  const result = _validateStdio(stdio3, false);
+  assert.deepStrictEqual(result, {
+    stdio: [
+      { type: 'fd', fd: 0 },
+      { type: 'fd', fd: 1 },
+      { type: 'fd', fd: 2 }
+    ],
+    ipc: undefined,
+    ipcFd: undefined
+  });
+}


### PR DESCRIPTION
A handful of child process tests had variables declared multiple times
in the same scope using `var`. This change scopes those declarations.