### PR TITLE
console: apply null as `this` for util.format

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -33,7 +33,7 @@ function Console(stdout, stderr) {
 }
 
 Console.prototype.log = function() {
-  this._stdout.write(util.format.apply(this, arguments) + '\n');
+  this._stdout.write(util.format.apply(null, arguments) + '\n');
 };
 
 
@@ -41,7 +41,7 @@ Console.prototype.info = Console.prototype.log;
 
 
 Console.prototype.warn = function() {
-  this._stderr.write(util.format.apply(this, arguments) + '\n');
+  this._stderr.write(util.format.apply(null, arguments) + '\n');
 };
 
 
@@ -77,7 +77,7 @@ Console.prototype.trace = function trace() {
   // exposed.
   var err = new Error();
   err.name = 'Trace';
-  err.message = util.format.apply(this, arguments);
+  err.message = util.format.apply(null, arguments);
   Error.captureStackTrace(err, trace);
   this.error(err.stack);
 };
@@ -86,7 +86,7 @@ Console.prototype.trace = function trace() {
 Console.prototype.assert = function(expression) {
   if (!expression) {
     var arr = Array.prototype.slice.call(arguments, 1);
-    require('assert').ok(false, util.format.apply(this, arr));
+    require('assert').ok(false, util.format.apply(null, arr));
   }
 };
 


### PR DESCRIPTION
the util.format just a stateless function. apply current console
as `this` is unnecessary.