### PR TITLE
string_decoder: fix performance regression

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -69,6 +69,7 @@ StringDecoder.prototype.write = function(buffer) {
   var charReceived = this.charReceived;
   var surrogateSize = this.surrogateSize;
   var encoding = this.encoding;
+  var charCode;
   // if our last write ended with an incomplete multibyte character
   while (charLength) {
     // determine how many remaining bytes this buffer has to offer for this char
@@ -96,7 +97,7 @@ StringDecoder.prototype.write = function(buffer) {
     charStr = charBuffer.toString(encoding, 0, charLength);
 
     // CESU-8: lead surrogate (D800-DBFF) is also the incomplete character
-    const charCode = charStr.charCodeAt(charStr.length - 1);
+    charCode = charStr.charCodeAt(charStr.length - 1);
     if (charCode >= 0xD800 && charCode <= 0xDBFF) {
       charLength += surrogateSize;
       charStr = '';
@@ -129,7 +130,7 @@ StringDecoder.prototype.write = function(buffer) {
   charStr += buffer.toString(encoding, 0, end);
 
   end = charStr.length - 1;
-  const charCode = charStr.charCodeAt(end);
+  charCode = charStr.charCodeAt(end);
   // CESU-8: lead surrogate (D800-DBFF) is also the incomplete character
   if (charCode >= 0xD800 && charCode <= 0xDBFF) {
     charLength += surrogateSize;


### PR DESCRIPTION
This commit reverts the `const` usage introduced by 68a6abc806 because v8 currently cannot optimize functions that contain these uses of const (unsupported phi use of const variable). The performance difference in this case can be up to ~130% for non-ascii/binary string encodings.