### PR TITLE
tools: lint for spacing around unary operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -81,6 +81,8 @@ rules:
   space-after-keywords: 2
   ## no leading/trailing spaces in parens
   space-in-parens: [2, "never"]
+  ## no spaces with non-word unary operators, require for word unary operators
+  space-unary-ops: [2]
 
   # ECMAScript 6
   # list: http://eslint.org/docs/rules/#ecmascript-6

--- a/.eslintrc
+++ b/.eslintrc
@@ -82,7 +82,7 @@ rules:
   ## no leading/trailing spaces in parens
   space-in-parens: [2, "never"]
   ## no spaces with non-word unary operators, require for word unary operators
-  space-unary-ops: [2]
+  space-unary-ops: 2
 
   # ECMAScript 6
   # list: http://eslint.org/docs/rules/#ecmascript-6

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -327,7 +327,7 @@ function unrefdHandle() {
 Timeout.prototype.unref = function() {
   if (this._handle) {
     this._handle.unref();
-  } else if (typeof(this._onTimeout) === 'function') {
+  } else if (typeof this._onTimeout === 'function') {
     var now = Timer.now();
     if (!this._idleStart) this._idleStart = now;
     var delay = this._idleStart + this._idleTimeout - now;

--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -48,7 +48,7 @@ for (var i = 0; i < 10; i++)
   getall();
 
 function afterGC() {
-  countGC ++;
+  countGC++;
 }
 
 var timer;

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -56,7 +56,7 @@ function runTest() {
 }
 
 function afterGC() {
-  countGC ++;
+  countGC++;
 }
 
 var timer;

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -57,7 +57,7 @@ for (var i = 0; i < 10; i++)
   getall();
 
 function afterGC() {
-  countGC ++;
+  countGC++;
 }
 
 var timer;

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -51,7 +51,7 @@ for (var i = 0; i < 10; i++)
   getall();
 
 function afterGC() {
-  countGC ++;
+  countGC++;
 }
 
 setInterval(status, 1000).unref();

--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -57,7 +57,7 @@ for (var i = 0; i < 10; i++)
   getall();
 
 function afterGC() {
-  countGC ++;
+  countGC++;
 }
 
 setInterval(status, 100).unref();

--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -10,8 +10,8 @@ var str = 'hello';
 
 // default encoding
 exec('echo ' + str, function(err, stdout, stderr) {
-  assert.ok('string', typeof(stdout), 'Expected stdout to be a string');
-  assert.ok('string', typeof(stderr), 'Expected stderr to be a string');
+  assert.ok('string', typeof stdout, 'Expected stdout to be a string');
+  assert.ok('string', typeof stderr, 'Expected stderr to be a string');
   assert.equal(str + os.EOL, stdout);
 
   success_count++;

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -55,7 +55,7 @@ file.on('close', function() {
 var file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
 file3.length = 0;
 file3.on('data', function(data) {
-  assert.equal('string', typeof(data));
+  assert.equal('string', typeof data);
   file3.length += data.length;
 
   for (var i = 0; i < data.length; i++) {

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -55,7 +55,7 @@ file.on('close', function() {
 var file3 = fs.createReadStream(fn, {encoding: 'utf8'});
 file3.length = 0;
 file3.on('data', function(data) {
-  assert.equal('string', typeof(data));
+  assert.equal('string', typeof data);
   file3.length += data.length;
 
   for (var i = 0; i < data.length; i++) {

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -16,7 +16,7 @@ var httpServer = http.createServer(function(req, res) {
 
   res.on('finish', function() {
     sawFinish = true;
-    assert(typeof(req.connection.bytesWritten) === 'number');
+    assert(typeof req.connection.bytesWritten === 'number');
     assert(req.connection.bytesWritten > 0);
   });
   res.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/test/parallel/test-http-date-header.js
+++ b/test/parallel/test-http-date-header.js
@@ -6,7 +6,7 @@ var http = require('http');
 var testResBody = 'other stuff!\n';
 
 var server = http.createServer(function(req, res) {
-  assert.ok(! ('date' in req.headers),
+  assert.ok(!('date' in req.headers),
             'Request headers contained a Date.');
   res.writeHead(200, {
     'Content-Type': 'text/plain'

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -59,7 +59,7 @@ server.listen(common.PORT, common.mustCall(function() {
     http.get(
       {port:common.PORT, headers:{'x-num': n}},
       common.mustCall(function(res) {
-        if (++ count === 2) server.close();
+        if (++count === 2) server.close();
         assert.equal(res.headers['content-length'], 1);
         for (const name of norepeat) {
           assert.equal(res.headers[name], 'A');

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -33,7 +33,7 @@ server.on('listening', function() {
 
   c.on('end', function() {
     c.end();
-    assert.ok(! /x-foo/.test(res_buffer), 'Trailer in HTTP/1.0 response.');
+    assert.ok(!/x-foo/.test(res_buffer), 'Trailer in HTTP/1.0 response.');
     outstanding_reqs--;
     if (outstanding_reqs == 0) {
       server.close();

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -18,7 +18,7 @@ var body = 'hello world\n';
 
 var httpsServer = https.createServer(options, function(req, res) {
   res.on('finish', function() {
-    assert(typeof(req.connection.bytesWritten) === 'number');
+    assert(typeof req.connection.bytesWritten === 'number');
     assert(req.connection.bytesWritten > 0);
     httpsServer.close();
     console.log('ok');

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -21,8 +21,8 @@ assert.throws(function() {
   vm.runInDebugContext('(function(f) { f(f) })(function(f) { f(f) })');
 }, /RangeError/);
 
-assert.equal(typeof(vm.runInDebugContext('this')), 'object');
-assert.equal(typeof(vm.runInDebugContext('Debug')), 'object');
+assert.equal(typeof vm.runInDebugContext('this'), 'object');
+assert.equal(typeof vm.runInDebugContext('Debug'), 'object');
 
 assert.strictEqual(vm.runInDebugContext(), undefined);
 assert.strictEqual(vm.runInDebugContext(0), 0);

--- a/test/sequential/test-cluster-listening-port.js
+++ b/test/sequential/test-cluster-listening-port.js
@@ -12,7 +12,7 @@ if (cluster.isMaster) {
     // ensure that the port is not 0 or null
     assert(port);
     // ensure that the port is numerical
-    assert.strictEqual(typeof(port), 'number');
+    assert.strictEqual(typeof port, 'number');
     worker.kill();
   });
   process.on('exit', function() {


### PR DESCRIPTION
Enable `space-unary-ops` in `.eslintrc`. This prohibits things like:

    i ++        // use `i++` instead
    typeof(foo) // use `typeof foo` or `typeof (foo)` instead

Ref: https://github.com/nodejs/node/pull/4772#discussion_r51732299