### PR TITLE
tools: add recommended ES6 lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,7 +67,12 @@ rules:
   # http://eslint.org/docs/rules/#ecmascript-6
   arrow-parens: [2, "always"]
   arrow-spacing: [2, {"before": true, "after": true}]
+  constructor-super: 2
   no-arrow-condition: 2
+  no-class-assign: 2
+  no-const-assign: 2
+  no-dupe-class-members: 2
+  no-this-before-super: 2
   prefer-const: 2
 
   # Strict Mode


### PR DESCRIPTION
Add the following (seemingly non-controversial) ESLint rules:

* `constructor-super`: Verify calls of `super()` in constructors. Flags
situations that will result in runtime errors. Since we do not have 100%
code coverage in tests, linting for runtime errors is useful.
* `no-class-assign`: Flags cases where a class declaration is
overwritten via variable assignment later. It is difficult to think of a
situation where this is not an error, and easy to think of situations
(particularly in lengthy test files) where it could come up.
* `no-const-assign`: Assigning to a const after declaration is a
runtime error.
* `no-dupe-class-members`: Declare a class member twice, then only the
second one counts. This is analogous to redeclaring a variable.
* `no-this-before-super`: Using `this` or `super` in a derived class
before a call to `super()` is a `ReferenceError`