### PR TITLE
test: mark test-http-regr-gh-2928 flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -14,6 +14,7 @@ test-vm-syntax-error-stderr : PASS,FLAKY
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS
+test-http-regr-gh-2928      : PASS,FLAKY
 
 [$system==freebsd]
 
@@ -22,4 +23,4 @@ test-vm-syntax-error-stderr : PASS,FLAKY
 # Tests are disabled so CI can be green and we can spot other
 # regressions until this work is complete
 [$system==aix]
-test-fs-watch                        : FAIL, PASS
+test-fs-watch               : FAIL,PASS


### PR DESCRIPTION
`test-http-regr-gh-2928` is flay on SmartOS in CI.

Refs: https://github.com/nodejs/node/issues/5264