### PR TITLE
module: refactor redeclared variable

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -456,10 +456,11 @@ Module.runMain = function() {
 Module._initPaths = function() {
   const isWindows = process.platform === 'win32';
 
+  var homeDir;
   if (isWindows) {
-    var homeDir = process.env.USERPROFILE;
+    homeDir = process.env.USERPROFILE;
   } else {
-    var homeDir = process.env.HOME;
+    homeDir = process.env.HOME;
   }
 
   var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];


### PR DESCRIPTION
`homedir` was declared with `var` twice in the same scope in
`lib/module.js`. This change makes it a single declaration.