### PR TITLE
test: fix flaky tls-inception

### DIFF
--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -32,8 +32,15 @@ a = tls.createServer(options, function(socket) {
   dest.pipe(socket);
   socket.pipe(dest);
 
+  if (common.isWindows) {
+    socket.on('error', function(err) {
+      if (err.code !== 'ECONNRESET')
+        throw err;
+    });
+  }
+
   dest.on('end', function() {
-    socket.destroy();
+    socket.end();
   });
 });
 


### PR DESCRIPTION
PR to address #5386 . 
### Affected core subsystem(s)

test
### Description of change

The test now catches ECONNRESET errors thrown in parallel/test-tls-inception on windows. It also ~~replaces~~ **removes** `socket.destroy()` ~~with `socket.end()`,~~ as `socket.destroy()` also seemed to be causing occasional failures on windows.
