### PR TITLE
Enable linting for benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,8 +578,8 @@ bench-idle:
 	$(NODE) benchmark/idle_clients.js &
 
 jslint:
-	$(NODE) tools/eslint/bin/eslint.js lib src test tools/doc tools/eslint-rules \
-		--rulesdir tools/eslint-rules
+	$(NODE) tools/eslint/bin/eslint.js benchmark lib src test tools/doc \
+	  tools/eslint-rules --rulesdir tools/eslint-rules
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc

--- a/benchmark/arrays/var-int.js
+++ b/benchmark/arrays/var-int.js
@@ -1,7 +1,9 @@
 'use strict';
 var common = require('../common.js');
 var bench = common.createBenchmark(main, {
-  type: 'Array Buffer Int8Array Uint8Array Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array'.split(' '),
+  type: ['Array', 'Buffer', 'Int8Array', 'Uint8Array', 'Int16Array',
+         'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
+         'Float64Array'],
   n: [25]
 });
 

--- a/benchmark/arrays/zero-float.js
+++ b/benchmark/arrays/zero-float.js
@@ -1,7 +1,9 @@
 'use strict';
 var common = require('../common.js');
 var bench = common.createBenchmark(main, {
-  type: 'Array Buffer Int8Array Uint8Array Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array'.split(' '),
+  type: ['Array', 'Buffer', 'Int8Array', 'Uint8Array', 'Int16Array',
+         'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
+         'Float64Array'],
   n: [25]
 });
 

--- a/benchmark/arrays/zero-int.js
+++ b/benchmark/arrays/zero-int.js
@@ -1,7 +1,9 @@
 'use strict';
 var common = require('../common.js');
 var bench = common.createBenchmark(main, {
-  type: 'Array Buffer Int8Array Uint8Array Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array'.split(' '),
+  type: ['Array', 'Buffer', 'Int8Array', 'Uint8Array', 'Int16Array',
+         'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
+         'Float64Array'],
   n: [25]
 });
 

