### PR TITLE
doc: add in guide generation using remark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,10 @@ apidoc_dirs = out/doc out/doc/api/ out/doc/api/assets
 
 apiassets = $(subst api_assets,api/assets,$(addprefix out/,$(wildcard doc/api_assets/*)))
 
+docguide:
+	mkdir -p out/doc/guides
+	$(NODE) tools/doc/guide.js
+
 doc: $(apidoc_dirs) $(apiassets) $(apidocs) tools/doc/ $(NODE_EXE)
 
 $(apidoc_dirs):

--- a/doc/template-guide.html
+++ b/doc/template-guide.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Node.js __VERSION__ Manual &amp; Guide</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic">
+  <link rel="stylesheet" href="assets/style.css">
+  <link rel="stylesheet" href="assets/sh.css">
+  <link rel="canonical" href="https://nodejs.org/guides/__FILENAME__.html">
+</head>
+<body class="alt apidoc" id="api-section-__FILENAME__">
+  <div id="content" class="clearfix">
+    <div id="column2" class="interior">
+      <div id="intro" class="interior">
+        <a href="/" title="Go back to the home page">
+          Node.js (1)
+        </a>
+      </div>
+      __GTOC__
+    </div>
+
+    <div id="column1" data-id="__ID__" class="interior">
+      <div id="apicontent">
+        __CONTENT__
+      </div>
+    </div>
+  </div>
+  <script src="assets/sh_main.js"></script>
+  <script src="assets/sh_javascript.min.js"></script>
+  <script>highlight(undefined, undefined, 'pre');</script>
+</body>
+</html>

--- a/tools/doc/guide.js
+++ b/tools/doc/guide.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const fs = require('fs');
+
+const remark = require('remark');
+const html = require('remark-html');
+const toc = require('remark-toc');
+const hljs = require('remark-highlight.js');
+
+const processor = remark()
+  .use(toc)
+  .use(html)
+  .use(hljs)
+const remarkOptions = {
+  yaml: true,
+  bullet: '*'
+}
+
+const guidesDir = path.join(__dirname, '../../', 'doc', 'guides');
+const outputDir = path.join(__dirname, '../../', 'out', 'doc', 'guides');
+const templateFile = path.join(__dirname, '../../', 'doc', 'template-guide.html');
+const template = fs.readFileSync(templateFile, { encoding: 'utf8' })
+
+fs.readdir(guidesDir, function(err, files) {
+  if (err) {
+    throw err;
+  }
+  files.forEach(function(fileName) {
+    const pageSlug = path.basename(fileName, '.md');
+    fs.readFile(path.join(guidesDir, fileName), { encoding: 'utf8' }, function(err, content) {
+      var mdast = processor.parse(content, remarkOptions);
+      mdast = processor.run(mdast);
+      const html = processor.stringify(mdast, remarkOptions);
+      // Locate YAML front matter
+      if (mdast.children[0] && mdast.children[0].type === 'yaml') {
+        // Found YAML
+        var yamlData = {}
+        mdast.children[0].value.split('\n').forEach(function(line) {
+          const keyValue = line.match(/(\w+):\s?(.+)/)
+          yamlData[keyValue[1]] = keyValue[2]
+        })
+        // console.log(yamlData)
+      }
+      var output = template.replace(/__VERSION__/g, process.version);
+      output = output.replace(/__CONTENT__/g, html);
+      output = output.replace(/__FILENAME__/g, pageSlug);
+      fs.writeFile(path.join(outputDir, pageSlug + '.html'), output, function(err) {
+        if (err) {
+          throw err;
+        }
+      })
+    })
+  })
+})

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -7,7 +7,11 @@
     "node": ">=0.6.10"
   },
   "dependencies": {
-    "marked": "~0.1.9"
+    "marked": "~0.1.9",
+    "remark": "^3.2.2",
+    "remark-highlight.js": "^3.0.0",
+    "remark-html": "^3.0.0",
+    "remark-toc": "^3.0.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
*Do not merge.*

I did not commit in node_modules. This intends to generate guides, it is related to #4866. This generates HTML from MarkDown and implements highlight.js.

Currently it generates `building-node-with-ninja.md` into corresponding HTML.

To run it:

```sh
cd tools/doc
npm i
cd ../../
make docguide
```

This differs from #4866 by being group processing Markdown guide files.

CC: @nodejs/documentation 

By the way, if I commit in `node_modules`, there are a lot of files going in. Is this an approach we should proceed with?