### PR TITLE
tools: add Node.js-specific ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,18 @@ rules:
   no-octal: 2
   no-redeclare: 2
 
+  # Variables
+  # http://eslint.org/docs/rules/#variables
+  no-delete-var: 2
+  no-undef: 2
+  no-unused-vars: [2, {"args": "none"}]
+
+  # Node.js and CommonJS
+  # http://eslint.org/docs/rules/#nodejs-and-commonjs
+  no-mixed-requires: 2
+  no-new-require: 2
+  no-restricted-modules: [2, "sys", "_linklist"]
+
   # Stylistic Issues
   # https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
   comma-spacing: 2
@@ -65,12 +77,6 @@ rules:
   # Strict Mode
   # https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
   strict: [2, "global"]
-
-  # Variables
-  # https://github.com/eslint/eslint/tree/master/docs/rules#variables
-  no-delete-var: 2
-  no-undef: 2
-  no-unused-vars: [2, {"args": "none"}]
 
   # Custom rules in tools/eslint-rules
   require-buffer: 2

--- a/test/parallel/test-sys.js
+++ b/test/parallel/test-sys.js
@@ -1,7 +1,7 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-var sys = require('sys');
+var sys = require('sys'); // eslint-disable-line no-restricted-modules
 var util = require('util');
 
 assert.strictEqual(sys, util);

--- a/test/parallel/test-timers-linked-list.js
+++ b/test/parallel/test-timers-linked-list.js
@@ -4,7 +4,7 @@
 
 require('../common');
 const assert = require('assert');
-const L = require('_linklist');
+const L = require('_linklist'); // eslint-disable-line no-restricted-modules
 const internalL = require('internal/linkedlist');
 
 assert.strictEqual(L, internalL);


### PR DESCRIPTION
Add these rules:

* no-restricted-modules: See
http://eslint.org/docs/rules/no-restricted-modules. It has been
configured to prohibit the use of the deprecated `sys` and `_linklist`
modules.
* no-new-require: See http://eslint.org/docs/rules/no-new-require
* no-mixed-requires: http://eslint.org/docs/rules/no-mixed-requires