### PR TITLE
crypto: remove POINT_CONVERSION_HYBRID

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -472,9 +472,9 @@ Generates private and public EC Diffie-Hellman key values, and returns
 the public key in the specified `format` and `encoding`. This key should be
 transferred to the other party.
 
-The `format` arguments specifies point encoding and can be `'compressed'`,
-`'uncompressed'`, or `'hybrid'`. If `format` is not specified, the point will
-be returned in `'uncompressed'` format.
+The `format` arguments specifies point encoding and can be `'compressed'` or
+`'uncompressed'`. If `format` is not specified, the point will be returned in
+`'uncompressed'` format.
 
 The `encoding` argument can be `'latin1'`, `'hex'`, or `'base64'`. If
 `encoding` is provided a string is returned; otherwise a [`Buffer`][]
@@ -491,9 +491,9 @@ a string is returned; otherwise a [`Buffer`][] is returned.
 Returns the EC Diffie-Hellman public key in the specified `encoding` and
 `format`.
 
-The `format` argument specifies point encoding and can be `'compressed'`,
-`'uncompressed'`, or `'hybrid'`. If `format` is not specified the point will be
-returned in `'uncompressed'` format.
+The `format` argument specifies point encoding and can be `'compressed'` or
+`'uncompressed'`. If `format` is not specified the point will be returned in
+`'uncompressed'` format.
 
 The `encoding` argument can be `'latin1'`, `'hex'`, or `'base64'`. If
 `encoding` is specified, a string is returned; otherwise a [`Buffer`][] is


### PR DESCRIPTION
Compressed points are already rare and, as far as I know, nobody has used
the 'hybrid' format anywhere, ever. It's prohibited in X.509
certificates too[1].

This change removes support for it in the interests of trying to
pare-down the complexity of cryptography.

[1] https://tools.ietf.org/html/rfc5480#section-2.2