### PR TITLE
debugger: fix debugger blocked main thread

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -37,6 +37,7 @@ exports.start = function start() {
     });
 
     agent.close();
+    agent.clients.forEach(client => client.destroy());
   };
 
   // Not used now, but anyway

--- a/src/debug-agent.cc
+++ b/src/debug-agent.cc
@@ -147,7 +147,7 @@ void Agent::Stop() {
   err = uv_thread_join(&thread_);
   CHECK_EQ(err, 0);
 
-  uv_close(reinterpret_cast<uv_handle_t*>(&child_signal_), nullptr);
+  uv_walk(&child_loop_, reinterpret_cast<uv_walk_cb>(uv_close), nullptr);
   uv_run(&child_loop_, UV_RUN_NOWAIT);
 
   err = uv_loop_close(&child_loop_);

--- a/test/debugger/test-debugger-stop.js
+++ b/test/debugger/test-debugger-stop.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const debug = require('_debugger');
+
+const fork = require('child_process').fork;
+
+const scriptToDebug = common.fixturesDir + '/debug-connect.js';
+
+var nodeProcess;
+
+try {
+  process._debugProcess(process.pid);
+} catch (ex) {
+  common.fail('Debugging should not fail');
+}
+
+
+nodeProcess = fork(scriptToDebug);
+nodeProcess.send({ pid: process.pid });
+
+nodeProcess.on('message', common.mustCall(function(m) {
+  process._debugEnd();
+  process.exit(0);
+}));

--- a/test/fixtures/debug-connect.js
+++ b/test/fixtures/debug-connect.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+const debug = require('_debugger');
+var pid;
+
+setTimeout(function() {
+  if (pid) process.kill(pid, 'SIGTERM');
+  throw new Error('timeout');
+}, 5000).unref();
+
+function connectToDebug() {
+  var c = new debug.Client();
+  c.connect(5858);
+  c.on('break', function(brk) {
+    c.reqContinue(function() {});
+  });
+}
+
+process.on('message', function(m) {
+  pid = m.pid;
+  connectToDebug();
+  process.send({ exit: 'exit' });
+});


### PR DESCRIPTION
see #2110 
Call `uv_walk` to close all handles， otherwise would meat error below.

> Assertion failed: ((err) == (0)), function Stop, file ../src/debug-agent.cc, line 156.
