### PR TITLE
repl: support standalone blocks

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -220,7 +220,7 @@ function REPLServer(prompt,
   eval_ = eval_ || defaultEval;
 
   function defaultEval(code, context, file, cb) {
-    var err, result, retry = false;
+    var err, result, retry = false, input = code, wrappedErr;
     // first, create the Script object to check the syntax
     while (true) {
       try {
@@ -238,14 +238,23 @@ function REPLServer(prompt,
         debug('parse error %j', code, e);
         if (self.replMode === exports.REPL_MODE_MAGIC &&
             e.message === BLOCK_SCOPED_ERROR &&
-            !retry) {
-          retry = true;
+            !retry || self.wrappedCmd) {
+          if (self.wrappedCmd) {
+            self.wrappedCmd = false;
+            // unwrap and try again
+            code = `${input.substring(1, input.length - 2)}\n`;
+            wrappedErr = e;
+          } else {
+            retry = true;
+          }
           continue;
         }
-        if (isRecoverableError(e, self))
-          err = new Recoverable(e);
+        // preserve original error for wrapped command
+        const error = wrappedErr || e;
+        if (isRecoverableError(error, self))
+          err = new Recoverable(error);
         else
-          err = e;
+          err = error;
       }
       break;
     }
@@ -418,6 +427,7 @@ function REPLServer(prompt,
         // to wrap it in parentheses, so that it will be interpreted as
         // an expression.
         evalCmd = '(' + evalCmd + ')\n';
+        self.wrappedCmd = true;
       } else {
         // otherwise we just append a \n so that it will be either
         // terminated, or continued onto the next expression if it's an
@@ -435,6 +445,7 @@ function REPLServer(prompt,
       debug('finish', e, ret);
       self.memory(cmd);
 
+      self.wrappedCmd = false;
       if (e && !self.bufferedCommand && cmd.trim().match(/^npm /)) {
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -323,6 +323,8 @@ function error_test() {
     { client: client_unix, send: 'function x(s) {\nreturn s.replace(/.*/,"");\n}',
       expect: prompt_multiline + prompt_multiline +
             'undefined\n' + prompt_unix },
+    { client: client_unix, send: '{ var x = 4; }',
+      expect: 'undefined\n' + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)
repl
[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change
Enable support for standalone block statements.
Fixes #5576.

```js
node 🙈 ₹ git:(upstream ⚡ bare-block) ./node
> { var x = 3; console.log(x); }
3
undefined
> {}
{}
> { x:1, y:"why not", z: function() {} }
{ x: 1, y: 'why not', z: [Function] }
>
```
For the [ambiguous](https://github.com/nodejs/node/issues/5576#issuecomment-192869900) inputs like `{ x }`, the existing REPL behaviour (ES6 literal shorthand) is preserved (prefers expression over statement).