--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -14,7 +14,7 @@ function main(conf) {
   var clazz = conf.type === 'fast' ? Buffer : SlowBuffer;
   bench.start();
   for (var i = 0; i < n * 1024; i++) {
-    b = new clazz(len);
+    new clazz(len);
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -1,6 +1,7 @@
 'use strict';
 var common = require('../common.js');
 var fs = require('fs');
+const path = require('path');
 
 var bench = common.createBenchmark(main, {
   search: ['@', 'SQ', '10x', '--l', 'Alice', 'Gryphon', 'Panther',
@@ -15,7 +16,9 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   var iter = (conf.iter) * 100000;
-  var aliceBuffer = fs.readFileSync(__dirname + '/../fixtures/alice.html');
+  var aliceBuffer = fs.readFileSync(
+    path.resolve(__dirname, '../fixtures/alice.html')
+  );
   var search = conf.search;
   var encoding = conf.encoding;
 

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -77,10 +77,15 @@ function run() {
 
   var out = '';
   var child;
-  if (Array.isArray(benchmarks) && benchmarks.length)
-    child = spawn(node, ['benchmark/common.js'].concat(benchmarks), { env: env });
-  else
+  if (Array.isArray(benchmarks) && benchmarks.length) {
+    child = spawn(
+      node,
+      ['benchmark/common.js'].concat(benchmarks),
+      { env: env }
+    );
+  } else {
     child = spawn('make', [runBench], { env: env });
+  }
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(c) {
     out += c;
@@ -136,8 +141,18 @@ function compare() {
     if (show === 'green' && !g || show === 'red' && !r)
       return;
 
-    var r0 = util.format('%s%s: %d%s', g, nodes[0], n0.toPrecision(5), g ? reset : '');
-    var r1 = util.format('%s%s: %d%s', r, nodes[1], n1.toPrecision(5), r ? reset : '');
+    var r0 = util.format(
+      '%s%s: %d%s',
+      g,
+      nodes[0],
+      n0.toPrecision(5), g ? reset : ''
+    );
+    var r1 = util.format(
+      '%s%s: %d%s',
+      r,
+      nodes[1],
+      n1.toPrecision(5), r ? reset : ''
+    );
     pct = c + pct + '%' + reset;
     var l = util.format('%s: %s %s', bench, r0, r1);
     maxLen = Math.max(l.length + pct.length, maxLen);

--- a/benchmark/domain/domain-fn-args.js
+++ b/benchmark/domain/domain-fn-args.js
@@ -20,9 +20,9 @@ function main(conf) {
   for (var i = 0; i < n; i++) {
     if (myArguments.length >= 2) {
       args = Array.prototype.slice.call(myArguments, 1);
-      ret = fn.apply(this, args);
+      fn.apply(this, args);
     } else {
-      ret = fn.call(this);
+      fn.call(this);
     }
   }
   bdomain.exit();

--- a/benchmark/fs/bench-readdir.js
+++ b/benchmark/fs/bench-readdir.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const fs = require('fs');
+const path = require('path');
 
 const bench = common.createBenchmark(main, {
   n: [1e4],
@@ -15,7 +16,7 @@ function main(conf) {
   (function r(cntr) {
     if (--cntr <= 0)
       return bench.end(n);
-    fs.readdir(__dirname + '/../../lib/', function() {
+    fs.readdir(path.resolve(__dirname, '../../lib/'), function() {
       r(cntr);
     });
   }(n));

--- a/benchmark/fs/bench-readdirSync.js
+++ b/benchmark/fs/bench-readdirSync.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const fs = require('fs');
+const path = require('path');
 
 const bench = common.createBenchmark(main, {
   n: [1e4],
@@ -13,7 +14,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    fs.readdirSync(__dirname + '/../../lib/');
+    fs.readdirSync(path.resolve(__dirname, '../../lib/'));
   }
   bench.end(n);
 }

--- a/benchmark/http_simple_auto.js
+++ b/benchmark/http_simple_auto.js
@@ -111,10 +111,10 @@ server.listen(port, function() {
 });
 
 function dump_mm_stats() {
-  if (typeof gc != 'function') return;
+  if (typeof global.gc != 'function') return;
 
   var before = process.memoryUsage();
-  for (var i = 0; i < 10; ++i) gc();
+  for (var i = 0; i < 10; ++i) global.gc();
   var after = process.memoryUsage();
   setTimeout(print_stats, 250); // give GC time to settle
 

--- a/benchmark/http_simple_cluster.js
+++ b/benchmark/http_simple_cluster.js
@@ -1,10 +1,11 @@
 'use strict';
-var cluster = require('cluster');
-var os = require('os');
+const cluster = require('cluster');
+const os = require('os');
+const path = require('path');
 
 if (cluster.isMaster) {
   console.log('master running on pid %d', process.pid);
   for (var i = 0, n = os.cpus().length; i < n; ++i) cluster.fork();
 } else {
-  require(__dirname + '/http_simple.js');
+  require(path.join(__dirname, 'http_simple.js'));
 }

--- a/benchmark/idle_clients.js
+++ b/benchmark/idle_clients.js
@@ -17,7 +17,6 @@ function connect() {
 
     s.on('close', function() {
       if (gotConnected) connections--;
-      lastClose = new Date();
     });
 
     s.on('error', function() {

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -22,7 +22,7 @@ function main(conf) {
 
   bench.start();
 
-  for (i = 0; i < n; i++){
+  for (i = 0; i < n; i++) {
     // Return all the items to the pool
     for (j = 0; j < poolSize; j++) {
       list.free(used[j]);

--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -20,4 +20,4 @@ global.load = function(filename) {
   global.RegExp = $RegExp;
 };
 
-load('run.js');
+global.load('run.js');

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -18,8 +18,14 @@ function main(conf) {
   var n = +conf.thousands * 1e3;
   for (var i = 0; i <= n; i++) {
     fs.mkdirSync(benchmarkDirectory + i);
-    fs.writeFileSync(benchmarkDirectory + i + '/package.json', '{"main": "index.js"}');
-    fs.writeFileSync(benchmarkDirectory + i + '/index.js', 'module.exports = "";');
+    fs.writeFileSync(
+      benchmarkDirectory + i + '/package.json',
+      '{"main": "index.js"}'
+    );
+    fs.writeFileSync(
+      benchmarkDirectory + i + '/index.js',
+      'module.exports = "";'
+    );
   }
 
   measure(n);

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -45,9 +45,10 @@ function main(conf) {
 
   server = tls.createServer(options, onConnection);
   setTimeout(done, dur * 1000);
+  var conn;
   server.listen(common.PORT, function() {
     var opt = { port: common.PORT, rejectUnauthorized: false };
-    var conn = tls.connect(opt, function() {
+    conn = tls.connect(opt, function() {
       bench.start();
       conn.on('drain', write);
       write();
@@ -68,7 +69,8 @@ function main(conf) {
   function done() {
     var mbits = (received * 8) / (1024 * 1024);
     bench.end(mbits);
-    conn.destroy();
+    if (conn)
+      conn.destroy();
     server.close();
   }
 }

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -259,7 +259,7 @@ goto jslint
 :jslint
 if not defined jslint goto exit
 echo running jslint
-%config%\node tools\eslint\bin\eslint.js lib src test tools\doc tools\eslint-rules --rulesdir tools\eslint-rules
+%config%\node tools\eslint\bin\eslint.js benchmark lib src test tools\doc tools\eslint-rules --rulesdir tools\eslint-rules
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION
Refactor benchmarks to conform with existing lint rules. (In the process, a few broken benchmarks were fixed, e.g. the one for domains.) Enable linting for benchmarks.

/cc @nodejs/benchmarking @mscdex 