### PR TITLE
Revert "fs: deprecate fs.read's string interface"

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -35,7 +35,6 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
-const printDeprecation = require('internal/util').printDeprecationMessage;
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +
@@ -585,14 +584,9 @@ fs.openSync = function(path, flags, mode) {
   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
 };
 
-var readWarned = false;
 fs.read = function(fd, buffer, offset, length, position, callback) {
   if (!(buffer instanceof Buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
-    readWarned = printDeprecation('fs.read\'s legacy String interface ' +
-                                  'is deprecated. Use the Buffer API as ' +
-                                  'mentioned in the documentation instead.',
-                                  readWarned);
     const cb = arguments[4];
     const encoding = arguments[3];
 
@@ -642,17 +636,12 @@ function tryToStringWithEnd(buf, encoding, end, callback) {
   callback(e, buf, end);
 }
 
-var readSyncWarned = false;
 fs.readSync = function(fd, buffer, offset, length, position) {
   var legacy = false;
   var encoding;
 
   if (!(buffer instanceof Buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
-    readSyncWarned = printDeprecation('fs.readSync\'s legacy String interface' +
-                                      'is deprecated. Use the Buffer API as ' +
-                                      'mentioned in the documentation instead.',
-                                      readSyncWarned);
     legacy = true;
     encoding = arguments[3];
 

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+
+const path = require('path');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const npmPath = path.join(
+  common.testDir,
+  '..',
+  'deps',
+  'npm',
+  'bin',
+  'npm-cli.js'
+);
+
+const args = [
+  npmPath,
+  'install'
+];
+
+const proc = spawn(process.execPath, args, {
+  cwd: common.tmpDir
+});
+
+proc.on('exit', function(code) {
+  // npm install in tmpDir should be essentially a no-op.
+  // If npm is not broken the process should always exit 0.
+  // Assert that there are no obvious failures.
+  assert.equal(code, 0, 'npm install should run wihtout an error');
+});


### PR DESCRIPTION
This reverts commit 1124de2d76ad7118267d91a08485aa928a5f0865
which landed in https://github.com/nodejs/node/pull/4525

This commit has broken both npm + node-gyp

How did it break npm?

Deprecating fs.read's string interface includes `internal/util`
Currently npm's dep tree includes an old version of graceful-fs
that is monkey patching fs. As such everything explodes when
trying to require `internal/util`

https://github.com/nodejs/node/pull/5102 is waiting for review
but has not landed. We should revert ASAP to fix master while
we decide what to do.

/cc @nodejs/collaborators @rvagg @jasnell 