### PR TITLE
node: set process._eventsCount to 0 on startup

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -12,6 +12,7 @@
 
   function startup() {
     var EventEmitter = NativeModule.require('events');
+    process._eventsCount = 0;
 
     Object.setPrototypeOf(process, Object.create(EventEmitter.prototype, {
       constructor: {

--- a/test/parallel/test-process-emit.js
+++ b/test/parallel/test-process-emit.js
@@ -18,3 +18,5 @@ process.on('SIGPIPE', common.mustCall((data) => {
 process.emit('normal', 'normalData');
 process.emit(sym, 'symbolData');
 process.emit('SIGPIPE', 'signalData');
+
+assert.strictEqual(isNaN(process._eventsCount), false);


### PR DESCRIPTION
`process` is an `EventEmitter`. There are operations that increment and
decrement the `_eventsCount` property of an `EventEmitter`.
`process._eventsCount` would previously get set to `NaN`. This change makes
`process._eventsCount` be calculated as expected.