### PR TITLE
tools: disallow mixed spaces and tabs for indents

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,6 +65,8 @@ rules:
   max-len: [2, 80, 2]
   ## require parens for Constructor
   new-parens: 2
+  ## disallow mixed spaces and tabs for indentation
+  no-mixed-spaces-and-tabs: 2
   ## max 2 consecutive empty lines
   no-multiple-empty-lines: [2, {max: 2}]
   ## no trailing spaces

--- a/.eslintrc
+++ b/.eslintrc
@@ -55,36 +55,36 @@ rules:
 
   # Stylistic Issues
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
-  ## use single quote, we can use double quote when escape chars
-  quotes: [2, "single", "avoid-escape"]
-  ## 2 space indentation
-  indent: [2, 2, {SwitchCase: 1}]
   ## add space after comma
   comma-spacing: 2
+  ## require newline at end of files
+  eol-last: 2
+  ## 2 space indentation
+  indent: [2, 2, {SwitchCase: 1}]
+  ## max 80 length
+  max-len: [2, 80, 2]
+  ## require parens for Constructor
+  new-parens: 2
+  ## max 2 consecutive empty lines
+  no-multiple-empty-lines: [2, {max: 2}]
+  ## no trailing spaces
+  no-trailing-spaces: 2
+  ## use single quote, we can use double quote when escape chars
+  quotes: [2, "single", "avoid-escape"]
   ## put semi-colon
   semi: 2
+  ## require space after keywords, eg 'for (..)'
+  space-after-keywords: 2
+  ## require space before blocks, eg 'function() {'
+  space-before-blocks: [2, "always"]
+  ## no space before function, eg. 'function()'
+  space-before-function-paren: [2, "never"]
+  ## no leading/trailing spaces in parens
+  space-in-parens: [2, "never"]
   ## require spaces operator like var sum = 1 + 1;
   space-infix-ops: 2
   ## require spaces return, throw, case
   space-return-throw-case: 2
-  ## no space before function, eg. 'function()'
-  space-before-function-paren: [2, "never"]
-  ## require space before blocks, eg 'function() {'
-  space-before-blocks: [2, "always"]
-  ## require parens for Constructor
-  new-parens: 2
-  ## max 80 length
-  max-len: [2, 80, 2]
-  ## max 2 consecutive empty lines
-  no-multiple-empty-lines: [2, {max: 2}]
-  ## require newline at end of files
-  eol-last: 2
-  ## no trailing spaces
-  no-trailing-spaces: 2
-  ## require space after keywords, eg 'for (..)'
-  space-after-keywords: 2
-  ## no leading/trailing spaces in parens
-  space-in-parens: [2, "never"]
   ## no spaces with non-word unary operators, require for word unary operators
   space-unary-ops: 2
 

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -22,14 +22,16 @@ var certificate = new crypto.Certificate();
 assert.equal(certificate.verifySpkac(spkacValid), true);
 assert.equal(certificate.verifySpkac(spkacFail), false);
 
-assert.equal(stripLineEndings(certificate.exportPublicKey(spkacValid)
-							  .toString('utf8')),
-			 stripLineEndings(spkacPem.toString('utf8')));
+assert.equal(
+  stripLineEndings(certificate.exportPublicKey(spkacValid).toString('utf8')),
+  stripLineEndings(spkacPem.toString('utf8'))
+);
 assert.equal(certificate.exportPublicKey(spkacFail), '');
 
-assert.equal(certificate.exportChallenge(spkacValid)
-			 .toString('utf8'),
-			 'fb9ab814-6677-42a4-a60c-f905d1a6924d');
+assert.equal(
+  certificate.exportChallenge(spkacValid).toString('utf8'),
+  'fb9ab814-6677-42a4-a60c-f905d1a6924d'
+);
 assert.equal(certificate.exportChallenge(spkacFail), '');
 
 function stripLineEndings(obj) {


### PR DESCRIPTION
Enable ESLlint rule disallowing mixing tabs and spaces for indentation.
Modify the one file that had been mixing tabs and spaces.

While at it, I rearranged the style rules in .eslintrc to be in
alphabetical order. This has two benefits: It means the rules appear
in the same order as they do in the ESLint documentation, easing
cross-referencing. It also means that it is much easier to determine
with visual inspection if a rule is set or not.