### PR TITLE
Add @Trott to the CTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ information about the governance of the Node.js project, see
 * [rvagg](https://github.com/rvagg) - **Rod Vagg** &lt;rod@vagg.org&gt;
 * [shigeki](https://github.com/shigeki) - **Shigeki Ohtsu** &lt;ohtsu@iij.ad.jp&gt;
 * [trevnorris](https://github.com/trevnorris) - **Trevor Norris** &lt;trev.norris@gmail.com&gt;
+* [Trott](https://github.com/Trott) - **Rich Trott** &lt;rtrott@gmail.com&gt;
 
 ### Collaborators
 
@@ -425,7 +426,6 @@ information about the governance of the Node.js project, see
 * [thealphanerd](http://github.com/thealphanerd) - **Myles Borins** &lt;myles.borins@gmail.com&gt;
 * [thefourtheye](https://github.com/thefourtheye) - **Sakthipriyan Vairamani** &lt;thechargingvolcano@gmail.com&gt;
 * [thlorenz](https://github.com/thlorenz) - **Thorsten Lorenz** &lt;thlorenz@gmx.de&gt;
-* [Trott](https://github.com/Trott) - **Rich Trott** &lt;rtrott@gmail.com&gt;
 * [tunniclm](https://github.com/tunniclm) - **Mike Tunnicliffe** &lt;m.j.tunnicliffe@gmail.com&gt;
 * [vkurchatkin](https://github.com/vkurchatkin) - **Vladimir Kurchatkin** &lt;vladimir.kurchatkin@gmail.com&gt;
 * [yosuke-furukawa](https://github.com/yosuke-furukawa) - **Yosuke Furukawa** &lt;yosuke.furukawa@gmail.com&gt;


### PR DESCRIPTION
Further to #4750, this PR calls for a vote of the CTC on February 24th to accept @Trott to the CTC. @Trott has been participating in observer status on the CTC meetings for a few weeks now after being nominated.

@Trott: please let us know if you have any concerns about proceeding with this, here or in private.

@nodejs/ctc: feel free to raise any of your own concerns regarding @Trott's nomination, here or in private.