### PR TITLE
doc: vm, run http server in vm by requiring

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -304,6 +304,39 @@ e.g. `(0,eval)('code')`. However, it also has the following additional options:
 - `timeout`: a number of milliseconds to execute `code` before terminating
   execution. If execution is terminated, an [`Error`][] will be thrown.
 
+## Example: Run a Server within a VM
+
+The context of `.runInThisContext()` refers to the V8 context. The code passed
+to this VM context will have it's own isolated scope. To run a simple web server
+using the `http` module, for instance, the code passed to the context must either
+call `require('http')` on its own, or have a reference to the `http` module passed
+to it. For instance:
+
+```js
+'use strict';
+const vm = require('vm');
+
+let code =
+`(function(require) {
+
+   const http = require('http');
+
+   http.createServer( (request, response) => {
+     response.writeHead(200, {'Content-Type': 'text/plain'});
+     response.end('Hello World\\n');
+   }).listen(8124);
+
+   console.log('Server running at http://127.0.0.1:8124/');
+ })`;
+
+ vm.runInThisContext(code)(require);
+ ```   
+
+_Note: `require()` in the above case shares the state with context it is passed
+from. This might introduce risks when unknown code is executed, e.g. altering
+objects from the calling thread's context in unwanted ways. It is advisable to
+run `vm` code in a separate process._
+
 [indirect `eval()` call]: https://es5.github.io/#x10.4.2
 [global object]: https://es5.github.io/#x15.1
 [`Error`]: errors.html#errors_class_error


### PR DESCRIPTION
As user in order to run `node` code in a `vm`, you would need to apply some objects to it. This is not quite well documented and may or may not have been reason for a series of issues and SO questions.

This PR would add an example to explain this. It is to some extent controversial and was discussed in a code PR https://github.com/nodejs/node/pull/4955. Issue would have been https://github.com/nodejs/node-v0.x-archive/issues/9211 and [this link to SO](http://stackoverflow.com/questions/20899863/the-module-property-is-undefined-when-using-vm-runinthiscontext).

An easier solution would be to use `eval()`, which I regard as an anti-pattern.
~~Also it uses `require('module').wrap(code)`, which I believe to be a "private" API.~~ I have taken and modified this example from the referenced issues.

/cc @nodejs/documentation 