### PR TITLE
tools: apply custom buffer lint rule to /lib only

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,6 @@ rules:
   strict: [2, "global"]
 
   # Custom rules in tools/eslint-rules
-  require-buffer: 2
   new-with-error: [2, "Error", "RangeError", "TypeError", "SyntaxError", "ReferenceError"]
 
 

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,3 @@
+rules:
+  # Custom rules in tools/eslint-rules
+  require-buffer: 2


### PR DESCRIPTION
The lint rule is there to avoid a circular-dependency issue that only
applies to `/lib`. In preparation for linting `/benchmark`, apply that
rule to `/lib` only to avoid churn in `/benchmark`.

Refs: https://github.com/nodejs/node/issues/3983#issuecomment-158956113

/cc @silverwind 