### PR TITLE
Add @ChALkeR to the CTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ information about the governance of the Node.js project, see
 ### TSC (Technical Steering Committee)
 
 * [bnoordhuis](https://github.com/bnoordhuis) - **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
+* [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt;
 * [chrisdickinson](https://github.com/chrisdickinson) - **Chris Dickinson** &lt;christopher.s.dickinson@gmail.com&gt;
 * [cjihrig](https://github.com/cjihrig) - **Colin Ihrig** &lt;cjihrig@gmail.com&gt;
 * [fishrock123](https://github.com/fishrock123) - **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
@@ -391,7 +392,6 @@ information about the governance of the Node.js project, see
 
 * [brendanashworth](https://github.com/brendanashworth) - **Brendan Ashworth** &lt;brendan.ashworth@me.com&gt;
 * [calvinmetcalf](https://github.com/calvinmetcalf) - **Calvin Metcalf** &lt;calvin.metcalf@gmail.com&gt;
-* [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич** &lt;chalkerx@gmail.com&gt;
 * [domenic](https://github.com/domenic) - **Domenic Denicola** &lt;d@domenic.me&gt;
 * [evanlucas](https://github.com/evanlucas) - **Evan Lucas** &lt;evanlucas@me.com&gt;
 * [geek](https://github.com/geek) - **Wyatt Preul** &lt;wpreul@gmail.com&gt;


### PR DESCRIPTION
Further to #4750, this PR calls for a vote of the CTC on February 24th to accept @ChALkeR to the CTC. @ChALkeR has been participating in observer status on the CTC meetings for a few weeks now after being nominated.

@ChALkeR: please let us know if you have any concerns about proceeding with this, here or in private.

@nodejs/ctc: feel free to raise any of your own concerns regarding @ChALkeR's nomination, here or in private.