### PR TITLE
Removed --quiet from eslint invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,7 +579,7 @@ bench-idle:
 
 jslint:
 	$(NODE) tools/eslint/bin/eslint.js lib src test tools/doc tools/eslint-rules \
-		--rulesdir tools/eslint-rules --quiet
+		--rulesdir tools/eslint-rules 
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -259,7 +259,7 @@ goto jslint
 :jslint
 if not defined jslint goto exit
 echo running jslint
-%config%\node tools\eslint\bin\eslint.js lib src test tools\doc tools\eslint-rules --rulesdir tools\eslint-rules --quiet
+%config%\node tools\eslint\bin\eslint.js lib src test tools\doc tools\eslint-rules --rulesdir tools\eslint-rules
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION
Removed --quiet flag from Makefile and vcbuild. That flag causes eslint to only report lint errors and not lint warnings. This is unnecessary as all rules are configured to report as errors. None of the rules are configured to report as warnings.

[fixes#5520](https://github.com/nodejs/node/issues/5516)