### PR TITLE
build: run lint before tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,9 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH) $(V8_BUILD_OPTIONS)
 
 test: | cctest  # Depends on 'all'.
-	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
 	$(MAKE) jslint
 	$(MAKE) cpplint
+	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
 
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J


### PR DESCRIPTION
Have `make test` run linting tools before tests rather than after. Lint
is likely to find issues quickly. Tests may take a while to run. So do
the linting first.

Interestingly, it appears that `vcbuild.bat` is already set up this way
on Windows.

Refs: https://github.com/nodejs/node/issues/4546#issuecomment-189755007