### PR TITLE
(vee-eight-4.9) Replace more deprecated V8 API usage

### DIFF
--- a/src/base-object-inl.h
+++ b/src/base-object-inl.h
@@ -39,7 +39,7 @@ inline Environment* BaseObject::env() const {
 
 template <typename Type>
 inline void BaseObject::WeakCallback(
-    const v8::WeakCallbackData<v8::Object, Type>& data) {
+    const v8::WeakCallbackInfo<Type>& data) {
   Type* self = data.GetParameter();
   self->persistent().Reset();
   delete self;
@@ -53,7 +53,8 @@ inline void BaseObject::MakeWeak(Type* ptr) {
   CHECK_GT(handle->InternalFieldCount(), 0);
   Wrap(handle, ptr);
   handle_.MarkIndependent();
-  handle_.SetWeak<Type>(ptr, WeakCallback<Type>);
+  handle_.SetWeak<Type>(ptr, WeakCallback<Type>,
+                        v8::WeakCallbackType::kParameter);
 }
 
 

--- a/src/base-object.h
+++ b/src/base-object.h
@@ -40,7 +40,7 @@ class BaseObject {
 
   template <typename Type>
   static inline void WeakCallback(
-      const v8::WeakCallbackData<v8::Object, Type>& data);
+      const v8::WeakCallbackInfo<Type>& data);
 
   v8::Persistent<v8::Object> handle_;
   Environment* env_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -116,6 +116,7 @@ using v8::Local;
 using v8::Locker;
 using v8::MaybeLocal;
 using v8::Message;
+using v8::Name;
 using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -2467,7 +2468,7 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(exports);
 }
 
-static void ProcessTitleGetter(Local<String> property,
+static void ProcessTitleGetter(Local<Name> property,
                                const PropertyCallbackInfo<Value>& info) {
   char buffer[512];
   uv_get_process_title(buffer, sizeof(buffer));
@@ -2475,7 +2476,7 @@ static void ProcessTitleGetter(Local<String> property,
 }
 
 
-static void ProcessTitleSetter(Local<String> property,
+static void ProcessTitleSetter(Local<Name> property,
                                Local<Value> value,
                                const PropertyCallbackInfo<void>& info) {
   node::Utf8Value title(info.GetIsolate(), value);
@@ -2704,13 +2705,13 @@ static Local<Object> GetFeatures(Environment* env) {
 }
 
 
-static void DebugPortGetter(Local<String> property,
+static void DebugPortGetter(Local<Name> property,
                             const PropertyCallbackInfo<Value>& info) {
   info.GetReturnValue().Set(debug_port);
 }
 
 
-static void DebugPortSetter(Local<String> property,
+static void DebugPortSetter(Local<Name> property,
                             Local<Value> value,
                             const PropertyCallbackInfo<void>& info) {
   debug_port = value->Int32Value();
@@ -2722,7 +2723,7 @@ static void DebugPause(const FunctionCallbackInfo<Value>& args);
 static void DebugEnd(const FunctionCallbackInfo<Value>& args);
 
 
-void NeedImmediateCallbackGetter(Local<String> property,
+void NeedImmediateCallbackGetter(Local<Name> property,
                                  const PropertyCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   const uv_check_t* immediate_check_handle = env->immediate_check_handle();
@@ -2733,7 +2734,7 @@ void NeedImmediateCallbackGetter(Local<String> property,
 
 
 static void NeedImmediateCallbackSetter(
-    Local<String> property,
+    Local<Name> property,
     Local<Value> value,
     const PropertyCallbackInfo<void>& info) {
   Environment* env = Environment::GetCurrent(info);
@@ -2822,10 +2823,12 @@ void SetupProcessObject(Environment* env,
 
   Local<Object> process = env->process_object();
 
-  process->SetAccessor(env->title_string(),
-                       ProcessTitleGetter,
-                       ProcessTitleSetter,
-                       env->as_external());
+  auto maybe = process->SetAccessor(env->context(),
+                                    env->title_string(),
+                                    ProcessTitleGetter,
+                                    ProcessTitleSetter,
+                                    env->as_external());
+  CHECK(maybe.FromJust());
 
   // process.version
   READONLY_PROPERTY(process,
@@ -2989,10 +2992,12 @@ void SetupProcessObject(Environment* env,
 
   READONLY_PROPERTY(process, "pid", Integer::New(env->isolate(), getpid()));
   READONLY_PROPERTY(process, "features", GetFeatures(env));
-  process->SetAccessor(env->need_imm_cb_string(),
-                       NeedImmediateCallbackGetter,
-                       NeedImmediateCallbackSetter,
-                       env->as_external());
+  maybe = process->SetAccessor(env->context(),
+                               env->need_imm_cb_string(),
+                               NeedImmediateCallbackGetter,
+                               NeedImmediateCallbackSetter,
+                               env->as_external());
+  CHECK(maybe.FromJust());
 
   // -e, --eval
   if (eval_string) {
@@ -3067,10 +3072,13 @@ void SetupProcessObject(Environment* env,
   process->Set(env->exec_path_string(), exec_path_value);
   delete[] exec_path;
 
-  process->SetAccessor(env->debug_port_string(),
-                       DebugPortGetter,
-                       DebugPortSetter,
-                       env->as_external());
+  maybe = process->SetAccessor(env->context(),
+                               env->debug_port_string(),
+                               DebugPortGetter,
+                               DebugPortSetter,
+                               env->as_external());
+  CHECK(maybe.FromJust());
+
 
   // define various internal methods
   env->SetMethod(process,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -79,20 +79,18 @@ class CallbackInfo {
  public:
   static inline void Free(char* data, void* hint);
   static inline CallbackInfo* New(Isolate* isolate,
-                                  Local<Object> object,
+                                  Local<ArrayBuffer> object,
                                   FreeCallback callback,
                                   void* hint = 0);
-  inline void Dispose(Isolate* isolate);
-  inline Persistent<Object>* persistent();
  private:
-  static void WeakCallback(const WeakCallbackData<Object, CallbackInfo>&);
-  inline void WeakCallback(Isolate* isolate, Local<Object> object);
+  static void WeakCallback(const WeakCallbackData<ArrayBuffer, CallbackInfo>&);
+  inline void WeakCallback(Isolate* isolate, Local<ArrayBuffer> object);
   inline CallbackInfo(Isolate* isolate,
-                      Local<Object> object,
+                      Local<ArrayBuffer> object,
                       FreeCallback callback,
                       void* hint);
   ~CallbackInfo();
-  Persistent<Object> persistent_;
+  Persistent<ArrayBuffer> persistent_;
   FreeCallback const callback_;
   void* const hint_;
   DISALLOW_COPY_AND_ASSIGN(CallbackInfo);
@@ -105,30 +103,25 @@ void CallbackInfo::Free(char* data, void*) {
 
 
 CallbackInfo* CallbackInfo::New(Isolate* isolate,
-                                Local<Object> object,
+                                Local<ArrayBuffer> object,
                                 FreeCallback callback,
                                 void* hint) {
   return new CallbackInfo(isolate, object, callback, hint);
 }
 
 
-void CallbackInfo::Dispose(Isolate* isolate) {
-  WeakCallback(isolate, PersistentToLocal(isolate, persistent_));
-}
-
-
-Persistent<Object>* CallbackInfo::persistent() {
-  return &persistent_;
-}
-
-
 CallbackInfo::CallbackInfo(Isolate* isolate,
-                           Local<Object> object,
+                           Local<ArrayBuffer> object,
                            FreeCallback callback,
                            void* hint)
     : persistent_(isolate, object),
       callback_(callback),
       hint_(hint) {
+  ArrayBuffer::Contents obj_c = object->GetContents();
+  char* const data = static_cast<char*>(obj_c.Data());
+  if (object->ByteLength() != 0)
+    CHECK_NE(data, nullptr);
+
   persistent_.SetWeak(this, WeakCallback);
   persistent_.SetWrapperClassId(BUFFER_ID);
   persistent_.MarkIndependent();
@@ -142,19 +135,14 @@ CallbackInfo::~CallbackInfo() {
 
 
 void CallbackInfo::WeakCallback(
-    const WeakCallbackData<Object, CallbackInfo>& data) {
+    const WeakCallbackData<ArrayBuffer, CallbackInfo>& data) {
   data.GetParameter()->WeakCallback(data.GetIsolate(), data.GetValue());
 }
 
 
-void CallbackInfo::WeakCallback(Isolate* isolate, Local<Object> object) {
-  CHECK(object->IsArrayBuffer());
-  Local<ArrayBuffer> buf = object.As<ArrayBuffer>();
+void CallbackInfo::WeakCallback(Isolate* isolate, Local<ArrayBuffer> buf) {
   ArrayBuffer::Contents obj_c = buf->GetContents();
   char* const obj_data = static_cast<char*>(obj_c.Data());
-  if (buf->ByteLength() != 0)
-    CHECK_NE(obj_data, nullptr);
-
   buf->Neuter();
   callback_(obj_data, hint_);
   int64_t change_in_bytes = -static_cast<int64_t>(sizeof(*this));

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -10,6 +10,10 @@ namespace Buffer {
 static const unsigned int kMaxLength =
     sizeof(int32_t) == sizeof(intptr_t) ? 0x3fffffff : 0x7fffffff;
 
+// Buffers have two internal fields, the first of which is reserved for use by
+// Node.
+static const unsigned int kBufferInternalFieldIndex = 0;
+
 NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
 
 NODE_EXTERN bool HasInstance(v8::Local<v8::Value> val);


### PR DESCRIPTION
Continuing from https://github.com/nodejs/node/pull/5159, this PR replaces deprecated uses of `SetAccessor` and most uses of `SetWeak` on the `vee-eight-4.9` branch.

~~The use of `SetWeak` in `src/node_buffer.cc` is more involved because it expects to get a handle to the weak object in the weak callback. I need to understand the buffer code a bit more before attempting to change that.~~

**EDIT**: the original change for `SetWeak` usage in `node_contextify` was flawed. I have removed that. 

Remaining work:
* [x] SetWeak – src/node_contextify.cc: #5392 
* [x] SetWeak – src/node_buffer.cc
* [ ]  NewExternal — src/string_bytes.cc

See also: https://github.com/nodejs/node/issues/4869
R=@bnoordhuis , @targos 
/cc @nodejs/v8