### PR TITLE
doc: note util.isError() @@toStringTag limitations

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -335,6 +335,22 @@ util.isError({ name: 'Error', message: 'an error occurred' })
   // false
 ```
 
+Note that this method relies on `Object.prototype.toString()` behavior. It is
+possible to obtain an incorrect result when the `object` argument manipulates
+`@@toStringTag`.
+
+```js
+// This example requires the `--harmony-tostring` flag
+const util = require('util');
+const obj = { name: 'Error', message: 'an error occurred' };
+
+util.isError(obj);
+  // false
+obj[Symbol.toStringTag] = 'Error';
+util.isError(obj);
+  // true
+```
+
 ## util.isFunction(object)
 
     Stability: 0 - Deprecated


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

`util.isError()` is the only remaining `util.is*()` method that depends on `Object.prototype.toString()` behavior. This commit notes the limitations of `isError()` related to `@@toStringTag`.

Refs: https://github.com/nodejs/node/pull/2201