### PR TITLE
test: enable timers test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,6 @@ deps/npm/node_modules/.bin/
 /SHASUMS*.txt*
 
 # test artifacts
-tools/faketime
 icu_config.gypi
 test.tap
 

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -32,7 +32,7 @@ var intervalFired = false;
  */
 
 var monoTimer = new Timer();
-monoTimer.ontimeout = function() {
+monoTimer[Timer.kOnTimeout] = function() {
     /*
      * Make sure that setTimeout's and setInterval's callbacks have
      * already fired, otherwise it means that they are vulnerable to

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,20 +1,10 @@
-FAKETIME_REPO       := git://github.com/wolfcw/libfaketime.git
 FAKETIME_LOCAL_REPO := $(CURDIR)/faketime
-FAKETIME_BRANCH     := master
 FAKETIME_BINARY     := $(FAKETIME_PREFIX)/bin/faketime
 
 .PHONY: faketime
 
 faketime: $(FAKETIME_BINARY)
 
-clean:
-	$(RM) -r $(FAKETIME_LOCAL_REPO)
-
-$(FAKETIME_BINARY): $(FAKETIME_LOCAL_REPO)
+$(FAKETIME_BINARY): 
 	cd $(FAKETIME_LOCAL_REPO) && \
-	git checkout $(FAKETIME_BRANCH) && \
 	PREFIX=$(FAKETIME_LOCAL_REPO)/src make
-
-$(FAKETIME_LOCAL_REPO):
-	git clone $(FAKETIME_REPO) $(FAKETIME_LOCAL_REPO)
-

--- a/tools/faketime/.gitignore
+++ b/tools/faketime/.gitignore
@@ -1,0 +1,9 @@
+*.o
+*.so.1
+timetest
+
+src/libfaketime.dylib.1
+src/libfaketime.1.dylib
+src/core
+src/faketime
+

--- a/tools/faketime/COPYING
+++ b/tools/faketime/COPYING
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/tools/faketime/Makefile
+++ b/tools/faketime/Makefile
@@ -1,0 +1,34 @@
+INSTALL ?= install
+
+UNAME=$(shell uname)
+SELECTOR:=$(shell if test "${UNAME}" = "Darwin" ; then echo "-f Makefile.OSX" ; fi)
+
+all:
+	$(MAKE) $(SELECTOR) -C src all
+
+test:
+	$(MAKE) $(SELECTOR) -C test all
+
+install:
+	$(MAKE) $(SELECTOR) -C src install
+	$(MAKE) $(SELECTOR) -C man install
+	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/share/doc/faketime/"
+	$(INSTALL) -m0644 README "${DESTDIR}${PREFIX}/share/doc/faketime/README"
+	$(INSTALL) -m0644 NEWS "${DESTDIR}${PREFIX}/share/doc/faketime/NEWS"
+
+uninstall:
+	$(MAKE) $(SELECTOR) -C src uninstall
+	$(MAKE) $(SELECTOR) -C man uninstall
+	rm -f "${DESTDIR}${PREFIX}/share/doc/faketime/README"
+	rm -f "${DESTDIR}${PREFIX}/share/doc/faketime/NEWS"
+	rmdir "${DESTDIR}${PREFIX}/share/doc/faketime"
+
+clean:
+	$(MAKE) $(SELECTOR) -C src clean
+	$(MAKE) $(SELECTOR) -C test clean
+
+distclean:
+	$(MAKE) $(SELECTOR) -C src distclean
+	$(MAKE) $(SELECTOR) -C test distclean
+
+.PHONY: all test install uninstall clean distclean

--- a/tools/faketime/NEWS
+++ b/tools/faketime/NEWS
@@ -1,0 +1,130 @@
+Since 0.9.6:
+    - Julien Gilli added an option to disable monotonic time faking
+    - Azat Khuzhin added support for COARSE clocks
+
+Since 0.9.5:
+    - fixed crashes that happened when other LD_PRELOAD libraries were used
+    - fixed passing through of return values when using the faketime wrapper
+    - fixed compile-time issues with CLOCK_MONOTONIC_RAW on some platforms
+    - rbalint added Filter commands: FAKETIME_ONLY_CMDS and
+      FAKETIME_SKIP_CMDS control which (sub-)processes libfaketime
+      is applied to.
+
+Since 0.9:
+    - ryandesign at MacPorts provided a Portfile for MacPorts and
+      fixed various build issues on OSX.
+    - Balint Reczey added support for nanosecond resolution, saving
+      timestamps to files, speeding up and slowing down per-process
+      timers, CLOCK_MONOTONIC and CLOCK_MONOTONIC_RAW, faketime
+      support for system calls such as sleep() and alarm().
+    - Applied a patch by Gerardo Malazdrewicz and Toni G to restore
+      compatibility with newer versions of glibc.
+    - Balint Reczey added an option to use the same global clock setting
+      for all libfaketime-spawned processes.
+    - Balint Reczey has rewritten the faketime wrapper shell script in C
+      and refactored libfaketime.
+    - Balint Reczey added support for advancing the time with each time-
+      related system call ("deterministic time").
+    - Added "timeprivacy" wrapper by adrelanos; it ensures that programs
+      are started with unique timestamps.
+    - Code and documentation cleanup by Tomi Ollila.
+    - Reworked Makefiles for more flexible installation, including fixes
+      by Lukas Fleischner, Daniel Kahm Gillmor, and Hugues Andreux.
+    - Fixed license issues as pointed out by Paul Wouters.
+    - Mac OS X support has been improved for OS X 10.7 and 10.8; due to
+      changes to the underlying libraries on OS X, libfaketime 0.9.5 will
+      no longer work with OS X < 10.6; use libfaketime 0.9(.1) for older
+      OS X installations.
+    - Don Fong has contributed a new framework for functional tests.
+      Petr Salinger ensured its compatibility with GNU/kFreeBSD.
+
+Since 0.8.2:
+    - Added support for "limited faking".
+      You can optionally specify when libfaketime starts to fake the
+      returned timestamps and when it shall stop doing so. For example,
+      a program can be started regularly, and after 5 minutes run-time
+      it will be sent two years into the future. Those limiting
+      start and stop times can be specified in seconds or as the
+      number of any time-related function calls within the program.
+    - Added a feature to spawn an external process after x seconds
+      or y time-related system calls. This can, for example, be used
+      to execute an arbitrary shell script x seconds after a program
+      has been started.
+
+Since 0.8.1:
+    - Added a MacOS port.
+      Thanks to Derrick Brashear!
+    - Added a functional test framework that aids in automatically
+      determining whether libfaketime works properly on the current
+      machine. Thanks to Don Fong!
+
+Since 0.8:
+    - Changed directory layout and Makefile structure.
+      Thanks to Lukas Fleischer!
+
+Since 0.7:
+    - Added support for fstatat() and fstatat64() which were introduced in
+      Linux kernel 2.6.16 and used in recent coreutils.
+      Thanks to Daniel Kahn Gillmor for the report!
+      This can be disabled by passing -DNO_ATFILE in the Makefile.
+    - Added a simple wrapper shell script and a man page for it. Makes it
+      easier to run commands under faked system times. It assumes that the
+      libraries will be copied to /usr/lib/faketime during installation,
+      please adjust this path if necessary. The "install" target in the
+      Makefile has been adapted accordingly.
+    - Added support for fractional time offsets, such as FAKETIME="+1,5h".
+      Please note that either , or . has to be used as a delimiter
+      depending on your locale. Thanks to Karl Chen!
+    - Added support for speeding the clock up or slowing it down. For
+      example, FAKETIME="+5d x2,0" will set the faked time 5 days into
+      the future and make the clock run twice as fast for the specified
+      program. Slowing it down can be done e.g. by using FAKETIME="+0 x0,5".
+      Again, the delimiter to use for the fraction depends on your locale.
+      Thanks to Karl Chen!
+
+Since 0.6:
+    Main version 0.7 contributions by David North, TDI:
+    - Added ability to 'start clock at' a specific time.
+    - Added pthread synchronization support
+    - Added a 2 second delay to timetest.c so one can observe if the
+      clock is relative or absolute
+    - Added test.sh example of 'start clock at'
+    - Added ability to disable the FAKE_STAT functionality at library-start
+      in the case that the library was compiled -DFAKE_STAT, and added another
+      test case for demonstrating this
+    - Repaired a bug w.r.t. strptime/mktime wherein 'isdst' was uninitialized
+      which led to pseudorandom +/- 1 hour results being returned in 'start at'
+      or absolute time modes
+
+    Other enhancements:
+    - Fixed missing interceptions to libc-internal functions and added notes
+      about a workaround for running Java programs with faked times in the
+      future (they worked properly, but often locked up at exiting). Thanks to
+      Jamie Cameron of Google for in-depth analysis and prototype solution!
+
+Since 0.5:
+    - Performance enhancements by means of caching the data read
+      e.g. from $HOME/.faketimerc for 10 seconds.
+    - Several file timestamp related system calls such as fstat() will be
+      intercepted now. See the README file on how to turn this off if you
+      do not need it. Thanks to Philipp Hachtmann!
+    - A system-wide /etc/faketimerc file will now be used if no FAKETIME
+      environment variable has been set and no $HOME/.faketimerc is present.
+      Thanks to David Burley, Jacob Moorman, and Wayne Davison of
+      SourceForge, Inc.!
+    - Added trivial Makefile targets clean/distclean/install
+    - Changed Makefile target test to run new test.sh script
+    - Added new test cases to timetest.c
+
+Since 0.4:
+    - Allow "y" for years of offset specification. Thanks to Bas ten Berge!
+
+Since 0.3:
+    - Support for FAKETIME_FMT environment variable. Thanks to Moreno Baricevic!
+
+Since 0.2:
+    - Intercept clock_gettime(). Thanks to Andreas Thienemann!
+
+Since 0.1:
+    - Fixed segfault when calling time(NULL). Thanks to Andres Ojamaa!
+    - Added additional sanity checks.

--- a/tools/faketime/README
+++ b/tools/faketime/README
@@ -1,0 +1,539 @@
+      =======================================================
+             libfaketime, version 0.9.6 (June 2014)
+        (previously also know as FakeTime Preload Library)
+      =======================================================
+
+
+Content of this file:
+---------------------
+
+1. Introduction
+2. Compatibility issues
+3. Installation
+4. Usage
+   a) Basics
+   b) Using absolute dates
+   c) Using 'start at' dates
+   d) Using offsets for relative dates
+   e) Advanced features and caveats
+   f) Faking the date and time system-wide
+   g) Using the "faketime" wrapper script
+   h) "Limiting" libfaketime based on elapsed time or number of calls
+   i) "Limiting" libfaketime per process
+   j) Spawning an external process
+   k) Saving timestamps to file, loading them from file
+5. License
+6. Contact
+
+
+
+1. Introduction
+---------------
+
+libfaketime intercepts various system calls which programs use to
+retrieve the current date and time. It can then report faked dates and times
+(as specified by you, the user) to these programs. This means you can modify
+the system time a program sees without having to change the time system-wide.
+
+libfaketime allows you to specify both absolute dates (e.g., 01/01/2004) and
+relative dates (e.g., 10 days ago).
+
+libfaketime might be used for various purposes, for example
+
+- running legacy software with y2k bugs
+- testing software for year-2038 compliance
+- debugging time-related issues, such as expired SSL certificates
+- running software which ceases to run outside a certain timeframe
+- using different system-wide date and time settings, e.g., on OpenVZ-
+  based virtual machines running on the same host
+- deterministic build processes.
+
+
+
+2. Compatibility issues
+-----------------------
+
+* libfaketime has been designed on and for Linux, but is supposed and has been
+  reported to work on other *NIXes as well, including Mac OS X.
+
+* libfaketime uses the library preload mechanism and thus cannot work with
+  statically linked binaries or binaries that have the setuid-flag set (e.g.,
+  suidroot programs like "ping" or "passwd"). Please see you system linker's
+  manpage for further details (man ld).
+
+* As of version 0.7, support has been added for use in a pthreads environment. A
+  separate library is built (libfaketimeMT.so.1) which contains the pthread
+  synchronization calls. This library also single-threads calls through the
+  time() intercept, because several variables are statically cached by the
+  library and could cause issues when accessed without synchronization. However,
+  the performance penalty for this might be an issue for some applications. If
+  this is the case, you can try using an unsynchronized time() intercept by
+  removing the -DPTHREAD_SINGLETHREADED_TIME from the Makefile and rebuilding
+  libfaketimeMT.so.1 . Thanks to David North, TDI!
+
+* If and only if you want to run Java programs with faked times in the future
+  (not in the past) on Linux, you also should set the environment variable
+  LD_ASSUME_KERNEL=2.4.19 before running the appropriate "java" command. This
+  fixes an occasional bug where Java locks up at exiting. Again, this is only
+  required for Java with faked times in the future. Thanks to Jamie Cameron for
+  reporting this issue and finding a workaround!
+
+* libfaketime will eventually be bypassed by applications that dynamically load
+  system libraries, such as librt, explicitly themselves instead of relying on
+  the linker to do so at application start time. libfaketime will not work with
+  those applications unless you can modify them.
+
+* Applications can explicitly be designed to prevent libfaketime from working,
+  e.g., by checking whether certain environment variables are set or whether
+  libfaketime-specific files are present.
+
+
+
+3. Installation
+---------------
+
+Running "make" should compile both library versions and a test program, which
+it then also executes.
+
+If the test works fine, you should copy the libfaketime libraries
+(libfaketime.so.1, and libfaketimeMT.so.1) to the place you want them in.
+Running "make install" will attempt to place them in /usr/local/lib/faketime
+and will install the wrapper shell script "faketime" in /usr/local/bin, both of
+which most likely will require root privileges; however, from a technical point
+of view, there is no necessity for a system-wide installation, so you can use
+libfaketime also on machines where you do not have root privileges. You may want
+to adjust the PREFIX variable in the Makefiles accordingly.
+
+By default, the Makefile compiles/links libfaketime for your default system
+architecture. If you need to build, e.g., 32-bit files on a 64-bit platform,
+please see the notes about CFLAGS and LDFLAGS in src/Makefile.
+
+Since version 0.6, system calls to file timestamps are also intercepted,
+thanks to a contribution by Philipp Hachtmann. This is especially useful in
+combination with relative time offsets as explained in section 4d) below, if a
+program writes and reads files whose timestamps also shall be faked. If you do
+not need this feature or if it confuses the application you want to use FTPL
+with, define the environment variable NO_FAKE_STAT, and the intercepted stat
+calls will be passed through unaltered.
+
+On OS X, it is necessary to compile differently, due to the different
+behavior dyld has. Use the Makefile provided to compile
+libfaketime.1.dylib. Additionally, instead of using LD_PRELOAD,
+the variable DYLD_INSERT_LIBRARIES should be set to the path to
+libfaketime.1.dylib, and the variable DYLD_FORCE_FLAT_NAMESPACE should be
+set (to anything). Mac OS X users should read README.OSX for additional
+details.
+
+
+
+4. Usage
+--------
+
+4a) Usage basics
+----------------
+
+Using libfaketime on a program of your choice consists of two steps:
+
+1. Making sure libfaketime gets loaded by the system's linker.
+2. Specify the faked time.
+
+
+As an example, we want the "date" command to report our faked time. To do so,
+we could use the following command line on Linux:
+
+user@host> date
+Tue Nov 23 12:01:05 CEST 2007
+
+user@host> LD_PRELOAD=/usr/local/lib/libfaketime.so.1 FAKETIME="-15d" date
+Mon Nov  8 12:01:12 CEST 2007
+
+
+The basic way of running any command/program with libfaketime enabled is to
+make sure the environment variable LD_PRELOAD contains the path and
+filename of the libfaketime library. This can either be done by setting it once
+beforehand:
+
+export LD_PRELOAD=/path/to/libfaketime.so.1
+(now run any command you want)
+
+
+Or it can be done by specifying it on the command line itself:
+
+LD_PRELOAD=/path/to/libfaketime.so.1 your_command_here
+
+(These examples are for the bash shell; how environment variables are set may
+vary on your system.)
+
+On Linux, library search paths can be set as part of the linker configuration.
+LD_PRELOAD then also works with relative paths. For example, when libfaketime.so.1
+is installed as /path/to/libfaketime.so.1, you can add /path/to to an appropriate
+linker configuration file, e.g., /etc/ld.so.conf.d/local.conf and then run
+the "ldconfig" command. Afterwards, using LD_PRELOAD=libfaketime.so.1 suffices.
+
+However, also the faked time should be specified; otherwise, libfaketime
+will be loaded, but just report the real system time. There are three
+ways to specify the faked time:
+
+a) By setting the environment variable FAKETIME.
+b) By using the file given in the environment variable FAKETIME_TIMESTAMP_FILE
+c) By using the file .faketimerc in your home directory.
+d) By using the file /etc/faketimerc for a system-wide default.
+
+If you want to use b) c) or d), $HOME/.faketimerc or /etc/faketimerc consist of
+only one line of text with exactly the same content as the FAKETIME environment
+variable, which is described below. Note that /etc/faketimerc will only be used
+if there is no $HOME/.faketimerc nor FAKETIME_TIMESTAMP_FILE file exists, and
+the FAKETIME environment variable always has priority over the files.
+
+
+4b) Using absolute dates
+------------------------
+
+The format which _must_ be used for _absolute_ dates is "YYYY-MM-DD hh:mm:ss".
+For example, the 24th of December, 2002, 8:30 PM would have to be specified as
+FAKETIME="2002-12-24 20:30:00".
+
+
+4c) Using 'start at' dates
+--------------------------
+
+(Thanks to a major contribution by David North, TDI in version 0.7)
+
+The format which _must_ be used for _start_at_ dates is "@YYYY-MM-DD hh:mm:ss".
+For example, the 24th of December, 2002, 8:30 PM would have to be specified as
+FAKETIME="@2002-12-24 20:30:00".
+
+The absolute dates described in 4b simulate a STOPPED system clock at the
+specified absolute time. The 'start at' format allows a 'relative' clock
+operation as described below in section 4d, but using a 'start at' time
+instead of an offset time.
+
+
+4d) Using offsets for relative dates
+------------------------------------
+
+Relative date offsets can be positive or negative, thus what you put into
+FAKETIME _must_ either start with a + or a -, followed by a number, and
+optionally followed by a multiplier:
+
+- by default, the offset you specify is in seconds. Example:
+
+  export FAKETIME="-120" will set the faked time 2 minutes (120 seconds) behind
+  the real time.
+
+- the multipliers "m", "h", "d" and "y" can be used to specify the offset in
+  minutes, hours, days and years (365 days each), respectively. Examples:
+
+  export FAKETIME="-10m" sets the faked time 10 minutes behind the real time.
+  export FAKETIME="+14d" sets the faked time to 14 days in the future.
+
+
+You now should understand the complete example we've used before:
+
+LD_PRELOAD=/usr/local/lib/libfaketime.so.1 FAKETIME="-15d" date
+
+This command line makes sure FTPL gets loaded and sets the faked time to
+15 days in the past.
+
+Moreno Baricevic has contributed support for the FAKETIME_FMT environment
+variable, which allows to optionally set the strptime() format:
+
+Some simple examples:
+LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%s FAKETIME="`date +%s -d'1 year ago'`" date
+LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%s FAKETIME="`stat -c %Y somefile`" date
+LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%c FAKETIME="`date`" date
+
+
+4e) Advanced features and caveats
+---------------------------------
+
+Advanced time specification options:
+------------------------------------
+
+Since version 0.8, thanks to a contribution by Karl Chen, fractions can be used
+in the specification of time offsets. For example,
+
+FAKETIME="+1,5h"
+
+is equivalent to FAKETIME="+90m". Please be aware that the fraction delimiter
+depends on your locale settings, so actually you might need to use
+
+FAKETIME="+1.5h"
+
+You should figure out the proper delimiter, e.g. by using libfaketime on
+a command like /bin/date where you immediately can verify whether it worked as
+expected.
+
+Also contributed by Karl Chen in v0.8 is the option to speed up or slow
+down the wall clock time for the program which is executed using libfaketime.
+For example,
+
+FAKETIME="+1y x2"
+
+will set the faked time one year into the future and will make the clock run
+twice as fast. Similarly,
+
+FAKETIME="+1y x0,5"
+
+will make the clock run only half as fast. As stated above, the fraction
+delimiter depends on your locale.
+
+FAKETIME="+1y i2,0"
+
+will make the clock step two seconds per each time(), etc. call, running
+completely independently of the system clock. It helps running programs
+with some determinism. In this single case all spawned processes will use
+the same global clock without restaring it at the start of each process.
+
+For testing, your should run a command like
+
+LD_PRELOAD=./libfaketime.so.1 FAKETIME="+1,5y x10,0" \
+/bin/bash -c 'while true; do echo $SECONDS ; sleep 1 ; done'
+
+For each second that the endless loop sleeps, the executed bash shell will
+think that 10 seconds have passed ($SECONDS is a bash-internal variable
+measuring the time since the shell was started).
+
+(Please note that replacing "echo $SECONDS" e.g. with a call to "/bin/date"
+will not give the expected result, since /bin/date will always be started
+as a new process for which also FTPL will be re-initialized. It will show
+the correct offset (1.5 years in the future), but no speed-ups or
+slow-downs.)
+
+For applications that should use a different date & time each time they are
+run, consider using the included timeprivacy wrapper shellscript (contributed
+by adrelanos at riseup dot net).
+
+
+Caveats:
+--------
+
+Whenever possible, you should use relative offsets or 'start at' dates,
+and not use absolute dates.
+
+Why? Because the absolute date/time you set is fixed, i.e., if a program
+retrieves the current time, and retrieves the current time again 5
+minutes later, it will still get the same result twice. This is likely to break
+programs which measure the time passing by (e.g., a mail program which checks
+for new mail every X minutes).
+
+Using relative offsets or 'start at' dates solves this problem.
+libfaketime then will always report the faked time based on the real
+current time and the offset you've specified.
+
+Please also note that your default specification of the fake time is cached for
+10 seconds in order to enhance the library's performance. Thus, if you change the
+content of $HOME/.faketimerc or /etc/faketimerc while a program is running, it
+may take up to 10 seconds before the new fake time is applied. If this is a
+problem in your scenario, you can change number of seconds before the file is read
+again with environment variable FAKETIME_CACHE_DURATION, or disable caching at all
+with FAKETIME_NO_CACHE=1. Remember that disabling the cache may negatively
+influence the performance.
+
+
+4f) Faking the date and time system-wide
+----------------------------------------
+
+David Burley of SourceForge, Inc. reported an interesting use case of applying
+libfaketime system-wide: Currently, all virtual machines running inside
+an OpenVZ host have the same system date and time. In order to use multiple
+sandboxes with different system dates, the libfaketime library can be put into
+/etc/ld.so.preload; it will then be applied to all commands and programs
+automatically. This is of course best used with a system-wide /etc/faketimerc
+file. Kudos to SourceForge, Inc. for providing the patch!
+
+Caveat: If you run a virtual machine, its real-time clock might be reset to the
+real world date & time when you reboot. Depending on your FAKETIME setting,
+this may lead to side effects, such as forced file system checks on each reboot.
+System-wide faked time may also lead to unexpected side effects with software
+auto-update tools, if the offset between real world time and faked system time
+is too large. If in doubt, set your system's date to the faked time and try out
+whether everything still works as expected before applying libfaketime
+system-wide.
+
+
+4g) Using the "faketime" wrapper
+--------------------------------
+
+As of version 0.8, libfaketime provides a command named "faketime", which is
+placed into /usr/bin by "make install". It spares the hassle of setting
+the LD_PRELOAD and FAKETIME environment variables manually, but only exposes
+a subset of libfaketime's functionality. On the other hand, it uses the date
+interpretation function by /bin/date in order to provide higher flexibility
+regarding the specification of the faked date and time. For example, you
+can use
+
+faketime 'last Friday 5 pm' /your/command/here
+
+Of course, also absolute dates can be used, such as in
+
+faketime '2008-12-24 08:15:42' /bin/date
+
+Thanks to Daniel Kahn Gillmor for providing these suggestions!
+
+Balint Reczey has rewritten the wrapper in 0.9.5 from a simple shell script
+to an efficient wrapper application.
+
+
+4h) "Limiting" libfaketime based on elapsed time or number of calls
+--------------------------
+
+Starting with version 0.9, libfaketime can be configured to not be continuously
+active, but only during a certain time interval.
+
+For example, you might want to start a program with the real current time, but
+after 5 minutes of usage, you might want it to see a faked time, e.g., a year
+in the future.
+
+Dynamic changes to the faked time are alternatively possible by
+
+- changing the FAKETIME environment variable at run-time; this is the preferred
+  way if you use libfaketime for debugging and testing as a programmer, as it
+  gives you the most direct control of libfaketime without any performance
+  penalities.
+
+- not using the FAKETIME environment variable, but specifying the fake time in a
+  file (such as ~/.faketimerc). You can change the content of this file at
+  run-time. This works best with caching disabled (see Makefile), but comes at a
+  performance cost because this file has to be read and evaluated each time.
+
+The feature described here works based on two pairs of environment variables,
+
+  FAKETIME_START_AFTER_SECONDS and FAKETIME_STOP_AFTER_SECONDS, and
+  FAKETIME_START_AFTER_NUMCALLS and FAKETIME_STOP_AFTER_NUMCALLS
+
+The default value for each of these environment variables is -1, which means
+"ignore this value".
+
+If you want libfaketime to be only active during the run-time minutes 2 to 5
+of your application, you would set
+
+  FAKETIME_START_AFTER_SECONDS=60
+  FAKETIME_STOP_AFTER_SECONDS=300
+
+This means that your application will work with the real time from start (second
+0) up to second 60. It will then see a faked time from run-time seconds 60 to
+300 (minutes 2, 3, 4, and 5). After run-time second 600, it will again see the
+real (not-faked) time.
+
+This approach is not as flexible as changing the FAKETIME environment variable
+during runtime, but may be easier to use, works on a per-program (and not a
+per-user or system-wide) scope, and has only a minor performance overhead.
+
+Using the other pair of environment variables, you can limit the activity time
+of libfaketime not based on wall-clock seconds, but on the number of
+time-related function calls the started program performs. This alternative is
+probably only suitable for programmers who either know the code of the program
+in order to determine useful start/stop values or want to perform fuzzing
+tests.
+
+Both pairs of environment variables can be combined to further restrict
+libfaketime activity, although this is only useful in very few scenarios.
+
+Limiting libfaketime activity in this way is not recommended in general. Many
+programs will break when they are subject to sudden changes in time, especially
+if they are started using the current (real) time and are then sent back into
+the past after, e.g., 5 minutes. For example, they may appear to be frozen or
+stuck because they are waiting until a certain point in time that, however, is
+never reached due to the delayed libfaketime activity. Avoid using this
+functionality unless you are sure you really need it and know what you are
+doing.
+
+
+4i) "Limiting" libfaketime per process
+--------------------------------------
+
+Faketime can be instructed to fake time related calls only for selected
+commands or to fake time for each command except for a certain subset of
+commands.
+
+The environment variables are FAKETIME_ONLY_CMDS and FAKETIME_SKIP_CMDS
+respectively.
+
+Example:
+    FAKETIME_ONLY_CMDS=javadoc faketime '2008-12-24 08:15:42' make
+will run the "make" command but the time faking will only be applied
+to javadoc processes.
+
+Multiple commands are separated by commas.
+
+Example:
+    FAKETIME_SKIP_CMDS="javadoc,ctags" faketime '2008-12-24 08:15:42' make
+will run the "make" command and apply time faking for everything "make"
+does except for javadoc and ctags processes.
+
+FAKETIME_ONLY_CMDS and FAKETIME_SKIP_CMDS are mutually exclusive, i.e.,
+you cannot set them both at the same time. Faketime will terminate with
+an error message if both environment variables are set.
+
+
+4j) Spawning an external process
+--------------------------------
+
+From version 0.9 on, libfaketime can execute a shell command once after an
+arbitrary number of seconds or number of time-related system calls of the
+program started. This has two limitations one needs to be aware of:
+
+* Spawning the external process happens during a time-related system call
+  of the original program. If you want the external process to be started
+  5 seconds after program start, but this program does not make any time-
+  related system calls before run-time second 8, the start of your external
+  process will be delayed until run-time second 8.
+
+* The original program is blocked until the external process is finished,
+  because the intercepting time-related system call will not return earlier. If
+  you need to start a long-running external process, make sure it forks into the
+  background.
+
+Spawning the external process is controlled using three environment variables:
+FAKETIME_SPAWN_TARGET, FAKETIME_SPAWN_SECONDS, FAKETIME_SPAWN_NUMCALLS.
+
+Example (using bash on Linux):
+
+(... usual libfaketime setup here, setting LD_PRELOAD and FAKETIME ...)
+export FAKETIME_SPAWN_TARGET="/bin/echo 'Hello world'"
+export FAKETIME_SPAWN_SECONDS=5
+/opt/local/bin/myprogram
+
+This will run the "echo" command with the given parameter during the first
+time-related system function call that "myprogram" performs after running for 5
+seconds.
+
+
+4k) Saving timestamps to file, loading them from file
+-----------------------------------------------------
+
+Faketime can save faked timestamps to a file specified by FAKETIME_SAVE_FILE
+environment variable. It can also use the file specified by FAKETIME_LOAD_FILE
+to replay timestamps from it. After consuming the whole file, libfaketime
+returns to using the rule set in FAKETIME variable, but the timestamp processes
+will start counting from will be the last timestamp in the file.
+
+The file stores each timestamp in a stream of saved_timestamp structs
+without any metadata or padding:
+
+/* Storage format for timestamps written to file. Big endian. */
+struct saved_timestamp {
+  int64_t sec;
+  uint64_t nsec;
+};
+
+Faketime needs to be run using the faketime wrapper to use these files. This
+functionality has been added by Balint Reczey in v0.9.5.
+
+
+5. License
+----------
+
+libfaketime has been released under the GNU Public License, GPL. Please see the
+included COPYING file.
+
+
+6. Contact
+-----------
+
+Bug reports, feature suggestions, success reports, and patches/pull
+requests are highly appreciated:
+
+            https://github.com/wolfcw/libfaketime
+

--- a/tools/faketime/README.OSX
+++ b/tools/faketime/README.OSX
@@ -1,0 +1,136 @@
+README file for libfaketime on Mac OS X
+=======================================
+
+Support for Mac OS X has meanwhile matured and many command line and
+GUI applications will run stable.
+
+Developments and tests are done on OSX 10.8+ currently, although the
+current version will also work with OSX 10.7.
+
+Version 0.9.5 and higher no longer works with OSX <= 10.6 due to
+changes in the underlying system libraries. If you need libfaketime
+on OSX <= 10.6, please use libfaketime version 0.9.
+
+
+Installing and using libfaketime on OS X is slightly different than
+on Linux. Please make sure to read the README file for general
+setup and usage, and refer to this file only about OS X specifics.
+
+
+1) Installing libfaketime on OS X
+---------------------------------
+
+If you use MacPorts, libfaketime can be installed on the command line
+as follows:
+
+    sudo port install libfaketime
+
+Or, if you use Fink, install using:
+
+    fink install libfaketime
+
+Or, if you use Homebrew, install using:
+
+    brew install libfaketime
+
+Otherwise, you have to compile and install libfaketime manually; this
+will require a working installation of Xcode and its command line tools
+on your machine.
+
+You can compile libfaketime by running the command
+
+    make
+
+in libfaketime's top-level directory.
+
+The resulting library will be named libfaketime.1.dylib ; to check
+whether it works properly, run the test suite and verify whether its
+output is correct:
+
+    cd test
+    make -f Makefile.OSX
+
+
+2) Using libfaketime from the command line on OS X
+--------------------------------------------------
+
+You will need to set three environment variables. In a Terminal.app
+or iTerm2 session, the following commands can be used:
+
+export DYLD_FORCE_FLAT_NAMESPACE=1
+export DYLD_INSERT_LIBRARIES=/path/to/libfaketime.1.dylib
+export FAKETIME="your favorite faketime-spec here"
+
+Please refer to the general README file concerning the format
+of the FAKETIME environment variable value and other environment
+variables that are related to it.
+
+The "faketime" wrapper application has been adapted to OS X;
+it offers the same limited libfaketime functionality as on Linux
+in a simple-to-use manner without the need to manually set
+those environment variables. Run "faketime" without parameters
+for help and use "man faketime" for details.
+
+
+3) Integrating libfaketime with applications
+--------------------------------------------
+
+Given the limited number of system calls libfaketime intercepts,
+it may not work too well with specific GUI applications on OS X.
+This can result in crashes after a seemingly random time, or an
+application will not or at least not always see the faked time,
+and so on.
+
+A safe way to try out whether a specific application works fine
+with libfaketime is to start it from the command line. Perform
+the steps outlined above and run the application by issuing the
+following command:
+
+/Applications/ApplicationName.app/Contents/MacOS/ApplicationName
+
+(Make sure to replace "ApplicationName" twice in that command with
+the name of your actual application.)
+
+If it works fine, you can configure the application to permanently
+run with libfaketime by editing its Info.plist file. Add the
+LSEnvironment key unless it is already there and add a dictionary
+with the three keys like this:
+
+    <key>LSEnvironment</key>
+    <dict>
+        <key>DYLD_FORCE_FLAT_NAMESPACE</key>
+        <string>1</string>
+        <key>DYLD_INSERT_LIBRARIES</key>
+        <string>/path/to/libfaketime.1.dylib</string>
+        <key>FAKETIME</key>
+        <string>value of FAKETIME here</string>
+    </dict>
+
+(If the application is installed in /Applications instead of in
+$HOME/Applications, you eventually will need root privileges. If
+the application's Info.plist is not in XML, but in binary format,
+use appropriate editing or conversion tools.)
+
+Afterwards, you will probably need to run
+
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -v -f /Applications/ApplicationName.app
+
+to make sure the change to Info.plist does not go unnoticed.
+
+Please note that modifications to Info.plist will be lost when the
+application is updated, so this process needs to be repeated after
+such updates, including own new builds when using Xcode.
+
+Please feel free to report non-working applications on the Github
+libfaketime issues website. This may help us to identify further
+time-related system calls that need to be intercepted on OS X.
+
+    https://github.com/wolfcw/libfaketime/issues
+
+
+4) Notes for developers of OS X applications
+--------------------------------------------
+
+The environment variable FAKETIME can be changed at application run-time
+and always takes precedence over other user-controlled settings. It can
+be re-set to 0 (zero) to work around potential incompatibilities.

