### PR TITLE
doc: fix minor typo

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -59,7 +59,7 @@ is emitted with the following arguments:
 
 There is no notion of a top level for a promise chain at which rejections can
 always be handled. Being inherently asynchronous in nature, a promise rejection
-can be be handled at a future point in time — possibly much later than the
+can be handled at a future point in time — possibly much later than the
 event loop turn it takes for the `'unhandledRejection'` event to be emitted.
 
 Another way of stating this is that, unlike in synchronous code where there is


### PR DESCRIPTION
Remove extra `be`