### PR TITLE
lib: scope loop variables

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -270,7 +270,7 @@ win32.relative = function(from, to) {
 
   var length = Math.min(lowerFromParts.length, lowerToParts.length);
   var samePartsLength = length;
-  for (let i = 0; i < length; i++) {
+  for (var i = 0; i < length; i++) {
     if (lowerFromParts[i] !== lowerToParts[i]) {
       samePartsLength = i;
       break;
@@ -282,7 +282,7 @@ win32.relative = function(from, to) {
   }
 
   var outputParts = [];
-  for (let i = samePartsLength; i < lowerFromParts.length; i++) {
+  for (var j = samePartsLength; j < lowerFromParts.length; j++) {
     outputParts.push('..');
   }
 
@@ -495,7 +495,7 @@ posix.relative = function(from, to) {
 
   var length = Math.min(fromParts.length, toParts.length);
   var samePartsLength = length;
-  for (let i = 0; i < length; i++) {
+  for (var i = 0; i < length; i++) {
     if (fromParts[i] !== toParts[i]) {
       samePartsLength = i;
       break;
@@ -503,7 +503,7 @@ posix.relative = function(from, to) {
   }
 
   var outputParts = [];
-  for (let i = samePartsLength; i < fromParts.length; i++) {
+  for (var j = samePartsLength; j < fromParts.length; j++) {
     outputParts.push('..');
   }
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -270,7 +270,7 @@ win32.relative = function(from, to) {
 
   var length = Math.min(lowerFromParts.length, lowerToParts.length);
   var samePartsLength = length;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     if (lowerFromParts[i] !== lowerToParts[i]) {
       samePartsLength = i;
       break;
@@ -282,7 +282,7 @@ win32.relative = function(from, to) {
   }
 
   var outputParts = [];
-  for (var i = samePartsLength; i < lowerFromParts.length; i++) {
+  for (let i = samePartsLength; i < lowerFromParts.length; i++) {
     outputParts.push('..');
   }
 
@@ -495,7 +495,7 @@ posix.relative = function(from, to) {
 
   var length = Math.min(fromParts.length, toParts.length);
   var samePartsLength = length;
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     if (fromParts[i] !== toParts[i]) {
       samePartsLength = i;
       break;
@@ -503,7 +503,7 @@ posix.relative = function(from, to) {
   }
 
   var outputParts = [];
-  for (var i = samePartsLength; i < fromParts.length; i++) {
+  for (let i = samePartsLength; i < fromParts.length; i++) {
     outputParts.push('..');
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,8 +13,8 @@ const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (typeof f !== 'string') {
     var objects = [];
-    for (let i = 0; i < arguments.length; i++) {
-      objects.push(inspect(arguments[i]));
+    for (var index = 0; index < arguments.length; index++) {
+      objects.push(inspect(arguments[index]));
     }
     return objects.join(' ');
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,7 +13,7 @@ const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (typeof f !== 'string') {
     var objects = [];
-    for (var i = 0; i < arguments.length; i++) {
+    for (let i = 0; i < arguments.length; i++) {
       objects.push(inspect(arguments[i]));
     }
     return objects.join(' ');


### PR DESCRIPTION
Refactor instances in `lib` where a loop variable is redeclared in the
same scope with `var`. In these cases, `let` can be used to scope the
variable declarations more precisely.