### PR TITLE
url: group slashed protocols by protocol name

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -48,14 +48,14 @@ const hostlessProtocol = {
 // protocols that always contain a // bit.
 const slashedProtocol = {
   'http': true,
-  'https': true,
-  'ftp': true,
-  'gopher': true,
-  'file': true,
   'http:': true,
+  'https': true,
   'https:': true,
+  'ftp': true,
   'ftp:': true,
+  'gopher': true,
   'gopher:': true,
+  'file': true,
   'file:': true
 };
 const querystring = require('querystring');


### PR DESCRIPTION
Reorder slashed protocols so they are grouped by protocol name.

This is done so it doesn't look like we're duplicating protocol names at the
bottom of the list.