### PR TITLE
Update install.py

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -25,8 +25,8 @@ def abspath(*args):
 
 def load_config():
   s = open('config.gypi').read()
-  s = re.sub(r'#.*?\n', '', s) # strip comments
-  s = re.sub(r'\'', '"', s) # convert quotes
+  s = re.sub(r'#.*\n?', '', s) # strip comments
+  s = s.replace("'", '"') # convert quotes
   return json.loads(s)
 
 def try_unlink(path):


### PR DESCRIPTION
 -> Why I have changed `s = re.sub(r'#.*?\n', '', s)` to `s = re.sub(r'#.*\n?', '', s)`?

Because your regex won't match the comment line which exists at the last (End of a file) because it expects a newline character . But `s = re.sub(r'#.*\n?', '', s)` should remove all the comment lines irrespective of their locations. `.*?` -> `.*` because dot by default won't match line breaks. 

-> A simple `string.replace` should do this `re.sub(r'\'', '"', s)` job, you don't need to go for `re.sub

If you want to further reduce these two lines of code into a single line then go with this,

    re.sub(r"#.*\n?|(')", lambda x: '"' if x.group(1) else '', s)