### PR TITLE
Child process stdout tty methods

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -643,6 +643,13 @@
           writable: true
         });
         stream._type = 'pipe';
+        stream.cursorTo = function() {};
+        stream.moveCursor = function() {};
+        stream.clearLine = function() {};
+        stream.clearScreenDown = function() {};
+        stream.getWindowSize = function() {
+          return [0, 0];
+        };
         break;
 
       default:

--- a/test/fixtures/child-process-stdout-tty-functions.js
+++ b/test/fixtures/child-process-stdout-tty-functions.js
@@ -1,0 +1,41 @@
+'use strict';
+const assert = require('assert');
+
+const stdout = process.stdout;
+
+try {
+  stdout.cursorTo();
+}
+catch (e) {
+  console.error(new Error(e));
+}
+
+try {
+  stdout.moveCursor();
+}
+catch (e) {
+  console.error(new Error(e));
+}
+
+try {
+  stdout.clearLine();
+}
+catch (e) {
+  console.error(new Error(e));
+}
+
+try {
+  stdout.clearScreenDown();
+}
+catch (e) {
+  console.error(new Error(e));
+}
+
+try {
+  const windowSize = stdout.getWindowSize();
+  assert.deepEqual(windowSize, [0, 0],
+    'the window size should be [0,0]');
+}
+catch (e) {
+  console.error(new Error(e));
+}

--- a/test/parallel/test-child-process-stdout-tty-functions.js
+++ b/test/parallel/test-child-process-stdout-tty-functions.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+
+const spawn = require('child_process').spawn;
+const path = require('path');
+const assert = require('assert');
+
+
+const fixture = path.join(
+  common.fixturesDir,
+  'child-process-stdout-tty-functions.js'
+);
+
+const proc = spawn(process.execPath, [fixture], { stdio: 'pipe' });
+proc.stderr.setEncoding('utf8');
+
+let stderr = '';
+
+proc.stderr.on('data', (data) => stderr += data);
+
+process.on('exit', (code) => {
+  assert.equal(code, 0, 'the program should exit cleanly');
+  assert.equal(stderr, '', stderr);
+});


### PR DESCRIPTION
The process object in child_process creates stdout using net.
The process object in a non child_process uses tty.

As such there are a handful of methods that exist for tty that do not for net,
and will cause the child_process to throw if they are used.

This PR adds no-ops for the offending methods