### PR TITLE
test: don't run test-tick-processor.js on Aix

### DIFF
--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -4,6 +4,16 @@ var assert = require('assert');
 var cp = require('child_process');
 var common = require('../common');
 
+// TODO(mhdawson) Currently the test-tick-processor functionality in V8
+// depends on addresses being smaller than a full 64 bits.  Aix supports
+// the full 64 bits and the result is that it does not process the
+// addresses correctly and runs out of memory
+// Disabling until we get a fix upstreamed into V8
+if (common.isAix) {
+  console.log('1..0 # Skipped: Aix address range too big for scripts.');
+  return;
+}
+
 common.refreshTmpDir();
 process.chdir(common.tmpDir);
 // Unknown checked for to prevent flakiness, if pattern is not found,


### PR DESCRIPTION
Currently the test-tick-processor functionality in V8
depends on addresses being smaller than a full 64 bits.  Aix supports
the full 64 bits and the result is that it does not process the
addresses correctly and runs of out memory.
Disabling until we get a fix upstreamed into V8.