### PR TITLE
module: cache and return effective module exports from linked bindings on first call

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2450,9 +2450,10 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Linked module has no declared entry point.");
   }
 
-  cache->Set(module_name, module->Get(exports_prop));
+  auto effective_exports = module->Get(exports_prop);
+  cache->Set(module_name, effective_exports);
 
-  args.GetReturnValue().Set(exports);
+  args.GetReturnValue().Set(effective_exports);
 }
 
 static void ProcessTitleGetter(Local<String> property,


### PR DESCRIPTION
Related to fix #4771 of #4756

In #4771 the correct `exports` object goes to the cache, but on the first call of `LinkedBinding` another (precreated) `exports` object returned as result. :neutral_face: 