### PR TITLE
Remove deprecated Buffer.write(...)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const binding = process.binding('buffer');
-const internalUtil = require('internal/util');
 const bindingObj = {};
 
 exports.Buffer = Buffer;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -557,6 +557,9 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       length = undefined;
     }
   } else {
+    // if someone is still calling the obsolete form of write(), tell them.
+    // we don't want eg buf.write("foo", "utf8", 10) to silently turn into
+    // buf.write("foo", "utf8"), so we can't ignore extra args
     throw new Error('Buffer.write(string, encoding, offset[, length]) ' +
                     'is no longer supported');
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -533,10 +533,6 @@ Buffer.prototype.fill = function fill(val, start, end) {
 };
 
 
-var writeWarned = false;
-const writeMsg = 'Buffer.write(string, encoding, offset, length) is ' +
-                 'deprecated. Use write(string[, offset[, length]]' +
-                 '[, encoding]) instead.';
 Buffer.prototype.write = function(string, offset, length, encoding) {
   // Buffer#write(string);
   if (offset === undefined) {
@@ -551,7 +547,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
     offset = 0;
 
   // Buffer#write(string, offset[, length][, encoding])
-  } else if (isFinite(offset)) {
+  } else {
     offset = offset >>> 0;
     if (isFinite(length)) {
       length = length >>> 0;
@@ -561,14 +557,6 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       encoding = length;
       length = undefined;
     }
-
-  // XXX legacy write(string, encoding, offset, length) - remove in v0.13
-  } else {
-    writeWarned = internalUtil.printDeprecationMessage(writeMsg, writeWarned);
-    var swap = encoding;
-    encoding = offset;
-    offset = length >>> 0;
-    length = swap;
   }
 
   var remaining = this.length - offset;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -547,7 +547,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
     offset = 0;
 
   // Buffer#write(string, offset[, length][, encoding])
-  } else {
+  } else if (isFinite(offset)) {
     offset = offset >>> 0;
     if (isFinite(length)) {
       length = length >>> 0;
@@ -557,6 +557,9 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       encoding = length;
       length = undefined;
     }
+  } else {
+    throw new Error('Buffer.write(string, encoding, offset[, length]) ' +
+                    'is no longer supported');
   }
 
   var remaining = this.length - offset;

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -344,10 +344,10 @@ assert.equal(rangeBuffer.toString({toString: function() {
 // testing for smart defaults and ability to pass string values as offset
 var writeTest = new Buffer('abcdes');
 writeTest.write('n', 'ascii');
-writeTest.write('o', 'ascii', '1');
+writeTest.write('o', '1', 'ascii');
 writeTest.write('d', '2', 'ascii');
 writeTest.write('e', 3, 'ascii');
-writeTest.write('j', 'ascii', 4);
+writeTest.write('j', 4, 'ascii');
 assert.equal(writeTest.toString(), 'nodejs');
 
 // ASCII slice test
@@ -888,7 +888,7 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
   assert.equal(buf[3], 0x63);
 
   buf.fill(0xFF);
-  written = buf.write('abcd', 'utf8', 1, 2);  // legacy style
+  written = buf.write('abcd', 1, 2, 'utf8');
   console.log(buf);
   assert.equal(written, 2);
   assert.equal(buf[0], 0xFF);


### PR DESCRIPTION
It said:
```js
// XXX legacy write(string, encoding, offset, length) - remove in v0.13
```

And we're just a few versions past that :)

@mikeal 