### PR TITLE
path: fix win32 parse()

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1007,8 +1007,8 @@ const win32 = {
         isAbsolute = true;
 
         code = path.charCodeAt(1);
+        rootEnd = 1;
         if (code === 47/*/*/ || code === 92/*\*/) {
-          rootEnd = 1;
           // Matched double path separator at beginning
           var j = 2;
           var last = j;

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -20,6 +20,10 @@ const winPaths = [
   '\\\\?\\UNC\\server\\share'
 ];
 
+const winSpecialCaseParseTests = [
+  ['/foo/bar', {root: '/'}]
+];
+
 const winSpecialCaseFormatTests = [
   [{dir: 'some\\dir'}, 'some\\dir\\'],
   [{base: 'index.html'}, 'index.html'],
@@ -86,6 +90,7 @@ const errors = [
 
 checkParseFormat(path.win32, winPaths);
 checkParseFormat(path.posix, unixPaths);
+checkSpecialCaseParseFormat(path.win32, winSpecialCaseParseTests);
 checkErrors(path.win32);
 checkErrors(path.posix);
 checkFormat(path.win32, winSpecialCaseFormatTests);
@@ -181,6 +186,17 @@ function checkParseFormat(path, paths) {
     assert.strictEqual(output.dir, output.dir ? path.dirname(element) : '');
     assert.strictEqual(output.base, path.basename(element));
     assert.strictEqual(output.ext, path.extname(element));
+  });
+}
+
+function checkSpecialCaseParseFormat(path, testCases) {
+  testCases.forEach(function(testCase) {
+    const element = testCase[0];
+    const expect = testCase[1];
+    const output = path.parse(element);
+    Object.keys(expect).forEach(function(key) {
+      assert.strictEqual(output[key], expect[key]);
+    });
   });
 }
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?


### Affected core subsystem(s)

path

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

In Node v5.7.0, use `path.win32.parse` to parse '/foo/bar' will returns '' for `root`, but not '/'(v5.6.0).

* https://github.com/koajs/static/issues/77
