### PR TITLE
doc: fix relative links in net docs

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -107,7 +107,7 @@ The last parameter `callback` will be added as a listener for the
 [`'listening'`][] event.
 
 The parameter `backlog` behaves the same as in
-[`server.listen(port, \[host\], \[backlog\], \[callback\])`][].
+[`server.listen(port[, hostname][, backlog][, callback])`][`server.listen(port, host, backlog, callback)`].
 
 ### server.listen(options[, callback])
 
@@ -121,8 +121,8 @@ The parameter `backlog` behaves the same as in
 
 The `port`, `host`, and `backlog` properties of `options`, as well as the
 optional callback function, behave as they do on a call to
-[`server.listen(port, \[host\], \[backlog\], \[callback\])`][]. Alternatively,
-the `path` option can be used to specify a UNIX socket.
+[`server.listen(port[, hostname][, backlog][, callback])`][`server.listen(port, host, backlog, callback)`].
+Alternatively, the `path` option can be used to specify a UNIX socket.
 
 If `exclusive` is `false` (default), then cluster workers will use the same
 underlying handle, allowing connection handling duties to be shared. When
@@ -167,7 +167,7 @@ double-backslashes, such as:
         path.join('\\\\?\\pipe', process.cwd(), 'myctl'))
 
 The parameter `backlog` behaves the same as in
-[`server.listen(port, \[host\], \[backlog\], \[callback\])`][].
+[`server.listen(port[, hostname][, backlog][, callback])`][`server.listen(port, host, backlog, callback)`].
 
 ### server.listen(port[, hostname][, backlog][, callback])
 
@@ -392,7 +392,7 @@ The `connectListener` parameter will be added as a listener for the
 ### socket.connect(path[, connectListener])
 ### socket.connect(port[, host][, connectListener])
 
-As [`socket.connect(options\[, connectListener\])`][],
+As [`socket.connect(options\[, connectListener\])`][`socket.connect(options, connectListener)`],
 with options either as either `{port: port, host: host}` or `{path: path}`.
 
 ### socket.destroy()
@@ -723,8 +723,8 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`pause()`]: #net_socket_pause
 [`resume()`]: #net_socket_resume
 [`server.getConnections()`]: #net_server_getconnections_callback
-[`server.listen(port, \[host\], \[backlog\], \[callback\])`]: #net_server_listen_port_hostname_backlog_callback
-[`socket.connect(options\[, connectListener\])`]: #net_socket_connect_options_connectlistener
+[`server.listen(port, host, backlog, callback)`]: #net_server_listen_port_hostname_backlog_callback
+[`socket.connect(options, connectListener)`]: #net_socket_connect_options_connectlistener
 [`socket.connect`]: #net_socket_connect_options_connectlistener
 [`socket.setTimeout()`]: #net_socket_settimeout_timeout_callback
 [`stream.setEncoding()`]: stream.html#stream_readable_setencoding_encoding


### PR DESCRIPTION
They were not being processed as relative links. Marked apparently does not like square brackets inside of relative links.

![screen shot 2016-02-22 at 1 29 31 am](https://cloud.githubusercontent.com/assets/677994/13212079/e28b0fd2-d903-11e5-9a60-2aa590895655.png)
