### PR TITLE
net: remove unused `var self = this` from old code

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -277,9 +277,8 @@ function writeAfterFIN(chunk, encoding, cb) {
 
   var er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  var self = this;
   // TODO: defer error events consistently everywhere, not just the cb
-  self.emit('error', er);
+  this.emit('error', er);
   if (typeof cb === 'function') {
     process.nextTick(cb, er);
   }


### PR DESCRIPTION
This method has an unused `var self = this`. 

Unless I'm missing something obvious here it's redundant.