### PR TITLE
test: fix test runner arg regression

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -709,7 +709,10 @@ class TestRepository(TestSuite):
       (file, pathname, description) = imp.find_module('testcfg', [ self.path ])
       module = imp.load_module('testcfg', file, pathname, description)
       self.config = module.GetConfiguration(context, self.path)
-      self.config.additional_flags = context.node_args
+      if hasattr(self.config, 'additional_flags'):
+        self.config.additional_flags += context.node_args
+      else:
+        self.config.additional_flags = context.node_args
     finally:
       if file:
         file.close()


### PR DESCRIPTION
### Affected core subsystem(s)

test
### Description of change

In https://github.com/nodejs/node/pull/5376 I introduced the "--node-args" facility to test.py by overwriting the test configuration additional argument list. Instead, I should have simply appended to the list to preserve the existing arguments. This PR fixes the regression introduced and reported in https://github.com/nodejs/node/issues/5442.

After this PR the test runner will append --node-args to the existing argument list (if it is present), instead of simply overwriting it.