### PR TITLE
doc: document base64url encoding support

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -62,7 +62,9 @@ The character encodings currently supported by Node.js include:
 
 * `'ucs2'` - Alias of `'utf16le'`.
 
-* `'base64'` - Base64 string encoding.
+* `'base64'` - Base64 string encoding. When creating a buffer from a string,
+  this encoding will also correctly accept "URL and Filename Safe Alphabet" as
+  specified in [RFC 4648, Section 5].
 
 * `'binary'` - A way of encoding the buffer into a one-byte (`latin-1`)
   encoded string. The string `'latin-1'` is not supported. Instead, pass
@@ -1379,3 +1381,4 @@ has observed undue memory retention in their applications.
 [`String.prototype.length`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+[RFC 4648, Section 5]: https://tools.ietf.org/html/rfc4648#section-5


### PR DESCRIPTION
Documents that creating a buffer from base64 encoded string transparently 
supports "URL and Filename Safe Alphabet" base64url encoding.