### PR TITLE
test: prevent flakey test on pi2

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -10,7 +10,6 @@ prefix parallel
 test-tick-processor     : PASS,FLAKY
 
 [$system==linux]
-test-process-getactivehandles : PASS,FLAKY
 test-tick-processor           : PASS,FLAKY
 
 [$system==macos]

--- a/test/parallel/test-process-getactivehandles.js
+++ b/test/parallel/test-process-getactivehandles.js
@@ -10,13 +10,16 @@ var clients_counter = 0;
 
 const server = net.createServer(function listener(c) {
   connections.push(c);
-}).listen(common.PORT, function makeConnections() {
-  for (var i = 0; i < NUM; i++) {
-    net.connect(common.PORT, function connected() {
-      clientConnected(this);
-    });
-  }
-});
+}).listen(common.PORT, makeConnection);
+
+
+function makeConnection() {
+  if (clients_counter >= NUM) return;
+  net.connect(common.PORT, function connected() {
+    clientConnected(this);
+    makeConnection();
+  });
+}
 
 
 function clientConnected(client) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Description of change

Looping rapidly and making new connections causes problems on pi2.
Instead create a new connection when an old connection has already been
made. Running a stress test of 600 times and they all passed.

Fixes: https://github.com/nodejs/node/issues/5302

R= @orangemocha 
R= @Trott 

CI: https://ci.nodejs.org/job/node-test-pull-request/1824/