### PR TITLE
tools: enable no-redeclare rule for linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,8 @@ rules:
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#best-practices
   ## require falls through comment on switch-case
   no-fallthrough: 2
+  ## disallow declaring the same variable more than once
+  no-redeclare: 2
 
   # Stylistic Issues
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -184,14 +184,13 @@ function processList(section) {
     var type = tok.type;
     if (type === 'space') return;
     if (type === 'list_item_start') {
+      var n = {};
       if (!current) {
-        var n = {};
         values.push(n);
         current = n;
       } else {
         current.options = current.options || [];
         stack.push(current);
-        var n = {};
         current.options.push(n);
         current = n;
       }
@@ -478,14 +477,14 @@ function deepCopy(src, dest) {
 function deepCopy_(src) {
   if (!src) return src;
   if (Array.isArray(src)) {
-    var c = new Array(src.length);
+    const c = new Array(src.length);
     src.forEach(function(v, i) {
       c[i] = deepCopy_(v);
     });
     return c;
   }
   if (typeof src === 'object') {
-    var c = {};
+    const c = {};
     Object.keys(src).forEach(function(k) {
       c[k] = deepCopy_(src[k]);
     });


### PR DESCRIPTION
At long last, `no-redeclare` is ready to be enabled.