### PR TITLE
test: disable fs watch tests for AIX

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -19,3 +19,10 @@ test-tick-processor                  : PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
+
+# fs-watch currently needs special configuration on AIX and we
+# want to improve under https://github.com/nodejs/node/issues/5085.
+# Tests are disabled so CI can be green and we can spot other
+# regressions until this work is complete
+[$system==aix]
+test-fs-watch-enoent                 : FAIL, PASS

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -17,3 +17,9 @@ test-vm-syntax-error-stderr : PASS,FLAKY
 
 [$system==freebsd]
 
+# fs-watch currently needs special configuration on AIX and we
+# want to improve under https://github.com/nodejs/node/issues/5085.
+# Tests are disabled so CI can be green and we can spot other
+# regressions until this work is complete
+[$system==aix]
+test-fs-watch                        : FAIL, PASS


### PR DESCRIPTION
fs watch currently needs special configuration on AIX and we
want to improve under https://github.com/nodejs/node/issues/5085.
Tests are disabled so CI can be green and we can spot other
regressions until this work is complete.

test-async-wrap-check-providers does not aim to test fs watch
but uses it as part of what it is testing so its included in
those disabled.