### PR TITLE
Bugfix cpplint windows path

### DIFF
--- a/test/parallel/test-cpplint-windows-fullname-path.js
+++ b/test/parallel/test-cpplint-windows-fullname-path.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+var child;
+const EXPECTATION = 'tools/cpplint.py';
+
+
+try {
+  process.chdir('./tools');
+} catch (err) {
+  throw err;
+}
+
+child = spawn(
+  'python', [
+    '-c',
+    'import cpplint as c; print(c.FileInfo("cpplint.py").RepositoryName())'
+  ]
+);
+
+var response = '';
+
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', function(chunk) {
+  response += chunk;
+});
+
+child.on('close', function() {
+  assert.equal(response.replace(/\n/,'').replace(/\r/, ''), EXPECTATION);
+  process.chdir('../');
+});

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -1073,8 +1073,9 @@ class FileInfo(object):
     locations won't see bogus errors.
     """
     fullname = self.FullName()
-    # XXX(bnoordhuis) Expects that cpplint.py lives in the tools/ directory.
-    toplevel = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    toplevel = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..')
+    ).replace('\\', '/')
     prefix = os.path.commonprefix([fullname, toplevel])
     return fullname[len(prefix) + 1:]
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit)?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
### Description of change

Ref: #4635 

Fix toplevel operation in FileInfo class located in `tools/cpplint.py` where developement is taking place within a windows environment. This also addresses @bnoordhuis comment `# XXX(bnoordhis) Expects that cpplint.py lives in tools directory.`
