### PR TITLE
tls: nullify `.ssl` on handle close

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -299,6 +299,9 @@ proxiedMethods.forEach(function(name) {
 });
 
 tls_wrap.TLSWrap.prototype.close = function closeProxy(cb) {
+  if (this.owner)
+    this.owner.ssl = null;
+
   if (this._parentWrap && this._parentWrap._handle === this._parent) {
     this._parentWrap.once('close', cb);
     return this._parentWrap.destroy();

--- a/test/parallel/test-tls-regr-gh-5108.js
+++ b/test/parallel/test-tls-regr-gh-5108.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: node compiled without crypto.');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+const fs = require('fs');
+const path = require('path');
+
+const keyDir = path.join(common.fixturesDir, 'keys');
+const key = fs.readFileSync(path.join(keyDir, 'agent1-key.pem'));
+const cert = fs.readFileSync(path.join(keyDir, 'agent1-cert.pem'));
+
+const server = tls.createServer({
+  key: key,
+  cert: cert
+}, function(c) {
+  c.end();
+}).listen(common.PORT, function() {
+  var client = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false
+  }, common.mustCall(function() {
+    client.destroy();
+    if (!client._events.close)
+      client._events.close = [];
+    else if (!Array.isArray(client._events.close))
+      client._events.close = [ client._events.close ];
+
+    client._events.close.unshift(common.mustCall(function() {
+      setImmediate(function() {
+        // Make it crash on unpatched node.js
+        var fd = client.ssl && client.ssl.fd;
+        assert(client.ssl === null);
+        assert(!fd);
+      });
+    }));
+    server.close();
+  }));
+});


### PR DESCRIPTION
This is an intermediate fix for an issue of accessing `TLSWrap` fields
after the parent handle was destroyed. While `close` listener cleans up
this field automatically, it can be done even earlier at the
`TLSWrap.close` call.

Proper fix is going to be submitted and landed after this one.

Fix: #5108

R = @bnoordhuis or @shigeki 

cc @nodejs/crypto 