### PR TITLE
http: fix http-parser regression (v0.10)

### DIFF
--- a/deps/http_parser/http_parser.c
+++ b/deps/http_parser/http_parser.c
@@ -388,7 +388,7 @@ enum http_host_state
 #endif
 
 #define IS_HEADER_CHAR(ch)                                                     \
-  (ch == CR || ch == LF || ch == 9 || (ch > 31 && ch != 127))
+  (ch == CR || ch == LF || ch == 9 || ((unsigned char)ch > 31 && ch != 127))
 
 #define start_state (parser->type == HTTP_REQUEST ? s_start_req : s_start_res)
 

--- a/deps/http_parser/http_parser.h
+++ b/deps/http_parser/http_parser.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define HTTP_PARSER_VERSION_MAJOR 1
-#define HTTP_PARSER_VERSION_MINOR 1
+#define HTTP_PARSER_VERSION_MINOR 2
 
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)

--- a/test/simple/test-http-header-obstext.js
+++ b/test/simple/test-http-header-obstext.js
@@ -1,0 +1,16 @@
+var common = require('../common');
+var http = require('http');
+var assert = require('assert');
+
+var server = http.createServer(common.mustCall(function(req, res) {
+  res.end('ok');
+}));
+server.listen(common.PORT, function() {
+  http.get({
+    port: common.PORT,
+    headers: {'Test': 'Düsseldorf'}
+  }, common.mustCall(function(res) {
+    assert.equal(res.statusCode, 200);
+    server.close();
+  }));
+});


### PR DESCRIPTION
The new IS_HEADER_CHAR check in http-parser is improperly
checking char when it should be checking unsigned char.

/cc @ChALkeR 