### PR TITLE
test: increase timeout for test-tls-fast-writing

### DIFF
--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -23,7 +23,7 @@ var gotDrain = false;
 setTimeout(function() {
   console.log('not ok - timed out');
   process.exit(1);
-}, common.platformTimeout(500));
+}, common.platformTimeout(1000));
 
 function onconnection(conn) {
   conn.on('data', function(c) {


### PR DESCRIPTION
Increase timeout for test from 500ms to 5000ms so busy slow machines
don't produce false positives.

Fixes: https://github.com/nodejs/node/issues/4964