### PR TITLE
doc: improve for httpVersionMajor & httpVersionMinor

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -941,8 +941,8 @@ In case of server request, the HTTP version sent by the client. In the case of
 client response, the HTTP version of the connected-to server.
 Probably either `'1.1'` or `'1.0'`.
 
-Also `response.httpVersionMajor` is the first integer and
-`response.httpVersionMinor` is the second.
+Also `message.httpVersionMajor` is the first integer and
+`message.httpVersionMinor` is the second.
 
 ### message.method
 


### PR DESCRIPTION
The description of httpVersionMajor & httpVersionMinor should
have same context like httpVersion.