### PR TITLE
Add the fs.mkdtemp() function.

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -522,6 +522,30 @@ to the completion callback. `mode` defaults to `0o777`.
 
 Synchronous mkdir(2). Returns `undefined`.
 
+## fs.mkdtemp(prefix, callback)
+
+Creates a unique temporary directory.
+
+Generates six random characters to be appended behind a required
+`prefix` to create a unique temporary directory.
+
+The created folder path is passed as a string to the callback's second
+parameter.
+
+Example:
+
+```js
+fs.mkdtemp('/tmp/foo-', (err, folder) => {
+  console.log(folder);
+    // Prints: /tmp/foo-itXde2
+});
+```
+
+## fs.mkdtempSync(template)
+
+The synchronous version of [`fs.mkdtemp()`][]. Returns the created
+folder path.
+
 ## fs.open(path, flags[, mode], callback)
 
 Asynchronous file open. See open(2). `flags` can be:

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2138,3 +2138,24 @@ SyncWriteStream.prototype.destroy = function() {
 };
 
 SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
+
+fs.mkdtemp = function(prefix, callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('"callback" argument must be a function');
+  }
+
+  if (!nullCheck(prefix, callback)) {
+    return;
+  }
+
+  var req = new FSReqWrap();
+  req.oncomplete = callback;
+
+  binding.mkdtemp(prefix + 'XXXXXX', req);
+};
+
+fs.mkdtempSync = function(prefix) {
+  nullCheck(prefix);
+
+  return binding.mkdtemp(prefix + 'XXXXXX');
+};

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -200,6 +200,11 @@ static void After(uv_fs_t *req) {
                                    static_cast<const uv_stat_t*>(req->ptr));
         break;
 
+      case UV_FS_MKDTEMP:
+        argv[1] = String::NewFromUtf8(env->isolate(),
+                                      static_cast<const char*>(req->path));
+        break;
+
       case UV_FS_READLINK:
         argv[1] = String::NewFromUtf8(env->isolate(),
                                       static_cast<const char*>(req->ptr));
@@ -1291,6 +1296,25 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  if (args.Length() < 1)
+    return TYPE_ERROR("template is required");
+  if (!args[0]->IsString())
+    return TYPE_ERROR("template must be a string");
+
+  node::Utf8Value tmpl(env->isolate(), args[0]);
+
+  if (args[1]->IsObject()) {
+    ASYNC_CALL(mkdtemp, args[1], *tmpl);
+  } else {
+    SYNC_CALL(mkdtemp, *tmpl, *tmpl);
+    args.GetReturnValue().Set(String::NewFromUtf8(env->isolate(),
+                                                  SYNC_REQ.path));
+  }
+}
+
 void FSInitialize(const FunctionCallbackInfo<Value>& args) {
   Local<Function> stats_constructor = args[0].As<Function>();
   CHECK(stats_constructor->IsFunction());
@@ -1343,6 +1367,8 @@ void InitFs(Local<Object> target,
 
   env->SetMethod(target, "utimes", UTimes);
   env->SetMethod(target, "futimes", FUTimes);
+
+  env->SetMethod(target, "mkdtemp", Mkdtemp);
 
   StatWatcher::Initialize(env, target);
 

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const Buffer = require('buffer').Buffer;
+
+common.refreshTmpDir();
+
+const tmpFolder = fs.mkdtempSync(path.join(common.tmpDir, 'foo.'));
+
+assert(path.basename(tmpFolder).length === 'foo.XXXXXX'.length);
+assert(common.fileExists(tmpFolder));
+
+const utf8 = fs.mkdtempSync(path.join(common.tmpDir, '\u0222abc.'));
+assert.equal(Buffer.byteLength(path.basename(utf8)),
+             Buffer.byteLength('\u0222abc.XXXXXX'));
+assert(common.fileExists(utf8));
+
+fs.mkdtemp(
+    path.join(common.tmpDir, 'bar.'),
+    common.mustCall(function(err, folder) {
+      assert.ifError(err);
+      assert(common.fileExists(folder));
+    })
+);


### PR DESCRIPTION
Follow up on #5332 

This PR only implements `mkdtemp` since libuv only provides it. (cf. https://github.com/joyent/libuv/pull/1368)

Implementing `mkstemp` would require having it in libuv first, so I guess this can wait. I'd argue that the most common use case is creating a temporary directory anyway.