### PR TITLE
doc: update removeListener behaviour

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -380,7 +380,7 @@ multiple times to remove each instance.
 Note that once an event has been emitted, all listeners attached to it at the
 time of emitting will be called in order. This implies that any `removeListener`
 call *after* emitting and *before* the last listener finishes execution will
-not affect the current listener array. Subsequent events will behave as expected.
+not affect that `emit()`. Subsequent events will behave as expected.
 
 ```js
 const myEmitter = new MyEmitter();
@@ -402,8 +402,8 @@ myEmitter.on('event', callbackB);
 // Interal listener array at time of emit [callbackA, callbackB]
 myEmitter.emit('event');
   // Prints:
-  //   B
   //   A
+  //   B
 
 // callbackB is now removed.
 // Interal listener array [callbackA]

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -377,6 +377,42 @@ listener array. If any single listener has been added multiple times to the
 listener array for the specified `event`, then `removeListener` must be called
 multiple times to remove each instance.
 
+Note that once an event has been emitted, all listeners attached to it at the
+time of emitting will be called in order. This implies that any `removeListener`
+call *after* emitting and *before* the last listener finishes execution will
+not affect the current listener array. Subsequent events will behave as expected.
+
+```js
+const myEmitter = new MyEmitter();
+
+var callbackA = () => {
+  console.log('A');
+  myEmitter.removeListener('event', callbackB);
+};
+
+var callbackB = () => {
+  console.log('B');
+};
+
+myEmitter.on('event', callbackA);
+
+myEmitter.on('event', callbackB);
+
+// callbackA removes listener callbackB but it will still be called.
+// Interal listener array at time of emit [callbackA, callbackB]
+myEmitter.emit('event');
+  // Prints:
+  //   B
+  //   A
+
+// callbackB is now removed.
+// Interal listener array [callbackA]
+myEmitter.emit('event');
+  // Prints:
+  //   A
+
+```
+
 Because listeners are managed using an internal array, calling this will
 change the position indices of any listener registered *after* the listener
 being removed. This will not impact the order in which listeners are called,

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -378,9 +378,10 @@ listener array for the specified `event`, then `removeListener` must be called
 multiple times to remove each instance.
 
 Note that once an event has been emitted, all listeners attached to it at the
-time of emitting will be called in order. This implies that any `removeListener`
-call *after* emitting and *before* the last listener finishes execution will
-not affect that `emit()`. Subsequent events will behave as expected.
+time of emitting will be called in order. This implies that any `removeListener()`
+or `removeAllListeners()` calls *after* emitting and *before* the last listener
+finishes execution will not remove them from `emit()` in progress. Subsequent
+events will behave as expected.
 
 ```js
 const myEmitter = new MyEmitter();

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -84,17 +84,16 @@ e5.once('removeListener', common.mustCall(function(name, cb) {
 e5.removeListener('hello', listener1);
 assert.deepEqual([], e5.listeners('hello'));
 
-var e6 = new events.EventEmitter();
-count = 0;
+const e6 = new events.EventEmitter();
 
-function listener3() {
-  count++;
+var listener3 = common.mustCall(() => {
+  console.log('listener3');
   e6.removeListener('hello', listener4);
-}
+}, 2);
 
-function listener4() {
-  count++;
-}
+var listener4 = common.mustCall(() => {
+  console.log('listener4');
+}, 1);
 
 e6.on('hello', listener3);
 e6.on('hello', listener4);
@@ -103,9 +102,6 @@ e6.on('hello', listener4);
 e6.emit('hello');
 // This is so because the interal listener array at time of emit
 // was [listener3,listener4]
-assert.equal(count, 2);
 
-count = 0;
 // Interal listener array [listener3]
 e6.emit('hello');
-assert.equal(count, 1);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -86,14 +86,11 @@ assert.deepEqual([], e5.listeners('hello'));
 
 const e6 = new events.EventEmitter();
 
-var listener3 = common.mustCall(() => {
-  console.log('listener3');
+const listener3 = common.mustCall(() => {
   e6.removeListener('hello', listener4);
 }, 2);
 
-var listener4 = common.mustCall(() => {
-  console.log('listener4');
-}, 1);
+const listener4 = common.mustCall(() => {}, 1);
 
 e6.on('hello', listener3);
 e6.on('hello', listener4);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -83,3 +83,29 @@ e5.once('removeListener', common.mustCall(function(name, cb) {
 }));
 e5.removeListener('hello', listener1);
 assert.deepEqual([], e5.listeners('hello'));
+
+var e6 = new events.EventEmitter();
+count = 0;
+
+function listener3() {
+  count++;
+  e6.removeListener('hello', listener4);
+}
+
+function listener4() {
+  count++;
+}
+
+e6.on('hello', listener3);
+e6.on('hello', listener4);
+
+//listener4 will still be called although it is removed by listener 3.
+e6.emit('hello');
+//This is so because the interal listener array at time of emit
+//was [listener3,listener4]
+assert.equal(count, 2);
+
+count = 0;
+//Interal listener array [listener3]
+e6.emit('hello');
+assert.equal(count, 1);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -99,13 +99,13 @@ function listener4() {
 e6.on('hello', listener3);
 e6.on('hello', listener4);
 
-//listener4 will still be called although it is removed by listener 3.
+// listener4 will still be called although it is removed by listener 3.
 e6.emit('hello');
-//This is so because the interal listener array at time of emit
-//was [listener3,listener4]
+// This is so because the interal listener array at time of emit
+// was [listener3,listener4]
 assert.equal(count, 2);
 
 count = 0;
-//Interal listener array [listener3]
+// Interal listener array [listener3]
 e6.emit('hello');
 assert.equal(count, 1);


### PR DESCRIPTION
This commit updates events doc to describe removeListener behaviour
when it is called within a listener. An example is added to make it 
more evident.

A test is also incuded to make this behaviour consistent in future
releases.
ref #4764 
fixes #4759 
@cjihrig @jasnell 
