### PR TITLE
build: handle aarch64 as arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,9 @@ else
 ifeq ($(DESTCPU),arm)
 ARCH=arm
 else
+ifeq ($(DESTCPU),aarch64)
+ARCH=arm64
+else
 ifeq ($(DESTCPU),ppc64)
 ARCH=ppc64
 else
@@ -279,6 +282,7 @@ ifeq ($(DESTCPU),ppc)
 ARCH=ppc
 else
 ARCH=x86
+endif
 endif
 endif
 endif


### PR DESCRIPTION
`Makefile` is now consistent with `configure` on how we treat aarch64.
Refs #5175.

/r=@nodejs/build.