### PR TITLE
net: Supply host argument in the Socket lookup event callback.

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -317,6 +317,7 @@ Not applicable to UNIX sockets.
 * `err` {Error|Null} The error object.  See [`dns.lookup()`][].
 * `address` {String} The IP address.
 * `family` {String|Null} The address type.  See [`dns.lookup()`][].
+* `host` {String} The hostname.
 
 ### Event: 'timeout'
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -961,7 +961,7 @@ function lookupAndConnect(self, options) {
   self._host = host;
   var lookup = options.lookup || dns.lookup;
   lookup(host, dnsopts, function(err, ip, addressType) {
-    self.emit('lookup', err, ip, addressType);
+    self.emit('lookup', err, ip, addressType, host);
 
     // It's possible we were destroyed while looking this up.
     // XXX it would be great if we could cancel the promise returned by

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -10,12 +10,14 @@ var server = net.createServer(function(client) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  net.connect(common.PORT, 'localhost').on('lookup', function(err, ip, type) {
-    assert.equal(err, null);
-    assert.equal(ip, '127.0.0.1');
-    assert.equal(type, '4');
-    ok = true;
-  });
+  net.connect(common.PORT, 'localhost')
+    .on('lookup', function(err, ip, type, host) {
+      assert.equal(err, null);
+      assert.equal(ip, '127.0.0.1');
+      assert.equal(type, '4');
+      assert.equal(host, 'localhost');
+      ok = true;
+    });
 });
 
 process.on('exit', function() {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

net 

### Description of change

Supply host argument in Socket lookup event callback

Also removes _host field in Socket.