### PR TITLE
buffer: validate list elements in Buffer.concat

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -241,6 +241,8 @@ Buffer.concat = function(list, length) {
   var pos = 0;
   for (let i = 0; i < list.length; i++) {
     var buf = list[i];
+    if (!Buffer.isBuffer(buf))
+      throw new TypeError('"list" argument must be an Array of Buffers');
     buf.copy(buffer, pos);
     pos += buf.length;
   }

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -20,8 +20,18 @@ assert(flatOne !== one[0]);
 assert(flatLong.toString() === (new Array(10 + 1).join('asdf')));
 assert(flatLongLen.toString() === (new Array(10 + 1).join('asdf')));
 
-assert.throws(function() {
-  Buffer.concat([42]);
-}, TypeError);
+assertWrongList();
+assertWrongList(null);
+assertWrongList(new Buffer('hello'));
+assertWrongList([42]);
+assertWrongList(['hello', 'world']);
+assertWrongList(['hello', new Buffer('world')]);
 
-console.log('ok');
+function assertWrongList(value) {
+  assert.throws(function() {
+    Buffer.concat(value);
+  }, function(err) {
+    return err instanceof TypeError &&
+           err.message === '"list" argument must be an Array of Buffers';
+  });
+}


### PR DESCRIPTION
buffer: validate list elements in Buffer.concat

Without this change, if any of the elements in the list to be concatenated
is not a Buffer instance, the method fails with "buf.copy is not a function".
Make an instanceof check before using the copy method so that we can throw
a with a better message.

Fixes: https://github.com/nodejs/node/issues/4949