### PR TITLE
dns: return real system error instead of 'ENOTFOUND'

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -4,7 +4,6 @@ const net = require('net');
 const util = require('util');
 
 const cares = process.binding('cares_wrap');
-const uv = process.binding('uv');
 const internalNet = require('internal/net');
 
 const GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
@@ -16,13 +15,6 @@ const isLegalPort = internalNet.isLegalPort;
 
 
 function errnoException(err, syscall, hostname) {
-  // FIXME(bnoordhuis) Remove this backwards compatibility nonsense and pass
-  // the true error to the user. ENOTFOUND is not even a proper POSIX error!
-  if (err === uv.UV_EAI_MEMORY ||
-      err === uv.UV_EAI_NODATA ||
-      err === uv.UV_EAI_NONAME) {
-    err = 'ENOTFOUND';
-  }
   var ex = null;
   if (typeof err === 'string') {  // c-ares error code.
     ex = new Error(syscall + ' ' + err + (hostname ? ' ' + hostname : ''));

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -27,13 +27,13 @@ function test(mod) {
   // Ensure that there is time to attach an error listener.
   var req1 = mod.get({host: host, port: 42}, do_not_call);
   req1.on('error', common.mustCall(function(err) {
-    assert.equal(err.code, 'ENOTFOUND');
+    assert.equal(err.code, 'EAI_NONAME');
   }));
   // http.get() called req1.end() for us
 
   var req2 = mod.request({method: 'GET', host: host, port: 42}, do_not_call);
   req2.on('error', common.mustCall(function(err) {
-    assert.equal(err.code, 'ENOTFOUND');
+    assert.equal(err.code, 'EAI_NONAME');
   }));
   req2.end();
 }

--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -3,12 +3,12 @@ var common = require('../common');
 var net = require('net');
 var assert = require('assert');
 
-var c = net.createConnection(common.PORT, '...');
+var c = net.createConnection(common.PORT, '***');
 
 c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
-  assert.equal(e.code, 'ENOTFOUND');
+  assert.equal(e.code, 'EAI_NONAME');
   assert.equal(e.port, common.PORT);
-  assert.equal(e.hostname, '...');
+  assert.equal(e.hostname, '***');
 }));

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -3,14 +3,14 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const client = net.connect({host: '...', port: common.PORT});
+const client = net.connect({host: '***', port: common.PORT});
 
 client.once('error', common.mustCall(function(err) {
   assert(err);
   assert.strictEqual(err.code, err.errno);
-  assert.strictEqual(err.code, 'ENOTFOUND');
+  assert.strictEqual(err.code, 'EAI_NONAME');
   assert.strictEqual(err.host, err.hostname);
-  assert.strictEqual(err.host, '...');
+  assert.strictEqual(err.host, '***');
   assert.strictEqual(err.syscall, 'getaddrinfo');
 }));
 

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -40,7 +40,8 @@ function tryConnect() {
       server.close();
     });
   }).on('error', function(err) {
-    if (err.syscall === 'getaddrinfo' && err.code === 'ENOTFOUND') {
+    if (err.syscall === 'getaddrinfo'
+        && (err.code === 'EAI_NODATA' || err.code === 'EAI_NONAME')) {
       if (host !== 'localhost' || --localhostTries === 0)
         host = hosts[++hostIdx];
       if (host)

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -20,12 +20,12 @@ function do_not_call() {
 
 var socket = net.connect(42, host, do_not_call);
 socket.on('error', function(err) {
-  assert.equal(err.code, 'ENOTFOUND');
+  assert.equal(err.code, 'EAI_NONAME');
   actual_bad_connections++;
 });
 socket.on('lookup', function(err, ip, type) {
   assert(err instanceof Error);
-  assert.equal(err.code, 'ENOTFOUND');
+  assert.equal(err.code, 'EAI_NONAME');
   assert.equal(ip, undefined);
   assert.equal(type, undefined);
 });


### PR DESCRIPTION
Return the real system error to user insetad of injecting 'ENOTFOUND'
which is not a proper POSIX error.

https://github.com/nodejs/node/pull/5099#issuecomment-181538896

Also fix the test suite to check for the corresponding error message.

The hostname '...' was replaced with '***' because '...' returns
inconsistent error message on different system. On GNU libc it intantly
returns EAI_NONAME but on musl libc it returns EAI_AGAIN after a
timeout.
