### PR TITLE
zlib: support concatenated archives

### DIFF
--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -1,0 +1,18 @@
+'use strict';
+// Test unzipping a gzip file that contains multiple concatenated "members"
+
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+const data = Buffer.concat([
+  zlib.gzipSync('abc'),
+  zlib.gzipSync('def')
+]);
+
+assert.equal(zlib.gunzipSync(data).toString(), 'abcdef');
+
+zlib.gunzip(data, common.mustCall((err, result) => {
+  assert.ifError(err);
+  assert.equal(result, 'abcdef', 'result should match original string');
+}));

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -1,0 +1,50 @@
+'use strict';
+// test unzipping a gzip file that has trailing garbage
+
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+// should ignore trailing null-bytes
+let data = Buffer.concat([
+  zlib.gzipSync('abc'),
+  zlib.gzipSync('def'),
+  Buffer(10).fill(0)
+]);
+
+assert.equal(zlib.gunzipSync(data).toString(), 'abcdef');
+
+zlib.gunzip(data, common.mustCall((err, result) => {
+  assert.ifError(err);
+  assert.equal(result, 'abcdef', 'result should match original string');
+}));
+
+// if the trailing garbage happens to look like a gzip header, it should
+// throw an error.
+data = Buffer.concat([
+  zlib.gzipSync('abc'),
+  zlib.gzipSync('def'),
+  Buffer([0x1f, 0x8b, 0xff, 0xff]),
+  Buffer(10).fill(0)
+]);
+
+assert.throws(() => zlib.gunzipSync(data));
+
+zlib.gunzip(data, common.mustCall((err, result) => {
+  assert(err);
+}));
+
+// In this case the trailing junk is too short to be a gzip segment
+// So we ignore it and decompression succeeds.
+data = Buffer.concat([
+  zlib.gzipSync('abc'),
+  zlib.gzipSync('def'),
+  Buffer([0x1f, 0x8b, 0xff, 0xff])
+]);
+
+assert.equal(zlib.gunzipSync(data).toString(), 'abcdef');
+
+zlib.gunzip(data, common.mustCall((err, result) => {
+  assert.ifError(err);
+  assert.equal(result, 'abcdef', 'result should match original string');
+}));


### PR DESCRIPTION
This PR adds support for gunzipping archives that consists of multiple concatenated members.
This has not been supported by node's implementation so far but is a part of the spec [rfc1952](http://tools.ietf.org/html/rfc1952#page-5).

The problem was raised in #4306, and there is more detailed discussion on this feature in the issue.

I also refactored some of `lib/zlib.js` but I will submit that in a separate PR later.