### PR TITLE
fs: add a temporary fix for re-evaluation support

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -35,7 +35,42 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
-const printDeprecation = require('internal/util').printDeprecationMessage;
+
+var printDeprecation;
+try {
+  printDeprecation = require('internal/util').printDeprecationMessage;
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
+
+  // TODO(ChALkeR): remove this in master after 6.x
+  // This code was based upon internal/util and is required to give users
+  // a grace period before actually breaking modules that re-evaluate fs
+  // sources from context where internal modules are not allowed, e.g.
+  // older versions of graceful-fs module.
+
+  const prefix = `(${process.release.name}:${process.pid}) `;
+
+  printDeprecation = function(msg, warned) {
+    if (process.noDeprecation)
+      return true;
+
+    if (warned)
+      return warned;
+
+    if (process.throwDeprecation)
+      throw new Error(`${prefix}${msg}`);
+    else if (process.traceDeprecation)
+      console.trace(msg);
+    else
+      console.error(`${prefix}${msg}`);
+
+    return true;
+  };
+  printDeprecation('fs: re-evaluating native module sources is not ' +
+                   'supported. If you are using the graceful-fs module, ' +
+                   'please update it to a more recent version.',
+                    false);
+}
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +


### PR DESCRIPTION
This is needed to give users a grace period before actually breaking modules that re-evaluate `fs` sources from context where internal modules are not allowed, e.g. older version of `graceful-fs` module.

To be reverted in Node.js 7.0.

Fixes #5097, see also #1898, #2026, and #4525.