### PR TITLE
vm: fix `produceCachedData`

### DIFF
--- a/doc/api/vm.markdown
+++ b/doc/api/vm.markdown
@@ -41,9 +41,12 @@ The options when creating a script are:
 - `cachedData`: an optional `Buffer` with V8's code cache data for the supplied
   source. When supplied `cachedDataRejected` value will be set to either
   `true` or `false` depending on acceptance of the data by V8.
-- `produceCachedData`: if `true` and no `cachedData` is present - a `Buffer`
-  with V8's code cache data will be produced and stored in `cachedData` property
-  of the returned `vm.Script` instance.
+- `produceCachedData`: if `true` and no `cachedData` is present - V8 tries to
+  produce code cache data for `code`. Upon success, a `Buffer` with V8's code
+  cache data will be produced and stored in `cachedData` property of the
+  returned `vm.Script` instance. `cachedDataProduced` value will be set to
+  either `true` or `false` depending on whether code cache data is produced
+  successfully.
 
 ### script.runInContext(contextifiedSandbox[, options])
 

--- a/src/env.h
+++ b/src/env.h
@@ -72,6 +72,7 @@ namespace node {
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
   V(cached_data_string, "cachedData")                                         \
+  V(cached_data_produced_string, "cachedDataProduced")                        \
   V(cached_data_rejected_string, "cachedDataRejected")                        \
   V(callback_string, "callback")                                              \
   V(change_string, "change")                                                  \

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -545,7 +545,7 @@ class ContextifyScript : public BaseObject {
           Boolean::New(env->isolate(), source.GetCachedData()->rejected));
     } else if (compile_options == ScriptCompiler::kProduceCodeCache) {
       const ScriptCompiler::CachedData* cached_data = source.GetCachedData();
-      bool cached_data_produced = (cached_data != nullptr);
+      bool cached_data_produced = cached_data != nullptr;
       if (cached_data_produced) {
         MaybeLocal<Object> buf = Buffer::Copy(
             env,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -545,11 +545,17 @@ class ContextifyScript : public BaseObject {
           Boolean::New(env->isolate(), source.GetCachedData()->rejected));
     } else if (compile_options == ScriptCompiler::kProduceCodeCache) {
       const ScriptCompiler::CachedData* cached_data = source.GetCachedData();
-      MaybeLocal<Object> buf = Buffer::Copy(
-          env,
-          reinterpret_cast<const char*>(cached_data->data),
-          cached_data->length);
-      args.This()->Set(env->cached_data_string(), buf.ToLocalChecked());
+      bool cached_data_produced = (cached_data != nullptr);
+      if (cached_data_produced) {
+        MaybeLocal<Object> buf = Buffer::Copy(
+            env,
+            reinterpret_cast<const char*>(cached_data->data),
+            cached_data->length);
+        args.This()->Set(env->cached_data_string(), buf.ToLocalChecked());
+      }
+      args.This()->Set(
+          env->cached_data_produced_string(),
+          Boolean::New(env->isolate(), cached_data_produced));
     }
   }
 

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -12,7 +12,7 @@ function produce(source) {
   const script = new vm.Script(source, {
     produceCachedData: true
   });
-  assert(script.cachedData instanceof Buffer);
+  assert(!script.cachedDataProduced || script.cachedData instanceof Buffer);
 
   return script.cachedData;
 }
@@ -30,6 +30,15 @@ function testProduceConsume() {
   assert.equal(script.runInThisContext()(), 'original');
 }
 testProduceConsume();
+
+function testProduceMultiple() {
+  const source = getSource('original');
+
+  produce(source);
+  produce(source);
+  produce(source);
+}
+testProduceMultiple();
 
 function testRejectInvalid() {
   const source = getSource('invalid');


### PR DESCRIPTION
Fix segmentation faults when compiling the same code with
`produceCachedData` option. V8 ignores the option when the code is in its
compilation cache and does not return cached data. Added
`cachedDataProduced` property to `v8.Script` to denote whether the cached
data is produced successfully.