### PR TITLE
path: fix normalize for absolutes

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -44,7 +44,7 @@ function normalizeStringWin32(path, allowAboveRoot) {
               dots = 0;
               continue;
             }
-          } else if (res.length === 2) {
+          } else if (res.length === 2 || res.length === 1) {
             res = '';
             lastSlash = i;
             dots = 0;
@@ -110,7 +110,7 @@ function normalizeStringPosix(path, allowAboveRoot) {
               dots = 0;
               continue;
             }
-          } else if (res.length === 2) {
+          } else if (res.length === 2 || res.length === 1) {
             res = '';
             lastSlash = i;
             dots = 0;

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -377,6 +377,7 @@ assert.equal(path.win32.normalize('a//b//./c'), 'a\\b\\c');
 assert.equal(path.win32.normalize('a//b//.'), 'a\\b');
 assert.equal(path.win32.normalize('//server/share/dir/file.ext'),
              '\\\\server\\share\\dir\\file.ext');
+assert.equal(path.win32.normalize('/a/b/c/../../../x/y/z'), '\\x\\y\\z');
 
 assert.equal(path.posix.normalize('./fixtures///b/../b/c.js'),
              'fixtures/b/c.js');
@@ -384,6 +385,8 @@ assert.equal(path.posix.normalize('/foo/../../../bar'), '/bar');
 assert.equal(path.posix.normalize('a//b//../b'), 'a/b');
 assert.equal(path.posix.normalize('a//b//./c'), 'a/b/c');
 assert.equal(path.posix.normalize('a//b//.'), 'a/b');
+assert.equal(path.posix.normalize('/a/b/c/../../../x/y/z'), '/x/y/z');
+assert.equal(path.posix.normalize('///..//./foo/.//bar'), '/foo/bar');
 
 
 // path.resolve tests


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

`path`

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Fixes a regression introduced by
b212be08f62a48656c5befd8be0a82d691ea66e4.

`path.normalize(''/a/b/c/../../../x/y/z'')` should return `'/x/y/z'`.

Ref: https://github.com/nodejs/node/issues/5585