### PR TITLE
dgram: default send address to 127.0.0.1 or ::1

### DIFF
--- a/doc/api/dgram.markdown
+++ b/doc/api/dgram.markdown
@@ -209,10 +209,7 @@ If `msg` is an array, `offset` and `length` must not be specified.
 
 The `address` argument is a string. If the value of `address` is a host name,
 DNS will be used to resolve the address of the host. If the `address` is not
-specified or is an empty string, `'0.0.0.0'` or `'::0'` will be used instead.
-It is possible, depending on the network configuration, that these defaults
-may not work; accordingly, it is best to be explicit about the destination
-address.
+specified or is an empty string, `'127.0.0.1'` or `'::1'` will be used instead.
 
 If the socket has not been previously bound with a call to `bind`, the socket
 is assigned a random port number and is bound to the "all interfaces" address

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -29,12 +29,12 @@ function lookup(address, family, callback) {
 
 
 function lookup4(address, callback) {
-  return lookup(address || '0.0.0.0', 4, callback);
+  return lookup(address || '127.0.0.1', 4, callback);
 }
 
 
 function lookup6(address, callback) {
-  return lookup(address || '::0', 6, callback);
+  return lookup(address || '::1', 6, callback);
 }
 
 
@@ -164,6 +164,13 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
   } else {
     address = typeof arguments[1] === 'function' ? '' : arguments[1];
     exclusive = false;
+  }
+
+  // defaulting address for bind to all interfaces
+  if (!address && self._handle.lookup === lookup4) {
+    address = '0.0.0.0';
+  } else if (!address && self._handle.lookup === lookup6) {
+    address = '::';
   }
 
   // resolve address first

--- a/test/parallel/test-dgram-udp6-send-default-host.js
+++ b/test/parallel/test-dgram-udp6-send-default-host.js
@@ -4,7 +4,12 @@ const common = require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
 
-const client = dgram.createSocket('udp4');
+if (!common.hasIPv6) {
+  console.log('1..0 # Skipped: no IPv6 support');
+  return;
+}
+
+const client = dgram.createSocket('udp6');
 
 const toSend = [new Buffer(256), new Buffer(256), new Buffer(256), 'hello'];
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

dgram

### Description of change

In net we default to 'localhost' as the default address for connect.
Not doing the same on dgram is confusing, because sending to 0.0.0.0
works on Linux/OS X but not on Windows. Defaulting that to 127.0.0.1 /
::1 addresses that.

Related: https://github.com/nodejs/node/pull/5407
Related: https://github.com/nodejs/node/issues/5398

Fixes: https://github.com/nodejs/node/issues/5487

cc @mafintosh @rvagg @cjihrig @saghul @feross @silverwind