### PR TITLE
stream,doc: make `writable.setDefaultEncoding()` return `this`

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -695,6 +695,7 @@ file.end('world!');
 #### writable.setDefaultEncoding(encoding)
 
 * `encoding` {String} The new default encoding
+* Return: `this`
 
 Sets the default encoding for a writable stream.
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -251,6 +251,7 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
   if (!Buffer.isEncoding(encoding))
     throw new TypeError('Unknown encoding: ' + encoding);
   this._writableState.defaultEncoding = encoding;
+  return this;
 };
 
 function decodeChunk(state, chunk, encoding) {


### PR DESCRIPTION
Let this function return `this` for parity with `readable.setEncoding()` though they set encodings for different purposes. (#5013).