### PR TITLE
test: use String.prototype.repeat() for clarity

### DIFF
--- a/test/parallel/test-crypto-from-binary.js
+++ b/test/parallel/test-crypto-from-binary.js
@@ -19,7 +19,7 @@ var ucs2_control = 'a\u0000';
 
 // grow the strings to proper length
 while (ucs2_control.length <= EXTERN_APEX) {
-  ucs2_control += ucs2_control;
+  ucs2_control = ucs2_control.repeat(2);
 }
 
 

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -10,12 +10,7 @@ if (common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
 }
 
-var host = '********';
-host += host;
-host += host;
-host += host;
-host += host;
-host += host;
+var host = '*'.repeat(256);
 
 function do_not_call() {
   throw new Error('This function should not have been called.');

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -245,7 +245,7 @@ function expectBody(expected) {
 (function() {
   // 256 X-Filler headers
   var lots_of_headers = 'X-Filler: 42' + CRLF;
-  for (var i = 0; i < 8; ++i) lots_of_headers += lots_of_headers;
+  lots_of_headers = lots_of_headers.repeat(256);
 
   var request = Buffer(
       'GET /foo/bar/baz?quux=42#1337 HTTP/1.0' + CRLF +

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -7,12 +7,7 @@ var net = require('net');
 var expected_bad_connections = 1;
 var actual_bad_connections = 0;
 
-var host = '********';
-host += host;
-host += host;
-host += host;
-host += host;
-host += host;
+var host = '*'.repeat(256);
 
 function do_not_call() {
   throw new Error('This function should not have been called.');


### PR DESCRIPTION
There are a few places where tests repeatedly concatenate strings to
themselves in order to make them very long. Using `.repeat()` makes the
code clearer.

For example, before:

    for (var i = 0; i < 8; ++i) lots_of_headers += lots_of_headers;

After:

    lots_of_headers = lots_of_headers.repeat(256);

Using `.repeat()` makes it clear that the string will be repeated 256
times rather than 8 times. ("What?! That first one doesn't repeat 256
times! It only repeats 8... Oh, wait. Yes, I see your point now.")