### PR TITLE
test: remove timer from test-http-1.0

### DIFF
--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -15,13 +15,6 @@ function test(handler, request_generator, response_validator) {
   var client_got_eof = false;
   var server_response = '';
 
-  function cleanup() {
-    server.close();
-    response_validator(server_response, client_got_eof, true);
-  }
-  var timer = setTimeout(cleanup, common.platformTimeout(1000));
-  process.on('exit', cleanup);
-
   server.listen(port);
   server.on('listening', function() {
     var c = net.createConnection(port);
@@ -36,14 +29,12 @@ function test(handler, request_generator, response_validator) {
       server_response += chunk;
     });
 
-    c.on('end', function() {
+    c.on('end', common.mustCall(function() {
       client_got_eof = true;
       c.end();
       server.close();
-      clearTimeout(timer);
-      process.removeListener('exit', cleanup);
       response_validator(server_response, client_got_eof, false);
-    });
+    }));
   });
 }
 


### PR DESCRIPTION
It's possible that the `end` event is emitted after the timeout fires
causing the test to fail. Just remove the timer. If for some reason the
`end` would never fire, the test will fail with a timeout.

It tries to fix the issue described here: https://github.com/nodejs/node/pull/4600#issuecomment-180388736, that I also have rarely experienced on `Debian Jessie 64`.