### PR TITLE
lib: EventEmitter emit performance improvement

### DIFF
--- a/benchmark/events/ee-emit-variable-args.js
+++ b/benchmark/events/ee-emit-variable-args.js
@@ -1,0 +1,23 @@
+var common = require('../common.js');
+var EventEmitter = require('events').EventEmitter;
+
+var bench = common.createBenchmark(main, {n: [2e6]});
+
+function main(conf) {
+  var n = conf.n | 0;
+
+  var ee = new EventEmitter();
+  var listeners = [];
+
+  for (var k = 0; k < 10; k += 1)
+    ee.on('dummy', function() {});
+
+  bench.start();
+  for (var i = 0; i < n; i += 1) {
+    ee.emit('dummy');
+    ee.emit('dummy', 5);
+    ee.emit('dummy', 5, true, 'hi');
+    ee.emit('dummy', 5, true, 'hi', {});
+  }
+  bench.end(n);
+}

--- a/lib/events.js
+++ b/lib/events.js
@@ -71,65 +71,8 @@ EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
   return $getMaxListeners(this);
 };
 
-// These standalone emit* functions are used to optimize calling of event
-// handlers for fast cases because emit() itself often has a variable number of
-// arguments and can be deoptimized because of that. These functions always have
-// the same number of arguments and thus do not get deoptimized, so the code
-// inside them can execute faster.
-function emitNone(handler, isFn, self) {
-  if (isFn)
-    handler.call(self);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self);
-  }
-}
-function emitOne(handler, isFn, self, arg1) {
-  if (isFn)
-    handler.call(self, arg1);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self, arg1);
-  }
-}
-function emitTwo(handler, isFn, self, arg1, arg2) {
-  if (isFn)
-    handler.call(self, arg1, arg2);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self, arg1, arg2);
-  }
-}
-function emitThree(handler, isFn, self, arg1, arg2, arg3) {
-  if (isFn)
-    handler.call(self, arg1, arg2, arg3);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self, arg1, arg2, arg3);
-  }
-}
-
-function emitMany(handler, isFn, self, args) {
-  if (isFn)
-    handler.apply(self, args);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].apply(self, args);
-  }
-}
-
 EventEmitter.prototype.emit = function emit(type) {
-  var er, handler, len, args, i, events, domain;
+  var er, handler, args, i, events, domain;
   var needDomainExit = false;
   var doError = (type === 'error');
 
@@ -172,28 +115,16 @@ EventEmitter.prototype.emit = function emit(type) {
     needDomainExit = true;
   }
 
-  var isFn = typeof handler === 'function';
-  len = arguments.length;
-  switch (len) {
-    // fast cases
-    case 1:
-      emitNone(handler, isFn, this);
-      break;
-    case 2:
-      emitOne(handler, isFn, this, arguments[1]);
-      break;
-    case 3:
-      emitTwo(handler, isFn, this, arguments[1], arguments[2]);
-      break;
-    case 4:
-      emitThree(handler, isFn, this, arguments[1], arguments[2], arguments[3]);
-      break;
-    // slower
-    default:
-      args = new Array(len - 1);
-      for (i = 1; i < len; i++)
-        args[i - 1] = arguments[i];
-      emitMany(handler, isFn, this, args);
+  args = new Array(arguments.length - 1);
+  for (i = 1; i < arguments.length; i++)
+    args[i - 1] = arguments[i];
+  if (typeof handler === 'function')
+    handler.apply(this, args);
+  else {
+    var listenerLength = handler.length;
+    var listeners = arrayClone(handler, listenerLength);
+    for (var i = 0; i < listenerLength; ++i)
+      listeners[i].apply(this, args);
   }
 
   if (needDomainExit)


### PR DESCRIPTION
Previously, there were specialized emit functions used for calls to emit
with different numbers of arguments. Though originally used to improve
performance and avoid V8 deopts, they are no longer necessary. Removing
them results in a substantial peformance increasing benchmark
performance by as much as 150%. Removing these specialized functions
also simplifies the code and reduces overall code size.

This also adds a new benchmark which calls emit with different argument
counts inside a tight loop to expose v8 deopts if present. Emit performs
better without the specialized emit functions on this new benchmark as
well.