### PR TITLE
test: fix flaky test-dgram-pingpong

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -10,7 +10,6 @@ prefix sequential
 
 [$system==linux]
 test-vm-syntax-error-stderr : PASS,FLAKY
-test-dgram-pingpong         : PASS,FLAKY
 test-http-regr-gh-2928      : PASS,FLAKY
 
 [$system==macos]


### PR DESCRIPTION
There is no guarantee UDP messages will be received. Accommodate the
occasional dropped message.

This is a functionality test, not a performance benchmark. Speed up the
test by sending 5 messages per server rather than 500.

Fixes: https://github.com/nodejs/node/issues/4526