### PR TITLE
url: fix off-by-one error with parse()

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -413,7 +413,7 @@ function validateHostname(self, rest, hostname) {
     }
     // Invalid host character
     self.hostname = hostname.slice(0, i);
-    if (i < hostname.length - 1)
+    if (i < hostname.length)
       return '/' + hostname.slice(i) + rest;
     break;
   }

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -851,6 +851,21 @@ var parseTests = {
     pathname: '/:npm/npm',
     path: '/:npm/npm',
     href: 'git+ssh://git@github.com/:npm/npm'
+  },
+
+  'https://*': {
+    protocol: 'https:',
+    slashes: true,
+    auth: null,
+    host: '',
+    port: null,
+    hostname: '',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/*',
+    path: '/*',
+    href: 'https:///*'
   }
 
 };


### PR DESCRIPTION
### Description of change

This fixes an off-by-one error with `url.parse()`. Ref #5393.

### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [X] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

* url

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit