### PR TITLE
test: add a place for reproducing known bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,9 @@ test-internet: all
 test-debugger: all
 	$(PYTHON) tools/test.py debugger
 
+test-known-issues: all
+	$(PYTHON) tools/test.py known_issues --expect-fail
+
 test-npm: $(NODE_EXE)
 	NODE=$(NODE) tools/test-npm.sh
 

--- a/test/known_issues/test-vm-function-redefinition.js
+++ b/test/known_issues/test-vm-function-redefinition.js
@@ -1,0 +1,11 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/issues/548
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+const context = vm.createContext();
+
+vm.runInContext('function test() { return 0; }', context);
+vm.runInContext('function test() { return 1; }', context);
+const result = vm.runInContext('test()', context);
+assert.strictEqual(result, 1);

--- a/test/known_issues/testcfg.py
+++ b/test/known_issues/testcfg.py
@@ -1,0 +1,6 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import testpy
+
+def GetConfiguration(context, root):
+  return testpy.SimpleTestConfiguration(context, root, 'known_issues')

--- a/tools/test.py
+++ b/tools/test.py
@@ -430,7 +430,7 @@ class TestCase(object):
     self.thread_id = 0
 
   def IsNegative(self):
-    return False
+    return self.context.expect_fail
 
   def CompareTime(self, other):
     return cmp(other.duration, self.duration)
@@ -778,13 +778,14 @@ TIMEOUT_SCALEFACTOR = {
 
 class Context(object):
 
-  def __init__(self, workspace, buildspace, verbose, vm, args, timeout,
-               processor, suppress_dialogs, store_unexpected_output):
+  def __init__(self, workspace, buildspace, verbose, vm, args, expect_fail,
+               timeout, processor, suppress_dialogs, store_unexpected_output):
     self.workspace = workspace
     self.buildspace = buildspace
     self.verbose = verbose
     self.vm_root = vm
     self.node_args = args
+    self.expect_fail = expect_fail
     self.timeout = timeout
     self.processor = processor
     self.suppress_dialogs = suppress_dialogs
@@ -1289,6 +1290,8 @@ def BuildOptions():
   result.add_option("--special-command", default=None)
   result.add_option("--node-args", dest="node_args", help="Args to pass through to Node",
       default=[], action="append")
+  result.add_option("--expect-fail", dest="expect_fail",
+      help="Expect test cases to fail", default=False, action="store_true")
   result.add_option("--valgrind", help="Run tests through valgrind",
       default=False, action="store_true")
   result.add_option("--cat", help="Print the source of the tests",
@@ -1480,6 +1483,7 @@ def Main():
                     VERBOSE,
                     shell,
                     options.node_args,
+                    options.expect_fail,
                     options.timeout,
                     processor,
                     options.suppress_dialogs,

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -62,6 +62,7 @@ if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&got
 if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
 if /i "%1"=="test-all"      set test_args=%test_args% sequential parallel message gc internet pummel&set buildnodeweak=1&set jslint=1&goto arg-ok
+if /i "%1"=="test-known-issues" set test_args=%test_args% known_issues --expect-fail&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="msi"           set msi=1&set licensertf=1&set download_arg="--download=all"&set i18n_arg=small-icu&goto arg-ok
 if /i "%1"=="build-release" set build_release=1&goto arg-ok


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

test

### Description of change

This PR is a proof of concept related to https://github.com/nodejs/testing/issues/18. The point is to create a place to track the state of current known bugs, with a single command to verify that they still exist (the issue tracker has proven to be a difficult way to manage this).

There are currently a few hundred open issues, so I only bothered to port one bug reproduction. I also need to add `make test-bugs` to vcbuild for Windows. If this can get in, I'll work to create more reproductions.
