### PR TITLE
cluster: dont rely `fork` on `this`

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -342,7 +342,7 @@ function masterInit() {
     });
 
     worker.on('message', (message, handle) =>
-      this.emit('message', message, handle)
+      cluster.emit('message', message, handle)
     );
 
     worker.process.once('exit', function(exitCode, signalCode) {

--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -2,10 +2,11 @@
 var common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
+var fork = cluster.fork;
 
 if (cluster.isMaster) {
-  cluster.fork();
-  cluster.fork();
+  fork();
+  fork();
   cluster.disconnect(common.mustCall(function() {
     assert.deepEqual(Object.keys(cluster.workers), []);
   }));

--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -5,8 +5,8 @@ var cluster = require('cluster');
 var fork = cluster.fork;
 
 if (cluster.isMaster) {
-  fork();
-  fork();
+  fork(); // it is intentionally called `fork` instead of
+  fork(); // `cluster.fork` to test that `this` is not used
   cluster.disconnect(common.mustCall(function() {
     assert.deepEqual(Object.keys(cluster.workers), []);
   }));


### PR DESCRIPTION
Avoid using `this` in `fork` function to be able to run just `fork()` instead of `cluster.fork()`