### PR TITLE
tools: lint for strict equality for non null checks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,8 @@ rules:
   no-fallthrough: 2
   ## disallow declaring the same variable more than once
   no-redeclare: 2
+  ## enforce using strict comparison besides equal null checks
+  eqeqeq: [2, "allow-null"]
 
   # Stylistic Issues
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -187,7 +187,7 @@ Client.prototype._addScript = function(desc) {
   this.scripts[desc.id] = desc;
   if (desc.name) {
     desc.isNative = (desc.name.replace('.js', '') in natives) ||
-                    desc.name == 'node.js';
+                    desc.name === 'node.js';
   }
 };
 
@@ -202,7 +202,7 @@ Client.prototype._onResponse = function(res) {
   var index = -1;
 
   this._reqCallbacks.some(function(fn, i) {
-    if (fn.request_seq == res.body.request_seq) {
+    if (fn.request_seq === res.body.request_seq) {
       cb = fn;
       index = i;
       return true;
@@ -212,25 +212,25 @@ Client.prototype._onResponse = function(res) {
   var self = this;
   var handled = false;
 
-  if (res.headers.Type == 'connect') {
+  if (res.headers.Type === 'connect') {
     // Request a list of scripts for our own storage.
     self.reqScripts();
     self.emit('ready');
     handled = true;
 
-  } else if (res.body && res.body.event == 'break') {
+  } else if (res.body && res.body.event === 'break') {
     this.emit('break', res.body);
     handled = true;
 
-  } else if (res.body && res.body.event == 'exception') {
+  } else if (res.body && res.body.event === 'exception') {
     this.emit('exception', res.body);
     handled = true;
 
-  } else if (res.body && res.body.event == 'afterCompile') {
+  } else if (res.body && res.body.event === 'afterCompile') {
     this._addHandle(res.body.body.script);
     handled = true;
 
-  } else if (res.body && res.body.event == 'scriptCollected') {
+  } else if (res.body && res.body.event === 'scriptCollected') {
     // ???
     this._removeScript(res.body.body.script);
     handled = true;
@@ -328,7 +328,7 @@ Client.prototype.reqScopes = function(cb) {
 Client.prototype.reqEval = function(expression, cb) {
   var self = this;
 
-  if (this.currentFrame == NO_FRAME) {
+  if (this.currentFrame === NO_FRAME) {
     // Only need to eval in global scope.
     this.reqFrameEval(expression, NO_FRAME, cb);
     return;
@@ -358,7 +358,7 @@ Client.prototype.reqEval = function(expression, cb) {
 
 // Finds the first scope in the array in which the expression evals.
 Client.prototype._reqFramesEval = function(expression, evalFrames, cb) {
-  if (evalFrames.length == 0) {
+  if (evalFrames.length === 0) {
     // Just eval in global scope.
     this.reqFrameEval(expression, NO_FRAME, cb);
     return;
@@ -382,7 +382,7 @@ Client.prototype.reqFrameEval = function(expression, frame, cb) {
     arguments: { expression: expression }
   };
 
-  if (frame == NO_FRAME) {
+  if (frame === NO_FRAME) {
     req.arguments.global = true;
   } else {
     req.arguments.frame = frame;
@@ -529,9 +529,9 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
       var mirror;
       var waiting = 1;
 
-      if (handle.className == 'Array') {
+      if (handle.className === 'Array') {
         mirror = [];
-      } else if (handle.className == 'Date') {
+      } else if (handle.className === 'Date') {
         mirror = new Date(handle.value);
       } else {
         mirror = {};
@@ -1103,7 +1103,7 @@ Interface.prototype.list = function(delta) {
     for (var i = 0; i < lines.length; i++) {
       var lineno = res.fromLine + i + 1;
       if (lineno < from || lineno > to) continue;
-
+      /* eslint-disable eqeqeq */
       const current = lineno == 1 + client.currentSourceLine;
       const breakpoint = client.breakpoints.some(function(bp) {
         return (bp.scriptReq === client.currentScript ||
@@ -1119,6 +1119,7 @@ Interface.prototype.list = function(delta) {
 
         client.currentSourceColumn -= wrapper.length;
       }
+      /* eslint-enable eqeqeq */
 
       // Highlight executing statement
       var line;
@@ -1158,7 +1159,7 @@ Interface.prototype.backtrace = function() {
       return;
     }
 
-    if (bt.totalFrames == 0) {
+    if (bt.totalFrames === 0) {
       self.print('(empty stack)');
     } else {
       const trace = [];
@@ -1200,10 +1201,10 @@ Interface.prototype.scripts = function() {
     var script = client.scripts[id];
     if (script !== null && typeof script === 'object' && script.name) {
       if (displayNatives ||
-          script.name == client.currentScript ||
+          script.name === client.currentScript ||
           !script.isNative) {
         scripts.push(
-            (script.name == client.currentScript ? '* ' : '  ') +
+            (script.name === client.currentScript ? '* ' : '  ') +
             id + ': ' +
             path.basename(script.name)
         );
@@ -1363,7 +1364,9 @@ Interface.prototype.setBreakpoint = function(script, line,
     };
   } else {
     // setBreakpoint('scriptname')
-    if (script != +script && !this.client.scripts[script]) {
+    if (script != +script && // eslint-disable-line eqeqeq
+      !this.client.scripts[script]
+    ) {
       var scripts = this.client.scripts;
       for (var id in scripts) {
         if (scripts[id] &&

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -27,8 +27,8 @@ function IncomingMessage(socket) {
   this.socket = socket;
   this.connection = socket;
 
-  this.httpVersionMajor = null;
-  this.httpVersionMinor = null;
+  this.httpVersionMajor = 0;
+  this.httpVersionMinor = 0;
   this.httpVersion = null;
   this.complete = false;
   this.headers = {};

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -516,7 +516,7 @@ function connectionListener(socket) {
     }
 
     if (req.headers.expect !== undefined &&
-        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1)) {
+        (req.httpVersionMajor === 1 && req.httpVersionMinor === 1)) {
       if (continueExpression.test(req.headers.expect)) {
         res._expect_continue = true;
 

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -183,7 +183,7 @@ function done(stream, er) {
   var ts = stream._transformState;
 
   if (ws.length)
-    throw new Error('Calling transform done when ws.length != 0');
+    throw new Error('Calling transform done when ws.length !== 0');
 
   if (ts.transforming)
     throw new Error('Calling transform done when still transforming');

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -523,7 +523,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
 };
 
 TLSSocket.prototype.setMaxSendFragment = function setMaxSendFragment(size) {
-  return this._handle.setMaxSendFragment(size) == 1;
+  return this._handle.setMaxSendFragment(size) === 1;
 };
 
 TLSSocket.prototype.getTLSTicket = function getTLSTicket() {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -23,6 +23,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
+/* eslint-disable eqeqeq */
 
 // UTILITY
 const compare = process.binding('buffer').compare;
@@ -164,7 +165,7 @@ function _deepEqual(actual, expected, strict) {
            actual.lastIndex === expected.lastIndex &&
            actual.ignoreCase === expected.ignoreCase;
 
-  // 7.4. Other pairs that do not both pass typeof value == 'object',
+  // 7.4. Other pairs that do not both pass typeof value === 'object',
   // equivalence is determined by ==.
   } else if ((actual === null || typeof actual !== 'object') &&
              (expected === null || typeof expected !== 'object')) {
@@ -187,7 +188,7 @@ function _deepEqual(actual, expected, strict) {
 }
 
 function isArguments(object) {
-  return Object.prototype.toString.call(object) == '[object Arguments]';
+  return Object.prototype.toString.call(object) === '[object Arguments]';
 }
 
 function objEquiv(a, b, strict) {
@@ -271,7 +272,7 @@ function expectedException(actual, expected) {
     return false;
   }
 
-  if (Object.prototype.toString.call(expected) == '[object RegExp]') {
+  if (Object.prototype.toString.call(expected) === '[object RegExp]') {
     return expected.test(actual);
   }
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -72,7 +72,7 @@ Object.setPrototypeOf(Buffer, Uint8Array);
 
 
 function SlowBuffer(length) {
-  if (+length != length)
+  if (+length != length) // eslint-disable-line eqeqeq
     length = 0;
   if (length > 0)
     flags[kNoZeroFill] = 1;

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -39,13 +39,13 @@ function lookup6(address, callback) {
 
 
 function newHandle(type) {
-  if (type == 'udp4') {
+  if (type === 'udp4') {
     const handle = new UDP();
     handle.lookup = lookup4;
     return handle;
   }
 
-  if (type == 'udp6') {
+  if (type === 'udp6') {
     const handle = new UDP();
     handle.lookup = lookup6;
     handle.bind = handle.bind6;
@@ -53,7 +53,7 @@ function newHandle(type) {
     return handle;
   }
 
-  if (type == 'unix_dgram')
+  if (type === 'unix_dgram')
     throw new Error('"unix_dgram" type sockets are not supported any more');
 
   throw new Error('Bad socket type specified. Valid types are: udp4, udp6');
@@ -140,7 +140,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
 
   self._healthCheck();
 
-  if (this._bindState != BIND_STATE_UNBOUND)
+  if (this._bindState !== BIND_STATE_UNBOUND)
     throw new Error('Socket is already bound');
 
   this._bindState = BIND_STATE_BINDING;
@@ -326,12 +326,12 @@ Socket.prototype.send = function(buffer,
 
   self._healthCheck();
 
-  if (self._bindState == BIND_STATE_UNBOUND)
+  if (self._bindState === BIND_STATE_UNBOUND)
     self.bind({port: 0, exclusive: true}, null);
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.
-  if (self._bindState != BIND_STATE_BOUND) {
+  if (self._bindState !== BIND_STATE_BOUND) {
     enqueue(self, [buffer, port, address, callback]);
     return;
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1113,9 +1113,11 @@ fs.chownSync = function(path, uid, gid) {
 
 // converts Date or number to a fractional UNIX timestamp
 function toUnixTimestamp(time) {
+  /* eslint-disable eqeqeq */
   if (typeof time === 'string' && +time == time) {
     return +time;
   }
+  /* eslint-enable eqeqeq */
   if (typeof time === 'number') {
     if (!Number.isFinite(time) || time < 0) {
       return Date.now() / 1000;

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -823,7 +823,7 @@ function getSocketList(type, slave, key) {
 function maybeClose(subprocess) {
   subprocess._closesGot++;
 
-  if (subprocess._closesGot == subprocess._closesNeeded) {
+  if (subprocess._closesGot === subprocess._closesNeeded) {
     subprocess.emit('close', subprocess.exitCode, subprocess.signalCode);
   }
 }

--- a/lib/internal/linkedlist.js
+++ b/lib/internal/linkedlist.js
@@ -9,7 +9,7 @@ exports.init = init;
 
 // show the most idle item
 function peek(list) {
-  if (list._idlePrev == list) return null;
+  if (list._idlePrev === list) return null;
   return list._idlePrev;
 }
 exports.peek = peek;

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -34,7 +34,7 @@ const os = {
       // Filter out vdso and vsyscall entries.
       const arg = args[args.length - 1];
       if (arg === '[vdso]' ||
-          arg == '[vsyscall]' ||
+          arg === '[vsyscall]' ||
           /^[0-9a-f]+-[0-9a-f]+$/.test(arg)) {
         return '';
       }

--- a/lib/net.js
+++ b/lib/net.js
@@ -129,7 +129,7 @@ function Socket(options) {
   } else if (options.fd !== undefined) {
     this._handle = createHandle(options.fd);
     this._handle.open(options.fd);
-    if ((options.fd == 1 || options.fd == 2) &&
+    if ((options.fd === 1 || options.fd === 2) &&
         (this._handle instanceof Pipe) &&
         process.platform === 'win32') {
       // Make stdout and stderr blocking on Windows
@@ -503,7 +503,7 @@ Socket.prototype.destroy = function(exception) {
 function onread(nread, buffer) {
   var handle = this;
   var self = handle.owner;
-  assert(handle === self._handle, 'handle != self._handle');
+  assert(handle === self._handle, 'handle !== self._handle');
 
   self._unrefTimer();
 
@@ -678,7 +678,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
 
   // If it was entirely flushed, we can write some more right now.
   // However, if more is left in the queue, then wait until that clears.
-  if (req.async && this._handle.writeQueueSize != 0)
+  if (req.async && this._handle.writeQueueSize !== 0)
     req.cb = cb;
   else
     cb();
@@ -1034,7 +1034,7 @@ function afterConnect(status, handle, req, readable, writable) {
   self._connecting = false;
   self._sockname = null;
 
-  if (status == 0) {
+  if (status === 0) {
     self.readable = readable;
     self.writable = writable;
     self._unrefTimer();

--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -2,11 +2,11 @@
 ;(function(root) {
 
 	/** Detect free variables */
-	var freeExports = typeof exports == 'object' && exports &&
+	var freeExports = typeof exports === 'object' && exports &&
 		!exports.nodeType && exports;
-	var freeModule = typeof module == 'object' && module &&
+	var freeModule = typeof module === 'object' && module &&
 		!module.nodeType && module;
-	var freeGlobal = typeof global == 'object' && global;
+	var freeGlobal = typeof global === 'object' && global;
 	if (
 		freeGlobal.global === freeGlobal ||
 		freeGlobal.window === freeGlobal ||
@@ -206,7 +206,7 @@
 	function digitToBasic(digit, flag) {
 		//  0..25 map to ASCII a..z or A..Z
 		// 26..35 map to ASCII 0..9
-		return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
+		return digit + 22 + 75 * (digit < 26) - ((flag !== 0) << 5);
 	}
 
 	/**
@@ -508,8 +508,8 @@
 	// Some AMD build optimizers, like r.js, check for specific condition patterns
 	// like the following:
 	if (
-		typeof define == 'function' &&
-		typeof define.amd == 'object' &&
+		typeof define === 'function' &&
+		typeof define.amd === 'object' &&
 		define.amd
 	) {
 		define('punycode', function() {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -428,7 +428,7 @@ Interface.prototype._tabComplete = function() {
 
 // this = Interface instance
 function handleGroup(self, group, width, maxColumns) {
-  if (group.length == 0) {
+  if (group.length === 0) {
     return;
   }
   var minRows = Math.ceil(group.length / maxColumns);
@@ -453,14 +453,14 @@ function handleGroup(self, group, width, maxColumns) {
 }
 
 function commonPrefix(strings) {
-  if (!strings || strings.length == 0) {
+  if (!strings || strings.length === 0) {
     return '';
   }
   var sorted = strings.slice().sort();
   var min = sorted[0];
   var max = sorted[sorted.length - 1];
   for (var i = 0, len = min.length; i < len; i++) {
-    if (min[i] != max[i]) {
+    if (min[i] !== max[i]) {
       return min.slice(0, i);
     }
   }
@@ -673,7 +673,7 @@ Interface.prototype._ttyWrite = function(s, key) {
   key = key || {};
 
   // Ignore escape key - Fixes #2876
-  if (key.name == 'escape') return;
+  if (key.name === 'escape') return;
 
   if (key.ctrl && key.shift) {
     /* Control and shift pressed */
@@ -754,7 +754,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'z':
-        if (process.platform == 'win32') break;
+        if (process.platform === 'win32') break;
         if (this.listenerCount('SIGTSTP') > 0) {
           this.emit('SIGTSTP');
         } else {
@@ -939,7 +939,7 @@ function emitKeypressEvents(stream) {
   }
 
   function onNewListener(event) {
-    if (event == 'keypress') {
+    if (event === 'keypress') {
       stream.on('data', onData);
       stream.removeListener('newListener', onNewListener);
     }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -785,7 +785,7 @@ REPLServer.prototype.complete = function(line, callback) {
         this.eval(expr, this.context, 'repl', function(e, obj) {
           // if (e) console.log(e);
 
-          if (obj != null) {
+          if (obj) {
             if (typeof obj === 'object' || typeof obj === 'function') {
               try {
                 memberGroups.push(filteredOwnPropertyNames(obj));
@@ -850,7 +850,7 @@ REPLServer.prototype.complete = function(line, callback) {
       var newCompletionGroups = [];
       for (i = 0; i < completionGroups.length; i++) {
         group = completionGroups[i].filter(function(elem) {
-          return elem.indexOf(filter) == 0;
+          return elem.indexOf(filter) === 0;
         });
         if (group.length) {
           newCompletionGroups.push(group);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -335,11 +335,11 @@ function Zlib(opts, mode) {
   }
 
   if (opts.strategy) {
-    if (opts.strategy != exports.Z_FILTERED &&
-        opts.strategy != exports.Z_HUFFMAN_ONLY &&
-        opts.strategy != exports.Z_RLE &&
-        opts.strategy != exports.Z_FIXED &&
-        opts.strategy != exports.Z_DEFAULT_STRATEGY) {
+    if (opts.strategy !== exports.Z_FILTERED &&
+        opts.strategy !== exports.Z_HUFFMAN_ONLY &&
+        opts.strategy !== exports.Z_RLE &&
+        opts.strategy !== exports.Z_FIXED &&
+        opts.strategy !== exports.Z_DEFAULT_STRATEGY) {
       throw new Error('Invalid strategy: ' + opts.strategy);
     }
   }
@@ -394,11 +394,11 @@ Zlib.prototype.params = function(level, strategy, callback) {
       level > exports.Z_MAX_LEVEL) {
     throw new RangeError('Invalid compression level: ' + level);
   }
-  if (strategy != exports.Z_FILTERED &&
-      strategy != exports.Z_HUFFMAN_ONLY &&
-      strategy != exports.Z_RLE &&
-      strategy != exports.Z_FIXED &&
-      strategy != exports.Z_DEFAULT_STRATEGY) {
+  if (strategy !== exports.Z_FILTERED &&
+      strategy !== exports.Z_HUFFMAN_ONLY &&
+      strategy !== exports.Z_RLE &&
+      strategy !== exports.Z_FIXED &&
+      strategy !== exports.Z_DEFAULT_STRATEGY) {
     throw new TypeError('Invalid strategy: ' + strategy);
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -71,11 +71,11 @@
         NativeModule.require('_third_party_main');
       });
 
-    } else if (process.argv[1] == 'debug') {
+    } else if (process.argv[1] === 'debug') {
       // Start the debugger agent
       NativeModule.require('_debugger').start();
 
-    } else if (process.argv[1] == '--debug-agent') {
+    } else if (process.argv[1] === '--debug-agent') {
       // Start the debugger agent
       NativeModule.require('_debug_agent').start();
 
@@ -799,7 +799,7 @@
     process.kill = function(pid, sig) {
       var err;
 
-      if (pid != (pid | 0)) {
+      if (pid != (pid | 0)) { // eslint-disable-line eqeqeq
         throw new TypeError('invalid pid');
       }
 
@@ -927,7 +927,7 @@
   NativeModule._cache = {};
 
   NativeModule.require = function(id) {
-    if (id == 'native_module') {
+    if (id === 'native_module') {
       return NativeModule;
     }
 

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -26,4 +26,4 @@ fs.writeFileSync(addonDestinationPath, contents);
 // Attempt to load at long path destination
 var addon = require(addonDestinationPath);
 assert(addon != null);
-assert(addon.hello() == 'world');
+assert(addon.hello() === 'world');

--- a/test/debugger/test-debugger-pid.js
+++ b/test/debugger/test-debugger-pid.js
@@ -24,9 +24,9 @@ interfacer.stderr.on('data', onData);
 interfacer.on('line', function(line) {
   line = line.replace(/^(debug> *)+/, '');
   var expected = 'Target process: 655555 doesn\'t exist.';
-  assert.ok(expected == line, 'Got unexpected line: ' + line);
+  assert.ok(expected === line, 'Got unexpected line: ' + line);
 });
 
 interfacer.on('exit', function(code, signal) {
-  assert.ok(code == 1, 'Got unexpected code: ' + code);
+  assert.ok(code === 1, 'Got unexpected code: ' + code);
 });

--- a/test/debugger/test-debugger-remote.js
+++ b/test/debugger/test-debugger-remote.js
@@ -32,7 +32,7 @@ interfacer.on('line', function(line) {
   line = line.replace(/^(debug> *)+/, '');
   console.log(line);
   var expected = '\bconnecting to localhost:5959 ... ok';
-  assert.ok(expected == line, 'Got unexpected line: ' + line);
+  assert.ok(expected === line, 'Got unexpected line: ' + line);
 });
 
 // allow time to start up the debugger

--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -46,7 +46,7 @@ var SOCK_PATH = path.join(__dirname,
                           path.basename(__filename, '.js') + '.sock');
 
 var logChild = function(d) {
-  if (typeof d == 'object') {
+  if (typeof d === 'object') {
     d = d.toString();
   }
 

--- a/test/fixtures/not-main-module.js
+++ b/test/fixtures/not-main-module.js
@@ -1,4 +1,4 @@
 var assert = require('assert');
-assert.notEqual(module, require.main, 'require.main should not == module');
+assert.notEqual(module, require.main, 'require.main should not === module');
 assert.notEqual(module, process.mainModule,
                 'process.mainModule should not === module');

--- a/test/fixtures/recvfd.js
+++ b/test/fixtures/recvfd.js
@@ -8,7 +8,7 @@ var receivedFDs = [];
 var numSentMessages = 0;
 
 function processData(s) {
-  if (receivedData.length == 0 || receivedFDs.length == 0) {
+  if (receivedData.length === 0 || receivedFDs.length === 0) {
     return;
   }
 
@@ -25,7 +25,7 @@ function processData(s) {
   var drainFunc = function() {
     pipeStream.destroy();
 
-    if (++numSentMessages == 2) {
+    if (++numSentMessages === 2) {
       s.destroy();
     }
   };

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -66,7 +66,7 @@ if (process.argv[2] !== 'child') {
         // don't consider this the true death if the worker
         // has finished successfully
         // or if the exit code is 0
-        if (worker.isDone || code == 0) {
+        if (worker.isDone || code === 0) {
           return;
         }
 
@@ -211,7 +211,7 @@ if (process.argv[2] === 'child') {
 
     process.send({ message: buf.toString() });
 
-    if (receivedMessages.length == messages.length) {
+    if (receivedMessages.length === messages.length) {
       process.nextTick(function() {
         listenSocket.close();
       });

--- a/test/internet/test-dgram-multicast-multi-process.js
+++ b/test/internet/test-dgram-multicast-multi-process.js
@@ -192,7 +192,7 @@ if (process.argv[2] === 'child') {
 
       process.send({ message: buf.toString() });
 
-      if (receivedMessages.length == messages.length) {
+      if (receivedMessages.length === messages.length) {
         // .dropMembership() not strictly needed but here as a sanity check.
         listenSocket.dropMembership(LOCAL_BROADCAST_HOST);
         process.nextTick(function() {

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -375,7 +375,7 @@ req.oncomplete = function(err, domains) {
   console.log('nodejs.org = ', domains);
   assert.ok(Array.isArray(domains));
   assert.ok(domains.length >= 1);
-  assert.ok(typeof domains[0] == 'string');
+  assert.ok(typeof domains[0] === 'string');
   getaddrinfoCallbackCalled = true;
 };
 

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -20,7 +20,7 @@ keyList.splice(0, 1);
 
 
 function init(id) {
-  keyList = keyList.filter((e) => e != pkeys[id]);
+  keyList = keyList.filter((e) => e !== pkeys[id]);
 }
 
 function noop() { }

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -10,7 +10,7 @@ var cntr = 0;
 
 var b = Buffer(1024); // safe constructor
 
-console.log('b.length == %d', b.length);
+console.log('b.length === %d', b.length);
 assert.strictEqual(1024, b.length);
 
 b[0] = -1;
@@ -25,7 +25,7 @@ for (let i = 0; i < 1024; i++) {
 }
 
 var c = new Buffer(512);
-console.log('c.length == %d', c.length);
+console.log('c.length === %d', c.length);
 assert.strictEqual(512, c.length);
 
 var d = new Buffer([]);

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -26,7 +26,7 @@ exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
   } else {
     success_count++;
     console.log(stdout);
-    assert.ok(stdout.indexOf(dir) == 0);
+    assert.ok(stdout.indexOf(dir) === 0);
   }
 });
 

--- a/test/parallel/test-child-process-exec-env.js
+++ b/test/parallel/test-child-process-exec-env.js
@@ -16,7 +16,7 @@ function after(err, stdout, stderr) {
     assert.equal(false, err.killed);
   } else {
     success_count++;
-    assert.equal(true, stdout != '');
+    assert.equal(true, stdout !== '');
   }
 }
 

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -28,5 +28,5 @@ n.on('exit', function(c) {
 });
 
 process.on('exit', function() {
-  assert.ok(childExitCode == 0);
+  assert.ok(childExitCode === 0);
 });

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -86,7 +86,7 @@ function worker() {
     received++;
 
     // Every 10 messages, notify the master.
-    if (received == PACKETS_PER_WORKER) {
+    if (received === PACKETS_PER_WORKER) {
       process.send({received: received});
       process.disconnect();
     }

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -31,7 +31,7 @@ function master() {
   socket.on('message', function(data, info) {
     received++;
 
-    if (received == PACKETS_PER_WORKER * NUM_WORKERS) {
+    if (received === PACKETS_PER_WORKER * NUM_WORKERS) {
       console.log('master received %d packets', received);
 
       // Close the socket.

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -10,7 +10,7 @@ var fork = require('child_process').fork;
 
 var MAGIC_EXIT_CODE = 42;
 
-var isTestRunner = process.argv[2] != 'child';
+var isTestRunner = process.argv[2] !== 'child';
 
 if (isTestRunner) {
   var exitCode = -1;

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -88,7 +88,7 @@ if (cluster.isWorker) {
       checkResults(expected_results, results);
     } catch (exc) {
       console.error('FAIL: ' + exc.message);
-      if (exc.name != 'AssertionError') {
+      if (exc.name !== 'AssertionError') {
         console.trace(exc);
       }
 

--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -88,7 +88,7 @@ if (cluster.isWorker) {
       checkResults(expected_results, results);
     } catch (exc) {
       console.error('FAIL: ' + exc.message);
-      if (exc.name != 'AssertionError') {
+      if (exc.name !== 'AssertionError') {
         console.trace(exc);
       }
 

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -55,7 +55,7 @@ var ciphers = crypto.getCiphers();
 for (var i in TEST_CASES) {
   var test = TEST_CASES[i];
 
-  if (ciphers.indexOf(test.algo) == -1) {
+  if (ciphers.indexOf(test.algo) === -1) {
     console.log('1..0 # Skipped: unsupported ' + test.algo + ' test');
     continue;
   }

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -62,7 +62,7 @@ var wikipedia = [
 for (let i = 0, l = wikipedia.length; i < l; i++) {
   for (const hash in wikipedia[i]['hmac']) {
     // FIPS does not support MD5.
-    if (common.hasFipsCrypto && hash == 'md5')
+    if (common.hasFipsCrypto && hash === 'md5')
       continue;
     const result = crypto.createHmac(hash, wikipedia[i]['key'])
                          .update(wikipedia[i]['data'])

--- a/test/parallel/test-dgram-empty-packet.js
+++ b/test/parallel/test-dgram-empty-packet.js
@@ -17,7 +17,7 @@ client.bind(common.PORT);
 
 function callback() {
   callbacks++;
-  if (callbacks == 2) {
+  if (callbacks === 2) {
     clearTimeout(timer);
     client.close();
   } else if (callbacks > 2) {

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -30,10 +30,10 @@ file
   .on('drain', function() {
     console.error('drain!', callbacks.drain);
     callbacks.drain++;
-    if (callbacks.drain == -1) {
+    if (callbacks.drain === -1) {
       assert.equal(EXPECTED, fs.readFileSync(fn, 'utf8'));
       file.write(EXPECTED);
-    } else if (callbacks.drain == 0) {
+    } else if (callbacks.drain === 0) {
       assert.equal(EXPECTED + EXPECTED, fs.readFileSync(fn, 'utf8'));
       file.end();
     }

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -60,7 +60,7 @@ file.on('drain', function() {
     assert.equal(fs.readFileSync(filepath, 'utf8'), EXPECTED);
     console.error('ondrain write ret=%j', file.write(EXPECTED));
     cb_occurred += 'write ';
-  } else if (countDrains == 2) {
+  } else if (countDrains === 2) {
     console.error('second drain, end');
     assert.equal(fs.readFileSync(filepath, 'utf8'), EXPECTED + EXPECTED);
     file.end();
@@ -85,6 +85,6 @@ for (var i = 0; i < 11; i++) {
   console.error('%d %j', i, ret);
 
   // return false when i hits 10
-  assert(ret === (i != 10));
+  assert(ret === (i !== 10));
 }
 cb_occurred += 'write ';

--- a/test/parallel/test-fs-read-stream-fd-leak.js
+++ b/test/parallel/test-fs-read-stream-fd-leak.js
@@ -30,7 +30,7 @@ function testLeak(endFn, callback) {
   var check = 0;
 
   var checkFunction = function() {
-    if (openCount != 0 && check < totalCheck) {
+    if (openCount !== 0 && check < totalCheck) {
       check++;
       setTimeout(checkFunction, 100);
       return;

--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -13,14 +13,14 @@ try {
   fs.mkdirSync(dirName);
 } catch (e) {
   // Ignore if the directory already exists.
-  if (e.code != 'EEXIST') throw e;
+  if (e.code !== 'EEXIST') throw e;
 }
 
 fs.writeFileSync(fileName, buf);
 
 fs.readFile(fileName, function(err, data) {
   assert.ifError(err);
-  assert(data.length == buf.length);
+  assert(data.length === buf.length);
   assert.strictEqual(buf[0], 42);
 
   fs.unlinkSync(fileName);

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -18,7 +18,7 @@ if (common.isWindows) {
   // We'll only try to run symlink test if we have enough privileges.
   try {
     exec('whoami /priv', function(err, o) {
-      if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
+      if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') === -1) {
         skipSymlinks = true;
       }
       runTest();

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -12,7 +12,7 @@ if (common.isWindows) {
   // On Windows, creating symlinks requires admin privileges.
   // We'll only try to run symlink test if we have enough privileges.
   exec('whoami /priv', function(err, o) {
-    if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
+    if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') === -1) {
       console.log('1..0 # Skipped: insufficient privileges');
       return;
     }

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -8,7 +8,7 @@ var tests_ok = 0;
 var tests_run = 0;
 
 function stat_resource(resource) {
-  if (typeof resource == 'string') {
+  if (typeof resource === 'string') {
     return fs.statSync(resource);
   } else {
     // ensure mtime has been written to disk

--- a/test/parallel/test-http-agent.js
+++ b/test/parallel/test-http-agent.js
@@ -18,7 +18,7 @@ server.listen(common.PORT, function() {
       for (var j = 0; j < M; j++) {
         http.get({ port: common.PORT, path: '/' }, function(res) {
           console.log('%d %d', responses, res.statusCode);
-          if (++responses == N * M) {
+          if (++responses === N * M) {
             console.error('Received all responses, closing server');
             server.close();
           }

--- a/test/parallel/test-http-allow-req-after-204-res.js
+++ b/test/parallel/test-http-allow-req-after-204-res.js
@@ -28,7 +28,7 @@ function nextRequest() {
     path: '/'
   }, function(response) {
     response.on('end', function() {
-      if (methods.length == 0) {
+      if (methods.length === 0) {
         console.error('close server');
         server.close();
       } else {

--- a/test/parallel/test-http-client-abort.js
+++ b/test/parallel/test-http-client-abort.js
@@ -37,7 +37,7 @@ server.listen(common.PORT, function() {
       console.log('Client response code ' + res.statusCode);
 
       res.resume();
-      if (++responses == N) {
+      if (++responses === N) {
         console.log('All clients connected, destroying.');
         requests.forEach(function(outReq) {
           console.log('abort');

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -72,6 +72,6 @@ server.listen(options.port, options.host, function() {
 
 process.on('exit', function() {
   console.error('done=%j sent=%j', requests_done, requests_sent);
-  assert.ok(requests_done == requests_sent,
+  assert.ok(requests_done === requests_sent,
             'timeout on http request called too much');
 });

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -20,6 +20,6 @@ var exception_count = 0;
 process.on('uncaughtException', function(err) {
   console.log('Caught an exception: ' + err);
   if (err.name === 'AssertionError') throw err;
-  if (++exception_count == 4) process.exit(0);
+  if (++exception_count === 4) process.exit(0);
 });
 

--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -58,7 +58,7 @@ server.on('listening', function() {
       assert.equal(body, test_res_body, 'Response body doesn\'t match.');
       assert.ok('abcd' in res.headers, 'Response headers missing.');
       outstanding_reqs--;
-      if (outstanding_reqs == 0) {
+      if (outstanding_reqs === 0) {
         server.close();
         process.exit();
       }

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -17,7 +17,7 @@ var total = 100;
 var requests = 0, responses = 0;
 
 var server = http.Server(function(req, res) {
-  if (++requests == total) {
+  if (++requests === total) {
     server.close();
   }
 
@@ -49,7 +49,7 @@ server.listen(common.PORT, function() {
 
         s.on('finish', function() {
           console.error('done ' + x);
-          if (++responses == total) {
+          if (++responses === total) {
             checkFiles();
           }
         });

--- a/test/parallel/test-http-incoming-pipelined-socket-destroy.js
+++ b/test/parallel/test-http-incoming-pipelined-socket-destroy.js
@@ -52,7 +52,7 @@ server.listen(common.PORT, function() {
   var client = net.connect({ port: common.PORT });
   var done = 0;
   server.on('requestDone', function() {
-    if (++done == seeds.length) {
+    if (++done === seeds.length) {
       server.close();
     }
   });

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -10,7 +10,7 @@ var body0 = '';
 var body1 = '';
 
 var server = http.createServer(function(req, res) {
-  if (responses_sent == 0) {
+  if (responses_sent === 0) {
     assert.equal('GET', req.method);
     assert.equal('/hello', url.parse(req.url).pathname);
 
@@ -22,7 +22,7 @@ var server = http.createServer(function(req, res) {
     assert.equal('bar', req.headers['foo']);
   }
 
-  if (responses_sent == 1) {
+  if (responses_sent === 1) {
     assert.equal('POST', req.method);
     assert.equal('/world', url.parse(req.url).pathname);
     this.close();

--- a/test/parallel/test-http-malformed-request.js
+++ b/test/parallel/test-http-malformed-request.js
@@ -18,7 +18,7 @@ var server = http.createServer(function(req, res) {
   res.write('Hello World');
   res.end();
 
-  if (++nrequests_completed == nrequests_expected) server.close();
+  if (++nrequests_completed === nrequests_expected) server.close();
 });
 server.listen(common.PORT);
 

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -28,14 +28,14 @@ const norepeat = [
 ];
 
 const server = http.createServer(function(req, res) {
-  var num = req.headers['x-num'];
-  if (num == 1) {
+  var num = +req.headers['x-num'];
+  if (num === 1) {
     res.setHeader('content-length', [1, 2]);
     for (const name of norepeat) {
       res.setHeader(name, ['A', 'B']);
     }
     res.setHeader('X-A', ['A', 'B']);
-  } else if (num == 2) {
+  } else if (num === 2) {
     const headers = {};
     headers['content-length'] = [1, 2];
     for (const name of norepeat) {

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -15,23 +15,23 @@ var server = http.createServer(function(req, res) {
   res.id = request_number;
   req.id = request_number++;
 
-  if (req.id == 0) {
+  if (req.id === 0) {
     assert.equal('GET', req.method);
     assert.equal('/hello', url.parse(req.url).pathname);
     assert.equal('world', qs.parse(url.parse(req.url).query).hello);
     assert.equal('b==ar', qs.parse(url.parse(req.url).query).foo);
   }
 
-  if (req.id == 1) {
+  if (req.id === 1) {
     assert.equal('POST', req.method);
     assert.equal('/quit', url.parse(req.url).pathname);
   }
 
-  if (req.id == 2) {
+  if (req.id === 2) {
     assert.equal('foo', req.headers['x-x']);
   }
 
-  if (req.id == 3) {
+  if (req.id === 3) {
     assert.equal('bar', req.headers['x-x']);
     this.close();
   }
@@ -60,12 +60,12 @@ server.on('listening', function() {
   c.on('data', function(chunk) {
     server_response += chunk;
 
-    if (requests_sent == 1) {
+    if (requests_sent === 1) {
       c.write('POST /quit HTTP/1.1\r\n\r\n');
       requests_sent += 1;
     }
 
-    if (requests_sent == 2) {
+    if (requests_sent === 2) {
       c.write('GET / HTTP/1.1\r\nX-X: foo\r\n\r\n' +
               'GET / HTTP/1.1\r\nX-X: bar\r\n\r\n');
       // Note: we are making the connection half-closed here

--- a/test/parallel/test-http-set-cookies.js
+++ b/test/parallel/test-http-set-cookies.js
@@ -6,7 +6,7 @@ var http = require('http');
 var nresponses = 0;
 
 var server = http.createServer(function(req, res) {
-  if (req.url == '/one') {
+  if (req.url === '/one') {
     res.writeHead(200, [['set-cookie', 'A'],
                         ['content-type', 'text/plain']]);
     res.end('one\n');
@@ -34,7 +34,7 @@ server.on('listening', function() {
     });
 
     res.on('end', function() {
-      if (++nresponses == 2) {
+      if (++nresponses === 2) {
         server.close();
       }
     });
@@ -51,7 +51,7 @@ server.on('listening', function() {
     });
 
     res.on('end', function() {
-      if (++nresponses == 2) {
+      if (++nresponses === 2) {
         server.close();
       }
     });

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -35,7 +35,7 @@ server.on('listening', function() {
     c.end();
     assert.ok(!/x-foo/.test(res_buffer), 'Trailer in HTTP/1.0 response.');
     outstanding_reqs--;
-    if (outstanding_reqs == 0) {
+    if (outstanding_reqs === 0) {
       server.close();
       process.exit();
     }
@@ -66,7 +66,7 @@ server.on('listening', function() {
           /0\r\nx-foo: bar\r\n\r\n$/.test(res_buffer),
           'No trailer in HTTP/1.1 response.'
       );
-      if (outstanding_reqs == 0) {
+      if (outstanding_reqs === 0) {
         server.close();
         process.exit();
       }
@@ -81,7 +81,7 @@ server.on('listening', function() {
       //console.log(res.trailers);
       assert.ok('x-foo' in res.trailers, 'Client doesn\'t see trailers.');
       outstanding_reqs--;
-      if (outstanding_reqs == 0) {
+      if (outstanding_reqs === 0) {
         server.close();
         process.exit();
       }

--- a/test/parallel/test-http-timeout.js
+++ b/test/parallel/test-http-timeout.js
@@ -31,7 +31,7 @@ server.listen(port, function() {
         res.on('end', function() {
           count++;
 
-          if (count == 11) {
+          if (count === 11) {
             server.close();
           }
         });

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -39,7 +39,7 @@ function testServer() {
 
     socket.on('data', function(d) {
       var data = d.toString('utf8');
-      if (data == 'kill') {
+      if (data === 'kill') {
         socket.end();
       } else {
         socket.write(data, 'utf8');
@@ -79,11 +79,11 @@ function test_upgrade_with_listener(_server) {
 
     assert.equal('string', typeof data);
 
-    if (state == 1) {
+    if (state === 1) {
       assert.equal('HTTP/1.1 101', data.substr(0, 12));
       assert.equal('WjN}|M(6', request_upgradeHead.toString('utf8'));
       conn.write('test', 'utf8');
-    } else if (state == 2) {
+    } else if (state === 2) {
       assert.equal('test', data);
       conn.write('kill', 'utf8');
     }

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -10,7 +10,7 @@ var body0 = '';
 var body1 = '';
 
 var server = http.Server(function(req, res) {
-  if (responses_sent == 0) {
+  if (responses_sent === 0) {
     assert.equal('GET', req.method);
     assert.equal('/hello', url.parse(req.url).pathname);
 
@@ -22,7 +22,7 @@ var server = http.Server(function(req, res) {
     assert.equal('bar', req.headers['foo']);
   }
 
-  if (responses_sent == 1) {
+  if (responses_sent === 1) {
     assert.equal('POST', req.method);
     assert.equal('/world', url.parse(req.url).pathname);
     this.close();

--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -37,7 +37,7 @@ server.listen(common.PORT, function() {
         }, function(res) {
           res.resume();
           console.log(res.statusCode);
-          if (++responses == N * M) server.close();
+          if (++responses === N * M) server.close();
         }).on('error', function(e) {
           console.log(e.message);
           process.exit(1);

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -9,7 +9,7 @@ if (enablei18n === undefined) {
 }
 
 // is the Intl object present?
-var haveIntl = (global.Intl != undefined);
+var haveIntl = (global.Intl !== undefined);
 
 // Returns true if no specific locale ids were configured (i.e. "all")
 // Else, returns true if loc is in the configured list

--- a/test/parallel/test-net-binary.js
+++ b/test/parallel/test-net-binary.js
@@ -7,8 +7,8 @@ var binaryString = '';
 for (var i = 255; i >= 0; i--) {
   var s = '\'\\' + i.toString(8) + '\'';
   var S = eval(s);
-  assert.ok(S.charCodeAt(0) == i);
-  assert.ok(S == String.fromCharCode(i));
+  assert.ok(S.charCodeAt(0) === i);
+  assert.ok(S === String.fromCharCode(i));
   binaryString += S;
 }
 

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -30,7 +30,7 @@ if (common.isWindows) {
     try {
       fs.unlinkSync(emptyTxt);
     } catch (e) {
-      if (e.code != 'ENOENT')
+      if (e.code !== 'ENOENT')
         throw e;
     }
   }

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -19,7 +19,7 @@ var server = net.createServer(function(socket) {
   assert.ok(socket.remotePort);
   assert.notEqual(socket.remotePort, common.PORT);
   socket.on('end', function() {
-    if (++conns_closed == 2) server.close();
+    if (++conns_closed === 2) server.close();
   });
   socket.on('close', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));

--- a/test/parallel/test-net-server-try-ports.js
+++ b/test/parallel/test-net-server-try-ports.js
@@ -26,7 +26,7 @@ server2.on('error', function(e) {
   server2errors++;
   console.error('server2 error');
 
-  if (e.code == 'EADDRINUSE') {
+  if (e.code === 'EADDRINUSE') {
     server2eaddrinuse = true;
   }
 

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -71,7 +71,7 @@ var arch = os.arch();
 console.log('arch = ', arch);
 assert.ok(arch.length > 0);
 
-if (process.platform != 'sunos') {
+if (process.platform !== 'sunos') {
   // not implemeneted yet
   assert.ok(os.loadavg().length > 0);
   assert.ok(os.freemem() > 0);
@@ -84,7 +84,7 @@ console.error(interfaces);
 switch (platform) {
   case 'linux':
     {
-      const filter = function(e) { return e.address == '127.0.0.1'; };
+      const filter = function(e) { return e.address === '127.0.0.1'; };
       const actual = interfaces.lo.filter(filter);
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                         mac: '00:00:00:00:00:00', family: 'IPv4',
@@ -94,7 +94,7 @@ switch (platform) {
     }
   case 'win32':
     {
-      const filter = function(e) { return e.address == '127.0.0.1'; };
+      const filter = function(e) { return e.address === '127.0.0.1'; };
       const actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                         mac: '00:00:00:00:00:00', family: 'IPv4',

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -25,7 +25,7 @@ assert.equal(5, date.getHours());
 
 
 // changes in environment should be visible to child processes
-if (process.argv[2] == 'you-are-the-child') {
+if (process.argv[2] === 'you-are-the-child') {
   // failed assertion results in process exiting with status code 1
   assert.equal(false, 'NODE_PROCESS_ENV_DELETED' in process.env);
   assert.equal(42, process.env.NODE_PROCESS_ENV);
@@ -54,7 +54,7 @@ if (process.argv[2] == 'you-are-the-child') {
   child.stdout.on('data', function(data) { console.log(data.toString()); });
   child.stderr.on('data', function(data) { console.log(data.toString()); });
   child.on('exit', function(statusCode) {
-    if (statusCode != 0) {
+    if (statusCode !== 0) {
       process.exit(statusCode);  // failed assertion in child process
     }
   });

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -32,7 +32,7 @@ var i = 0;
 setInterval(function() {
   console.log('running process...' + ++i);
 
-  if (i == 5) {
+  if (i === 5) {
     process.kill(process.pid, 'SIGUSR1');
   }
 }, 1);

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -38,7 +38,7 @@ function runTest(pattern, code) {
   var matches = fs.readdirSync(common.tmpDir).filter(function(file) {
     return /^isolate-/.test(file);
   });
-  if (matches.length != 1) {
+  if (matches.length !== 1) {
     assert.fail(null, null, 'There should be a single log file.');
   }
   var log = matches[0];

--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -30,7 +30,7 @@ var assert = require('assert');
     assert.equal(a, 'foo');
     assert.equal(b, 'bar');
     assert.equal(c, 'baz');
-    if (++ncalled == 3) clearTimeout(iv);
+    if (++ncalled === 3) clearTimeout(iv);
   }
 
   process.on('exit', function() {

--- a/test/parallel/test-tty-wrap.js
+++ b/test/parallel/test-tty-wrap.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var TTY = process.binding('tty_wrap').TTY;
 var isTTY = process.binding('tty_wrap').isTTY;
 
-if (isTTY(1) == false) {
+if (isTTY(1) === false) {
   console.log('1..0 # Skipped: fd 1 is not a tty.');
   return;
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -306,9 +306,9 @@ try {
   assert.equal(util.inspect(e), e.stack);
 }
 var ex = util.inspect(new Error('FAIL'), true);
-assert.ok(ex.indexOf('Error: FAIL') != -1);
-assert.ok(ex.indexOf('[stack]') != -1);
-assert.ok(ex.indexOf('[message]') != -1);
+assert.ok(ex.indexOf('Error: FAIL') !== -1);
+assert.ok(ex.indexOf('[stack]') !== -1);
+assert.ok(ex.indexOf('[message]') !== -1);
 // Doesn't capture stack trace
 function BadCustomError(msg) {
   Error.call(this);
@@ -353,7 +353,7 @@ assert.doesNotThrow(function() {
 // GH-2225
 {
   const x = { inspect: util.inspect };
-  assert.ok(util.inspect(x).indexOf('inspect') != -1);
+  assert.ok(util.inspect(x).indexOf('inspect') !== -1);
 }
 
 // util.inspect should not display the escaped value of a key.

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -42,7 +42,7 @@ for (const name in hashes) {
 
 for (const name in hashes) {
   // modp1 is 768 bits, FIPS requires >= 1024
-  if (name == 'modp1' && common.hasFipsCrypto)
+  if (name === 'modp1' && common.hasFipsCrypto)
     continue;
   var group1 = crypto.getDiffieHellman(name);
   var group2 = crypto.getDiffieHellman(name);

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -3,7 +3,7 @@ require('../common');
 var assert = require('assert');
 var os = require('os');
 
-if (os.type() != 'SunOS') {
+if (os.type() !== 'SunOS') {
   console.log('1..0 # Skipped: no DTRACE support');
   return;
 }
@@ -52,7 +52,7 @@ dtrace.stdout.on('data', function(data) {
 });
 
 dtrace.on('exit', function(code) {
-  if (code != 0) {
+  if (code !== 0) {
     console.error('dtrace exited with code ' + code);
     process.exit(code);
   }
@@ -65,7 +65,7 @@ dtrace.on('exit', function(code) {
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
 
-    if (line.indexOf(sentinel) == -1 || frames.length === 0)
+    if (line.indexOf(sentinel) === -1 || frames.length === 0)
       continue;
 
     var frame = line.substr(line.indexOf(sentinel) + sentinel.length);

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -39,7 +39,7 @@ exec('thisisnotavalidcommand', function(err, stdout, stderr) {
   if (err) {
     error_count++;
     assert.equal('', stdout);
-    assert.equal(true, err.code != 0);
+    assert.equal(true, err.code !== 0);
     assert.equal(false, err.killed);
     assert.strictEqual(null, err.signal);
     console.log('error code: ' + err.code);
@@ -48,7 +48,7 @@ exec('thisisnotavalidcommand', function(err, stdout, stderr) {
   } else {
     success_count++;
     console.dir(stdout);
-    assert.equal(true, stdout != '');
+    assert.equal(true, stdout !== '');
   }
 });
 

--- a/test/pummel/test-http-upload-timeout.js
+++ b/test/pummel/test-http-upload-timeout.js
@@ -16,7 +16,7 @@ server.on('request', function(req, res) {
     connections--;
     res.writeHead(200);
     res.end('done\n');
-    if (connections == 0) {
+    if (connections === 0) {
       server.close();
     }
   });

--- a/test/pummel/test-net-connect-econnrefused.js
+++ b/test/pummel/test-net-connect-econnrefused.js
@@ -19,7 +19,7 @@ function pummel() {
     net.createConnection(common.PORT).on('error', function(err) {
       assert.equal(err.code, 'ECONNREFUSED');
       if (--pending > 0) return;
-      if (rounds == ROUNDS) return check();
+      if (rounds === ROUNDS) return check();
       rounds++;
       pummel();
     });

--- a/test/pummel/test-net-connect-memleak.js
+++ b/test/pummel/test-net-connect-memleak.js
@@ -16,7 +16,7 @@ var before = 0;
   before = process.memoryUsage().rss;
 
   net.createConnection(common.PORT, '127.0.0.1', function() {
-    assert(junk.length != 0);  // keep reference alive
+    assert(junk.length !== 0);  // keep reference alive
     setTimeout(done, 10);
     gc();
   });

--- a/test/pummel/test-net-many-clients.js
+++ b/test/pummel/test-net-many-clients.js
@@ -72,7 +72,7 @@ server.listen(common.PORT, function() {
   var finished_clients = 0;
   for (var i = 0; i < concurrency; i++) {
     runClient(function() {
-      if (++finished_clients == concurrency) server.close();
+      if (++finished_clients === concurrency) server.close();
     });
   }
 });

--- a/test/pummel/test-net-timeout.js
+++ b/test/pummel/test-net-timeout.js
@@ -52,7 +52,7 @@ echo_server.listen(common.PORT, function() {
         client.write('hello\r\n');
       }, 500);
 
-      if (exchanges == 5) {
+      if (exchanges === 5) {
         console.log('wait for timeout - should come in ' + timeout + ' ms');
         starttime = new Date();
         console.dir(starttime);

--- a/test/pummel/test-net-timeout2.js
+++ b/test/pummel/test-net-timeout2.js
@@ -21,7 +21,7 @@ var server = net.createServer(function(socket) {
   var interval = setInterval(function() {
     counter++;
 
-    if (counter == seconds) {
+    if (counter === seconds) {
       clearInterval(interval);
       server.close();
       socket.destroy();

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -41,7 +41,7 @@ setInterval(function() {
   assert.equal(true, t - WINDOW < diff && diff < t + WINDOW);
 
   assert.equal(true, interval_count <= 3);
-  if (interval_count == 3)
+  if (interval_count === 3)
     clearInterval(this);
 }, 1000);
 
@@ -56,7 +56,7 @@ setInterval(function(param) {
   ++interval_count2;
   assert.equal('test param', param);
 
-  if (interval_count2 == 3)
+  if (interval_count2 === 3)
     clearInterval(this);
 }, 1000, 'test param');
 
@@ -73,7 +73,7 @@ setInterval(function(param1, param2) {
   assert.equal('param1', param1);
   assert.equal('param2', param2);
 
-  if (interval_count3 == 3)
+  if (interval_count3 === 3)
     clearInterval(this);
 }, 1000, 'param1', 'param2');
 

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -25,7 +25,7 @@ tls.createServer({
 
   var options = { rejectUnauthorized: false };
   tls.connect(common.PORT, '127.0.0.1', options, function() {
-    assert(junk.length != 0);  // keep reference alive
+    assert(junk.length !== 0);  // keep reference alive
     setTimeout(done, 10);
     gc();
   });

--- a/test/pummel/test-watch-file.js
+++ b/test/pummel/test-watch-file.js
@@ -14,7 +14,7 @@ function watchFile() {
   fs.watchFile(f, function(curr, prev) {
     console.log(f + ' change');
     changes++;
-    assert.ok(curr.mtime != prev.mtime);
+    assert.ok(curr.mtime !== prev.mtime);
     fs.unwatchFile(f);
     watchFile();
     fs.unwatchFile(f);

--- a/test/sequential/test-regress-GH-877.js
+++ b/test/sequential/test-regress-GH-877.js
@@ -25,7 +25,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
     };
 
     var req = http.get(options, function(res) {
-      if (++responses == N) {
+      if (++responses === N) {
         server.close();
       }
       res.resume();
@@ -47,6 +47,6 @@ server.listen(common.PORT, '127.0.0.1', function() {
 });
 
 process.on('exit', function() {
-  assert.ok(responses == N);
+  assert.ok(responses === N);
   assert.ok(maxQueued <= 10);
 });

--- a/test/sequential/test-tcp-wrap-listen.js
+++ b/test/sequential/test-tcp-wrap-listen.js
@@ -22,7 +22,7 @@ server.onconnection = function(err, client) {
   console.log('got connection');
 
   function maybeCloseClient() {
-    if (client.pendingWrites.length == 0 && client.gotEOF) {
+    if (client.pendingWrites.length === 0 && client.gotEOF) {
       console.log('close client');
       client.close();
     }


### PR DESCRIPTION
Enable linter to check for type safe comparison checks
See http://eslint.org/docs/rules/eqeqeq

I think it would be good to enable the type safe check for null checks too but I thought that might be controversial.

Right now a couple spots use `+var != var` and I kept them in place while disabling the linter in those cases.