### PR TITLE
test: disable gh-5100 test when in FIPS mode

### DIFF
--- a/test/parallel/test-tls-pfx-gh-5100-regr.js
+++ b/test/parallel/test-tls-pfx-gh-5100-regr.js
@@ -7,6 +7,11 @@ if (!common.hasCrypto) {
   return;
 }
 
+if (common.hasFipsCrypto) {
+  console.log('1..0 # Skipped: PFX does not work in FIPS mode');
+  return;
+}
+
 const assert = require('assert');
 const tls = require('tls');
 const fs = require('fs');


### PR DESCRIPTION
This is a follow-up fix for half-broken test in 23196fe, and an attempt
to recover some dignity after breaking CI.

cc @Trott 