### PR TITLE
Prevent node from running and installing on Windows Vista or earlier

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -1,7 +1,15 @@
 #include "node.h"
 
 #ifdef _WIN32
+#include <VersionHelpers.h>
+
 int wmain(int argc, wchar_t *wargv[]) {
+  if (!IsWindows7OrGreater()) {
+    fprintf(stderr, "This application is only supported on Windows 7, "
+                    "Windows Server 2008 R2, or higher.");
+    exit(1);
+  }
+
   // Convert argv to to UTF8
   char** argv = new char*[argc];
   for (int i = 0; i < argc; i++) {

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -23,6 +23,10 @@
              Compressed="yes"
              InstallScope="perMachine"/>
 
+    <Condition Message="This application is only supported on Windows 7, Windows Server 2008 R2, or higher.">
+      <![CDATA[Installed OR (VersionNT >= 601)]]>
+    </Condition>
+
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
     <MajorUpgrade AllowSameVersionUpgrades="yes"


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/3804
R: @nodejs/platform-windows @ChALkeR 

The last commit is not necessary to achieve the objective, but as a consequence of supporting Windows 7 or greater we can use features from Windows Installer 5.0.

Tested on Vista and Win7 (boundary versions). Screenshots of outcomes on Vista:

Running node.exe
![windows vista-2016-02-09-20-07-55 - copy](https://cloud.githubusercontent.com/assets/1625870/12929139/a503bb84-cf47-11e5-968c-0632ea77179e.png)

Launching the msi, with Windows Installer 5.0 (it's available as an update)
![windows vista-2016-02-09-20-13-03 - copy](https://cloud.githubusercontent.com/assets/1625870/12929188/d3afa786-cf47-11e5-8c2e-7f23c60152bd.png)

Launching the msi, with Windows Installer < 5.0
![windows vista-2016-02-09-20-42-19 - copy](https://cloud.githubusercontent.com/assets/1625870/12929206/e463eb46-cf47-11e5-9763-7537816dce09.png)

**UPDATE**
The latest version of this change only shows the second dialog during MSI install.
When running node.exe, an error is printed on stderr.