### PR TITLE
.eslintrc: enable es6's spread

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@ ecmaFeatures:
   objectLiteralShorthandMethods: true
   objectLiteralShorthandProperties: true
   octalLiterals: true
+  spread: true
   templateStrings: true
 
 rules:

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,6 @@ ecmaFeatures:
   destructuring: true
   forOf: true
   generators: true
-  modules: true
   objectLiteralComputedProperties: true
   objectLiteralDuplicateProperties: true
   objectLiteralShorthandMethods: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,13 +7,23 @@ ecmaFeatures:
   binaryLiterals: true
   blockBindings: true
   classes: true
+  defaultParams: true
+  destructuring: true
   forOf: true
   generators: true
+  modules: true
+  objectLiteralComputedProperties: true
+  objectLiteralDuplicateProperties: true
   objectLiteralShorthandMethods: true
   objectLiteralShorthandProperties: true
   octalLiterals: true
+  regexUFlag: true
+  regexYFlag: true
+  restParams: true
   spread: true
+  superInFunctions: true
   templateStrings: true
+  unicodeCodePointEscapes: true
 
 rules:
   # Possible Errors


### PR DESCRIPTION
This came up in
https://github.com/nodejs/node/pull/5020#discussion_r51395940. This
patch basically enables spread option so that eslint will be happy.