### PR TITLE
tools: remove excessive comments from .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,102 +17,61 @@ ecmaFeatures:
 rules:
   # Possible Errors
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#possible-errors
-  ## Disallow Use of __proto__
-  no-proto: 2
-  ## disallow control characters in regular expressions
   no-control-regex: 2
-  ## check debugger sentence
   no-debugger: 2
-  ## check duplicate arguments
   no-dupe-args: 2
-  ## check duplicate object keys
   no-dupe-keys: 2
-  ## check duplicate switch-case
   no-duplicate-case: 2
-  ## disallow the use of empty character classes in regular expressions
   no-empty-character-class: 2
-  ## disallow assignment of exceptional params
   no-ex-assign: 2
-  ## disallow extra boolean casts
   no-extra-boolean-cast : 2
-  ## disallow superfluous semicolons
   no-extra-semi: 2
-  ## validate regular expressions
   no-invalid-regexp: 2
-  ## forbid weird whitespace characters
   no-irregular-whitespace: 2
-  ## avoid unexpected multiline expressions
+  no-proto: 2
   no-unexpected-multiline: 2
-  ## disallow unreachable code
   no-unreachable: 2
-  ## require valid typeof compared string like typeof foo === 'strnig'
   valid-typeof: 2
 
   # Best Practices
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#best-practices
-  ## require falls through comment on switch-case
   no-fallthrough: 2
-  ## disallow declaring the same variable more than once
   no-redeclare: 2
 
   # Stylistic Issues
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
-  ## add space after comma
   comma-spacing: 2
-  ## require newline at end of files
   eol-last: 2
-  ## 2 space indentation
   indent: [2, 2, {SwitchCase: 1}]
-  ## max 80 length
   max-len: [2, 80, 2]
-  ## require parens for Constructor
   new-parens: 2
-  ## disallow mixed spaces and tabs for indentation
   no-mixed-spaces-and-tabs: 2
-  ## max 2 consecutive empty lines
   no-multiple-empty-lines: [2, {max: 2}]
-  ## no trailing spaces
   no-trailing-spaces: 2
-  ## use single quote, we can use double quote when escape chars
   quotes: [2, "single", "avoid-escape"]
-  ## put semi-colon
   semi: 2
-  ## require space after keywords, eg 'for (..)'
   space-after-keywords: 2
-  ## require space before blocks, eg 'function() {'
   space-before-blocks: [2, "always"]
-  ## no space before function, eg. 'function()'
   space-before-function-paren: [2, "never"]
-  ## no leading/trailing spaces in parens
   space-in-parens: [2, "never"]
-  ## require spaces operator like var sum = 1 + 1;
   space-infix-ops: 2
-  ## require spaces return, throw, case
   space-return-throw-case: 2
-  ## no spaces with non-word unary operators, require for word unary operators
   space-unary-ops: 2
 
   # ECMAScript 6
   # list: http://eslint.org/docs/rules/#ecmascript-6
-  ## Suggest using 'const' wherever possible
-  prefer-const: 2
-  ## Enforce parens around arrow function arguments
   arrow-parens: [2, "always"]
-  ## Require a space on each side of arrow operator
   arrow-spacing: [2, {"before": true, "after": true}]
-  ## Prevent using => in a condition where <= is intended
   no-arrow-condition: 2
+  prefer-const: 2
 
   # Strict Mode
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
-  ## 'use strict' on top
   strict: [2, "global"]
 
   # Variables
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#variables
-  ## disallow use of undefined variables (globals)
   no-undef: 2
-  ## disallow declaration of variables that are not used in the code
   no-unused-vars: [2, {"args": "none"}]
 
   # Custom rules in tools/eslint-rules

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@ ecmaFeatures:
 
 rules:
   # Possible Errors
-  # list: https://github.com/eslint/eslint/tree/master/docs/rules#possible-errors
+  # https://github.com/eslint/eslint/tree/master/docs/rules#possible-errors
   no-control-regex: 2
   no-debugger: 2
   no-dupe-args: 2
@@ -34,12 +34,12 @@ rules:
   valid-typeof: 2
 
   # Best Practices
-  # list: https://github.com/eslint/eslint/tree/master/docs/rules#best-practices
+  # https://github.com/eslint/eslint/tree/master/docs/rules#best-practices
   no-fallthrough: 2
   no-redeclare: 2
 
   # Stylistic Issues
-  # list: https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
+  # https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
   comma-spacing: 2
   eol-last: 2
   indent: [2, 2, {SwitchCase: 1}]
@@ -59,18 +59,18 @@ rules:
   space-unary-ops: 2
 
   # ECMAScript 6
-  # list: http://eslint.org/docs/rules/#ecmascript-6
+  # http://eslint.org/docs/rules/#ecmascript-6
   arrow-parens: [2, "always"]
   arrow-spacing: [2, {"before": true, "after": true}]
   no-arrow-condition: 2
   prefer-const: 2
 
   # Strict Mode
-  # list: https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
+  # https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
   strict: [2, "global"]
 
   # Variables
-  # list: https://github.com/eslint/eslint/tree/master/docs/rules#variables
+  # https://github.com/eslint/eslint/tree/master/docs/rules#variables
   no-undef: 2
   no-unused-vars: [2, {"args": "none"}]
 


### PR DESCRIPTION
This PR is on top of #5135 and should not be landed until that PR lands.

The comments make the config hard to scan. They do not provide any
information that isn't in the documentation links referred to in
comments (that are not being removed here).

Additionally, all rule config sections are alphabetically ordered for
easier scanning etc.

/cc @silverwind 