### PR TITLE
repl: Assignment of _ allowed with warning

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -86,8 +86,7 @@ The special variable `_` (underscore) contains the result of the last expression
 4
 ```
 
-Explicitly setting `_` will disable this behavior. To re-enable auto-assigning
-`_`, you will need to reset the context. To do this, type `.clear`.
+Explicitly setting `_` will disable this behavior until the context is reset.
 
 The REPL provides access to any variables in the global scope. You can expose
 a variable to the REPL explicitly by assigning it to the `context` object

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -86,6 +86,9 @@ The special variable `_` (underscore) contains the result of the last expression
 4
 ```
 
+Explicitly setting `_` will disable this behavior. To re-enable auto-assigning
+`_`, you will need to reset the context. To do this, type `.clear`.
+
 The REPL provides access to any variables in the global scope. You can expose
 a variable to the REPL explicitly by assigning it to the `context` object
 associated with each `REPLServer`.  For example:

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -205,7 +205,7 @@ function REPLServer(prompt,
   self.useGlobal = !!useGlobal;
   self.ignoreUndefined = !!ignoreUndefined;
   self.replMode = replMode || exports.REPL_MODE_SLOPPY;
-  self.setLast = true;
+  self.underscoreAssigned = false;
   self.last = undefined;
 
   self._inTemplateLiteral = false;
@@ -473,7 +473,9 @@ function REPLServer(prompt,
           // the second argument to this function is there, print it.
           arguments.length === 2 &&
           (!self.ignoreUndefined || ret !== undefined)) {
-        if (self.setLast) self.last = ret;
+        if (!self.underscoreAssigned) {
+          self.last = ret;
+        }
         self.outputStream.write(self.writer(ret) + '\n');
       }
 
@@ -547,22 +549,22 @@ REPLServer.prototype.createContext = function() {
   context.module = module;
   context.require = require;
 
-  const repl = this;
 
+  this.underscoreAssigned = false;
   this.lines = [];
   this.lines.level = [];
 
   // make built-in modules available directly
   // (loaded lazily)
-  exports._builtinLibs.forEach(function(name) {
+  exports._builtinLibs.forEach((name) => {
     Object.defineProperty(context, name, {
-      get: function() {
+      get: () => {
         var lib = require(name);
-        repl.last = context[name] = lib;
+        this.last = context[name] = lib;
         return lib;
       },
       // allow the creation of other globals with this name
-      set: function(val) {
+      set: (val) => {
         delete context[name];
         context[name] = val;
       },
@@ -572,14 +574,14 @@ REPLServer.prototype.createContext = function() {
 
   Object.defineProperty(context, '_', {
     configurable: true,
-    get: function() {
-      return repl.last;
+    get: () => {
+      return this.last;
     },
-    set: function(value) {
-      repl.last = value;
-      if (repl.setLast) {
-        repl.setLast = false;
-        repl.outputStream.write('expression assignment to _ now disabled\n');
+    set: (value) => {
+      this.last = value;
+      if (!this.underscoreAssigned) {
+        this.underscoreAssigned = true;
+        this.outputStream.write('expression assignment to _ now disabled\n');
       }
     }
   });

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -581,7 +581,7 @@ REPLServer.prototype.createContext = function() {
       this.last = value;
       if (!this.underscoreAssigned) {
         this.underscoreAssigned = true;
-        this.outputStream.write('expression assignment to _ now disabled\n');
+        this.outputStream.write('Expression assignment to _ now disabled.\n');
       }
     }
   });

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -205,6 +205,8 @@ function REPLServer(prompt,
   self.useGlobal = !!useGlobal;
   self.ignoreUndefined = !!ignoreUndefined;
   self.replMode = replMode || exports.REPL_MODE_SLOPPY;
+  self.setLast = true;
+  self.last = undefined;
 
   self._inTemplateLiteral = false;
 
@@ -471,7 +473,7 @@ function REPLServer(prompt,
           // the second argument to this function is there, print it.
           arguments.length === 2 &&
           (!self.ignoreUndefined || ret !== undefined)) {
-        self.context._ = ret;
+        if (self.setLast) self.last = ret;
         self.outputStream.write(self.writer(ret) + '\n');
       }
 
@@ -545,6 +547,8 @@ REPLServer.prototype.createContext = function() {
   context.module = module;
   context.require = require;
 
+  const repl = this;
+
   this.lines = [];
   this.lines.level = [];
 
@@ -554,7 +558,7 @@ REPLServer.prototype.createContext = function() {
     Object.defineProperty(context, name, {
       get: function() {
         var lib = require(name);
-        context._ = context[name] = lib;
+        repl.last = context[name] = lib;
         return lib;
       },
       // allow the creation of other globals with this name
@@ -564,6 +568,20 @@ REPLServer.prototype.createContext = function() {
       },
       configurable: true
     });
+  });
+
+  Object.defineProperty(context, '_', {
+    configurable: true,
+    get: function() {
+      return repl.last;
+    },
+    set: function(value) {
+      repl.last = value;
+      if (repl.setLast) {
+        repl.setLast = false;
+        repl.outputStream.write('expression assignment to _ now disabled\n');
+      }
+    }
   });
 
   return context;

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -4,18 +4,37 @@ require('../common');
 const assert = require('assert');
 const repl = require('repl');
 const stream = require('stream');
-const inputStream = new stream.PassThrough();
-const outputStream = new stream.PassThrough();
-let output = '';
 
-outputStream.on('data', (data) => {
-  output += data;
+var tests = [
+  testSloppyMode,
+  testStrictMode,
+  testResetContext
+];
+
+tests.forEach(function(test) {
+  test();
 });
 
-process.on('exit', () => {
-  const lines = output.trim().split('\n');
+function testSloppyMode() {
+  const r = initRepl(repl.REPL_MODE_SLOPPY);
 
-  assert.deepStrictEqual(lines, [
+  // cannot use `let` in sloppy mode
+  r.write(`_;          // initial value undefined
+          var x = 10;  // evaluates to undefined
+          _;           // still undefined
+          y = 10;      // evaluates to 10
+          _;           // 10 from last eval
+          _ = 20;      // explicitly set to 20
+          _;           // 20 from user input
+          _ = 30;      // make sure we can set it twice and no prompt
+          _;           // 30 from user input
+          y = 40;      // make sure eval doesn't change _
+          _;           // remains 30 from user input
+          `);
+
+  assertOutput(r.output, [
+    'undefined',
+    'undefined',
     'undefined',
     '10',
     '10',
@@ -23,27 +42,88 @@ process.on('exit', () => {
     '20',
     '20',
     '30',
-    '20',
+    '30',
     '40',
-    '40',
-    '40'
+    '30'
   ]);
-});
+}
 
-const r = repl.start({
-  prompt: '',
-  input: inputStream,
-  output: outputStream
-});
+function testStrictMode() {
+  const r = initRepl(repl.REPL_MODE_STRICT);
 
-r.write('_;\n');
-r.write('x = 10;\n');
-r.write('_;\n');
-r.write('_ = 20;\n');
-r.write('_;\n');
-r.write('y = 30;\n');
-r.write('_;\n');
-r.write('_ = 40;\n');
-r.write('_;\n');
-r.resetContext();
-r.write('_;\n');
+  r.write(`_;          // initial value undefined
+          var x = 10;  // evaluates to undefined
+          _;           // still undefined
+          let _ = 20;  // use 'let' only in strict mode - evals to undefined
+          _;           // 20 from user input
+          _ = 30;      // make sure we can set it twice and no prompt
+          _;           // 30 from user input
+          var y = 40;  // make sure eval doesn't change _
+          _;           // remains 30 from user input
+          function f() { let _ = 50; } // undefined
+          f();         // undefined
+          _;           // remains 30 from user input
+          `);
+
+  assertOutput(r.output, [
+    'undefined',
+    'undefined',
+    'undefined',
+    'undefined',
+    '20',
+    '30',
+    '30',
+    'undefined',
+    '30',
+    'undefined',
+    'undefined',
+    '30'
+  ]);
+}
+
+function testResetContext() {
+  const r = initRepl(repl.REPL_MODE_SLOPPY);
+
+  r.write(`_ = 10;     // explicitly set to 10
+          _;           // 10 from user input
+          .clear       // Clearing context...
+          _;           // remains 10
+          x = 20;      // but behavior reverts to last eval
+          _;           // expect 20
+          `);
+
+  assertOutput(r.output, [
+    'expression assignment to _ now disabled',
+    '10',
+    '10',
+    'Clearing context...',
+    '10',
+    '20',
+    '20'
+  ]);
+}
+
+function initRepl(mode, useGlobal) {
+  const inputStream = new stream.PassThrough();
+  const outputStream = new stream.PassThrough();
+  outputStream.accum = '';
+
+  outputStream.on('data', (data) => {
+    outputStream.accum += data;
+  });
+
+  return repl.start({
+    input: inputStream,
+    output: outputStream,
+    useColors: false,
+    terminal: false,
+    prompt: '',
+    useGlobal: !!useGlobal,
+    replMode: mode
+  });
+}
+
+function assertOutput(output, expected) {
+  const lines = output.accum.trim().split('\n');
+  assert.deepStrictEqual(lines, expected);
+}

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -5,15 +5,9 @@ const assert = require('assert');
 const repl = require('repl');
 const stream = require('stream');
 
-var tests = [
-  testSloppyMode,
-  testStrictMode,
-  testResetContext
-];
-
-tests.forEach(function(test) {
-  test();
-});
+testSloppyMode();
+testStrictMode();
+testResetContext();
 
 function testSloppyMode() {
   const r = initRepl(repl.REPL_MODE_SLOPPY);

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -33,7 +33,7 @@ function testSloppyMode() {
     'undefined',
     '10',
     '10',
-    'expression assignment to _ now disabled',
+    'Expression assignment to _ now disabled.',
     '20',
     '20',
     '30',
@@ -121,7 +121,7 @@ function testResetContext() {
           `);
 
   assertOutput(r.output, [
-    'expression assignment to _ now disabled',
+    'Expression assignment to _ now disabled.',
     '10',
     '10',
     'Clearing context...',
@@ -131,7 +131,7 @@ function testResetContext() {
   ]);
 }
 
-function initRepl(mode, useGlobal) {
+function initRepl(mode) {
   const inputStream = new stream.PassThrough();
   const outputStream = new stream.PassThrough();
   outputStream.accum = '';
@@ -146,7 +146,6 @@ function initRepl(mode, useGlobal) {
     useColors: false,
     terminal: false,
     prompt: '',
-    useGlobal: !!useGlobal,
     replMode: mode
   });
 }

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -8,6 +8,7 @@ const stream = require('stream');
 testSloppyMode();
 testStrictMode();
 testResetContext();
+testMagicMode();
 
 function testSloppyMode() {
   const r = initRepl(repl.REPL_MODE_SLOPPY);
@@ -71,6 +72,39 @@ function testStrictMode() {
     '30',
     'undefined',
     'undefined',
+    '30'
+  ]);
+}
+
+function testMagicMode() {
+  const r = initRepl(repl.REPL_MODE_MAGIC);
+
+  r.write(`_;          // initial value undefined
+          x = 10;      //
+          _;           // last eval - 10
+          let _ = 20;  // undefined
+          _;           // 20 from user input
+          _ = 30;      // make sure we can set it twice and no prompt
+          _;           // 30 from user input
+          var y = 40;  // make sure eval doesn't change _
+          _;           // remains 30 from user input
+          function f() { let _ = 50; return _; } // undefined
+          f();         // 50
+          _;           // remains 30 from user input
+          `);
+
+  assertOutput(r.output, [
+    'undefined',
+    '10',
+    '10',
+    'undefined',
+    '20',
+    '30',
+    '30',
+    'undefined',
+    '30',
+    'undefined',
+    '50',
     '30'
   ]);
 }

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -1,0 +1,49 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const stream = require('stream');
+const inputStream = new stream.PassThrough();
+const outputStream = new stream.PassThrough();
+let output = '';
+
+outputStream.on('data', (data) => {
+  output += data;
+});
+
+process.on('exit', () => {
+  const lines = output.trim().split('\n');
+
+  assert.deepStrictEqual(lines, [
+    'undefined',
+    '10',
+    '10',
+    'expression assignment to _ now disabled',
+    '20',
+    '20',
+    '30',
+    '20',
+    '40',
+    '40',
+    '40'
+  ]);
+});
+
+const r = repl.start({
+  prompt: '',
+  input: inputStream,
+  output: outputStream
+});
+
+r.write('_;\n');
+r.write('x = 10;\n');
+r.write('_;\n');
+r.write('_ = 20;\n');
+r.write('_;\n');
+r.write('y = 30;\n');
+r.write('_;\n');
+r.write('_ = 40;\n');
+r.write('_;\n');
+r.resetContext();
+r.write('_;\n');


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

If acceptable, I can add a PR for the REPL documentation.

### Affected core subsystem(s)

repl

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This commit addresses https://github.com/nodejs/node/issues/5431 by
changing the way that the repl handles assignment to the global _
variable.

Prior to this commit, node sets the result of the last expression
evaluated in the repl to `_`. This causes problems for users of
underscore, lodash and other packages where it is common to assign
`_` to the package, e.g. `_ = require('lodash');`.

Changes in this commit now result in the following behavior.

- If unassigned on the repl, `_` continues to refer to the last
  evaluated expression.
- If assigned, the default behavior of assigning `_` to the last
  evaluated expression is disabled, and `_` now references whatever
  value was explicitly set. A warning is issued on the repl -
  'expression assignment to _ now disabled'.
- If `_` is assigned multiple times, the warning is only displayed once.
- When `.clear` is executed in the repl, `_` continues to refer to its
  most recent value, whatever that is (this is per existing behavior).
  If `_` had been explicitly set prior to `.clear` it will not change
  again with the evaluation of the next expression.