--- a/tools/faketime/README.developers
+++ b/tools/faketime/README.developers
@@ -1,0 +1,106 @@
+This file contains information for libfaketime developers and contributors.
+
+
+GENERAL
+=======
+
+Starting with libfaketime v0.9.5, development and issue handling is 
+completely done via Github: 
+
+	https://github.com/wolfcw/libfaketime
+
+- Official releases are tagged. 
+- Code contributions and bugfixes are merged into the "development" branch, 
+  which is considered unstable and may contain code that is not yet fully 
+  tested.
+- The "master" branch is updated with tested code only; it is ensured that
+  it compiles and works cleanly at least on current Linux and OS X systems.
+
+Code contributions are highly welcome, preferrably via pull requests on Github.
+
+
+CODE STYLE
+==========
+
+Please try to stick to the following code formatting style guidelines:
+
+- No tabs, only spaces for indentation.
+- Avoid trailing whitespace.
+- Indentation is 2 spaces for each level.
+- Opening and closing curly brackets have to be on lines of their own.
+- Use under_score_names for function and variable names; avoid using camelCase.
+- // and /*...*/ style comments may and shall be used.
+
+Example:
+
+/* This function will do nothing */
+void do_nothing(int how_often)
+{
+  int counter;
+  for (counter = 0; counter < how_often; counter++)
+  {
+    counter = counter; // our do-nothing algorithm
+  }
+}
+
+- Use -DDEBUG and #ifdef DEBUG for development and testing. Avoid printing
+  to stdout or stderr outside "#ifdef DEBUG"; if it is necessary to inform
+  the user a run-time, prefix your output with "faketime" or make otherwise
+  sure that the user knows where the message is coming from.  
+
+- If you add new functions to libfaketime.c, try placing them somewhere
+  where they fit will: Usually, functions are grouped by functionality
+  (e.g., all functions related to faking file timestamps). If that's not
+  possible, group them by contributor, or document your placement strategy
+  in the commit message. 
+
+
+DEVELOPMENT, BUILDING, AND TESTING
+==================================
+
+- Don't break existing behaviour. Backward compatibility matters (unless
+  the modification fixes bugs :-)).
+
+- Add tests for new features. Extend test/timetest.c appropriately and
+  try to use the functional testing framework wherever possible. 
+
+- Compiler and linker warnings are treated as errors and not acceptable.
+
+- If you cannot test the code on both Linux and OS X yourself, please 
+  let us know and consider wrapping your code in #ifdef / #ifndef __APPLE__ 
+  statements. 
+
+
+DOCUMENTATION
+=============
+
+For anything more than small bugfixes, please update the user documentation 
+and credits appropriately:
+
+- The NEWS file should mention the change and your credits.
+- The README and README.OSX files should be updated whenever functionality
+  is added or modified.
+- The manpage man/faketime.1 should be updated when the wrapper application
+  is modified.
+
+For credits, please either mention your real name, your Github username, or 
+your email address. 
+
+In your own interest, please be verbose on user documentation and comments
+in the source code. Users will not know about new features unless they are
+documented. Other authors and maintainers will need to understand your code
+easily.
+
+
+RELEASES
+========
+
+Official new releases are created whenever a significant amount of changes
+(bugfixes or new functionality) has piled up; on average, there is one new
+official release per year. Users who need to stick to the bleeding edge
+are supposed to use the current state of the "master" branch at any time.
+
+libfaketime maintainers for several Linux distributions are informed about
+release candidates and new releases by email. Contact wolfcw on Github if
+you are interested in receiving notifications, or use Github functionality
+to get informed about updates.

--- a/tools/faketime/TODO
+++ b/tools/faketime/TODO
@@ -1,0 +1,11 @@
+Open issues / next steps for libfaketime development
+
+- add more functional tests that check more than the basic functionality
+- use the testing framework to also implement unit tests
+- make the new "limiting" and "spawning" features more flexible to use
+  and available through the wrapper shell script
+- fake timer_create and friends
+- handle CLOCK_REALTIME_COARSE and CLOCK_MONOTONIC_COARSE
+- work around thread local storage issue, e.g., by using pthreads
+- add autoconf/automake support to get rid of separate Makefile.OSX
+

--- a/tools/faketime/man/Makefile
+++ b/tools/faketime/man/Makefile
@@ -1,0 +1,14 @@
+INSTALL ?= install
+
+PREFIX ?= /usr/local
+
+all:
+
+install:
+	$(INSTALL) -Dm0644 faketime.1 "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
+	gzip -f "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
+
+uninstall:
+	rm -f "${DESTDIR}${PREFIX}/share/man/man1/faketime.1.gz"
+
+.PHONY: all install uninstall

--- a/tools/faketime/man/Makefile.OSX
+++ b/tools/faketime/man/Makefile.OSX
@@ -1,0 +1,15 @@
+INSTALL ?= install
+
+PREFIX ?= /usr/local
+
+all:
+
+install:
+	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/share/man/man1"
+	$(INSTALL) -m0644 faketime.1 "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
+	gzip -f "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
+
+uninstall:
+	rm -f "${DESTDIR}${PREFIX}/share/man/man1/faketime.1.gz"
+
+.PHONY: all install uninstall

