### PR TITLE
doc: `require` behavior on case-insensitive systems

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -212,6 +212,12 @@ module (loading from `node_modules` folders), it is not a *guarantee*
 that `require('foo')` will always return the exact same object, if it
 would resolve to different files.
 
+Additionally, on case-insensitive file systems or operating systems, different
+resolved filenames can point to the same file, but the cache will still treat
+them as different modules and will reload the file multiple times. For example,
+`require('./foo')` and `require('./FOO')` return two different objects,
+irrespective of whether or not `./foo` and `./FOO` are the same file.
+
 ## Core Modules
 
 <!--type=misc-->


### PR DESCRIPTION
See #5143 and https://github.com/nodejs/node-v0.x-archive/issues/6829.

This adds a paragraph in the `Module Caching Caveats` section about the behavior of `require` when Node is running on top of a file system (e.g. HFS) or operating system (e.g. Windows) that will not consider the case of file paths to find files.

The goal is to make the behavior unambiguously clear, even though the previous paragraph might hint to the same caveat (to be honest, [I'm not sure I understand that previous paragraph](https://github.com/nodejs/node/issues/5143#issuecomment-186387706)).

What do you think?

And thanks for making Node!