### PR TITLE
doc: clarify child_process.execFile{,Sync} file argument

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -184,7 +184,7 @@ replace the existing process and uses a shell to execute the command.*
 
 ### child_process.execFile(file[, args][, options][, callback])
 
-* `file` {String} A path to an executable file
+* `file` {String} The name or path of the executable file to run
 * `args` {Array} List of string arguments
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
@@ -502,7 +502,7 @@ configuration at startup.
 
 ### child_process.execFileSync(file[, args][, options])
 
-* `file` {String} The filename of the program to run
+* `file` {String} The name or path of the executable file to run
 * `args` {Array} List of string arguments
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process


### PR DESCRIPTION
This may be a bit of a nit, but I thought it was worth fixing for clarity.

The changes to the `file` argument of `execFile` in #4504 make it appear that `execFile` requires an absolute or relative path to the executable file, when in fact it also supports a filename which will be resolved using `$PATH`.  Although the example clarifies this somewhat, assuming there isn't a `node` binary in `$CWD`, it's easy to overlook.  This commit clarifies that point.

It also updates the argument description for `execFileSync` to match, since it was overlooked in #4504 and behaves identically.

Thanks for considering,
Kevin