--- a/tools/faketime/man/faketime.1
+++ b/tools/faketime/man/faketime.1
@@ -1,0 +1,80 @@
+.TH FAKETIME "1" "June 2014" "faketime 0.9.6" wolfcw
+.SH NAME
+faketime \- manipulate the system time for a given command
+.SH SYNOPSIS
+.B faketime
+\fI[options] timestamp program [arguments...]\fR
+.SH DESCRIPTION
+.\" \fIfaketime\fR will trick the given program into seeing the specified timestamp as its starting date and time.
+.PP
+The given command will be tricked into believing that the current system time is the one specified in the timestamp. The wall clock will continue to run
+from this date and time unless specified otherwise (see advanced options). Actually, faketime is a simple wrapper for libfaketime, which uses the LD_PRELOAD
+mechanism to load a small library which intercepts system calls to functions such as
+\fItime(2)\fR and \fIfstat(2)\fR. This wrapper exposes only a subset of libfaketime's functionality; please refer to the README file that came with faketime
+for more details and advanced options, or have a look at http://github.com/wolfcw/libfaketime
+.SH OPTIONS
+.TP
+\fB\-\-help\fR
+show usage information and quit.
+.TP
+\fB\-\-version\fR
+show version information and quit.
+.TP
+\fB\-m\fR
+use the multi-threading variant of libfaketime.
+.TP
+\fB\-f\fR
+use the advanced timestamp specification format.
+.TP
+\fB\--exclude-monotonic\fR
+Do not fake time when the program makes a call to clock_gettime with a CLOCK_MONOTONIC clock.
+
+.SH EXAMPLES
+.nf
+faketime 'last Friday 5 pm' /bin/date
+faketime '2008-12-24 08:15:42' /bin/date
+faketime -f '+2,5y x10,0' /bin/bash -c 'date; while true; do echo $SECONDS ; sleep 1 ; done'
+faketime -f '+2,5y x0,50' /bin/bash -c 'date; while true; do echo $SECONDS ; sleep 1 ; done'
+faketime -f '+2,5y i2,0' /bin/bash -c 'while true; do date ; sleep 1 ; done'
+In this single case all spawned processes will use the same global clock without restaring it at the start of each process.
+
+(Please note that it depends on your locale settings whether . or , has to be used for fractional offsets)
+.fi
+.SH ADVANCED TIMESTAMP FORMAT
+The simple timestamp format used by default applies the \fB/bin/date -d\fR command to parse user-friendly specifications such as 'last friday'. When using
+the faketime option \fB\-f\fR, the timestamp specified on the command line is directly passed to libfaketime, which enables a couple of additional features
+such as speeding the clock up or slowing it down for the target program. It is strongly recommended that you have a look at the libfaketime documentation. Summary:
+.TP
+Freeze clock at absolute timestamp: \fB"YYYY-MM-DD hh:mm:ss"\fR
+If you want to specify an absolute point in time, exactly this format must be used. Please note that freezing the clock is usually not what you want and may break the application. Only use if you know what you're doing!
+.TP
+Relative time offset: \fB"[+/-]123[m/h/d/y]\fR, e.g. "+60m", "+2y"
+This is the most often used format and specifies the faked time relatively to the current real time. The first character of the format string \fBmust\fR be a + or a -. The numeric value by default represents seconds, but the modifiers m, h, d, and y can be used to specify minutes, hours, days, or years, respectively. For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g. "+2,5y", which means "two and a half years in the future". Please note that the fraction delimiter depends on your locale settings, so if "+2,5y" does not work, you might want to try "+2.5y".
+.TP
+Start-at timestamps: \fB"@YYYY-MM-DD hh:mm:ss"\fR
+The wall clock will start counting at the given timestamp for the program. This can be used for specifying absolute timestamps without freezing the clock.
+.SH ADVANCED USAGE
+When using relative time offsets or start-at timestamps (see ADVANCED TIMESTAMP FORMAT above and option \fB\-f\fR), the clock speed can be adjusted, i.e. time may run faster or slower for the executed program. For example, \fB"+5y x10"\fR will set the faked time 5 years into the future and make the time pass 10 times as fast (one real second equals 10 seconds measured by the program). Similarly, the flow of time can be slowed, e.g. using \fB"-7d x0,2"\fR, which will set the faked time 7 days in the past and set the clock speed to 20 percent, i.e. it takes five real world seconds for one second measured by the program. Again, depending on your locale, either "x2.0" or "x2,0" may be required regarding the delimiter. You can also make faketime to advance the reported time by a preset interval upon each time() call independently from the system's time using \fB"-7d i2,0"\fR, where 
+\fB"i"\fR is followed by the increase interval in seconds.
+.PP
+Faking times for multiple programs or even system-wide can be simplified by using ~/.faketimerc files and /etc/faketimerc. Please refer to the README that came with faketime for warnings and details.
+.SH AUTHOR
+Please see the README and NEWS files for contributers.
+.SH BUGS
+Due to limitations of the LD_PRELOAD mechanism, faketime will not work with suidroot and statically linked programs.
+While timestamps and time offsets will work for child processes, speeding the clock up or slowing it down might not
+work for child processes spawned by the executed program as expected; a new instance of libfaketime is used for each
+child process, which means that the libfaketime start time, which is used in speed adjustments, will also be
+re-initialized. Some programs may dynamically load system libraries, such as librt, at run-time and therefore bypass libfaketime. You may report programs that do not work with libfaketime, but only if they are available as open source.
+.SH "REPORTING BUGS"
+Please use https://github.com/wolfcw/libfaketime/issues
+.SH COPYRIGHT
+Copyright \(co 2003-2013 by the libfaketime authors.
+.PP
+There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. You may redistribute copies of faketime under the
+terms of the GNU General Public License.
+.br
+For more information about these matters, see the file named COPYING.
+.SH "SEE ALSO"
+ld.so(1), time(2), fstat(2)

--- a/tools/faketime/packaging/Linux/Arch/PKGBUILD-32bit.txt
+++ b/tools/faketime/packaging/Linux/Arch/PKGBUILD-32bit.txt
@@ -1,0 +1,25 @@
+# Maintainer: Robert Orzanna <orschiro@gmail.com>
+
+_pkgbasename=libfaketime
+pkgname=lib32-$_pkgbasename
+pkgver=0.9.5
+pkgrel=1
+pkgdesc='Report fake dates and times to programs without having to change the system-wide time.'
+arch=('x86_64')
+url='http://www.code-wizards.com/projects/libfaketime/'
+license=('GPL2')
+source=("http://www.code-wizards.com/projects/${_pkgbasename}/${_pkgbasename}-${pkgver}.tar.gz"
+        'lib32.patch')
+md5sums=('89b5c71e6c6a93b1c6feba374ac37719'
+         '0a01f842df4c8acbd2b081be046e8d67')
+
+build() {
+  cd "${_pkgbasename}-${pkgver}"
+  patch -p1 -i ../lib32.patch
+  make
+}
+
+package() {
+  cd "${_pkgbasename}-${pkgver}"
+  make PREFIX=/usr DESTDIR="${pkgdir}" install
+}

--- a/tools/faketime/packaging/Linux/Debian/avoid-spurious-lrt.patch
+++ b/tools/faketime/packaging/Linux/Debian/avoid-spurious-lrt.patch
@@ -1,0 +1,30 @@
+Author: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+
+On i386 systems, for some reason if i do not clean up this extra -lrt, i get the following error:
+
+ [...]
+make[1]: Entering directory `/home/dkg/src/faketime/faketime/src'
+cc -o libfaketime.o -c -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'/usr/local'"' -DLIBDIRNAME='"'/lib/faketime'"' -DMULTI_ARCH  libfaketime.c
+cc -o libfaketime.so.1 -Wl,-soname,libfaketime.so.1 -Wl,-z,relro -Wl,--version-script=libfaketime.map -lrt -shared libfaketime.o -ldl -lm -lpthread -lrt
+libfaketime.o: In function `ft_cleanup':
+/home/dkg/src/faketime/faketime/src/libfaketime.c:1277: multiple definition of `timer_gettime'
+/home/dkg/src/faketime/faketime/src/libfaketime.c:1277: multiple definition of `timer_settime'
+collect2: error: ld returned 1 exit status
+make[1]: *** [libfaketime.so.1] Error 1
+ [...]
+
+I confess i don't really understand why removing this would fix
+things, but i also don't see the need to have multiple attempts to
+link to librt.
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -69,7 +69,7 @@
+ 
+ CFLAGS += -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"'
+ LIB_LDFLAGS += -shared
+-LDFLAGS += -Wl,--version-script=libfaketime.map -lrt
++LDFLAGS += -Wl,--version-script=libfaketime.map
+ LDADD += -ldl -lm -lpthread -lrt
+ 
+ SRC = libfaketime.c

--- a/tools/faketime/packaging/Linux/Debian/control
+++ b/tools/faketime/packaging/Linux/Debian/control
@@ -1,0 +1,40 @@
+Source: faketime
+Section: utils
+Priority: extra
+Maintainer: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+Build-Depends:
+ debhelper (>= 9),
+ dh-exec (>= 0.3)
+Standards-Version: 3.9.4
+Homepage: http://www.code-wizards.com/projects/libfaketime/
+Vcs-Browser: http://anonscm.debian.org/gitweb/?p=collab-maint/faketime.git
+Vcs-Git: git://anonscm.debian.org/collab-maint/faketime.git
+
+Package: faketime
+Architecture: any
+Pre-Depends: multiarch-support
+Depends: ${shlibs:Depends}, ${misc:Depends}, libfaketime (= ${binary:Version})
+Multi-Arch: foreign
+Description: report faked system time to programs
+ The Fake Time Preload Library (FTPL, a.k.a. libfaketime) intercepts
+ various system calls which programs use to retrieve the current date
+ and time. It can then report faked dates and times (as specified by
+ you, the user) to these programs. This means you can modify the
+ system time a program sees without having to change the time
+ system-wide. FTPL allows you to specify both absolute dates (e.g.,
+ 2004-01-01) and relative dates (e.g., 10 days ago).
+
+Package: libfaketime
+Architecture: any
+Pre-Depends: multiarch-support
+Multi-Arch: same
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: report faked system time to programs
+ The Fake Time Preload Library (FTPL, a.k.a. libfaketime) intercepts
+ various system calls which programs use to retrieve the current date
+ and time. It can then report faked dates and times (as specified by
+ you, the user) to these programs. This means you can modify the
+ system time a program sees without having to change the time
+ system-wide. FTPL allows you to specify both absolute dates (e.g.,
+ 2004-01-01) and relative dates (e.g., 10 days ago).
+

--- a/tools/faketime/packaging/Linux/Debian/fix-infinite-recursion-on-real_clock_gettime.patch
+++ b/tools/faketime/packaging/Linux/Debian/fix-infinite-recursion-on-real_clock_gettime.patch
@@ -1,0 +1,29 @@
+From: Gerardo Malazdrewicz <gerardo@malazdrewicz.com.ar>
+To: 699559@bugs.debian.org
+Subject: Avoiding loop (very dirty patch)
+Date: Tue, 26 Mar 2013 01:18:05 +0100
+
+[Message part 1 (text/plain, inline)]
+
+Attached patch works for me, but it is very very dirty.
+
+Possibly side effects.
+
+Alternative seems to be to protect the call to real_clock_gettime so it is
+executed just once (to validate the parameters). Subsequent calls are not
+needed (parameters have been validated).
+
+Thanks,
+       Gerardo
+
+--- a/src/libfaketime.c
++++ b/src/libfaketime.c
+@@ -1380,7 +1380,7 @@ void __attribute__ ((constructor)) ftpl_init(void)
+   real_clock_get_time =     dlsym(RTLD_NEXT, "clock_get_time");
+   real_clock_gettime  =     apple_clock_gettime;
+ #else
+-  real_clock_gettime  =     dlsym(RTLD_NEXT, "clock_gettime");
++  real_clock_gettime  =     dlsym(RTLD_NEXT, "__clock_gettime");
+ #ifdef FAKE_TIMERS
+   real_timer_settime_22 =   dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.2");
+   real_timer_settime_233 =  dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.3.3");

--- a/tools/faketime/packaging/Linux/Debian/libfaketime.install
+++ b/tools/faketime/packaging/Linux/Debian/libfaketime.install
@@ -1,0 +1,3 @@
+#!/usr/bin/dh-exec
+src/libfaketime.so.1 usr/lib/${DEB_HOST_MULTIARCH}/faketime/
+src/libfaketimeMT.so.1 usr/lib/${DEB_HOST_MULTIARCH}/faketime/

--- a/tools/faketime/packaging/Linux/Debian/rules
+++ b/tools/faketime/packaging/Linux/Debian/rules
@@ -1,0 +1,17 @@
+#!/usr/bin/make -f
+
+# Author: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+# Date: Tue, 26 Aug 2008 14:24:50 -0400
+
+export DEB_CFLAGS_MAINT_APPEND=-DMULTI_ARCH
+
+# make sure dh_makeshlibs does not modify post{inst,rm} scripts:
+# (avoids lintian's postinst-has-useless-call-to-ldconfig)
+override_dh_makeshlibs:
+	dh_makeshlibs --noscripts
+
+override_dh_installchangelogs:
+	dh_installchangelogs NEWS
+
+%:
+	PREFIX=/usr dh $@

--- a/tools/faketime/packaging/Linux/Redhat/libfaketime-fix-infinite-recursion-on-real_clock_gettime.patch
+++ b/tools/faketime/packaging/Linux/Redhat/libfaketime-fix-infinite-recursion-on-real_clock_gettime.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libfaketime.c b/src/libfaketime.c
+index 3ec372b..f70283b 100644
+--- a/src/libfaketime.c
++++ b/src/libfaketime.c
+@@ -1380,7 +1380,7 @@ void __attribute__ ((constructor)) ftpl_init(void)
+   real_clock_get_time =     dlsym(RTLD_NEXT, "clock_get_time");
+   real_clock_gettime  =     apple_clock_gettime;
+ #else
+-  real_clock_gettime  =     dlsym(RTLD_NEXT, "clock_gettime");
++  real_clock_gettime  =     dlsym(RTLD_NEXT, "__clock_gettime");
+ #ifdef FAKE_TIMERS
+   real_timer_settime_22 =   dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.2");
+   real_timer_settime_233 =  dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.3.3");

--- a/tools/faketime/packaging/Linux/Redhat/libfaketime.spec.txt
+++ b/tools/faketime/packaging/Linux/Redhat/libfaketime.spec.txt
@@ -1,0 +1,55 @@
+Summary: Manipulate system time per process for testing purposes
+Name: libfaketime
+Version: 0.9.5
+Release: 4%{?dist}
+License: GPLv2+
+Url: http://www.code-wizards.com/projects/%{name}/
+Source: http://www.code-wizards.com/projects/%{name}/%{name}-%{version}.tar.gz
+Group: System Environment/Libraries
+Patch1: libfaketime-0.9.5-fix-infinite-recursion-on-real_clock_gettime.patch
+
+%description
+libfaketime intercepts various system calls which programs use to
+retrieve the current date and time. It can then report faked dates and
+times (as specified by you, the user) to these programs. This means you
+can modify the system time a program sees without having to change the
+time system- wide.
+
+%prep
+%setup -q
+%patch1 -p1
+# work around from upstream for autodetecting glibc version bug on i686
+sed -i -e 's/__asm__(".symver timer_gettime_22/\/\/__asm__(".symver timer_gettime_22/' src/libfaketime.c
+sed -i -e 's/__asm__(".symver timer_settime_22/\/\/__asm__(".symver timer_settime_22/' src/libfaketime.c
+
+
+%build
+cd src ; CFLAGS="$RPM_OPT_FLAGS -Wno-strict-aliasing" make %{?_smp_mflags} \
+         PREFIX="%{_prefix}" LIBDIRNAME="/%{_lib}/faketime" all
+
+%check
+make %{?_smp_mflags} -C test all 
+
+%install
+make PREFIX="%{_prefix}" DESTDIR=%{buildroot} LIBDIRNAME="/%{_lib}/faketime" install
+rm -r %{buildroot}/%{_docdir}/faketime
+
+%files 
+%{_bindir}/faketime
+%{_libdir}/faketime/libfaketime*so.*
+%doc README COPYING NEWS README README.developers
+%{_mandir}/man1/*
+
+%changelog
+* Tue Oct 15 2013 Paul Wouters <pwouters@redhat.com> - 0.9.5-4
+- Infinite recursion patch is still needed, make test causes
+  segfaults otherwise.
+
+* Mon Oct 14 2013 Paul Wouters <pwouters@redhat.com> - 0.9.5-3
+- Work around from upstream for autodetecting glibc version bug on i686
+
+* Mon Oct 14 2013 Paul Wouters <pwouters@redhat.com> - 0.9.5-2
+- Remove use of ifarch for _lib macro for multilib
+
+* Sun Oct 13 2013 Paul Wouters <pwouters@redhat.com> - 0.9.5-1
+- Initial package

--- a/tools/faketime/packaging/OSX/Fink/libfaketime.info
+++ b/tools/faketime/packaging/OSX/Fink/libfaketime.info
@@ -1,0 +1,54 @@
+Package: libfaketime
+Version: 0.9.5
+Revision: 1
+
+Source: http://www.code-wizards.com/projects/%n/%n-%v.tar.gz
+Source-MD5: 89b5c71e6c6a93b1c6feba374ac37719
+
+Maintainer: Wolfgang Hommel <wolf@fink.code-wizards.com>
+HomePage: http://www.code-wizards.com/projects/%n
+License: GPL
+
+Description: Modify system time for single applications
+
+DescDetail: <<
+libfaketime is a library that is dynamically linked to applications
+or system commands at run-time by using the DYLD_INSERT_LIBRARIES
+mechanism. It then intercepts various system calls, which programs
+use to retrieve the current date and time. libfaketime can then
+report faked dates and times to these programs. This means you can
+modify the system time a program uses without having to change the
+date and time system-wide.
+<<
+
+DescUsage: <<
+libfaketime includes a simple wrapper called faketime. Run the
+command faketime without any parameters for usage information.
+For information on how to use libfaketime without the wrapper
+and access its full raw functionality, please see
+%p/share/doc/libfaketime/README*
+<<
+
+BuildDepends: fink (>= 0.28)
+Distribution: 10.7, 10.8, 10.9
+
+CompileScript: <<
+#! /bin/sh -ev
+make -f Makefile.OSX -C src PREFIX=%{p}
+<<
+
+InfoTest: <<
+  TestScript: make -f Makefile.OSX test || exit 2
+<<
+
+InstallScript: <<
+#! /bin/sh -ev
+make -f Makefile.OSX -C src install PREFIX=%{i}
+<<
+
+DocFiles: COPYING README README.OSX
+
+Shlibs: <<
+  !%p/lib/faketime/%N.1.dylib
+<<
+

--- a/tools/faketime/packaging/OSX/Homebrew/libfaketime.rb
+++ b/tools/faketime/packaging/OSX/Homebrew/libfaketime.rb
@@ -1,0 +1,22 @@
+require 'formula'
+
+class Libfaketime < Formula
+  homepage 'http://www.code-wizards.com/projects/libfaketime'
+  url 'http://code-wizards.com/projects/libfaketime/libfaketime-0.9.5.tar.gz'
+  sha1 '12199af854004f231892ab6976c2e99b937e2d61'
+
+  depends_on :macos => :lion
+
+  fails_with :llvm do
+    build 2336
+    cause 'No thread local storage support'
+  end
+
+  def install
+    system "make", "-C", "src", "-f", "Makefile.OSX", "PREFIX=#{prefix}"
+    bin.install 'src/faketime'
+    (lib/'faketime').install 'src/libfaketime.1.dylib'
+    man1.install 'man/faketime.1'
+  end
+end
+

--- a/tools/faketime/packaging/OSX/MacPorts/Portfile
+++ b/tools/faketime/packaging/OSX/MacPorts/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# $Id: Portfile 112093 2013-10-11 19:57:13Z ryandesign@macports.org $
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        wolfcw libfaketime 0.9.5rc3 v
+
+checksums           rmd160  8d10140a181e0d5ce93bd7b0e7eeaa380eb7a9c6 \
+                    sha256  ee2234335b3d730fdf6898d8dba9195d9ab3068c29af25270be03682d24a424f
+
+categories          sysutils
+platforms           darwin
+maintainers         code-wizards.com:wolf openmaintainer
+license             GPL-2
+
+description         libfaketime modifies the system time for a single application
+
+long_description    libfaketime intercepts various system calls that applications use to \
+                    retrieve the current date and time. It can then report user-specified \
+                    faked dates and times to these applications. This allows us to modify \
+                    the system time an application sees without having to change the time \
+                    system-wide. The faketime wrapper can be used from command line. \
+                    Check the documentation on how to integrate into installed applications.
+
+patchfiles          patch-test-Makefile.OSX.diff
+
+use_configure       no
+
+variant universal {}
+
+compiler.blacklist  *cc* *dragonegg*
+
+build.args          -f Makefile.OSX
+build.env           CC="${configure.cc}" \
+                    CFLAGS="[get_canonical_archflags cc]" \
+                    LDFLAGS="[get_canonical_archflags ld]" \
+                    PREFIX=${prefix}
+
+test.run            yes
+test.args           ${build.args}
+eval test.env       ${build.env}
+
+destroot.args       ${build.args}
+eval destroot.env   ${build.env}

--- a/tools/faketime/packaging/OSX/MacPorts/patch-test-Makefile.OSX.diff
+++ b/tools/faketime/packaging/OSX/MacPorts/patch-test-Makefile.OSX.diff
@@ -1,0 +1,12 @@
+--- test/Makefile.OSX.orig	2013-10-11 09:42:38.000000000 -0500
++++ test/Makefile.OSX	2013-10-11 14:46:11.000000000 -0500
+@@ -1,7 +1,6 @@
+-CC = gcc
++CC ?= clang
+ 
+-CFLAGS = -std=gnu99 -Wall -DFAKE_STAT
+-LDFLAGS =
++CFLAGS += -std=gnu99 -Wall -DFAKE_STAT
+ 
+ SRC = timetest.c
+ OBJ = ${SRC:.c=.o}

--- a/tools/faketime/packaging/OSX/README
+++ b/tools/faketime/packaging/OSX/README
@@ -1,0 +1,67 @@
+# Packaging for OS X
+
+Several software tools assist with the installation of open source software
+on OS X. The authors of libfaketime maintain the libfaketime build spec files
+for MacPorts, Homebrew, and Fink.
+
+
+## MacPorts
+
+Installing libfaketime via MacPorts is based on the provided Portfile, which
+has been included in the official MacPorts distribution since October, 2013.
+Users therefore can use "sudo port install libfaketime" as installation
+command.
+
+Some libfaketime Portfile caveats:
+
+- Github-based source file distribution
+    (0.9.5rc3 is code-identical to 0.9.5 release except for Makefile patches)
+- Non-clang-compilers need to be blacklisted (for libfaketime =0.9.5)
+- MacPorts folks have requested to avoid a platform-specific Makefile.OSX in
+  the future
+
+Portfile submission is documented in https://www.macports.org/guide/#project.contributing
+and handled via a ticketing system:
+
+- https://trac.macports.org/ticket/40662
+- https://trac.macports.org/ticket/40748
+
+
+## Homebrew
+
+The libfaketime 'formula' for Homebrew is available since November, 2013.
+Homebrew users can use 'brew install libfaketime' as installation command.
+
+Some libfaketime formula caveats:
+
+- "depends_on :macos => :lion" must be set for libfaketime >=0.9.5
+- :llvm builds <= 2336 must be blacklisted because libfaketime =0.9.5
+  requires a compiler with thread local storage support.
+
+Formula submission is handled via pull request on Github following the
+"one formula per commit, one commit per formula" rule, which necessitates
+squashing commits and forced pushes when applying fixes. Style issues
+complementary to the documentation have been discussed in
+
+    https://github.com/mxcl/homebrew/pull/23245
+
+
+## Fink
+
+A libfaketime.info file is included in the Fink 10.7 tree since October,
+2013, and installed using
+
+    fink install libfaketime
+
+Some libfaketime fink info file caveats:
+
+- The dynamic library must be declared as private Shlib; this also necessitates
+  BuildDepends: fink (>= 0.28)
+- "Distribution: 10.7, 10.8, 10.9" is required because libfaketime >=0.9.5 does
+  not work on OS X 10.6 or before anymore.
+- When compiling, PREFIX=%{p} needs to be used because this path is hardcoded
+  into the wrapper. However, "make install" needs to deploy into PREFIX=%{i} to
+  make packaging work.
+
+Submission is via https://sourceforge.net/p/fink/package-submissions/
+

--- a/tools/faketime/packaging/README
+++ b/tools/faketime/packaging/README
@@ -1,0 +1,14 @@
+# libfaketime packaging
+
+Not everyone feels comfortable with installing tools and libraries manually
+by downloading and building them from source. Luckily enough, voluntary
+maintainers prepare new libfaketime releases for various platforms and make
+them available as binary packages or otherwise automatically installable
+software.
+
+In this directory, we collect build specification files for the platforms
+that we are aware of being actively supported. They help us to analyze
+build issues, create awareness for platform-specific patches that had to
+be applied and might be merged with our code, and provide the contact
+information for future "early release warnings".
+

--- a/tools/faketime/src/Makefile
+++ b/tools/faketime/src/Makefile
@@ -1,0 +1,118 @@
+#
+# Notes:
+#
+#   * Compilation Defines:
+#
+#     FAKE_STAT
+#         - Enables time faking also for files' timestamps.
+#
+#     NO_ATFILE
+#         - Disables support for the fstatat() group of functions
+#
+#     PTHREAD
+#         - Define this to enable multithreading support.
+#
+#     PTHREAD_SINGLETHREADED_TIME
+#         - Define this if you want to single-thread time() ... there ARE
+#           possibile caching side-effects in a multithreaded environment
+#           without this, but the performance impact may require you to
+#           try it unsynchronized.
+#
+#     FAKE_INTERNAL_CALLS
+#         - Also intercept libc internal __functions, e.g. not just time(),
+#           but also __time(). Enhances compatibility with applications
+#           that make use of low-level system calls, such as Java Virtual
+#           Machines.
+#
+# 	  FAKE_SLEEP
+# 	      - Also intercept sleep(), nanosleep(), usleep(), alarm(), [p]poll()
+#
+#	  FAKE_TIMERS
+#	      - Also intercept timer_settime() and timer_gettime()
+#
+#	  MULTI_ARCH
+#	  	  - If MULTI_ARCH is set, the faketime wrapper program will put a literal
+#	  	    $LIB into the LD_PRELOAD environment variable it creates, which makes
+#	  	    ld automatically choose the correct library version to use for the
+#	  	    target binary. Use for Linux platforms with Multi-Arch support only!
+#
+#   * Compilation addition: second libMT target added for building the pthread-
+#     enabled library as a separate library
+#
+#   * Compilation switch change: previous versions compiled using '-nostartfiles'
+#     This is no longer the case since there is a 'startup' constructor for the library
+#     which is used to activate the start-at times when specified. This also initializes
+#     the dynamic disabling of the FAKE_STAT calls.
+#
+# By default, libfaketime will be compiled for your system's default architecture.
+# To build 32-bit libraries and binaries, add -m32 to CFLAGS and LDFLAGS.
+#
+# Change PREFIX to where you want libfaketime (libraries and wrapper binary) installed.
+# LIBDIRNAME is relative to PREFIX. The default is to install into $PREFIX/lib/faketime,
+# but you can set LIBDIRNAME to, e.g., /lib64 if you want to install it elsewhere.
+# LIBDIRNAME has been introduced to support MultiLib systems. Please do not change the 
+# default value on MultiArch systems. 
+#
+# For testing in the current directory without installation, try make PREFIX= LIBDIRNAME='.'
+
+CC ?= gcc
+INSTALL ?= install
+
+PREFIX ?= /usr/local
+LIBDIRNAME ?= /lib/faketime
+PLATFORM ?=$(shell uname)
+
+CFLAGS += -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"'
+ifeq ($(PLATFORM),SunOS)
+CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=600
+endif
+
+LIB_LDFLAGS += -shared
+
+LDFLAGS += -lpthread
+ifneq ($(PLATFORM),SunOS)
+LDFLAGS += -Wl,--version-script=libfaketime.map
+endif
+
+LDADD += -ldl -lm -lrt
+BIN_LDFLAGS += -lrt
+
+SRC = libfaketime.c
+LIBS_OBJ = libfaketime.o libfaketimeMT.o
+BINS = faketime
+
+SONAME = 1
+LIBS = libfaketime.so.${SONAME} libfaketimeMT.so.${SONAME}
+
+all: ${LIBS} ${BINS}
+
+libfaketimeMT.o: EXTRA_FLAGS := -DPTHREAD -DPTHREAD_SINGLETHREADED_TIME
+
+${LIBS_OBJ}: libfaketime.c
+	${CC} -o $@ -c ${CFLAGS} ${EXTRA_FLAGS} $<
+
+%.so.${SONAME}: %.o libfaketime.map
+	${CC} -o $@ -Wl,-soname,$@ ${LDFLAGS} ${LIB_LDFLAGS} $< ${LDADD}
+
+${BINS}: faketime.c
+	${CC} -o $@ ${CFLAGS} ${EXTRA_FLAGS} $< ${LDFLAGS} ${BIN_LDFLAGS}
+
+clean:
+	@rm -f ${LIBS_OBJ} ${LIBS} ${BINS}
+
+distclean: clean
+	@echo
+
+install: ${LIBS} ${BINS}
+	@echo
+	@echo "Copying the faketime libraries to ${DESTDIR}${PREFIX}${LIBDIRNAME} and the faketime wrapper script to ${DESTDIR}${PREFIX}/bin ..."
+	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}${LIBDIRNAME}/"
+	$(INSTALL) -m0644 ${LIBS} "${DESTDIR}${PREFIX}${LIBDIRNAME}/"
+	$(INSTALL) -Dm0755 faketime "${DESTDIR}${PREFIX}/bin/faketime"
+
+uninstall:
+	for f in ${LIBS}; do rm -f "${DESTDIR}${PREFIX}${LIBDIRNAME}/$$f"; done
+	rmdir "${DESTDIR}${PREFIX}${LIBDIRNAME}"
+	rm -f "${DESTDIR}${PREFIX}/bin/faketime"
+
+.PHONY: all clean distclean install uninstall

--- a/tools/faketime/src/Makefile.OSX
+++ b/tools/faketime/src/Makefile.OSX
@@ -1,0 +1,75 @@
+#
+# Notes:
+#
+#   * Compilation Defines:
+#
+#     FAKE_STAT
+#         - Enables time faking also for files' timestamps.
+#
+#     NO_ATFILE
+#         - Disables support for the fstatat() group of functions
+#
+#     PTHREAD
+#         - Define this to enable multithreading support.
+#
+#     PTHREAD_SINGLETHREADED_TIME
+#         - Define this if you want to single-thread time() ... there ARE
+#           possibile caching side-effects in a multithreaded environment
+#           without this, but the performance impact may require you to
+#           try it unsynchronized.
+#
+# 	  FAKE_SLEEP
+# 	      - Also intercept sleep(), nanosleep(), usleep(), alarm(), [p]poll()
+#
+#   * Compilation addition: second libMT target added for building the pthread-
+#     enabled library as a separate library
+#
+#   * Compilation switch change: previous versions compiled using '-nostartfiles'
+#     This is no longer the case since there is a 'startup' constructor for the library
+#     which is used to activate the start-at times when specified. This also initializes
+#     the dynamic disabling of the FAKE_STAT calls.
+#
+# By default, libfaketime will be compiled for your system's default architecture.
+# To build for a different architecture, add -arch flags to CFLAGS and LDFLAGS.
+#
+# default to clang to support thread local variables
+CC ?= clang
+INSTALL ?= install
+
+PREFIX ?= /usr/local
+
+CFLAGS += -DFAKE_SLEEP -DFAKE_INTERNAL_CALLS -DPREFIX='"'${PREFIX}'"'
+LIB_LDFLAGS += -dynamiclib -current_version 0.9.6 -compatibility_version 0.7
+
+SONAME = 1
+LIBS = libfaketime.${SONAME}.dylib
+BINS = faketime
+
+all: ${LIBS} ${BINS}
+
+libfaketime.${SONAME}.dylib: libfaketime.c
+	${CC} -o $@ ${CFLAGS} ${LDFLAGS} ${LIB_LDFLAGS} -install_name ${PREFIX}/lib/faketime/$@ $<
+
+faketime: faketime.c
+	${CC} -o $@ ${CFLAGS} ${LDFLAGS} $<
+
+clean:
+	@rm -f ${OBJ} ${LIBS} ${BINS}
+
+distclean: clean
+	@echo
+
+install: ${LIBS} ${BINS}
+	@echo
+	@echo "Copying the faketime libraries to ${DESTDIR}${PREFIX}/lib/faketime and the faketime wrapper script to ${DESTDIR}${PREFIX}/bin ..."
+	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/lib/faketime/"
+	$(INSTALL) -m0644 ${LIBS} "${DESTDIR}${PREFIX}/lib/faketime/"
+	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/bin"
+	$(INSTALL) -m0755 faketime "${DESTDIR}${PREFIX}/bin/faketime"
+
+uninstall:
+	for f in ${LIBS}; do rm -f "${DESTDIR}${PREFIX}/lib/faketime/$$f"; done
+	rmdir "${DESTDIR}${PREFIX}/lib/faketime"
+	rm -f "${DESTDIR}${PREFIX}/bin/faketime"
+
+.PHONY: all clean distclean install uninstall

--- a/tools/faketime/src/faketime.c
+++ b/tools/faketime/src/faketime.c
@@ -1,0 +1,385 @@
+/*
+ *  libfaketime wrapper command
+ *
+ *  This file is part of libfaketime, version 0.9.6
+ *
+ *  libfaketime is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License v2 as published by the
+ *  Free Software Foundation.
+ *
+ *  libfaketime is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ *  more details.
+ *
+ *  You should have received a copy of the GNU General Public License v2 along
+ *  with the libfaketime; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Converted from shell script by Balint Reczey with the following credits
+ * and comments:
+ *
+ * Thanks to Daniel Kahn Gillmor for improvement suggestions.
+
+ * This wrapper exposes only a small subset of the libfaketime functionality.
+ * Please see libfaketime's README file and man page for more details.
+
+ * Acknowledgment: Parts of the functionality of this wrapper have been
+ * inspired by Matthias Urlichs' datefudge 1.14.
+
+ * Compile time configuration: Path where the libfaketime libraries can be found
+ * on Linux/UNIX
+ *
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <semaphore.h>
+
+#include "faketime_common.h"
+
+const char version[] = "0.9.6";
+
+#ifdef __APPLE__
+static const char *date_cmd = "gdate";
+#else
+static const char *date_cmd = "date";
+#endif
+
+#define PATH_BUFSIZE 4096
+
+/* semaphore and shared memory names */
+char sem_name[PATH_BUFSIZE] = {0}, shm_name[PATH_BUFSIZE] = {0};
+
+void usage(const char *name)
+{
+  printf("\n");
+  printf("Usage: %s [switches] <timestamp> <program with arguments>\n", name);
+  printf("\n");
+  printf("This will run the specified 'program' with the given 'arguments'.\n");
+  printf("The program will be tricked into seeing the given 'timestamp' as its starting date and time.\n");
+  printf("The clock will continue to run from this timestamp. Please see the manpage (man faketime)\n");
+  printf("for advanced options, such as stopping the wall clock and make it run faster or slower.\n");
+  printf("\n");
+  printf("The optional switches are:\n");
+  printf("  -m                  : Use the multi-threaded version of libfaketime\n");
+  printf("  -f                  : Use the advanced timestamp specification format (see manpage)\n");
+  printf("  --exclude-monotonic : Prevent monotonic clock from drifting (not the raw monotonic one)\n");
+  printf("\n");
+  printf("Examples:\n");
+  printf("%s 'last friday 5 pm' /bin/date\n", name);
+  printf("%s '2008-12-24 08:15:42' /bin/date\n", name);
+  printf("%s -f '+2,5y x10,0' /bin/bash -c 'date; while true; do echo $SECONDS ; sleep 1 ; done'\n", name);
+  printf("%s -f '+2,5y x0,50' /bin/bash -c 'date; while true; do echo $SECONDS ; sleep 1 ; done'\n", name);
+  printf("%s -f '+2,5y i2,0' /bin/bash -c 'date; while true; do date; sleep 1 ; done'\n", name);
+  printf("In this single case all spawned processes will use the same global clock\n");
+  printf("without restaring it at the start of each process.\n\n");
+  printf("(Please note that it depends on your locale settings whether . or , has to be used for fractions)\n");
+  printf("\n");
+}
+
+/** Clean up shared objects */
+static void cleanup_shobjs()
+{
+  if (-1 == sem_unlink(sem_name))
+  {
+    perror("sem_unlink");
+  }
+  if (-1 == shm_unlink(shm_name))
+  {
+    perror("shm_unlink");
+  }
+}
+
+int main (int argc, char **argv)
+{
+  pid_t child_pid;
+  int curr_opt = 1;
+  bool use_mt = false, use_direct = false;
+  long offset;
+
+  while(curr_opt < argc)
+  {
+    if (0 == strcmp(argv[curr_opt], "-m"))
+    {
+      use_mt = true;
+      curr_opt++;
+      continue;
+    }
+    else if (0 == strcmp(argv[curr_opt], "-f"))
+    {
+      use_direct = true;
+      curr_opt++;
+      continue;
+    }
+    else if (0 == strcmp(argv[curr_opt], "--exclude-monotonic"))
+    {
+      setenv("DONT_FAKE_MONOTONIC", "1", true);
+      curr_opt++;
+      continue;
+    }
+    else if ((0 == strcmp(argv[curr_opt], "-v")) ||
+             (0 == strcmp(argv[curr_opt], "--version")))
+    {
+      printf("\n%s: Version %s\n"
+         "For usage information please use '%s --help'.\n",
+         argv[0], version, argv[0]);
+      exit(EXIT_SUCCESS);
+    }
+    else if ((0 == strcmp(argv[curr_opt], "-h")) ||
+             (0 == strcmp(argv[curr_opt], "-?")) ||
+             (0 == strcmp(argv[curr_opt], "--help")))
+    {
+      usage(argv[0]);
+      exit(EXIT_SUCCESS);
+    }
+    else
+    {
+      /* we parsed all options */
+      break;
+    }
+  }
+
+  /* we need at least a timestamp string and a command to run */
+  if (argc - curr_opt < 2)
+  {
+    usage(argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  if (!use_direct)
+  {
+    // TODO get seconds
+    int pfds[2];
+    (void) (pipe(pfds) + 1);
+    int ret = EXIT_SUCCESS;
+
+    if (0 == (child_pid = fork()))
+    {
+      close(1);       /* close normal stdout */
+      (void) (dup(pfds[1]) + 1);   /* make stdout same as pfds[1] */
+      close(pfds[0]); /* we don't need this */
+      if (EXIT_SUCCESS != execlp(date_cmd, date_cmd, "-d", argv[curr_opt], "+%s",(char *) NULL))
+      {
+        perror("Running (g)date failed");
+        exit(EXIT_FAILURE);
+      }
+    }
+    else
+    {
+      char buf[256] = {0}; /* e will have way less than 256 digits */
+      close(pfds[1]);   /* we won't write to this */
+      (void) (read(pfds[0], buf, 256) + 1);
+      waitpid(child_pid, &ret, 0);
+      if (ret != EXIT_SUCCESS)
+      {
+        printf("Error: Timestamp to fake not recognized, please re-try with a "
+               "different timestamp.\n");
+        exit(EXIT_FAILURE);
+      }
+      offset = atol(buf) - time(NULL);
+      ret = snprintf(buf, sizeof(buf), "%s%ld", (offset >= 0)?"+":"", offset);
+      setenv("FAKETIME", buf, true);
+      close(pfds[0]); /* finished reading */
+    }
+  }
+  else
+  {
+    /* simply pass format string along */
+    setenv("FAKETIME", argv[curr_opt], true);
+  }
+  int keepalive_fds[2];
+  (void) (pipe(keepalive_fds) + 1);
+
+  /* we just consumed the timestamp option */
+  curr_opt++;
+
+  {
+    /* create semaphores and shared memory */
+    int shm_fd;
+    sem_t *sem;
+    struct ft_shared_s *ft_shared;
+    char shared_objs[PATH_BUFSIZE];
+
+    /*
+     * Casting of getpid() return value to long needed to make GCC on SmartOS
+     * happy, since getpid's return value's type on SmartOS is long. Since
+     * getpid's return value's type is int on most other systems, and that
+     * sizeof(long) always >= sizeof(int), this works on all platforms without
+     * the need for crazy #ifdefs.
+     */
+    snprintf(sem_name, PATH_BUFSIZE -1 ,"/faketime_sem_%ld", (long)getpid());
+    snprintf(shm_name, PATH_BUFSIZE -1 ,"/faketime_shm_%ld", (long)getpid());
+
+    if (SEM_FAILED == (sem = sem_open(sem_name, O_CREAT|O_EXCL, S_IWUSR|S_IRUSR, 1)))
+    {
+      perror("sem_open");
+      exit(EXIT_FAILURE);
+    }
+
+    /* create shm */
+    if (-1 == (shm_fd = shm_open(shm_name, O_CREAT|O_EXCL|O_RDWR, S_IWUSR|S_IRUSR)))
+    {
+      perror("shm_open");
+      if (-1 == sem_unlink(argv[2]))
+      {
+        perror("sem_unlink");
+      }
+      exit(EXIT_FAILURE);
+    }
+
+    /* set shm size */
+    if (-1 == ftruncate(shm_fd, sizeof(uint64_t)))
+    {
+      perror("ftruncate");
+      cleanup_shobjs();
+      exit(EXIT_FAILURE);
+    }
+
+    /* map shm */
+    if (MAP_FAILED == (ft_shared = mmap(NULL, sizeof(struct ft_shared_s), PROT_READ|PROT_WRITE,
+                        MAP_SHARED, shm_fd, 0)))
+    {
+      perror("mmap");
+      cleanup_shobjs();
+      exit(EXIT_FAILURE);
+    }
+
+    if (sem_wait(sem) == -1)
+    {
+      perror("sem_wait");
+      cleanup_shobjs();
+      exit(EXIT_FAILURE);
+    }
+
+    /* init elapsed time ticks to zero */
+    ft_shared->ticks = 0;
+    ft_shared->file_idx = 0;
+    ft_shared->start_time.real.tv_sec = 0;
+    ft_shared->start_time.real.tv_nsec = -1;
+    ft_shared->start_time.mon.tv_sec = 0;
+    ft_shared->start_time.mon.tv_nsec = -1;
+    ft_shared->start_time.mon_raw.tv_sec = 0;
+    ft_shared->start_time.mon_raw.tv_nsec = -1;
+
+    if (-1 == munmap(ft_shared, (sizeof(struct ft_shared_s))))
+    {
+      perror("munmap");
+      cleanup_shobjs();
+      exit(EXIT_FAILURE);
+    }
+
+    if (sem_post(sem) == -1)
+    {
+      perror("semop");
+      cleanup_shobjs();
+      exit(EXIT_FAILURE);
+    }
+
+    snprintf(shared_objs, PATH_BUFSIZE, "%s %s", sem_name, shm_name);
+    setenv("FAKETIME_SHARED", shared_objs, true);
+    sem_close(sem);
+  }
+
+  {
+    char *ftpl_path;
+#ifdef __APPLE__
+    ftpl_path = PREFIX "/libfaketime.1.dylib";
+    FILE *check;
+    check = fopen(ftpl_path, "ro");
+    if (check == NULL)
+    {
+      ftpl_path = PREFIX "/lib/faketime/libfaketime.1.dylib";
+    }
+    else
+    {
+      fclose(check);
+    }
+    setenv("DYLD_INSERT_LIBRARIES", ftpl_path, true);
+    setenv("DYLD_FORCE_FLAT_NAMESPACE", "1", true);
+#else
+    {
+      char *ld_preload_new, *ld_preload = getenv("LD_PRELOAD");
+      size_t len;
+      if (use_mt)
+      {
+        /*
+         * on MultiArch platforms, such as Debian, we put a literal $LIB into LD_PRELOAD.
+         */
+#ifndef MULTI_ARCH
+        ftpl_path = PREFIX LIBDIRNAME "/libfaketimeMT.so.1";
+#else
+        ftpl_path = PREFIX "/$LIB/faketime/libfaketimeMT.so.1";
+#endif
+      }
+      else
+      {
+#ifndef MULTI_ARCH
+        ftpl_path = PREFIX LIBDIRNAME "/libfaketime.so.1";
+#else
+        ftpl_path = PREFIX "/$LIB/faketime/libfaketime.so.1";
+#endif
+      }
+      len = ((ld_preload)?strlen(ld_preload) + 1: 0) + 1 + strlen(ftpl_path);
+      ld_preload_new = malloc(len);
+      snprintf(ld_preload_new, len ,"%s%s%s", (ld_preload)?ld_preload:"",
+              (ld_preload)?":":"", ftpl_path);
+      setenv("LD_PRELOAD", ld_preload_new, true);
+      free(ld_preload_new);
+    }
+#endif
+  }
+
+  /* run command and clean up shared objects */
+  if (0 == (child_pid = fork()))
+  {
+    close(keepalive_fds[0]); /* only parent needs to read this */
+    if (EXIT_SUCCESS != execvp(argv[curr_opt], &argv[curr_opt]))
+    {
+      perror("Running specified command failed");
+      exit(EXIT_FAILURE);
+    }
+  }
+  else
+  {
+    int ret;
+    char buf;
+    close(keepalive_fds[1]); /* only children need keep this open */
+    waitpid(child_pid, &ret, 0);
+    (void) (read(keepalive_fds[0], &buf, 1) + 1); /* reads 0B when all children exit */
+    cleanup_shobjs();
+    if (WIFSIGNALED(ret))
+    {
+      fprintf(stderr, "Caught %s\n", strsignal(WTERMSIG(ret)));
+      exit(EXIT_FAILURE);
+    }
+    exit(WEXITSTATUS(ret));
+  }
+
+  return EXIT_SUCCESS;
+}
+
+/*
+ * Editor modelines
+ *
+ * Local variables:
+ * c-basic-offset: 2
+ * tab-width: 2
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=2 tabstop=2 expandtab:
+ * :indentSize=2:tabSize=2:noTabs=true:
+ */
+
+/* eof */

--- a/tools/faketime/src/faketime_common.h
+++ b/tools/faketime/src/faketime_common.h
@@ -1,0 +1,50 @@
+/*
+ * Faketime's common definitions
+ *
+ * Copyright 2013 Balint Reczey <balint@balintreczey.hu>
+ *
+ * This file is part of the libfaketime.
+ *
+ * libfaketime is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License v2 as published by the Free
+ * Software Foundation.
+ *
+ * libfaketime is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2 along
+ * with libfaketime; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef FAKETIME_COMMON_H
+#define FAKETIME_COMMON_H
+
+#include <stdint.h>
+
+struct system_time_s
+{
+  /* System time according to CLOCK_REALTIME */
+  struct timespec real;
+  /* System time according to CLOCK_MONOTONIC */
+  struct timespec mon;
+  /* System time according to CLOCK_MONOTONIC_RAW */
+  struct timespec mon_raw;
+};
+
+/* Data shared among faketime-spawned processes */
+struct ft_shared_s
+{
+  /*
+   * When advancing time linearly with each time(), etc. call, the calls are
+   * counted here */
+  uint64_t ticks;
+  /* Index of timstamp to be loaded from file */
+  uint64_t file_idx;
+  /* System time Faketime started at */
+  struct system_time_s start_time;
+};
+
+#endif

--- a/tools/faketime/src/libfaketime.c
+++ b/tools/faketime/src/libfaketime.c
@@ -1,0 +1,2313 @@
+/*
+ *  This file is part of libfaketime, version 0.9.6
+ *
+ *  libfaketime is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License v2 as published by the
+ *  Free Software Foundation.
+ *
+ *  libfaketime is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ *  more details.
+ *
+ *  You should have received a copy of the GNU General Public License v2 along
+ *  with the libfaketime; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/*
+ *      =======================================================================
+ *      Global settings, includes, and macros                          === HEAD
+ *      =======================================================================
+ */
+
+#define _GNU_SOURCE             /* required to get RTLD_NEXT defined */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <time.h>
+#include <math.h>
+#include <errno.h>
+#include <string.h>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <limits.h>
+
+#include "time_ops.h"
+#include "faketime_common.h"
+
+/* pthread-handling contributed by David North, TDI in version 0.7 */
+#ifdef PTHREAD
+#include <pthread.h>
+#endif
+
+#include <sys/timeb.h>
+#include <dlfcn.h>
+
+#define BUFFERLEN   256
+
+#ifndef __APPLE__
+extern char *__progname;
+#ifdef __sun
+#include "sunos_endian.h"
+#else
+#include <endian.h>
+#endif
+#else
+/* endianness related macros */
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+/* clock_gettime() and related clock definitions are missing on __APPLE__ */
+#ifndef CLOCK_REALTIME
+/* from GNU C Library time.h */
+/* Identifier for system-wide realtime clock. ( == 1) */
+#define CLOCK_REALTIME               CALENDAR_CLOCK
+/* Monotonic system-wide clock. (== 0) */
+#define CLOCK_MONOTONIC              SYSTEM_CLOCK
+/* High-resolution timer from the CPU.  */
+#define CLOCK_PROCESS_CPUTIME_ID     2
+/* Thread-specific CPU-time clock.  */
+#define CLOCK_THREAD_CPUTIME_ID      3
+/* Monotonic system-wide clock, not adjusted for frequency scaling.  */
+#define CLOCK_MONOTONIC_RAW          4
+typedef int clockid_t;
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+#endif
+
+/* some systems lack raw clock */
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW (CLOCK_MONOTONIC + 1)
+#endif
+
+/*
+ * Per thread variable, which we turn on inside real_* calls to avoid modifying
+ * time multiple times of for the whole process to prevent faking time
+ */
+static __thread bool dont_fake = false;
+
+/* Wrapper for function calls, which we want to return system time */
+#define DONT_FAKE_TIME(call)          \
+  {                                   \
+    bool dont_fake_orig = dont_fake;  \
+    if (!dont_fake)                   \
+    {                                 \
+      dont_fake = true;               \
+    }                                 \
+    call;                             \
+    dont_fake = dont_fake_orig;       \
+  } while (0)
+
+/* pointers to real (not faked) functions */
+static int          (*real_stat)            (int, const char *, struct stat *);
+static int          (*real_fstat)           (int, int, struct stat *);
+static int          (*real_fstatat)         (int, int, const char *, struct stat *, int);
+static int          (*real_lstat)           (int, const char *, struct stat *);
+static int          (*real_stat64)          (int, const char *, struct stat64 *);
+static int          (*real_fstat64)         (int, int , struct stat64 *);
+static int          (*real_fstatat64)       (int, int , const char *, struct stat64 *, int);
+static int          (*real_lstat64)         (int, const char *, struct stat64 *);
+static time_t       (*real_time)            (time_t *);
+static int          (*real_ftime)           (struct timeb *);
+static int          (*real_gettimeofday)    (struct timeval *, void *);
+static int          (*real_clock_gettime)   (clockid_t clk_id, struct timespec *tp);
+#ifdef FAKE_INTERNAL_CALLS
+static int          (*real___ftime)           (struct timeb *);
+static int          (*real___gettimeofday)    (struct timeval *, void *);
+static int          (*real___clock_gettime)   (clockid_t clk_id, struct timespec *tp);
+#endif
+#ifndef __APPLE__
+#ifdef FAKE_TIMERS
+static int          (*real_timer_settime_22)   (int timerid, int flags, const struct itimerspec *new_value,
+                                                struct itimerspec * old_value);
+static int          (*real_timer_settime_233)  (timer_t timerid, int flags,
+                                                const struct itimerspec *new_value,
+                                                struct itimerspec * old_value);
+static int          (*real_timer_gettime_22)   (int timerid,
+                                                struct itimerspec *curr_value);
+static int          (*real_timer_gettime_233)  (timer_t timerid,
+                                                struct itimerspec *curr_value);
+#endif
+#endif
+#ifdef FAKE_SLEEP
+static int          (*real_nanosleep)       (const struct timespec *req, struct timespec *rem);
+static int          (*real_usleep)          (useconds_t usec);
+static unsigned int (*real_sleep)           (unsigned int seconds);
+static unsigned int (*real_alarm)           (unsigned int seconds);
+static int          (*real_poll)            (struct pollfd *, nfds_t, int);
+static int          (*real_ppoll)           (struct pollfd *, nfds_t, const struct timespec *, const sigset_t *);
+static int          (*real_sem_timedwait)   (sem_t*, const struct timespec*);
+#endif
+#ifdef __APPLE__
+static int          (*real_clock_get_time)  (clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t);
+static int          apple_clock_gettime     (clockid_t clk_id, struct timespec *tp);
+static clock_serv_t clock_serv_real;
+#endif
+
+static int initialized = 0;
+
+/* prototypes */
+static int    fake_gettimeofday(struct timeval *tv);
+static int    fake_clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+/** Semaphore protecting shared data */
+static sem_t *shared_sem = NULL;
+
+/** Data shared among faketime-spawned processes */
+static struct ft_shared_s *ft_shared = NULL;
+
+/** Storage format for timestamps written to file. Big endian.*/
+struct saved_timestamp
+{
+  int64_t sec;
+  uint64_t nsec;
+};
+
+static inline void timespec_from_saved (struct timespec *tp,
+  struct saved_timestamp *saved)
+{
+  /* read as big endian */
+  tp->tv_sec = be64toh(saved->sec);
+  tp->tv_nsec = be64toh(saved->nsec);
+}
+
+/** Saved timestamps */
+static struct saved_timestamp *stss = NULL;
+static size_t infile_size;
+static bool infile_set = false;
+
+/** File fd to save timestamps to */
+static int outfile = -1;
+
+static bool limited_faking = false;
+static long callcounter = 0;
+static long ft_start_after_secs = -1;
+static long ft_stop_after_secs = -1;
+static long ft_start_after_ncalls = -1;
+static long ft_stop_after_ncalls = -1;
+
+static bool spawnsupport = false;
+static int spawned = 0;
+static char ft_spawn_target[1024];
+static long ft_spawn_secs = -1;
+static long ft_spawn_ncalls = -1;
+
+static int fake_monotonic_clock = 1;
+static int cache_enabled = 1;
+static int cache_duration = 10;     /* cache fake time input for 10 seconds */
+
+/*
+ * Static timespec to store our startup time, followed by a load-time library
+ * initialization declaration.
+ */
+static struct system_time_s ftpl_starttime = {{0, -1}, {0, -1}, {0, -1}};
+
+static char user_faked_time_fmt[BUFSIZ] = {0};
+
+/* User supplied base time to fake */
+static struct timespec user_faked_time_timespec = {0, -1};
+/* User supplied base time is set */
+static bool user_faked_time_set = false;
+static char user_faked_time_saved[BUFFERLEN] = {0};
+
+/* Fractional user offset provided through FAKETIME env. var.*/
+static struct timespec user_offset = {0, -1};
+/* Speed up or slow down clock */
+static double user_rate = 1.0;
+static bool user_rate_set = false;
+static struct timespec user_per_tick_inc = {0, -1};
+static bool user_per_tick_inc_set = false;
+
+enum ft_mode_t {FT_FREEZE, FT_START_AT, FT_NOOP} ft_mode = FT_FREEZE;
+
+/* Time to fake is not provided through FAKETIME env. var. */
+static bool parse_config_file = true;
+
+void ft_cleanup (void) __attribute__ ((destructor));
+void ftpl_init (void) __attribute__ ((constructor));
+
+
+/*
+ *      =======================================================================
+ *      Shared memory related functions                                 === SHM
+ *      =======================================================================
+ */
+
+static void ft_shm_init (void)
+{
+  int ticks_shm_fd;
+  char sem_name[256], shm_name[256], *ft_shared_env = getenv("FAKETIME_SHARED");
+
+  if (ft_shared_env != NULL)
+  {
+    if (sscanf(ft_shared_env, "%255s %255s", sem_name, shm_name) < 2)
+    {
+      printf("Error parsing semaphore name and shared memory id from string: %s", ft_shared_env);
+      exit(1);
+    }
+
+    if (SEM_FAILED == (shared_sem = sem_open(sem_name, 0)))
+    {
+      perror("sem_open");
+      exit(1);
+    }
+
+    if (-1 == (ticks_shm_fd = shm_open(shm_name, O_CREAT|O_RDWR, S_IWUSR|S_IRUSR)))
+    {
+      perror("shm_open");
+      exit(1);
+    }
+
+    if (MAP_FAILED == (ft_shared = mmap(NULL, sizeof(struct ft_shared_s), PROT_READ|PROT_WRITE,
+            MAP_SHARED, ticks_shm_fd, 0)))
+    {
+      perror("mmap");
+      exit(1);
+    }
+  }
+}
+
+void ft_cleanup (void)
+{
+  /* detach from shared memory */
+  if (ft_shared != NULL)
+  {
+    munmap(ft_shared, sizeof(uint64_t));
+  }
+  if (stss != NULL)
+  {
+    munmap(stss, infile_size);
+  }
+  if (shared_sem != NULL)
+  {
+    sem_close(shared_sem);
+  }
+}
+
+
+/*
+ *      =======================================================================
+ *      Internal time retrieval                                     === INTTIME
+ *      =======================================================================
+ */
+
+/* Get system time from system for all clocks */
+static void system_time_from_system (struct system_time_s * systime)
+{
+#ifdef __APPLE__
+  /* from http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x */
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &clock_serv_real);
+  (*real_clock_get_time)(clock_serv_real, &mts);
+  systime->real.tv_sec = mts.tv_sec;
+  systime->real.tv_nsec = mts.tv_nsec;
+  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+  (*real_clock_get_time)(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  systime->mon.tv_sec = mts.tv_sec;
+  systime->mon.tv_nsec = mts.tv_nsec;
+  systime->mon_raw.tv_sec = mts.tv_sec;
+  systime->mon_raw.tv_nsec = mts.tv_nsec;
+#else
+  DONT_FAKE_TIME((*real_clock_gettime)(CLOCK_REALTIME, &systime->real));
+  DONT_FAKE_TIME((*real_clock_gettime)(CLOCK_MONOTONIC, &systime->mon));
+  DONT_FAKE_TIME((*real_clock_gettime)(CLOCK_MONOTONIC_RAW, &systime->mon_raw));
+#endif
+}
+
+static void next_time(struct timespec *tp, struct timespec *ticklen)
+{
+  if (shared_sem != NULL)
+  {
+    struct timespec inc;
+    /* lock */
+    if (sem_wait(shared_sem) == -1)
+    {
+      perror("sem_wait");
+      exit(1);
+    }
+    /* calculate and update elapsed time */
+    timespecmul(ticklen, ft_shared->ticks, &inc);
+    timespecadd(&user_faked_time_timespec, &inc, tp);
+    (ft_shared->ticks)++;
+    /* unlock */
+    if (sem_post(shared_sem) == -1)
+    {
+      perror("sem_post");
+      exit(1);
+    }
+  }
+}
+
+
+/*
+ *      =======================================================================
+ *      Saving & loading time                                          === SAVE
+ *      =======================================================================
+ */
+
+static void save_time(struct timespec *tp)
+{
+  if ((shared_sem != NULL) && (outfile != -1))
+  {
+    struct saved_timestamp time_write;
+    ssize_t written;
+    size_t n = 0;
+
+    time_write.sec = htobe64(tp->tv_sec);
+    time_write.nsec = htobe64(tp->tv_nsec);
+
+    /* lock */
+    if (sem_wait(shared_sem) == -1)
+    {
+      perror("sem_wait");
+      exit(1);
+    }
+
+    lseek(outfile, 0, SEEK_END);
+    do
+    {
+      written = write(outfile, &(((char*)&time_write)[n]), sizeof(time_write) - n);
+    }
+    while (((written == -1) && (errno == EINTR)) ||
+            (sizeof(time_write) < (n += written)));
+
+    if ((written == -1) || (n < sizeof(time_write)))
+    {
+      perror("Saving timestamp to file failed");
+    }
+
+    /* unlock */
+    if (sem_post(shared_sem) == -1)
+    {
+      perror("sem_post");
+      exit(1);
+    }
+  }
+}
+
+/*
+ * Provide faked time from file.
+ * @return time is set from filen
+ */
+static bool load_time(struct timespec *tp)
+{
+  bool ret = false;
+  if ((shared_sem != NULL) && (infile_set))
+  {
+    /* lock */
+    if (sem_wait(shared_sem) == -1)
+    {
+      perror("sem_wait");
+      exit(1);
+    }
+
+    if ((sizeof(stss[0]) * (ft_shared->file_idx + 1)) > infile_size)
+    {
+      /* we are out of timstamps to replay, return to faking time by rules
+       * using last timestamp from file as the user provided timestamp */
+      timespec_from_saved(&user_faked_time_timespec, &stss[(infile_size / sizeof(stss[0])) - 1 ]);
+
+      if (ft_shared->ticks == 0)
+      {
+        /* we set shared memory to stop using infile */
+        ft_shared->ticks = 1;
+        system_time_from_system(&ftpl_starttime);
+        ft_shared->start_time = ftpl_starttime;
+      }
+      else
+      {
+        ftpl_starttime = ft_shared->start_time;
+      }
+
+      munmap(stss, infile_size);
+      infile_set = false;
+    }
+    else
+    {
+      timespec_from_saved(tp, &stss[ft_shared->file_idx]);
+      ft_shared->file_idx++;
+      ret = true;
+    }
+
+    /* unlock */
+    if (sem_post(shared_sem) == -1)
+    {
+      perror("sem_post");
+      exit(1);
+    }
+  }
+  return ret;
+}
+
+
+/*
+ *      =======================================================================
+ *      Faked system functions: file related                     === FAKE(FILE)
+ *      =======================================================================
+ */
+
+#ifdef FAKE_STAT
+
+#ifndef NO_ATFILE
+#ifndef _ATFILE_SOURCE
+#define _ATFILE_SOURCE
+#endif
+#include <fcntl.h> /* Definition of AT_* constants */
+#endif
+
+#include <sys/stat.h>
+
+static int fake_stat_disabled = 0;
+
+#define FAKE_STRUCT_STAT_TIME(which) {                \
+    struct timespec t = {buf->st_##which##time,       \
+                         buf->st_##which##timensec};  \
+    fake_clock_gettime(CLOCK_REALTIME, &t);           \
+    buf->st_##which##time = t.tv_sec;                 \
+    buf->st_##which##timensec = t.tv_nsec;            \
+  } while (0)
+
+static inline void fake_statbuf (struct stat *buf) {
+#ifndef st_atime
+  FAKE_STRUCT_STAT_TIME(c);
+  FAKE_STRUCT_STAT_TIME(a);
+  FAKE_STRUCT_STAT_TIME(m);
+#else
+  fake_clock_gettime(CLOCK_REALTIME, &buf->st_ctim);
+  fake_clock_gettime(CLOCK_REALTIME, &buf->st_atim);
+  fake_clock_gettime(CLOCK_REALTIME, &buf->st_mtim);
+#endif
+}
+
+static inline void fake_stat64buf (struct stat64 *buf) {
+#ifndef st_atime
+  FAKE_STRUCT_STAT_TIME(c);
+  FAKE_STRUCT_STAT_TIME(a);
+  FAKE_STRUCT_STAT_TIME(m);
+#else
+  fake_clock_gettime(CLOCK_REALTIME, &buf->st_ctim);
+  fake_clock_gettime(CLOCK_REALTIME, &buf->st_atim);
+  fake_clock_gettime(CLOCK_REALTIME, &buf->st_mtim);
+#endif
+}
+
+/* Contributed by Philipp Hachtmann in version 0.6 */
+int __xstat (int ver, const char *path, struct stat *buf)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_stat)
+  { /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original stat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_stat(ver, path, buf));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+   if (buf != NULL)
+   {
+     if (!fake_stat_disabled)
+     {
+       fake_statbuf(buf);
+     }
+   }
+
+  return result;
+}
+
+/* Contributed by Philipp Hachtmann in version 0.6 */
+int __fxstat (int ver, int fildes, struct stat *buf)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_fstat)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original fstat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_fstat(ver, fildes, buf));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_statbuf(buf);
+    }
+  }
+  return result;
+}
+
+/* Added in v0.8 as suggested by Daniel Kahn Gillmor */
+#ifndef NO_ATFILE
+int __fxstatat(int ver, int fildes, const char *filename, struct stat *buf, int flag)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_fstatat)
+  { /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original fstatat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_fstatat(ver, fildes, filename, buf, flag));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_statbuf(buf);
+    }
+  }
+  return result;
+}
+#endif
+
+/* Contributed by Philipp Hachtmann in version 0.6 */
+int __lxstat (int ver, const char *path, struct stat *buf)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_lstat)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original lstat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_lstat(ver, path, buf));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_statbuf(buf);
+    }
+  }
+  return result;
+}
+
+/* Contributed by Philipp Hachtmann in version 0.6 */
+int __xstat64 (int ver, const char *path, struct stat64 *buf)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_stat64)
+  { /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original stat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_stat64(ver, path, buf));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_stat64buf(buf);
+    }
+  }
+  return result;
+}
+
+/* Contributed by Philipp Hachtmann in version 0.6 */
+int __fxstat64 (int ver, int fildes, struct stat64 *buf)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_fstat64)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original fstat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_fstat64(ver, fildes, buf));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_stat64buf(buf);
+    }
+  }
+  return result;
+}
+
+/* Added in v0.8 as suggested by Daniel Kahn Gillmor */
+#ifndef NO_ATFILE
+int __fxstatat64 (int ver, int fildes, const char *filename, struct stat64 *buf, int flag)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_fstatat64)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original fstatat64() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_fstatat64(ver, fildes, filename, buf, flag));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_stat64buf(buf);
+    }
+  }
+  return result;
+}
+#endif
+
+/* Contributed by Philipp Hachtmann in version 0.6 */
+int __lxstat64 (int ver, const char *path, struct stat64 *buf)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (NULL == real_lstat64)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original lstat() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  int result;
+  DONT_FAKE_TIME(result = real_lstat64(ver, path, buf));
+  if (result == -1)
+  {
+    return -1;
+  }
+
+  if (buf != NULL)
+  {
+    if (!fake_stat_disabled)
+    {
+      fake_stat64buf(buf);
+    }
+  }
+  return result;
+}
+#endif
+
+/*
+ *      =======================================================================
+ *      Faked system functions: sleep/alarm/poll/timer related  === FAKE(SLEEP)
+ *      =======================================================================
+ *      Contributed by Balint Reczey in v0.9.5
+ */
+
+#ifdef FAKE_SLEEP
+/*
+ * Faked nanosleep()
+ */
+int nanosleep(const struct timespec *req, struct timespec *rem)
+{
+  int result;
+  struct timespec real_req;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_nanosleep == NULL)
+  {
+    return -1;
+  }
+  if (req != NULL)
+  {
+    if (user_rate_set && !dont_fake)
+    {
+      timespecmul(req, 1.0 / user_rate, &real_req);
+    }
+    else
+    {
+      real_req = *req;
+    }
+  }
+  else
+  {
+    return -1;
+  }
+
+  DONT_FAKE_TIME(result = (*real_nanosleep)(&real_req, rem));
+  if (result == -1)
+  {
+    return result;
+  }
+
+  /* fake returned parts */
+  if ((rem != NULL) && ((rem->tv_sec != 0) || (rem->tv_nsec != 0)))
+  {
+    if (user_rate_set && !dont_fake)
+    {
+      timespecmul(rem, user_rate, rem);
+    }
+  }
+  /* return the result to the caller */
+  return result;
+}
+
+/*
+ * Faked usleep()
+ */
+int usleep(useconds_t usec)
+{
+  int result;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (user_rate_set && !dont_fake)
+  {
+    struct timespec real_req;
+
+    if (real_nanosleep == NULL)
+    {
+      /* fall back to usleep() */
+      if (real_usleep == NULL)
+      {
+        return -1;
+      }
+      DONT_FAKE_TIME(result = (*real_usleep)((1.0 / user_rate) * usec));
+      return result;
+    }
+
+    real_req.tv_sec = usec / 1000000;
+    real_req.tv_nsec = (usec % 1000000) * 1000;
+    timespecmul(&real_req, 1.0 / user_rate, &real_req);
+    DONT_FAKE_TIME(result = (*real_nanosleep)(&real_req, NULL));
+  }
+  else
+  {
+    DONT_FAKE_TIME(result = (*real_usleep)(usec));
+  }
+  return result;
+}
+
+/*
+ * Faked sleep()
+ */
+unsigned int sleep(unsigned int seconds)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (user_rate_set && !dont_fake)
+  {
+    if (real_nanosleep == NULL)
+    {
+      /* fall back to sleep */
+      unsigned int ret;
+      if (real_sleep == NULL)
+      {
+        return 0;
+      }
+      DONT_FAKE_TIME(ret = (*real_sleep)((1.0 / user_rate) * seconds));
+      return (user_rate_set && !dont_fake)?(user_rate * ret):ret;
+    }
+    else
+    {
+      int result;
+      struct timespec real_req = {seconds, 0}, rem;
+      timespecmul(&real_req, 1.0 / user_rate, &real_req);
+      DONT_FAKE_TIME(result = (*real_nanosleep)(&real_req, &rem));
+      if (result == -1)
+      {
+        return 0;
+      }
+
+      /* fake returned parts */
+      if ((rem.tv_sec != 0) || (rem.tv_nsec != 0))
+      {
+        timespecmul(&rem, user_rate, &rem);
+      }
+      /* return the result to the caller */
+      return rem.tv_sec;
+    }
+  }
+  else
+  {
+    /* no need to fake anything */
+    unsigned int ret;
+    DONT_FAKE_TIME(ret = (*real_sleep)(seconds));
+    return ret;
+  }
+}
+
+/*
+ * Faked alarm()
+ * @note due to rounding alarm(2) with faketime -f '+0 x7' won't wait 2/7
+ * wall clock seconds but 0 seconds
+ */
+unsigned int alarm(unsigned int seconds)
+{
+  unsigned int ret;
+  unsigned int seconds_real = (user_rate_set && !dont_fake)?((1.0 / user_rate) * seconds):seconds;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_alarm == NULL)
+  {
+    return -1;
+  }
+
+  DONT_FAKE_TIME(ret = (*real_alarm)(seconds_real));
+  return (user_rate_set && !dont_fake)?(user_rate * ret):ret;
+}
+
+/*
+ * Faked ppoll()
+ */
+int ppoll(struct pollfd *fds, nfds_t nfds,
+    const struct timespec *timeout_ts, const sigset_t *sigmask)
+{
+  struct timespec real_timeout, *real_timeout_pt;
+  int ret;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_ppoll == NULL)
+  {
+    return -1;
+  }
+  if (timeout_ts != NULL)
+  {
+    if (user_rate_set && !dont_fake && (timeout_ts->tv_sec > 0))
+    {
+      timespecmul(timeout_ts, 1.0 / user_rate, &real_timeout);
+      real_timeout_pt = &real_timeout;
+    }
+    else
+    {
+      /* cast away constness */
+      real_timeout_pt = (struct timespec *)timeout_ts;
+    }
+  }
+  else
+  {
+    real_timeout_pt = NULL;
+  }
+
+  DONT_FAKE_TIME(ret = (*real_ppoll)(fds, nfds, real_timeout_pt, sigmask));
+  return ret;
+}
+
+/*
+ * Faked poll()
+ */
+int poll(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+  int ret, timeout_real = (user_rate_set && !dont_fake && (timeout > 0))?(timeout / user_rate):timeout;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_poll == NULL)
+  {
+    return -1;
+  }
+
+  DONT_FAKE_TIME(ret = (*real_poll)(fds, nfds, timeout_real));
+  return ret;
+}
+
+int sem_timedwait(sem_t *sem, const struct timespec *abs_timeout)
+{
+  int result;
+  struct timespec real_abs_timeout, *real_abs_timeout_pt;
+
+  /* sanity check */
+  if (abs_timeout == NULL)
+  {
+    return -1;
+  }
+
+  if (NULL == real_sem_timedwait)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original sem_timedwait() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  if (!dont_fake)
+  {
+    struct timespec tdiff, timeadj;
+
+    timespecsub(abs_timeout, &ftpl_starttime.real, &tdiff);
+
+    if (user_rate_set)
+    {
+      timespecmul(&tdiff, user_rate, &timeadj);
+    }
+    else
+    {
+        timeadj = tdiff;
+    }
+    timespecadd(&user_faked_time_timespec, &timeadj, &real_abs_timeout);
+    real_abs_timeout_pt = &real_abs_timeout;
+  }
+  else
+  {
+    /* cast away constness */
+    real_abs_timeout_pt = (struct timespec *)abs_timeout;
+  }
+
+  DONT_FAKE_TIME(result = (*real_sem_timedwait)(sem, real_abs_timeout_pt));
+  return result;
+}
+#endif
+
+#ifndef __APPLE__
+#ifdef FAKE_TIMERS
+
+/* timer related functions and structures */
+typedef union {
+  int int_member;
+  timer_t timer_t_member;
+} timer_t_or_int;
+
+/*
+ * Faketime's function implementation's compatibility mode
+ */
+typedef enum {FT_COMPAT_GLIBC_2_2, FT_COMPAT_GLIBC_2_3_3} ft_lib_compat;
+
+
+/*
+ * Faked timer_settime()
+ * Does not affect timer speed when stepping clock with each time() call.
+ */
+static int
+timer_settime_common(timer_t_or_int timerid, int flags,
+         const struct itimerspec *new_value,
+         struct itimerspec *old_value, ft_lib_compat compat)
+{
+  int result;
+  struct itimerspec new_real;
+  struct itimerspec *new_real_pt = &new_real;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (new_value == NULL)
+  {
+    new_real_pt = NULL;
+  }
+  else if (dont_fake)
+  {
+    /* cast away constness*/
+    new_real_pt = (struct itimerspec *)new_value;
+  }
+  else
+  {
+    /* set it_value */
+    if ((new_value->it_value.tv_sec != 0) ||
+        (new_value->it_value.tv_nsec != 0))
+    {
+      if (flags & TIMER_ABSTIME)
+      {
+        struct timespec tdiff, timeadj;
+        timespecsub(&new_value->it_value, &user_faked_time_timespec, &timeadj);
+        if (user_rate_set)
+        {
+          timespecmul(&timeadj, 1.0/user_rate, &tdiff);
+        }
+        else
+        {
+          tdiff = timeadj;
+        }
+        /* only CLOCK_REALTIME is handled */
+        timespecadd(&ftpl_starttime.real, &tdiff, &new_real.it_value);
+      }
+      else
+      {
+        if (user_rate_set)
+        {
+          timespecmul(&new_value->it_value, 1.0/user_rate, &new_real.it_value);
+        }
+        else
+        {
+          new_real.it_value = new_value->it_value;
+        }
+      }
+    }
+    else
+    {
+      new_real.it_value = new_value->it_value;
+    }
+    /* set it_interval */
+    if (user_rate_set && ((new_value->it_interval.tv_sec != 0) ||
+       (new_value->it_interval.tv_nsec != 0)))
+    {
+      timespecmul(&new_value->it_interval, 1.0/user_rate, &new_real.it_interval);
+    }
+    else
+    {
+      new_real.it_interval = new_value->it_interval;
+    }
+  }
+
+  switch (compat)
+  {
+    case FT_COMPAT_GLIBC_2_2:
+      DONT_FAKE_TIME(result = (*real_timer_settime_22)(timerid.int_member, flags,
+                    new_real_pt, old_value));
+      break;
+    case FT_COMPAT_GLIBC_2_3_3:
+       DONT_FAKE_TIME(result = (*real_timer_settime_233)(timerid.timer_t_member,
+                    flags, new_real_pt, old_value));
+       break;
+    default:
+      result = -1;
+      break;
+  }
+
+  if (result == -1)
+  {
+    return result;
+  }
+
+  /* fake returned parts */
+  if ((old_value != NULL) && !dont_fake)
+  {
+    if ((old_value->it_value.tv_sec != 0) ||
+        (old_value->it_value.tv_nsec != 0))
+    {
+      result = fake_clock_gettime(CLOCK_REALTIME, &old_value->it_value);
+    }
+    if (user_rate_set && ((old_value->it_interval.tv_sec != 0) ||
+       (old_value->it_interval.tv_nsec != 0)))
+    {
+      timespecmul(&old_value->it_interval, user_rate, &old_value->it_interval);
+    }
+  }
+
+  /* return the result to the caller */
+  return result;
+}
+
+/*
+ * Faked timer_settime() compatible with implementation in GLIBC 2.2
+ */
+int timer_settime_22(int timerid, int flags,
+         const struct itimerspec *new_value,
+         struct itimerspec *old_value)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_timer_settime_22 == NULL)
+  {
+    return -1;
+  }
+  else
+  {
+    return (timer_settime_common((timer_t_or_int)timerid, flags, new_value, old_value,
+            FT_COMPAT_GLIBC_2_2));
+  }
+}
+
+/*
+ * Faked timer_settime() compatible with implementation in GLIBC 2.3.3
+ */
+int timer_settime_233(timer_t timerid, int flags,
+      const struct itimerspec *new_value,
+      struct itimerspec *old_value)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_timer_settime_233 == NULL)
+  {
+    return -1;
+  }
+  else
+  {
+    return (timer_settime_common((timer_t_or_int)timerid, flags, new_value, old_value,
+            FT_COMPAT_GLIBC_2_3_3));
+  }
+}
+
+/*
+ * Faked timer_gettime()
+ * Does not affect timer speed when stepping clock with each time() call.
+ */
+int timer_gettime_common(timer_t_or_int timerid, struct itimerspec *curr_value, ft_lib_compat compat)
+{
+  int result;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_timer_gettime_233 == NULL)
+  {
+    return -1;
+  }
+
+  switch (compat)
+  {
+    case FT_COMPAT_GLIBC_2_2:
+      DONT_FAKE_TIME(result = (*real_timer_gettime_22)(timerid.int_member, curr_value));
+      break;
+    case FT_COMPAT_GLIBC_2_3_3:
+      DONT_FAKE_TIME(result = (*real_timer_gettime_233)(timerid.timer_t_member, curr_value));
+      break;
+    default:
+      result = -1;
+      break;
+  }
+
+  if (result == -1)
+  {
+    return result;
+  }
+
+  /* fake returned parts */
+  if (curr_value != NULL)
+  {
+    if (user_rate_set && !dont_fake)
+    {
+      timespecmul(&curr_value->it_interval, user_rate, &curr_value->it_interval);
+      timespecmul(&curr_value->it_value, user_rate, &curr_value->it_value);
+    }
+  }
+  /* return the result to the caller */
+  return result;
+}
+
+/*
+ * Faked timer_gettime() compatible with implementation in GLIBC 2.2
+ */
+int timer_gettime_22(timer_t timerid, struct itimerspec *curr_value)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_timer_gettime_22 == NULL)
+  {
+    return -1;
+  }
+  else
+  {
+    return (timer_gettime_common((timer_t_or_int)timerid, curr_value,
+         FT_COMPAT_GLIBC_2_2));
+  }
+}
+
+/*
+ * Faked timer_gettime() compatible with implementation in GLIBC 2.3.3
+ */
+int timer_gettime_233(timer_t timerid, struct itimerspec *curr_value)
+{
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  if (real_timer_gettime_233 == NULL)
+  {
+    return -1;
+  }
+  else
+  {
+    return (timer_gettime_common((timer_t_or_int)timerid, curr_value,
+            FT_COMPAT_GLIBC_2_3_3));
+  }
+}
+
+__asm__(".symver timer_gettime_22, timer_gettime@GLIBC_2.2");
+__asm__(".symver timer_gettime_233, timer_gettime@@GLIBC_2.3.3");
+__asm__(".symver timer_settime_22, timer_settime@GLIBC_2.2");
+__asm__(".symver timer_settime_233, timer_settime@@GLIBC_2.3.3");
+
+#endif
+#endif
+
+
+/*
+ *      =======================================================================
+ *      Faked system functions: basic time functions             === FAKE(TIME)
+ *      =======================================================================
+ */
+
+/*
+ * time() implementation using clock_gettime()
+ * @note Does not check for EFAULT, see man 2 time
+ */
+time_t time(time_t *time_tptr)
+{
+  struct timespec tp;
+  time_t result;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
+  if (result == -1) return -1;
+
+  /* pass the real current time to our faking version, overwriting it */
+  (void)fake_clock_gettime(CLOCK_REALTIME, &tp);
+
+  if (time_tptr != NULL)
+  {
+    *time_tptr = tp.tv_sec;
+  }
+  return tp.tv_sec;
+}
+
+int ftime(struct timeb *tb)
+{
+  struct timespec tp;
+  int result;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  /* sanity check */
+  if (tb == NULL)
+    return 0;               /* ftime() always returns 0, see manpage */
+
+  /* Check whether we've got a pointer to the real ftime() function yet */
+  if (NULL == real_ftime)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original ftime() not found.\n");
+#endif
+    return 0; /* propagate error to caller */
+  }
+
+  /* initialize our TZ result with the real current time */
+  DONT_FAKE_TIME(result = (*real_ftime)(tb));
+  if (result == -1)
+  {
+    return result;
+  }
+
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
+  if (result == -1) return -1;
+
+  /* pass the real current time to our faking version, overwriting it */
+  (void)fake_clock_gettime(CLOCK_REALTIME, &tp);
+
+  tb->time = tp.tv_sec;
+  tb->millitm = tp.tv_nsec / 1000000;
+
+  /* return the result to the caller */
+  return result; /* will always be 0 (see manpage) */
+}
+
+int gettimeofday(struct timeval *tv, void *tz)
+{
+  int result;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  /* sanity check */
+  if (tv == NULL)
+  {
+    return -1;
+  }
+
+  /* Check whether we've got a pointer to the real ftime() function yet */
+  if (NULL == real_gettimeofday)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original gettimeofday() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  /* initialize our result with the real current time */
+  DONT_FAKE_TIME(result = (*real_gettimeofday)(tv, tz));
+  if (result == -1) return result; /* original function failed */
+
+  /* pass the real current time to our faking version, overwriting it */
+  result = fake_gettimeofday(tv);
+
+  /* return the result to the caller */
+  return result;
+}
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp)
+{
+  int result;
+
+  if (!initialized)
+  {
+    ftpl_init();
+  }
+  /* sanity check */
+  if (tp == NULL)
+  {
+    return -1;
+  }
+
+  if (NULL == real_clock_gettime)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original clock_gettime() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  /* initialize our result with the real current time */
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(clk_id, tp));
+  if (result == -1) return result; /* original function failed */
+
+  /* pass the real current time to our faking version, overwriting it */
+  if (fake_monotonic_clock || clk_id != CLOCK_MONOTONIC)
+  {
+    result = fake_clock_gettime(clk_id, tp);
+  }
+
+  /* return the result to the caller */
+  return result;
+}
+
+
+/*
+ *      =======================================================================
+ *      Parsing the user's faketime requests                          === PARSE
+ *      =======================================================================
+ */
+
+static void parse_ft_string(const char *user_faked_time)
+{
+  struct tm user_faked_time_tm;
+  char * tmp_time_fmt;
+
+  if (!strncmp(user_faked_time, user_faked_time_saved, BUFFERLEN))
+  {
+      /* No change */
+      return;
+  }
+
+  /* check whether the user gave us an absolute time to fake */
+  switch (user_faked_time[0])
+  {
+
+    default:  /* Try and interpret this as a specified time */
+      if (ft_mode != FT_NOOP) ft_mode = FT_FREEZE;
+      user_faked_time_tm.tm_isdst = -1;
+      if (NULL != strptime(user_faked_time, user_faked_time_fmt, &user_faked_time_tm))
+      {
+        user_faked_time_timespec.tv_sec = mktime(&user_faked_time_tm);
+        user_faked_time_timespec.tv_nsec = 0;
+        user_faked_time_set = true;
+      }
+      else
+      {
+        perror("Failed to parse FAKETIME timestamp");
+        exit(EXIT_FAILURE);
+      }
+      break;
+
+    case '+':
+    case '-': /* User-specified offset */
+      if (ft_mode != FT_NOOP) ft_mode = FT_START_AT;
+      /* fractional time offsets contributed by Karl Chen in v0.8 */
+      double frac_offset = atof(user_faked_time);
+
+      /* offset is in seconds by default, but the string may contain
+       * multipliers...
+       */
+      if (strchr(user_faked_time, 'm') != NULL) frac_offset *= 60;
+      else if (strchr(user_faked_time, 'h') != NULL) frac_offset *= 60 * 60;
+      else if (strchr(user_faked_time, 'd') != NULL) frac_offset *= 60 * 60 * 24;
+      else if (strchr(user_faked_time, 'y') != NULL) frac_offset *= 60 * 60 * 24 * 365;
+
+      user_offset.tv_sec = floor(frac_offset);
+      user_offset.tv_nsec = (frac_offset - user_offset.tv_sec) * SEC_TO_nSEC;
+      timespecadd(&ftpl_starttime.real, &user_offset, &user_faked_time_timespec);
+      goto parse_modifiers;
+      break;
+
+      /* Contributed by David North, TDI in version 0.7 */
+    case '@': /* Specific time, but clock along relative to that starttime */
+      ft_mode = FT_START_AT;
+      user_faked_time_tm.tm_isdst = -1;
+      (void) strptime(&user_faked_time[1], user_faked_time_fmt, &user_faked_time_tm);
+
+      user_faked_time_timespec.tv_sec = mktime(&user_faked_time_tm);
+      user_faked_time_timespec.tv_nsec = 0;
+
+      /* Reset starttime */
+      system_time_from_system(&ftpl_starttime);
+      goto parse_modifiers;
+      break;
+
+    case 'i':
+    case 'x': /* Only modifiers are passed, don't fall back to strptime */
+parse_modifiers:
+      /* Speed-up / slow-down contributed by Karl Chen in v0.8 */
+      if (strchr(user_faked_time, 'x') != NULL)
+      {
+        user_rate = atof(strchr(user_faked_time, 'x')+1);
+        user_rate_set = true;
+      }
+      else if (NULL != (tmp_time_fmt = strchr(user_faked_time, 'i')))
+      {
+        double tick_inc = atof(tmp_time_fmt + 1);
+        /* increment time with every time() call*/
+        user_per_tick_inc.tv_sec = floor(tick_inc);
+        user_per_tick_inc.tv_nsec = (tick_inc - user_per_tick_inc.tv_sec) * SEC_TO_nSEC ;
+        user_per_tick_inc_set = true;
+      }
+      break;
+  } // end of switch
+
+  strncpy(user_faked_time_saved, user_faked_time, BUFFERLEN-1);
+  user_faked_time_saved[BUFFERLEN-1] = 0;
+#ifdef DEBUG
+  fprintf(stderr, "new FAKETIME: %s\n", user_faked_time_saved);
+#endif
+}
+
+
+/*
+ *      =======================================================================
+ *      Initialization                                                 === INIT
+ *      =======================================================================
+ */
+
+void ftpl_init(void)
+{
+  char *tmp_env;
+
+#ifdef __APPLE__
+  const char *progname = getprogname();
+#else
+  const char *progname = __progname;
+#endif
+
+  /* Look up all real_* functions. NULL will mark missing ones. */
+  real_stat =               dlsym(RTLD_NEXT, "__xstat");
+  real_fstat =              dlsym(RTLD_NEXT, "__fxstat");
+  real_fstatat =            dlsym(RTLD_NEXT, "__fxstatat");
+  real_lstat =              dlsym(RTLD_NEXT, "__lxstat");
+  real_stat64 =             dlsym(RTLD_NEXT,"__xstat64");
+  real_fstat64 =            dlsym(RTLD_NEXT, "__fxstat64");
+  real_fstatat64 =          dlsym(RTLD_NEXT, "__fxstatat64");
+  real_lstat64 =            dlsym(RTLD_NEXT, "__lxstat64");
+  real_time =               dlsym(RTLD_NEXT, "time");
+  real_ftime =              dlsym(RTLD_NEXT, "ftime");
+  real_gettimeofday =       dlsym(RTLD_NEXT, "gettimeofday");
+#ifdef FAKE_SLEEP
+  real_nanosleep =          dlsym(RTLD_NEXT, "nanosleep");
+  real_usleep =             dlsym(RTLD_NEXT, "usleep");
+  real_sleep =              dlsym(RTLD_NEXT, "sleep");
+  real_alarm =              dlsym(RTLD_NEXT, "alarm");
+  real_poll =               dlsym(RTLD_NEXT, "poll");
+  real_ppoll =              dlsym(RTLD_NEXT, "ppoll");
+  real_sem_timedwait =      dlsym(RTLD_NEXT, "sem_timedwait");
+#endif
+#ifdef FAKE_INTERNAL_CALLS
+  real___ftime =              dlsym(RTLD_NEXT, "__ftime");
+  real___gettimeofday =       dlsym(RTLD_NEXT, "__gettimeofday");
+  real___clock_gettime  =     dlsym(RTLD_NEXT, "__clock_gettime");
+#endif
+#ifdef __APPLE__
+  real_clock_get_time =     dlsym(RTLD_NEXT, "clock_get_time");
+  real_clock_gettime  =     apple_clock_gettime;
+#else
+  real_clock_gettime  =     dlsym(RTLD_NEXT, "__clock_gettime");
+  if (NULL == real_clock_gettime)
+  {
+    real_clock_gettime  =   dlsym(RTLD_NEXT, "clock_gettime");
+  }
+#ifdef FAKE_TIMERS
+#if defined(__sun)
+    real_timer_gettime_233 =  dlsym(RTLD_NEXT, "timer_gettime");
+    real_timer_settime_233 =  dlsym(RTLD_NEXT, "timer_settime");
+#else
+  real_timer_settime_22 =   dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.2");
+  real_timer_settime_233 =  dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.3.3");
+  if (NULL == real_timer_settime_233)
+  {
+    real_timer_settime_233 =  dlsym(RTLD_NEXT, "timer_settime");
+  }
+  real_timer_gettime_22 =   dlvsym(RTLD_NEXT, "timer_gettime","GLIBC_2.2");
+  real_timer_gettime_233 =  dlvsym(RTLD_NEXT, "timer_gettime","GLIBC_2.3.3");
+  if (NULL == real_timer_gettime_233)
+  {
+    real_timer_gettime_233 =  dlsym(RTLD_NEXT, "timer_gettime");
+  }
+#endif
+#endif
+#endif
+
+  initialized = 1;
+
+  ft_shm_init();
+#ifdef FAKE_STAT
+  if (getenv("NO_FAKE_STAT")!=NULL)
+  {
+    fake_stat_disabled = 1;  //Note that this is NOT re-checked
+  }
+#endif
+
+  if ((tmp_env = getenv("FAKETIME_CACHE_DURATION")) != NULL)
+  {
+    cache_duration = atoi(tmp_env);
+  }
+  if ((tmp_env = getenv("FAKETIME_NO_CACHE")) != NULL)
+  {
+    if (0 == strcmp(tmp_env, "1"))
+    {
+      cache_enabled = 0;
+    }
+  }
+  if ((tmp_env = getenv("DONT_FAKE_MONOTONIC")) != NULL)
+  {
+    if (0 == strcmp(tmp_env, "1"))
+    {
+      fake_monotonic_clock = 0;
+    }
+  }
+  /* Check whether we actually should be faking the returned timestamp. */
+
+  /* We can prevent faking time for specified commands */
+  if ((tmp_env = getenv("FAKETIME_SKIP_CMDS")) != NULL)
+  {
+    char *skip_cmd, *saveptr, *tmpvar;
+    /* Don't mess with the env variable directly. */
+    tmpvar = strdup(tmp_env);
+    if (tmpvar != NULL)
+    {
+      skip_cmd = strtok_r(tmpvar, ",", &saveptr);
+      while (skip_cmd != NULL)
+      {
+        if (0 == strcmp(progname, skip_cmd))
+        {
+          ft_mode = FT_NOOP;
+          dont_fake = true;
+          break;
+        }
+        skip_cmd = strtok_r(NULL, ",", &saveptr);
+      }
+      free(tmpvar);
+      tmpvar = NULL;
+    }
+    else
+    {
+      fprintf(stderr, "Error: Could not copy the environment variable value.\n");
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  /* We can limit faking time to specified commands */
+  if ((tmp_env = getenv("FAKETIME_ONLY_CMDS")) != NULL)
+  {
+    char *only_cmd, *saveptr;
+    bool cmd_matched = false;
+
+    if (getenv("FAKETIME_SKIP_CMDS") != NULL)
+    {
+      fprintf(stderr, "Error: Both FAKETIME_SKIP_CMDS and FAKETIME_ONLY_CMDS can't be set.\n");
+      exit(EXIT_FAILURE);
+    }
+
+    only_cmd = strtok_r(tmp_env, ",", &saveptr);
+    while (only_cmd != NULL)
+    {
+      if (0 == strcmp(progname, only_cmd))
+      {
+        cmd_matched = true;
+        break;
+      }
+      only_cmd = strtok_r(NULL, ",", &saveptr);
+    }
+
+    if (!cmd_matched)
+    {
+      ft_mode = FT_NOOP;
+      dont_fake = true;
+    }
+  }
+
+  if ((tmp_env = getenv("FAKETIME_START_AFTER_SECONDS")) != NULL)
+  {
+    ft_start_after_secs = atol(tmp_env);
+    limited_faking = true;
+  }
+  if ((tmp_env = getenv("FAKETIME_STOP_AFTER_SECONDS")) != NULL)
+  {
+    ft_stop_after_secs = atol(tmp_env);
+    limited_faking = true;
+  }
+  if ((tmp_env = getenv("FAKETIME_START_AFTER_NUMCALLS")) != NULL)
+  {
+    ft_start_after_ncalls = atol(tmp_env);
+    limited_faking = true;
+  }
+  if ((tmp_env = getenv("FAKETIME_STOP_AFTER_NUMCALLS")) != NULL)
+  {
+    ft_stop_after_ncalls = atol(tmp_env);
+    limited_faking = true;
+  }
+
+  /* check whether we should spawn an external command */
+  if ((tmp_env = getenv("FAKETIME_SPAWN_TARGET")) != NULL)
+  {
+    spawnsupport = true;
+    (void) strncpy(ft_spawn_target, getenv("FAKETIME_SPAWN_TARGET"), 1024);
+    if ((tmp_env = getenv("FAKETIME_SPAWN_SECONDS")) != NULL)
+    {
+      ft_spawn_secs = atol(tmp_env);
+    }
+    if ((tmp_env = getenv("FAKETIME_SPAWN_NUMCALLS")) != NULL)
+    {
+      ft_spawn_ncalls = atol(tmp_env);
+    }
+  }
+
+  if ((tmp_env = getenv("FAKETIME_SAVE_FILE")) != NULL)
+  {
+    if (-1 == (outfile = open(tmp_env, O_RDWR | O_APPEND | O_CLOEXEC | O_CREAT,
+                              S_IWUSR | S_IRUSR)))
+    {
+      perror("Opening file for saving timestamps failed");
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  /* load file only if reading timstamps from it is not finished yet */
+  if ((tmp_env = getenv("FAKETIME_LOAD_FILE")) != NULL)
+  {
+    int infile = -1;
+    struct stat sb;
+    if (-1 == (infile = open(tmp_env, O_RDONLY|O_CLOEXEC)))
+    {
+      perror("Opening file for loading timestamps failed");
+      exit(EXIT_FAILURE);
+    }
+
+    fstat(infile, &sb);
+    if (sizeof(stss[0]) > (infile_size = sb.st_size))
+    {
+      printf("There are no timestamps in the provided file to load timestamps from");
+      exit(EXIT_FAILURE);
+    }
+
+    if ((infile_size % sizeof(stss[0])) != 0)
+    {
+      printf("File size is not multiple of timestamp size. It is probably damaged.");
+      exit(EXIT_FAILURE);
+    }
+
+    stss = mmap(NULL, infile_size, PROT_READ, MAP_SHARED, infile, 0);
+    if (stss == MAP_FAILED)
+    {
+      perror("Mapping file for loading timestamps failed");
+      exit(EXIT_FAILURE);
+    }
+    infile_set = true;
+  }
+
+  tmp_env = getenv("FAKETIME_FMT");
+  if (tmp_env == NULL)
+  {
+    strcpy(user_faked_time_fmt, "%Y-%m-%d %T");
+  }
+  else
+  {
+    strncpy(user_faked_time_fmt, tmp_env, BUFSIZ);
+  }
+
+  if (shared_sem != 0)
+  {
+    if (sem_wait(shared_sem) == -1)
+    {
+      perror("sem_wait");
+      exit(1);
+    }
+    if (ft_shared->start_time.real.tv_nsec == -1)
+    {
+      /* set up global start time */
+      system_time_from_system(&ftpl_starttime);
+      ft_shared->start_time = ftpl_starttime;
+    }
+    else
+    {
+      /** get preset start time */
+      ftpl_starttime = ft_shared->start_time;
+    }
+    if (sem_post(shared_sem) == -1)
+    {
+      perror("sem_post");
+      exit(1);
+    }
+  }
+  else
+  {
+    system_time_from_system(&ftpl_starttime);
+  }
+  /* fake time supplied as environment variable? */
+  if (NULL != (tmp_env = getenv("FAKETIME")))
+  {
+    parse_config_file = false;
+    parse_ft_string(tmp_env);
+  }
+}
+
+
+/*
+ *      =======================================================================
+ *      Helper functions                                             === HELPER
+ *      =======================================================================
+ */
+
+static void remove_trailing_eols(char *line)
+{
+  char *endp = line + strlen(line);
+  /*
+   * erase the last char if it's a newline
+   * or carriage return, and back up.
+   * keep doing this, but don't back up
+   * past the beginning of the string.
+   */
+# define is_eolchar(c) ((c) == '\n' || (c) == '\r')
+  while (endp > line && is_eolchar(endp[-1]))
+  {
+    *--endp = '\0';
+  }
+}
+
+
+/*
+ *      =======================================================================
+ *      Implementation of faked functions                        === FAKE(FAKE)
+ *      =======================================================================
+ */
+
+int fake_clock_gettime(clockid_t clk_id, struct timespec *tp)
+{
+  /* variables used for caching, introduced in version 0.6 */
+  static time_t last_data_fetch = 0;  /* not fetched previously at first call */
+  static int cache_expired = 1;       /* considered expired at first call */
+
+  if (dont_fake) return 0;
+  /* Per process timers are only sped up or slowed down */
+  if ((clk_id == CLOCK_PROCESS_CPUTIME_ID ) || (clk_id == CLOCK_THREAD_CPUTIME_ID))
+  {
+    if (user_rate_set)
+    {
+      timespecmul(tp, user_rate, tp);
+    }
+    return 0;
+  }
+
+  /* Sanity check by Karl Chan since v0.8 */
+  if (tp == NULL) return -1;
+
+#ifdef PTHREAD_SINGLETHREADED_TIME
+  static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
+  pthread_mutex_lock(&time_mutex);
+  pthread_cleanup_push((void (*)(void *))pthread_mutex_unlock, (void *)&time_mutex);
+#endif
+
+  if ((limited_faking &&
+     ((ft_start_after_ncalls != -1) || (ft_stop_after_ncalls != -1))) ||
+     (spawnsupport && ft_spawn_ncalls))
+  {
+    if (callcounter < LONG_MAX) callcounter++;
+  }
+
+  if (limited_faking || spawnsupport)
+  {
+    struct timespec tmp_ts;
+    /* For debugging, output #seconds and #calls */
+    switch (clk_id)
+    {
+      case CLOCK_REALTIME:
+#ifdef CLOCK_REALTIME_COARSE
+      case CLOCK_REALTIME_COARSE:
+#endif
+        timespecsub(tp, &ftpl_starttime.real, &tmp_ts);
+        break;
+      case CLOCK_MONOTONIC:
+#ifdef CLOCK_MONOTONIC_COARSE
+      case CLOCK_MONOTONIC_COARSE:
+#endif
+        timespecsub(tp, &ftpl_starttime.mon, &tmp_ts);
+        break;
+      case CLOCK_MONOTONIC_RAW:
+        timespecsub(tp, &ftpl_starttime.mon_raw, &tmp_ts);
+        break;
+      default:
+        printf("Invalid clock_id for clock_gettime: %d", clk_id);
+        exit(EXIT_FAILURE);
+    }
+
+    if (limited_faking)
+    {
+      /* Check whether we actually should be faking the returned timestamp. */
+      /* fprintf(stderr, "(libfaketime limits -> runtime: %lu, callcounter: %lu\n", (*time_tptr - ftpl_starttime), callcounter); */
+      if ((ft_start_after_secs != -1)   && (tmp_ts.tv_sec < ft_start_after_secs)) return 0;
+      if ((ft_stop_after_secs != -1)    && (tmp_ts.tv_sec >= ft_stop_after_secs)) return 0;
+      if ((ft_start_after_ncalls != -1) && (callcounter < ft_start_after_ncalls)) return 0;
+      if ((ft_stop_after_ncalls != -1)  && (callcounter >= ft_stop_after_ncalls)) return 0;
+      /* fprintf(stderr, "(libfaketime limits -> runtime: %lu, callcounter: %lu continues\n", (*time_tptr - ftpl_starttime), callcounter); */
+    }
+
+    if (spawnsupport)
+    {
+      /* check whether we should spawn an external command */
+      if (spawned == 0)
+      { /* exec external command once only */
+        if (((tmp_ts.tv_sec == ft_spawn_secs) || (callcounter == ft_spawn_ncalls)) && (spawned == 0))
+        {
+          spawned = 1;
+          (void) (system(ft_spawn_target) + 1);
+        }
+      }
+    }
+  }
+
+  if (last_data_fetch > 0)
+  {
+    if ((tp->tv_sec - last_data_fetch) > cache_duration)
+    {
+      cache_expired = 1;
+    }
+    else
+    {
+      cache_expired = 0;
+    }
+  }
+
+  if (cache_enabled == 0)
+  {
+    cache_expired = 1;
+  }
+
+  if (cache_expired == 1)
+  {
+    static char user_faked_time[BUFFERLEN]; /* changed to static for caching in v0.6 */
+    /* initialize with default or env. variable */
+    char *tmp_env;
+
+    /* Can be enabled for testing ...
+      fprintf(stderr, "***************++ Cache expired ++**************\n");
+    */
+
+    if (NULL != (tmp_env = getenv("FAKETIME")))
+    {
+      strncpy(user_faked_time, tmp_env, BUFFERLEN);
+    }
+    else
+    {
+      snprintf(user_faked_time, BUFFERLEN, "+0");
+    }
+
+    last_data_fetch = tp->tv_sec;
+    /* fake time supplied as environment variable? */
+    if (parse_config_file)
+    {
+      char custom_filename[BUFSIZ];
+      char filename[BUFSIZ];
+      FILE *faketimerc;
+      /* check whether there's a .faketimerc in the user's home directory, or
+       * a system-wide /etc/faketimerc present.
+       * The /etc/faketimerc handling has been contributed by David Burley,
+       * Jacob Moorman, and Wayne Davison of SourceForge, Inc. in version 0.6 */
+      (void) snprintf(custom_filename, BUFSIZ, "%s", getenv("FAKETIME_TIMESTAMP_FILE"));
+      (void) snprintf(filename, BUFSIZ, "%s/.faketimerc", getenv("HOME"));
+      if ((faketimerc = fopen(custom_filename, "rt")) != NULL ||
+          (faketimerc = fopen(filename, "rt")) != NULL ||
+          (faketimerc = fopen("/etc/faketimerc", "rt")) != NULL)
+      {
+        char line[BUFFERLEN];
+        while(fgets(line, BUFFERLEN, faketimerc) != NULL)
+        {
+          if ((strlen(line) > 1) && (line[0] != ' ') &&
+              (line[0] != '#') && (line[0] != ';'))
+          {
+            remove_trailing_eols(line);
+            strncpy(user_faked_time, line, BUFFERLEN-1);
+            user_faked_time[BUFFERLEN-1] = 0;
+            break;
+          }
+        }
+        fclose(faketimerc);
+      }
+    } /* read fake time from file */
+    parse_ft_string(user_faked_time);
+  } /* cache had expired */
+
+  if (infile_set)
+  {
+    if (load_time(tp))
+    {
+      return 0;
+    }
+  }
+
+  /* check whether the user gave us an absolute time to fake */
+  switch (ft_mode)
+  {
+    case FT_FREEZE:  /* a specified time */
+      if (user_faked_time_set)
+      {
+        *tp = user_faked_time_timespec;
+      }
+      break;
+
+    case FT_START_AT: /* User-specified offset */
+      if (user_per_tick_inc_set)
+      {
+        /* increment time with every time() call*/
+        next_time(tp, &user_per_tick_inc);
+      }
+      else
+      {
+        /* Speed-up / slow-down contributed by Karl Chen in v0.8 */
+        struct timespec tdiff, timeadj;
+        switch (clk_id)
+        {
+          case CLOCK_REALTIME:
+#ifdef CLOCK_REALTIME_COARSE
+          case CLOCK_REALTIME_COARSE:
+#endif
+            timespecsub(tp, &ftpl_starttime.real, &tdiff);
+            break;
+          case CLOCK_MONOTONIC:
+#ifdef CLOCK_MONOTONIC_COARSE
+          case CLOCK_MONOTONIC_COARSE:
+#endif
+            timespecsub(tp, &ftpl_starttime.mon, &tdiff);
+            break;
+          case CLOCK_MONOTONIC_RAW:
+            timespecsub(tp, &ftpl_starttime.mon_raw, &tdiff);
+            break;
+          default:
+            printf("Invalid clock_id for clock_gettime: %d", clk_id);
+            exit(EXIT_FAILURE);
+        } // end of switch (clk_id)
+        if (user_rate_set)
+        {
+          timespecmul(&tdiff, user_rate, &timeadj);
+        }
+        else
+        {
+          timeadj = tdiff;
+        }
+        timespecadd(&user_faked_time_timespec, &timeadj, tp);
+      }
+      break;
+
+    default:
+      return -1;
+  } // end of switch(ft_mode)
+
+#ifdef PTHREAD_SINGLETHREADED_TIME
+  pthread_cleanup_pop(1);
+#endif
+  save_time(tp);
+  return 0;
+}
+
+int fake_gettimeofday(struct timeval *tv)
+{
+  struct timespec ts;
+  int ret;
+  ts.tv_sec = tv->tv_sec;
+  ts.tv_nsec = tv->tv_usec * 1000  + ftpl_starttime.real.tv_nsec % 1000;
+
+  ret = fake_clock_gettime(CLOCK_REALTIME, &ts);
+  tv->tv_sec = ts.tv_sec;
+  tv->tv_usec =ts.tv_nsec / 1000;
+
+  return ret;
+}
+
+
+/*
+ *      =======================================================================
+ *      Faked system functions: Apple Mac OS X specific           === FAKE(OSX)
+ *      =======================================================================
+ */
+
+#ifdef __APPLE__
+/*
+ * clock_gettime implementation for __APPLE__
+ * @note It always behave like being called with CLOCK_REALTIME.
+ */
+static int apple_clock_gettime(clockid_t clk_id, struct timespec *tp)
+{
+  int result;
+  mach_timespec_t cur_timeclockid_t;
+  (void) clk_id; /* unused */
+
+  if (NULL == real_clock_get_time)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original clock_get_time() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  DONT_FAKE_TIME(result = (*real_clock_get_time)(clock_serv_real, &cur_timeclockid_t));
+  tp->tv_sec =  cur_timeclockid_t.tv_sec;
+  tp->tv_nsec = cur_timeclockid_t.tv_nsec;
+  return result;
+}
+
+int clock_get_time(clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t)
+{
+  int result;
+  struct timespec ts;
+
+  /*
+   * Initialize our result with the real current time from CALENDAR_CLOCK.
+   * This is a bit of cheating, but we don't keep track of obtained clock
+   * services.
+   */
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &ts));
+  if (result == -1) return result; /* original function failed */
+
+  /* pass the real current time to our faking version, overwriting it */
+  result = fake_clock_gettime(CLOCK_REALTIME, &ts);
+  cur_timeclockid_t->tv_sec = ts.tv_sec;
+  cur_timeclockid_t->tv_nsec = ts.tv_nsec;
+
+  /* return the result to the caller */
+  return result;
+}
+#endif
+
+
+/*
+ *      =======================================================================
+ *      Faked system-internal functions                           === FAKE(INT)
+ *      =======================================================================
+ */
+
+#ifdef FAKE_INTERNAL_CALLS
+int __gettimeofday(struct timeval *tv, void *tz)
+{
+  int result;
+
+  /* sanity check */
+  if (tv == NULL)
+  {
+    return -1;
+  }
+
+  /* Check whether we've got a pointer to the real ftime() function yet */
+  if (NULL == real___gettimeofday)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original __gettimeofday() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  /* initialize our result with the real current time */
+  DONT_FAKE_TIME(result = (*real___gettimeofday)(tv, tz));
+  if (result == -1) return result; /* original function failed */
+
+  /* pass the real current time to our faking version, overwriting it */
+  result = fake_gettimeofday(tv);
+
+  /* return the result to the caller */
+  return result;
+}
+
+int __clock_gettime(clockid_t clk_id, struct timespec *tp)
+{
+  int result;
+
+  /* sanity check */
+  if (tp == NULL)
+  {
+    return -1;
+  }
+
+  if (NULL == real___clock_gettime)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original __clock_gettime() not found.\n");
+#endif
+    return -1; /* propagate error to caller */
+  }
+
+  /* initialize our result with the real current time */
+  DONT_FAKE_TIME(result = (*real___clock_gettime)(clk_id, tp));
+  if (result == -1) return result; /* original function failed */
+
+  /* pass the real current time to our faking version, overwriting it */
+  if (fake_monotonic_clock || clk_id != CLOCK_MONOTONIC)
+  {
+    result = fake_clock_gettime(clk_id, tp);
+  }
+
+  /* return the result to the caller */
+  return result;
+}
+
+time_t __time(time_t *time_tptr)
+{
+  struct timespec tp;
+  time_t result;
+
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
+  if (result == -1) return -1;
+
+  /* pass the real current time to our faking version, overwriting it */
+  (void)fake_clock_gettime(CLOCK_REALTIME, &tp);
+
+  if (time_tptr != NULL)
+  {
+    *time_tptr = tp.tv_sec;
+  }
+  return tp.tv_sec;
+}
+
+int __ftime(struct timeb *tb)
+{
+  struct timespec tp;
+  int result;
+
+  /* sanity check */
+  if (tb == NULL)
+    return 0;               /* ftime() always returns 0, see manpage */
+
+  /* Check whether we've got a pointer to the real ftime() function yet */
+  if (NULL == real___ftime)
+  {  /* dlsym() failed */
+#ifdef DEBUG
+    (void) fprintf(stderr, "faketime problem: original ftime() not found.\n");
+#endif
+    return 0; /* propagate error to caller */
+  }
+
+  /* initialize our TZ result with the real current time */
+  DONT_FAKE_TIME(result = (*real___ftime)(tb));
+  if (result == -1)
+  {
+    return result;
+  }
+
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
+  if (result == -1) return -1;
+
+  /* pass the real current time to our faking version, overwriting it */
+  (void)fake_clock_gettime(CLOCK_REALTIME, &tp);
+
+  tb->time = tp.tv_sec;
+  tb->millitm = tp.tv_nsec / 1000000;
+
+  /* return the result to the caller */
+  return result; /* will always be 0 (see manpage) */
+}
+
+#endif
+
+/*
+ * Editor modelines
+ *
+ * Local variables:
+ * c-basic-offset: 2
+ * tab-width: 2
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=2 tabstop=2 expandtab:
+ * :indentSize=2:tabSize=2:noTabs=true:
+ */
+
+/* eof */

--- a/tools/faketime/src/libfaketime.map
+++ b/tools/faketime/src/libfaketime.map
@@ -1,0 +1,10 @@
+GLIBC_2.2 {
+  global:
+
+  timer_gettime; timer_settime;
+  local: timer_settime_*; timer_gettime_*;
+};
+GLIBC_2.3.3 {
+  # Changed timer_t.
+  timer_gettime; timer_settime;
+} GLIBC_2.2;

--- a/tools/faketime/src/sunos_endian.h
+++ b/tools/faketime/src/sunos_endian.h
@@ -1,0 +1,12 @@
+
+#ifndef SUN_OS_ENDIAN_H
+#define SUN_OS_ENDIAN_H
+
+#include <sys/byteorder.h>
+
+#define htobe64(x) BE_64(x)
+#define be64toh(x) BE_64(x)
+#define htole64(x) LE_64(x)
+#define le64toh(x) LE_64(x)
+
+#endif /* SUN_OS_ENDIAN_H */

--- a/tools/faketime/src/time_ops.h
+++ b/tools/faketime/src/time_ops.h
@@ -1,0 +1,104 @@
+/*
+ * Time operation macros based on sys/time.h
+ * Copyright 2013 Balint Reczey <balint@balintreczey.hu>
+ *
+ * This file is part of libfaketime.
+ *
+ * libfaketime is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License v2 as published by the Free
+ * Software Foundation.
+ *
+ * libfaketime is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License v2 along
+ * with libfaketime; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef TIME_OPS_H
+#define TIME_OPS_H
+#include <time.h>
+
+#define SEC_TO_uSEC 1000000
+#define SEC_TO_nSEC 1000000000
+
+/* Convenience macros for operations on timevals.
+   NOTE: `timercmp' does not work for >= or <=.  */
+#define timerisset2(tvp, prefix) ((tvp)->tv_sec || (tvp)->tv_##prefix##sec)
+#define timerclear2(tvp, prefix) ((tvp)->tv_sec = (tvp)->tv_##prefix##sec = 0)
+#define timercmp2(a, b, CMP, prefix)                                \
+  (((a)->tv_sec == (b)->tv_sec) ?                                   \
+   ((a)->tv_##prefix##sec CMP (b)->tv_##prefix##sec) :              \
+   ((a)->tv_sec CMP (b)->tv_sec))
+#define timeradd2(a, b, result, prefix)                             \
+  do                                                                \
+  {                                                                 \
+    (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;                   \
+    (result)->tv_##prefix##sec = (a)->tv_##prefix##sec +            \
+      (b)->tv_##prefix##sec;                                        \
+    if ((result)->tv_##prefix##sec >= SEC_TO_##prefix##SEC)         \
+      {                                                             \
+        ++(result)->tv_sec;                                         \
+        (result)->tv_##prefix##sec -= SEC_TO_##prefix##SEC;         \
+      }                                                             \
+  } while (0)
+#define timersub2(a, b, result, prefix)                             \
+  do                                                                \
+  {                                                                 \
+    (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;                   \
+    (result)->tv_##prefix##sec = (a)->tv_##prefix##sec -            \
+      (b)->tv_##prefix##sec;                                        \
+    if ((result)->tv_##prefix##sec < 0)                             \
+    {                                                               \
+      --(result)->tv_sec;                                           \
+      (result)->tv_##prefix##sec += SEC_TO_##prefix##SEC;           \
+    }                                                               \
+  } while (0)
+#define timermul2(tvp, c, result, prefix)                           \
+  do                                                                \
+  {                                                                 \
+    long long tmp_time;                                             \
+    tmp_time = (c) * ((tvp)->tv_sec * SEC_TO_##prefix##SEC +        \
+               (tvp)->tv_##prefix##sec);                            \
+    (result)->tv_##prefix##sec = tmp_time % SEC_TO_##prefix##SEC;   \
+    (result)->tv_sec = (tmp_time - (result)->tv_##prefix##sec) /    \
+      SEC_TO_##prefix##SEC;                                         \
+    if ((result)->tv_##prefix##sec < 0)                             \
+    {                                                               \
+      (result)->tv_##prefix##sec +=  SEC_TO_##prefix##SEC;          \
+      (result)->tv_sec -= 1;                                        \
+    }                                                               \
+  } while (0)
+
+/* ops for microsecs */
+#ifndef timerisset
+#define timerisset(tvp) timerisset2(tvp,u)
+#endif
+#ifndef timerclear
+#define timerclear(tvp) timerclear2(tvp, u)
+#endif
+#ifndef timercmp
+#define timercmp(a, b, CMP) timercmp2(a, b, CMP, u)
+#endif
+#ifndef timeradd
+#define timeradd(a, b, result) timeradd2(a, b, result, u)
+#endif
+#ifndef timersub
+#define timersub(a, b, result) timersub2(a, b, result, u)
+#endif
+#ifndef timersub
+#define timermul(a, c, result) timermul2(a, c, result, u)
+#endif
+
+/* ops for nanosecs */
+#define timespecisset(tvp) timerisset2(tvp,n)
+#define timespecclear(tvp) timerclear2(tvp, n)
+#define timespeccmp(a, b, CMP) timercmp2(a, b, CMP, n)
+#define timespecadd(a, b, result) timeradd2(a, b, result, n)
+#define timespecsub(a, b, result) timersub2(a, b, result, n)
+#define timespecmul(a, c, result) timermul2(a, c, result, n)
+
+#endif

--- a/tools/faketime/src/timeprivacy
+++ b/tools/faketime/src/timeprivacy
@@ -1,0 +1,270 @@
+#!/bin/bash
+
+## Copyright (c) 2013, adrelanos at riseup dot net
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met: 
+##
+## 1. Redistributions of source code must retain the above copyright notice, this
+## list of conditions and the following disclaimer. 
+## 2. Redistributions in binary form must reproduce the above copyright notice,
+## this list of conditions and the following disclaimer in the documentation
+## and/or other materials provided with the distribution. 
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+## ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+## WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+## DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+## ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+## (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+## LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+## ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+## (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#set -x
+
+SCRIPTNAME="$(basename $0)"
+
+usage() {
+   echo "$SCRIPTNAME
+
+Usage: $SCRIPTNAME [-h help] [-d day] [-m month] [-y year] [-i increment in seconds (0-60)] [-r random increment in seconds (0-60)] [-f history folder]
+Example: $SCRIPTNAME -d 30 -m 12 -y 2013 -i 10 -f /tmp/$SCRIPTNAMEtest
+         sudo $SCRIPTNAME -d 30 -m 12 -y 2013 -r -f /tmp/$SCRIPTNAMEtest"
+}
+
+_randomincrement="none"
+_increment="none"
+
+while [ -n "$1" ]; do
+  case "$1" in
+      -h)
+          usage
+          exit 0
+          ;;
+      -d)
+          _day="$2"
+          shift
+          ;;
+      -m)
+          _month="$2"
+          shift
+          ;;
+      -y)
+          _year="$2"
+          shift
+          ;;
+      -i)
+          _increment="$2"
+          shift
+          ;;
+      -r)
+          _randomincrement="$2"
+          shift
+          ;;
+      -f)
+          TIMEDIR="$2"
+          shift
+          ;;
+      *)
+          command="$(which $1)"
+          ## From now on the complete to-be wrapped command + its args
+          ## are stored in $@, which will expand like we want it for
+          ## handling quoted arguments with whitespaces in it, etc.
+          break
+  esac
+  shift
+done
+
+if [ -z "$_day" ]; then
+   _day="$(date +"%d")"
+fi
+
+if [ -z "$_month" ]; then
+   _month="$(date +"%m")"
+fi
+
+if [ -z "$_year" ]; then
+   _year="$(date +"%Y")"
+fi
+
+if [ "$_randomincrement" = "none" ] && [ "$_increment" = "none" ]; then
+   _increment="1"
+fi
+
+if [ "$_randomincrement" = "none" ]; then
+   if [ -z "$_increment" ]; then
+      _increment="1"
+   fi
+elif [ "$_increment" = "none" ]; then
+   if [ "$_randomincrement" = "" ]; then
+      echo "randomincrement must be a positive number."
+      exit 1
+   else
+      ## random number between 1 and $_randomincrement
+      random_number="$(( 0+($(od -An -N2 -i /dev/random) )%($_randomincrement-0+1) ))"
+      _increment="$random_number"
+   fi
+else
+   echo "You can not combine -r and -i."
+   exit 1
+fi
+
+if [ -z "$TIMEDIR" ]; then
+   TIMEDIR=~/.timeprivacy
+fi
+
+nodigits="$(echo $_increment | sed 's/[[:digit:]]//g')"
+if [ ! -z "$nodigits" ]; then
+   echo "increment is not a digit."
+   exit 1
+fi
+
+nodigits="$(echo $_year | sed 's/[[:digit:]]//g')"
+if [ ! -z "$nodigits" ]; then
+   echo "_day is not a digit."
+   exit 1
+fi
+
+nodigits="$(echo $_year | sed 's/[[:digit:]]//g')"
+if [ ! -z "$nodigits" ]; then
+   echo "year is not a digit."
+   exit 1
+fi
+
+nodigits="$(echo $_month | sed 's/[[:digit:]]//g')"
+if [ ! -z "$nodigits" ]; then
+   echo "month is not a digit."
+   exit 1
+fi
+
+nodigits="$(echo $_day | sed 's/[[:digit:]]//g')"
+if [ ! -z "$nodigits" ]; then
+   echo "day is not a digit."
+   exit 1
+fi
+
+nodigits="$(echo $_increment | sed 's/[[:digit:]]//g')"
+if [ ! -z "$nodigits" ]; then
+   echo "increment is not a digit."
+   exit 1
+fi
+
+SECONDS_FILE="$TIMEDIR/seconds_file"
+MINUTES_FILE="$TIMEDIR/minutes_file"
+HOURS_FILE="$TIMEDIR/hours_file"
+
+#DAYS_FILE="$TIMEDIR/days_file"
+#MONTHS_FILE="$TIMEDIR/months_file"
+#YEARS_FILE="$TIMEDIR/years_file"
+
+#true "TIMEDIR: $TIMEDIR"
+#true "year: $_year"
+#true "month: $_month"
+#true "day: $_day"
+#true "_randomincrement: $_randomincrement"
+#true "_increment: $_increment"
+
+read_date_file() {
+   if [ ! -d "$TIMEDIR" ]; then
+      mkdir -p "$TIMEDIR"
+   fi
+
+   if [ ! -f "$SECONDS_FILE" ]; then
+      echo "0" > "$SECONDS_FILE"
+   fi
+
+   if [ ! -f "$MINUTES_FILE" ]; then
+      echo "0" > "$MINUTES_FILE"
+   fi
+
+   if [ ! -f "$HOURS_FILE" ]; then
+      echo "0" > "$HOURS_FILE"
+   fi
+
+   #if [ ! -f "$DAYS_FILE" ]; then
+      #echo "1" > "$DAYS_FILE"
+   #fi
+
+   #if [ ! -f "$MONTHS_FILE" ]; then
+      #echo "1" > "$MONTHS_FILE"
+   #fi
+
+   #if [ ! -f "$YEARS_FILE" ]; then
+      #echo "2013" > "$YEARS_FILE"
+   #fi
+
+   SECONDS="$(cat "$SECONDS_FILE")"
+   MINUTES="$(cat "$MINUTES_FILE")"
+   HOURS="$(cat "$HOURS_FILE")"
+
+   if [ -z "$SECONDS" ]; then
+      SECONDS="0"
+   fi
+
+   if [ -z "$MINUTES" ]; then
+      MINUTES="0"
+   fi
+
+   if [ -z "$HOURS" ]; then
+      HOURS="0"
+   fi
+
+   local nodigits="$(echo $SECONDS | sed 's/[[:digit:]]//g')"
+   if [ ! -z "$nodigits" ]; then
+      SECONDS="0"
+   fi
+
+   local nodigits="$(echo $MINUTES | sed 's/[[:digit:]]//g')"
+   if [ ! -z "$nodigits" ]; then
+      MINUTES="0"
+   fi
+
+   local nodigits="$(echo $HOURS | sed 's/[[:digit:]]//g')"
+   if [ ! -z "$nodigits" ]; then
+      HOURS="0"
+   fi
+
+   SECONDS="$(expr "$SECONDS" + "$_increment")" || true
+   if [ "$SECONDS" -ge "60" ]; then
+      SECONDS="0"
+
+      MINUTES="$(expr "$MINUTES" + "1")" || true
+      if [ "$MINUTES" -ge "60" ]; then
+         MINUTES="0"
+
+         HOURS="$(expr "$HOURS" + "1")" || true
+         if [ "$HOURS" -ge "24" ]; then
+            HOURS="0"
+         fi
+         echo "$HOURS" > "$HOURS_FILE"
+
+      fi
+      echo "$MINUTES" > "$MINUTES_FILE"
+
+   fi
+
+   echo "$SECONDS" > "$SECONDS_FILE"
+
+   #echo "$HOURS $MINUTES $SECONDS"
+}
+
+need_new_date() {
+   ## Testing
+   #while [ 1 ]; do
+   #   read_date_file
+   #done
+
+   read_date_file
+
+   ## Testing
+   #echo "faketime '$_year-$_month-$_day $HOURS:$MINUTES:$SECONDS' /bin/date"
+   #faketime "$_year-$_month-$_day $HOURS:$MINUTES:$SECONDS" /bin/date
+
+   echo "$_year-$_month-$_day $HOURS:$MINUTES:$SECONDS"
+}
+
+need_new_date
+

--- a/tools/faketime/test/Makefile
+++ b/tools/faketime/test/Makefile
@@ -1,0 +1,31 @@
+CC = gcc
+
+CFLAGS = -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra
+LDFLAGS = -lrt
+
+SRC = timetest.c
+OBJ = ${SRC:.c=.o}
+
+all: timetest test
+
+.c.o:
+	${CC} -c ${CFLAGS} $<
+
+timetest: ${OBJ}
+	${CC} -o $@ ${OBJ} ${LDFLAGS}
+
+test: timetest functest
+	@echo
+	@./test.sh
+
+# run functional tests
+functest:
+	./testframe.sh functests
+
+clean:
+	@rm -f ${OBJ} timetest
+
+distclean: clean
+	@echo
+
+.PHONY: all test clean distclean

--- a/tools/faketime/test/Makefile.OSX
+++ b/tools/faketime/test/Makefile.OSX
@@ -1,0 +1,30 @@
+CC ?= clang
+
+CFLAGS += -std=gnu99 -Wall -DFAKE_STAT 
+
+SRC = timetest.c
+OBJ = ${SRC:.c=.o}
+
+all: timetest test
+
+.c.o:
+	${CC} -c ${CFLAGS} $<
+
+timetest: ${OBJ}
+	${CC} -o $@ ${OBJ} ${LDFLAGS}
+
+test: timetest functest
+	@echo
+	@./test_OSX.sh
+
+# run functional tests
+functest:
+	./testframe.sh functests
+
+clean:
+	@rm -f ${OBJ} timetest
+
+distclean: clean
+	@echo
+
+.PHONY: all test clean distclean

--- a/tools/faketime/test/README-testframe.txt
+++ b/tools/faketime/test/README-testframe.txt
@@ -1,0 +1,39 @@
+# here's how the testframe script works.
+#
+# Usage for testing:
+#	usage: testframe.sh DIR
+# testframe.sh runs each testsuite script found within DIR.
+# (in the context of libfaketime, the DIR is functest.)
+# exits with status 0 if all tests succeed.
+#
+# Interface:
+# by convention, each testsuite script (within DIR) must be
+# a bash script named test_*.sh.  the script must define a
+# function named "run".  run takes no arguments.  run is
+# expected to call the framework-provided function
+# run_testcase once for each test function.  run_testcase
+# uses the global vars NFAIL and NSUCC to keep track of how
+# many testcases failed/succeeded.
+#
+# the test function is expected to call something like
+# asserteq or assertneq (again, framework-provided).
+#
+# fine print: for each testsuite, the framework creates a
+# subshell and dots in the script.  also dotted in are
+# testframe.inc and DIR/common.inc (if it exists).  the
+# testsuite script can make use of any functions defined
+# in these inc files.  the environment variable
+# TESTSUITE_NAME is set to the filename of the testsuite
+# script, for possible use in warning or info messages.
+#
+# see functests/test_true.sh for a simple example of
+# a test suite script.
+#
+# Simple steps to add a new testsuite:
+# 1. decide its name - eg, XXX.
+# 2. choose a DIR of similar testsuites to put it in, or create a new one.
+# 3. create DIR/test_XXX.sh.
+# 4. write a run function and testcase functions in DIR/test_XXX.sh.
+# 5. within the run function, call run_testcase for each testcase function.
+# 6. within each testcase funtion, call assertneq or asserteq, or do
+#    the equivalent.

--- a/tools/faketime/test/functests/common.inc
+++ b/tools/faketime/test/functests/common.inc
@@ -1,0 +1,63 @@
+# libfaketime-specific common support routines for tests
+
+# say which *_fakecmd wrapper to use
+platform()
+{
+	# may want to expand the pattern for linuxlike
+	typeset out=$(uname)
+	case "$out" in
+	*Darwin*) echo "mac" ;;
+	*Linux*) echo "linuxlike" ;;
+    GNU|GNU/kFreeBSD) echo "linuxlike" ;;
+        *SunOS*) echo "sunos" ;;
+	*) echo 1>&2 unsupported platform, uname=\"$out\" ;;
+	esac
+}
+
+# run faked command on a mac
+# UNTESTED
+mac_fakecmd()
+{
+	typeset timestring="$1"; shift
+	typeset fakelib=../src/libfaketime.1.dylib
+	export DYLD_INSERT_LIBRARIES=$fakelib
+	export DYLD_FORCE_FLAT_NAMESPACE=1
+	FAKETIME="$timestring" \
+	"$@"
+}
+
+sunos_fakecmd()
+{
+        typeset timestring="$1"; shift
+        typeset fakelib=../src/libfaketime.so.1
+        export LD_PRELOAD=$fakelib
+        FAKETIME="$timestring" \
+        "$@"
+}
+
+# run faked command on linuxlike OS
+linuxlike_fakecmd()
+{
+	typeset timestring="$1"; shift
+	typeset fakelib=../src/libfaketime.so.1
+	export LD_PRELOAD=$fakelib
+	FAKETIME="$timestring" \
+	"$@"
+}
+
+# run a command with libfaketime using the given timestring
+fakecmd()
+{
+	${PLATFORM}_fakecmd "$@"
+}
+
+# generate a sequence of numbers from a to b
+range()
+{
+	typeset a=$1 b=$2
+	typeset i=$a
+	while ((i <= b)); do
+		echo $i
+		((i = i+1))
+	done
+}

