### PR TITLE
test: remove an unnecessary call to bind and related comments

### DIFF
--- a/test/internet/test-dgram-multicast-multi-process.js
+++ b/test/internet/test-dgram-multicast-multi-process.js
@@ -132,10 +132,6 @@ if (process.argv[2] !== 'child') {
   }
 
   var sendSocket = dgram.createSocket('udp4');
-  // FIXME: a libuv limitation makes it necessary to bind()
-  // before calling any of the set*() functions. The bind()
-  // call is what creates the actual socket.
-  sendSocket.bind();
 
   // The socket is actually created async now.
   sendSocket.on('listening', function() {


### PR DESCRIPTION
Ref: #4640.

As mentioned in the above issue, some of the files have `TODO`, `FIXME` and `XXX` comments which should be removed. This is one of them. The comment(which is to be removed) says, "a libuv limitation makes it necessary to bind()". But, that is not the case any more. So, it can be removed.

/cc @Trott @Fishrock123 