### PR TITLE
test: fix test-timers.reliability on OS X

### DIFF
--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -32,7 +32,7 @@ var intervalFired = false;
  */
 
 var monoTimer = new Timer();
-monoTimer.ontimeout = function() {
+monoTimer[Timer.kOnTimeout] = function() {
     /*
      * Make sure that setTimeout's and setInterval's callbacks have
      * already fired, otherwise it means that they are vulnerable to


### PR DESCRIPTION
Fix `make test-timers` so that it works on OS X. (Still won't work everywhere else except some Linux variants.)

/cc @misterdjules @Fishrock123 

Fixes: https://github.com/nodejs/node/issues/4404