--- a/tools/faketime/test/functests/dont_test_false.sh
+++ b/tools/faketime/test/functests/dont_test_false.sh
@@ -1,0 +1,6 @@
+# a testsuite that will force failure - for testing purposes
+
+run()
+{
+	run_testcase false
+}

--- a/tools/faketime/test/functests/test_exclude_mono.sh
+++ b/tools/faketime/test/functests/test_exclude_mono.sh
@@ -1,0 +1,87 @@
+# Checks that setting DONT_FAKE_MONOTONIC actually prevent
+# libfaketime from faking monotonic clocks.
+#
+# We do this by freezing time at a specific and arbitrary date with faketime,
+# and making sure that if we set DONT_FAKE_MONOTONIC to 1, calling
+# clock_gettime(CLOCK_MONOTONIC) returns two different values.
+#
+# We also make sure that if we don't set DONT_FAKE_MONOTONIC to 1, in other
+# words when we use the default behavior, two subsequent calls to
+# clock_gettime(CLOCK_MONOTONIC) do return different values.
+
+init()
+{
+    typeset testsuite="$1"
+    PLATFORM=$(platform)
+    if [ -z "$PLATFORM" ]; then
+        echo "$testsuite: unknown platform! quitting"
+        return 1
+    fi
+    echo "# PLATFORM=$PLATFORM"
+    return 0
+}
+
+run()
+{
+    init
+
+    run_testcase dont_fake_mono
+    run_testcase fake_mono
+}
+
+get_token()
+{
+    string=$1
+    token_index=$2
+    separator=$3
+
+    echo $string | cut -d "$separator" -f $token_index
+}
+
+assert_timestamps_neq()
+{
+    timestamps=$1
+    msg=$2
+
+    first_timestamp=$(get_token "${timestamps}" 1 ' ')
+    second_timestamp=$(get_token "${timestamps}" 2 ' ')
+
+    assertneq "${first_timestamp}" "${second_timestamp}" "${msg}"
+}
+
+assert_timestamps_eq()
+{
+    timestamps=$1
+    msg=$2
+
+    first_timestamp=$(get_token "${timestamps}" 1 ' ')
+    second_timestamp=$(get_token "${timestamps}" 2 ' ')
+
+    asserteq "${first_timestamp}" "${second_timestamp}" "${msg}"
+}
+
+get_monotonic_time()
+{
+    dont_fake_mono=$1; shift;
+    clock_id=$1; shift;
+    DONT_FAKE_MONOTONIC=${dont_fake_mono} fakecmd "2014-07-21 09:00:00" \
+    /bin/bash -c "for i in 1 2; do \
+    perl -w -MTime::HiRes=clock_gettime,${clock_id} -E \
+    'say clock_gettime(${clock_id})'; \
+    sleep 1; \
+    done"
+}
+
+dont_fake_mono()
+{
+    timestamps=$(get_monotonic_time 1 CLOCK_MONOTONIC)
+    msg="When not faking monotonic time, timestamps should be different"
+    assert_timestamps_neq "${timestamps}" "${msg}"
+}
+
+fake_mono()
+{
+    timestamps=$(get_monotonic_time 0 CLOCK_MONOTONIC)
+    msg="When faking monotonic, timestamps should be equal"
+    assert_timestamps_eq "${timestamps}" "${msg}"
+}

