### PR TITLE
tools: reduce verbosity of cpplint

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -3025,9 +3025,6 @@ def ProcessFile(filename, vlevel):
             'One or more unexpected \\r (^M) found;'
             'better to use only a \\n')
 
-  if not _cpplint_state.output_format == 'tap':
-    sys.stderr.write('Done processing %s\n' % filename)
-
 
 def PrintUsage(message):
   """Prints a brief usage string and exits, optionally with an error message.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)
tools

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Every time `make test` is run, the cpplint prints the file it
successfully linted. None of the other linters in the project does
that. This patch simply removes the "Done processing" message from the
cpplint.