### PR TITLE
util: improve util.format performance

### DIFF
--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const util = require('util');
+const common = require('../common');
+const v8 = require('v8');
+const bench = common.createBenchmark(main, {
+  n: [1e6]
+, type: ['string',
+         'number',
+         'object',
+         'unknown',
+         'no-replace']
+});
+
+const inputs = {
+  'string': ['Hello, my name is %s', 'fred'],
+  'number': ['Hi, I was born in %d', 1942],
+  'object': ['An error occurred %j', {msg: 'This is an error', code: 'ERR'}],
+  'unknown': ['hello %a', 'test'],
+  'no-replace': [1, 2]
+};
+
+function main(conf) {
+  const n = conf.n | 0;
+  const type = conf.type;
+
+  const input = inputs[type];
+
+  v8.setFlagsFromString('--allow_natives_syntax');
+
+  util.format(input[0], input[1]);
+  eval('%OptimizeFunctionOnNextCall(util.format)');
+  util.format(input[0], input[1]);
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    util.format(input[0], input[1]);
+  }
+  bench.end(n);
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,39 +9,48 @@ const isError = internalUtil.isError;
 
 var Debug;
 
+function tryStringify(arg) {
+  try {
+    return JSON.stringify(arg);
+  } catch (_) {
+    return '[Circular]';
+  }
+}
+
 const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (typeof f !== 'string') {
-    var objects = [];
+    const objects = new Array(arguments.length);
     for (var index = 0; index < arguments.length; index++) {
-      objects.push(inspect(arguments[index]));
+      objects[index] = inspect(arguments[index]);
     }
     return objects.join(' ');
   }
 
   if (arguments.length === 1) return f;
 
-  var i = 1;
-  var args = arguments;
-  var len = args.length;
-  var str = String(f).replace(formatRegExp, function(x) {
+  const len = arguments.length;
+  const args = new Array(len);
+  var i;
+  for (i = 0; i < len; i++) {
+    args[i] = arguments[i];
+  }
+
+  i = 1;
+  var str = f.replace(formatRegExp, function(x) {
     if (x === '%%') return '%';
     if (i >= len) return x;
     switch (x) {
       case '%s': return String(args[i++]);
       case '%d': return Number(args[i++]);
-      case '%j':
-        try {
-          return JSON.stringify(args[i++]);
-        } catch (_) {
-          return '[Circular]';
-        }
+      case '%j': return tryStringify(args[i++]);
         // falls through
       default:
         return x;
     }
   });
-  for (var x = args[i]; i < len; x = args[++i]) {
+  while (i < len) {
+    const x = args[i++];
     if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
       str += ' ' + x;
     } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,6 @@ function tryStringify(arg) {
   }
 }
 
-const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (typeof f !== 'string') {
     const objects = new Array(arguments.length);
@@ -27,30 +26,56 @@ exports.format = function(f) {
     return objects.join(' ');
   }
 
-  if (arguments.length === 1) return f;
+  var argLen = arguments.length;
 
-  const len = arguments.length;
-  const args = new Array(len);
-  var i;
-  for (i = 0; i < len; i++) {
-    args[i] = arguments[i];
-  }
+  if (argLen === 1) return f;
 
-  i = 1;
-  var str = f.replace(formatRegExp, function(x) {
-    if (x === '%%') return '%';
-    if (i >= len) return x;
-    switch (x) {
-      case '%s': return String(args[i++]);
-      case '%d': return Number(args[i++]);
-      case '%j': return tryStringify(args[i++]);
-        // falls through
-      default:
-        return x;
+  var str = '';
+  var a = 1;
+  var lastPos = 0;
+  for (var i = 0; i < f.length;) {
+    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
+      switch (f.charCodeAt(i + 1)) {
+        case 100: // 'd'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += Number(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 106: // 'j'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += tryStringify(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 115: // 's'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += String(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 37: // '%'
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += '%';
+          lastPos = i = i + 2;
+          continue;
+      }
     }
-  });
-  while (i < len) {
-    const x = args[i++];
+    ++i;
+  }
+  if (lastPos === 0)
+    str = f;
+  else if (lastPos < f.length)
+    str += f.slice(lastPos);
+  while (a < argLen) {
+    const x = arguments[a++];
     if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
       str += ' ' + x;
     } else {


### PR DESCRIPTION
By manually copying arguments and breaking the try/catch out, we are able to improve the performance of util.format by 20-100% (depending on the types).

Also includes a util.format benchmark.

The numbers:

```
running ./node
util/format.js
running ./node_before
util/format.js

util/format.js n=1000000 type=string: ./node: 7866600 ./node_before: 1705900 ... 361.13%
util/format.js n=1000000 type=number: ./node: 7718000 ./node_before: 1778900 ... 333.87%
util/format.js n=1000000 type=object: ./node: 1811800 ./node_before: 800160 .... 126.43%
util/format.js n=1000000 type=unknown: ./node: 13045000 ./node_before: 2650300 . 392.22%
util/format.js n=1000000 type=no-replace: ./node: 1541500 ./node_before: 956760 . 61.11%
```

*EDIT:* I updated the numbers after rebasing on master and with @mscdex's changes included as well.