### PR TITLE
doc: add clarification on birthtime

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -190,10 +190,11 @@ The times in the stat object have the following semantics:
 * `birthtime` "Birth Time" -  Time of file creation. Set once when the
   file is created.  On filesystems where birthtime is not available,
   this field may instead hold either the `ctime` or
-  `1970-01-01T00:00Z` (ie, unix epoch timestamp `0`).  On Darwin and
-  other FreeBSD variants, also set if the `atime` is explicitly set to
-  an earlier value than the current `birthtime` using the `utimes(2)`
-  system call.
+  `1970-01-01T00:00Z` (ie, unix epoch timestamp `0`). Note that this
+  value may be greater than `atime` or `mtime` in this case. On Darwin
+  and other FreeBSD variants, also set if the `atime` is explicitly
+  set to an earlier value than the current `birthtime` using the
+  `utimes(2)` system call.
 
 Prior to Node v0.12, the `ctime` held the `birthtime` on Windows
 systems.  Note that as of v0.12, `ctime` is not "creation time", and


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

N/A

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This PR adds a small clarification to the docs on `fs.Stat` regarding the `birthtime` field.
The issue was raised in #2222.