### PR TITLE
doc: spell writable consistently

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -566,7 +566,7 @@ The file is created if it does not exist.
 * `'ax+'` - Like `'a+'` but fails if `path` exists.
 
 `mode` sets the file mode (permission and sticky bits), but only if the file was
-created. It defaults to `0666`, readable and writeable.
+created. It defaults to `0666`, readable and writable.
 
 The callback gets two arguments `(err, fd)`.
 


### PR DESCRIPTION
Docs have 108 instances of "writable" and only 1 "writeable" so
fix this one.