### PR TITLE
net: refactor redeclared variables

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -651,10 +651,8 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     var chunks = new Array(data.length << 1);
     for (var i = 0; i < data.length; i++) {
       var entry = data[i];
-      var chunk = entry.chunk;
-      var enc = entry.encoding;
-      chunks[i * 2] = chunk;
-      chunks[i * 2 + 1] = enc;
+      chunks[i * 2] = entry.chunk;
+      chunks[i * 2 + 1] = entry.encoding;
     }
     err = this._handle.writev(req, chunks);
 
@@ -806,14 +804,14 @@ function connect(self, address, port, addressType, localAddress, localPort) {
     err = bind(localAddress, localPort);
 
     if (err) {
-      var ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
+      const ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
       self._destroy(ex);
       return;
     }
   }
 
   if (addressType === 6 || addressType === 4) {
-    var req = new TCPConnectWrap();
+    const req = new TCPConnectWrap();
     req.oncomplete = afterConnect;
     req.address = address;
     req.port = port;
@@ -826,7 +824,7 @@ function connect(self, address, port, addressType, localAddress, localPort) {
       err = self._handle.connect6(req, address, port);
 
   } else {
-    var req = new PipeConnectWrap();
+    const req = new PipeConnectWrap();
     req.address = address;
     req.oncomplete = afterConnect;
     err = self._handle.connect(req, address, afterConnect);
@@ -840,7 +838,7 @@ function connect(self, address, port, addressType, localAddress, localPort) {
       details = sockname.address + ':' + sockname.port;
     }
 
-    var ex = exceptionWithHostPort(err, 'connect', address, port, details);
+    const ex = exceptionWithHostPort(err, 'connect', address, port, details);
     self._destroy(ex);
   }
 }
@@ -1353,7 +1351,7 @@ Server.prototype.listen = function() {
         else
           listen(self, null, h.port | 0, 4, backlog, undefined, h.exclusive);
       } else if (h.path && isPipeName(h.path)) {
-        var pipeName = self._pipeName = h.path;
+        const pipeName = self._pipeName = h.path;
         listen(self, pipeName, -1, -1, backlog, undefined, h.exclusive);
       } else {
         throw new Error('Invalid listen argument: ' + h);
@@ -1361,7 +1359,7 @@ Server.prototype.listen = function() {
     }
   } else if (isPipeName(arguments[0])) {
     // UNIX socket or Windows pipe.
-    var pipeName = self._pipeName = arguments[0];
+    const pipeName = self._pipeName = arguments[0];
     listen(self, pipeName, -1, -1, backlog);
 
   } else if (arguments[1] === undefined ||


### PR DESCRIPTION
`lib/net.js` contained four variables that were redeclared with `var` in
the same scope. This change refactors those redeclarations so they are
scoped properly.