### PR TITLE
tools: enable no-self-assign ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,12 @@ rules:
   no-fallthrough: 2
   no-octal: 2
   no-redeclare: 2
+  no-self-assign: 2
   no-unused-labels: 2
+
+  # Strict Mode
+  # http://eslint.org/docs/rules/#strict-mode
+  strict: [2, "global"]
 
   # Variables
   # http://eslint.org/docs/rules/#variables
@@ -78,10 +83,6 @@ rules:
   no-new-symbol: 2
   no-this-before-super: 2
   prefer-const: 2
-
-  # Strict Mode
-  # https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
-  strict: [2, "global"]
 
   # Custom rules in tools/eslint-rules
   new-with-error: [2, "Error", "RangeError", "TypeError", "SyntaxError", "ReferenceError"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@ env:
 
 rules:
   # Possible Errors
-  # https://github.com/eslint/eslint/tree/master/docs/rules#possible-errors
+  # http://eslint.org/docs/rules/#possible-errors
   comma-dangle: [2, "only-multiline"]
   no-control-regex: 2
   no-debugger: 2
@@ -28,7 +28,7 @@ rules:
   valid-typeof: 2
 
   # Best Practices
-  # https://github.com/eslint/eslint/tree/master/docs/rules#best-practices
+  # http://eslint.org/docs/rules/#best-practices
   no-fallthrough: 2
   no-octal: 2
   no-redeclare: 2
@@ -53,7 +53,7 @@ rules:
   no-restricted-modules: [2, "sys", "_linklist"]
 
   # Stylistic Issues
-  # https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
+  # http://eslint.org/docs/rules/#stylistic-issues
   comma-spacing: 2
   eol-last: 2
   indent: [2, 2, {SwitchCase: 1}]

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -1,14 +1,14 @@
 'use strict';
-var assert = require('assert');
-var common = require('../common.js');
+const assert = require('assert');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {});
+const bench = common.createBenchmark(main, {});
 
 function main(conf) {
-  for (var s = 'abcd'; s.length < 32 << 20; s += s);
+  const s = 'abcd'.repeat(8 << 20);
   s.match(/./);  // Flatten string.
   assert.equal(s.length % 4, 0);
-  var b = Buffer(s.length / 4 * 3);
+  const b = Buffer(s.length / 4 * 3);
   b.write(s, 0, s.length, 'base64');
   bench.start();
   for (var i = 0; i < 32; i += 1) b.base64Write(s, 0, s.length);


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

Enabled no-self-assign rule in ESLint.

This required one change in a benchmark file. Changed a loop (that is
outside of the benchmark itself, so performance is not critical) from a
for loop that repeats a string to use String.prototype.repeat() instead.

While at it, took the opportunity to const-ify the benchmark file.

Also moved the "Strict" section in the .eslintrc to match where it is in
the ESLint documentation. Updated the link for Strict rules to point to
the ESLint website rather than the GitHub-hosted code.