### PR TITLE
node: improve nextTick performance

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -373,6 +373,26 @@
         scheduleMicrotasks();
     }
 
+    function _combinedTickCallback(args, callback) {
+      if (args === undefined) {
+        callback();
+      } else {
+        switch (args.length) {
+          case 1:
+            callback(args[0]);
+            break;
+          case 2:
+            callback(args[0], args[1]);
+            break;
+          case 3:
+            callback(args[0], args[1], args[2]);
+            break;
+          default:
+            callback.apply(null, args);
+        }
+      }
+    }
+
     // Run callbacks that have no domain.
     // Using domains will cause this to be overridden.
     function _tickCallback() {
@@ -383,27 +403,10 @@
           tock = nextTickQueue[tickInfo[kIndex]++];
           callback = tock.callback;
           args = tock.args;
-          // Using separate callback execution functions helps to limit the
-          // scope of DEOPTs caused by using try blocks and allows direct
+          // Using separate callback execution functions allows direct
           // callback invocation with small numbers of arguments to avoid the
           // performance hit associated with using `fn.apply()`
-          if (args === undefined) {
-            nextTickCallbackWith0Args(callback);
-          } else {
-            switch (args.length) {
-              case 1:
-                nextTickCallbackWith1Arg(callback, args[0]);
-                break;
-              case 2:
-                nextTickCallbackWith2Args(callback, args[0], args[1]);
-                break;
-              case 3:
-                nextTickCallbackWith3Args(callback, args[0], args[1], args[2]);
-                break;
-              default:
-                nextTickCallbackWithManyArgs(callback, args);
-            }
-          }
+          _combinedTickCallback(args, callback);
           if (1e4 < tickInfo[kIndex])
             tickDone();
         }
@@ -424,27 +427,10 @@
           args = tock.args;
           if (domain)
             domain.enter();
-          // Using separate callback execution functions helps to limit the
-          // scope of DEOPTs caused by using try blocks and allows direct
+          // Using separate callback execution functions allows direct
           // callback invocation with small numbers of arguments to avoid the
           // performance hit associated with using `fn.apply()`
-          if (args === undefined) {
-            nextTickCallbackWith0Args(callback);
-          } else {
-            switch (args.length) {
-              case 1:
-                nextTickCallbackWith1Arg(callback, args[0]);
-                break;
-              case 2:
-                nextTickCallbackWith2Args(callback, args[0], args[1]);
-                break;
-              case 3:
-                nextTickCallbackWith3Args(callback, args[0], args[1], args[2]);
-                break;
-              default:
-                nextTickCallbackWithManyArgs(callback, args);
-            }
-          }
+          _combinedTickCallback(args, callback);
           if (1e4 < tickInfo[kIndex])
             tickDone();
           if (domain)
@@ -454,61 +440,6 @@
         _runMicrotasks();
         emitPendingUnhandledRejections();
       } while (tickInfo[kLength] !== 0);
-    }
-
-    function nextTickCallbackWith0Args(callback) {
-      var threw = true;
-      try {
-        callback();
-        threw = false;
-      } finally {
-        if (threw)
-          tickDone();
-      }
-    }
-
-    function nextTickCallbackWith1Arg(callback, arg1) {
-      var threw = true;
-      try {
-        callback(arg1);
-        threw = false;
-      } finally {
-        if (threw)
-          tickDone();
-      }
-    }
-
-    function nextTickCallbackWith2Args(callback, arg1, arg2) {
-      var threw = true;
-      try {
-        callback(arg1, arg2);
-        threw = false;
-      } finally {
-        if (threw)
-          tickDone();
-      }
-    }
-
-    function nextTickCallbackWith3Args(callback, arg1, arg2, arg3) {
-      var threw = true;
-      try {
-        callback(arg1, arg2, arg3);
-        threw = false;
-      } finally {
-        if (threw)
-          tickDone();
-      }
-    }
-
-    function nextTickCallbackWithManyArgs(callback, args) {
-      var threw = true;
-      try {
-        callback.apply(null, args);
-        threw = false;
-      } finally {
-        if (threw)
-          tickDone();
-      }
     }
 
     function TickObject(c, args) {

--- a/src/node.js
+++ b/src/node.js
@@ -457,9 +457,9 @@
 
       var args;
       if (arguments.length > 1) {
-        args = [];
+        args = new Array(arguments.length - 1);
         for (var i = 1; i < arguments.length; i++)
-          args.push(arguments[i]);
+          args[i - 1] = arguments[i];
       }
 
       nextTickQueue.push(new TickObject(callback, args));

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -7,7 +7,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 42
 42
@@ -20,7 +20,7 @@ Error: hello
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 [eval]:1
 throw new Error("hello")
@@ -31,7 +31,7 @@ Error: hello
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 100
 [eval]:1
@@ -43,7 +43,7 @@ ReferenceError: y is not defined
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 [eval]:1
 var ______________________________________________; throw 10

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -4,7 +4,7 @@
         ^
 ReferenceError: undefined_reference_error_maker is not defined
     at *test*message*nexttick_throw.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
     at Function.Module.runMain (module.js:*:*)
     at startup (node.js:*:*)

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -8,7 +8,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 42
 42
@@ -22,7 +22,7 @@ Error: hello
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 
 [stdin]:1
@@ -34,7 +34,7 @@ Error: hello
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 100
 
@@ -47,7 +47,7 @@ ReferenceError: y is not defined
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
+    at _combinedTickCallback (node.js:*:*)
     at process._tickCallback (node.js:*:*)
 
 [stdin]:1


### PR DESCRIPTION
1. The try final block around the nextTick callback prevents optimizing the executing function. The try was introduced in a [commit](https://github.com/nodejs/node/commit/0109a9f90acdfdb287436676f2384f7b072fbb6a) that was [reverted](https://github.com/nodejs/node/commit/95ac576bf956055d3d5758cacbd336b53570f89f) later but without reverting the try code.

2. Initializing the array with the proper argument size is faster as using a literal.

The performance gain is between 5-10% looking at the already existing nextTick benchmarks.

@trevnorris pointed out that this is might be depending on https://github.com/nodejs/node/pull/4507. I guess this could be handled independently though.

<s>@bnoordhuis the new [v8::Private api](https://github.com/nodejs/node/commit/924cc6c6335e58f61b04d2f41d348bd6b8be98a1) seems to change the error handling in C and after that commit the nextTick callback errors are not handled in C anymore. I'm not sure this was a intended change?</s>