### PR TITLE
tools: add test/addons/0* to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ lib/internal/v8_prof_polyfill.js
 lib/internal/v8_prof_processor.js
 lib/punycode.js
 test/addons/??_*/
+test/addons/0*
 test/fixtures
 test/**/node_modules
 test/disabled


### PR DESCRIPTION
The scripts generated by `make test-addons` do not pass the linter.
For now I think it is best that we ignore it as they are not tracked in the tree.

Fixes #5424