### PR TITLE
build: correctly detect clang version

### DIFF
--- a/configure
+++ b/configure
@@ -454,8 +454,7 @@ def get_version_helper(cc, regexp):
         '''
     sys.exit()
 
-  match = re.search(regexp,
-                    proc.communicate()[1])
+  match = re.search(regexp, proc.communicate()[1])
 
   if match:
     return match.group(2)
@@ -463,10 +462,12 @@ def get_version_helper(cc, regexp):
     return 0
 
 def get_llvm_version(cc):
-  return get_version_helper(cc, r"(^clang version|based on LLVM) ([3-9]\.[0-9]+)")
+  return get_version_helper(
+      cc, r"(^clang version|based on LLVM) ([3-9]\.[0-9]+)")
 
 def get_xcode_version(cc):
-  return get_version_helper(cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
+  return get_version_helper(
+      cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
 
 def get_gas_version(cc):
   try:

--- a/configure
+++ b/configure
@@ -441,7 +441,7 @@ def try_check_compiler(cc, lang):
 # Commands and regular expressions to obtain its version number are taken from
 # https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/sha/asm/sha512-x86_64.pl#L112-L129
 #
-def get_llvm_version(cc):
+def get_version_helper(cc, regexp):
   try:
     proc = subprocess.Popen(shlex.split(cc) + ['-v'], stdin=subprocess.PIPE,
                             stderr=subprocess.PIPE, stdout=subprocess.PIPE)
@@ -454,7 +454,7 @@ def get_llvm_version(cc):
         '''
     sys.exit()
 
-  match = re.search(r"(^clang version|based on LLVM) ([3-9]\.[0-9]+)",
+  match = re.search(regexp,
                     proc.communicate()[1])
 
   if match:
@@ -462,6 +462,11 @@ def get_llvm_version(cc):
   else:
     return 0
 
+def get_llvm_version(cc):
+  return get_version_helper(cc, r"(^clang version|based on LLVM) ([3-9]\.[0-9]+)")
+
+def get_xcode_version(cc):
+  return get_version_helper(cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
 
 def get_gas_version(cc):
   try:
@@ -516,6 +521,8 @@ def check_compiler(o):
 
   if is_clang:
     o['variables']['llvm_version'] = get_llvm_version(CC)
+    if sys.platform == 'darwin':
+      o['variables']['xcode_version'] = get_xcode_version(CC)
   else:
     o['variables']['gas_version'] = get_gas_version(CC)
 

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -8,6 +8,7 @@
     'gcc_version': 0,
     'openssl_no_asm%': 0,
     'llvm_version%': 0,
+    'xcode_version%': 0,
     'gas_version%': 0,
     'openssl_fips%': 'false',
   },

--- a/deps/openssl/openssl.gypi
+++ b/deps/openssl/openssl.gypi
@@ -1040,7 +1040,7 @@
     #
     'conditions': [
       ['(OS=="win" and MSVS_VERSION>="2012") or '
-       'llvm_version>="3.3" or gas_version>="2.23"', {
+       'llvm_version>="3.3" or xcode_version>="5.0" or gas_version>="2.23"', {
         'openssl_sources_x64_win_masm': [
           '<@(openssl_sources_asm_latest_x64_win_masm)',
           '<@(openssl_sources_common_x64_win_masm)',


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)? **Yes**
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]? **Yes**
- [X] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included? **n/a**
- [X] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)? **n/a**

### Affected core subsystem(s)

build

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

We provide our own build system on top of OpenSSL's, part of which is responsible for detecting support for newer assembly instructions (AVX2, etc). The optimized assembly is located in the deps/openssl/asm folder, whereas the fallback path is in deps/openssl/asm_obsolete.

The configuration script relies on scraping "cc -v" to obtain the LLVM version number on Mac OS X. However, as of Xcode 7 this information is no longer included in the banner, see here for a history of the banners: https://gist.github.com/yamaya/2924292

As a result, on systems with Xcode 7 OpenSSL will be compiled with the obsolete assembly path, regardless of actual hardware capability. I've resolved this issue by separately checking for the Xcode version. Note that there doesn't seem to be a way of obtaining the LLVM version, other than manually encoding it in a table such as this https://en.wikipedia.org/wiki/Xcode#Version_comparison_table. Storing this information is not reasonable for the config script, so verifying the Xcode version is a better way.

Note that both the get_llvm_version and get_xcode_version functions rely on minimum versions to return a match. Please see here for more details: https://github.com/nodejs/node/issues/5550#issuecomment-191968283

I've tested this change on Ubuntu 14.04 and Mac OS 10.11.3.