### PR TITLE
test: mark flaky tests on Raspberry Pi

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -13,6 +13,7 @@ test-tick-processor                  : PASS,FLAKY
 
 [$system==linux]
 test-tick-processor                  : PASS,FLAKY
+test-child-process-fork-regr-gh-2847 : PASS,FLAKY
 
 [$system==macos]
 

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -9,7 +9,9 @@ prefix sequential
 [$system==win32]
 
 [$system==linux]
-test-vm-syntax-error-stderr                     : PASS,FLAKY
+test-vm-syntax-error-stderr : PASS,FLAKY
+test-dgram-pingpong         : PASS,FLAKY
+test-http-regr-gh-2928      : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
A few tests have started failing on Raspberry Pi devices in CI.
https://ci.nodejs.org/job/node-test-binary-arm/943/

Ref: https://github.com/nodejs/node/issues/4830
Ref: https://github.com/nodejs/node/issues/3635
Ref: https://github.com/nodejs/node/issues/4526