--- a/tools/faketime/test/functests/test_null.sh
+++ b/tools/faketime/test/functests/test_null.sh
@@ -1,0 +1,13 @@
+# check that the date doesn't happen to be 0.
+
+run()
+{
+	run_testcase nulltest
+}
+
+nulltest()
+{
+	typeset tdate=${I2DATES[0]}
+
+	assertneq 0 "$(date +%s)" "($tdate)"
+}

--- a/tools/faketime/test/functests/test_true.sh
+++ b/tools/faketime/test/functests/test_true.sh
@@ -1,0 +1,7 @@
+# test suite that always succeds - for testing framework
+
+run()
+{
+	run_testcase true
+	return 0
+}

--- a/tools/faketime/test/functests/test_walkone.sh
+++ b/tools/faketime/test/functests/test_walkone.sh
@@ -1,0 +1,67 @@
+# walking-1 test.
+# sourced in from testframe.sh.
+#
+# this script defines a suite of functional tests
+# that verifies the correct operation of libfaketime
+# with the date command.
+
+run()
+{
+	init
+
+	for i in $(range 0 30); do
+		run_testcase test_with_i $i
+	done
+}
+
+# ----- support routines
+init()
+{
+	typeset testsuite="$1"
+	PLATFORM=$(platform)
+	if [ -z "$PLATFORM" ]; then
+		echo "$testsuite: unknown platform! quitting"
+		return 1
+	fi
+	echo "# PLATFORM=$PLATFORM"
+	return 0
+}
+
+
+# run date cmd under faketime, print time in secs
+fakedate()
+{
+	#
+	# let the time format be raw seconds since Epoch
+	# for both input to libfaketime, and output of the date cmd.
+	#
+	typeset fmt='%s'
+	export FAKETIME_FMT=$fmt
+	fakecmd "$1" date +$fmt
+}
+
+#
+# compute x**n.
+# use only the shell, in case we need to run on machines
+# without bc, dc, perl, etc.
+#
+pow()
+{
+	typeset x="$1" n="$2"
+	typeset r=1
+	typeset i=0
+	while ((i < n)); do
+		((r = r*x))
+		((i++))
+	done
+	echo $r
+}
+
+# run a fakedate test with a given time t
+test_with_i()
+{
+	typeset i="$1"
+	typeset t=$(pow 2 $i)
+
+	asserteq $(fakedate $t) $t "(secs since Epoch)"
+}

