### PR TITLE
test: fix child-process-fork-regr-gh-2847 again

### DIFF
--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -15,6 +15,13 @@ if (!cluster.isMaster) {
 }
 
 var server = net.createServer(function(s) {
+  if (common.isWindows) {
+    s.on('error', function(err) {
+      // Prevent possible ECONNRESET errors from popping up
+      if (err.code !== 'ECONNRESET')
+        throw err;
+    });
+  }
   setTimeout(function() {
     s.destroy();
   }, 100);


### PR DESCRIPTION
Windows is still sometimes failing with ECONNRESET. Bring back the
handling of this error as was initially introduced in PR #4442.