### PR TITLE
repl: accept no arguments to start()

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -243,7 +243,7 @@ blocks. The `preserveCursor` argument is passed to [`readline.prompt`][]. This i
 used primarily with `defineCommand`. It's also used internally to render each
 prompt line.
 
-## repl.start(options)
+## repl.start([options])
 
 Returns and starts a `REPLServer` instance, that inherits from
 [Readline Interface][]. Accepts an "options" Object that takes

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -194,8 +194,6 @@ function REPLServer(prompt,
     prompt = options.prompt;
     dom = options.domain;
     replMode = options.replMode;
-  } else if (typeof prompt !== 'string') {
-    throw new Error('An options Object, or a prompt String are required');
   } else {
     options = {};
   }

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -77,3 +77,17 @@ var r3 = repl.start({
 
 assert.equal(r3.replMode, repl.REPL_MODE_MAGIC);
 assert.equal(r3.historySize, 50);
+
+// Verify that defaults are used when no arguments are provided
+const r4 = repl.start();
+
+assert.strictEqual(r4._prompt, '> ');
+assert.strictEqual(r4.input, process.stdin);
+assert.strictEqual(r4.output, process.stdout);
+assert.strictEqual(r4.terminal, !!r4.output.isTTY);
+assert.strictEqual(r4.useColors, r4.terminal);
+assert.strictEqual(r4.useGlobal, false);
+assert.strictEqual(r4.ignoreUndefined, false);
+assert.strictEqual(r4.replMode, repl.REPL_MODE_SLOPPY);
+assert.strictEqual(r4.historySize, 30);
+r4.close();


### PR DESCRIPTION
Currently, there is a check to ensure that the user either provides an object or a string to `repl.start()`. The string case is used to set a REPL prompt. However, a default of `'> '` already exists, so forcing the user to specify a prompt is a bit redundant. This commit removes this restriction.

Closes https://github.com/nodejs/node/issues/5385