### PR TITLE
doc: crypto docs updated to use good defaults for createDiffieHellman

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -338,7 +338,6 @@ const bob_secret = bob.computeSecret(alice_key);
 
 // OK
 assert.equal(alice_secret.toString('hex'), bob_secret.toString('hex'));
-  
 ```
 
 ### diffieHellman.computeSecret(other_public_key[, input_encoding][, output_encoding])

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -329,7 +329,7 @@ const alice = crypto.createDiffieHellman(2048);
 const alice_key = alice.generateKeys();
 
 // Generate Bob's keys...
-const bob = crypto.createDiffieHellman(alice.getPrime(), 'binary', alice.getGenerator(), 'binary');
+const bob = crypto.createDiffieHellman(alice.getPrime(), alice.getGenerator());
 const bob_key = bob.generateKeys();
 
 // Exchange and generate the secret...

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -325,19 +325,20 @@ const crypto = require('crypto');
 const assert = require('assert');
 
 // Generate Alice's keys...
-const alice = crypto.createDiffieHellman(11);
+const alice = crypto.createDiffieHellman(2048);
 const alice_key = alice.generateKeys();
 
 // Generate Bob's keys...
-const bob = crypto.createDiffieHellman(11);
+const bob = crypto.createDiffieHellman(alice.getPrime(), 'binary', alice.getGenerator(), 'binary');
 const bob_key = bob.generateKeys();
 
 // Exchange and generate the secret...
 const alice_secret = alice.computeSecret(bob_key);
 const bob_secret = bob.computeSecret(alice_key);
 
-assert(alice_secret, bob_secret);
-  // OK
+// OK
+assert.equal(alice_secret.toString('hex'), bob_secret.toString('hex'));
+  
 ```
 
 ### diffieHellman.computeSecret(other_public_key[, input_encoding][, output_encoding])


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

* Crypto API docs for `createDiffieHellman`

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

[Diffie-Hellman](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange#Cryptographic_explanation) keys are composed of a `generator` a `prime` a `secret_key` and the `public_key` resulting from the math operation:

```
(generator ^ secret_key) mod prime = public_key
```

Diffie-Hellman keypairs will compute a matching shared secret if and only if the generator and prime match for both recipients.  The generator is usually **2** and the prime is what is called a [Safe Prime](https://en.wikipedia.org/wiki/Safe_prime).

Usually this matching is accomplished by using [standard published groups](http://tools.ietf.org/html/rfc3526).  We expose access those groups with the `crypto.getDiffieHellman` function.

`createDiffieHellman` is trickier to use.  The original example had the user creating 11 bit keys, and creating random groups of generators and primes.  11 bit keys are very very small, can be cracked by a single person on a single sheet of paper.  A byproduct of using such small keys were that it was a high likelihood that two calls of `createDiffieHellman(11)` would result in using the same 11 bit safe prime.  

The original example code would fail when the safe primes generated at 11 bit lengths did not match for alice and bob.

If you want to use your own generated safe `prime` then the proper use of `createDiffieHellman` is to pass the `prime` and `generator` to the recipient's constructor, so that when they compute the shared secret their `prime` and `generator` match, which is fundamental to the algorithm.