### PR TITLE
updates crypto.markdown to use good default settings

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -325,11 +325,11 @@ const crypto = require('crypto');
 const assert = require('assert');
 
 // Generate Alice's keys...
-const alice = crypto.createDiffieHellman(11);
+const alice = crypto.createDiffieHellman('modp14');
 const alice_key = alice.generateKeys();
 
 // Generate Bob's keys...
-const bob = crypto.createDiffieHellman(11);
+const bob = crypto.createDiffieHellman('modp14');
 const bob_key = bob.generateKeys();
 
 // Exchange and generate the secret...


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

* Crypto docs

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

_Please provide a description of the change here._

`createDiffieHellman(11)` asks people to create 11 bit keys, which is laughable.  I could crack it by hand. A very smart person could crack it in their heads, in less than five minutes.

We should be advising nodejs users to pass a group by name, like we do with the ECDH example.  `modp14` is suitable strength while maintaining good performance.

[This](http://tools.ietf.org/html/rfc3526#page-3) is the reference for the diffiehellman modp group.