### PR TITLE
doc,tools,test: lint doc-based addon tests

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -318,7 +318,7 @@ Once compiled, the example Addon can be required and used from within Node.js:
 // test.js
 const addon = require('./build/Release/addon');
 
-console.log('This should be eight:', addon.add(3,5));
+console.log('This should be eight:', addon.add(3, 5));
 ```
 
 
@@ -423,7 +423,7 @@ const addon = require('./build/Release/addon');
 
 var obj1 = addon('hello');
 var obj2 = addon('world');
-console.log(obj1.msg+' '+obj2.msg); // 'hello world'
+console.log(obj1.msg + ' ' + obj2.msg); // 'hello world'
 ```
 
 
@@ -638,9 +638,9 @@ Test it with:
 const addon = require('./build/Release/addon');
 
 var obj = new addon.MyObject(10);
-console.log( obj.plusOne() ); // 11
-console.log( obj.plusOne() ); // 12
-console.log( obj.plusOne() ); // 13
+console.log(obj.plusOne()); // 11
+console.log(obj.plusOne()); // 12
+console.log(obj.plusOne()); // 13
 ```
 
 ### Factory of wrapped objects
@@ -824,14 +824,14 @@ Test it with:
 const createObject = require('./build/Release/addon');
 
 var obj = createObject(10);
-console.log( obj.plusOne() ); // 11
-console.log( obj.plusOne() ); // 12
-console.log( obj.plusOne() ); // 13
+console.log(obj.plusOne()); // 11
+console.log(obj.plusOne()); // 12
+console.log(obj.plusOne()); // 13
 
 var obj2 = createObject(20);
-console.log( obj2.plusOne() ); // 21
-console.log( obj2.plusOne() ); // 22
-console.log( obj2.plusOne() ); // 23
+console.log(obj2.plusOne()); // 21
+console.log(obj2.plusOne()); // 22
+console.log(obj2.plusOne()); // 23
 ```
 
 

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -70,6 +70,12 @@ function verifyFiles(files, blockName, onprogress, ondone) {
   );
 
   files = Object.keys(files).map(function(name) {
+    if (name === 'test.js') {
+      files[name] = `'use strict';
+require('../../common');
+${files[name]}
+`;
+    }
     return {
       path: path.resolve(dir, name),
       name: name,


### PR DESCRIPTION
Modify doc-based addon tests (from addon doc examples) so that they pass linting.

Fixes: https://github.com/nodejs/node/issues/5424

This is perhaps an alternative (or follow-on) for https://github.com/nodejs/node/pull/5425.

/cc @TheAlphaNerd 