### PR TITLE
repl: handle quotes within regexp literal in multiline mode

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -84,6 +84,7 @@ class LineParser {
     this._literal = null;
     this.shouldFail = false;
     this.blockComment = false;
+    this.regExpLiteral = false;
   }
 
   parseLine(line) {
@@ -99,6 +100,11 @@ class LineParser {
       }
 
       if (!this._literal) {
+        if (this.regExpLiteral && current === '/') {
+          this.regExpLiteral = false;
+          previous = null;
+          continue;
+        }
         if (previous === '*' && current === '/') {
           if (this.blockComment) {
             this.blockComment = false;
@@ -115,13 +121,17 @@ class LineParser {
           break;
         }
 
-        if (previous === '/' && current === '*') {
-          this.blockComment = true;
+        if (previous === '/') {
+          if (current === '*') {
+            this.blockComment = true;
+          } else {
+            this.regExpLiteral = true;
+          }
           previous = null;
         }
       }
 
-      if (this.blockComment) continue;
+      if (this.blockComment || this.regExpLiteral) continue;
 
       if (current === this._literal) {
         this._literal = null;

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -287,6 +287,19 @@ function error_test() {
     // access to internal modules without the --expose_internals flag.
     { client: client_unix, send: 'require("internal/repl")',
       expect: /^Error: Cannot find module 'internal\/repl'/ },
+    // REPL should handle quotes within regexp literal in multiline mode
+    { client: client_unix, send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
+      expect: prompt_multiline + prompt_multiline +
+            'undefined\n' + prompt_unix },
+    { client: client_unix, send: "function x(s) {\nreturn s.replace(/\'/,'');\n}",
+      expect: prompt_multiline + prompt_multiline +
+            'undefined\n' + prompt_unix },
+    { client: client_unix, send: 'function x(s) {\nreturn s.replace(/"/,"");\n}',
+      expect: prompt_multiline + prompt_multiline +
+            'undefined\n' + prompt_unix },
+    { client: client_unix, send: 'function x(s) {\nreturn s.replace(/.*/,"");\n}',
+      expect: prompt_multiline + prompt_multiline +
+            'undefined\n' + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
Fix for #5113 