### PR TITLE
github: put description of PR to the end of tmpl

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-### Description of change
-
-_Please provide a description of the change here._
-
 ### Pull Request check-list
 
 _Please make sure to review and check all of these items:_
@@ -22,3 +18,7 @@ while the PR is open._
 _Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_
 
 [0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit
+
+### Description of change
+
+_Please provide a description of the change here._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,8 @@ _Please make sure to review and check all of these items:_
 - [ ] Is a documentation update included (if this change modifies
   existing APIs, or introduces new ones)?
 
-_NOTE: these things are not required to open a PR and can be done afterwards /
-while the PR is open._
+_NOTE: these things are not required to open a PR and can be done
+afterwards / while the PR is open._
 
 ### Affected core subsystem(s)
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done afterwards /
while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

It looks like github appends commit log right after the template
contents. Seeing this it does not look logical to ask for details first.

This commit puts `Description of change` part to the end of the
template.

_NOTE: I had to manually re-order this to put Description of change to the bottom in this PR_