### PR TITLE
Fix typo in pbkdf2Sync code sample

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -1128,7 +1128,7 @@ Example:
 
 ```js
 const crypto = require('crypto');
-const key = crypto.pbkdf2sync('secret', 'salt', 100000, 512, 'sha512');
+const key = crypto.pbkdf2Sync('secret', 'salt', 100000, 512, 'sha512');
 console.log(key.toString('hex'));  // 'c5e478d...1469e50'
 ```
 


### PR DESCRIPTION
Function name in code sample had the wrong capitalization.