### PR TITLE
emit `error` events consistently in next tick

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -5,6 +5,8 @@ const util = require('util');
 const EventEmitter = require('events');
 const debug = util.debuglog('http');
 
+const emitError = require('internal/util').emitError;
+
 // New Agent code.
 
 // The largest departure from the previous implementation is that
@@ -143,10 +145,7 @@ Agent.prototype.addRequest = function(req, options) {
     // If we are under maxSockets create a new one.
     this.createSocket(req, options, function(err, newSocket) {
       if (err) {
-        process.nextTick(function() {
-          req.emit('error', err);
-        });
-        return;
+        return process.nextTick(emitError, req, err);
       }
       req.onSocket(newSocket);
     });
@@ -252,10 +251,7 @@ Agent.prototype.removeSocket = function(s, options) {
     // If we have pending requests and a socket gets closed make a new one
     this.createSocket(req, options, function(err, newSocket) {
       if (err) {
-        process.nextTick(function() {
-          req.emit('error', err);
-        });
-        return;
+        return process.nextTick(emitError, req, err);
       }
       newSocket.emit('free');
     });

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -14,6 +14,7 @@ const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const Agent = require('_http_agent');
 const Buffer = require('buffer').Buffer;
 
+const emitError = require('internal/util').emitError;
 
 function ClientRequest(options, cb) {
   var self = this;
@@ -168,10 +169,7 @@ function ClientRequest(options, cb) {
       return;
     called = true;
     if (err) {
-      process.nextTick(function() {
-        self.emit('error', err);
-      });
-      return;
+      return process.nextTick(emitError, self, err);
     }
     self.onSocket(socket);
     self._deferToConnect(null, null, function() {
@@ -268,7 +266,7 @@ function socketCloseListener() {
     // This socket error fired before we started to
     // receive a response. The error needs to
     // fire on the request.
-    req.emit('error', createHangUpError());
+    process.nextTick(emitError, req, createHangUpError());
     req.socket._hadError = true;
   }
 
@@ -292,7 +290,7 @@ function socketErrorListener(err) {
   debug('SOCKET ERROR:', err.message, err.stack);
 
   if (req) {
-    req.emit('error', err);
+    process.nextTick(emitError, req, err);
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
     req.socket._hadError = true;
@@ -328,7 +326,7 @@ function socketOnEnd() {
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
-    req.emit('error', createHangUpError());
+    process.nextTick(emitError, req, createHangUpError());
     req.socket._hadError = true;
   }
   if (parser) {
@@ -350,7 +348,7 @@ function socketOnData(d) {
     debug('parse error');
     freeParser(parser, req, socket);
     socket.destroy();
-    req.emit('error', ret);
+    process.nextTick(emitError, req, ret);
     req.socket._hadError = true;
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade or CONNECT

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -12,6 +12,7 @@ const debug = util.debuglog('tls-legacy');
 const Buffer = require('buffer').Buffer;
 const Timer = process.binding('timer_wrap').Timer;
 const Connection = process.binding('crypto').Connection;
+const emitError = require('internal/util').emitError;
 
 function SlabBuffer() {
   this.create();
@@ -833,14 +834,14 @@ SecurePair.prototype.error = function(returnOnly) {
       err = connReset;
     }
     this.destroy();
-    if (!returnOnly) this.emit('error', err);
+    if (!returnOnly) process.nextTick(emitError, this, err);
   } else if (this._isServer &&
              this._rejectUnauthorized &&
              /peer did not return a certificate/.test(err.message)) {
     // Not really an error.
     this.destroy();
   } else {
-    if (!returnOnly) this.cleartext.emit('error', err);
+    if (!returnOnly) process.nextTick(emitError, this.cleartext, err);
   }
   return err;
 };
@@ -878,7 +879,7 @@ exports.pipe = function pipe(pair, socket) {
 
   function onerror(e) {
     if (cleartext._controlReleased) {
-      cleartext.emit('error', e);
+      process.nextTick(emitError, cleartext, e);
     }
   }
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -17,6 +17,8 @@ const tls_wrap = process.binding('tls_wrap');
 const TCP = process.binding('tcp_wrap').TCP;
 const Pipe = process.binding('pipe_wrap').Pipe;
 
+const emitError = require('internal/util').emitError;
+
 function onhandshakestart() {
   debug('onhandshakestart');
 
@@ -536,7 +538,7 @@ TLSSocket.prototype._handleTimeout = function() {
 TLSSocket.prototype._emitTLSError = function(err) {
   var e = this._tlsError(err);
   if (e)
-    this.emit('error', e);
+    process.nextTick(emitError, this, e);
 };
 
 TLSSocket.prototype._tlsError = function(err) {
@@ -1047,7 +1049,7 @@ exports.connect = function(/* [port, host], options, cb */) {
     if (ekeyinfo.type === 'DH' && ekeyinfo.size < options.minDHSize) {
       var err = new Error('DH parameter size ' + ekeyinfo.size +
                           ' is less than ' + options.minDHSize);
-      socket.emit('error', err);
+      process.nextTick(emitError, socket, err);
       socket.destroy();
       return;
     }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -10,7 +10,7 @@ const SCHED_NONE = 1;
 const SCHED_RR = 2;
 
 const uv = process.binding('uv');
-
+const emitError = require('internal/util').emitError;
 const cluster = new EventEmitter();
 module.exports = cluster;
 cluster.Worker = Worker;
@@ -33,8 +33,8 @@ function Worker(options) {
 
   if (options.process) {
     this.process = options.process;
-    this.process.on('error', (code, signal) =>
-      this.emit('error', code, signal)
+    this.process.on('error',
+      (code, signal) => process.nextTick(emitError, this, code, signal)
     );
     this.process.on('message', (message, handle) =>
       this.emit('message', message, handle)

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -8,6 +8,7 @@ const constants = require('constants');
 
 const UDP = process.binding('udp_wrap').UDP;
 const SendWrap = process.binding('udp_wrap').SendWrap;
+const emitError = require('internal/util').emitError;
 
 const BIND_STATE_UNBOUND = 0;
 const BIND_STATE_BINDING = 1;
@@ -177,8 +178,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
   self._handle.lookup(address, function(err, ip) {
     if (err) {
       self._bindState = BIND_STATE_UNBOUND;
-      self.emit('error', err);
-      return;
+      return process.nextTick(emitError, self, err);
     }
 
     if (!cluster)
@@ -191,10 +191,9 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
     if (cluster.isWorker && !exclusive) {
       function onHandle(err, handle) {
         if (err) {
-          var ex = exceptionWithHostPort(err, 'bind', ip, port);
-          self.emit('error', ex);
           self._bindState = BIND_STATE_UNBOUND;
-          return;
+          const er = exceptionWithHostPort(err, 'bind', ip, port);
+          return process.nextTick(emitError, self, er);
         }
 
         if (!self._handle)
@@ -218,11 +217,10 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
 
       const err = self._handle.bind(ip, port || 0, flags);
       if (err) {
-        var ex = exceptionWithHostPort(err, 'bind', ip, port);
-        self.emit('error', ex);
-        self._bindState = BIND_STATE_UNBOUND;
         // Todo: close?
-        return;
+        self._bindState = BIND_STATE_UNBOUND;
+        const er = exceptionWithHostPort(err, 'bind', ip, port);
+        return process.nextTick(emitError, self, er);
       }
 
       startListening(self);
@@ -362,8 +360,7 @@ function doSend(ex, self, ip, buffer, address, port, callback) {
       return;
     }
 
-    self.emit('error', ex);
-    return;
+    return process.nextTick(emitError, self, ex);
   } else if (!self._handle) {
     return;
   }
@@ -526,7 +523,7 @@ Socket.prototype._stopReceiving = function() {
 function onMessage(nread, handle, buf, rinfo) {
   var self = handle.owner;
   if (nread < 0) {
-    return self.emit('error', errnoException(nread, 'recvmsg'));
+    return process.nextTick(emitError, self, errnoException(nread, 'recvmsg'));
   }
   rinfo.size = buf.length; // compatibility
   self.emit('message', buf, rinfo);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -35,6 +35,7 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
+const emitError = require('internal/util').emitError;
 
 var printDeprecation;
 try {
@@ -1387,7 +1388,7 @@ function FSWatcher() {
           errnoException(status,
                          `Error watching file ${filename} for changes:`);
       error.filename = filename;
-      self.emit('error', error);
+      process.nextTick(emitError, self, error);
     } else {
       self.emit('change', event, filename);
     }
@@ -1852,8 +1853,7 @@ ReadStream.prototype.open = function() {
       if (self.autoClose) {
         self.destroy();
       }
-      self.emit('error', er);
-      return;
+      return process.nextTick(emitError, self, er);
     }
 
     self.fd = fd;
@@ -1907,7 +1907,7 @@ ReadStream.prototype._read = function(n) {
       if (self.autoClose) {
         self.destroy();
       }
-      self.emit('error', er);
+      return process.nextTick(emitError, self, er);
     } else {
       var b = null;
       if (bytesRead > 0)
@@ -1944,7 +1944,7 @@ ReadStream.prototype.close = function(cb) {
   function close(fd) {
     fs.close(fd || self.fd, function(er) {
       if (er)
-        self.emit('error', er);
+        process.nextTick(emitError, self, er);
       else
         self.emit('close');
     });
@@ -2018,8 +2018,7 @@ WriteStream.prototype.open = function() {
       if (this.autoClose) {
         this.destroy();
       }
-      this.emit('error', er);
-      return;
+      return process.nextTick(emitError, this, er);
     }
 
     this.fd = fd;
@@ -2030,7 +2029,7 @@ WriteStream.prototype.open = function() {
 
 WriteStream.prototype._write = function(data, encoding, cb) {
   if (!(data instanceof Buffer))
-    return this.emit('error', new Error('Invalid data'));
+    return process.nextTick(emitError, this, new Error('Invalid data'));
 
   if (typeof this.fd !== 'number')
     return this.once('open', function() {

--- a/lib/http.js
+++ b/lib/http.js
@@ -74,7 +74,7 @@ Client.prototype.request = function(method, path, headers) {
   options.agent = self.agent;
   var c = new ClientRequest(options);
   c.on('error', function(e) {
-    self.emit('error', e);
+    process.nextTick(internalUtil.emitError, self, e);
   });
   // The old Client interface emitted 'end' on socket end.
   // This doesn't map to how we want things to operate in the future

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -22,6 +22,8 @@ const errnoException = util._errnoException;
 const SocketListSend = SocketList.SocketListSend;
 const SocketListReceive = SocketList.SocketListReceive;
 
+const emitError = require('internal/util').emitError;
+
 module.exports = {
   ChildProcess,
   setupChannel,
@@ -199,7 +201,7 @@ function ChildProcess() {
         err.path = self.spawnfile;
 
       err.spawnargs = self.spawnargs.slice(1);
-      self.emit('error', err);
+      process.nextTick(emitError, self, err);
     } else {
       self.emit('exit', self.exitCode, self.signalCode);
     }
@@ -378,7 +380,7 @@ ChildProcess.prototype.kill = function(sig) {
       throw errnoException(err, 'kill');
     } else {
       /* Other error, almost certainly EPERM. */
-      this.emit('error', errnoException(err, 'kill'));
+      process.nextTick(emitError, this, errnoException(err, 'kill'));
     }
   }
 
@@ -524,7 +526,7 @@ function setupChannel(target, channel) {
     if (typeof callback === 'function') {
       process.nextTick(callback, ex);
     } else {
-      this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+      process.nextTick(emitError, this, ex);
     }
     return false;
   };
@@ -635,7 +637,7 @@ function setupChannel(target, channel) {
         if (typeof callback === 'function') {
           process.nextTick(callback, ex);
         } else {
-          this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
+          process.nextTick(emitError, this, ex);
         }
       }
     }
@@ -657,8 +659,8 @@ function setupChannel(target, channel) {
 
   target.disconnect = function() {
     if (!this.connected) {
-      this.emit('error', new Error('IPC channel is already disconnected'));
-      return;
+      const err = new Error('IPC channel is already disconnected');
+      return process.nextTick(emitError, this, err);
     }
 
     // Do not allow any new messages to be written.

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -90,3 +90,11 @@ exports.assertCrypto = function(exports) {
   if (noCrypto)
     throw new Error('Node.js is not compiled with openssl crypto support');
 };
+
+exports.emitError = function emitError(emitter, err, arg) {
+  if (arguments.length === 3) {
+    emitter.emit('error', err, arg);
+  } else {
+    emitter.emit('error', err);
+  }
+};

--- a/lib/net.js
+++ b/lib/net.js
@@ -18,7 +18,7 @@ const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
 const PipeConnectWrap = process.binding('pipe_wrap').PipeConnectWrap;
 const ShutdownWrap = process.binding('stream_wrap').ShutdownWrap;
 const WriteWrap = process.binding('stream_wrap').WriteWrap;
-
+const emitError = require('internal/util').emitError;
 
 var cluster;
 const errnoException = util._errnoException;
@@ -277,8 +277,7 @@ function writeAfterFIN(chunk, encoding, cb) {
 
   var er = new Error('This socket has been ended by the other party');
   er.code = 'EPIPE';
-  // TODO: defer error events consistently everywhere, not just the cb
-  this.emit('error', er);
+  process.nextTick(emitError, this, er);
   if (typeof cb === 'function') {
     process.nextTick(cb, er);
   }
@@ -447,7 +446,7 @@ Socket.prototype._destroy = function(exception, cb) {
   function fireErrorCallbacks(self) {
     if (cb) cb(exception);
     if (exception && !self._writableState.errorEmitted) {
-      process.nextTick(emitErrorNT, self, exception);
+      process.nextTick(emitError, self, exception);
       self._writableState.errorEmitted = true;
     }
   }
@@ -1219,8 +1218,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
     if (typeof rval === 'number') {
       var error = exceptionWithHostPort(rval, 'listen', address, port);
-      process.nextTick(emitErrorNT, this, error);
-      return;
+      return process.nextTick(emitError, this, error);
     }
     this._handle = rval;
   }
@@ -1231,11 +1229,10 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
   var err = _listen(this._handle, backlog);
 
   if (err) {
-    var ex = exceptionWithHostPort(err, 'listen', address, port);
     this._handle.close();
     this._handle = null;
-    process.nextTick(emitErrorNT, this, ex);
-    return;
+    const er = exceptionWithHostPort(err, 'listen', address, port);
+    return process.nextTick(emitError, this, er);
   }
 
   // generate connection key, this should be unique to the connection
@@ -1247,11 +1244,6 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
   process.nextTick(emitListeningNT, this);
 };
-
-
-function emitErrorNT(self, err) {
-  self.emit('error', err);
-}
 
 
 function emitListeningNT(self) {
@@ -1296,8 +1288,8 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
     }
 
     if (err) {
-      var ex = exceptionWithHostPort(err, 'bind', address, port);
-      return self.emit('error', ex);
+      const er = exceptionWithHostPort(err, 'bind', address, port);
+      return process.nextTick(emitError, self, er);
     }
 
     self._handle = handle;
@@ -1374,7 +1366,7 @@ Server.prototype.listen = function() {
   function listenAfterLookup(port, address, backlog, exclusive) {
     require('dns').lookup(address, function(err, ip, addressType) {
       if (err) {
-        self.emit('error', err);
+        process.nextTick(emitError, self, err);
       } else {
         addressType = ip ? addressType : 4;
         listen(self, ip, port, addressType, backlog, undefined, exclusive);
@@ -1413,8 +1405,7 @@ function onconnection(err, clientHandle) {
   debug('onconnection');
 
   if (err) {
-    self.emit('error', errnoException(err, 'accept'));
-    return;
+    return process.nextTick(emitError, self, errnoException(err, 'accept'));
   }
 
   if (self.maxConnections && self._connections >= self.maxConnections) {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -6,6 +6,7 @@ const TTY = process.binding('tty_wrap').TTY;
 const isTTY = process.binding('tty_wrap').isTTY;
 const inherits = util.inherits;
 const errnoException = util._errnoException;
+const emitError = require('internal/util').emitError;
 
 
 exports.isatty = function(fd) {
@@ -68,8 +69,8 @@ WriteStream.prototype._refreshSize = function() {
   var winSize = [];
   var err = this._handle.getWindowSize(winSize);
   if (err) {
-    this.emit('error', errnoException(err, 'getWindowSize'));
-    return;
+    const er = errnoException(err, 'getWindowSize');
+    return process.nextTick(emitError, this, er);
   }
   var newCols = winSize[0];
   var newRows = winSize[1];

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -363,6 +363,9 @@ function Zlib(opts, mode) {
     var error = new Error(message);
     error.errno = errno;
     error.code = exports.codes[errno];
+    // TODO: Can't defer the error emission to nextTick because both the sync
+    // and the async versions depend on this code. Sync versions want this
+    // error to be emitted immediately, so that it is handled in `_processChunk`
     self.emit('error', error);
   };
 

--- a/test/parallel/test-child-process-disconnect.js
+++ b/test/parallel/test-child-process-disconnect.js
@@ -77,7 +77,13 @@ if (process.argv[2] === 'child') {
         // ready to be disconnected
         if (data === 'ready') {
           child.disconnect();
-          assert.throws(child.disconnect.bind(child), Error);
+
+          // following call will throw an error, as it is already disconnected
+          // and that will be caught in the error event handler, in the nextTick
+          child.disconnect();
+          child.once('error', common.mustCall((e) =>
+            assert(/IPC channel is already disconnected/.test(e))));
+
           return;
         }
 

--- a/test/parallel/test-child-process-exec-error.js
+++ b/test/parallel/test-child-process-exec-error.js
@@ -4,23 +4,19 @@ var assert = require('assert');
 var child_process = require('child_process');
 
 function test(fun, code) {
-  var errors = 0;
-
-  fun('does-not-exist', function(err) {
-    assert.equal(err.code, code);
-    assert(/does\-not\-exist/.test(err.cmd));
-    errors++;
-  });
-
-  process.on('exit', function() {
-    assert.equal(errors, 1);
-  });
+  child_process[fun]('does-not-exist', common.mustCall(function(er, _, stderr) {
+    assert.equal(er.code, code);
+    assert(/does\-not\-exist/.test(er.cmd));
+    if (fun === 'exec') {
+      assert(/does-not-exist: not found/.test(stderr));
+    }
+  }));
 }
 
 if (common.isWindows) {
-  test(child_process.exec, 1); // exit code of cmd.exe
+  test('exec', 1); // exit code of cmd.exe
 } else {
-  test(child_process.exec, 127); // exit code of /bin/sh
+  test('exec', 127); // exit code of /bin/sh
 }
 
-test(child_process.execFile, 'ENOENT');
+test('execFile', 'ENOENT');

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var W = require('_stream_writable');
 var D = require('_stream_duplex');
 var assert = require('assert');
@@ -281,13 +281,11 @@ test('encoding should be ignored for buffers', function(t) {
 test('writables are not pipable', function(t) {
   var w = new W();
   w._write = function() {};
-  var gotError = false;
-  w.on('error', function(er) {
-    gotError = true;
-  });
+  w.on('error', common.mustCall((e) => {
+    assert(/Cannot pipe, not readable/.test(e));
+    t.end();
+  }));
   w.pipe(process.stdout);
-  assert(gotError);
-  t.end();
 });
 
 test('duplexes are pipable', function(t) {


### PR DESCRIPTION
Similar to callbacks, `error` events also have to be emitted in the
nextTick, so that they will be guaranteed to work asynchronously. This
patch makes sure all the `error` events
1. use arrow functions consistently (this is chosen because they
    maintain the context and that would be useful more often)
2. are emitted in the `process.nextTick`

I added major label as well, as this changes the behaviour of the existing system.

Also, this removes few TODOs left by @isaacs and @bnoordhuis 
