### PR TITLE
test: fix test-http-extra-response flakiness

### DIFF
--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -37,6 +37,10 @@ var server = net.createServer(function(socket) {
       socket.end(fullResponse);
     }
   });
+
+  socket.on('error', function(err) {
+    assert.equal(err.code, 'ECONNRESET');
+  });
 });
 
 


### PR DESCRIPTION
It can happen that the extra response is to be sent in a different chunk
from the rest of the data. At this moment, the client might have already
closed the socket causing an `ECONNRESET` error.

I am sometimes getting this error running the test suite in `OS X`:
```
Path: parallel/test-http-extra-response
Got res code: 500
Response ended, read 13 bytes
events.js:155
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at exports._errnoException (util.js:859:11)
    at TCP.onread (net.js:544:26)
Command: out/Release/node /Users/sgimeno/node/node/test/parallel/test-http-extra-response.js
```