### PR TITLE
tools: add recommended linting rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,16 +26,21 @@ rules:
   no-ex-assign: 2
   no-extra-boolean-cast : 2
   no-extra-semi: 2
+  no-func-assign: 2
   no-invalid-regexp: 2
   no-irregular-whitespace: 2
+  no-negated-in-lhs: 2
+  no-obj-calls: 2
   no-proto: 2
   no-unexpected-multiline: 2
   no-unreachable: 2
+  use-isnan: 2
   valid-typeof: 2
 
   # Best Practices
   # https://github.com/eslint/eslint/tree/master/docs/rules#best-practices
   no-fallthrough: 2
+  no-octal: 2
   no-redeclare: 2
 
   # Stylistic Issues
@@ -71,6 +76,7 @@ rules:
 
   # Variables
   # https://github.com/eslint/eslint/tree/master/docs/rules#variables
+  no-delete-var: 2
   no-undef: 2
   no-unused-vars: [2, {"args": "none"}]
 


### PR DESCRIPTION
This change adds ESLint rules that meet two criteria:

* recommended by ESLint
* require no code changes in the current code base

These rules are:

* `no-func-assign`: Disallow overwriting a function that was written
as a function declaration.
* `no-negated-in-lhs`: Disallow negated left operand of `in` operator.
It prevents `if(!a in b)` when `if(!(a in b))` is intended.
* `no-obj-calls`: Disallow global object function calls. It prevents
errors like `JSON()` and `Math()`.
* `use-isnan`: Prevents errors like `if (foo == NaN)`
* `no-octal`: Disallows confusing constructs like `var num = 071;`
* `no-delete-var`: Delete works on properties, not variables. Disallows
`delete foo`.

This may make configuration much more concise if we turn on recommended rules and then disable ones that we aren't using.

And it may prevent some errors from making it into the PR stage and requiring a reviewer to correct.