### PR TITLE
doc: add simple http clientError example

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -464,6 +464,23 @@ Default behavior is to destroy the socket immediately on malformed request.
 
 `socket` is the [`net.Socket`][] object that the error originated from.
 
+```js
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  res.end();
+});
+server.on('clientError', (err, socket) => {
+  socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+});
+server.listen(8000);
+```
+
+When the `'clientError'` event occurs, there is no `request` or `response`
+object, so any HTTP response sent, including response headers and payload,
+*must* be written directly to the `socket` object. Care must be taken to
+ensure the response is a properly formatted HTTP response message.
+
 ### Event: 'close'
 
 `function () { }`


### PR DESCRIPTION
The clientError event allows proper http 4xx responses to
be returned when a parse error occurs, but the documentation
did not demonstrate how to use it.

/cc @nodejs/http @indutny 