### PR TITLE
test: add test-npm-install to parallel tests suite

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+
+const path = require('path');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
+const fs = require('fs');
+
+common.refreshTmpDir();
+
+const npmPath = path.join(
+  common.testDir,
+  '..',
+  'deps',
+  'npm',
+  'bin',
+  'npm-cli.js'
+);
+
+const args = [
+  npmPath,
+  'install'
+];
+
+const pkgContent = '{}';
+
+const pkgPath = path.join(common.tmpDir, 'package.json');
+
+fs.writeFileSync(pkgPath, pkgContent);
+
+const proc = spawn(process.execPath, args, {
+  cwd: common.tmpDir
+});
+
+function handleExit(code, signalCode) {
+  assert.equal(code, 0, 'npm install should run without an error');
+  assert.ok(signalCode === null, 'signalCode should be null');
+}
+
+proc.on('exit', common.mustCall(handleExit));


### PR DESCRIPTION
Currently we are not testing that `npm install` works.

This is a very naive / basic test that shells out to `npm install`
in an empty `tempDir`. While this test will not be able to check
that `npm install` is 100% working, it should catch certain edge
cases that break it.

This is currently blocked from being tested until #4525 lands

/cc @nodejs/npm @nodejs/testing 