### PR TITLE
repl: wrong repl stack trace column number in strict mode

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -230,7 +230,7 @@ function REPLServer(prompt,
             (self.replMode === exports.REPL_MODE_STRICT || retry)) {
           // "void 0" keeps the repl from returning "use strict" as the
           // result value for let/const statements.
-          code = `'use strict'; void 0; ${code}`;
+          code = `'use strict'; void 0;\n${code}`;
         }
         var script = vm.createScript(code, {
           filename: file,
@@ -289,6 +289,10 @@ function REPLServer(prompt,
     debug('domain error');
     const top = replMap.get(self);
     internalUtil.decorateErrorStack(e);
+    if (e.stack && self.replMode === exports.REPL_MODE_STRICT) {
+      e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
+                                (_, pre, line) => pre + (line - 1));
+    }
     top.outputStream.write((e.stack || e) + '\n');
     top.lineParser.reset();
     top.bufferedCommand = '';

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -15,7 +15,7 @@ const prompt_npm = 'npm should be run outside of the ' +
                    'node repl, in your normal shell.\n' +
                    '(Press Control-D to exit.)\n';
 const expect_npm = prompt_npm + prompt_unix;
-var server_tcp, server_unix, client_tcp, client_unix, timer;
+var server_tcp, server_unix, client_tcp, client_unix, timer, replServer;
 
 
 // absolute path to test/fixtures/a.js
@@ -48,9 +48,17 @@ function clean_up() {
   clearTimeout(timer);
 }
 
+function strict_mode_error_test() {
+  send_expect([
+    { client: client_unix, send: 'ref = 1',
+      expect: /^ReferenceError:\sref\sis\snot\sdefined\n\s+at\srepl:1:5/ },
+  ]);
+}
+
 function error_test() {
   // The other stuff is done so reuse unix socket
   var read_buffer = '';
+  var run_strict_test = true;
   client_unix.removeAllListeners('data');
 
   client_unix.on('data', function(data) {
@@ -72,6 +80,10 @@ function error_test() {
       read_buffer = '';
       if (client_unix.list && client_unix.list.length > 0) {
         send_expect(client_unix.list);
+      } else if (run_strict_test) {
+        replServer.replMode = repl.REPL_MODE_STRICT;
+        run_strict_test = false;
+        strict_mode_error_test();
       } else {
         console.error('End of Error test, running TCP test.');
         tcp_test();
@@ -83,6 +95,10 @@ function error_test() {
       read_buffer = '';
       if (client_unix.list && client_unix.list.length > 0) {
         send_expect(client_unix.list);
+      } else if (run_strict_test) {
+        replServer.replMode = repl.REPL_MODE_STRICT;
+        run_strict_test = false;
+        strict_mode_error_test();
       } else {
         console.error('End of Error test, running TCP test.\n');
         tcp_test();
@@ -381,12 +397,13 @@ function unix_test() {
       socket.end();
     });
 
-    repl.start({
+    replServer = repl.start({
       prompt: prompt_unix,
       input: socket,
       output: socket,
       useGlobal: true
-    }).context.message = message;
+    });
+    replServer.context.message = message;
   });
 
   server_unix.on('listening', function() {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

repl

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change
This PR addresses the below problem.

### Problem
On REPL strict mode, `'use strict'; void 0; ` is added as prefix in order to prevent 
`"use strict"` as the result value for `let`/`const` statements. It causes wrong column number in
stack trace.

##### Code for REPL with strict mode
``` js
Desktop 🙈 ₹ cat strict-repl.js
'use strict';
let net = require('net');
let repl = require('repl')

repl.start({
  replMode: repl.REPL_MODE_STRICT
});

net.createServer(function(socket) {
  repl.start("node via TCP socket> ", socket);
}).listen(5001);
```
##### Output
```js
Desktop 🙈 ₹ node strict-repl.js
> x = 1
ReferenceError: x is not defined
    at repl:1:25 // <- column number should be 3
    at REPLServer.defaultEval (repl.js:264:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:427:12)
    at emitOne (events.js:90:13)
    at REPLServer.emit (events.js:182:7)
    at REPLServer.Interface._onLine (readline.js:211:10)
    at REPLServer.Interface._line (readline.js:550:8)
    at REPLServer.Interface._ttyWrite (readline.js:827:14)
>
``` 
##### Behavior
Length of `'use strict'; void 0; ` (22 chars) is added up to column number. :x:

##### Output (after fix)
```js
node 🙈 ₹ git:(upstream ⚡ repl-linenumber) ./node ~/Desktop/strict-repl.js
> x = 1
ReferenceError: x is not defined
    at repl:1:3
    at REPLServer.defaultEval (repl.js:264:27)
    at bound (domain.js:281:14)
    at REPLServer.runBound [as eval] (domain.js:294:12)
    at REPLServer.<anonymous> (repl.js:431:12)
    at emitOne (events.js:91:13)
    at REPLServer.emit (events.js:183:7)
    at REPLServer.Interface._onLine (readline.js:216:10)
    at REPLServer.Interface._line (readline.js:555:8)
    at REPLServer.Interface._ttyWrite (readline.js:832:14)
>
```


