### PR TITLE
os: make the os.EOL read only

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -51,7 +51,11 @@ exports.getNetworkInterfaces = internalUtil.deprecate(function() {
 }, 'os.getNetworkInterfaces is deprecated. ' +
    'Use os.networkInterfaces instead.');
 
-exports.EOL = isWindows ? '\r\n' : '\n';
+Object.defineProperty(exports, 'EOL', {
+  enumerable: true,
+  value: isWindows ? '\r\n' : '\n',
+  writable: false
+});
 
 if (binding.isBigEndian)
   exports.endianness = function() { return 'BE'; };

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -103,6 +103,8 @@ switch (platform) {
 var EOL = os.EOL;
 assert.ok(EOL.length > 0);
 
+var descriptor = Object.getOwnPropertyDescriptor(os, 'EOL');
+assert.ok(descriptor.writable === false);
 
 var home = os.homedir();
 


### PR DESCRIPTION
The EOL property can be changed in userland.