### PR TITLE
fs: improve error message for invalid flag

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -536,8 +536,8 @@ fs.readFileSync = function(path, options) {
 
 // Used by binding.open and friends
 function stringToFlags(flag) {
-  // Only mess with strings
-  if (typeof flag !== 'string') {
+  // Return early if it's a number
+  if (typeof flag === 'number') {
     return flag;
   }
 

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -34,3 +34,18 @@ assert.equal(fs._stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
   .forEach(function(flags) {
     assert.throws(function() { fs._stringToFlags(flags); });
   });
+
+assert.throws(
+  () => fs._stringToFlags({}),
+  /Unknown file open flag: \[object Object\]/
+);
+
+assert.throws(
+  () => fs._stringToFlags(true),
+  /Unknown file open flag: true/
+);
+
+assert.throws(
+  () => fs._stringToFlags(null),
+  /Unknown file open flag: null/
+);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

fs

### Description of change

Flags on fs.open and others can be passed as strings or int.
Previously, if passing anything other than string or int,
the error message would only say that flags must be an int.