### PR TITLE
test: refactor test-dgram-udp4

### DIFF
--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -4,57 +4,29 @@ const assert = require('assert');
 const dgram = require('dgram');
 const server_port = common.PORT;
 const message_to_send = 'A message to send';
-let client;
-let timer;
 
 const server = dgram.createSocket('udp4');
-server.on('message', function(msg, rinfo) {
-  console.log('server got: ' + msg +
-              ' from ' + rinfo.address + ':' + rinfo.port);
+server.on('message', common.mustCall((msg, rinfo) => {
   assert.strictEqual(rinfo.address, common.localhostIPv4);
   assert.strictEqual(msg.toString(), message_to_send.toString());
   server.send(msg, 0, msg.length, rinfo.port, rinfo.address);
-});
-server.on('listening', function() {
-  var address = server.address();
-  console.log('server is listening on ' + address.address + ':' + address.port);
-  client = dgram.createSocket('udp4');
-  client.on('message', function(msg, rinfo) {
-    console.log('client got: ' + msg +
-                ' from ' + rinfo.address + ':' + address.port);
+}));
+server.on('listening', common.mustCall(() => {
+  const client = dgram.createSocket('udp4');
+  client.on('message', common.mustCall((msg, rinfo) => {
     assert.strictEqual(rinfo.address, common.localhostIPv4);
     assert.strictEqual(rinfo.port, server_port);
     assert.strictEqual(msg.toString(), message_to_send.toString());
     client.close();
     server.close();
-  });
-  client.send(
-    message_to_send,
-    0,
-    message_to_send.length,
-    server_port,
-    'localhost',
-    function(err) {
-      if (err) {
-        console.log('Caught error in client send.');
-        throw err;
-      }
-    }
-  );
-  client.on('close',
-            function() {
-              if (server.fd === null) {
-                clearTimeout(timer);
-              }
-            });
-});
-server.on('close', function() {
-  if (client.fd === null) {
-    clearTimeout(timer);
-  }
-});
+  }));
+  client.send(message_to_send,
+              0,
+              message_to_send.length,
+              server_port,
+              'localhost');
+  client.on('close', common.mustCall(() => {}));
+}));
+server.on('close', common.mustCall(() => {}));
 server.bind(server_port);
 
-timer = setTimeout(function() {
-  throw new Error('Timeout');
-}, common.platformTimeout(200));


### PR DESCRIPTION
This test was sometimes timing out in `OS X`. Remove the timeout and
clean up the code.

This test has failed in my `OS X` box with this error:
```
=== release test-dgram-udp4 ===                                                
Path: parallel/test-dgram-udp4
server is listening on 0.0.0.0:12446
/Users/sgimeno/node/node/test/parallel/test-dgram-udp4.js:59
  throw new Error('Timeout');
  ^

Error: Timeout
    at null._onTimeout (/Users/sgimeno/node/node/test/parallel/test-dgram-udp4.js:59:9)
    at Timer.listOnTimeout (timers.js:92:15)
Command: out/Release/node /Users/sgimeno/node/node/test/parallel/test-dgram-udp4.js
```