### PR TITLE
tools: enable all es6 rules in linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,18 +1,6 @@
 env:
   node: true
-
-# enable ECMAScript features
-ecmaFeatures:
-  arrowFunctions: true
-  binaryLiterals: true
-  blockBindings: true
-  classes: true
-  forOf: true
-  generators: true
-  objectLiteralShorthandMethods: true
-  objectLiteralShorthandProperties: true
-  octalLiterals: true
-  templateStrings: true
+  es6: true
 
 rules:
   # Possible Errors


### PR DESCRIPTION
This change enables the es6 environment in eslint. Rather than selecting
es6 rules one at a time, this turns all of them on with the exception of
modules.

Ref: https://github.com/nodejs/node/pull/5028

Not sure if this will be controversial or not. And not sure if it makes sense
to land on LTS or not. (Maybe we shouldn't use es6-isms not supported by
LTS? Certainly not for code that needs to land on LTS, of course. But I'm not
sure a lot of these rules will actually cover things that don't work in LTS but work
in Stable. Will have to look into that...)