### PR TITLE
benchmark: add benchmark for buf.compare()

### DIFF
--- a/benchmark/buffers/buffer-compare-instance-method.js
+++ b/benchmark/buffers/buffer-compare-instance-method.js
@@ -1,18 +1,25 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
+const v8 = require('v8');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   size: [16, 512, 1024, 4096, 16386],
   millions: [1]
 });
 
 function main(conf) {
-  var iter = (conf.millions >>> 0) * 1e6;
-  var size = (conf.size >>> 0);
-  var b0 = new Buffer(size).fill('a');
-  var b1 = new Buffer(size).fill('a');
+  const iter = (conf.millions >>> 0) * 1e6;
+  const size = (conf.size >>> 0);
+  const b0 = new Buffer(size).fill('a');
+  const b1 = new Buffer(size).fill('a');
 
   b1[size - 1] = 'b'.charCodeAt(0);
+
+  // Force optimization before starting the benchmark
+  b0.compare(b0, b1);
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(b0.compare)');
+  b0.compare(b0, b1);
 
   bench.start();
   for (var i = 0; i < iter; i++) {

--- a/benchmark/buffers/buffer-compare-instance-method.js
+++ b/benchmark/buffers/buffer-compare-instance-method.js
@@ -1,0 +1,22 @@
+'use strict';
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {
+  size: [16, 512, 1024, 4096, 16386],
+  millions: [1]
+});
+
+function main(conf) {
+  var iter = (conf.millions >>> 0) * 1e6;
+  var size = (conf.size >>> 0);
+  var b0 = new Buffer(size).fill('a');
+  var b1 = new Buffer(size).fill('a');
+
+  b1[size - 1] = 'b'.charCodeAt(0);
+
+  bench.start();
+  for (var i = 0; i < iter; i++) {
+    b0.compare(b1);
+  }
+  bench.end(iter / 1e6);
+}

--- a/benchmark/buffers/buffer-compare-instance-method.js
+++ b/benchmark/buffers/buffer-compare-instance-method.js
@@ -16,10 +16,10 @@ function main(conf) {
   b1[size - 1] = 'b'.charCodeAt(0);
 
   // Force optimization before starting the benchmark
-  b0.compare(b0, b1);
+  b0.compare(b1);
   v8.setFlagsFromString('--allow_natives_syntax');
   eval('%OptimizeFunctionOnNextCall(b0.compare)');
-  b0.compare(b0, b1);
+  b0.compare(b1);
 
   bench.start();
   for (var i = 0; i < iter; i++) {


### PR DESCRIPTION
There is a benchmark for the class method `Buffer.compare()` but not for
the instance method `buf.compare()`. This adds that benchmark.

I used this to confirm a performance regression in an implementation I
was considering. While the implementation was a bust, it does seem like
the benchmark is worthwhile.

The benchmark is nearly identical to the existing `Buffer.compare()`
benchmark except, of course, that it calls `buf.compare()` instead.