### PR TITLE
src,http: fix uncaughtException miss in http

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -220,7 +220,10 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (ret.IsEmpty()) {
-    return Undefined(env()->isolate());
+    if (callback_scope.in_makecallback())
+      return ret;
+    else
+      return Undefined(env()->isolate());
   }
 
   if (has_domain) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1185,7 +1185,10 @@ Local<Value> MakeCallback(Environment* env,
   }
 
   if (ret.IsEmpty()) {
-    return Undefined(env->isolate());
+    if (callback_scope.in_makecallback())
+      return ret;
+    else
+      return Undefined(env->isolate());
   }
 
   if (has_domain) {

--- a/test/parallel/test-http-catch-uncaughtexception.js
+++ b/test/parallel/test-http-catch-uncaughtexception.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const uncaughtCallback = common.mustCall(function(er) {
+  assert.equal(er.message, 'get did fail');
+});
+
+process.on('uncaughtException', uncaughtCallback);
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('bye');
+}).listen(common.PORT, function() {
+  http.get({ port: common.PORT }, function(res) {
+    res.resume();
+    throw new Error('get did fail');
+  }).on('close', function() {
+    server.close();
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?


#### Description
    
    If the call to MakeCallback is currently in_makecallback() then return
    the empty handle instead of Undefined. This allows the error to
    propagate through multiple MakeCallback calls.

R=@misterdjules 
R=@indutny 
R=@TheAlphaNerd 