### PR TITLE
crypto: simplify Certificate class bindings

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -592,23 +592,21 @@ exports.Certificate = Certificate;
 function Certificate() {
   if (!(this instanceof Certificate))
     return new Certificate();
-
-  this._handle = new binding.Certificate();
 }
 
 
 Certificate.prototype.verifySpkac = function(object) {
-  return this._handle.verifySpkac(object);
+  return binding.certVerifySpkac(object);
 };
 
 
 Certificate.prototype.exportPublicKey = function(object, encoding) {
-  return this._handle.exportPublicKey(toBuf(object, encoding));
+  return binding.certExportPublicKey(toBuf(object, encoding));
 };
 
 
 Certificate.prototype.exportChallenge = function(object, encoding) {
-  return this._handle.exportChallenge(toBuf(object, encoding));
+  return binding.certExportChallenge(toBuf(object, encoding));
 };
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5475,29 +5475,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Certificate::Initialize(Environment* env, Local<Object> target) {
-  HandleScope scope(env->isolate());
-
-  Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
-
-  t->InstanceTemplate()->SetInternalFieldCount(1);
-
-  env->SetProtoMethod(t, "verifySpkac", VerifySpkac);
-  env->SetProtoMethod(t, "exportPublicKey", ExportPublicKey);
-  env->SetProtoMethod(t, "exportChallenge", ExportChallenge);
-
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Certificate"),
-              t->GetFunction());
-}
-
-
-void Certificate::New(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  new Certificate(env, args.This());
-}
-
-
-bool Certificate::VerifySpkac(const char* data, unsigned int len) {
+bool VerifySpkac(const char* data, unsigned int len) {
   bool i = 0;
   EVP_PKEY* pkey = nullptr;
   NETSCAPE_SPKI* spki = nullptr;
@@ -5523,9 +5501,8 @@ bool Certificate::VerifySpkac(const char* data, unsigned int len) {
 }
 
 
-void Certificate::VerifySpkac(const FunctionCallbackInfo<Value>& args) {
-  Certificate* certificate = Unwrap<Certificate>(args.Holder());
-  Environment* env = certificate->env();
+void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   bool i = false;
 
   if (args.Length() < 1)
@@ -5540,13 +5517,13 @@ void Certificate::VerifySpkac(const FunctionCallbackInfo<Value>& args) {
   char* data = Buffer::Data(args[0]);
   CHECK_NE(data, nullptr);
 
-  i = certificate->VerifySpkac(data, length);
+  i = VerifySpkac(data, length);
 
   args.GetReturnValue().Set(i);
 }
 
 
-const char* Certificate::ExportPublicKey(const char* data, int len) {
+const char* ExportPublicKey(const char* data, int len) {
   char* buf = nullptr;
   EVP_PKEY* pkey = nullptr;
   NETSCAPE_SPKI* spki = nullptr;
@@ -5587,10 +5564,8 @@ const char* Certificate::ExportPublicKey(const char* data, int len) {
 }
 
 
-void Certificate::ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
+void ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-
-  Certificate* certificate = Unwrap<Certificate>(args.Holder());
 
   if (args.Length() < 1)
     return env->ThrowTypeError("Missing argument");
@@ -5604,7 +5579,7 @@ void Certificate::ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   char* data = Buffer::Data(args[0]);
   CHECK_NE(data, nullptr);
 
-  const char* pkey = certificate->ExportPublicKey(data, length);
+  const char* pkey = ExportPublicKey(data, length);
   if (pkey == nullptr)
     return args.GetReturnValue().SetEmptyString();
 
@@ -5616,7 +5591,7 @@ void Certificate::ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-const char* Certificate::ExportChallenge(const char* data, int len) {
+const char* ExportChallenge(const char* data, int len) {
   NETSCAPE_SPKI* sp = nullptr;
 
   sp = NETSCAPE_SPKI_b64_decode(data, len);
@@ -5632,10 +5607,8 @@ const char* Certificate::ExportChallenge(const char* data, int len) {
 }
 
 
-void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
+void ExportChallenge(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-
-  Certificate* crt = Unwrap<Certificate>(args.Holder());
 
   if (args.Length() < 1)
     return env->ThrowTypeError("Missing argument");
@@ -5649,7 +5622,7 @@ void Certificate::ExportChallenge(const FunctionCallbackInfo<Value>& args) {
   char* data = Buffer::Data(args[0]);
   CHECK_NE(data, nullptr);
 
-  const char* cert = crt->ExportChallenge(data, len);
+  const char* cert = ExportChallenge(data, len);
   if (cert == nullptr)
     return args.GetReturnValue().SetEmptyString();
 
@@ -5758,8 +5731,10 @@ void InitCrypto(Local<Object> target,
   Hash::Initialize(env, target);
   Sign::Initialize(env, target);
   Verify::Initialize(env, target);
-  Certificate::Initialize(env, target);
 
+  env->SetMethod(target, "certVerifySpkac", VerifySpkac);
+  env->SetMethod(target, "certExportPublicKey", ExportPublicKey);
+  env->SetMethod(target, "certExportChallenge", ExportChallenge);
 #ifndef OPENSSL_NO_ENGINE
   env->SetMethod(target, "setEngine", SetEngine);
 #endif  // !OPENSSL_NO_ENGINE

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -732,29 +732,6 @@ class ECDH : public BaseObject {
   const EC_GROUP* group_;
 };
 
-class Certificate : public AsyncWrap {
- public:
-  static void Initialize(Environment* env, v8::Local<v8::Object> target);
-
-  v8::Local<v8::Value> CertificateInit(const char* sign_type);
-  bool VerifySpkac(const char* data, unsigned int len);
-  const char* ExportPublicKey(const char* data, int len);
-  const char* ExportChallenge(const char* data, int len);
-
-  size_t self_size() const override { return sizeof(*this); }
-
- protected:
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void VerifySpkac(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void ExportPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void ExportChallenge(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-  Certificate(Environment* env, v8::Local<v8::Object> wrap)
-      : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_CRYPTO) {
-    MakeWeak<Certificate>(this);
-  }
-};
-
 bool EntropySource(unsigned char* buffer, size_t length);
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
### Description of change

Replace Certificate C++ class with simple functions. Update
crypto.Certificate methods accordingly.

Original talk was in comments of #5230.

I removed `Certificate` C++ class from `crypto` bindings and replaced its methods with simple functions. I also prefixed function names with `cert` in order to separate these functions from others like `randomBytes`, etc. (to be discussed).

### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

- crypto

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit