### PR TITLE
test: refactor test-dgram-send-callback-recursive

### DIFF
--- a/test/parallel/test-dgram-send-callback-recursive.js
+++ b/test/parallel/test-dgram-send-callback-recursive.js
@@ -5,23 +5,25 @@ const assert = require('assert');
 const dgram = require('dgram');
 const client = dgram.createSocket('udp4');
 const chunk = 'abc';
-var recursiveCount = 0;
-var received = 0;
+let received = 0;
+let sent = 0;
 const limit = 10;
-const recursiveLimit = 100;
+let async = false;
 
 function onsend() {
-  if (recursiveCount > recursiveLimit) {
-    throw new Error('infinite loop detected');
-  }
-  if (received < limit) {
+  if (sent++ < limit) {
     client.send(
       chunk, 0, chunk.length, common.PORT, common.localhostIPv4, onsend);
+  } else {
+    assert.strictEqual(async, true, 'Send should be asynchronous.');
   }
-  recursiveCount++;
 }
 
 client.on('listening', function() {
+  setImmediate(function() {
+    async = true;
+  });
+
   onsend();
 });
 


### PR DESCRIPTION
Just send 10 messages recursively and check that the send calls are
asynchronous by asserting that a `setImmediate` callback has been called
in-between. It avoids a race condition in the test where the recursive
limit is reached without having received at least 10 messages.

I was sometimes getting this error in OS X:
```
/Users/sgimeno/node/node/test/parallel/test-dgram-send-callback-recursive.js:15
    throw new Error('infinite loop detected');
    ^

Error: infinite loop detected
    at SendWrap.onsend [as callback] (/Users/sgimeno/node/node/test/parallel/test-dgram-send-callback-recursive.js:15:11)
    at SendWrap.afterSend [as oncomplete] (dgram.js:383:8)
```

I've verified this test fails with node before the commit where this test was introduced: https://github.com/nodejs/node/commit/18d457bd3408557a48b453f13b2b99e1ab5e7159 and passes after this commit: https://github.com/nodejs/node/commit/b5cd2f098691935b6bef6ded1b0de7ef37431f27 when the `libuv` implementation of udp send was made asynchronous.