### PR TITLE
readable: Update docs for a case with a binary safe string reading

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -416,6 +416,10 @@ potentially mangled if you simply pulled the Buffers directly and
 called [`buf.toString(encoding)`][] on them. If you want to read the data
 as strings, always use this method.
 
+Also you can disable any encoding at all with `readable.setEncoding(null)`.
+This approach is very useful if you deal with binary data or with large
+multi-byte strings spread out over multiple chunks.
+
 ```js
 var readable = getReadableStreamSomehow();
 readable.setEncoding('utf8');


### PR DESCRIPTION
`readable.setEncoding(null)` - may be the most preferable way to proxy a binary data without any encoding/decoding overhead

See nodejs/readable-stream#180 for details