### PR TITLE
debugger: limit size of mirrored buffer

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -493,6 +493,7 @@ Client.prototype.step = function(action, count, cb) {
   this.req(req, cb);
 };
 
+var BUFFER_INSPECT_MAX_BYTES = require('buffer').INSPECT_MAX_BYTES;
 
 Client.prototype.mirrorObject = function(handle, depth, cb) {
   var self = this;
@@ -514,9 +515,17 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
     // TJ's method of object inspection would probably be good for this:
     // https://groups.google.com/forum/?pli=1#!topic/nodejs-dev/4gkWBOimiOg
 
-    var propertyRefs = handle.properties.map(function(p) {
-      return p.ref;
-    });
+    var isBuffer = handle.text === '#<Buffer>' &&
+      handle.className === 'Uint8Array';
+
+    var propertyRefs = handle.properties.map((p) => p.ref);
+    if (isBuffer) {
+      // this is Node Buffer, no need to retrieve all values,
+      // Buffer.inspect prints only INSPECT_MAX_BYTES of them
+      // we'll leave INSPECT_MAX_BYTES + 1 so if actual size is
+      // bigger it's displayed with ... ellipses
+      propertyRefs = propertyRefs.slice(0, BUFFER_INSPECT_MAX_BYTES + 1);
+    }
 
     cb = cb || function() {};
     this.reqLookup(propertyRefs, function(err, res) {
@@ -533,6 +542,16 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
         mirror = [];
       } else if (handle.className == 'Date') {
         mirror = new Date(handle.value);
+      } else if (isBuffer) {
+        mirror = new Buffer(propertyRefs.length);
+        handle.properties.forEach((prop) => {
+          var value = res[prop.ref];
+          if (value)
+            mirror[prop.name] = value.value;
+        });
+        if (cb)
+          cb(null, mirror);
+        return;
       } else {
         mirror = {};
       }

--- a/test/debugger/test-debugger-repl.js
+++ b/test/debugger/test-debugger-repl.js
@@ -75,3 +75,14 @@ addTest('for (var i in process.env) delete process.env[i]', []);
 addTest('process.env', [
   /\{\}/
 ]);
+
+addTest('new Buffer([1, 10, 20])', [
+  '<Buffer 01 0a 14>'
+]);
+
+addTest('var bigBuf = Buffer(200); for (var i=0; i < bb.length; ++i) bb[i] = i',
+  []
+);
+addTest('bigBuf', [
+  /28 29 2a 2b 2c 2d 2e 2f 30 31 \.\.\. >$/
+]);


### PR DESCRIPTION
this commit makes output of debugger repl for buffer values similar to
one from `util.inspect()`. Mirrored object is now returned as Buffer if
handle points to Buffer in debuggee. Also number of mirrored properties is
limited to INSPECT_MAX_BYTES. This will help significantly improve
speed of inspecting objects in debugger when one of the properties in
the tree is buffer. Most common case - inspecting http response object.
