### PR TITLE
http_parser: use `MakeCallback`

### DIFF
--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -17,6 +17,7 @@ namespace node {
   V(FSREQWRAP)                                                                \
   V(GETADDRINFOREQWRAP)                                                       \
   V(GETNAMEINFOREQWRAP)                                                       \
+  V(HTTPPARSER)                                                               \
   V(JSSTREAM)                                                                 \
   V(PIPEWRAP)                                                                 \
   V(PIPECONNECTWRAP)                                                          \

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -11,6 +11,7 @@ const tls = require('tls');
 const zlib = require('zlib');
 const ChildProcess = require('child_process').ChildProcess;
 const StreamWrap = require('_stream_wrap').StreamWrap;
+const HTTPParser = process.binding('http_parser').HTTPParser;
 const async_wrap = process.binding('async_wrap');
 const pkeys = Object.keys(async_wrap.Providers);
 
@@ -105,6 +106,8 @@ function checkTLS() {
 zlib.createGzip();
 
 new ChildProcess();
+
+new HTTPParser(HTTPParser.REQUEST);
 
 process.on('exit', function() {
   if (keyList.length !== 0) {


### PR DESCRIPTION
Make `HTTPParser` an instance of `AsyncWrap` and make it use
`MakeCallback`. This means that async wrap hooks will be called on
consumed TCP sockets as well as on non-consumed ones.

Fix: https://github.com/nodejs/node/issues/4416

This PR overrides https://github.com/nodejs/node/pull/4509.

R= @indutny 
R= @bnoordhuis 