### PR TITLE
os: improve os.tmpdir() method

### DIFF
--- a/benchmark/os/tmpdir.js
+++ b/benchmark/os/tmpdir.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common.js');
+const os = require('os');
+
+const bench = common.createBenchmark(main, {
+  n: [100, 1000, 10000]
+});
+
+function main(conf) {
+  var n = +conf.n;
+  bench.start();
+  for (let i = 0; i < n * 1024; i++) {
+    os.tmpdir();
+  }
+  bench.end(n);
+}

--- a/lib/os.js
+++ b/lib/os.js
@@ -27,21 +27,26 @@ exports.platform = function() {
 const trailingSlashRe = isWindows ? /[^:]\\$/
                                   : /.\/$/;
 
+var tmpdir;
+
 exports.tmpdir = function() {
-  var path;
-  if (isWindows) {
-    path = process.env.TEMP ||
-           process.env.TMP ||
-           (process.env.SystemRoot || process.env.windir) + '\\temp';
-  } else {
-    path = process.env.TMPDIR ||
-           process.env.TMP ||
-           process.env.TEMP ||
-           '/tmp';
+  if (!tmpdir) {
+    if (isWindows) {
+      tmpdir = process.env.TEMP ||
+             process.env.TMP ||
+             (process.env.SystemRoot || process.env.windir) + '\\temp';
+    } else {
+      tmpdir = process.env.TMPDIR ||
+             process.env.TMP ||
+             process.env.TEMP ||
+             '/tmp';
+    }
+
+    if (trailingSlashRe.test(tmpdir))
+      tmpdir = tmpdir.slice(0, -1);
   }
-  if (trailingSlashRe.test(path))
-    path = path.slice(0, -1);
-  return path;
+
+  return tmpdir;
 };
 
 exports.tmpDir = exports.tmpdir;


### PR DESCRIPTION
Improve os.tmpdir() speed, avoid duplicate REGExp test.

following is benchmark result:

Before:

$ node benchmark/os/tmpdir.js
os/tmpdir.js n=100: 1720.48425
os/tmpdir.js n=1000: 2028.35615
os/tmpdir.js n=10000: 1984.48570

After:
$ ./node benchmark/os/tmpdir.js
os/tmpdir.js n=100: 15024.67502
os/tmpdir.js n=1000: 121723.59639
os/tmpdir.js n=10000: 129720.92049