### PR TITLE
buffer: add offset check for buffer#fill

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -514,10 +514,8 @@ Buffer.prototype.fill = function fill(val, start, end) {
   start = start >> 0;
   end = (end === undefined) ? this.length : end >> 0;
 
-  if (start < 0 || end > this.length)
+  if (start < 0 || end > this.length || start >= this.length)
     throw new RangeError('Out of range index');
-  if (end <= start)
-    return this;
 
   if (typeof val !== 'string') {
     val = val >>> 0;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -514,7 +514,7 @@ Buffer.prototype.fill = function fill(val, start, end) {
   start = start >> 0;
   end = (end === undefined) ? this.length : end >> 0;
 
-  if (start < 0 || end > this.length || start >= this.length)
+  if (start < 0 || end > this.length || start >= end)
     throw new RangeError('Out of range index');
 
   if (typeof val !== 'string') {

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -38,6 +38,10 @@ assert.throws(function() {
   Buffer(8).fill('a', 0, 9);
 });
 
+assert.throws(function() {
+  Buffer(8).fill('a', 10);
+});
+
 // Make sure this doesn't hang indefinitely.
 Buffer(8).fill('');
 

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -40,7 +40,7 @@ assert.throws(function() {
 
 assert.throws(function() {
   Buffer(8).fill('a', 10);
-});
+}, RangeError);
 
 // Make sure this doesn't hang indefinitely.
 Buffer(8).fill('');

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -28,8 +28,11 @@ r.on('readable', function() {
     // stream, like a parser might do.  We just fill it with
     // 'y' so that it's easy to see which bits were touched,
     // and which were not.
-    var putBack = new Buffer(readAll ? 0 : 5);
-    putBack.fill('y');
+    const putBack = new Buffer(readAll ? 0 : 5);
+    if (!readAll) {
+      putBack.fill('y');
+    }
+
     readAll = !readAll;
     r.unshift(putBack);
   }


### PR DESCRIPTION
Buffer#fill already checked that the end was greater than the start and that the end is not greater than the length of the buffer. This commit adds a check to make sure that the offset is not greater
than the length of the buffer.

Refs: #4972 