### PR TITLE
test: fix child-process-fork-regr-gh-2847

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -13,7 +13,6 @@ test-tick-processor                  : PASS,FLAKY
 
 [$system==linux]
 test-tick-processor                  : PASS,FLAKY
-test-child-process-fork-regr-gh-2847 : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
The test would sometimes time out on some platforms. Take the initial
version of the test and instead of sending 100 handles, just send 2.
It still fails when run with the code before the change was introduced
and passes afterwards.