### PR TITLE
(vee-eight-4.9) contextify: update deprecated SetWeak usage

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -52,21 +52,19 @@ class ContextifyContext {
  protected:
   enum Kind {
     kSandbox,
-    kContext,
-    kProxyGlobal
+    kContext
   };
 
   Environment* const env_;
   Persistent<Object> sandbox_;
   Persistent<Context> context_;
-  Persistent<Object> proxy_global_;
   int references_;
 
  public:
   explicit ContextifyContext(Environment* env, Local<Object> sandbox)
       : env_(env),
         sandbox_(env->isolate(), sandbox),
-        // Wait for sandbox_, proxy_global_, and context_ to die
+        // Wait for sandbox_ and context_ to die
         references_(0) {
     context_.Reset(env->isolate(), CreateV8Context(env));
 
@@ -80,17 +78,11 @@ class ContextifyContext {
     context_.SetWeak(this, WeakCallback<Context, kContext>);
     context_.MarkIndependent();
     references_++;
-
-    proxy_global_.Reset(env->isolate(), context()->Global());
-    proxy_global_.SetWeak(this, WeakCallback<Object, kProxyGlobal>);
-    proxy_global_.MarkIndependent();
-    references_++;
   }
 
 
   ~ContextifyContext() {
     context_.Reset();
-    proxy_global_.Reset();
     sandbox_.Reset();
   }
 
@@ -104,6 +96,10 @@ class ContextifyContext {
     return PersistentToLocal(env()->isolate(), context_);
   }
 
+
+  inline Local<Object> global_proxy() const {
+    return context()->Global();
+  }
 
   // XXX(isaacs): This function only exists because of a shortcoming of
   // the V8 SetNamedPropertyHandler function.
@@ -321,10 +317,8 @@ class ContextifyContext {
     ContextifyContext* context = data.GetParameter();
     if (kind == kSandbox)
       context->sandbox_.ClearWeak();
-    else if (kind == kContext)
-      context->context_.ClearWeak();
     else
-      context->proxy_global_.ClearWeak();
+      context->context_.ClearWeak();
 
     if (--context->references_ == 0)
       delete context;
@@ -362,15 +356,14 @@ class ContextifyContext {
     MaybeLocal<Value> maybe_rv =
         sandbox->GetRealNamedProperty(ctx->context(), property);
     if (maybe_rv.IsEmpty()) {
-      Local<Object> proxy_global = PersistentToLocal(isolate,
-                                                     ctx->proxy_global_);
-      maybe_rv = proxy_global->GetRealNamedProperty(ctx->context(), property);
+      maybe_rv =
+          ctx->global_proxy()->GetRealNamedProperty(ctx->context(), property);
     }
 
     Local<Value> rv;
     if (maybe_rv.ToLocal(&rv)) {
       if (rv == ctx->sandbox_)
-        rv = PersistentToLocal(isolate, ctx->proxy_global_);
+        rv = ctx->global_proxy();
 
       args.GetReturnValue().Set(rv);
     }
@@ -411,11 +404,8 @@ class ContextifyContext {
         sandbox->GetRealNamedPropertyAttributes(ctx->context(), property);
 
     if (maybe_prop_attr.IsNothing()) {
-      Local<Object> proxy_global = PersistentToLocal(isolate,
-          ctx->proxy_global_);
-
       maybe_prop_attr =
-          proxy_global->GetRealNamedPropertyAttributes(ctx->context(),
+          ctx->global_proxy()->GetRealNamedPropertyAttributes(ctx->context(),
               property);
     }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -50,40 +50,29 @@ using v8::WeakCallbackData;
 
 class ContextifyContext {
  protected:
-  enum Kind {
-    kSandbox,
-    kContext
-  };
+  // V8 reserves the first field in context objects for the debugger. We use the
+  // second field to hold a reference to the sandbox object.
+  enum { kSandboxObjectIndex = 1 };
 
   Environment* const env_;
-  Persistent<Object> sandbox_;
   Persistent<Context> context_;
-  int references_;
 
  public:
-  explicit ContextifyContext(Environment* env, Local<Object> sandbox)
-      : env_(env),
-        sandbox_(env->isolate(), sandbox),
-        // Wait for sandbox_ and context_ to die
-        references_(0) {
-    context_.Reset(env->isolate(), CreateV8Context(env));
-
-    sandbox_.SetWeak(this, WeakCallback<Object, kSandbox>);
-    sandbox_.MarkIndependent();
-    references_++;
+  explicit ContextifyContext(Environment* env, Local<Object> sandbox_obj)
+      : env_(env) {
+    Local<Context> v8_context = CreateV8Context(env, sandbox_obj);
+    context_.Reset(env->isolate(), v8_context);
 
     // Allocation failure or maximum call stack size reached
     if (context_.IsEmpty())
       return;
-    context_.SetWeak(this, WeakCallback<Context, kContext>);
+    context_.SetWeak(this, WeakCallback<Context>);
     context_.MarkIndependent();
-    references_++;
   }
 
 
   ~ContextifyContext() {
     context_.Reset();
-    sandbox_.Reset();
   }
 
 
@@ -99,6 +88,11 @@ class ContextifyContext {
 
   inline Local<Object> global_proxy() const {
     return context()->Global();
+  }
+
+
+  inline Local<Object> sandbox() const {
+    return Local<Object>::Cast(context()->GetEmbedderData(kSandboxObjectIndex));
   }
 
   // XXX(isaacs): This function only exists because of a shortcoming of
@@ -128,7 +122,6 @@ class ContextifyContext {
     Local<Context> context = PersistentToLocal(env()->isolate(), context_);
     Local<Object> global =
         context->Global()->GetPrototype()->ToObject(env()->isolate());
-    Local<Object> sandbox = PersistentToLocal(env()->isolate(), sandbox_);
 
     Local<Function> clone_property_method;
 
@@ -136,7 +129,7 @@ class ContextifyContext {
     int length = names->Length();
     for (int i = 0; i < length; i++) {
       Local<String> key = names->Get(i)->ToString(env()->isolate());
-      bool has = sandbox->HasOwnProperty(context, key).FromJust();
+      bool has = sandbox()->HasOwnProperty(context, key).FromJust();
       if (!has) {
         // Could also do this like so:
         //
@@ -168,7 +161,7 @@ class ContextifyContext {
           clone_property_method = Local<Function>::Cast(script->Run());
           CHECK(clone_property_method->IsFunction());
         }
-        Local<Value> args[] = { global, key, sandbox };
+        Local<Value> args[] = { global, key, sandbox() };
         clone_property_method->Call(global, ARRAY_SIZE(args), args);
       }
     }
@@ -193,14 +186,13 @@ class ContextifyContext {
   }
 
 
-  Local<Context> CreateV8Context(Environment* env) {
+  Local<Context> CreateV8Context(Environment* env, Local<Object> sandbox_obj) {
     EscapableHandleScope scope(env->isolate());
     Local<FunctionTemplate> function_template =
         FunctionTemplate::New(env->isolate());
     function_template->SetHiddenPrototype(true);
 
-    Local<Object> sandbox = PersistentToLocal(env->isolate(), sandbox_);
-    function_template->SetClassName(sandbox->GetConstructorName());
+    function_template->SetClassName(sandbox_obj->GetConstructorName());
 
     Local<ObjectTemplate> object_template =
         function_template->InstanceTemplate();
@@ -217,6 +209,7 @@ class ContextifyContext {
 
     CHECK(!ctx.IsEmpty());
     ctx->SetSecurityToken(env->context()->GetSecurityToken());
+    ctx->SetEmbedderData(kSandboxObjectIndex, sandbox_obj);
 
     env->AssignToContext(ctx);
 
@@ -312,16 +305,11 @@ class ContextifyContext {
   }
 
 
-  template <class T, Kind kind>
+  template <class T>
   static void WeakCallback(const WeakCallbackData<T, ContextifyContext>& data) {
     ContextifyContext* context = data.GetParameter();
-    if (kind == kSandbox)
-      context->sandbox_.ClearWeak();
-    else
-      context->context_.ClearWeak();
-
-    if (--context->references_ == 0)
-      delete context;
+    context->context_.ClearWeak();
+    delete context;
   }
 
 
@@ -343,8 +331,6 @@ class ContextifyContext {
   static void GlobalPropertyGetterCallback(
       Local<Name> property,
       const PropertyCallbackInfo<Value>& args) {
-    Isolate* isolate = args.GetIsolate();
-
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
 
@@ -352,9 +338,8 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    Local<Object> sandbox = PersistentToLocal(isolate, ctx->sandbox_);
     MaybeLocal<Value> maybe_rv =
-        sandbox->GetRealNamedProperty(ctx->context(), property);
+        ctx->sandbox()->GetRealNamedProperty(ctx->context(), property);
     if (maybe_rv.IsEmpty()) {
       maybe_rv =
           ctx->global_proxy()->GetRealNamedProperty(ctx->context(), property);
@@ -362,7 +347,7 @@ class ContextifyContext {
 
     Local<Value> rv;
     if (maybe_rv.ToLocal(&rv)) {
-      if (rv == ctx->sandbox_)
+      if (rv == ctx->sandbox())
         rv = ctx->global_proxy();
 
       args.GetReturnValue().Set(rv);
@@ -374,8 +359,6 @@ class ContextifyContext {
       Local<Name> property,
       Local<Value> value,
       const PropertyCallbackInfo<Value>& args) {
-    Isolate* isolate = args.GetIsolate();
-
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
 
@@ -383,15 +366,13 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    PersistentToLocal(isolate, ctx->sandbox_)->Set(property, value);
+    ctx->sandbox()->Set(property, value);
   }
 
 
   static void GlobalPropertyQueryCallback(
       Local<Name> property,
       const PropertyCallbackInfo<Integer>& args) {
-    Isolate* isolate = args.GetIsolate();
-
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
 
@@ -399,9 +380,9 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    Local<Object> sandbox = PersistentToLocal(isolate, ctx->sandbox_);
     Maybe<PropertyAttribute> maybe_prop_attr =
-        sandbox->GetRealNamedPropertyAttributes(ctx->context(), property);
+        ctx->sandbox()->GetRealNamedPropertyAttributes(ctx->context(),
+                                                       property);
 
     if (maybe_prop_attr.IsNothing()) {
       maybe_prop_attr =
@@ -419,8 +400,6 @@ class ContextifyContext {
   static void GlobalPropertyDeleterCallback(
       Local<Name> property,
       const PropertyCallbackInfo<Boolean>& args) {
-    Isolate* isolate = args.GetIsolate();
-
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
 
@@ -428,9 +407,7 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    Local<Object> sandbox = PersistentToLocal(isolate, ctx->sandbox_);
-
-    Maybe<bool> success = sandbox->Delete(ctx->context(), property);
+    Maybe<bool> success = ctx->sandbox()->Delete(ctx->context(), property);
 
     if (success.IsJust())
       args.GetReturnValue().Set(success.FromJust());
@@ -446,8 +423,7 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    Local<Object> sandbox = PersistentToLocal(args.GetIsolate(), ctx->sandbox_);
-    args.GetReturnValue().Set(sandbox->GetPropertyNames());
+    args.GetReturnValue().Set(ctx->sandbox()->GetPropertyNames());
   }
 };
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -45,7 +45,7 @@ using v8::Uint8Array;
 using v8::UnboundScript;
 using v8::V8;
 using v8::Value;
-using v8::WeakCallbackData;
+using v8::WeakCallbackInfo;
 
 
 class ContextifyContext {
@@ -66,7 +66,7 @@ class ContextifyContext {
     // Allocation failure or maximum call stack size reached
     if (context_.IsEmpty())
       return;
-    context_.SetWeak(this, WeakCallback<Context>);
+    context_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
     context_.MarkIndependent();
   }
 
@@ -305,10 +305,8 @@ class ContextifyContext {
   }
 
 
-  template <class T>
-  static void WeakCallback(const WeakCallbackData<T, ContextifyContext>& data) {
+  static void WeakCallback(const WeakCallbackInfo<ContextifyContext>& data) {
     ContextifyContext* context = data.GetParameter();
-    context->context_.ClearWeak();
     delete context;
   }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -58,8 +58,7 @@ class ContextifyContext {
   Persistent<Context> context_;
 
  public:
-  explicit ContextifyContext(Environment* env, Local<Object> sandbox_obj)
-      : env_(env) {
+  ContextifyContext(Environment* env, Local<Object> sandbox_obj) : env_(env) {
     Local<Context> v8_context = CreateV8Context(env, sandbox_obj);
     context_.Reset(env->isolate(), v8_context);
 
@@ -122,6 +121,7 @@ class ContextifyContext {
     Local<Context> context = PersistentToLocal(env()->isolate(), context_);
     Local<Object> global =
         context->Global()->GetPrototype()->ToObject(env()->isolate());
+    Local<Object> sandbox_obj = sandbox();
 
     Local<Function> clone_property_method;
 
@@ -129,7 +129,7 @@ class ContextifyContext {
     int length = names->Length();
     for (int i = 0; i < length; i++) {
       Local<String> key = names->Get(i)->ToString(env()->isolate());
-      bool has = sandbox()->HasOwnProperty(context, key).FromJust();
+      bool has = sandbox_obj->HasOwnProperty(context, key).FromJust();
       if (!has) {
         // Could also do this like so:
         //
@@ -161,7 +161,7 @@ class ContextifyContext {
           clone_property_method = Local<Function>::Cast(script->Run());
           CHECK(clone_property_method->IsFunction());
         }
-        Local<Value> args[] = { global, key, sandbox() };
+        Local<Value> args[] = { global, key, sandbox_obj };
         clone_property_method->Call(global, ARRAY_SIZE(args), args);
       }
     }
@@ -336,16 +336,18 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
+    Local<Context> context = ctx->context();
+    Local<Object> sandbox = ctx->sandbox();
     MaybeLocal<Value> maybe_rv =
-        ctx->sandbox()->GetRealNamedProperty(ctx->context(), property);
+        sandbox->GetRealNamedProperty(context, property);
     if (maybe_rv.IsEmpty()) {
       maybe_rv =
-          ctx->global_proxy()->GetRealNamedProperty(ctx->context(), property);
+          ctx->global_proxy()->GetRealNamedProperty(context, property);
     }
 
     Local<Value> rv;
     if (maybe_rv.ToLocal(&rv)) {
-      if (rv == ctx->sandbox())
+      if (rv == sandbox)
         rv = ctx->global_proxy();
 
       args.GetReturnValue().Set(rv);
@@ -378,14 +380,14 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
+    Local<Context> context = ctx->context();
     Maybe<PropertyAttribute> maybe_prop_attr =
-        ctx->sandbox()->GetRealNamedPropertyAttributes(ctx->context(),
-                                                       property);
+        ctx->sandbox()->GetRealNamedPropertyAttributes(context, property);
 
     if (maybe_prop_attr.IsNothing()) {
       maybe_prop_attr =
-          ctx->global_proxy()->GetRealNamedPropertyAttributes(ctx->context(),
-              property);
+          ctx->global_proxy()->GetRealNamedPropertyAttributes(context,
+                                                              property);
     }
 
     if (maybe_prop_attr.IsJust()) {


### PR DESCRIPTION
### Description of change

Follow on from #5204 (which is pending landing once the CI resumes).

This PR cleans up the complexity with how weakness was being used in node_contextify and updates to the new style Phantom weakness API.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done afterwards /
while the PR is open._

### Affected core subsystem(s)

contextify

R=@bnoordhuis, @indutny 
/cc @nodejs/v8

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit
