### PR TITLE
test: eval a strict function

### DIFF
--- a/test/parallel/test-regress-GH-2245.js
+++ b/test/parallel/test-regress-GH-2245.js
@@ -1,0 +1,28 @@
+/* eslint-disable strict */
+require('../common');
+var assert = require('assert');
+
+/*
+in node 0.10 a bug existed that caused strict functions to not capture
+their environment when evaluated. When run in 0.10 `test()` fails with a
+`ReferenceError`. See https://github.com/nodejs/node/issues/2245 for details.
+*/
+
+function test() {
+
+  var code = [
+    'var foo = {m: 1};',
+    '',
+    'function bar() {',
+    '\'use strict\';',
+    'return foo; // foo isn\'t captured in 0.10',
+    '};'
+  ].join('\n');
+
+  eval(code);
+
+  return bar();
+
+}
+
+assert.deepEqual(test(), {m: 1});


### PR DESCRIPTION
This PR adds a regression test for the bug mentioned in #2245 where when a strict function is `eval`ed it would not capture it's context.
