### PR TITLE
tools: enable no-extra-parens in ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@ rules:
   no-empty-character-class: 2
   no-ex-assign: 2
   no-extra-boolean-cast : 2
+  no-extra-parens: [2, "functions"]
   no-extra-semi: 2
   no-func-assign: 2
   no-invalid-regexp: 2

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -640,7 +640,7 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
 }
 
 {
-  const x = new (function() {});
+  const x = new function() {};
   assert.equal(util.inspect(x), '{}');
 }
 


### PR DESCRIPTION
Enable `no-extra-parens`. This rule restricts the use of parentheses to
only where they are necessary. It is set to be restricted to report only
function expressions.