### PR TITLE
Fix missing property in Cluster Ex.

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -624,6 +624,7 @@ cluster.setupMaster({
 });
 cluster.fork(); // https worker
 cluster.setupMaster({
+  exec: 'worker.js',
   args: ['--use', 'http']
 });
 cluster.fork(); // http worker


### PR DESCRIPTION
`Cluster.setupMaster(options)` Options object was missing an `args` property on the example.