### PR TITLE
2012.02.14, Version 0.7.4 (unstable)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,25 @@
-2012.02.07, Version 0.7.3 (unstable)
+2012.02.14, Version 0.7.4 (unstable)
+
+* Upgrade V8 to 3.9.5
+
+* Upgrade npm to 1.1.1
+
+* build: Detect host_arch better (Karl Skomski)
+
+* debugger: export `debug_port` to `process` (Fedor Indutny)
+
+* api docs: CSS bug fixes (isaacs)
+
+* build: use -fPIC for native addons on UNIX (Nathan Rajlich)
+
+* Re-add top-level v8::Locker (Marcel Laverdet)
+
+* Move images out of the dist tarballs (isaacs)
+
+* libuv: Remove uv_export and uv_import (Ben Noordhuis)
+
+
+2012.02.07, Version 0.7.3 (unstable), 99059aad8d654acda4abcfaa68df182b50f2ec90
 
 * Upgrade V8 to 3.9.2
 

--- a/doc/about/index.html
+++ b/doc/about/index.html
@@ -130,7 +130,7 @@ console.log('Server running at http://127.0.0.1:1337/');</pre>
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.3/LICENSE">license</a>.</p>
+        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.4/LICENSE">license</a>.</p>
     </div>
 
 

--- a/doc/community/index.html
+++ b/doc/community/index.html
@@ -180,7 +180,7 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.3/LICENSE">license</a>.</p>
+        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.4/LICENSE">license</a>.</p>
     </div>
 
     <script>

--- a/doc/index.html
+++ b/doc/index.html
@@ -31,7 +31,7 @@
 
         <a href="#download" class="button" id="downloadbutton">Download</a>
         <a href="http://nodejs.org/docs/latest/api/index.html" class="button" id="docsbutton">Docs</a>
-        <p class="version">v0.7.3</p> 
+        <p class="version">v0.7.4</p> 
     </div>
     <div id="quotes" class="clearfix">
         <h2>Node.js in the Industry</h2>
@@ -78,15 +78,15 @@
         <a href="#" id="download-close">X</a>
         <img id="download-logo" src="http://nodejs.org/images/download-logo.png" alt="node.js">
         <ul id="installers" class="clearfix">
-            <li><a href="http://nodejs.org/dist/v0.7.3/node-v0.7.3.msi">Windows Installer</a><br>node-v0.7.3.msi</li>
-            <li><a href="http://nodejs.org/dist/v0.7.3/node-v0.7.3.pkg">Macintosh Installer</a><br>node-v0.7.3.pkg</li>
-            <li id="source"><a href="http://nodejs.org/dist/v0.7.3/node-v0.7.3.tar.gz">Source Code</a><br>node-v0.7.3.tar.gz</li>
+            <li><a href="http://nodejs.org/dist/v0.7.4/node-v0.7.4.msi">Windows Installer</a><br>node-v0.7.4.msi</li>
+            <li><a href="http://nodejs.org/dist/v0.7.4/node-v0.7.4.pkg">Macintosh Installer</a><br>node-v0.7.4.pkg</li>
+            <li id="source"><a href="http://nodejs.org/dist/v0.7.4/node-v0.7.4.tar.gz">Source Code</a><br>node-v0.7.4.tar.gz</li>
         </ul>
         <ul id="documentation">
-            <li><a href="https://raw.github.com/joyent/node/v0.7.3/ChangeLog">Change Log</a></li>
-            <li><a href="http://nodejs.org/docs/v0.7.3/api/index.html">Documentation</a></li>
-            <li><a href="http://nodejs.org/dist/v0.7.3">Other release files</a></li>
-            <li><a href="https://raw.github.com/joyent/node/v0.7.3/LICENSE">License</a></li>
+            <li><a href="https://raw.github.com/joyent/node/v0.7.4/ChangeLog">Change Log</a></li>
+            <li><a href="http://nodejs.org/docs/v0.7.4/api/index.html">Documentation</a></li>
+            <li><a href="http://nodejs.org/dist/v0.7.4">Other release files</a></li>
+            <li><a href="https://raw.github.com/joyent/node/v0.7.4/LICENSE">License</a></li>
             <li><a href="https://github.com/joyent/node">Git Repository</a></li>
             <li><a href="https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager">Installing
             with a Package Manager</a>
@@ -211,7 +211,7 @@ server.listen(1337, "127.0.0.1");</pre>
             <!-- <li><a hrfe="http://twitter.com/nodejs" class="twitter">@nodejs</a></li> -->
         </ul>
 
-        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.3/LICENSE">license</a>.</p>
+        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.4/LICENSE">license</a>.</p>
     </div>
 
 

--- a/doc/logos/index.html
+++ b/doc/logos/index.html
@@ -85,7 +85,7 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>., Node.js is a <a href="/trademark-policy.pdf">trademark of Joyent, Inc</a>., <a href="https://raw.github.com/joyent/node/v0.7.3/LICENSE">View License</a></p>
+        <p>Copyright <a href="http://joyent.com">Joyent, Inc</a>., Node.js is a <a href="/trademark-policy.pdf">trademark of Joyent, Inc</a>., <a href="https://raw.github.com/joyent/node/v0.7.4/LICENSE">View License</a></p>
     </div>
 
 

--- a/doc/template.html
+++ b/doc/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{{section}}Node.js v0.7.3 Manual &amp; Documentation</title>
+  <title>{{section}}Node.js v0.7.4 Manual &amp; Documentation</title>
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/sh.css">
   <link rel="canonical" href="http://nodejs.org/docs/latest/api/{{filename}}.html">
@@ -31,7 +31,7 @@
 
         <div id="column1" class="interior">
         <header>
-          <h1>Node.js v0.7.3 Manual &amp; Documentation</h1>
+          <h1>Node.js v0.7.4 Manual &amp; Documentation</h1>
           <div id="gtoc">
             <p><a href="index.html" name="toc">Index</a> | <a href="all.html">View on single page</a></p>
           </div>
@@ -56,7 +56,7 @@
             <li><a href="http://twitter.com/nodejs" class="twitter">@nodejs</a></li>
         </ul>
 
-        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.3/LICENSE">license</a>.</p>
+        <p>Copyright 2010 <a href="http://joyent.com">Joyent, Inc</a>, Node.js is a <a href="/trademark-policy.pdf">trademark</a> of Joyent, Inc. View <a href="https://raw.github.com/joyent/node/v0.7.4/LICENSE">license</a>.</p>
     </div>
     
   <script src="assets/sh_main.js"></script>


### PR DESCRIPTION
* Upgrade V8 to 3.9.5

* Upgrade npm to 1.1.1

* build: Detect host_arch better (Karl Skomski)

* debugger: export `debug_port` to `process` (Fedor Indutny)

* api docs: CSS bug fixes (isaacs)

* build: use -fPIC for native addons on UNIX (Nathan Rajlich)

* Re-add top-level v8::Locker (Marcel Laverdet)

* Move images out of the dist tarballs (isaacs)

* libuv: Remove uv_export and uv_import (Ben Noordhuis)