### PR TITLE
Revert "test: try other ipv6 localhost alternatives"

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -80,19 +80,6 @@ var opensslCli = null;
 var inFreeBSDJail = null;
 var localhostIPv4 = null;
 
-exports.localIPv6Hosts = [
-  // Debian/Ubuntu
-  'ip6-localhost',
-  'ip6-loopback',
-
-  // SUSE
-  'ipv6-localhost',
-  'ipv6-loopback',
-
-  // Typically universal
-  'localhost',
-];
-
 Object.defineProperty(exports, 'inFreeBSDJail', {
   get: function() {
     if (inFreeBSDJail !== null) return inFreeBSDJail;

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -1,56 +1,58 @@
 'use strict';
-const common = require('../common');
-const assert = require('assert');
-const net = require('net');
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var dns = require('dns');
 
 if (!common.hasIPv6) {
   console.log('1..0 # Skipped: no IPv6 support');
   return;
 }
 
-const hosts = common.localIPv6Hosts;
-var hostIdx = 0;
-var host = hosts[hostIdx];
-var localhostTries = 10;
+var serverGotEnd = false;
+var clientGotEnd = false;
 
-const server = net.createServer({allowHalfOpen: true}, function(socket) {
-  socket.resume();
-  socket.on('end', common.mustCall(function() {}));
-  socket.end();
-});
+dns.lookup('localhost', 6, function(err) {
+  if (err) {
+    console.error('Looks like IPv6 is not really supported');
+    console.error(err);
+    return;
+  }
 
-server.listen(common.PORT, '::1', tryConnect);
-
-function tryConnect() {
-  const client = net.connect({
-    host: host,
-    port: common.PORT,
-    family: 6,
-    allowHalfOpen: true
-  }, function() {
-    console.error('client connect cb');
-    client.resume();
-    client.on('end', common.mustCall(function() {
-      setTimeout(function() {
-        assert(client.writable);
-        client.end();
-      }, 10);
-    }));
-    client.on('close', function() {
-      server.close();
+  var server = net.createServer({allowHalfOpen: true}, function(socket) {
+    socket.resume();
+    socket.on('end', function() {
+      serverGotEnd = true;
     });
-  }).on('error', function(err) {
-    if (err.syscall === 'getaddrinfo' && err.code === 'ENOTFOUND') {
-      if (host !== 'localhost' || --localhostTries === 0)
-        host = hosts[++hostIdx];
-      if (host)
-        tryConnect();
-      else {
-        console.log('1..0 # Skipped: no IPv6 localhost support');
-        server.close();
-      }
-      return;
-    }
-    throw err;
+    socket.end();
   });
-}
+
+  server.listen(common.PORT, '::1', function() {
+    var client = net.connect({
+      host: 'localhost',
+      port: common.PORT,
+      family: 6,
+      allowHalfOpen: true
+    }, function() {
+      console.error('client connect cb');
+      client.resume();
+      client.on('end', function() {
+        clientGotEnd = true;
+        setTimeout(function() {
+          assert(client.writable);
+          client.end();
+        }, 10);
+      });
+      client.on('close', function() {
+        server.close();
+      });
+    });
+  });
+
+  process.on('exit', function() {
+    console.error('exit', serverGotEnd, clientGotEnd);
+    assert(serverGotEnd);
+    assert(clientGotEnd);
+  });
+});


### PR DESCRIPTION
This reverts commit 852313af651f30818b2dc24234f9b49036cc40e3.
```
Conflicts:
	test/parallel/test-net-connect-options-ipv6.js
```
Edit: (Note: It is possible I resolved the conflicts incorrectly.)

See https://github.com/nodejs/node/issues/4546 -- this test has 100% timeout rate on my OS X machine after said patch.

CI: https://ci.nodejs.org/job/node-test-pull-request/1609/

ping @mscdex 