### PR TITLE
debugger: remove unneeded callback check

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -568,7 +568,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
 
       waitForOthers();
       function waitForOthers() {
-        if (--waiting === 0 && cb) {
+        if (--waiting === 0) {
           keyValues.forEach(function(kv) {
             mirror[kv.name] = kv.value;
           });


### PR DESCRIPTION
In `lib/_debugger.js`, remove check for `cb` in line 571 as it is guaranteed to be truthy due to line 521.
