### PR TITLE
(vee-eight-4.9) src: update uses of deprecated NewExternal

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -77,7 +77,7 @@ class ExternString: public ResourceType {
       ExternString* h_str = new ExternString<ResourceType, TypeName>(isolate,
                                                                      data,
                                                                      length);
-      MaybeLocal<String> str = String::NewExternal(isolate, h_str);
+      MaybeLocal<String> str = NewExternal(isolate, h_str);
       isolate->AdjustAmountOfExternalAllocatedMemory(h_str->byte_length());
 
       if (str.IsEmpty()) {
@@ -93,6 +93,9 @@ class ExternString: public ResourceType {
   private:
     ExternString(Isolate* isolate, const TypeName* data, size_t length)
       : isolate_(isolate), data_(data), length_(length) { }
+    static MaybeLocal<String> NewExternal(Isolate* isolate,
+                                          ExternString* h_str);
+
     Isolate* isolate_;
     const TypeName* data_;
     size_t length_;
@@ -103,6 +106,20 @@ typedef ExternString<String::ExternalOneByteStringResource,
                      char> ExternOneByteString;
 typedef ExternString<String::ExternalStringResource,
                      uint16_t> ExternTwoByteString;
+
+
+template <>
+MaybeLocal<String> ExternOneByteString::NewExternal(
+    Isolate* isolate, ExternOneByteString* h_str) {
+  return String::NewExternalOneByte(isolate, h_str);
+}
+
+
+template <>
+MaybeLocal<String> ExternTwoByteString::NewExternal(
+    Isolate* isolate, ExternTwoByteString* h_str) {
+  return String::NewExternalTwoByte(isolate, h_str);
+}
 
 
 //// Base 64 ////


### PR DESCRIPTION
### Pull Request check-list


- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

src (string_bytes)

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

V8 String::NewExternal is deprecated in 4.9. Migrate string_bytes.cc to
the alternatives.

R=@bnoordhuis @nodejs/v8 
Ref: #5392, #5204, #4869