### PR TITLE
crypto: add secure key comparsion function

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -1273,6 +1273,13 @@ is a bit field taking one of or a mix of the following flags (defined in the
 * `ENGINE_METHOD_ALL`
 * `ENGINE_METHOD_NONE`
 
+### crypto.areKeysEqual(userKey, originalKey)
+
+Securely compares two cryptographic keys. Using this function to compare keys
+prevents timing attacks. Usually slower than plain comparsion.
+
+Both `userKey` and `originalKey` should be a string or a [`Buffer`][].
+
 ## Notes
 
 ### Legacy Streams API (pre Node.js v0.10)

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -662,6 +662,29 @@ function filterDuplicates(names) {
   }).sort();
 }
 
+
+exports.areKeysEqual = function(userKey, originalKey) {
+  return securelyCompareKeys(userKey, originalKey);
+};
+
+
+function securelyCompareKeys(userKey, originalKey) {
+  // Excludes timing attacks
+  var n1 = userKey.length;
+  var n2 = originalKey.length;
+  var fail = false;
+
+  if (n1 !== n2)
+    fail = true;
+
+  for (var i = 0; i < Math.min(n1, n2); i++)
+    if (userKey[i] !== originalKey[i])
+      fail = true;
+
+  return !fail;
+}
+
+
 // Legacy API
 exports.__defineGetter__('createCredentials',
   internalUtil.deprecate(function() {


### PR DESCRIPTION
This commit adds function to compare cryptographic keys (as strings or buffers) without risk of timing attacks. Default comparators return result right after first symbol mismatch which can be measured and used to determine what symbol is wrong. The difference is about 5-6 times if we compare string keys of usually used lengths (2048 bits) and even higher on longer keys.
