### PR TITLE
events: fix unwrapping of ee.once() listeners

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -396,9 +396,9 @@ EventEmitter.prototype.listeners = function listeners(type) {
     if (!evlistener)
       ret = [];
     else if (typeof evlistener === 'function')
-      ret = [evlistener];
+      ret = [unwrapListener(evlistener)];
     else
-      ret = arrayClone(evlistener, evlistener.length);
+      ret = arrayMap(evlistener, unwrapListener);
   }
 
   return ret;
@@ -450,6 +450,14 @@ function arrayClone(arr, i) {
   while (i--)
     copy[i] = arr[i];
   return copy;
+}
+
+function arrayMap(arr, fn) {
+  var ret = new Array(arr.length);
+  for (var i = 0; i < ret.length; ++i) {
+    ret[i] = fn(arr[i]);
+  }
+  return ret;
 }
 
 function unwrapListener(listener) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -300,7 +300,8 @@ EventEmitter.prototype.removeListener =
         else {
           delete events[type];
           if (events.removeListener)
-            this.emit('removeListener', type, listener);
+            this.emit('removeListener', type,
+                      listener.listener ? listener.listener : listener);
         }
       } else if (typeof list !== 'function') {
         position = -1;
@@ -329,7 +330,8 @@ EventEmitter.prototype.removeListener =
         }
 
         if (events.removeListener)
-          this.emit('removeListener', type, listener);
+          this.emit('removeListener', type,
+                    listener.listener ? listener.listener : listener);
       }
 
       return this;

--- a/lib/events.js
+++ b/lib/events.js
@@ -217,8 +217,7 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
     if (events.newListener) {
-      this.emit('newListener', type,
-                listener.listener ? listener.listener : listener);
+      this.emit('newListener', type, unwrapListener(listener));
 
       // Re-assign `events` because a newListener handler could have caused the
       // this._events to be assigned to a new object
@@ -294,21 +293,20 @@ EventEmitter.prototype.removeListener =
       if (!list)
         return this;
 
-      if (list === listener || (list.listener && list.listener === listener)) {
+      if (list === listener || unwrapListener(list) === listener) {
         if (--this._eventsCount === 0)
           this._events = {};
         else {
           delete events[type];
           if (events.removeListener)
-            this.emit('removeListener', type,
-                      listener.listener ? listener.listener : listener);
+            this.emit('removeListener', type, unwrapListener(listener));
         }
       } else if (typeof list !== 'function') {
         position = -1;
 
         for (i = list.length; i-- > 0;) {
           if (list[i] === listener ||
-              (list[i].listener && list[i].listener === listener)) {
+              unwrapListener(list[i]) === listener) {
             position = i;
             break;
           }
@@ -330,8 +328,7 @@ EventEmitter.prototype.removeListener =
         }
 
         if (events.removeListener)
-          this.emit('removeListener', type,
-                    listener.listener ? listener.listener : listener);
+          this.emit('removeListener', type, unwrapListener(listener));
       }
 
       return this;
@@ -453,4 +450,8 @@ function arrayClone(arr, i) {
   while (i--)
     copy[i] = arr[i];
   return copy;
+}
+
+function unwrapListener(listener) {
+  return listener.listener ? listener.listener : listener;
 }

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -30,3 +30,12 @@ var e3ListenersCopy = e3.listeners('foo');
 e3.on('foo', listener2);
 assert.deepEqual(e3.listeners('foo'), [listener, listener2]);
 assert.deepEqual(e3ListenersCopy, [listener]);
+
+var e4 = new events.EventEmitter();
+e4.once('foo', listener);
+assert.deepEqual(e4.listeners('foo'), [listener]);
+
+var e5 = new events.EventEmitter();
+e5.on('foo', listener);
+e5.once('foo', listener2);
+assert.deepEqual(e5.listeners('foo'), [listener, listener2]);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -102,3 +102,19 @@ e6.emit('hello');
 
 // Interal listener array [listener3]
 e6.emit('hello');
+
+const e7 = new events.EventEmitter();
+e7.on('hello', listener1);
+e7.once('hello', listener2);
+e7.once('removeListener', common.mustCall(function(name, cb) {
+  assert.equal(name, 'hello');
+  assert.equal(cb, listener2);
+  assert.deepEqual([listener1], e7.listeners('hello'));
+  e7.once('removeListener', common.mustCall(function(name, cb) {
+    assert.equal(name, 'hello');
+    assert.equal(cb, listener1);
+    assert.deepEqual([], e7.listeners('hello'));
+  }));
+  e7.removeListener('hello', listener1);
+}));
+e7.emit('hello');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

* events

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

The wrapped listeners from `once()` weren't handled consistently. This PR fixes up the two additional places that they are exposed publicly (`'removeListener'` and `listeners()`). There is a slowdown in doing so, but not too bad.

Unsure if a documentation update would be necessary (to say "it used to behave like so").

**make bench-events:**
```
make -C out BUILDTYPE=Release V=1 
make[1]: Entering directory '/home/omsmith/dev/node/out'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/omsmith/dev/node/out'
ln -fs out/Release/node node
events/ee-add-remove.js
events/ee-add-remove.js n=250000: 1603452.07582

events/ee-emit-multi-args.js
events/ee-emit-multi-args.js n=2000000: 8104495.63870

events/ee-emit.js
events/ee-emit.js n=2000000: 11585336.72431

events/ee-listener-count-on-prototype.js
events/ee-listener-count-on-prototype.js n=50000000: 627837401.26347

events/ee-listeners-many.js
events/ee-listeners-many.js n=5000000: 4315208.71881

events/ee-listeners.js
events/ee-listeners.js n=5000000: 26674496.30709
```

(master):
```
make -C out BUILDTYPE=Release V=1
make[1]: Entering directory '/home/omsmith/dev/node/out'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/omsmith/dev/node/out'
ln -fs out/Release/node node
events/ee-add-remove.js
events/ee-add-remove.js n=250000: 1721243.70130

events/ee-emit-multi-args.js
events/ee-emit-multi-args.js n=2000000: 8197063.10213

events/ee-emit.js
events/ee-emit.js n=2000000: 11848856.46094

events/ee-listener-count-on-prototype.js
events/ee-listener-count-on-prototype.js n=50000000: 617810355.54937

events/ee-listeners-many.js
events/ee-listeners-many.js n=5000000: 4734838.53093

events/ee-listeners.js
events/ee-listeners.js n=5000000: 28938418.31657
```
