### PR TITLE
doc: add Testing WG

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -32,6 +32,7 @@ back in to the CTC.
 * [Intl](#intl)
 * [HTTP](#http)
 * [Documentation](#documentation)
+* [Testing](#testing)
 
 #### Process:
 
@@ -286,6 +287,18 @@ Its responsibilities are:
 * Ensuring that Node's documentation addresses a wide variety of audiences.
 * Creating and operating a process for documentation review that produces
   quality documentation and avoids impeding the progress of Core work.
+
+### [Testing](https://github.com/nodejs/testing)
+
+The Node.js Testing Working Group's purpose is to extend and improve testing of
+the Node.js source code.
+
+It's responsibilities are:
+
+* Coordinating an overall strategy for improving testing.
+* Documenting guidelines around tests.
+* Working with the Build Working Group to improve continuous integration.
+* Improving tooling for testing.
 
 ## Starting a WG
 


### PR DESCRIPTION
Add the proposed Testing WG. WORKING_GROUPS.md indicates that opening
a pull request to that file is the way to request that a charter be
ratified by the TC. So, that's what this is.

The charter document is currently:
https://github.com/nodejs/testing/blob/master/Charter.md

If this charter overlaps with the Build WG charter, then the Build WG will also have to ratify it. @nodejs/build 

