### PR TITLE
child_process: guard against race condition

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -313,6 +313,9 @@ function getSocketList(type, slave, key) {
 
 var INTERNAL_PREFIX = 'NODE_';
 function handleMessage(target, message, handle) {
+  if (!target._channel)
+    return;
+
   var eventName = 'message';
   if (!util.isNull(message) &&
       util.isObject(message) &&

--- a/test/simple/test-cluster-disconnect-race.js
+++ b/test/simple/test-cluster-disconnect-race.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// This code triggers an AssertionError on Linux in Node.js 5.3.0 and earlier.
+// Ref: https://github.com/nodejs/node/issues/4205
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var cluster = require('cluster');
+cluster.schedulingPolicy = cluster.SCHED_NONE;
+
+if (cluster.isMaster) {
+  var worker1, worker2;
+
+  worker1 = cluster.fork();
+  worker1.on('message', common.mustCall(function() {
+    worker2 = cluster.fork();
+    worker1.disconnect();
+    worker2.on('online', common.mustCall(worker2.disconnect));
+  }, 2));
+
+  cluster.on('exit', function(worker, code) {
+    assert.strictEqual(code, 0, 'worker exited with error');
+  });
+
+  return;
+}
+
+var server = net.createServer();
+
+server.listen(common.PORT, function retry() {
+  process.send('listening');
+  process.send('listening');
+});


### PR DESCRIPTION
It is possible that the internal hnadleMessage() might try to send to a channel that has been closed. The result can be an AssertionError. Guard against this.

This is a backport of 57a51a00e84 to v0.12 with a tweaked version of the test in order to trigger the same assertion on v0.12.