### PR TITLE
test: fix flaky test-http-regr-gh-2928

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -10,7 +10,6 @@ prefix sequential
 
 [$system==linux]
 test-vm-syntax-error-stderr : PASS,FLAKY
-test-http-regr-gh-2928      : PASS,FLAKY
 
 [$system==macos]
 

--- a/test/sequential/test-http-regr-gh-2928.js
+++ b/test/sequential/test-http-regr-gh-2928.js
@@ -1,3 +1,6 @@
+// This test is designed to fail with a segmentation fault in Node.js 4.1.0 and
+// execute without issues in Node.js 4.1.1 and up.
+
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -5,8 +8,7 @@ const httpCommon = require('_http_common');
 const HTTPParser = process.binding('http_parser').HTTPParser;
 const net = require('net');
 
-const PARALLEL = 30;
-const COUNT = httpCommon.parsers.max + 100;
+const COUNT = httpCommon.parsers.max + 1;
 
 const parsers = new Array(COUNT);
 for (var i = 0; i < parsers.length; i++)
@@ -41,10 +43,7 @@ var server = net.createServer(function(c) {
   c.end('HTTP/1.1 200 OK\r\n\r\n', function() {
     c.destroySoon();
   });
-}).listen(common.PORT, function() {
-  for (var i = 0; i < PARALLEL; i++)
-    execAndClose();
-});
+}).listen(common.PORT, execAndClose);
 
 process.on('exit', function() {
   assert.equal(gotResponses, COUNT);


### PR DESCRIPTION
Fix flaky test-http-regr-gh-2928 that has been failing on Raspberry Pi
devices in CI.

Fixes: https://github.com/nodejs/node/issues/4830

/cc @indutny 

Confirmed (on OS X, anyway) that the test still segmentation faults (as expected/designed) when run with Node 4.1.0 but succeeds with Node 4.1.1.