### PR TITLE
Fixed template string in Crypto Documentation

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -1228,8 +1228,7 @@ If an error occurs, `err` will be an Error object; otherwise it is null. The
 const crypto = require('crypto');
 crypto.randomBytes(256, (err, buf) => {
   if (err) throw err;
-  console.log(
-    `${buf.length}` bytes of random data: ${buf.toString('hex')});
+  console.log(`${buf.length} bytes of random data: ${buf.toString('hex')}`);
 });
 ```
 


### PR DESCRIPTION
Template string was syntactically incorrect. Copied Documentation code
would throw an error.