### PR TITLE
process: expose heapLimit

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -670,7 +670,7 @@ As with `require.main`, it will be `undefined` if there was no entry script.
 ## process.memoryUsage()
 
 Returns an object describing the memory usage of the Node.js process
-measured in bytes.
+measured in *bytes*.
 
 ```js
 const util = require('util');
@@ -683,10 +683,11 @@ This will generate:
 ```js
 { rss: 4935680,
   heapTotal: 1826816,
-  heapUsed: 650472 }
+  heapUsed: 650472,
+  heapLimit: 1535115264 }
 ```
 
-`heapTotal` and `heapUsed` refer to V8's memory usage.
+`heapTotal`, `heapUsed`, and `heapLimit` refer to V8's memory usage.
 
 
 ## process.nextTick(callback[, arg][, ...])

--- a/src/env.h
+++ b/src/env.h
@@ -120,6 +120,7 @@ namespace node {
   V(handle_string, "handle")                                                  \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
+  V(heap_limit_string, "heapLimit")                                           \
   V(hostmaster_string, "hostmaster")                                          \
   V(ignore_string, "ignore")                                                  \
   V(immediate_callback_string, "_immediateCallback")                          \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2119,11 +2119,14 @@ void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
       Number::New(env->isolate(), v8_heap_stats.total_heap_size());
   Local<Number> heap_used =
       Number::New(env->isolate(), v8_heap_stats.used_heap_size());
+  Local<Number> heap_limit =
+      Number::New(env->isolate(), v8_heap_stats.heap_size_limit());
 
   Local<Object> info = Object::New(env->isolate());
   info->Set(env->rss_string(), Number::New(env->isolate(), rss));
   info->Set(env->heap_total_string(), heap_total);
   info->Set(env->heap_used_string(), heap_used);
+  info->Set(env->heap_limit_string(), heap_limit);
 
   args.GetReturnValue().Set(info);
 }

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -1,6 +1,9 @@
 'use strict';
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var r = process.memoryUsage();
-assert.equal(true, r['rss'] > 0);
+const r = process.memoryUsage();
+assert.ok(r.rss > 0);
+assert.ok(r.heapTotal > 0);
+assert.ok(r.heapUsed > 0);
+assert.ok(r.heapLimit > 0);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [X] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?


### Affected core subsystem(s)

process

### Description of change

Since we already expose the other heap information, I don't see a reason not to also provide the current heap limit information.  

This is the change that exposed it on the v8 api: https://github.com/v8/v8/commit/6f72caf92d6d07216108bc06423b78603255cc7d