### PR TITLE
Ensure there's a channel before trying to send on it

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -482,7 +482,8 @@ function setupChannel(target, channel) {
     // the other side has disconnected) because this call to send() is not
     // initiated by the user and it shouldn't be fatal to be unable to ACK
     // a message.
-    target._send({ cmd: 'NODE_HANDLE_ACK' }, null, true);
+    if (this._channel)
+      target._send({ cmd: 'NODE_HANDLE_ACK' }, null, true);
 
     var obj = handleConversion[message.type];
 


### PR DESCRIPTION
Here's a trace on `v0.12.9`,

```
AssertionError: null == true
    at process.target._send (child_process.js:420:5)
    at process.<anonymous> (child_process.js:396:12)
    at process.emit (events.js:129:20)
    at handleMessage (child_process.js:324:10)
    at Pipe.channel.onread (child_process.js:350:11)
```

`_disconnect` nulls out the channel, but admits there may still be some buffering. If that's a `NODE_HANDLE` message, it'll attempt this ack. `handleMessage` has a similar check.

cc/ @inez 

