### PR TITLE
test: fix flaky http-end-throw-socket-handling

### DIFF
--- a/test/parallel/test-http-end-throw-socket-handling.js
+++ b/test/parallel/test-http-end-throw-socket-handling.js
@@ -30,11 +30,6 @@ server.listen(common.PORT, function() {
   }
 });
 
-setTimeout(function() {
-  process.removeListener('uncaughtException', catcher);
-  throw new Error('Taking too long!');
-}, common.platformTimeout(1000)).unref();
-
 process.on('uncaughtException', catcher);
 var errors = 0;
 function catcher() {


### PR DESCRIPTION
This test was sometimes failing because the internal timeout was fired
before the test completed. The reason was that sometimes some of the
connections were taking longer to be established. Removing the timeout
seems to fix the issue.

The trace I was getting on `OS X` was this:
```
=== release test-http-end-throw-socket-handling ===                     
Path: parallel/test-http-end-throw-socket-handling
/Users/sgimeno/node/node/test/parallel/test-http-end-throw-socket-handling.js:35
  throw new Error('Taking too long!');
  ^

Error: Taking too long!
    at null._onTimeout (/Users/sgimeno/node/node/test/parallel/test-http-end-throw-socket-handling.js:35:9)
    at Timer.unrefdHandle (timers.js:321:14)
```
The issue looks similar to the one that I observed on `test-net-socket-timeout-unref`: https://github.com/nodejs/node/commit/538813c45547d281e912b0e022f617baf2557791. Sometimes, when running the test suite, some TCP connections take a long time to be established (up to 5 seconds sometimes) (At least on my `OS X` box)