### PR TITLE
cluster: emit worker as first 'message' event arg

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -487,10 +487,28 @@ The `addressType` is one of:
 
 * `worker` {cluster.Worker}
 * `message` {Object}
+* `handle` {undefined|Object}
 
 Emitted when any worker receives a message.
 
 See [child_process event: 'message'][].
+
+Before Node.js v6.0, this event emitted only the message and the handle,
+but not the worker object, contrary to what the documentation stated.
+
+If you need to support older versions and don't need the worker object,
+you can work around the discrepancy by checking the number of arguments:
+
+```js
+cluster.on('message', function(worker, message, handle) {
+  if (arguments.length === 2) {
+    handle = message;
+    message = worker;
+    worker = undefined;
+  }
+  // ...
+});
+```
 
 ## Event: 'online'
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -341,9 +341,9 @@ function masterInit() {
       process: workerProcess
     });
 
-    worker.on('message', (message, handle) =>
-      cluster.emit('message', message, handle)
-    );
+    worker.on('message', function(message, handle) {
+      cluster.emit('message', this, message, handle);
+    });
 
     worker.process.once('exit', function(exitCode, signalCode) {
       /*

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -84,7 +84,8 @@ else if (cluster.isMaster) {
   worker.on('message', function(message) {
     check('master', message === 'message from worker');
   });
-  cluster.on('message', function(message) {
+  cluster.on('message', function(worker_, message) {
+    assert.strictEqual(worker_, worker);
     check('global', message === 'message from worker');
   });
 


### PR DESCRIPTION
It's documented as such but didn't actually behave that way.

Bug introduced in commit 66fc8ca ("cluster: emit 'message' event on
cluster master"), which is the commit that introduced the event.

Fixes: https://github.com/nodejs/node/issues/5126

R=@sam-github

CI: https://ci.nodejs.org/job/node-test-pull-request/1719/