### PR TITLE
crypto: add `pfx` certs as CA certs too

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -982,6 +982,17 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
                                     &sc->cert_,
                                     &sc->issuer_) &&
       SSL_CTX_use_PrivateKey(sc->ctx_, pkey)) {
+    // Add CA certs too
+    for (int i = 0; i < sk_X509_num(extra_certs); i++) {
+      X509* ca = sk_X509_value(extra_certs, i);
+
+      if (!sc->ca_store_) {
+        sc->ca_store_ = X509_STORE_new();
+        SSL_CTX_set_cert_store(sc->ctx_, sc->ca_store_);
+      }
+      X509_STORE_add_cert(sc->ca_store_, ca);
+      SSL_CTX_add_client_CA(sc->ctx_, ca);
+    }
     ret = true;
   }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1001,7 +1001,7 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
   if (cert != nullptr)
     X509_free(cert);
   if (extra_certs != nullptr)
-    sk_X509_free(extra_certs);
+    sk_X509_pop_free(extra_certs, X509_free);
 
   PKCS12_free(p12);
   BIO_free_all(in);

--- a/test/parallel/test-tls-pfx-gh-5100-regr.js
+++ b/test/parallel/test-tls-pfx-gh-5100-regr.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: node compiled without crypto.');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+const fs = require('fs');
+const path = require('path');
+
+const pfx = fs.readFileSync(
+    path.join(common.fixturesDir, 'keys', 'agent1-pfx.pem'));
+
+const server = tls.createServer({
+  pfx: pfx,
+  passphrase: 'sample',
+  requestCert: true,
+  rejectUnauthorized: false
+}, common.mustCall(function(c) {
+  assert(c.authorizationError === null, 'authorizationError must be null');
+  c.end();
+})).listen(common.PORT, function() {
+  var client = tls.connect({
+    port: common.PORT,
+    pfx: pfx,
+    passphrase: 'sample',
+    rejectUnauthorized: false
+  }, function() {
+    client.end();
+    server.close();
+  });
+});


### PR DESCRIPTION
According to documentation all certificates specified in `pfx` option
should be treated as a CA certificates too. While it doesn't seem to be
logically correct to me, we can't afford to break API stability at this
point.

Fix: #5100