### PR TITLE
test: mitigate flaky test-http-agent

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -11,9 +11,8 @@ test-tls-ticket-cluster : PASS,FLAKY
 test-tick-processor     : PASS,FLAKY
 
 [$system==linux]
-test-http-agent         : PASS,FLAKY
 test-process-getactivehandles : PASS,FLAKY
-test-tick-processor     : PASS,FLAKY
+test-tick-processor           : PASS,FLAKY
 
 [$system==macos]
 

--- a/test/parallel/test-http-agent.js
+++ b/test/parallel/test-http-agent.js
@@ -9,8 +9,8 @@ var server = http.Server(function(req, res) {
 });
 
 var responses = 0;
-var N = 10;
-var M = 10;
+var N = 4;
+var M = 4;
 
 server.listen(common.PORT, function() {
   for (var i = 0; i < N; i++) {


### PR DESCRIPTION
Reduce number of clients from 100 to 16 as Raspberry Pi in CI starts to
exhibit flakiness around 22 or so clients.

Fixes: https://github.com/nodejs/node/issues/5184