### PR TITLE
test: remove broken debugger scenarios

### DIFF
--- a/test/debugger/test-debug-break-on-uncaught.js
+++ b/test/debugger/test-debug-break-on-uncaught.js
@@ -7,11 +7,6 @@ var debug = require('_debugger');
 
 addScenario('global.js', null, 2);
 addScenario('timeout.js', null, 2);
-addScenario('domain.js', null, 10);
-
-// Exception is thrown from vm.js via module.js (internal file)
-//   var compiledWrapper = runInThisContext(wrapper, filename, 0, true);
-addScenario('parse-error.js', 'vm.js', null);
 
 run();
 


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?


`test-debug-break-on-uncaught` was hanging on the domain and parse error
scenarios. These tests are not run in CI and may have been broken
for a very long time.
    
Refs: https://github.com/nodejs/node/issues/3156
Refs: https://github.com/nodejs/node/commit/c16963b9

It's not clear to me that the two test scenarios removed here are valid. (/cc @bnoordhuis maybe? See https://github.com/nodejs/node/commit/c16963b9 for original commit creating the test)

If simple removal is valid, then this test can be subsequently moved to `parallel` so it can be run in CI on a regular basis.