### PR TITLE
test: fix test-net-* error code check for getaddrinfo(3)

### DIFF
--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -3,12 +3,12 @@ var common = require('../common');
 var net = require('net');
 var assert = require('assert');
 
-var c = net.createConnection(common.PORT, '...');
+var c = net.createConnection(common.PORT, '***');
 
 c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
   assert.equal(e.code, 'ENOTFOUND');
   assert.equal(e.port, common.PORT);
-  assert.equal(e.hostname, '...');
+  assert.equal(e.hostname, '***');
 }));

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -3,14 +3,14 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const client = net.connect({host: '...', port: common.PORT});
+const client = net.connect({host: '***', port: common.PORT});
 
 client.once('error', common.mustCall(function(err) {
   assert(err);
   assert.strictEqual(err.code, err.errno);
   assert.strictEqual(err.code, 'ENOTFOUND');
   assert.strictEqual(err.host, err.hostname);
-  assert.strictEqual(err.host, '...');
+  assert.strictEqual(err.host, '***');
   assert.strictEqual(err.syscall, 'getaddrinfo');
 }));
 


### PR DESCRIPTION
getaddrinfo(3) may (should?) return EAI_AGAIN on DNS errors. Some
systems apparently returns 'ENOTFOUND' so we check both.

This makes the tests work with musl libc which correctly return
EAI_AGAIN.

For valid errors see:
http://pubs.opengroup.org/onlinepubs/009619199/getad.htm#tagcjh_05_06_05