### PR TITLE
Android support

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -1,18 +1,49 @@
 #!/bin/bash
 
+if [ -z "$2" ]; then
+    ARCH=arm
+else
+    ARCH="$2"
+fi
+
+CC_VER="4.9"
+case $ARCH in
+    arm)
+        DEST_CPU="$ARCH"
+        SUFFIX="$ARCH-linux-androideabi"
+        TOOLCHAIN_NAME="$SUFFIX"
+        ;;
+    x86)
+        DEST_CPU="ia32"
+        SUFFIX="i686-linux-android"
+        TOOLCHAIN_NAME="$ARCH"
+        ;;
+    x86_64)
+        DEST_CPU="ia32"
+        SUFFIX="$ARCH-linux-android"
+        TOOLCHAIN_NAME="$ARCH"
+        ;;
+    *)
+        echo "Unsupported architecture provided: $ARCH"
+        exit 1
+        ;;
+esac
+
 export TOOLCHAIN=$PWD/android-toolchain
 mkdir -p $TOOLCHAIN
 $1/build/tools/make-standalone-toolchain.sh \
-    --toolchain=arm-linux-androideabi-4.9 \
-    --arch=arm \
+    --toolchain=$TOOLCHAIN_NAME-$CC_VER \
+    --arch=$ARCH \
     --install-dir=$TOOLCHAIN \
     --platform=android-21
 export PATH=$TOOLCHAIN/bin:$PATH
-export AR=$TOOLCHAIN/bin/arm-linux-androideabi-ar
-export CC=$TOOLCHAIN/bin/arm-linux-androideabi-gcc
-export CXX=$TOOLCHAIN/bin/arm-linux-androideabi-g++
-export LINK=$TOOLCHAIN/bin/arm-linux-androideabi-g++
+export AR=$TOOLCHAIN/bin/$SUFFIX-ar
+export CC=$TOOLCHAIN/bin/$SUFFIX-gcc
+export CXX=$TOOLCHAIN/bin/$SUFFIX-g++
+export LINK=$TOOLCHAIN/bin/$SUFFIX-g++
 
 ./configure \
-    --dest-cpu=arm \
-    --dest-os=android
+    --dest-cpu=$DEST_CPU \
+    --dest-os=android \
+    --without-snapshot \
+    --openssl-no-asm

--- a/common.gypi
+++ b/common.gypi
@@ -68,6 +68,10 @@
             'cflags': [ '-gxcoff' ],
             'ldflags': [ '-Wl,-bbigtoc' ],
           }],
+          ['OS == "android"', {
+            'cflags': [ '-fPIE' ],
+            'ldflags': [ '-fPIE', '-pie' ]
+          }]
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
@@ -101,6 +105,10 @@
           ['OS!="mac" and OS!="win"', {
             'cflags': [ '-fno-omit-frame-pointer' ],
           }],
+          ['OS == "android"', {
+            'cflags': [ '-fPIE' ],
+            'ldflags': [ '-fPIE', '-pie' ]
+          }]
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {

--- a/tools/create_android_makefiles
+++ b/tools/create_android_makefiles
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run this script ONLY inside an Android build system
+# and after you ran lunch command!
+
+if [ -z "$ANDROID_BUILD_TOP" ]; then
+    echo "Run lunch before running this script!"
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    ARCH="arm"
+else
+    ARCH="$1"
+fi
+
+if [ $ARCH = "x86" ]; then
+    TARGET_ARCH="ia32"
+else
+    TARGET_ARCH="$ARCH"
+fi
+
+cd $(dirname $0)/..
+
+./configure \
+    --without-snapshot \
+    --openssl-no-asm \
+    --dest-cpu=$TARGET_ARCH \
+    --dest-os=android
+
+export GYP_GENERATORS="android"
+export GYP_GENERATOR_FLAGS="limit_to_target_all=true"
+GYP_DEFINES="target_arch=$TARGET_ARCH"
+GYP_DEFINES+=" v8_target_arch=$TARGET_ARCH"
+GYP_DEFINES+=" android_target_arch=$ARCH"
+GYP_DEFINES+=" host_os=linux OS=android"
+export GYP_DEFINES
+
+./deps/npm/node_modules/node-gyp/gyp/gyp \
+    -Icommon.gypi \
+    -Iconfig.gypi \
+    --depth=. \
+    -Dcomponent=static_library \
+    -Dlibrary=static_library \
+    node.gyp
+
+echo -e "LOCAL_PATH := \$(call my-dir)\n\ninclude \$(LOCAL_PATH)/GypAndroid.mk" > Android.mk


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
I have one test failing (test-http-curl-chunk-problem), but this test also fails on a clean master branch, so it's not because of my patches
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

build

### Description of change

The provided patches add support for building node for Android systems (Brillo is also supported). This include building node with both NDK (building node outside of Android build system) and Bionic (building node inside Android build system). 
Building node with Bionic, inside an Android/Brillo build system is useful mostly for vendors who wants to include node in their products.
In order to successfully build node with Bionic, I have another patch inside libuv, but  I will submit that patch directly to libuv.