### PR TITLE
doc: fix typo in dgram doc

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -86,7 +86,7 @@ Returns an object containing the address information for a socket.
 For UDP sockets, this object will contain `address`, `family` and `port`
 properties.
 
-### [socket.bind([port][, address][, callback])]
+### socket.bind([port][, address][, callback])
 
 * `port` Integer, Optional
 * `address` String, Optional


### PR DESCRIPTION
I believe the outer square brackets are a typographical error. (Or is there a meaning I'm unfamiliar with?)

/cc @nodejs/documentation 