### PR TITLE
http: use `localAddress` instead of `path`

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -106,12 +106,12 @@ Agent.prototype.getName = function(options) {
 };
 
 Agent.prototype.addRequest = function(req, options) {
-  // Legacy API: addRequest(req, host, port, path)
+  // Legacy API: addRequest(req, host, port, localAddress)
   if (typeof options === 'string') {
     options = {
       host: options,
       port: arguments[2],
-      path: arguments[3]
+      localAddress: arguments[3]
     };
   }
 

--- a/test/parallel/test-regress-GH-5051.js
+++ b/test/parallel/test-regress-GH-5051.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const agent = require('http').globalAgent;
+
+// small stub just so we can call addRequest directly
+const req = {
+  getHeader: function() {}
+};
+
+agent.maxSockets = 0;
+
+// localAddress is used when naming requests / sockets
+// while using the Legacy API
+agent.addRequest(req, 'localhost', common.PORT, '127.0.0.1');
+assert.equal(Object.keys(agent.requests).length, 1);
+assert.equal(
+  Object.keys(agent.requests)[0],
+  'localhost:' + common.PORT + ':127.0.0.1');
+
+// path is *not* used when naming requests / sockets
+agent.addRequest(req, {
+  host: 'localhost',
+  port: common.PORT,
+  localAddress: '127.0.0.1',
+  path: '/foo'
+});
+assert.equal(Object.keys(agent.requests).length, 1);
+assert.equal(
+  Object.keys(agent.requests)[0],
+  'localhost:' + common.PORT + ':127.0.0.1');


### PR DESCRIPTION
Fix `options` usage on `lib/_http_agent.js` for the Legacy API.

Fixes: https://github.com/nodejs/node/issues/5051