### PR TITLE
tools: enable additional lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@ env:
 rules:
   # Possible Errors
   # https://github.com/eslint/eslint/tree/master/docs/rules#possible-errors
+  comma-dangle: [2, "only-multiline"]
   no-control-regex: 2
   no-debugger: 2
   no-dupe-args: 2
@@ -30,6 +31,7 @@ rules:
   no-fallthrough: 2
   no-octal: 2
   no-redeclare: 2
+  no-unused-labels: 2
 
   # Variables
   # http://eslint.org/docs/rules/#variables
@@ -41,6 +43,7 @@ rules:
   # http://eslint.org/docs/rules/#nodejs-and-commonjs
   no-mixed-requires: 2
   no-new-require: 2
+  no-path-concat: 2
   no-restricted-modules: [2, "sys", "_linklist"]
 
   # Stylistic Issues
@@ -71,6 +74,7 @@ rules:
   no-confusing-arrow: 2
   no-const-assign: 2
   no-dupe-class-members: 2
+  no-new-symbol: 2
   no-this-before-super: 2
   prefer-const: 2
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var doesNotExist = __filename + '__this_should_not_exist';
+var doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
 var readOnlyFile = path.join(common.tmpDir, 'read_only_file');
 var readWriteFile = path.join(common.tmpDir, 'read_write_file');
 

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -68,7 +68,7 @@ fs.open('.', 'r', undefined, function(err, fd) {
   fs.close(fd);
 });
 
-console.log('stating: ' + __filename);
+console.log(`stating:  ${__filename}`);
 fs.stat(__filename, function(err, s) {
   if (err) {
     got_error = true;

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -18,7 +18,7 @@ if (process.argv[2] === 'child') {
 }
 
 // Run the script in a shell but close stdout and stderr.
-var cmd = '"' + process.execPath + '" "' + __filename + '" child 1>&- 2>&-';
+var cmd = `"${process.execPath}" "${__filename}" child 1>&- 2>&-`;
 var proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
 
 proc.on('exit', common.mustCall(function(exitCode) {


### PR DESCRIPTION
Enable additional likely-uncontroversial lint rules:

* `comma-dangle` set to prohibit dangling commas on objects and arrays
that are defined on a single line. Multi-line definitions can use or
omit a trailing comma.

* `no-unused-labels` Prohibits defining a label that is not used.

* `no-path-concat` Prohibits string-concatenation using `__dirname` and
`__filename`. Use `path.join()`, `path.resolve()`, or template strings
instead.

* `no-new-symbol` disallow use of `new` operator with `Symbol` object.
Violating this rule would result in a `TypeError` at runtime.