### PR TITLE
net: make `isIPv4` and `isIPv6` more efficient

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1571,12 +1571,12 @@ exports.isIP = cares.isIP;
 
 
 exports.isIPv4 = function(input) {
-  return exports.isIP(input) === 4;
+  return cares.isIPv4(input);
 };
 
 
 exports.isIPv6 = function(input) {
-  return exports.isIP(input) === 6;
+  return cares.isIPv6(input);
 };
 
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1087,6 +1087,27 @@ static void IsIP(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(rc);
 }
 
+static void IsIPv4(const FunctionCallbackInfo<Value>& args) {
+  node::Utf8Value ip(args.GetIsolate(), args[0]);
+  char address_buffer[sizeof(struct in_addr)];
+
+  if (uv_inet_pton(AF_INET, *ip, &address_buffer) == 0) {
+    args.GetReturnValue().Set(true);
+  } else {
+    args.GetReturnValue().Set(false);
+  }
+}
+
+static void IsIPv6(const FunctionCallbackInfo<Value>& args) {
+  node::Utf8Value ip(args.GetIsolate(), args[0]);
+  char address_buffer[sizeof(struct in6_addr)];
+
+  if (uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0) {
+    args.GetReturnValue().Set(true);
+  } else {
+    args.GetReturnValue().Set(false);
+  }
+}
 
 static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -1327,6 +1348,8 @@ static void Initialize(Local<Object> target,
   env->SetMethod(target, "getaddrinfo", GetAddrInfo);
   env->SetMethod(target, "getnameinfo", GetNameInfo);
   env->SetMethod(target, "isIP", IsIP);
+  env->SetMethod(target, "isIPv4", IsIPv4);
+  env->SetMethod(target, "isIPv6", IsIPv6);
 
   env->SetMethod(target, "strerror", StrError);
   env->SetMethod(target, "getServers", GetServers);

--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -31,11 +31,40 @@ assert.equal(net.isIP('0000:0000:0000:0000:0000:0000:12345:0000'), 0);
 assert.equal(net.isIP('0'), 0);
 assert.equal(net.isIP(), 0);
 assert.equal(net.isIP(''), 0);
+assert.equal(net.isIP(null), 0);
+assert.equal(net.isIP(123), 0);
+assert.equal(net.isIP(true), 0);
+assert.equal(net.isIP({}), 0);
+assert.equal(net.isIP({ toString: () => '::2001:252:1:255.255.255.255' }), 6);
+assert.equal(net.isIP({ toString: () => '127.0.0.1' }), 4);
+assert.equal(net.isIP({ toString: () => 'bla' }), 0);
 
 assert.equal(net.isIPv4('127.0.0.1'), true);
 assert.equal(net.isIPv4('example.com'), false);
 assert.equal(net.isIPv4('2001:252:0:1::2008:6'), false);
+assert.equal(net.isIPv4(), false);
+assert.equal(net.isIPv4(''), false);
+assert.equal(net.isIPv4(null), false);
+assert.equal(net.isIPv4(123), false);
+assert.equal(net.isIPv4(true), false);
+assert.equal(net.isIPv4({}), false);
+assert.equal(net.isIPv4({
+  toString: () => '::2001:252:1:255.255.255.255'
+}), false);
+assert.equal(net.isIPv4({ toString: () => '127.0.0.1' }), true);
+assert.equal(net.isIPv4({ toString: () => 'bla' }), false);
 
 assert.equal(net.isIPv6('127.0.0.1'), false);
 assert.equal(net.isIPv6('example.com'), false);
 assert.equal(net.isIPv6('2001:252:0:1::2008:6'), true);
+assert.equal(net.isIPv6(), false);
+assert.equal(net.isIPv6(''), false);
+assert.equal(net.isIPv6(null), false);
+assert.equal(net.isIPv6(123), false);
+assert.equal(net.isIPv6(true), false);
+assert.equal(net.isIPv6({}), false);
+assert.equal(net.isIPv6({
+  toString: () => '::2001:252:1:255.255.255.255'
+}), true);
+assert.equal(net.isIPv6({ toString: () => '127.0.0.1' }), false);
+assert.equal(net.isIPv6({ toString: () => 'bla' }), false);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

net

### Description of change

`isIPv4` and `isIPv6` are implemented on top of `isIP`, which in turn
checks the sting for being both IPv4 and IPv6, which can be inefficient
in some scenarios. This commit makes them use `uv_inet_pton` directly
instead.