### PR TITLE
console: use `os.EOL` for line ending

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const EOL = require('os').EOL;
 const util = require('util');
 
 function Console(stdout, stderr) {
@@ -33,7 +34,7 @@ function Console(stdout, stderr) {
 }
 
 Console.prototype.log = function() {
-  this._stdout.write(util.format.apply(this, arguments) + '\n');
+  this._stdout.write(util.format.apply(this, arguments) + EOL);
 };
 
 
@@ -41,7 +42,7 @@ Console.prototype.info = Console.prototype.log;
 
 
 Console.prototype.warn = function() {
-  this._stderr.write(util.format.apply(this, arguments) + '\n');
+  this._stderr.write(util.format.apply(this, arguments) + EOL);
 };
 
 
@@ -51,7 +52,7 @@ Console.prototype.error = Console.prototype.warn;
 Console.prototype.dir = function(object, options) {
   this._stdout.write(util.inspect(object, util._extend({
     customInspect: false
-  }, options)) + '\n');
+  }, options)) + EOL);
 };
 
 


### PR DESCRIPTION
Replace default line ending (\n) with `os.EOL` (issue #5038).