### PR TITLE
Revert "deps: sync with upstream c-ares/c-ares@4ef6817"

### DIFF
--- a/deps/cares/include/ares.h
+++ b/deps/cares/include/ares.h
@@ -294,10 +294,6 @@ typedef int  (*ares_sock_create_callback)(ares_socket_t socket_fd,
                                           int type,
                                           void *data);
 
-typedef int  (*ares_sock_config_callback)(ares_socket_t socket_fd,
-                                          int type,
-                                          void *data);
-
 CARES_EXTERN int ares_library_init(int flags);
 
 CARES_EXTERN int ares_library_init_mem(int flags,
@@ -347,10 +343,6 @@ CARES_EXTERN void ares_set_local_dev(ares_channel channel,
 CARES_EXTERN void ares_set_socket_callback(ares_channel channel,
                                            ares_sock_create_callback callback,
                                            void *user_data);
-
-CARES_EXTERN void ares_set_socket_configure_callback(ares_channel channel,
-                                                     ares_sock_config_callback callback,
-                                                     void *user_data);
 
 CARES_EXTERN int ares_set_sortlist(ares_channel channel,
                                    const char *sortstr);

--- a/deps/cares/src/ares_private.h
+++ b/deps/cares/src/ares_private.h
@@ -311,9 +311,6 @@ struct ares_channeldata {
 
   ares_sock_create_callback sock_create_cb;
   void *sock_create_cb_data;
-
-  ares_sock_config_callback sock_config_cb;
-  void *sock_config_cb_data;
 };
 
 /* Memory management functions */

--- a/deps/cares/src/ares_process.c
+++ b/deps/cares/src/ares_process.c
@@ -1031,17 +1031,6 @@ static int open_tcp_socket(ares_channel channel, struct server_state *server)
     }
 #endif
 
-  if (channel->sock_config_cb)
-    {
-      int err = channel->sock_config_cb(s, SOCK_STREAM,
-                                        channel->sock_config_cb_data);
-      if (err < 0)
-        {
-          sclose(s);
-          return err;
-        }
-    }
-
   /* Connect to the server. */
   if (connect(s, sa, salen) == -1)
     {
@@ -1124,17 +1113,6 @@ static int open_udp_socket(ares_channel channel, struct server_state *server)
     {
        sclose(s);
        return -1;
-    }
-
-  if (channel->sock_config_cb)
-    {
-      int err = channel->sock_config_cb(s, SOCK_DGRAM,
-                                        channel->sock_config_cb_data);
-      if (err < 0)
-        {
-          sclose(s);
-          return err;
-        }
     }
 
   /* Connect to the server. */


### PR DESCRIPTION
This reverts commit 35c3832994156618c1221be35df49330a2390c31.

See [0] and [1] for background.  Let's hold off on upgrading c-ares
until upstream makes an official release.

[0] https://github.com/nodejs/node/issues/5185
[1] https://github.com/nodejs/node/pull/5199

R=@indutny

Aside: there isn't a v5.x-staging branch to target?