### PR TITLE
path: fix win32 relative() when "to" is a prefix

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -585,7 +585,12 @@ const win32 = {
       if (from.charCodeAt(fromStart) !== 92/*\*/)
         break;
     }
+    // Trim trailing backslashes (applicable to UNC paths only)
     var fromEnd = from.length;
+    for (; fromEnd - 1 > fromStart; --fromEnd) {
+      if (from.charCodeAt(fromEnd - 1) !== 92/*\*/)
+        break;
+    }
     var fromLen = (fromEnd - fromStart);
 
     // Trim any leading backslashes
@@ -594,7 +599,12 @@ const win32 = {
       if (to.charCodeAt(toStart) !== 92/*\*/)
         break;
     }
+    // Trim trailing backslashes (applicable to UNC paths only)
     var toEnd = to.length;
+    for (; toEnd - 1 > toStart; --toEnd) {
+      if (to.charCodeAt(toEnd - 1) !== 92/*\*/)
+        break;
+    }
     var toLen = (toEnd - toStart);
 
     // Compare paths to find the longest common path from root
@@ -662,12 +672,12 @@ const win32 = {
     // Lastly, append the rest of the destination (`to`) path that comes after
     // the common path parts
     if (out.length > 0)
-      return out + toOrig.slice(toStart + lastCommonSep);
+      return out + toOrig.slice(toStart + lastCommonSep, toEnd);
     else {
       toStart += lastCommonSep;
       if (toOrig.charCodeAt(toStart) === 92/*\*/)
         ++toStart;
-      return toOrig.slice(toStart);
+      return toOrig.slice(toStart, toEnd);
     }
   },
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -603,14 +603,28 @@ const win32 = {
     var i = 0;
     for (; i <= length; ++i) {
       if (i === length) {
-        if (lastCommonSep > 2 && // ignore separator match following device root
-            toLen > length &&
-            to.charCodeAt(i) === 92/*\*/) {
-          // We get here if `from` is the exact base path for `to`.
-          // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
-          return toOrig.slice(i + 1);
+        if (toLen > length) {
+          if (to.charCodeAt(toStart + i) === 92/*\*/) {
+            // We get here if `from` is the exact base path for `to`.
+            // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
+            return toOrig.slice(toStart + i + 1);
+          } else if (lastCommonSep === 2) {
+            // We get here if `from` is the device root.
+            // For example: from='C:\\'; to='C:\\foo'
+            return toOrig.slice(toStart + i);
+          }
         }
-        lastCommonSep = i;
+        if (fromLen > length) {
+          if (from.charCodeAt(fromStart + i) === 92/*\*/) {
+            // We get here if `to` is the exact base path for `from`.
+            // For example: from='C:\\foo\\bar'; to='C:\\foo'
+            lastCommonSep = i;
+          } else if (lastCommonSep === 2) {
+            // We get here if `to` is the device root.
+            // For example: from='C:\\foo\\bar'; to='C:\\'
+            lastCommonSep = 3;
+          }
+        }
         break;
       }
       var fromCode = from.charCodeAt(fromStart + i);

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -471,7 +471,12 @@ const relativeTests = [
      ['c:/aaaaa/', 'c:/aaaa/cccc', '..\\aaaa\\cccc'],
      ['C:\\foo\\bar\\baz\\quux', 'C:\\', '..\\..\\..\\..'],
      ['C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json', 'bar\\package.json'],
-     ['C:\\foo\\bar\\baz-quux', 'C:\\foo\\bar\\baz', '..\\baz']
+     ['C:\\foo\\bar\\baz-quux', 'C:\\foo\\bar\\baz', '..\\baz'],
+     ['C:\\foo\\bar\\baz', 'C:\\foo\\bar\\baz-quux', '..\\baz-quux'],
+     ['\\\\foo\\bar', '\\\\foo\\bar\\baz', 'baz'],
+     ['\\\\foo\\bar\\baz', '\\\\foo\\bar', '..'],
+     ['\\\\foo\\bar\\baz-quux', '\\\\foo\\bar\\baz', '..\\baz'],
+     ['\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz-quux', '..\\baz-quux']
     ]
   ],
   [ path.posix.relative,

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -470,7 +470,8 @@ const relativeTests = [
      ['c:/AaAa/bbbb', 'c:/aaaa/bbbb', ''],
      ['c:/aaaaa/', 'c:/aaaa/cccc', '..\\aaaa\\cccc'],
      ['C:\\foo\\bar\\baz\\quux', 'C:\\', '..\\..\\..\\..'],
-     ['C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json', 'bar\\package.json']
+     ['C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json', 'bar\\package.json'],
+     ['C:\\foo\\bar\\baz-quux', 'C:\\foo\\bar\\baz', '..\\baz']
     ]
   ],
   [ path.posix.relative,

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -488,7 +488,9 @@ const relativeTests = [
      ['/var/', '/var/lib', 'lib'],
      ['/', '/var/lib', 'var/lib'],
      ['/foo/test', '/foo/test/bar/package.json', 'bar/package.json'],
-     ['/Users/a/web/b/test/mails', '/Users/a/web/b', '../..']
+     ['/Users/a/web/b/test/mails', '/Users/a/web/b', '../..'],
+     ['/foo/bar/baz-quux', '/foo/bar/baz', '../baz'],
+     ['/foo/bar/baz', '/foo/bar/baz-quux', '../baz-quux']
     ]
   ]
 ];


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
  - [x] `make -j8 test`
  - [x] `vcbuild test nosign`
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] ~~Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?~~

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

- path

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

_Please provide a description of the change here._

when the basename of "to" was a prefix of the basename of "from" win32
relative() would miss including it in the result

Fixes #5447

R=@mscdex