### PR TITLE
node: deprecate process.EventEmitter

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -20,7 +20,17 @@
     });
     EventEmitter.call(process);
 
-    process.EventEmitter = EventEmitter; // process.EventEmitter is deprecated
+    let eeWarned = false;
+    Object.defineProperty(process, 'EventEmitter', {
+      get() {
+        const internalUtil = NativeModule.require('internal/util');
+        eeWarned = internalUtil.printDeprecationMessage(
+          `process.EventEmitter is deprecated. Use require('events') instead.`,
+          eeWarned
+        );
+        return EventEmitter;
+      }
+    });
 
     startup.setupProcessObject();
 


### PR DESCRIPTION
The comment stating it was deprecated was added in 2011 via
https://github.com/nodejs/node/commit/4ef8f06fe62edb74fded0e817266cb6398e69f36. It is time to actually deprecate it.