### PR TITLE
stream: prevent object map change in TransformState

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -58,6 +58,7 @@ function TransformState(stream) {
   this.transforming = false;
   this.writecb = null;
   this.writechunk = null;
+  this.writeencoding = null;
 }
 
 function afterTransform(stream, er, data) {


### PR DESCRIPTION
TransformState has the `writeencoding` property that gets set on the
first `_write`. It is not declared when the transform state is initially
constructed and can cause a deopt.