### PR TITLE
src: upgrade to new v8::Private api

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -10,6 +10,7 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Local;
 using v8::Object;
+using v8::Private;
 using v8::String;
 using v8::Value;
 
@@ -48,8 +49,10 @@ static void GetHiddenValue(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> obj = args[0].As<Object>();
   Local<String> name = args[1].As<String>();
+  auto private_symbol = Private::ForApi(env->isolate(), name);
+  auto maybe_value = obj->GetPrivate(env->context(), private_symbol);
 
-  args.GetReturnValue().Set(obj->GetHiddenValue(name));
+  args.GetReturnValue().Set(maybe_value.ToLocalChecked());
 }
 
 static void SetHiddenValue(const FunctionCallbackInfo<Value>& args) {
@@ -63,8 +66,10 @@ static void SetHiddenValue(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> obj = args[0].As<Object>();
   Local<String> name = args[1].As<String>();
+  auto private_symbol = Private::ForApi(env->isolate(), name);
+  auto maybe_value = obj->SetPrivate(env->context(), private_symbol, args[2]);
 
-  args.GetReturnValue().Set(obj->SetHiddenValue(name, args[2]));
+  args.GetReturnValue().Set(maybe_value.FromJust());
 }
 
 


### PR DESCRIPTION
Stop using the deprecated `GetHiddenValue()` and `SetHiddenValue()`
methods, start using `GetPrivate()` and `SetPrivate()` instead.

This commit turns some of the entries in the per-isolate string table
into private symbols.

R=@cjihrig or @trevnorris

CI: https://ci.nodejs.org/job/node-test-pull-request/1518/