### PR TITLE
doc: fix dgram doc indentation

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -373,6 +373,7 @@ s.bind(1234, () => {
 ## `dgram` module functions
 
 ### dgram.createSocket(options[, callback])
+
 * `options` Object
 * `callback` Function. Attached as a listener to `'message'` events.
 * Returns: Socket object
@@ -393,7 +394,7 @@ interfaces" address on a random port (it does the right thing for both `udp4`
 and `udp6` sockets). The bound address and port can be retrieved using
 [`socket.address().address`][] and [`socket.address().port`][].
 
-## dgram.createSocket(type[, callback])
+### dgram.createSocket(type[, callback])
 
 * `type` String. Either 'udp4' or 'udp6'
 * `callback` Function. Attached as a listener to `'message'` events.


### PR DESCRIPTION
One function is at incorrect heading/indentation. This fixes it.