### PR TITLE
querystring: check that maxKeys is finite

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -215,7 +215,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   }
 
   // maxKeys <= 0 means that we should not limit keys count
-  if (maxKeys > 0) {
+  if (maxKeys > 0 && isFinite(maxKeys)) {
     qs = qs.split(sep, maxKeys);
   } else {
     qs = qs.split(sep);

--- a/test/parallel/test-querystring-maxKeys-non-finite.js
+++ b/test/parallel/test-querystring-maxKeys-non-finite.js
@@ -1,0 +1,55 @@
+'use strict';
+// This test was originally written to test a regression
+// that was introduced by
+// https://github.com/nodejs/node/pull/2288#issuecomment-179543894
+require('../common');
+
+const assert = require('assert');
+const parse = require('querystring').parse;
+
+/*
+taken from express-js/body-parser
+https://github.com/expressjs/body-parser/
+blob/ed25264fb494cf0c8bc992b8257092cd4f694d5e/test/urlencoded.js#L636-L651
+*/
+function createManyParams(count) {
+  var str = '';
+
+  if (count === 0) {
+    return str;
+  }
+
+  str += '0=0';
+
+  for (var i = 1; i < count; i++) {
+    var n = i.toString(36);
+    str += '&' + n + '=' + n;
+  }
+
+  return str;
+}
+
+const count = 10000;
+const originalMaxLength = 1000;
+const params = createManyParams(count);
+
+// thealphanerd
+// 27def4f introduced a change to parse that would cause Inifity
+// to be passed to String.prototype.split as an argument for limit
+// In this instance split will always return an empty array
+// this test confirms that the output of parse is the expected length
+// when passed Infinity as the argument for maxKeys
+const resultInfinity = parse(params, undefined, undefined, {maxKeys: Infinity});
+const resultNaN = parse(params, undefined, undefined, {maxKeys: NaN});
+const resultInfinityString = parse(params, undefined, undefined, {
+  maxKeys: 'Infinity'
+});
+const resultNaNString = parse(params, undefined, undefined, {maxKeys: 'NaN'});
+
+// Non Finite maxKeys should return the length of input
+assert.equal(Object.keys(resultInfinity).length, count);
+assert.equal(Object.keys(resultNaN).length, count);
+// Strings maxKeys should return the maxLength
+// defined by parses internals
+assert.equal(Object.keys(resultInfinityString).length, originalMaxLength);
+assert.equal(Object.keys(resultNaNString).length, originalMaxLength);


### PR DESCRIPTION
There was a very subtle change in behavior introduced with 27def4f

In the past if querystring.parse was given Infinity for maxKeys,
everything worked as expected.

Check to see is maxKeys is Infinity before forwarding the value to
String.prototype.split which causes this regression