### PR TITLE
doc: update V8 URL

### DIFF
--- a/doc/api/v8.markdown
+++ b/doc/api/v8.markdown
@@ -89,5 +89,5 @@ v8.setFlagsFromString('--trace_gc');
 setTimeout(function() { v8.setFlagsFromString('--notrace_gc'); }, 60e3);
 ```
 
-[V8]: https://code.google.com/p/v8/
+[V8]: https://developers.google.com/v8/
 [here]: https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit
### Affected core subsystem(s)

docs

### Description of change

Update the link to V8 since the current URL is now redirecting to their issue tracker