### PR TITLE
http: fix http-parser regression

### DIFF
--- a/deps/http_parser/Makefile
+++ b/deps/http_parser/Makefile
@@ -22,14 +22,14 @@ PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
 HELPER ?=
 BINEXT ?=
 ifeq (darwin,$(PLATFORM))
-SONAME ?= libhttp_parser.2.6.1.dylib
+SONAME ?= libhttp_parser.2.6.2.dylib
 SOEXT ?= dylib
 else ifeq (wine,$(PLATFORM))
 CC = winegcc
 BINEXT = .exe.so
 HELPER = wine
 else
-SONAME ?= libhttp_parser.so.2.6.1
+SONAME ?= libhttp_parser.so.2.6.2
 SOEXT ?= so
 endif
 

--- a/deps/http_parser/http_parser.c
+++ b/deps/http_parser/http_parser.c
@@ -440,7 +440,7 @@ enum http_host_state
  * character or %x80-FF
  **/
 #define IS_HEADER_CHAR(ch)                                                     \
-  (ch == CR || ch == LF || ch == 9 || (ch > 31 && ch != 127))
+  (ch == CR || ch == LF || ch == 9 || ((unsigned char)ch > 31 && ch != 127))
 
 #define start_state (parser->type == HTTP_REQUEST ? s_start_req : s_start_res)
 

--- a/deps/http_parser/http_parser.h
+++ b/deps/http_parser/http_parser.h
@@ -27,7 +27,7 @@ extern "C" {
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
 #define HTTP_PARSER_VERSION_MINOR 6
-#define HTTP_PARSER_VERSION_PATCH 1
+#define HTTP_PARSER_VERSION_PATCH 2
 
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \

--- a/deps/http_parser/test.c
+++ b/deps/http_parser/test.c
@@ -3356,7 +3356,7 @@ test_double_content_length_error (int req)
 
   parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
   if (parsed != buflen) {
-    assert(HTTP_PARSER_ERRNO(&parser) == HPE_MULTIPLE_CONTENT_LENGTH);
+    assert(HTTP_PARSER_ERRNO(&parser) == HPE_UNEXPECTED_CONTENT_LENGTH);
     return;
   }
 

--- a/test/parallel/test-http-header-obstext.js
+++ b/test/parallel/test-http-header-obstext.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.end('ok');
+}));
+server.listen(common.PORT, () => {
+  http.get({
+    port: common.PORT,
+    headers: {'Test': 'Düsseldorf'}
+  }, common.mustCall((res) => {
+    assert.equal(res.statusCode, 200);
+    server.close();
+  }));
+});


### PR DESCRIPTION
The new IS_HEADER_CHAR check in http-parser is improperly
checking char when it should be checking unsigned char.

/cc @ChALkeR 