### PR TITLE
fs: make 'fs.exists' follow the error first callback convention

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -397,7 +397,18 @@ If `options` is a string, then it specifies the encoding.
     Stability: 0 - Deprecated: Use [`fs.stat()`][] or [`fs.access()`][] instead.
 
 Test whether or not the given path exists by checking with the file system.
-Then call the `callback` argument with either true or false.  Example:
+The last argument, `callback`, is a callback function that is invoked with
+a possible error argument and argument with value `true` if the file exists or `false`
+if not. Example:
+
+```js
+fs.exists('/etc/passwd', (err, exists) => {
+  console.log(exists ? 'it\'s there' : 'no passwd!');
+});
+```
+
+For backward compatibility `callback` can be a function invoked with single argument
+having value `true` if the file exists or `false` if not. Example:
 
 ```js
 fs.exists('/etc/passwd', (exists) => {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -214,7 +214,12 @@ fs.exists = function(path, callback) {
   req.oncomplete = cb;
   binding.stat(pathModule._makeLong(path), req);
   function cb(err, stats) {
-    if (callback) callback(err ? false : true);
+    if (callback) {
+      if (callback.length > 1)
+        callback(null, err ? false : true);
+      else
+        callback(err ? false : true);
+    }
   }
 };
 

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -5,6 +5,8 @@ var fs = require('fs');
 var f = __filename;
 var exists;
 var doesNotExist;
+var exists2;
+var doesNotExist2;
 
 fs.exists(f, function(y) {
   exists = y;
@@ -14,10 +16,20 @@ fs.exists(f + '-NO', function(y) {
   doesNotExist = y;
 });
 
+fs.exists(f, function(err, y) {
+  exists2 = y;
+});
+
+fs.exists(f + '-NO', function(err, y) {
+  doesNotExist2 = y;
+});
+
 assert(fs.existsSync(f));
 assert(!fs.existsSync(f + '-NO'));
 
 process.on('exit', function() {
   assert.strictEqual(exists, true);
   assert.strictEqual(doesNotExist, false);
+  assert.strictEqual(exists2, true);
+  assert.strictEqual(doesNotExist2, false);
 });


### PR DESCRIPTION
Make `fs.exists` follow the typical error first callback convention (nodeback-style) without breaking backward compatibility with single boolean argument callbacks.

Ref: #1592