### PR TITLE
test: allow passing args to executable

### DIFF
--- a/test/parallel/test-cluster-debug-port.js
+++ b/test/parallel/test-cluster-debug-port.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 const cluster = require('cluster');
 
 if (cluster.isMaster) {
-  assert.strictEqual(process.execArgv.length, 0, 'run test with no args');
 
   function checkExitCode(code, signal) {
     assert.strictEqual(code, 0);

--- a/tools/test.py
+++ b/tools/test.py
@@ -775,7 +775,8 @@ TIMEOUT_SCALEFACTOR = {
 
 class Context(object):
 
-  def __init__(self, workspace, buildspace, verbose, vm, args, timeout, processor, suppress_dialogs, store_unexpected_output):
+  def __init__(self, workspace, buildspace, verbose, vm, args, timeout,
+               processor, suppress_dialogs, store_unexpected_output):
     self.workspace = workspace
     self.buildspace = buildspace
     self.verbose = verbose

--- a/tools/test.py
+++ b/tools/test.py
@@ -709,6 +709,7 @@ class TestRepository(TestSuite):
       (file, pathname, description) = imp.find_module('testcfg', [ self.path ])
       module = imp.load_module('testcfg', file, pathname, description)
       self.config = module.GetConfiguration(context, self.path)
+      self.config.additional_flags = context.node_args
     finally:
       if file:
         file.close()
@@ -774,11 +775,12 @@ TIMEOUT_SCALEFACTOR = {
 
 class Context(object):
 
-  def __init__(self, workspace, buildspace, verbose, vm, timeout, processor, suppress_dialogs, store_unexpected_output):
+  def __init__(self, workspace, buildspace, verbose, vm, args, timeout, processor, suppress_dialogs, store_unexpected_output):
     self.workspace = workspace
     self.buildspace = buildspace
     self.verbose = verbose
     self.vm_root = vm
+    self.node_args = args
     self.timeout = timeout
     self.processor = processor
     self.suppress_dialogs = suppress_dialogs
@@ -1281,6 +1283,8 @@ def BuildOptions():
   result.add_option("--snapshot", help="Run the tests with snapshot turned on",
       default=False, action="store_true")
   result.add_option("--special-command", default=None)
+  result.add_option("--node-args", dest="node_args", help="Args to pass through to Node",
+      default=[], action="append")
   result.add_option("--valgrind", help="Run tests through valgrind",
       default=False, action="store_true")
   result.add_option("--cat", help="Print the source of the tests",
@@ -1471,6 +1475,7 @@ def Main():
                     buildspace,
                     VERBOSE,
                     shell,
+                    options.node_args,
                     options.timeout,
                     processor,
                     options.suppress_dialogs,


### PR DESCRIPTION
To set up CI jobs for https://github.com/nodejs/node/pull/5181 there has to be a way to pass an argument to the Node executable at test time. The makefile supports the TEST_CI_ARGS environment variable, but the test harness (test.py) provides no facility to further pass the argument to the executable under test.

There is a "--special-command" argument, but it is only able to suffix or prefix the existing command line in the format [node, test] so it is insufficient to produce commands in the form [node, node_args, test]. In this PR I've introduced an extra argument to the test harness called --node-args which can be used to pass commands verbatim.

Some support for this feature already existed in test/\__init\__.py in the form of the "additional" argument, however none of the individual test modules' testcfg.py make use of it, so in the interest of minimal footprint I've opted to directly set this value form test.py, instead of passing it through as a constructor argument.

There is an additional complication in "test-cluster-debug-port.js" which for reasons that are unclear refuses to run if any arguments are passed to the process. I've simply relaxed this requirement.