### PR TITLE
Skip build if with installer & no WiX install found

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -148,7 +148,7 @@ if defined msi (
   if not exist "%WIX%\SDK\VS2013" (
     echo Failed to find WiX install for Visual Studio 2013
     echo VS2013 support for WiX is only present starting at version 3.8
-    goto vc-set-2012
+    goto wix-not-found
   )
 )
 if "%VCVARS_VER%" NEQ "120" (


### PR DESCRIPTION
build: Skip node build if with installer & no WiX

When building node on windows with installer, and supported now WiX 
installations are not found (VS2013 / VS2015), skip build of node and
its installer.