### PR TITLE
test: remove flaky designation from fixed tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-tls-ticket-cluster : PASS,FLAKY
 test-tick-processor     : PASS,FLAKY
 
 [$system==linux]

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -9,7 +9,6 @@ prefix sequential
 [$system==win32]
 
 [$system==linux]
-test-vm-syntax-error-stderr : PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
`test-tls-ticket-cluster` and `test-vm-syntax-error-stderr` are no
longer flaky.

Refs: https://github.com/nodejs/node/issues/2510
Refs: https://github.com/nodejs/node/issues/2660