### PR TITLE
test: pummel test fixes

### DIFF
--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -30,7 +30,7 @@ var hashes = {
   modp18 : 'a870b491bbbec9b131ae9878d07449d32e54f160'
 };
 
-for (var name in hashes) {
+for (const name in hashes) {
   var group = crypto.getDiffieHellman(name);
   var private_key = group.getPrime('hex');
   var hash1 = hashes[name];
@@ -40,7 +40,7 @@ for (var name in hashes) {
   assert.equal(group.getGenerator('hex'), '02');
 }
 
-for (var name in hashes) {
+for (const name in hashes) {
   // modp1 is 768 bits, FIPS requires >= 1024
   if (name == 'modp1' && common.hasFipsCrypto)
     continue;

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -3,13 +3,14 @@ var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 
+var SLEEP3_COMMAND;
 if (!common.isWindows) {
   // Unix.
-  var SLEEP3_COMMAND = 'sleep 3';
+  SLEEP3_COMMAND = 'sleep 3';
 } else {
   // Windows: `choice` is a command built into cmd.exe. Use another cmd process
   // to create a process tree, so we can catch bugs related to it.
-  var SLEEP3_COMMAND = 'cmd /c choice /t 3 /c X /d X';
+  SLEEP3_COMMAND = 'cmd /c choice /t 3 /c X /d X';
 }
 
 

--- a/test/pummel/test-stream-pipe-multi.js
+++ b/test/pummel/test-stream-pipe-multi.js
@@ -49,10 +49,6 @@ process.on('exit', function() {
   assert.equal(cnt, rclosed, 'readable streams closed');
 });
 
-for (var i = 0; i < chunkSize; i++) {
-  chunkSize[i] = i % 256;
-}
-
 for (var i = 0; i < cnt; i++) {
   var r = new FakeStream();
   r.on('close', function() {

--- a/test/pummel/test-stream-pipe-multi.js
+++ b/test/pummel/test-stream-pipe-multi.js
@@ -49,7 +49,11 @@ process.on('exit', function() {
   assert.equal(cnt, rclosed, 'readable streams closed');
 });
 
-for (var i = 0; i < cnt; i++) {
+for (let i = 0; i < chunkSize; i++) {
+  data[i] = i;
+}
+
+for (let i = 0; i < cnt; i++) {
   var r = new FakeStream();
   r.on('close', function() {
     console.error(this.ID, 'read close');


### PR DESCRIPTION
This fixes some variable redeclarations in pummel tests and, in the
process, gets `test-stream-pipe-multi.js` to run again. It had been
failing to run.