### PR TITLE
repl: remove variable redeclaration

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -655,7 +655,7 @@ REPLServer.prototype.complete = function(line, callback) {
   // list of completion lists, one for each inheritance "level"
   var completionGroups = [];
 
-  var completeOn, match, filter, i, group, c;
+  var completeOn, i, group, c;
 
   // REPL commands (e.g. ".break").
   var match = null;


### PR DESCRIPTION
`match` and `filter` are declared twice with `var` in `repl.js`. Declare the variables only once.