--- a/tools/faketime/test/test.sh
+++ b/tools/faketime/test/test.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+if [ -f /etc/faketimerc ] ; then
+	echo "Running the test program with your system-wide default in /etc/faketimerc"
+	echo "\$ LD_PRELOAD=../src/libfaketime.so.1 ./timetest"
+	LD_PRELOAD=../src/libfaketime.so.1 ./timetest
+	echo
+else
+	echo "Running the test program with no faked time specified"
+	echo "\$ LD_PRELOAD=../src/libfaketime.so.1 ./timetest"
+	LD_PRELOAD=../src/libfaketime.so.1 ./timetest
+	echo
+fi
+
+echo "============================================================================="
+echo
+
+echo "Running the test program with absolute date 2003-01-01 10:00:05 specified"
+echo "\$ LD_PRELOAD=../src/libfaketime.so.1 FAKETIME=\"2003-01-01 10:00:05\" ./timetest"
+LD_PRELOAD=../src/libfaketime.so.1 FAKETIME="2003-01-01 10:00:05" ./timetest
+echo
+
+echo "============================================================================="
+echo
+
+echo "Running the test program with START date @2005-03-29 14:14:14 specified"
+echo "\$ LD_PRELOAD=../src/libfaketime.so.1 FAKETIME=\"@2005-03-29 14:14:14\" ./timetest"
+LD_PRELOAD=../src/libfaketime.so.1 FAKETIME="@2005-03-29 14:14:14" ./timetest
+echo
+
+echo "============================================================================="
+echo
+
+echo "Running the test program with 10 days negative offset specified"
+echo "LD_PRELOAD=../src/libfaketime.so.1 FAKETIME=\"-10d\" ./timetest"
+LD_PRELOAD=../src/libfaketime.so.1 FAKETIME="-10d" ./timetest
+echo
+
+echo "============================================================================="
+echo
+
+echo "Running the test program with 10 days negative offset specified, and FAKE_STAT disabled"
+echo "\$ LD_PRELOAD=../src/libfaketime.so.1 FAKETIME=\"-10d\" NO_FAKE_STAT=1 ./timetest"
+LD_PRELOAD=../src/libfaketime.so.1 FAKETIME="-10d" NO_FAKE_STAT=1 ./timetest
+echo
+
+echo "============================================================================="
+echo
+
+echo "Running the test program with 10 days postive offset specified, and sped up 2 times"
+echo "\$ LD_PRELOAD=../src/libfaketime.so.1 FAKETIME=\"+10d x2\" ./timetest"
+LD_PRELOAD=../src/libfaketime.so.1 FAKETIME="+10d x2" NO_FAKE_STAT=1 ./timetest
+echo
+
+echo "============================================================================="
+echo
+
+echo "Running the 'date' command with 15 days negative offset specified"
+echo "\$ LD_PRELOAD=../src/libfaketime.so.1 FAKETIME=\"-15d\" date"
+LD_PRELOAD=../src/libfaketime.so.1 FAKETIME="-15d" date
+echo
+
+echo "============================================================================="
+echo "Testing finished."
+
+exit 0

