### PR TITLE
doc: update process.send() signature

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -825,6 +825,8 @@ relied upon to exist.
 
 * `message` {Object}
 * `sendHandle` {Handle object}
+* `callback` {Function}
+* Return: {Boolean}
 
 When Node.js is spawned with an IPC channel attached, it can send messages to its
 parent process using `process.send()`. Each will be received as a


### PR DESCRIPTION
This commit brings the `process.send()` signature into sync with the `child_process.send()` documentation. Specifically, this commit adds the `callback` argument and return type to the docs.