### PR TITLE
vm: adds runInModuleContext()

### DIFF
--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -277,7 +277,7 @@ console.log('localVar: ', localVar);
 // vmResult: 'vm', localVar: 'initial value'
 // evalResult: 'eval', localVar: 'eval'
 ```
-
+<a name="runInThisContext"></a>
 `vm.runInThisContext` does not have access to the local scope, so `localVar` is
 unchanged. `eval` does have access to the local scope, so `localVar` is changed.
 
@@ -296,6 +296,31 @@ e.g. `(0,eval)('code')`. However, it also has the following additional options:
   `true`.
 - `timeout`: a number of milliseconds to execute `code` before terminating
   execution. If execution is terminated, an [`Error`][] will be thrown.
+
+## vm.runInModuleContext(code[, options])
+
+`vm.runInModuleContext()` compiles `code`, runs it and returns the result. Running
+code does not have access to local scope, but does have access to `module`,
+`exports` and `require`. You can expect the script to behave similar to scripts
+in the global context e.g. requiring global modules.
+
+Example of using `vm.runInModuleContext` requiring `http` and a run a server:
+
+```js
+const vm = require('vm')
+
+const vmResult = vm.runInModuleContext(`
+  const http = require('http');
+  http.createServer( (request, response) => {
+    response.writeHead(200, {'Content-Type': 'text/plain'});
+    response.end('Hello World\\n');
+  }).listen(8124);
+
+  console.log('Server running at http://127.0.0.1:8124/');
+`)
+```
+
+For options, see [`vm.runInThisContext()`](#runInThisContext)
 
 [indirect `eval` call]: https://es5.github.io/#x10.4.2
 [global object]: https://es5.github.io/#x15.1

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -54,4 +54,10 @@ exports.runInThisContext = function(code, options) {
   return script.runInThisContext(options);
 };
 
+exports.runInModuleContext = function(code, options) {
+  var script = new Script(require('module').wrap(code), options);
+  let passThrough = options && options.passThrough ? options.passThrough : []
+  return script.runInThisContext(options).apply(null, passThrough);
+};
+
 exports.isContext = binding.isContext;

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -35,16 +35,25 @@ var result = vm.runInThisContext(
 );
 assert.strictEqual(global.vmResult, 'foo');
 assert.strictEqual(result, '[object process]');
+
+// Test 4: vm.runInGlobalContext
+var result = vm.runInModuleContext(`
+  const path = require('path')
+  vmResult = path.dirname('/foo/bar/baz/asdf/quux');
+  Object.prototype.toString.call(process);`
+);
+assert.strictEqual(global.vmResult,
+  require('path').dirname('/foo/bar/baz/asdf/quux'));
 delete global.vmResult;
 
-// Test 4: vm.runInNewContext
+// Test 5: vm.runInNewContext
 var result = vm.runInNewContext(
   'vmResult = "foo"; typeof process;'
 );
 assert.strictEqual(global.vmResult, undefined);
 assert.strictEqual(result, 'undefined');
 
-// Test 5: vm.createContext
+// Test 6: vm.createContext
 var sandbox3 = {};
 var context2 = vm.createContext(sandbox3);
 assert.strictEqual(sandbox3, context2);


### PR DESCRIPTION
With regards to nodejs/node-v0.x-archive#9211, [this SO question](http://stackoverflow.com/questions/20899863/the-module-property-is-undefined-when-using-vm-runinthiscontext) and in order to prevent a signature like the below, I want to propose `vm.runInGlobalContext()`. This would make the `vm` API more clear to users, who expect at least one method `vm` that behaves exactly like their global context.

```js
const vmResult = vm.runInThisContext(require('module').wrap(`
   const http = require('http');
   http.createServer( (request, response) => {
     response.writeHead(200, {'Content-Type': 'text/plain'});
     response.end('Hello World\\n');
   }).listen(8124);

   console.log('Server running at http://127.0.0.1:8124/');
`))(exports, require, module, __filename, __dirname)
```