--- a/tools/faketime/test/test_OSX.sh
+++ b/tools/faketime/test/test_OSX.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+export DYLD_FORCE_FLAT_NAMESPACE=1
+export DYLD_INSERT_LIBRARIES=../src/libfaketime.1.dylib
+
+if [ -f /etc/faketimerc ] ; then
+	echo "Running the test program with your system-wide default in /etc/faketimerc"
+	./timetest
+	echo
+else
+	echo "Running the test program with no faked time specified"
+	./timetest
+	echo
+fi
+
+echo "Running the test program with absolute date 2003-01-01 10:00:05 specified"
+echo "FAKETIME=\"2003-01-01 10:00:05\" ./timetest"
+FAKETIME="2003-01-01 10:00:05" ./timetest
+echo
+
+echo "Running the test program with START date @2005-03-29 14:14:14 specified"
+echo "FAKETIME=\"@2005-03-29 14:14:14\" ./timetest"
+FAKETIME="@2005-03-29 14:14:14" ./timetest
+echo
+
+echo "Running the test program with 10 days negative offset specified"
+echo "FAKETIME=\"-10d\" ./timetest"
+FAKETIME="-10d" ./timetest
+echo
+
+echo "Running the test program with 10 days negative offset specified, and FAKE_STAT disabled"
+echo "FAKETIME=\"-10d\" NO_FAKE_STAT=1 ./timetest"
+FAKETIME="-10d" NO_FAKE_STAT=1 ./timetest
+echo
+
+echo "Running the test program with 10 days postive offset specified, and sped up 2 times"
+echo "FAKETIME=\"+10d x2\" ./timetest"
+FAKETIME="+10d x2" NO_FAKE_STAT=1 ./timetest
+echo
+
+echo "Running the 'date' command with 15 days negative offset specified"
+echo "FAKETIME=\"-15d\" date"
+FAKETIME="-15d" date
+echo
+
+exit 0

