### PR TITLE
fs: refactor redeclared variables

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1460,17 +1460,19 @@ fs.unwatchFile = function(filename, listener) {
 
 // Regexp that finds the next partion of a (partial) path
 // result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
+var nextPartRe;
 if (isWindows) {
-  var nextPartRe = /(.*?)(?:[\/\\]+|$)/g;
+  nextPartRe = /(.*?)(?:[\/\\]+|$)/g;
 } else {
-  var nextPartRe = /(.*?)(?:[\/]+|$)/g;
+  nextPartRe = /(.*?)(?:[\/]+|$)/g;
 }
 
 // Regex to find the device root, including trailing slash. E.g. 'c:\\'.
+var splitRootRe;
 if (isWindows) {
-  var splitRootRe = /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/;
+  splitRootRe = /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/;
 } else {
-  var splitRootRe = /^[\/]*/;
+  splitRootRe = /^[\/]*/;
 }
 
 fs.realpathSync = function realpathSync(p, cache) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1460,20 +1460,14 @@ fs.unwatchFile = function(filename, listener) {
 
 // Regexp that finds the next partion of a (partial) path
 // result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
-var nextPartRe;
-if (isWindows) {
-  nextPartRe = /(.*?)(?:[\/\\]+|$)/g;
-} else {
-  nextPartRe = /(.*?)(?:[\/]+|$)/g;
-}
+const nextPartRe = isWindows ?
+  /(.*?)(?:[\/\\]+|$)/g :
+  /(.*?)(?:[\/]+|$)/g;
 
 // Regex to find the device root, including trailing slash. E.g. 'c:\\'.
-var splitRootRe;
-if (isWindows) {
-  splitRootRe = /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/;
-} else {
-  splitRootRe = /^[\/]*/;
-}
+const splitRootRe = isWindows ?
+  /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/ :
+  /^[\/]*/;
 
 fs.realpathSync = function realpathSync(p, cache) {
   // make p is absolute


### PR DESCRIPTION
Two variables are declared twice with `var` in the same scope in
`lib/fs.js`. This change refactors the code so the variable is declared
just once.