### PR TITLE
deps: upgrade to npm 2.14.16

### DIFF
--- a/deps/npm/.travis.yml
+++ b/deps/npm/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "5"
   - "4"
@@ -11,7 +12,7 @@ env:
 before_install:
   - "npm config set spin false"
   - "npm install -g npm/npm#2.x"
-  - "sudo mkdir -p /var/run/couchdb"
+  - "mkdir -p /var/run/couchdb"
 script: "npm run-script test-all"
 notifications:
     slack: npm-inc:kRqQjto7YbINqHPb1X6nS3g8

--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -329,3 +329,12 @@ ekmartin <mail@ekmartin.com>
 Rafał Pocztarski <r.pocztarski@gmail.com>
 Ashley Williams <ashley666ashley@gmail.com>
 Mark Reeder <mreeder@uber.com>
+Tiago Rodrigues <tmcrodrigues@gmail.com>
+Chris Rebert <github@chrisrebert.com>
+Jeff McMahan <jeffrey.lee.mcmahan@gmail.com>
+Scott Addie <tobias.addie@gmail.com>
+Julian Simioni <julian@simioni.org>
+Jimb Esser <jimb@yahoo-inc.com>
+Hal Henke <halhenke@gmail.com>
+Alexis Campailla <alexis@janeasystems.com>
+Beau Gunderson <beau@beaugunderson.com>

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,124 @@
+### v2.14.16 (2016-01-21):
+
+Good to see you all again! It's been a while since we had an LTS release, and
+the team continues to work hard to both get the issue tracker under control, and
+get our test suite to be awesome and reliable.
+
+This is also the first LTS release of this year.
+
+We're gonna have an interesting time -- most of our focus this year will be
+around stability and maintainability of the CLI, so you might actually end up
+seeing a number of updates even over here, just for the sake of making sure
+we're stable, that bugs get fixed, and tests have proper coverage.
+
+What better way to start this effort, then, than getting Travis tests green, fix
+a few things here and there, and tweak a bunch of documentation? 😁
+
+#### FIX ALL THE BUGS AND TWEAK ALL THE THINGS
+
+* [`24b13fb`](https://github.com/npm/npm/commit/24b13fbc57d34db1d5b0a37bcca122c00deba978)
+  [#11158](https://github.com/npm/npm/pull/11158)
+  Fix custom node-gyp env var quoting on Windows.
+  ([@orangemocha](https://github.com/orangemocha))
+* [`e2503f2`](https://github.com/npm/npm/commit/e2503f2be40157b05a9c500ec3b5d16090ffee50)
+  [#11142](https://github.com/npm/npm/pull/11142)
+  Fix race condition with `correctMkdir` in the cache directory.
+  ([@Jimbly](https://github.com/Jimbly))
+
+* [`5c0e4c4`](https://github.com/npm/npm/commit/5c0e4c45a29d774ab729e86044377d4e5e424252)
+  [#10940](https://github.com/npm/npm/pull/10940)
+  Ignore failures replacing `package.json`. writeFileAtomic is not atomic in
+  Windows, it fails if the file is being accessed concurrently.
+  ([@orangemocha](https://github.com/orangemocha))
+* [`2c44d8d`](https://github.com/npm/npm/commit/2c44d8dc8c267d5e054d0175ce2f4750f0986463)
+  [#10903](https://github.com/npm/npm/pull/10903)
+  Add tests for `npm adduser --scope`.
+  ([@ekmartin](https://github.com/ekmartin))
+* [`4cb25d0`](https://github.com/npm/npm/commit/4cb25d0fed5c7792dfd1aec891380ecc1f8a5761)
+  [#10903](https://github.com/npm/npm/pull/10903)
+  Add a message informing users when they have been successfully logged in.
+  ([@ekmartin](https://github.com/ekmartin))
+* [`fe3ec6d`](https://github.com/npm/npm/commit/fe3ec6d6658262054c0c19c55373c21e84ab9f17)
+  [#10628](https://github.com/npm/npm/pull/10628)
+  Tell users how to open an issue with a package that has errored.
+  ([@trodrigues](https://github.com/trodrigues))
+
+#### DOCS DOCS DOCS
+
+We got a TON of lovely documentation patches, too! Thanks all for submitting!
+
+* [`22482a1`](https://github.com/npm/npm/commit/22482a1f22079d72c3f8ca55c2f0c153bdd024c0)
+  [#11188](https://github.com/npm/npm/pull/11188)
+  Briefly explain what's included when you publish.
+  ([@beaugunderson](https://github.com/beaugunderson))
+* [`fa47724`](https://github.com/npm/npm/commit/fa4772438df0c66a19309dd1c1a3ce43cbee5461)
+  [#11150](https://github.com/npm/npm/pull/11150)
+  Advise use of `--depth Infinity` instead of `--depth 9999` in `npm update`.
+  ([@halhenke](https://github.com/halhenke))
+* [`248ddfe`](https://github.com/npm/npm/commit/248ddfe8f7ddd3318e14bf61de41cab4a638c8a3)
+  [#11130](https://github.com/npm/npm/pull/11130)
+  Nuke "using npm programmatically" section from README. The programmatic npm
+  API is unsupported, and is not guaranteed not to break in non-major versions.
+  Removing this section so newcomers aren't encouraged to discover or use it.
+  ([@ljharb](https://github.com/ljharb))
+* [`ae9c452`](https://github.com/npm/npm/commit/ae9c4521222d60ab4a69c19fee5e361c62f41fae)
+  [#11128](https://github.com/npm/npm/pull/11128)
+  Add link to local paths section indocs for `package.json`.
+  ([@orangejulius](https://github.com/orangejulius))
+* [`663a8c6`](https://github.com/npm/npm/commit/663a8c6b4b1647f9b86c15ef32e30023edc8c060)
+  [#11044](https://github.com/npm/npm/pull/11044)
+  Update default value documentation for the color option in npm's config.
+  ([@scottaddie](https://github.com/scottaddie))
+* [`5c1dda0`](https://github.com/npm/npm/commit/5c1dda0d3a18b2954872dba33fbc696ff0700ffe)
+  [#11037](https://github.com/npm/npm/pull/11037)
+  Correct the name property max length constraint verbiage.
+  ([@scottaddie](https://github.com/scottaddie))
+* [`8288365`](https://github.com/npm/npm/commit/8288365d08e97fa3a5b0d31703c015a8be49e07f)
+  [#10990](https://github.com/npm/npm/pull/10990)
+  Update folder docs to reflect that process.installPrefix was removed as of
+  0.8.x.
+  ([@jeffmcmahan](https://github.com/jeffmcmahan))
+* [`61d63fa`](https://github.com/npm/npm/commit/61d63fa22c4f09742180c2de460a4ffb6c32738e)
+  [#10790](https://github.com/npm/npm/pull/10790)
+  Clarify that `npm install foo` is the same as `npm install foo@latest` now.
+  ([@cvrebert](https://github.com/cvrebert))
+* [`442c920`](https://github.com/npm/npm/commit/442c9207f375354c91d36df8711ba2d33e1c97f3)
+  [#10789](https://github.com/npm/npm/pull/10789)
+  Link over to `npm-dist-tag(1)` in `npm install` docs when they talk about the
+  `pkg@<tag>` syntax.
+  ([@cvrebert](https://github.com/cvrebert))
+* [`dca7a5e`](https://github.com/npm/npm/commit/dca7a5e2be3bfa306a870a123707d35c732406c0)
+  [#10788](https://github.com/npm/npm/pull/10788)
+  Link to tag docs in docs for `npm publish --tag`.
+  ([@cvrebert](https://github.com/cvrebert))
+* [`a72904e`](https://github.com/npm/npm/commit/a72904e8d4ab1d43ae8150fbe3f6468b0cbb1efd)
+  [#10787](https://github.com/npm/npm/pull/10787)
+  Explain why the `latest` tag matters.
+  ([@cvrebert](https://github.com/cvrebert))
+* [`9d0697a`](https://github.com/npm/npm/commit/9d0697a534046df7efda32170014041bbc1f4e7d)
+  [#10785](https://github.com/npm/npm/pull/10785)
+  Replace some quite marks in `npm dist-tag` docs for the sake of consistency.
+  ([@cvrebert](https://github.com/cvrebert))
+
+#### I REALLY LIKE GREEN. CAN YOU TELL?
+
+So Travis is all green now on `npm@2`, thanks to the removal of nock and a few
+other test suite tweaks. This is a fantastic step towards making sure we can all
+have confidence in our test suite! 🎉
+
+* [`64995be`](https://github.com/npm/npm/commit/64995be6d874356b15c136f9867302d805dfe1e9) [`75ab216`](https://github.com/npm/npm/commit/75ab2164cf79e28ac7f7ebe714f3c5aee99c6626) [`a9f6fe9`](https://github.com/npm/npm/commit/a9f6fe9dc558f17c4a7b9eb83329ac080f7df4b7) [`649c193`](https://github.com/npm/npm/commit/649c193adadf714c2819837f9372a29d724a5ec0) [`94cb05e`](https://github.com/npm/npm/commit/94cb05eaa9e5ad6675cf15c4ac0a44fbdde05900) [`6541690`](https://github.com/npm/npm/commit/65416907008061ac5a5f66b1630a57776803b526) [`255be6f`](https://github.com/npm/npm/commit/255be6f5bca9e3d216f3a5cbdf6714c6c9fcf132) [`9e84fa4`](https://github.com/npm/npm/commit/9e84fa43c49d04cf86ca1678e2a61412f5559cb9) [`8a587b0`](https://github.com/npm/npm/commit/8a587b0c1696ae7302891fa6355fc3e8670e00d3) [`bf812a5`](https://github.com/npm/npm/commit/bf812a54e497a573493346399798aa0b9373ac24)
+  [#10903](https://github.com/npm/npm/pull/10903)
+  Get rid of nock from tests, and get Travis green.
+  ([@zkat](https://github.com/zkat) and [@iarna](https://github.com/iarna))
+* [`70a5310`](https://github.com/npm/npm/commit/70a5310712c6666e753ca8f3bfff4a780ec6292d)
+  `npm-registry-couchapp@2.6.12`:
+  Better 0.8 compatibility, and ability to run in travis docker stuff. This
+  means the test suite should run a lot faster, too!
+  ([@iarna](https://github.com/iarna))
+* [`28fae39`](https://github.com/npm/npm/commit/28fae399212eda5554e6c0ffd8c9591144ab7b9d)
+  Get rid of sudo, for Travis!
+  ([@zkat](https://github.com/zkat))
+
 ### v2.14.15 (2015-12-10):
 
 Did you know that Bob Ross reached the rank of master sergeant in the US Air

--- a/deps/npm/README.md
+++ b/deps/npm/README.md
@@ -138,52 +138,6 @@ must remove them yourself manually if you want them gone.  Note that
 this means that future npm installs will not remember the settings that
 you have chosen.
 
-## Using npm Programmatically
-
-Although npm can be used programmatically, its API is meant for use by the CLI
-*only*, and no guarantees are made regarding its fitness for any other purpose.
-If you want to use npm to reliably perform some task, the safest thing to do is
-to invoke the desired `npm` command with appropriate arguments.
-
-The semantic version of npm refers to the CLI itself, rather than the
-underlying API. _The internal API is not guaranteed to remain stable even when
-npm's version indicates no breaking changes have been made according to
-semver._
-
-If you _still_ would like to use npm programmatically, it's _possible_. The API
-isn't very well documented, but it _is_ rather simple.
-
-Eventually, npm will be just a thin CLI wrapper around the modules that it
-depends on, but for now, there are some things that only the CLI can do. You
-should try using one of npm's dependencies first, and only use the API if what
-you're trying to do is only supported by npm itself.
-
-```javascript
-var npm = require("npm")
-npm.load(myConfigObject, function (er) {
-  if (er) return handlError(er)
-  npm.commands.install(["some", "args"], function (er, data) {
-    if (er) return commandFailed(er)
-    // command succeeded, and data might have some info
-  })
-  npm.registry.log.on("log", function (message) { .... })
-})
-```
-
-The `load` function takes an object hash of the command-line configs.
-The various `npm.commands.<cmd>` functions take an **array** of
-positional argument **strings**.  The last argument to any
-`npm.commands.<cmd>` function is a callback.  Some commands take other
-optional arguments.  Read the source.
-
-You cannot set configs individually for any single npm function at this
-time.  Since `npm` is a singleton, any call to `npm.config.set` will
-change the value for *all* npm commands in that process.
-
-See `./bin/npm-cli.js` for an example of pulling config values off of the
-command line arguments using nopt.  You may also want to check out `npm
-help config` to learn about all the options you can set there.
-
 ## More Docs
 
 Check out the [docs](https://docs.npmjs.com/),

--- a/deps/npm/bin/node-gyp-bin/node-gyp.cmd
+++ b/deps/npm/bin/node-gyp-bin/node-gyp.cmd
@@ -1,5 +1,5 @@
 if not defined npm_config_node_gyp (
   node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
 ) else (
-  node %npm_config_node_gyp% %*
+  node "%npm_config_node_gyp%" %*
 )

--- a/deps/npm/doc/cli/npm-dist-tag.md
+++ b/deps/npm/doc/cli/npm-dist-tag.md
@@ -33,17 +33,30 @@ When installing dependencies, a preferred tagged version may be specified:
 
 This also applies to `npm dedupe`.
 
-Publishing a package sets the "latest" tag to the published version unless the
+Publishing a package sets the `latest` tag to the published version unless the
 `--tag` option is used. For example, `npm publish --tag=beta`.
+
+By default, `npm install <pkg>` (without any `@<version>` or `@<tag>`
+specifier) installs the `latest` tag.
 
 ## PURPOSE
 
-Tags can be used to provide an alias instead of version numbers.  For
-example, `npm` currently uses the tag "next" to identify the upcoming
-version, and the tag "latest" to identify the current version.
+Tags can be used to provide an alias instead of version numbers.
 
-A project might choose to have multiple streams of development, e.g.,
-"stable", "canary".
+For example, a project might choose to have multiple streams of development
+and use a different tag for each stream,
+e.g., `stable`, `beta`, `dev`, `canary`.
+
+By default, the `latest` tag is used by npm to identify the current version of
+a package, and `npm install <pkg>` (without any `@<version>` or `@<tag>`
+specifier) installs the `latest` tag. Typically, projects only use the `latest`
+tag for stable release versions, and use other tags for unstable versions such
+as prereleases.
+
+The `next` tag is used by some projects to identify the upcoming version.
+
+By default, other than `latest`, no tag has any special significance to npm
+itself.
 
 ## CAVEATS
 

--- a/deps/npm/doc/cli/npm-install.md
+++ b/deps/npm/doc/cli/npm-install.md
@@ -25,7 +25,7 @@ A `package` is:
 * b) a gzipped tarball containing (a)
 * c) a url that resolves to (b)
 * d) a `<name>@<version>` that is published on the registry (see `npm-registry(7)`) with (c)
-* e) a `<name>@<tag>` that points to (d)
+* e) a `<name>@<tag>` (see `npm-dist-tag(1)`) that points to (d)
 * f) a `<name>` that has a "latest" tag satisfying (e)
 * g) a `<git remote url>` that resolves to (b)
 
@@ -76,7 +76,7 @@ after packing it up into a tarball (b).
 * `npm install [@<scope>/]<name> [--save|--save-dev|--save-optional]`:
 
     Do a `<name>@<tag>` install, where `<tag>` is the "tag" config. (See
-    `npm-config(7)`.)
+    `npm-config(7)`. The config's default value is `latest`.)
 
     In most cases, this will install the latest version
     of the module published on npm.

--- a/deps/npm/doc/cli/npm-publish.md
+++ b/deps/npm/doc/cli/npm-publish.md
@@ -9,9 +9,11 @@ npm-publish(1) -- Publish a package
 
 ## DESCRIPTION
 
-Publishes a package to the registry so that it can be installed by name. See
-`npm-developers(7)` for details on what's included in the published package, as
-well as details on how the package is built.
+Publishes a package to the registry so that it can be installed by name. All
+files in the package directory are included if no local `.gitignore` or
+`.npmignore` file is present. See `npm-developers(7)` for full details on
+what's included in the published package, as well as details on how the package
+is built.
 
 By default npm will publish to the public registry. This can be overridden by
 specifying a different default registry or using a `npm-scope(7)` in the name
@@ -27,7 +29,8 @@ specifying a different default registry or using a `npm-scope(7)` in the name
 * `[--tag <tag>]`
   Registers the published package with the given tag, such that `npm install
   <name>@<tag>` will install this version.  By default, `npm publish` updates
-  and `npm install` installs the `latest` tag.
+  and `npm install` installs the `latest` tag. See `npm-dist-tag(1)` for
+  details about tags.
 
 * `[--access <public|restricted>]`
   Tells the registry whether this package should be published as public or

--- a/deps/npm/doc/cli/npm-update.md
+++ b/deps/npm/doc/cli/npm-update.md
@@ -22,7 +22,7 @@ or local) will be updated.
 
 As of `npm@2.6.1`, the `npm update` will only inspect top-level packages.
 Prior versions of `npm` would also recursively inspect all dependencies.
-To get the old behavior, use `npm --depth 9999 update`, but be warned that
+To get the old behavior, use `npm --depth Infinity update`, but be warned that
 simultaneous asynchronous update of all packages, including `npm` itself
 and packages that `npm` depends on, often causes problems up to and including
 the uninstallation of `npm` itself.

--- a/deps/npm/doc/files/npm-folders.md
+++ b/deps/npm/doc/files/npm-folders.md
@@ -20,12 +20,10 @@ This document will tell you what it puts where.
 ### prefix Configuration
 
 The `prefix` config defaults to the location where node is installed.
-On most systems, this is `/usr/local`, and most of the time is the same
-as node's `process.installPrefix`.
-
-On windows, this is the exact location of the node.exe binary.  On Unix
-systems, it's one level up, since node is typically installed at
-`{prefix}/bin/node` rather than `{prefix}/node.exe`.
+On most systems, this is `/usr/local`. On windows, this is the exact
+location of the node.exe binary.  On Unix systems, it's one level up,
+since node is typically installed at `{prefix}/bin/node` rather than
+`{prefix}/node.exe`.
 
 When the `global` flag is set, npm installs things into this prefix.
 When it is not set, it uses the root of the current package, or the

--- a/deps/npm/doc/files/package.json.md
+++ b/deps/npm/doc/files/package.json.md
@@ -21,7 +21,7 @@ The name is what your thing is called.
 
 Some rules:
 
-* The name must be shorter than 214 characters. This includes the scope for
+* The name must be less than or equal to 214 characters. This includes the scope for
   scoped packages.
 * The name can't start with a dot or an underscore.
 * New packages must not have uppercase letters in the name.
@@ -410,7 +410,7 @@ See semver(7) for more details about specifying version ranges.
 * `git...` See 'Git URLs as Dependencies' below
 * `user/repo` See 'GitHub URLs' below
 * `tag` A specific version tagged and published as `tag`  See `npm-tag(1)`
-* `path/path/path` See Local Paths below
+* `path/path/path` See [Local Paths](#local-paths) below
 
 For example, these are all valid:
 

--- a/deps/npm/doc/misc/npm-config.md
+++ b/deps/npm/doc/misc/npm-config.md
@@ -232,7 +232,7 @@ A client certificate to pass when accessing the registry.
 
 ### color
 
-* Default: true on Posix, false on Windows
+* Default: true
 * Type: Boolean or `"always"`
 
 If false, never shows colors.  If `"always"` then always shows colors.

--- a/deps/npm/html/doc/README.html
+++ b/deps/npm/html/doc/README.html
@@ -92,42 +92,6 @@ npm config get globalconfig # defaults to /usr/local/etc/npmrc
 must remove them yourself manually if you want them gone.  Note that
 this means that future npm installs will not remember the settings that
 you have chosen.</p>
-<h2 id="using-npm-programmatically">Using npm Programmatically</h2>
-<p>Although npm can be used programmatically, its API is meant for use by the CLI
-<em>only</em>, and no guarantees are made regarding its fitness for any other purpose.
-If you want to use npm to reliably perform some task, the safest thing to do is
-to invoke the desired <code>npm</code> command with appropriate arguments.</p>
-<p>The semantic version of npm refers to the CLI itself, rather than the
-underlying API. <em>The internal API is not guaranteed to remain stable even when
-npm&#39;s version indicates no breaking changes have been made according to
-semver.</em></p>
-<p>If you <em>still</em> would like to use npm programmatically, it&#39;s <em>possible</em>. The API
-isn&#39;t very well documented, but it <em>is</em> rather simple.</p>
-<p>Eventually, npm will be just a thin CLI wrapper around the modules that it
-depends on, but for now, there are some things that only the CLI can do. You
-should try using one of npm&#39;s dependencies first, and only use the API if what
-you&#39;re trying to do is only supported by npm itself.</p>
-<pre><code class="lang-javascript">var npm = require(&quot;npm&quot;)
-npm.load(myConfigObject, function (er) {
-  if (er) return handlError(er)
-  npm.commands.install([&quot;some&quot;, &quot;args&quot;], function (er, data) {
-    if (er) return commandFailed(er)
-    // command succeeded, and data might have some info
-  })
-  npm.registry.log.on(&quot;log&quot;, function (message) { .... })
-})
-</code></pre>
-<p>The <code>load</code> function takes an object hash of the command-line configs.
-The various <code>npm.commands.&lt;cmd&gt;</code> functions take an <strong>array</strong> of
-positional argument <strong>strings</strong>.  The last argument to any
-<code>npm.commands.&lt;cmd&gt;</code> function is a callback.  Some commands take other
-optional arguments.  Read the source.</p>
-<p>You cannot set configs individually for any single npm function at this
-time.  Since <code>npm</code> is a singleton, any call to <code>npm.config.set</code> will
-change the value for <em>all</em> npm commands in that process.</p>
-<p>See <code>./bin/npm-cli.js</code> for an example of pulling config values off of the
-command line arguments using nopt.  You may also want to check out <code>npm
-help config</code> to learn about all the options you can set there.</p>
 <h2 id="more-docs">More Docs</h2>
 <p>Check out the <a href="https://docs.npmjs.com/">docs</a>,
 especially the <a href="https://docs.npmjs.com/misc/faq">faq</a>.</p>
@@ -163,5 +127,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@2.14.15</p>
+<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-bin.html
+++ b/deps/npm/html/doc/api/npm-bin.html
@@ -28,5 +28,5 @@ to the <code>npm.bin</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@2.14.15</p>
+<p id="footer">npm-bin &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-bugs.html
+++ b/deps/npm/html/doc/api/npm-bugs.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@2.14.15</p>
+<p id="footer">npm-bugs &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-cache.html
+++ b/deps/npm/html/doc/api/npm-cache.html
@@ -42,5 +42,5 @@ incrementation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@2.14.15</p>
+<p id="footer">npm-cache &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-commands.html
+++ b/deps/npm/html/doc/api/npm-commands.html
@@ -36,5 +36,5 @@ usage, or <code>man 3 npm-&lt;command&gt;</code> for programmatic usage.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-commands &mdash; npm@2.14.15</p>
+<p id="footer">npm-commands &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-config.html
+++ b/deps/npm/html/doc/api/npm-config.html
@@ -57,5 +57,5 @@ functions instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.14.15</p>
+<p id="footer">npm-config &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-deprecate.html
+++ b/deps/npm/html/doc/api/npm-deprecate.html
@@ -47,5 +47,5 @@ a deprecation warning to all who attempt to install it.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@2.14.15</p>
+<p id="footer">npm-deprecate &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-docs.html
+++ b/deps/npm/html/doc/api/npm-docs.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@2.14.15</p>
+<p id="footer">npm-docs &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-edit.html
+++ b/deps/npm/html/doc/api/npm-edit.html
@@ -36,5 +36,5 @@ and how this is used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@2.14.15</p>
+<p id="footer">npm-edit &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-explore.html
+++ b/deps/npm/html/doc/api/npm-explore.html
@@ -31,5 +31,5 @@ sure to use <code>npm rebuild &lt;pkg&gt;</code> if you make any changes.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@2.14.15</p>
+<p id="footer">npm-explore &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-help-search.html
+++ b/deps/npm/html/doc/api/npm-help-search.html
@@ -44,5 +44,5 @@ Name of the file that matched</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@2.14.15</p>
+<p id="footer">npm-help-search &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-init.html
+++ b/deps/npm/html/doc/api/npm-init.html
@@ -39,5 +39,5 @@ then go ahead and use this programmatically.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@2.14.15</p>
+<p id="footer">npm-init &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-install.html
+++ b/deps/npm/html/doc/api/npm-install.html
@@ -32,5 +32,5 @@ installed or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@2.14.15</p>
+<p id="footer">npm-install &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-link.html
+++ b/deps/npm/html/doc/api/npm-link.html
@@ -42,5 +42,5 @@ the package in the current working directory</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@2.14.15</p>
+<p id="footer">npm-link &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-load.html
+++ b/deps/npm/html/doc/api/npm-load.html
@@ -37,5 +37,5 @@ config object.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-load &mdash; npm@2.14.15</p>
+<p id="footer">npm-load &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-ls.html
+++ b/deps/npm/html/doc/api/npm-ls.html
@@ -63,5 +63,5 @@ dependency will only be output once.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@2.14.15</p>
+<p id="footer">npm-ls &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-outdated.html
+++ b/deps/npm/html/doc/api/npm-outdated.html
@@ -28,5 +28,5 @@ currently outdated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@2.14.15</p>
+<p id="footer">npm-outdated &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-owner.html
+++ b/deps/npm/html/doc/api/npm-owner.html
@@ -47,5 +47,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@2.14.15</p>
+<p id="footer">npm-owner &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-pack.html
+++ b/deps/npm/html/doc/api/npm-pack.html
@@ -33,5 +33,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@2.14.15</p>
+<p id="footer">npm-pack &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-ping.html
+++ b/deps/npm/html/doc/api/npm-ping.html
@@ -29,4 +29,4 @@ to npm registries.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ping &mdash; npm@2.14.15</p>
+<p id="footer">npm-ping &mdash; npm@2.14.16</p>

--- a/deps/npm/html/doc/api/npm-prefix.html
+++ b/deps/npm/html/doc/api/npm-prefix.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@2.14.15</p>
+<p id="footer">npm-prefix &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-prune.html
+++ b/deps/npm/html/doc/api/npm-prune.html
@@ -30,5 +30,5 @@ package&#39;s dependencies list.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@2.14.15</p>
+<p id="footer">npm-prune &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-publish.html
+++ b/deps/npm/html/doc/api/npm-publish.html
@@ -46,5 +46,5 @@ the registry.  Overwrites when the &quot;force&quot; environment variable is set
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@2.14.15</p>
+<p id="footer">npm-publish &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-rebuild.html
+++ b/deps/npm/html/doc/api/npm-rebuild.html
@@ -30,5 +30,5 @@ the new binary. If no &#39;packages&#39; parameter is specify, every package wil
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@2.14.15</p>
+<p id="footer">npm-rebuild &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-repo.html
+++ b/deps/npm/html/doc/api/npm-repo.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@2.14.15</p>
+<p id="footer">npm-repo &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-restart.html
+++ b/deps/npm/html/doc/api/npm-restart.html
@@ -52,5 +52,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@2.14.15</p>
+<p id="footer">npm-restart &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-root.html
+++ b/deps/npm/html/doc/api/npm-root.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@2.14.15</p>
+<p id="footer">npm-root &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-run-script.html
+++ b/deps/npm/html/doc/api/npm-run-script.html
@@ -41,5 +41,5 @@ assumed to be the command to run. All other elements are ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@2.14.15</p>
+<p id="footer">npm-run-script &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-search.html
+++ b/deps/npm/html/doc/api/npm-search.html
@@ -53,5 +53,5 @@ like).</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@2.14.15</p>
+<p id="footer">npm-search &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/api/npm-shrinkwrap.html
@@ -33,5 +33,5 @@ been saved.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@2.14.15</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-start.html
+++ b/deps/npm/html/doc/api/npm-start.html
@@ -28,5 +28,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@2.14.15</p>
+<p id="footer">npm-start &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-stop.html
+++ b/deps/npm/html/doc/api/npm-stop.html
@@ -28,5 +28,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@2.14.15</p>
+<p id="footer">npm-stop &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-tag.html
+++ b/deps/npm/html/doc/api/npm-tag.html
@@ -36,5 +36,5 @@ used. For more information about how to set this config, check
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@2.14.15</p>
+<p id="footer">npm-tag &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-test.html
+++ b/deps/npm/html/doc/api/npm-test.html
@@ -30,5 +30,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@2.14.15</p>
+<p id="footer">npm-test &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-uninstall.html
+++ b/deps/npm/html/doc/api/npm-uninstall.html
@@ -30,5 +30,5 @@ uninstalled or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@2.14.15</p>
+<p id="footer">npm-uninstall &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-unpublish.html
+++ b/deps/npm/html/doc/api/npm-unpublish.html
@@ -33,5 +33,5 @@ the root package entry is removed from the registry entirely.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@2.14.15</p>
+<p id="footer">npm-unpublish &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-update.html
+++ b/deps/npm/html/doc/api/npm-update.html
@@ -33,5 +33,5 @@ parameter will be called when done or when an error occurs.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@2.14.15</p>
+<p id="footer">npm-update &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-version.html
+++ b/deps/npm/html/doc/api/npm-version.html
@@ -32,5 +32,5 @@ not have exactly one element. The only element should be a version number.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@2.14.15</p>
+<p id="footer">npm-version &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-view.html
+++ b/deps/npm/html/doc/api/npm-view.html
@@ -81,5 +81,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@2.14.15</p>
+<p id="footer">npm-view &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm-whoami.html
+++ b/deps/npm/html/doc/api/npm-whoami.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@2.14.15</p>
+<p id="footer">npm-whoami &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/api/npm.html
+++ b/deps/npm/html/doc/api/npm.html
@@ -23,7 +23,7 @@ npm.load([configObject, ]function (er, npm) {
   npm.commands.install([&quot;package&quot;], cb)
 })
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.14.15</p>
+<p>2.14.16</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>This is the API documentation for npm.
 To find documentation of the command line
@@ -109,5 +109,5 @@ method names.  Use the <code>npm.deref</code> method to find the real name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@2.14.15</p>
+<p id="footer">npm &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-access.html
+++ b/deps/npm/html/doc/cli/npm-access.html
@@ -84,5 +84,5 @@ with an HTTP 402 status code (logically enough), unless you use
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-access &mdash; npm@2.14.15</p>
+<p id="footer">npm-access &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-adduser.html
+++ b/deps/npm/html/doc/cli/npm-adduser.html
@@ -68,5 +68,5 @@ precedence over any global configuration.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-adduser &mdash; npm@2.14.15</p>
+<p id="footer">npm-adduser &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-bin.html
+++ b/deps/npm/html/doc/cli/npm-bin.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@2.14.15</p>
+<p id="footer">npm-bin &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-bugs.html
+++ b/deps/npm/html/doc/cli/npm-bugs.html
@@ -54,5 +54,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@2.14.15</p>
+<p id="footer">npm-bugs &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-build.html
+++ b/deps/npm/html/doc/cli/npm-build.html
@@ -40,5 +40,5 @@ directly, run:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-build &mdash; npm@2.14.15</p>
+<p id="footer">npm-build &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-bundle.html
+++ b/deps/npm/html/doc/cli/npm-bundle.html
@@ -31,5 +31,5 @@ install packages into the local space.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bundle &mdash; npm@2.14.15</p>
+<p id="footer">npm-bundle &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-cache.html
+++ b/deps/npm/html/doc/cli/npm-cache.html
@@ -81,5 +81,5 @@ they do not make an HTTP request to the registry.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@2.14.15</p>
+<p id="footer">npm-cache &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-completion.html
+++ b/deps/npm/html/doc/cli/npm-completion.html
@@ -42,5 +42,5 @@ completions based on the arguments.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-completion &mdash; npm@2.14.15</p>
+<p id="footer">npm-completion &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-config.html
+++ b/deps/npm/html/doc/cli/npm-config.html
@@ -66,5 +66,5 @@ global config.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.14.15</p>
+<p id="footer">npm-config &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-dedupe.html
+++ b/deps/npm/html/doc/cli/npm-dedupe.html
@@ -63,5 +63,5 @@ versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dedupe &mdash; npm@2.14.15</p>
+<p id="footer">npm-dedupe &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-deprecate.html
+++ b/deps/npm/html/doc/cli/npm-deprecate.html
@@ -38,5 +38,5 @@ something like this:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@2.14.15</p>
+<p id="footer">npm-deprecate &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-dist-tag.html
+++ b/deps/npm/html/doc/cli/npm-dist-tag.html
@@ -35,14 +35,23 @@ of using a specific version number:</p>
 </code></pre><p>When installing dependencies, a preferred tagged version may be specified:</p>
 <pre><code>npm install --tag &lt;tag&gt;
 </code></pre><p>This also applies to <code>npm dedupe</code>.</p>
-<p>Publishing a package sets the &quot;latest&quot; tag to the published version unless the
+<p>Publishing a package sets the <code>latest</code> tag to the published version unless the
 <code>--tag</code> option is used. For example, <code>npm publish --tag=beta</code>.</p>
+<p>By default, <code>npm install &lt;pkg&gt;</code> (without any <code>@&lt;version&gt;</code> or <code>@&lt;tag&gt;</code>
+specifier) installs the <code>latest</code> tag.</p>
 <h2 id="purpose">PURPOSE</h2>
-<p>Tags can be used to provide an alias instead of version numbers.  For
-example, <code>npm</code> currently uses the tag &quot;next&quot; to identify the upcoming
-version, and the tag &quot;latest&quot; to identify the current version.</p>
-<p>A project might choose to have multiple streams of development, e.g.,
-&quot;stable&quot;, &quot;canary&quot;.</p>
+<p>Tags can be used to provide an alias instead of version numbers.</p>
+<p>For example, a project might choose to have multiple streams of development
+and use a different tag for each stream,
+e.g., <code>stable</code>, <code>beta</code>, <code>dev</code>, <code>canary</code>.</p>
+<p>By default, the <code>latest</code> tag is used by npm to identify the current version of
+a package, and <code>npm install &lt;pkg&gt;</code> (without any <code>@&lt;version&gt;</code> or <code>@&lt;tag&gt;</code>
+specifier) installs the <code>latest</code> tag. Typically, projects only use the <code>latest</code>
+tag for stable release versions, and use other tags for unstable versions such
+as prereleases.</p>
+<p>The <code>next</code> tag is used by some projects to identify the upcoming version.</p>
+<p>By default, other than <code>latest</code>, no tag has any special significance to npm
+itself.</p>
 <h2 id="caveats">CAVEATS</h2>
 <p>This command used to be known as <code>npm tag</code>, which only created new tags, and so
 had a different syntax.</p>
@@ -76,5 +85,5 @@ begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dist-tag &mdash; npm@2.14.15</p>
+<p id="footer">npm-dist-tag &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-docs.html
+++ b/deps/npm/html/doc/cli/npm-docs.html
@@ -56,5 +56,5 @@ the current folder and use the <code>name</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@2.14.15</p>
+<p id="footer">npm-docs &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-edit.html
+++ b/deps/npm/html/doc/cli/npm-edit.html
@@ -49,5 +49,5 @@ or <code>&quot;notepad&quot;</code> on Windows.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@2.14.15</p>
+<p id="footer">npm-edit &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-explore.html
+++ b/deps/npm/html/doc/cli/npm-explore.html
@@ -49,5 +49,5 @@ Windows</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@2.14.15</p>
+<p id="footer">npm-explore &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-help-search.html
+++ b/deps/npm/html/doc/cli/npm-help-search.html
@@ -46,5 +46,5 @@ where the terms were found in the documentation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@2.14.15</p>
+<p id="footer">npm-help-search &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-help.html
+++ b/deps/npm/html/doc/cli/npm-help.html
@@ -52,5 +52,5 @@ matches are equivalent to specifying a topic name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help &mdash; npm@2.14.15</p>
+<p id="footer">npm-help &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-init.html
+++ b/deps/npm/html/doc/cli/npm-init.html
@@ -48,5 +48,5 @@ defaults and not prompt you for any options.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@2.14.15</p>
+<p id="footer">npm-init &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-install.html
+++ b/deps/npm/html/doc/cli/npm-install.html
@@ -30,7 +30,7 @@ by that. See <a href="../cli/npm-shrinkwrap.html">npm-shrinkwrap(1)</a>.</p>
 <li>b) a gzipped tarball containing (a)</li>
 <li>c) a url that resolves to (b)</li>
 <li>d) a <code>&lt;name&gt;@&lt;version&gt;</code> that is published on the registry (see <code><a href="../misc/npm-registry.html">npm-registry(7)</a></code>) with (c)</li>
-<li>e) a <code>&lt;name&gt;@&lt;tag&gt;</code> that points to (d)</li>
+<li>e) a <code>&lt;name&gt;@&lt;tag&gt;</code> (see <code><a href="../cli/npm-dist-tag.html">npm-dist-tag(1)</a></code>) that points to (d)</li>
 <li>f) a <code>&lt;name&gt;</code> that has a &quot;latest&quot; tag satisfying (e)</li>
 <li>g) a <code>&lt;git remote url&gt;</code> that resolves to (b)</li>
 </ul>
@@ -68,7 +68,7 @@ after packing it up into a tarball (b).</p>
 </code></pre></li>
 <li><p><code>npm install [@&lt;scope&gt;/]&lt;name&gt; [--save|--save-dev|--save-optional]</code>:</p>
 <p>  Do a <code>&lt;name&gt;@&lt;tag&gt;</code> install, where <code>&lt;tag&gt;</code> is the &quot;tag&quot; config. (See
-  <code><a href="../misc/npm-config.html">npm-config(7)</a></code>.)</p>
+  <code><a href="../misc/npm-config.html">npm-config(7)</a></code>. The config&#39;s default value is <code>latest</code>.)</p>
 <p>  In most cases, this will install the latest version
   of the module published on npm.</p>
 <p>  Example:</p>
@@ -279,5 +279,5 @@ affects a real use-case, it will be investigated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@2.14.15</p>
+<p id="footer">npm-install &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-link.html
+++ b/deps/npm/html/doc/cli/npm-link.html
@@ -72,5 +72,5 @@ include that scope, e.g.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@2.14.15</p>
+<p id="footer">npm-link &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-logout.html
+++ b/deps/npm/html/doc/cli/npm-logout.html
@@ -55,5 +55,5 @@ that registry at the same time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-logout &mdash; npm@2.14.15</p>
+<p id="footer">npm-logout &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-ls.html
+++ b/deps/npm/html/doc/cli/npm-ls.html
@@ -22,7 +22,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
-<pre><code>npm@2.14.15 /path/to/npm
+<pre><code>npm@2.14.16 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre><p>It will print out extraneous, missing, and invalid packages.</p>
@@ -97,5 +97,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@2.14.15</p>
+<p id="footer">npm-ls &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-outdated.html
+++ b/deps/npm/html/doc/cli/npm-outdated.html
@@ -115,5 +115,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@2.14.15</p>
+<p id="footer">npm-outdated &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-owner.html
+++ b/deps/npm/html/doc/cli/npm-owner.html
@@ -49,5 +49,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@2.14.15</p>
+<p id="footer">npm-owner &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-pack.html
+++ b/deps/npm/html/doc/cli/npm-pack.html
@@ -41,5 +41,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@2.14.15</p>
+<p id="footer">npm-pack &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-ping.html
+++ b/deps/npm/html/doc/cli/npm-ping.html
@@ -32,4 +32,4 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ping &mdash; npm@2.14.15</p>
+<p id="footer">npm-ping &mdash; npm@2.14.16</p>

--- a/deps/npm/html/doc/cli/npm-prefix.html
+++ b/deps/npm/html/doc/cli/npm-prefix.html
@@ -38,5 +38,5 @@ to contain a package.json file unless <code>-g</code> is also specified.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@2.14.15</p>
+<p id="footer">npm-prefix &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-prune.html
+++ b/deps/npm/html/doc/cli/npm-prune.html
@@ -41,5 +41,5 @@ negate <code>NODE_ENV</code> being set to <code>production</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@2.14.15</p>
+<p id="footer">npm-prune &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-publish.html
+++ b/deps/npm/html/doc/cli/npm-publish.html
@@ -14,9 +14,11 @@
 <pre><code>npm publish &lt;tarball&gt; [--tag &lt;tag&gt;] [--access &lt;public|restricted&gt;]
 npm publish &lt;folder&gt; [--tag &lt;tag&gt;] [--access &lt;public|restricted&gt;]
 </code></pre><h2 id="description">DESCRIPTION</h2>
-<p>Publishes a package to the registry so that it can be installed by name. See
-<code><a href="../misc/npm-developers.html">npm-developers(7)</a></code> for details on what&#39;s included in the published package, as
-well as details on how the package is built.</p>
+<p>Publishes a package to the registry so that it can be installed by name. All
+files in the package directory are included if no local <code>.gitignore</code> or
+<code>.npmignore</code> file is present. See <code><a href="../misc/npm-developers.html">npm-developers(7)</a></code> for full details on
+what&#39;s included in the published package, as well as details on how the package
+is built.</p>
 <p>By default npm will publish to the public registry. This can be overridden by
 specifying a different default registry or using a <code><a href="../misc/npm-scope.html">npm-scope(7)</a></code> in the name
 (see <code><a href="../files/package.json.html">package.json(5)</a></code>).</p>
@@ -31,7 +33,8 @@ with a package.json file inside.</p>
 <li><p><code>[--tag &lt;tag&gt;]</code>
 Registers the published package with the given tag, such that <code>npm install
 &lt;name&gt;@&lt;tag&gt;</code> will install this version.  By default, <code>npm publish</code> updates
-and <code>npm install</code> installs the <code>latest</code> tag.</p>
+and <code>npm install</code> installs the <code>latest</code> tag. See <code><a href="../cli/npm-dist-tag.html">npm-dist-tag(1)</a></code> for
+details about tags.</p>
 </li>
 <li><p><code>[--access &lt;public|restricted&gt;]</code>
 Tells the registry whether this package should be published as public or
@@ -66,5 +69,5 @@ it is removed with <a href="../cli/npm-unpublish.html">npm-unpublish(1)</a>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@2.14.15</p>
+<p id="footer">npm-publish &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-rebuild.html
+++ b/deps/npm/html/doc/cli/npm-rebuild.html
@@ -38,5 +38,5 @@ the new binary.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@2.14.15</p>
+<p id="footer">npm-rebuild &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-repo.html
+++ b/deps/npm/html/doc/cli/npm-repo.html
@@ -42,5 +42,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@2.14.15</p>
+<p id="footer">npm-repo &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-restart.html
+++ b/deps/npm/html/doc/cli/npm-restart.html
@@ -53,5 +53,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@2.14.15</p>
+<p id="footer">npm-restart &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-rm.html
+++ b/deps/npm/html/doc/cli/npm-rm.html
@@ -39,5 +39,5 @@ on its behalf.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rm &mdash; npm@2.14.15</p>
+<p id="footer">npm-rm &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-root.html
+++ b/deps/npm/html/doc/cli/npm-root.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@2.14.15</p>
+<p id="footer">npm-root &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-run-script.html
+++ b/deps/npm/html/doc/cli/npm-run-script.html
@@ -57,5 +57,5 @@ you should write:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@2.14.15</p>
+<p id="footer">npm-run-script &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-search.html
+++ b/deps/npm/html/doc/cli/npm-search.html
@@ -49,5 +49,5 @@ fall on multiple lines.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@2.14.15</p>
+<p id="footer">npm-search &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/cli/npm-shrinkwrap.html
@@ -164,5 +164,5 @@ contents rather than versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@2.14.15</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-star.html
+++ b/deps/npm/html/doc/cli/npm-star.html
@@ -36,5 +36,5 @@ a vaguely positive way to show that you care.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-star &mdash; npm@2.14.15</p>
+<p id="footer">npm-star &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-stars.html
+++ b/deps/npm/html/doc/cli/npm-stars.html
@@ -37,5 +37,5 @@ you will most certainly enjoy this command.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stars &mdash; npm@2.14.15</p>
+<p id="footer">npm-stars &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-start.html
+++ b/deps/npm/html/doc/cli/npm-start.html
@@ -39,5 +39,5 @@ more details.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@2.14.15</p>
+<p id="footer">npm-start &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-stop.html
+++ b/deps/npm/html/doc/cli/npm-stop.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@2.14.15</p>
+<p id="footer">npm-stop &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-tag.html
+++ b/deps/npm/html/doc/cli/npm-tag.html
@@ -62,5 +62,5 @@ that do not begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@2.14.15</p>
+<p id="footer">npm-tag &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-team.html
+++ b/deps/npm/html/doc/cli/npm-team.html
@@ -67,4 +67,4 @@ use the <code>npm access</code> command to grant or revoke the appropriate permi
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-team &mdash; npm@2.14.15</p>
+<p id="footer">npm-team &mdash; npm@2.14.16</p>

--- a/deps/npm/html/doc/cli/npm-test.html
+++ b/deps/npm/html/doc/cli/npm-test.html
@@ -37,5 +37,5 @@ true.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@2.14.15</p>
+<p id="footer">npm-test &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-uninstall.html
+++ b/deps/npm/html/doc/cli/npm-uninstall.html
@@ -57,5 +57,5 @@ npm uninstall dtrace-provider --save-optional
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@2.14.15</p>
+<p id="footer">npm-uninstall &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-unpublish.html
+++ b/deps/npm/html/doc/cli/npm-unpublish.html
@@ -47,5 +47,5 @@ package again, a new version number must be used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@2.14.15</p>
+<p id="footer">npm-unpublish &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-update.html
+++ b/deps/npm/html/doc/cli/npm-update.html
@@ -24,7 +24,7 @@ packages.</p>
 or local) will be updated.</p>
 <p>As of <code>npm@2.6.1</code>, the <code>npm update</code> will only inspect top-level packages.
 Prior versions of <code>npm</code> would also recursively inspect all dependencies.
-To get the old behavior, use <code>npm --depth 9999 update</code>, but be warned that
+To get the old behavior, use <code>npm --depth Infinity update</code>, but be warned that
 simultaneous asynchronous update of all packages, including <code>npm</code> itself
 and packages that <code>npm</code> depends on, often causes problems up to and including
 the uninstallation of <code>npm</code> itself.</p>
@@ -119,5 +119,5 @@ be <em>downgraded</em>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@2.14.15</p>
+<p id="footer">npm-update &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-version.html
+++ b/deps/npm/html/doc/cli/npm-version.html
@@ -95,5 +95,5 @@ and tag up to the server, and deletes the <code>build/temp</code> directory.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@2.14.15</p>
+<p id="footer">npm-version &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-view.html
+++ b/deps/npm/html/doc/cli/npm-view.html
@@ -82,5 +82,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@2.14.15</p>
+<p id="footer">npm-view &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm-whoami.html
+++ b/deps/npm/html/doc/cli/npm-whoami.html
@@ -33,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@2.14.15</p>
+<p id="footer">npm-whoami &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/cli/npm.html
+++ b/deps/npm/html/doc/cli/npm.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <pre><code>npm &lt;command&gt; [args]
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.14.15</p>
+<p>2.14.16</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -110,7 +110,7 @@ easily by doing <code>npm view npm contributors</code>.</p>
 the issues list or ask on the mailing list.</p>
 <ul>
 <li><a href="https://github.com/npm/npm/issues">https://github.com/npm/npm/issues</a></li>
-<li><a href="&#x6d;&#97;&#105;&#x6c;&#116;&#111;&#58;&#110;&#x70;&#x6d;&#45;&#64;&#x67;&#x6f;&#111;&#x67;&#x6c;&#101;&#x67;&#x72;&#x6f;&#x75;&#x70;&#115;&#x2e;&#x63;&#111;&#x6d;">&#110;&#x70;&#x6d;&#45;&#64;&#x67;&#x6f;&#111;&#x67;&#x6c;&#101;&#x67;&#x72;&#x6f;&#x75;&#x70;&#115;&#x2e;&#x63;&#111;&#x6d;</a></li>
+<li><a href="&#109;&#97;&#105;&#x6c;&#116;&#111;&#x3a;&#x6e;&#x70;&#109;&#x2d;&#64;&#x67;&#x6f;&#111;&#x67;&#x6c;&#101;&#103;&#x72;&#x6f;&#117;&#112;&#x73;&#46;&#x63;&#x6f;&#x6d;">&#x6e;&#x70;&#109;&#x2d;&#64;&#x67;&#x6f;&#111;&#x67;&#x6c;&#101;&#103;&#x72;&#x6f;&#117;&#112;&#x73;&#46;&#x63;&#x6f;&#x6d;</a></li>
 </ul>
 <h2 id="bugs">BUGS</h2>
 <p>When you find issues, please report them:</p>
@@ -118,7 +118,7 @@ the issues list or ask on the mailing list.</p>
 <li>web:
 <a href="https://github.com/npm/npm/issues">https://github.com/npm/npm/issues</a></li>
 <li>email:
-<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#x3a;&#x6e;&#112;&#109;&#45;&#64;&#103;&#111;&#x6f;&#x67;&#108;&#101;&#103;&#x72;&#x6f;&#117;&#x70;&#x73;&#x2e;&#x63;&#111;&#109;">&#x6e;&#112;&#109;&#45;&#64;&#103;&#111;&#x6f;&#x67;&#108;&#101;&#103;&#x72;&#x6f;&#117;&#x70;&#x73;&#x2e;&#x63;&#111;&#109;</a></li>
+<a href="&#x6d;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#58;&#110;&#112;&#109;&#x2d;&#64;&#x67;&#x6f;&#111;&#103;&#x6c;&#101;&#103;&#114;&#x6f;&#117;&#x70;&#x73;&#46;&#x63;&#111;&#109;">&#110;&#112;&#109;&#x2d;&#64;&#x67;&#x6f;&#111;&#103;&#x6c;&#101;&#103;&#114;&#x6f;&#117;&#x70;&#x73;&#46;&#x63;&#111;&#109;</a></li>
 </ul>
 <p>Be sure to include <em>all</em> of the output from the npm command that didn&#39;t work
 as expected.  The <code>npm-debug.log</code> file is also helpful to provide.</p>
@@ -128,7 +128,7 @@ will no doubt tell you to put the output in a gist or email.</p>
 <p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
 <a href="https://github.com/isaacs/">isaacs</a> ::
 <a href="http://twitter.com/izs">@izs</a> ::
-<a href="&#109;&#x61;&#x69;&#108;&#116;&#x6f;&#x3a;&#x69;&#x40;&#105;&#122;&#x73;&#46;&#x6d;&#101;">&#x69;&#x40;&#105;&#122;&#x73;&#46;&#x6d;&#101;</a></p>
+<a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#58;&#105;&#x40;&#x69;&#122;&#x73;&#46;&#x6d;&#101;">&#105;&#x40;&#x69;&#122;&#x73;&#46;&#x6d;&#101;</a></p>
 <h2 id="see-also">SEE ALSO</h2>
 <ul>
 <li><a href="../cli/npm-help.html">npm-help(1)</a></li>
@@ -154,5 +154,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@2.14.15</p>
+<p id="footer">npm &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/files/npm-folders.html
+++ b/deps/npm/html/doc/files/npm-folders.html
@@ -25,11 +25,10 @@ is installed.</li>
 </ul>
 <h3 id="prefix-configuration">prefix Configuration</h3>
 <p>The <code>prefix</code> config defaults to the location where node is installed.
-On most systems, this is <code>/usr/local</code>, and most of the time is the same
-as node&#39;s <code>process.installPrefix</code>.</p>
-<p>On windows, this is the exact location of the node.exe binary.  On Unix
-systems, it&#39;s one level up, since node is typically installed at
-<code>{prefix}/bin/node</code> rather than <code>{prefix}/node.exe</code>.</p>
+On most systems, this is <code>/usr/local</code>. On windows, this is the exact
+location of the node.exe binary.  On Unix systems, it&#39;s one level up,
+since node is typically installed at <code>{prefix}/bin/node</code> rather than
+<code>{prefix}/node.exe</code>.</p>
 <p>When the <code>global</code> flag is set, npm installs things into this prefix.
 When it is not set, it uses the root of the current package, or the
 current working directory if not in a package already.</p>
@@ -184,5 +183,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@2.14.15</p>
+<p id="footer">npm-folders &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/files/npm-global.html
+++ b/deps/npm/html/doc/files/npm-global.html
@@ -25,11 +25,10 @@ is installed.</li>
 </ul>
 <h3 id="prefix-configuration">prefix Configuration</h3>
 <p>The <code>prefix</code> config defaults to the location where node is installed.
-On most systems, this is <code>/usr/local</code>, and most of the time is the same
-as node&#39;s <code>process.installPrefix</code>.</p>
-<p>On windows, this is the exact location of the node.exe binary.  On Unix
-systems, it&#39;s one level up, since node is typically installed at
-<code>{prefix}/bin/node</code> rather than <code>{prefix}/node.exe</code>.</p>
+On most systems, this is <code>/usr/local</code>. On windows, this is the exact
+location of the node.exe binary.  On Unix systems, it&#39;s one level up,
+since node is typically installed at <code>{prefix}/bin/node</code> rather than
+<code>{prefix}/node.exe</code>.</p>
 <p>When the <code>global</code> flag is set, npm installs things into this prefix.
 When it is not set, it uses the root of the current package, or the
 current working directory if not in a package already.</p>
@@ -184,5 +183,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@2.14.15</p>
+<p id="footer">npm-folders &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/files/npm-json.html
+++ b/deps/npm/html/doc/files/npm-json.html
@@ -24,7 +24,7 @@ changes to the version.</p>
 <p>The name is what your thing is called.</p>
 <p>Some rules:</p>
 <ul>
-<li>The name must be shorter than 214 characters. This includes the scope for
+<li>The name must be less than or equal to 214 characters. This includes the scope for
 scoped packages.</li>
 <li>The name can&#39;t start with a dot or an underscore.</li>
 <li>New packages must not have uppercase letters in the name.</li>
@@ -309,7 +309,7 @@ tarball or git URL.</p>
 <li><code>git...</code> See &#39;Git URLs as Dependencies&#39; below</li>
 <li><code>user/repo</code> See &#39;GitHub URLs&#39; below</li>
 <li><code>tag</code> A specific version tagged and published as <code>tag</code>  See <code><a href="../cli/npm-tag.html">npm-tag(1)</a></code></li>
-<li><code>path/path/path</code> See Local Paths below</li>
+<li><code>path/path/path</code> See <a href="#local-paths">Local Paths</a> below</li>
 </ul>
 <p>For example, these are all valid:</p>
 <pre><code>{ &quot;dependencies&quot; :
@@ -565,5 +565,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@2.14.15</p>
+<p id="footer">package.json &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/files/npmrc.html
+++ b/deps/npm/html/doc/files/npmrc.html
@@ -83,5 +83,5 @@ manner.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npmrc &mdash; npm@2.14.15</p>
+<p id="footer">npmrc &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/files/package.json.html
+++ b/deps/npm/html/doc/files/package.json.html
@@ -24,7 +24,7 @@ changes to the version.</p>
 <p>The name is what your thing is called.</p>
 <p>Some rules:</p>
 <ul>
-<li>The name must be shorter than 214 characters. This includes the scope for
+<li>The name must be less than or equal to 214 characters. This includes the scope for
 scoped packages.</li>
 <li>The name can&#39;t start with a dot or an underscore.</li>
 <li>New packages must not have uppercase letters in the name.</li>
@@ -309,7 +309,7 @@ tarball or git URL.</p>
 <li><code>git...</code> See &#39;Git URLs as Dependencies&#39; below</li>
 <li><code>user/repo</code> See &#39;GitHub URLs&#39; below</li>
 <li><code>tag</code> A specific version tagged and published as <code>tag</code>  See <code><a href="../cli/npm-tag.html">npm-tag(1)</a></code></li>
-<li><code>path/path/path</code> See Local Paths below</li>
+<li><code>path/path/path</code> See <a href="#local-paths">Local Paths</a> below</li>
 </ul>
 <p>For example, these are all valid:</p>
 <pre><code>{ &quot;dependencies&quot; :
@@ -565,5 +565,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@2.14.15</p>
+<p id="footer">package.json &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/index.html
+++ b/deps/npm/html/doc/index.html
@@ -242,5 +242,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@2.14.15</p>
+<p id="footer">npm-index &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-coding-style.html
+++ b/deps/npm/html/doc/misc/npm-coding-style.html
@@ -147,5 +147,5 @@ set to anything.&quot;</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-coding-style &mdash; npm@2.14.15</p>
+<p id="footer">npm-coding-style &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-config.html
+++ b/deps/npm/html/doc/misc/npm-config.html
@@ -196,7 +196,7 @@ explicitly used, and that only GET requests use the cache.</p>
 <p>A client certificate to pass when accessing the registry.</p>
 <h3 id="color">color</h3>
 <ul>
-<li>Default: true on Posix, false on Windows</li>
+<li>Default: true</li>
 <li>Type: Boolean or <code>&quot;always&quot;</code></li>
 </ul>
 <p>If false, never shows colors.  If <code>&quot;always&quot;</code> then always shows colors.
@@ -799,5 +799,5 @@ exit successfully.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.14.15</p>
+<p id="footer">npm-config &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-developers.html
+++ b/deps/npm/html/doc/misc/npm-developers.html
@@ -195,5 +195,5 @@ from a fresh checkout.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-developers &mdash; npm@2.14.15</p>
+<p id="footer">npm-developers &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-disputes.html
+++ b/deps/npm/html/doc/misc/npm-disputes.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <ol>
 <li>Get the author email with <code>npm owner ls &lt;pkgname&gt;</code></li>
-<li>Email the author, CC <a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#58;&#115;&#x75;&#112;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#x70;&#109;&#x6a;&#115;&#46;&#99;&#x6f;&#109;">&#115;&#x75;&#112;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#x70;&#109;&#x6a;&#115;&#46;&#99;&#x6f;&#109;</a></li>
+<li>Email the author, CC <a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#x73;&#117;&#x70;&#112;&#x6f;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#46;&#x63;&#x6f;&#x6d;">&#x73;&#117;&#x70;&#112;&#x6f;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#46;&#x63;&#x6f;&#x6d;</a></li>
 <li>After a few weeks, if there&#39;s no resolution, we&#39;ll sort it out.</li>
 </ol>
 <p>Don&#39;t squat on package names.  Publish code or move out of the way.</p>
@@ -51,12 +51,12 @@ Joe&#39;s appropriate course of action in each case is the same.</p>
 owner (Bob).</li>
 <li>Joe emails Bob, explaining the situation <strong>as respectfully as
 possible</strong>, and what he would like to do with the module name.  He
-adds the npm support staff <a href="&#109;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x73;&#x75;&#x70;&#112;&#111;&#x72;&#116;&#64;&#110;&#112;&#x6d;&#x6a;&#x73;&#x2e;&#x63;&#x6f;&#109;">&#x73;&#x75;&#x70;&#112;&#111;&#x72;&#116;&#64;&#110;&#112;&#x6d;&#x6a;&#x73;&#x2e;&#x63;&#x6f;&#109;</a> to the CC list of
+adds the npm support staff <a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x73;&#x75;&#112;&#112;&#x6f;&#114;&#x74;&#x40;&#110;&#x70;&#109;&#x6a;&#x73;&#46;&#99;&#x6f;&#109;">&#x73;&#x75;&#112;&#112;&#x6f;&#114;&#x74;&#x40;&#110;&#x70;&#109;&#x6a;&#x73;&#46;&#99;&#x6f;&#109;</a> to the CC list of
 the email.  Mention in the email that Bob can run <code>npm owner add
 joe foo</code> to add Joe as an owner of the <code>foo</code> package.</li>
 <li>After a reasonable amount of time, if Bob has not responded, or if
 Bob and Joe can&#39;t come to any sort of resolution, email support
-<a href="&#109;&#97;&#105;&#x6c;&#x74;&#x6f;&#58;&#x73;&#117;&#x70;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#106;&#x73;&#x2e;&#99;&#x6f;&#x6d;">&#x73;&#117;&#x70;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#106;&#x73;&#x2e;&#99;&#x6f;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
+<a href="&#109;&#97;&#x69;&#x6c;&#x74;&#x6f;&#x3a;&#115;&#x75;&#112;&#112;&#x6f;&#114;&#116;&#64;&#110;&#112;&#x6d;&#x6a;&#115;&#46;&#99;&#x6f;&#109;">&#115;&#x75;&#112;&#112;&#x6f;&#114;&#116;&#64;&#110;&#112;&#x6d;&#x6a;&#115;&#46;&#99;&#x6f;&#109;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
 usually at least 4 weeks, but extra time is allowed around common
 holidays.)</li>
 </ol>
@@ -112,5 +112,5 @@ things into it.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-disputes &mdash; npm@2.14.15</p>
+<p id="footer">npm-disputes &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-index.html
+++ b/deps/npm/html/doc/misc/npm-index.html
@@ -242,5 +242,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@2.14.15</p>
+<p id="footer">npm-index &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-orgs.html
+++ b/deps/npm/html/doc/misc/npm-orgs.html
@@ -86,4 +86,4 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-orgs &mdash; npm@2.14.15</p>
+<p id="footer">npm-orgs &mdash; npm@2.14.16</p>

--- a/deps/npm/html/doc/misc/npm-registry.html
+++ b/deps/npm/html/doc/misc/npm-registry.html
@@ -70,5 +70,5 @@ effectively implement the entire CouchDB API anyway.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-registry &mdash; npm@2.14.15</p>
+<p id="footer">npm-registry &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-scope.html
+++ b/deps/npm/html/doc/misc/npm-scope.html
@@ -91,5 +91,5 @@ that registry instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scope &mdash; npm@2.14.15</p>
+<p id="footer">npm-scope &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/npm-scripts.html
+++ b/deps/npm/html/doc/misc/npm-scripts.html
@@ -207,5 +207,5 @@ scripts is for compilation which must be done on the target architecture.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scripts &mdash; npm@2.14.15</p>
+<p id="footer">npm-scripts &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/removing-npm.html
+++ b/deps/npm/html/doc/misc/removing-npm.html
@@ -57,5 +57,5 @@ modules.  To track those down, you can do the following:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">removing-npm &mdash; npm@2.14.15</p>
+<p id="footer">removing-npm &mdash; npm@2.14.16</p>
 

--- a/deps/npm/html/doc/misc/semver.html
+++ b/deps/npm/html/doc/misc/semver.html
@@ -302,5 +302,5 @@ range, use the <code>satisfies(version, range)</code> function.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">semver &mdash; npm@2.14.15</p>
+<p id="footer">semver &mdash; npm@2.14.16</p>
 

--- a/deps/npm/lib/adduser.js
+++ b/deps/npm/lib/adduser.js
@@ -169,7 +169,9 @@ function save (c, u, cb) {
       })
     }
 
-    log.info("adduser", "Authorized user %s", u.u)
-    npm.config.save("user", cb)
+    log.info('adduser', 'Authorized user %s', u.u)
+    var scopeMessage = scope ? ' to scope ' + scope : ''
+    console.log('Logged in as %s%s on %s.', u.u, scopeMessage, uri)
+    npm.config.save('user', cb)
   })
 }

--- a/deps/npm/lib/cache.js
+++ b/deps/npm/lib/cache.js
@@ -337,6 +337,7 @@ function afterAdd (cb) { return function (er, data) {
 
   // Save the resolved, shasum, etc. into the data so that the next
   // time we load from this cached data, we have all the same info.
+  // Ignore if it fails.
   var pj = path.join(cachedPackageRoot(data), "package", "package.json")
 
   var done = inflight(pj, cb)
@@ -347,7 +348,7 @@ function afterAdd (cb) { return function (er, data) {
     if (er) return done(er)
     writeFileAtomic(pj, JSON.stringify(data), {chown : cs}, function (er) {
       if (!er) log.verbose("afterAdd", pj, "written")
-      return done(er, data)
+      return done(null, data)
     })
   })
 }}

--- a/deps/npm/lib/cache/add-local-tarball.js
+++ b/deps/npm/lib/cache/add-local-tarball.js
@@ -13,7 +13,7 @@ var mkdir = require("mkdirp")
   , chownr = require("chownr")
   , inflight = require("inflight")
   , once = require("once")
-  , writeStream = require("fs-write-stream-atomic")
+  , writeStreamAtomic = require("fs-write-stream-atomic")
   , randomBytes = require("crypto").pseudoRandomBytes // only need uniqueness
 
 module.exports = addLocalTarball
@@ -166,7 +166,7 @@ function addTmpTarball_ (tgz, data, shasum, cb) {
 
       if (er) return cb(er)
       var read = fs.createReadStream(tgz)
-      var write = writeStream(target, { mode: npm.modes.file })
+      var write = writeStreamAtomic(target, { mode: npm.modes.file })
       var fin = cs.uid && cs.gid ? chown : done
       read.on("error", cb).pipe(write).on("error", cb).on("close", fin)
     })

--- a/deps/npm/lib/pack.js
+++ b/deps/npm/lib/pack.js
@@ -11,7 +11,7 @@ var npm = require("./npm.js")
   , chain = require("slide").chain
   , path = require("path")
   , cwd = process.cwd()
-  , writeStream = require('fs-write-stream-atomic')
+  , writeStreamAtomic = require('fs-write-stream-atomic')
   , cachedPackageRoot = require("./cache/cached-package-root.js")
 
 pack.usage = "npm pack <pkg>"
@@ -52,7 +52,7 @@ function pack_ (pkg, cb) {
 
     var cached = path.join(cachedPackageRoot(data), "package.tgz")
       , from = fs.createReadStream(cached)
-      , to = writeStream(fname)
+      , to = writeStreamAtomic(fname)
       , errState = null
 
     from.on("error", cb_)

--- a/deps/npm/lib/utils/correct-mkdir.js
+++ b/deps/npm/lib/utils/correct-mkdir.js
@@ -10,6 +10,13 @@ var stats = {}
 var effectiveOwner
 module.exports = function correctMkdir (path, cb) {
   cb = dezalgo(cb)
+  cb = inflight('correctMkdir:' + path, cb)
+  if (!cb) {
+    return log.verbose('correctMkdir', path, 'correctMkdir already in flight; waiting')
+  } else {
+    log.verbose('correctMkdir', path, 'correctMkdir not in flight; initializing')
+  }
+
   if (stats[path]) return cb(null, stats[path])
 
   fs.stat(path, function (er, st) {

--- a/deps/npm/lib/utils/error-handler.js
+++ b/deps/npm/lib/utils/error-handler.js
@@ -11,7 +11,7 @@ var cbCalled = false
   , exitCode = 0
   , rollbacks = npm.rollbacks
   , chain = require("slide").chain
-  , writeStream = require("fs-write-stream-atomic")
+  , writeStreamAtomic = require("fs-write-stream-atomic")
   , nameValidator = require("validate-npm-package-name")
 
 
@@ -187,8 +187,10 @@ function errorHandler (er) {
               ,"not with npm itself."
               ,"Tell the author that this fails on your system:"
               ,"    "+er.script
-              ,"You can get their info via:"
-              ,"    npm owner ls "+er.pkgname
+              ,'You can get information on how to open an issue for this project with:'
+              ,'    npm bugs ' + er.pkgname
+              ,'Or if that isn\'t available, you can get their info via:',
+              ,'    npm owner ls ' + er.pkgname
               ,"There is likely additional logging output above."
               ].join("\n"))
     break
@@ -391,7 +393,7 @@ function writeLogFile (cb) {
   writingLogFile = true
   wroteLogFile = true
 
-  var fstr = writeStream("npm-debug.log")
+  var fstr = writeStreamAtomic("npm-debug.log")
     , os = require("os")
     , out = ""
 

--- a/deps/npm/man/man1/npm-README.1
+++ b/deps/npm/man/man1/npm-README.1
@@ -142,53 +142,6 @@ Uninstalling npm does not remove configuration files by default\.  You
 must remove them yourself manually if you want them gone\.  Note that
 this means that future npm installs will not remember the settings that
 you have chosen\.
-.SH Using npm Programmatically
-.P
-Although npm can be used programmatically, its API is meant for use by the CLI
-\fIonly\fR, and no guarantees are made regarding its fitness for any other purpose\.
-If you want to use npm to reliably perform some task, the safest thing to do is
-to invoke the desired \fBnpm\fP command with appropriate arguments\.
-.P
-The semantic version of npm refers to the CLI itself, rather than the
-underlying API\. \fIThe internal API is not guaranteed to remain stable even when
-npm's version indicates no breaking changes have been made according to
-semver\.\fR
-.P
-If you \fIstill\fR would like to use npm programmatically, it's \fIpossible\fR\|\. The API
-isn't very well documented, but it \fIis\fR rather simple\.
-.P
-Eventually, npm will be just a thin CLI wrapper around the modules that it
-depends on, but for now, there are some things that only the CLI can do\. You
-should try using one of npm's dependencies first, and only use the API if what
-you're trying to do is only supported by npm itself\.
-.P
-.RS 2
-.nf
-var npm = require("npm")
-npm\.load(myConfigObject, function (er) {
-  if (er) return handlError(er)
-  npm\.commands\.install(["some", "args"], function (er, data) {
-    if (er) return commandFailed(er)
-    // command succeeded, and data might have some info
-  })
-  npm\.registry\.log\.on("log", function (message) { \.\.\.\. })
-})
-.fi
-.RE
-.P
-The \fBload\fP function takes an object hash of the command\-line configs\.
-The various \fBnpm\.commands\.<cmd>\fP functions take an \fBarray\fR of
-positional argument \fBstrings\fR\|\.  The last argument to any
-\fBnpm\.commands\.<cmd>\fP function is a callback\.  Some commands take other
-optional arguments\.  Read the source\.
-.P
-You cannot set configs individually for any single npm function at this
-time\.  Since \fBnpm\fP is a singleton, any call to \fBnpm\.config\.set\fP will
-change the value for \fIall\fR npm commands in that process\.
-.P
-See \fB\|\./bin/npm\-cli\.js\fP for an example of pulling config values off of the
-command line arguments using nopt\.  You may also want to check out \fBnpm
-help config\fP to learn about all the options you can set there\.
 .SH More Docs
 .P
 Check out the docs \fIhttps://docs\.npmjs\.com/\fR,

--- a/deps/npm/man/man1/npm-dist-tag.1
+++ b/deps/npm/man/man1/npm-dist-tag.1
@@ -47,16 +47,29 @@ npm install \-\-tag <tag>
 .P
 This also applies to \fBnpm dedupe\fP\|\.
 .P
-Publishing a package sets the "latest" tag to the published version unless the
+Publishing a package sets the \fBlatest\fP tag to the published version unless the
 \fB\-\-tag\fP option is used\. For example, \fBnpm publish \-\-tag=beta\fP\|\.
+.P
+By default, \fBnpm install <pkg>\fP (without any \fB@<version>\fP or \fB@<tag>\fP
+specifier) installs the \fBlatest\fP tag\.
 .SH PURPOSE
 .P
-Tags can be used to provide an alias instead of version numbers\.  For
-example, \fBnpm\fP currently uses the tag "next" to identify the upcoming
-version, and the tag "latest" to identify the current version\.
+Tags can be used to provide an alias instead of version numbers\.
 .P
-A project might choose to have multiple streams of development, e\.g\.,
-"stable", "canary"\.
+For example, a project might choose to have multiple streams of development
+and use a different tag for each stream,
+e\.g\., \fBstable\fP, \fBbeta\fP, \fBdev\fP, \fBcanary\fP\|\.
+.P
+By default, the \fBlatest\fP tag is used by npm to identify the current version of
+a package, and \fBnpm install <pkg>\fP (without any \fB@<version>\fP or \fB@<tag>\fP
+specifier) installs the \fBlatest\fP tag\. Typically, projects only use the \fBlatest\fP
+tag for stable release versions, and use other tags for unstable versions such
+as prereleases\.
+.P
+The \fBnext\fP tag is used by some projects to identify the upcoming version\.
+.P
+By default, other than \fBlatest\fP, no tag has any special significance to npm
+itself\.
 .SH CAVEATS
 .P
 This command used to be known as \fBnpm tag\fP, which only created new tags, and so

--- a/deps/npm/man/man1/npm-install.1
+++ b/deps/npm/man/man1/npm-install.1
@@ -33,7 +33,7 @@ c) a url that resolves to (b)
 .IP \(bu 2
 d) a \fB<name>@<version>\fP that is published on the registry (see npm help 7 \fBnpm\-registry\fP) with (c)
 .IP \(bu 2
-e) a \fB<name>@<tag>\fP that points to (d)
+e) a \fB<name>@<tag>\fP (see npm help \fBnpm\-dist\-tag\fP) that points to (d)
 .IP \(bu 2
 f) a \fB<name>\fP that has a "latest" tag satisfying (e)
 .IP \(bu 2
@@ -86,7 +86,7 @@ after packing it up into a tarball (b)\.
 .IP \(bu 2
 \fBnpm install [@<scope>/]<name> [\-\-save|\-\-save\-dev|\-\-save\-optional]\fP:
   Do a \fB<name>@<tag>\fP install, where \fB<tag>\fP is the "tag" config\. (See
-  npm help 7 \fBnpm\-config\fP\|\.)
+  npm help 7 \fBnpm\-config\fP\|\. The config's default value is \fBlatest\fP\|\.)
   In most cases, this will install the latest version
   of the module published on npm\.
   Example:

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -23,7 +23,7 @@ For example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@2.14.15 /path/to/npm
+npm@2.14.16 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm-publish.1
+++ b/deps/npm/man/man1/npm-publish.1
@@ -11,9 +11,11 @@ npm publish <folder> [\-\-tag <tag>] [\-\-access <public|restricted>]
 .RE
 .SH DESCRIPTION
 .P
-Publishes a package to the registry so that it can be installed by name\. See
-npm help 7 \fBnpm\-developers\fP for details on what's included in the published package, as
-well as details on how the package is built\.
+Publishes a package to the registry so that it can be installed by name\. All
+files in the package directory are included if no local \fB\|\.gitignore\fP or
+\fB\|\.npmignore\fP file is present\. See npm help 7 \fBnpm\-developers\fP for full details on
+what's included in the published package, as well as details on how the package
+is built\.
 .P
 By default npm will publish to the public registry\. This can be overridden by
 specifying a different default registry or using a npm help 7 \fBnpm\-scope\fP in the name
@@ -30,7 +32,8 @@ with a package\.json file inside\.
 \fB[\-\-tag <tag>]\fP
 Registers the published package with the given tag, such that \fBnpm install
 <name>@<tag>\fP will install this version\.  By default, \fBnpm publish\fP updates
-and \fBnpm install\fP installs the \fBlatest\fP tag\.
+and \fBnpm install\fP installs the \fBlatest\fP tag\. See npm help \fBnpm\-dist\-tag\fP for
+details about tags\.
 .IP \(bu 2
 \fB[\-\-access <public|restricted>]\fP
 Tells the registry whether this package should be published as public or

--- a/deps/npm/man/man1/npm-update.1
+++ b/deps/npm/man/man1/npm-update.1
@@ -25,7 +25,7 @@ or local) will be updated\.
 .P
 As of \fBnpm@2\.6\.1\fP, the \fBnpm update\fP will only inspect top\-level packages\.
 Prior versions of \fBnpm\fP would also recursively inspect all dependencies\.
-To get the old behavior, use \fBnpm \-\-depth 9999 update\fP, but be warned that
+To get the old behavior, use \fBnpm \-\-depth Infinity update\fP, but be warned that
 simultaneous asynchronous update of all packages, including \fBnpm\fP itself
 and packages that \fBnpm\fP depends on, often causes problems up to and including
 the uninstallation of \fBnpm\fP itself\.

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SH VERSION
 .P
-2.14.15
+2.14.16
 .SH DESCRIPTION
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man3/npm.3
+++ b/deps/npm/man/man3/npm.3
@@ -20,7 +20,7 @@ npm\.load([configObject, ]function (er, npm) {
 .RE
 .SH VERSION
 .P
-2.14.15
+2.14.16
 .SH DESCRIPTION
 .P
 This is the API documentation for npm\.

--- a/deps/npm/man/man5/npm-folders.5
+++ b/deps/npm/man/man5/npm-folders.5
@@ -25,12 +25,10 @@ If you need both, then install it in both places, or use \fBnpm link\fP\|\.
 .SS prefix Configuration
 .P
 The \fBprefix\fP config defaults to the location where node is installed\.
-On most systems, this is \fB/usr/local\fP, and most of the time is the same
-as node's \fBprocess\.installPrefix\fP\|\.
-.P
-On windows, this is the exact location of the node\.exe binary\.  On Unix
-systems, it's one level up, since node is typically installed at
-\fB{prefix}/bin/node\fP rather than \fB{prefix}/node\.exe\fP\|\.
+On most systems, this is \fB/usr/local\fP\|\. On windows, this is the exact
+location of the node\.exe binary\.  On Unix systems, it's one level up,
+since node is typically installed at \fB{prefix}/bin/node\fP rather than
+\fB{prefix}/node\.exe\fP\|\.
 .P
 When the \fBglobal\fP flag is set, npm installs things into this prefix\.
 When it is not set, it uses the root of the current package, or the

--- a/deps/npm/man/man5/npm-global.5
+++ b/deps/npm/man/man5/npm-global.5
@@ -25,12 +25,10 @@ If you need both, then install it in both places, or use \fBnpm link\fP\|\.
 .SS prefix Configuration
 .P
 The \fBprefix\fP config defaults to the location where node is installed\.
-On most systems, this is \fB/usr/local\fP, and most of the time is the same
-as node's \fBprocess\.installPrefix\fP\|\.
-.P
-On windows, this is the exact location of the node\.exe binary\.  On Unix
-systems, it's one level up, since node is typically installed at
-\fB{prefix}/bin/node\fP rather than \fB{prefix}/node\.exe\fP\|\.
+On most systems, this is \fB/usr/local\fP\|\. On windows, this is the exact
+location of the node\.exe binary\.  On Unix systems, it's one level up,
+since node is typically installed at \fB{prefix}/bin/node\fP rather than
+\fB{prefix}/node\.exe\fP\|\.
 .P
 When the \fBglobal\fP flag is set, npm installs things into this prefix\.
 When it is not set, it uses the root of the current package, or the

--- a/deps/npm/man/man5/npm-json.5
+++ b/deps/npm/man/man5/npm-json.5
@@ -21,7 +21,7 @@ The name is what your thing is called\.
 Some rules:
 .RS 0
 .IP \(bu 2
-The name must be shorter than 214 characters\. This includes the scope for
+The name must be less than or equal to 214 characters\. This includes the scope for
 scoped packages\.
 .IP \(bu 2
 The name can't start with a dot or an underscore\.
@@ -506,7 +506,7 @@ See npm help 7 semver for more details about specifying version ranges\.
 .IP \(bu 2
 \fBtag\fP A specific version tagged and published as \fBtag\fP  See npm help \fBnpm\-tag\fP
 .IP \(bu 2
-\fBpath/path/path\fP See Local Paths below
+\fBpath/path/path\fP See Local Paths \fI#local\-paths\fR below
 
 .RE
 .P

--- a/deps/npm/man/man5/package.json.5
+++ b/deps/npm/man/man5/package.json.5
@@ -21,7 +21,7 @@ The name is what your thing is called\.
 Some rules:
 .RS 0
 .IP \(bu 2
-The name must be shorter than 214 characters\. This includes the scope for
+The name must be less than or equal to 214 characters\. This includes the scope for
 scoped packages\.
 .IP \(bu 2
 The name can't start with a dot or an underscore\.
@@ -506,7 +506,7 @@ See npm help 7 semver for more details about specifying version ranges\.
 .IP \(bu 2
 \fBtag\fP A specific version tagged and published as \fBtag\fP  See npm help \fBnpm\-tag\fP
 .IP \(bu 2
-\fBpath/path/path\fP See Local Paths below
+\fBpath/path/path\fP See Local Paths \fI#local\-paths\fR below
 
 .RE
 .P

--- a/deps/npm/man/man7/npm-config.7
+++ b/deps/npm/man/man7/npm-config.7
@@ -323,7 +323,7 @@ A client certificate to pass when accessing the registry\.
 .SS color
 .RS 0
 .IP \(bu 2
-Default: true on Posix, false on Windows
+Default: true
 .IP \(bu 2
 Type: Boolean or \fB"always"\fP
 

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.14.15",
+  "version": "2.14.16",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -173,10 +173,9 @@
   ],
   "devDependencies": {
     "deep-equal": "~1.0.1",
-    "marked": "~0.3.3",
+    "marked": "~0.3.5",
     "marked-man": "~0.1.5",
-    "nock": "~1.9.0",
-    "npm-registry-couchapp": "~2.6.7",
+    "npm-registry-couchapp": "~2.6.12",
     "npm-registry-mock": "~1.0.0",
     "require-inject": "~1.3.0",
     "sprintf-js": "~1.0.2",

--- a/deps/npm/test/common-tap.js
+++ b/deps/npm/test/common-tap.js
@@ -18,6 +18,8 @@ process.env.npm_config_cache = exports.npm_config_cache = npm_config_cache
 process.env.npm_config_userconfig = exports.npm_config_userconfig = path.join(__dirname, 'fixtures', 'config', 'userconfig')
 process.env.npm_config_globalconfig = exports.npm_config_globalconfig = path.join(__dirname, 'fixtures', 'config', 'globalconfig')
 process.env.random_env_var = 'foo'
+// suppress warnings about using a prerelease version of node
+process.env.npm_config_node_version = process.version.replace(/-.*$/, '')
 
 var bin = exports.bin = require.resolve('../bin/npm-cli.js')
 var chain = require('slide').chain

--- a/deps/npm/test/common-tap.js
+++ b/deps/npm/test/common-tap.js
@@ -18,8 +18,6 @@ process.env.npm_config_cache = exports.npm_config_cache = npm_config_cache
 process.env.npm_config_userconfig = exports.npm_config_userconfig = path.join(__dirname, 'fixtures', 'config', 'userconfig')
 process.env.npm_config_globalconfig = exports.npm_config_globalconfig = path.join(__dirname, 'fixtures', 'config', 'globalconfig')
 process.env.random_env_var = 'foo'
-// suppress warnings about using a prerelease version of node
-process.env.npm_config_node_version = process.version.replace(/-.*$/, '')
 
 var bin = exports.bin = require.resolve('../bin/npm-cli.js')
 var chain = require('slide').chain

--- a/deps/npm/test/tap/404-private-registry-scoped.js
+++ b/deps/npm/test/tap/404-private-registry-scoped.js
@@ -1,22 +1,38 @@
-var nock = require('nock')
 var test = require('tap').test
-var npm = require('../../')
-var addNamed = require('../../lib/cache/add-named')
+var common = require('../common-tap.js')
+var mr = require('npm-registry-mock')
+var server
 
-test('scoped package names not mangled on error with non-root registry', function test404 (t) {
-  nock('http://localhost:1337')
-    .get('/registry/@scope%2ffoo')
-    .reply(404, {
-      error: 'not_found',
-      reason: 'document not found'
-    })
-
-  npm.load({registry: 'http://localhost:1337/registry', global: true}, function () {
-    addNamed('@scope/foo', '*', null, function checkError (err) {
-      t.ok(err, 'should error')
-      t.equal(err.message, '404 Not Found: @scope/foo', 'should have package name in error')
-      t.equal(err.pkgid, '@scope/foo', 'err.pkgid should match package name')
-      t.end()
-    })
+test('setup', function (t) {
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    server = s
+    t.end()
   })
+})
+
+test('scoped package names not mangled on error with non-root registry', function (t) {
+  common.npm(
+    [
+      'cache',
+      'add',
+      '@scope/foo@*',
+      '--force'
+    ],
+    {},
+    function (er, code, stdout, stderr) {
+      t.ifError(er, 'correctly handled 404')
+      t.equal(code, 1, 'exited with error')
+      t.match(stderr, /404 Not found/, 'should notify the sort of error as a 404')
+      t.match(stderr, /@scope\/foo/, 'should have package name in error')
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  t.pass('cleaned up')
+  server.done()
+  server.close()
+  t.end()
 })

--- a/deps/npm/test/tap/404-private-registry.js
+++ b/deps/npm/test/tap/404-private-registry.js
@@ -1,25 +1,39 @@
-var nock = require('nock')
 var test = require('tap').test
 var path = require('path')
-var npm = require('../../')
-var addNamed = require('../../lib/cache/add-named')
+var common = require('../common-tap.js')
+var mr = require('npm-registry-mock')
+var server
 
 var packageName = path.basename(__filename,'.js')
 
-test('package names not mangled on error with non-root registry', function test404 (t) {
-  nock('http://localhost:1337')
-    .get('/registry/' + packageName)
-    .reply(404, {
-      error: 'not_found',
-      reason: 'document not found'
-    })
-
-  npm.load({registry: 'http://localhost:1337/registry', global: true}, function () {
-    addNamed(packageName, '*', null, function checkError (err) {
-      t.ok(err, 'should error')
-      t.equal(err.message, '404 Not Found: ' + packageName, 'should have package name in error')
-      t.equal(err.pkgid, packageName, 'err.pkgid should match package name')
-      t.end()
-    })
+test('setup', function (t) {
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    server = s
+    t.end()
   })
+})
+
+test('package names not mangled on error with non-root registry', function (t) {
+  common.npm(
+    [
+      'cache',
+      'add',
+      packageName + '@*'
+    ],
+    {},
+    function (er, code, stdout, stderr) {
+      t.ifError(er, 'correctly handled 404')
+      t.equal(code, 1, 'exited with error')
+      t.match(stderr, packageName, 'should have package name in error')
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  t.pass('cleaned up')
+  server.done()
+  server.close()
+  t.end()
 })

--- a/deps/npm/test/tap/add-named-update-protocol-port.js
+++ b/deps/npm/test/tap/add-named-update-protocol-port.js
@@ -1,9 +1,10 @@
 'use strict'
 var path = require('path')
-var nock = require('nock')
 var test = require('tap').test
-var npm = require('../../')
-var addNamed = require('../../lib/cache/add-named')
+var common = require('../common-tap')
+var mr = require('npm-registry-mock')
+var server1
+var server2
 
 var packageName = path.basename(__filename, '.js')
 
@@ -36,46 +37,77 @@ var fooiPkg = {
   }
 }
 
-test('tarball paths should update port if updating protocol', function (t) {
-  nock('http://localhost:1337/registry')
-    .get('/' + packageName)
-    .reply(200, fooPkg)
-
-  nock('http://localhost:1337/registry')
-    .get('/' + packageName + '/-/' + packageName + '-0.0.0.tgz')
-    .reply(200, '1')
-
-  nock('http://localhost:1338/registry')
-    .get('/' + packageName + '/-/' + packageName + '-0.0.0.tgz')
-    .reply(404)
-
-  npm.load({registry: 'http://localhost:1337/registry', global: true}, function () {
-    addNamed(packageName, '0.0.0', null, function checkPath (err, pkg) {
-      t.ifError(err, 'addNamed worked')
+test('setup', function (t) {
+  mr({
+    port: 1337,
+    throwOnUnmatched: true
+  }, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    server1 = s
+    mr({
+      port: 1338,
+      throwOnUnmatched: true
+    }, function (err, s) {
+      t.ifError(err, 'registry mocked successfully')
+      server2 = s
       t.end()
     })
   })
 
 })
 
-test('tarball paths should NOT update if different hostname', function (t) {
-  nock('http://localhost:1337/registry')
-    .get('/' + iPackageName)
-    .reply(200, fooiPkg)
+test('tarball paths should update port if updating protocol', function (t) {
+  server1.get('/registry/' + packageName).reply(200, fooPkg)
+  server1.get(
+    '/registry/' + packageName + '/-/' + packageName + '-0.0.0.tgz'
+  ).reply(200, '1')
 
-  nock('http://127.0.0.1:1338/registry')
-    .get('/' + iPackageName + '/-/' + iPackageName + '-0.0.0.tgz')
-    .reply(200, '1')
-
-  nock('http://127.0.0.1:1337/registry')
-    .get('/' + iPackageName + '/-/' + iPackageName + '-0.0.0.tgz')
-    .reply(404)
-
-  npm.load({registry: 'http://localhost:1337/registry', global: true}, function () {
-    addNamed(iPackageName, '0.0.0', null, function checkPath (err, pkg) {
-      t.ifError(err, 'addNamed worked')
+  common.npm(
+    [
+      'cache',
+      'add',
+      packageName + '@0.0.0',
+      '--registry',
+      'http://localhost:1337/registry'
+    ],
+    {},
+    function (er, code, stdout, stderr) {
+      if (er) { throw er }
+      t.equal(code, 0, 'addNamed worked')
+      server1.done()
       t.end()
-    })
-  })
+    }
+  )
+})
 
+test('tarball paths should NOT update if different hostname', function (t) {
+  server1.get('/registry/' + iPackageName).reply(200, fooiPkg)
+  server2.get(
+    '/registry/' + iPackageName + '/-/' + iPackageName + '-0.0.0.tgz'
+  ).reply(200, '1')
+
+  common.npm(
+    [
+      'cache',
+      'add',
+      iPackageName + '@0.0.0',
+      '--registry',
+      'http://localhost:1337/registry'
+    ],
+    {},
+    function (er, code, stdout, stderr) {
+      if (er) { throw er }
+      t.equal(code, 0, 'addNamed worked')
+      server1.done()
+      server2.done()
+      t.end()
+    }
+  )
+})
+
+test('cleanup', function (t) {
+  t.pass('cleaned up')
+  server1.close()
+  server2.close()
+  t.end()
 })

--- a/deps/npm/test/tap/add-remote-git-fake-windows.js
+++ b/deps/npm/test/tap/add-remote-git-fake-windows.js
@@ -20,7 +20,7 @@ var pjParent = JSON.stringify({
   name: 'parent',
   version: '1.2.3',
   dependencies: {
-    child: 'git://localhost:1233/child.git'
+    child: 'git://localhost:1234/child.git'
   }
 }, null, 2) + '\n'
 
@@ -93,7 +93,8 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
-          '--port=1233'
+          '--reuseaddr',
+          '--port=1234'
         ],
         {
           cwd: pkg,

--- a/deps/npm/test/tap/add-remote-git-shrinkwrap.js
+++ b/deps/npm/test/tap/add-remote-git-shrinkwrap.js
@@ -20,7 +20,7 @@ var pjParent = JSON.stringify({
   name: 'parent',
   version: '1.2.3',
   dependencies: {
-    'child': 'git://localhost:1235/child.git#master'
+    'child': 'git://localhost:1234/child.git#master'
   }
 }, null, 2) + '\n'
 
@@ -68,7 +68,7 @@ test('shrinkwrap gets correct _from and _resolved (#7121)', function (t) {
       var shrinkwrap = require(resolve(pkg, 'npm-shrinkwrap.json'))
       t.equal(
         shrinkwrap.dependencies.child.from,
-        'git://localhost:1235/child.git#master',
+        'git://localhost:1234/child.git#master',
         'npm shrinkwrapped from correctly'
       )
 
@@ -82,7 +82,7 @@ test('shrinkwrap gets correct _from and _resolved (#7121)', function (t) {
 
           t.equal(
             shrinkwrap.dependencies.child.resolved,
-            'git://localhost:1235/child.git#' + treeish,
+            'git://localhost:1234/child.git#' + treeish,
             'npm shrinkwrapped resolved correctly'
           )
 
@@ -121,7 +121,8 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
-          '--port=1235'
+          '--reuseaddr',
+          '--port=1234'
         ],
         {
           cwd: pkg,

--- a/deps/npm/test/tap/add-remote-git.js
+++ b/deps/npm/test/tap/add-remote-git.js
@@ -80,6 +80,7 @@ function setup (cb) {
           '--listen=localhost',
           '--export-all',
           '--base-path=.',
+          '--reuseaddr',
           '--port=1234'
         ],
         {

--- a/deps/npm/test/tap/adduser-always-auth.js
+++ b/deps/npm/test/tap/adduser-always-auth.js
@@ -14,7 +14,24 @@ var responses = {
   "Email"    : "u@p.me\n"
 }
 
-function mocks(server) {
+function verifyStdout (runner, successMessage, t) {
+  var remaining = Object.keys(responses).length
+  return function (chunk) {
+    if (remaining > 0) {
+      remaining--
+
+      var label = chunk.toString('utf8').split(':')[0]
+      runner.stdin.write(responses[label])
+
+      if (remaining === 0) runner.stdin.end()
+    } else {
+      var message = chunk.toString('utf8').trim()
+      t.equal(message, successMessage)
+    }
+  }
+}
+
+function mocks (server) {
   server.filteringRequestBody(function (r) {
     if (r.match(/\"_id\":\"org\.couchdb\.user:u\"/)) {
       return "auth"
@@ -46,17 +63,140 @@ test("npm login", function (t) {
       })
     })
 
-    var o = "", e = "", remaining = Object.keys(responses).length
-    runner.stdout.on("data", function (chunk) {
-      remaining--
-      o += chunk
+    var message = 'Logged in as u on ' + common.registry + '/.'
+    runner.stdout.on('data', verifyStdout(runner, message, t))
+  })
+})
 
-      var label = chunk.toString("utf8").split(":")[0]
-      runner.stdin.write(responses[label])
+test('npm login --scope <scope> uses <scope>:registry as its URI', function (t) {
+  var port = common.port + 1
+  var uri = 'http://localhost:' + port + '/'
+  var scope = '@myco'
+  common.npm(
+    [
+      'config',
+      '--userconfig', outfile,
+      'set',
+      scope + ':registry',
+      uri
+    ],
+  opts,
+  function (err, code) {
+    t.notOk(code, 'exited OK')
+    t.notOk(err, 'no error output')
 
-      if (remaining === 0) runner.stdin.end()
+    mr({ port: port, plugin: mocks }, function (er, s) {
+      var runner = common.npm(
+        [
+          'login',
+          '--loglevel', 'silent',
+          '--userconfig', outfile,
+          '--scope', scope
+        ],
+      opts,
+      function (err, code) {
+        t.notOk(code, 'exited OK')
+        t.notOk(err, 'no error output')
+        var config = fs.readFileSync(outfile, 'utf8')
+        t.like(config, new RegExp(scope + ':registry=' + uri), 'scope:registry is set')
+        s.close()
+        rimraf(outfile, function (err) {
+          t.ifError(err, 'removed config file OK')
+          t.end()
+        })
+      })
+
+      var message = 'Logged in as u to scope ' + scope + ' on ' + uri + '.'
+      runner.stdout.on('data', verifyStdout(runner, message, t))
     })
-    runner.stderr.on("data", function (chunk) { e += chunk })
+  })
+})
+
+test('npm login --scope <scope> makes sure <scope> is prefixed by an @', function (t) {
+  var port = common.port + 1
+  var uri = 'http://localhost:' + port + '/'
+  var scope = 'myco'
+  var prefixedScope = '@' + scope
+  common.npm(
+    [
+      '--userconfig', outfile,
+      'config',
+      'set',
+      prefixedScope + ':registry',
+      uri
+    ],
+  opts,
+  function (err, code) {
+    t.notOk(code, 'exited OK')
+    t.notOk(err, 'no error output')
+
+    mr({ port: port, plugin: mocks }, function (er, s) {
+      var runner = common.npm(
+        [
+          'login',
+          '--loglevel', 'silent',
+          '--userconfig', outfile,
+          '--scope', scope
+        ],
+      opts,
+      function (err, code) {
+        t.notOk(code, 'exited OK')
+        t.notOk(err, 'no error output')
+        var config = fs.readFileSync(outfile, 'utf8')
+        t.like(config, new RegExp(prefixedScope + ':registry=' + uri), 'scope:registry is set')
+        s.close()
+        rimraf(outfile, function (err) {
+          t.ifError(err, 'removed config file OK')
+          t.end()
+        })
+      })
+
+      var message = 'Logged in as u to scope ' + prefixedScope + ' on ' + uri + '.'
+      runner.stdout.on('data', verifyStdout(runner, message, t))
+    })
+  })
+})
+
+test('npm login --scope <scope> --registry <registry> uses <registry> as its URI', function (t) {
+  var scope = '@myco'
+  common.npm(
+    [
+      '--userconfig', outfile,
+      'config',
+      'set',
+      scope + ':registry',
+      'invalidurl'
+    ],
+  opts,
+  function (err, code) {
+    t.notOk(code, 'exited OK')
+    t.notOk(err, 'no error output')
+
+    mr({ port: common.port, plugin: mocks }, function (er, s) {
+      var runner = common.npm(
+        [
+          'login',
+          '--registry', common.registry,
+          '--loglevel', 'silent',
+          '--userconfig', outfile,
+          '--scope', scope
+        ],
+      opts,
+      function (err, code) {
+        t.notOk(code, 'exited OK')
+        t.notOk(err, 'no error output')
+        var config = fs.readFileSync(outfile, 'utf8')
+        t.like(config, new RegExp(scope + ':registry=' + common.registry), 'scope:registry is set')
+        s.close()
+        rimraf(outfile, function (err) {
+          t.ifError(err, 'removed config file OK')
+          t.end()
+        })
+      })
+
+      var message = 'Logged in as u to scope ' + scope + ' on ' + common.registry + '/.'
+      runner.stdout.on('data', verifyStdout(runner, message, t))
+    })
   })
 })
 
@@ -83,17 +223,8 @@ test("npm login --always-auth", function (t) {
       })
     })
 
-    var o = "", e = "", remaining = Object.keys(responses).length
-    runner.stdout.on("data", function (chunk) {
-      remaining--
-      o += chunk
-
-      var label = chunk.toString("utf8").split(":")[0]
-      runner.stdin.write(responses[label])
-
-      if (remaining === 0) runner.stdin.end()
-    })
-    runner.stderr.on("data", function (chunk) { e += chunk })
+    var message = 'Logged in as u on ' + common.registry + '/.'
+    runner.stdout.on('data', verifyStdout(runner, message, t))
   })
 })
 
@@ -120,17 +251,8 @@ test("npm login --no-always-auth", function (t) {
       })
     })
 
-    var o = "", e = "", remaining = Object.keys(responses).length
-    runner.stdout.on("data", function (chunk) {
-      remaining--
-      o += chunk
-
-      var label = chunk.toString("utf8").split(":")[0]
-      runner.stdin.write(responses[label])
-
-      if (remaining === 0) runner.stdin.end()
-    })
-    runner.stderr.on("data", function (chunk) { e += chunk })
+    var message = 'Logged in as u on ' + common.registry + '/.'
+    runner.stdout.on('data', verifyStdout(runner, message, t))
   })
 })
 

--- a/deps/npm/test/tap/adduser-legacy-auth.js
+++ b/deps/npm/test/tap/adduser-legacy-auth.js
@@ -73,17 +73,20 @@ test('npm login', function (t) {
       })
     })
 
-    var o = '', e = '', remaining = Object.keys(responses).length
+    var remaining = Object.keys(responses).length
     runner.stdout.on('data', function (chunk) {
-      remaining--
-      o += chunk
+      if (remaining > 0) {
+        remaining--
 
-      var label = chunk.toString('utf8').split(':')[0]
-      runner.stdin.write(responses[label])
+        var label = chunk.toString('utf8').split(':')[0]
+        runner.stdin.write(responses[label])
 
-      if (remaining === 0) runner.stdin.end()
+        if (remaining === 0) runner.stdin.end()
+      } else {
+        var message = chunk.toString('utf8').trim()
+        t.equal(message, 'Logged in as u on ' + common.registry + '/.')
+      }
     })
-    runner.stderr.on('data', function (chunk) { e += chunk })
   })
 })
 

--- a/deps/npm/test/tap/correct-mkdir.js
+++ b/deps/npm/test/tap/correct-mkdir.js
@@ -1,0 +1,58 @@
+var test = require('tap').test
+var assert = require('assert')
+var path = require('path')
+var requireInject = require('require-inject')
+var cache_dir = path.resolve(__dirname, 'correct-mkdir')
+
+test('correct-mkdir: no race conditions', function (t) {
+  var mock_fs = {}
+  var did_hook = false
+  mock_fs.stat = function (path, cb) {
+    if (path === cache_dir) {
+      // Return a non-matching owner
+      cb(null, {
+        uid: +process.uid + 1,
+        isDirectory: function () {
+          return true
+        }
+      })
+      if (!did_hook) {
+        did_hook = true
+        doHook()
+      }
+    } else {
+      assert.ok(false, 'Unhandled stat path: ' + path)
+    }
+  }
+  var chown_in_progress = 0
+  var mock_chownr = function (path, uid, gid, cb) {
+    ++chown_in_progress
+    process.nextTick(function () {
+      --chown_in_progress
+      cb(null)
+    })
+  }
+  var mocks = {
+    'graceful-fs': mock_fs,
+    'chownr': mock_chownr
+  }
+  var correctMkdir = requireInject('../../lib/utils/correct-mkdir.js', mocks)
+
+  var calls_in_progress = 3
+  function handleCallFinish () {
+    t.equal(chown_in_progress, 0, 'should not return while chown still in progress')
+    if (!--calls_in_progress) {
+      t.end()
+    }
+  }
+  function doHook () {
+    // This is fired during the first correctMkdir call, after the stat has finished
+    // but before the chownr has finished
+    // Buggy old code will fail and return a cached value before initial call is done
+    correctMkdir(cache_dir, handleCallFinish)
+  }
+  // Initial call
+  correctMkdir(cache_dir, handleCallFinish)
+  // Immediate call again in case of race condition there
+  correctMkdir(cache_dir, handleCallFinish)
+})

--- a/deps/npm/test/tap/git-dependency-install-link.js
+++ b/deps/npm/test/tap/git-dependency-install-link.js
@@ -135,6 +135,7 @@ function setup (cb) {
             '--listen=localhost',
             '--export-all',
             '--base-path=.',
+            '--reuseaddr',
             '--port=1234'
           ],
           {

--- a/deps/npm/test/tap/install-link-scripts.js
+++ b/deps/npm/test/tap/install-link-scripts.js
@@ -122,7 +122,8 @@ function setup () {
     path.join(dep, 'package.json'),
     JSON.stringify(dependency, null, 2)
   )
-  fs.writeFileSync(path.join(dep, 'bin', 'foo'), foo, { mode: '0755' })
+  fs.writeFileSync(path.join(dep, 'bin', 'foo'), foo)
+  fs.chmod(path.join(dep, 'bin', 'foo'), '0755')
 }
 
 function cleanup () {

--- a/deps/npm/test/tap/noargs-install-config-save.js
+++ b/deps/npm/test/tap/noargs-install-config-save.js
@@ -1,18 +1,14 @@
-var common = require("../common-tap.js")
-var test = require("tap").test
-var npm = require.resolve("../../bin/npm-cli.js")
-var path = require("path")
-var fs = require("fs")
-var rimraf = require("rimraf")
-var mkdirp = require("mkdirp")
+var common = require('../common-tap.js')
+var test = require('tap').test
+var path = require('path')
+var fs = require('fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
 
 var mr = require("npm-registry-mock")
 
-var spawn = require("child_process").spawn
-var node = process.execPath
-
-var pkg = path.resolve(process.env.npm_config_tmp || "/tmp",
-  "noargs-install-config-save")
+var pkg = path.resolve(process.env.npm_config_tmp || '/tmp',
+  'noargs-install-config-save')
 
 function writePackageJson() {
   rimraf.sync(pkg)
@@ -29,33 +25,32 @@ function writePackageJson() {
   }), "utf8")
 }
 
-function createChild (args) {
-  var env = {
-    "npm_config_save": true,
-    "npm_config_registry": common.registry,
-    "npm_config_cache": pkg + "/cache",
-    HOME: process.env.HOME,
-    Path: process.env.PATH,
-    PATH: process.env.PATH
-  }
-
-  if (process.platform === "win32")
-    env.npm_config_cache = "%APPDATA%\\npm-cache"
-
-  return spawn(node, args, {
-    cwd: pkg,
-    env: env
-  })
+var env = {
+  'npm_config_save': true,
+  'npm_config_registry': common.registry,
+  'npm_config_cache': pkg + '/cache',
+  HOME: process.env.HOME,
+  Path: process.env.PATH,
+  PATH: process.env.PATH
+}
+var OPTS = {
+  cwd: pkg,
+  env: env
 }
 
 test("does not update the package.json with empty arguments", function (t) {
   writePackageJson()
-  t.plan(1)
+  t.plan(2)
 
-  mr({port : common.port}, function (er, s) {
-    var child = createChild([npm, "install"])
-    child.on("close", function () {
-      var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))
+  mr({ port: common.port }, function (er, s) {
+    common.npm('install', OPTS, function (er, code, stdout, stderr) {
+      if (er) throw er
+      t.is(code, 0)
+      if (code !== 0) {
+        console.error('#', stdout)
+        console.error('#', stderr)
+      }
+      var text = JSON.stringify(fs.readFileSync(pkg + '/package.json', 'utf8'))
       s.close()
       t.ok(text.indexOf("\"dependencies") === -1)
     })
@@ -64,11 +59,12 @@ test("does not update the package.json with empty arguments", function (t) {
 
 test("updates the package.json (adds dependencies) with an argument", function (t) {
   writePackageJson()
-  t.plan(1)
+  t.plan(2)
 
-  mr({port : common.port}, function (er, s) {
-    var child = createChild([npm, "install", "underscore"])
-    child.on("close", function () {
+  mr({ port: common.port }, function (er, s) {
+    common.npm(['install', 'underscore'], OPTS, function (er, code, stdout, stderr) {
+      if (er) throw er
+      t.is(code, 0)
       s.close()
       var text = JSON.stringify(fs.readFileSync(pkg + "/package.json", "utf8"))
       t.ok(text.indexOf("\"dependencies") !== -1)

--- a/deps/npm/test/tap/publish-access-scoped.js
+++ b/deps/npm/test/tap/publish-access-scoped.js
@@ -1,81 +1,70 @@
 var fs = require("fs")
 var path = require("path")
 
-var test = require("tap").test
-var mkdirp = require("mkdirp")
-var rimraf = require("rimraf")
-var nock = require("nock")
-
-var npm = require("../../")
-var common = require("../common-tap.js")
+var test = require('tap').test
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var mr = require('npm-registry-mock')
+var common = require('../common-tap')
+var server
 
 var pkg = path.join(__dirname, "publish-access")
 
-// TODO: nock uses setImmediate, breaks 0.8: replace with mockRegistry
-if (!global.setImmediate) {
-  global.setImmediate = function () {
-    var args = [arguments[0], 0].concat([].slice.call(arguments, 1))
-    setTimeout.apply(this, args)
-  }
-}
-
-test("setup", function (t) {
-  mkdirp(path.join(pkg, "cache"), function () {
-    var configuration = {
-      cache    : path.join(pkg, "cache"),
-      loglevel : "silent",
-      registry : common.registry
-    }
-
-    npm.load(configuration, next)
+test('setup', function (t) {
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    t.pass('setup done')
+    server = s
+    t.end()
   })
+})
 
-  function next (er) {
-    t.ifError(er, "npm loaded successfully")
+test('scoped packages pass public access if set', function (t) {
+  server.filteringRequestBody(function (body) {
+    t.doesNotThrow(function () {
+      var parsed = JSON.parse(body)
+      t.equal(parsed.access, 'public', 'access level is correct')
+    }, 'converted body back into object')
+    return true
+  }).put('/@bigco%2fpublish-access', true).reply(201, {ok: true})
 
-    process.chdir(pkg)
+  mkdirp(path.join(pkg, 'cache'), function () {
     fs.writeFile(
       path.join(pkg, "package.json"),
       JSON.stringify({
-        name: "@bigco/publish-access",
-        version: "1.2.5"
+        name: '@bigco/publish-access',
+        version: '1.2.5',
+        public: true
       }),
       "ascii",
       function (er) {
-        t.ifError(er)
+        t.ifError(er, 'package file written')
+        common.npm(
+          [
+            'publish',
+            '--access', 'public',
+            '--cache', path.join(pkg, 'cache'),
+            '--loglevel', 'silly',
+            '--registry', common.registry
+          ],
+          {
+            cwd: pkg
+          },
+          function (er) {
+            t.ifError(er, 'published without error')
 
-        t.pass("setup done")
-        t.end()
+            server.done()
+            t.end()
+          }
+        )
       }
     )
-  }
-})
-
-test("scoped packages pass public access if set", function (t) {
-  var put = nock(common.registry)
-              .put("/@bigco%2fpublish-access")
-              .reply(201, verify)
-
-  npm.config.set("access", "public")
-  npm.commands.publish([], false, function (er) {
-    t.ifError(er, "published without error")
-
-    put.done()
-    t.end()
   })
-
-  function verify (_, body) {
-    t.doesNotThrow(function () {
-      var parsed = JSON.parse(body)
-      t.equal(parsed.access, "public", "access level is correct")
-    }, "converted body back into object")
-
-    return {ok: true}
-  }
 })
 
 test("cleanup", function (t) {
   process.chdir(__dirname)
+  server.close()
   rimraf(pkg, function (er) {
     t.ifError(er)
 

--- a/deps/npm/test/tap/publish-access-unscoped.js
+++ b/deps/npm/test/tap/publish-access-unscoped.js
@@ -1,81 +1,70 @@
 var fs = require("fs")
 var path = require("path")
 
-var test = require("tap").test
-var mkdirp = require("mkdirp")
-var rimraf = require("rimraf")
-var nock = require("nock")
-
-var npm = require("../../")
-var common = require("../common-tap.js")
+var test = require('tap').test
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var mr = require('npm-registry-mock')
+var common = require('../common-tap')
+var server
 
 var pkg = path.join(__dirname, "publish-access-unscoped")
 
-// TODO: nock uses setImmediate, breaks 0.8: replace with mockRegistry
-if (!global.setImmediate) {
-  global.setImmediate = function () {
-    var args = [arguments[0], 0].concat([].slice.call(arguments, 1))
-    setTimeout.apply(this, args)
-  }
-}
-
-test("setup", function (t) {
-  mkdirp(path.join(pkg, "cache"), function () {
-    var configuration = {
-      cache    : path.join(pkg, "cache"),
-      loglevel : "silent",
-      registry : common.registry
-    }
-
-    npm.load(configuration, next)
+test('setup', function (t) {
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    t.pass('setup done')
+    server = s
+    t.end()
   })
+})
 
-  function next (er) {
-    t.ifError(er, "npm loaded successfully")
+test('unscoped packages can be explicitly set as public', function (t) {
+  server.filteringRequestBody(function (body) {
+    t.doesNotThrow(function () {
+      var parsed = JSON.parse(body)
+      t.equal(parsed.access, 'public', 'access level is correct')
+    }, 'converted body back into object')
+    return true
+  }).put('/publish-access', true).reply(201, {ok: true})
 
-    process.chdir(pkg)
+  mkdirp(path.join(pkg, 'cache'), function () {
     fs.writeFile(
       path.join(pkg, "package.json"),
       JSON.stringify({
-        name: "publish-access",
-        version: "1.2.5"
+        name: 'publish-access',
+        version: '1.2.5',
+        public: true
       }),
       "ascii",
       function (er) {
-        t.ifError(er)
+        t.ifError(er, 'package file written')
+        common.npm(
+          [
+            'publish',
+            '--access', 'public',
+            '--cache', path.join(pkg, 'cache'),
+            '--loglevel', 'silly',
+            '--registry', common.registry
+          ],
+          {
+            cwd: pkg
+          },
+          function (er) {
+            t.ifError(er, 'published without error')
 
-        t.pass("setup done")
-        t.end()
+            server.done()
+            t.end()
+          }
+        )
       }
     )
-  }
-})
-
-test("unscoped packages can be explicitly set as public", function (t) {
-  var put = nock(common.registry)
-              .put("/publish-access")
-              .reply(201, verify)
-
-  npm.config.set("access", "public")
-  npm.commands.publish([], false, function (er) {
-    t.ifError(er, "published without error")
-
-    put.done()
-    t.end()
   })
-
-  function verify (_, body) {
-    t.doesNotThrow(function () {
-      var parsed = JSON.parse(body)
-      t.equal(parsed.access, "public", "access level is correct")
-    }, "converted body back into object")
-
-    return {ok: true}
-  }
 })
 
 test("cleanup", function (t) {
   process.chdir(__dirname)
+  server.close()
   rimraf(pkg, function (er) {
     t.ifError(er)
 

--- a/deps/npm/test/tap/publish-scoped.js
+++ b/deps/npm/test/tap/publish-scoped.js
@@ -1,68 +1,64 @@
 var fs = require("fs")
 var path = require("path")
 
-var test = require("tap").test
-var mkdirp = require("mkdirp")
-var rimraf = require("rimraf")
-var nock = require("nock")
-
-var npm = require("../../")
-var common = require("../common-tap.js")
+var test = require('tap').test
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var common = require('../common-tap')
+var mr = require('npm-registry-mock')
 
 var pkg = path.join(__dirname, "prepublish_package")
 
-test("setup", function (t) {
-  mkdirp(path.join(pkg, "cache"), next)
+var server
 
-  function next () {
-    process.chdir(pkg)
-    fs.writeFile(
-      path.join(pkg, "package.json"),
-      JSON.stringify({
-        name: "@bigco/publish-organized",
-        version: "1.2.5"
-      }),
-      "ascii",
-      function (er) {
-        t.ifError(er)
+function setup () {
+  cleanup()
+  mkdirp.sync(path.join(pkg, 'cache'))
 
-        t.pass("setup done")
-        t.end()
-      }
-    )
-  }
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify({
+      name: '@bigco/publish-organized',
+      version: '1.2.5'
+    }, null, 2),
+    'ascii')
+}
+
+test('setup', function (t) {
+  setup()
+  mr({port: common.port, throwOnUnmatched: true}, function (err, s) {
+    t.ifError(err, 'registry mocked successfully')
+    server = s
+    t.end()
+  })
 })
 
-test("npm publish should honor scoping", function (t) {
-  var put = nock(common.registry)
-              .put("/@bigco%2fpublish-organized")
-              .reply(201, verify)
+test('npm publish should honor scoping', function (t) {
+  server.filteringRequestBody(verify)
+        .put('/@bigco%2fpublish-organized', true)
+        .reply(201, {ok: true})
 
-  var configuration = {
-    cache    : path.join(pkg, "cache"),
-    loglevel : "silent",
-    registry : "http://nonexistent.lvh.me",
-    "//localhost:1337/:username" : "username",
-    "//localhost:1337/:_password" : new Buffer("password").toString("base64"),
-    "//localhost:1337/:email" : "ogd@aoaioxxysz.net"
-  }
+  var configuration = [
+    'progress=false',
+    'cache=' + path.join(pkg, 'cache'),
+    'registry=http://nonexistent.lvh.me',
+    '//localhost:1337/:username=username',
+    '//localhost:1337/:_password=' + new Buffer('password').toString('base64'),
+    '//localhost:1337/:email=' + 'ogd@aoaioxxysz.net',
+    '@bigco:registry=' + common.registry
+  ]
+  var configFile = path.join(pkg, '.npmrc')
 
-  npm.load(configuration, onload)
+  fs.writeFileSync(configFile, configuration.join('\n') + '\n')
 
-  function onload (er) {
-    t.ifError(er, "npm bootstrapped successfully")
+  common.npm(['publish'], {'cwd': pkg}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.is(code, 0, 'published without error')
+    server.done()
+    t.end()
+  })
 
-    npm.config.set("@bigco:registry", common.registry)
-    npm.commands.publish([], false, function (er) {
-      t.ifError(er, "published without error")
-
-      put.done()
-
-      t.end()
-    })
-  }
-
-  function verify (_, body) {
+  function verify (body) {
     t.doesNotThrow(function () {
       var parsed = JSON.parse(body)
       var current = parsed.versions["1.2.5"]
@@ -79,15 +75,17 @@ test("npm publish should honor scoping", function (t) {
       )
     }, "converted body back into object")
 
-    return {ok: true}
+    return true
   }
 })
 
-test("cleanup", function (t) {
-  process.chdir(__dirname)
-  rimraf(pkg, function (er) {
-    t.ifError(er)
-
-    t.end()
-  })
+test('cleanup', function (t) {
+  server.close()
+  t.end()
+  cleanup()
 })
+
+function cleanup () {
+  process.chdir(__dirname)
+  rimraf.sync(pkg)
+}

--- a/deps/npm/test/tap/registry.js
+++ b/deps/npm/test/tap/registry.js
@@ -38,11 +38,14 @@ function runTests () {
     cwd: ca,
     stdio: "inherit"
   }
-  common.npm(["install"], opts, function (err, code) {
+  common.npm(["install"], opts, function (err, code, stdout, stderr) {
     if (err) { throw err }
     if (code) {
       return test("need install to work", function (t) {
-        t.fail("install failed with: " + code)
+        t.fail(
+          "install failed with: " + code +
+          '\nstdout: ' + stdout +
+          '\nstderr: ' + stderr)
         t.end()
       })
 
@@ -52,24 +55,32 @@ function runTests () {
         env: env,
         stdio: "inherit"
       }
-      common.npm(["test", "--", "-Rtap"], opts, function (err, code) {
-        if (err) { throw err }
-        if (code) {
-          return test("need test to work", function (t) {
-            t.fail("test failed with: " + code)
-            t.end()
+      common.npm(
+        [
+          "test", "--", "-Rtap"
+        ],
+        opts,
+        function (err, code, stdout, stderr) {
+          if (err) { throw err }
+          if (code) {
+            return test("need test to work", function (t) {
+              t.fail(
+                "test failed with: " + code +
+                '\nstdout: ' + stdout +
+                '\nstderr: ' + stderr)
+                t.end()
+              })
+            }
+            opts = {
+              cwd: ca,
+              env: env,
+              stdio: "inherit"
+            }
+            common.npm(["prune", "--production"], opts, function (err, code) {
+              if (err) { throw err }
+              process.exit(code || 0)
+            })
           })
         }
-        opts = {
-          cwd: ca,
-          env: env,
-          stdio: "inherit"
-        }
-        common.npm(["prune", "--production"], opts, function (err, code) {
-          if (err) { throw err }
-          process.exit(code || 0)
-        })
-      })
-    }
   })
 }

--- a/deps/npm/test/tap/sorted-package-json.js
+++ b/deps/npm/test/tap/sorted-package-json.js
@@ -27,7 +27,7 @@ test("sorting dependencies", function (t) {
   mr({port : common.port}, function (er, s) {
     // underscore is already in the package.json,
     // but --save will trigger a rewrite with sort
-    var child = spawn(node, [npm, "install", "--save", "underscore@1.3.3"], {
+    var child = spawn(node, [npm, "install", "--save", "underscore@1.3.3", "--no-progress", "--loglevel=error"], {
       cwd: pkg,
       env: {
         "npm_config_registry": common.registry,
@@ -38,7 +38,8 @@ test("sorting dependencies", function (t) {
         HOME: process.env.HOME,
         Path: process.env.PATH,
         PATH: process.env.PATH
-      }
+      },
+      stdio: ['ignore', 'ignore', process.stderr]
     })
 
     child.on("close", function (code) {


### PR DESCRIPTION
Another day, another LTS!

The changelog for this version can be found here: https://github.com/npm/npm/releases/tag/v2.14.16

Interesting changes:

* [`24b13fb`](https://github.com/npm/npm/commit/24b13fbc57d34db1d5b0a37bcca122c00deba978) [#11158](https://github.com/npm/npm/pull/11158) and [`5c0e4c4`](https://github.com/npm/npm/commit/5c0e4c45a29d774ab729e86044377d4e5e424252) [#10940](https://github.com/npm/npm/pull/10940) which include patches by [@orangemocha](https://github.com/orangemocha) that they had asked about in #4872
* [`64995be`](https://github.com/npm/npm/commit/64995be6d874356b15c136f9867302d805dfe1e9) [`75ab216`](https://github.com/npm/npm/commit/75ab2164cf79e28ac7f7ebe714f3c5aee99c6626) [`a9f6fe9`](https://github.com/npm/npm/commit/a9f6fe9dc558f17c4a7b9eb83329ac080f7df4b7) [`649c193`](https://github.com/npm/npm/commit/649c193adadf714c2819837f9372a29d724a5ec0) [`94cb05e`](https://github.com/npm/npm/commit/94cb05eaa9e5ad6675cf15c4ac0a44fbdde05900) [`6541690`](https://github.com/npm/npm/commit/65416907008061ac5a5f66b1630a57776803b526) [`255be6f`](https://github.com/npm/npm/commit/255be6f5bca9e3d216f3a5cbdf6714c6c9fcf132) [`9e84fa4`](https://github.com/npm/npm/commit/9e84fa43c49d04cf86ca1678e2a61412f5559cb9) [`8a587b0`](https://github.com/npm/npm/commit/8a587b0c1696ae7302891fa6355fc3e8670e00d3) [`bf812a5`](https://github.com/npm/npm/commit/bf812a54e497a573493346399798aa0b9373ac24) [#10903](https://github.com/npm/npm/pull/10903) Get rid of nock from tests, and get Travis green, which might hopefully also make CI in general more reliable. ([@zkat](https://github.com/zkat) and [@iarna](https://github.com/iarna))
* A few other general bugfixes.
* Lots of doc updates/fixes.

**r**: @Fishrock123 
**r**: @iarna