--- a/tools/faketime/test/testframe.inc
+++ b/tools/faketime/test/testframe.inc
@@ -1,0 +1,55 @@
+# framework common functions for use in test suites and test cases
+
+#
+# run a test and keep stats on success/failure.
+# arguments: a command, possibly a shell function.
+# return value: 0 on success, 1 on failure.
+# side effects: increments global var NSUCC on success, NFAIL on failure.
+#
+run_testcase()
+{
+	if "$@"; then
+		((NSUCC++))
+		return 0
+	else
+		((NFAIL++))
+		return 1
+	fi
+}
+
+#
+# verbosely check that the test output matches the expected value.
+# arguments: the test output, the expected value, and a description.
+# return value: 0 on if test output equals expected value; 1 otherwise.
+# side effects: prints a descriptive message.
+#
+asserteq()
+{
+	typeset out="$1" expected="$2" desc="$3"
+	echo -n "out=$out $desc"
+	if [ "$out" = "$expected" ]; then
+		echo " - ok"
+		return 0
+	else
+		echo " expected=$expected - bad"
+		return 1
+	fi
+}
+
+#
+# verbosely check that the test output doesn't match the reference value.
+# return value: 1 on if test output equals expected value; 0 if not equal.
+# side effects: prints descriptive message.
+#
+assertneq()
+{
+	typeset out="$1" ref="$2" desc="$3"
+	echo -n "out=$out $desc"
+	if [ "$out" = "$ref" ]; then
+		echo " ref=$ref - bad"
+		return 1
+	else
+		echo " ref=$ref - ok"
+		return 0
+	fi
+}

--- a/tools/faketime/test/testframe.sh
+++ b/tools/faketime/test/testframe.sh
@@ -1,0 +1,99 @@
+#! /bin/bash
+#	testframe.sh DIR
+# bare-bones testing framework.
+# run the test suites in the given DIR;
+# exit with nonzero status if any of them failed.
+# see README.testframe.txt for details.
+#
+
+# echo labelled error/warning message to stderr
+report()
+{
+	echo $PROG: $* 1>&2
+}
+
+# echo OK or BAD depending on argument (0 or not)
+status_word()
+{
+	if [ "$1" -eq 0 ]; then
+		echo OK
+	else
+		echo BAD
+	fi
+}
+
+# run the given testsuite, return nonzero if any testcase failed.
+run_testsuite()
+{
+	typeset testsuite="$1"
+
+	NFAIL=0
+	NSUCC=0
+
+	# add testsuite dir to PATH for convenience
+	typeset dir=$(dirname $testsuite)
+	PATH=$dir:$PATH
+	. testframe.inc
+	if [ -f $dir/common.inc ]; then
+		. $dir/common.inc
+	fi
+	. $testsuite
+	export TESTSUITE_NAME=$testsuite
+
+	echo ""
+	echo "# Begin $testsuite"
+
+	run
+	typeset runstat=$?
+
+	echo "# $testsuite summary: $NSUCC succeeded, $NFAIL failed"
+	if [ $runstat -ne 0 ]; then
+		((NFAIL++))
+		report "error: $testsuite run exit_status=$runstat!"
+	fi
+	echo "# End $testsuite -" $(status_word $NFAIL)
+	[ $NFAIL -eq 0 ]
+}
+
+#
+# list all testsuite scripts in the given directories.
+# a testsuite file must be a bash script whose name is of the form test_*.sh .
+#
+list_testsuites()
+{
+	for dir in "$@"; do
+		ls $dir/test_*.sh 2>/dev/null
+	done
+}
+
+main()
+{
+	TS_NFAIL=0
+	TS_NSUCC=0
+
+	echo "# Begin Test Suites in $*"
+	typeset testsuites=$(list_testsuites "$@")
+
+	if [ -z "$testsuites" ]; then
+		report "error: no testsuites found"
+		exit 1
+	fi
+
+	for testsuite in $testsuites; do
+		if run_testsuite $testsuite; then
+			((TS_NSUCC++))
+		else
+			((TS_NFAIL++))
+		fi
+	done
+
+	echo ""
+	echo "# Test Suites summary: $TS_NSUCC succeeded, $TS_NFAIL failed"
+	echo "# End Test Suites -" $(status_word $TS_NFAIL)
+	[ $TS_NFAIL -eq 0 ]
+}
+
+# ----- start of mainline code
+PROG=${0##*/}
+
+main "${@:-.}"

--- a/tools/faketime/test/timetest.c
+++ b/tools/faketime/test/timetest.c
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (C) 2003,2007 Wolfgang Hommel
+ *
+ *  This file is part of the FakeTime Preload Library.
+ *
+ *  The FakeTime Preload Library is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU General Public License as
+ *  published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  The FakeTime Preload Library is distributed in the hope that it will
+ *  be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the FakeTime Preload Library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/timeb.h>
+
+#ifdef FAKE_STAT
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#ifndef __APPLE__
+#include <signal.h>
+
+#define VERBOSE 0
+
+#define SIG SIGUSR1
+
+static void
+handler(int sig, siginfo_t *si, void *uc)
+{
+  /* Note: calling printf() from a signal handler is not
+     strictly correct, since printf() is not async-signal-safe;
+     see signal(7) */
+
+  if ((si == NULL) || (si != uc))
+  {
+    printf("Caught signal %d\n", sig);
+  }
+}
+#endif
+
+int main (int argc, char **argv)
+{
+    time_t now;
+    struct timeb tb;
+    struct timeval tv;
+#ifndef __APPLE__
+    struct timespec ts;
+    timer_t timerid1 = 0, timerid2;
+    struct sigevent sev;
+    struct itimerspec its;
+    sigset_t mask;
+    struct sigaction sa;
+#endif
+#ifdef FAKE_STAT
+    struct stat buf;
+#endif
+
+#ifndef __APPLE__
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGUSR1, &sa, NULL) == -1)
+    {
+      perror("sigaction");
+      exit(EXIT_FAILURE);
+    }
+
+    /* Block timer signal temporarily */
+    printf("Blocking signal %d\n", SIGUSR1);
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGUSR1);
+    if (sigprocmask(SIG_SETMASK, &mask, NULL) == -1)
+    {
+      perror("sigaction");
+      exit(EXIT_FAILURE);
+    }
+
+    /* Create the timer */
+    sev.sigev_notify = SIGEV_SIGNAL;
+    sev.sigev_signo = SIGUSR1;
+    sev.sigev_value.sival_ptr = &timerid1;
+    if (timer_create(CLOCK_REALTIME, &sev, &timerid1) == -1)
+    {
+      perror("timer_create");
+      exit(EXIT_FAILURE);
+    }
+
+    /* Start timer1 */
+
+    /* start timer ticking after one second */
+    its.it_value.tv_sec = 1;
+    its.it_value.tv_nsec = 0;
+    /* fire in every 0.3 seconds */
+    its.it_interval.tv_sec = 0;
+    its.it_interval.tv_nsec = 300000000;
+
+    if (timer_settime(timerid1, 0, &its, NULL) == -1)
+    {
+      perror("timer_settime");
+      exit(EXIT_FAILURE);
+    }
+
+    sev.sigev_value.sival_ptr = &timerid2;
+    if (timer_create(CLOCK_REALTIME, &sev, &timerid2) == -1)
+    {
+      perror("timer_create");
+      exit(EXIT_FAILURE);
+    }
+
+    /* Start timer2 */
+
+    clock_gettime(CLOCK_REALTIME, &its.it_value);
+    /* start timer ticking after one second */
+    its.it_value.tv_sec += 3;
+    /* fire once */
+    its.it_interval.tv_sec = 0;
+    its.it_interval.tv_nsec = 0;
+
+    if (timer_settime(timerid2, TIMER_ABSTIME, &its, NULL) == -1)
+    {
+      perror("timer_settime");
+      exit(EXIT_FAILURE);
+    }
+#endif
+
+    time(&now);
+    printf("time()         : Current date and time: %s", ctime(&now));
+    printf("time(NULL)     : Seconds since Epoch  : %u\n", (unsigned int)time(NULL));
+
+    ftime(&tb);
+    printf("ftime()        : Current date and time: %s", ctime(&tb.time));
+
+    printf("(Intentionally sleeping 2 seconds...)\n");
+    fflush(stdout);
+    if (argc < 3)
+    {
+        sleep(1);
+        usleep(1000000);
+    }
+
+    gettimeofday(&tv, NULL);
+    printf("gettimeofday() : Current date and time: %s", ctime(&tv.tv_sec));
+
+#ifndef __APPLE__
+    if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1)
+    {
+      perror("sigprocmask");
+      exit(EXIT_FAILURE);
+    }
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    printf("clock_gettime(): Current date and time: %s", ctime(&ts.tv_sec));
+
+    int timer_getoverrun_timerid1 = timer_getoverrun(timerid1);
+    if (timer_getoverrun_timerid1 != 3)
+    {
+        printf("timer_getoverrun(timerid1) FAILED, must be 3 but got: %d\n", timer_getoverrun_timerid1);
+    }
+
+    timer_gettime(timerid1, &its);
+    if (VERBOSE == 1)
+    {
+        printf("timer_gettime(timerid1, &its); its = {{%ld, %ld}, {%ld, %ld}}}\n",
+                (long)its.it_interval.tv_sec, (long)its.it_interval.tv_nsec,
+                (long)its.it_value.tv_sec, (long)its.it_value.tv_nsec);
+    }
+
+    int timer_getoverrun_timerid2 = timer_getoverrun(timerid2);
+    if (timer_getoverrun_timerid2 != 0)
+    {
+        printf("timer_getoverrun(timerid2) FAILED, must be 0 but got: %d\n", timer_getoverrun_timerid2);
+    }
+
+    timer_gettime(timerid2, &its);
+    if (VERBOSE == 1)
+    {
+        printf("timer_gettime(timerid2, &its); its = {{%ld, %ld}, {%ld, %ld}}}\n",
+            (long)its.it_interval.tv_sec, (long)its.it_interval.tv_nsec,
+            (long)its.it_value.tv_sec, (long)its.it_value.tv_nsec);
+    }
+#endif
+
+#ifdef FAKE_STAT
+    lstat(argv[0], &buf);
+    printf("stat(): mod. time of file '%s': %s", argv[0], ctime(&buf.st_mtime));
+#endif
+
+    return 0;
+}
+
+/*
+ * Editor modelines
+ *
+ * Local variables:
+ * c-basic-offset: 2
+ * tab-width: 2
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=2 tabstop=2 expandtab:
+ * :indentSize=2:tabSize=2:noTabs=true:
+ */
+
+/* eof */


### PR DESCRIPTION
**Work in progress. Do not merge.** 

But do feel free to comment!

Add faketime to tools and enable test/timers in make test and make test-ci.

Fixes: https://github.com/nodejs/node/issues/4404

/cc @misterdjules @Fishrock123 

Didn't touch vcbuild.bat because `faketime` doesn't run on Windows. As it is, we'll probably have to skip some platforms. Will run CI to see which ones `faketime` successfully builds on...