### PR TITLE
tools: enable no-proto rule for linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,8 @@ ecmaFeatures:
 rules:
   # Possible Errors
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#possible-errors
+  ## Disallow Use of __proto__
+  no-proto: 2
   ## disallow control characters in regular expressions
   no-control-regex: 2
   ## check debugger sentence

--- a/test/common.js
+++ b/test/common.js
@@ -190,7 +190,7 @@ exports.hasIPv6 = Object.keys(ifaces).some(function(name) {
 
 function protoCtrChain(o) {
   var result = [];
-  for (; o; o = o.__proto__) { result.push(o.constructor); }
+  for (; o; o = Object.getPrototypeOf(o)) { result.push(o.constructor); }
   return result.join();
 }
 

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -40,8 +40,8 @@ assert.equal(dv.getFloat64(8, true), 3.1415);
 
 assert.throws(function() {
   function AB() { }
-  AB.__proto__ = ArrayBuffer;
-  AB.prototype.__proto__ = ArrayBuffer.prototype;
+  Object.setPrototypeOf(AB, ArrayBuffer);
+  Object.setPrototypeOf(AB.prototype, ArrayBuffer.prototype);
   new Buffer(new AB());
 }, TypeError);
 

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -5,8 +5,8 @@ const assert = require('assert');
 const Buffer = require('buffer').Buffer;
 
 function FakeBuffer() { }
-FakeBuffer.__proto__ = Buffer;
-FakeBuffer.prototype.__proto__ = Buffer.prototype;
+Object.setPrototypeOf(FakeBuffer, Buffer);
+Object.setPrototypeOf(FakeBuffer.prototype, Buffer.prototype);
 
 const fb = new FakeBuffer();
 

--- a/test/parallel/test-buffer-inheritance.js
+++ b/test/parallel/test-buffer-inheritance.js
@@ -24,8 +24,9 @@ const vals = [new T(4), T(4)];
 
 vals.forEach(function(t) {
   assert.equal(t.constructor, T);
-  assert.equal(t.__proto__, T.prototype);
-  assert.equal(t.__proto__.__proto__, Buffer.prototype);
+  assert.equal(Object.getPrototypeOf(t), T.prototype);
+  assert.equal(Object.getPrototypeOf(Object.getPrototypeOf(t)),
+    Buffer.prototype);
 
   t.fill(5);
   let cntr = 0;

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -7,9 +7,9 @@ var spawn = require('child_process').spawn;
 var env = {
   'HELLO': 'WORLD'
 };
-env.__proto__ = {
+Object.setPrototypeOf(env, {
   'FOO': 'BAR'
-};
+});
 
 var child;
 if (common.isWindows) {


### PR DESCRIPTION
Enable `no-proto` in `.eslintrc`.

Use `Object.setPrototypeOf()` and `Object.getPrototypeOf()`
instead of.