### PR TITLE
test: refactor test-http-destroyed-socket-write2

### DIFF
--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -19,28 +19,13 @@ server.listen(common.PORT, function() {
     method: 'POST'
   });
 
-  var timer = setTimeout(write, 50);
-  var writes = 0;
-
   function write() {
-    if (++writes === 128) {
-      clearTimeout(timer);
-      req.end();
-      test();
-    } else {
-      req.write('hello', function() {
-        timer = setImmediate(write);
-      });
-    }
+    req.write('hello', function() {
+      setImmediate(write);
+    });
   }
 
-  var gotError = false;
-  var sawData = false;
-  var sawEnd = false;
-
-  req.on('error', function(er) {
-    assert(!gotError);
-    gotError = true;
+  req.on('error', common.mustCall(function(er) {
     switch (er.code) {
       // This is the expected case
       case 'ECONNRESET':
@@ -56,39 +41,20 @@ server.listen(common.PORT, function() {
           'Writing to a torn down client should RESET or ABORT');
         break;
     }
-    clearTimeout(timer);
-    console.log('ECONNRESET was raised after %d writes', writes);
-    test();
-  });
+
+    assert.equal(req.output.length, 0);
+    assert.equal(req.outputEncodings.length, 0);
+    server.close();
+  }));
 
   req.on('response', function(res) {
     res.on('data', function(chunk) {
-      console.error('saw data: ' + chunk);
-      sawData = true;
+      common.fail('Should not receive response data');
     });
     res.on('end', function() {
-      console.error('saw end');
-      sawEnd = true;
+      common.fail('Should not receive response end');
     });
   });
 
-  var closed = false;
-
-  function test() {
-    if (closed)
-      return;
-
-    server.close();
-    closed = true;
-
-    if (req.output.length || req.outputEncodings.length)
-      console.error('bad happened', req.output, req.outputEncodings);
-
-    assert.equal(req.output.length, 0);
-    assert.equal(req.outputEncodings, 0);
-    assert(gotError);
-    assert(!sawData);
-    assert(!sawEnd);
-    console.log('ok');
-  }
+  write();
 });


### PR DESCRIPTION
Remove the limit of requests to be sent (128) as in some conditions it
was reached without the `error` event being fired, causing the
test to fail.
Remove the initial timeout.
Remove some variables used to check the validity of the test and replace
them with `common.mustCall` and `common.fail` calls.

The error I was getting from time to time in `OS X` was:
```
=== release test-http-destroyed-socket-write2 ===                    
Path: parallel/test-http-destroyed-socket-write2
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: false == true
    at test (/Users/sgimeno/node/node/test/parallel/test-http-destroyed-socket-write2.js:89:5)
    at Immediate.write [as _onImmediate] (/Users/sgimeno/node/node/test/parallel/test-http-destroyed-socket-write2.js:29:7)
    at processImmediate [as _immediateCallback] (timers.js:392:17)
Command: out/Release/node /Users/sgimeno/node/node/test/parallel/test-http-destroyed-socket-write2.js
```
