### PR TITLE
async_wrap: WIP/Experiment, init/destroy HTTPParser on each use

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -16,9 +16,27 @@ namespace node {
 inline AsyncWrap::AsyncWrap(Environment* env,
                             v8::Local<v8::Object> object,
                             ProviderType provider,
-                            AsyncWrap* parent)
-    : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1),
+                            AsyncWrap* parent,
+                            bool manageLifecycleEvents)
+    : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 2),
       uid_(env->get_async_wrap_uid()) {
+  if (manageLifecycleEvents) {
+    bits_ |= 2; // managed_lifecycle() is now true
+    InitAsyncWrap(env, object, provider, parent);
+  }
+}
+
+
+inline AsyncWrap::~AsyncWrap() {
+  if (managed_lifecycle()) {
+    DestroyAsyncWrap();
+  }
+}
+
+inline void AsyncWrap::InitAsyncWrap(Environment* env,
+                                    v8::Local<v8::Object> object,
+                                    ProviderType provider,
+                                    AsyncWrap* parent) {
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 
@@ -61,7 +79,7 @@ inline AsyncWrap::AsyncWrap(Environment* env,
 }
 
 
-inline AsyncWrap::~AsyncWrap() {
+inline void AsyncWrap::DestroyAsyncWrap() {
   if (!ran_init_callback())
     return;
 
@@ -77,13 +95,18 @@ inline AsyncWrap::~AsyncWrap() {
 }
 
 
+inline bool AsyncWrap::managed_lifecycle() const {
+  return static_cast<bool>(bits_ & 2);
+}
+
+
 inline bool AsyncWrap::ran_init_callback() const {
   return static_cast<bool>(bits_ & 1);
 }
 
 
 inline AsyncWrap::ProviderType AsyncWrap::provider_type() const {
-  return static_cast<ProviderType>(bits_ >> 1);
+  return static_cast<ProviderType>(bits_ >> 2);
 }
 
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -50,13 +50,20 @@ class AsyncWrap : public BaseObject {
   inline AsyncWrap(Environment* env,
                    v8::Local<v8::Object> object,
                    ProviderType provider,
-                   AsyncWrap* parent = nullptr);
+                   AsyncWrap* parent = nullptr,
+                   bool manageLifecycleEvents = true);
 
   inline virtual ~AsyncWrap();
 
   inline ProviderType provider_type() const;
 
   inline int64_t get_uid() const;
+
+  inline void InitAsyncWrap(Environment* env,
+                            v8::Local<v8::Object> object,
+                            ProviderType provider,
+                            AsyncWrap* parent = nullptr);
+  inline void DestroyAsyncWrap();
 
   // Only call these within a valid HandleScope.
   v8::Local<v8::Value> MakeCallback(const v8::Local<v8::Function> cb,
@@ -73,6 +80,7 @@ class AsyncWrap : public BaseObject {
 
  private:
   inline AsyncWrap();
+  inline bool managed_lifecycle() const;
   inline bool ran_init_callback() const;
 
   // When the async hooks init JS function is called from the constructor it is

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -150,7 +150,7 @@ struct StringPtr {
 class Parser : public AsyncWrap {
  public:
   Parser(Environment* env, Local<Object> wrap, enum http_parser_type type)
-      : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTPPARSER),
+      : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTPPARSER, nullptr, false),
         current_buffer_len_(0),
         current_buffer_data_(nullptr) {
     Wrap(object(), this);
@@ -457,6 +457,7 @@ class Parser : public AsyncWrap {
     // Should always be called from the same context.
     CHECK_EQ(env, parser->env());
     parser->Init(type);
+    parser->InitAsyncWrap(env, args.This(), AsyncWrap::PROVIDER_HTTPPARSER);
   }
 
 
@@ -488,6 +489,7 @@ class Parser : public AsyncWrap {
 
   static void Unconsume(const FunctionCallbackInfo<Value>& args) {
     Parser* parser = Unwrap<Parser>(args.Holder());
+    parser->DestroyAsyncWrap();
 
     // Already unconsumed
     if (parser->prev_alloc_cb_.is_empty())


### PR DESCRIPTION
Wasn't sure the best place to have this discussion, so I went with opening a PR and figure it can be closed.

Been working with `AsyncWrap` a bit and it was very cool to see a7e49c886f5cb8c351673f413dc66086ff1d75bc land the other day :). Was playing with the following, which I know is probably horrible, of firing the `init` and `destroy` hooks per usage of the `HTTPParser`, giving a clear parent/child relationship per-request, while still being able to reuse the actually instances.

Just wanted to get thoughts on the concept, @trevnorris 
