### PR TITLE
Fix timer._repeat() error

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -414,7 +414,7 @@ exports.setInterval = function(callback, repeat) {
   return timer;
 
   function wrapper() {
-    timer._repeat();
+    timer._repeat;
 
     // Timer might be closed - no point in restarting it
     if (!timer._repeat)


### PR DESCRIPTION
In win error occurs when calling setInterval():
```
timers.js:275
    timer._repeat();
          ^

TypeError: timer._repeat is not a function
    at wrapper [as _onTimeout] (timers.js:275:11)
    at Timer.listOnTimeout (timers.js:92:15)
```

Its fix this error