### PR TITLE
test: apply Linux workaround to Linux only

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -80,18 +80,21 @@ var opensslCli = null;
 var inFreeBSDJail = null;
 var localhostIPv4 = null;
 
-exports.localIPv6Hosts = [
-  // Debian/Ubuntu
-  'ip6-localhost',
-  'ip6-loopback',
+exports.localIPv6Hosts = ['localhost'];
+if (process.platform === 'linux') {
+  exports.localIPv6Hosts = [
+    // Debian/Ubuntu
+    'ip6-localhost',
+    'ip6-loopback',
 
-  // SUSE
-  'ipv6-localhost',
-  'ipv6-loopback',
+    // SUSE
+    'ipv6-localhost',
+    'ipv6-loopback',
 
-  // Typically universal
-  'localhost',
-];
+    // Typically universal
+    'localhost',
+  ];
+}
 
 Object.defineProperty(exports, 'inFreeBSDJail', {
   get: function() {


### PR DESCRIPTION
Do not try Ubuntu/SUSE/Debian-specific hostnames for IPv6 localhost
unless we are on Linux.

Fixes: https://github.com/nodejs/node/issues/4546