### PR TITLE
deps: Added methods to http parser

### DIFF
--- a/deps/http_parser/http_parser.h
+++ b/deps/http_parser/http_parser.h
@@ -86,47 +86,56 @@ typedef int (*http_cb) (http_parser*);
 
 
 /* Request Methods */
-#define HTTP_METHOD_MAP(XX)         \
-  XX(0,  DELETE,      DELETE)       \
-  XX(1,  GET,         GET)          \
-  XX(2,  HEAD,        HEAD)         \
-  XX(3,  POST,        POST)         \
-  XX(4,  PUT,         PUT)          \
-  /* pathological */                \
-  XX(5,  CONNECT,     CONNECT)      \
-  XX(6,  OPTIONS,     OPTIONS)      \
-  XX(7,  TRACE,       TRACE)        \
-  /* WebDAV */                      \
-  XX(8,  COPY,        COPY)         \
-  XX(9,  LOCK,        LOCK)         \
-  XX(10, MKCOL,       MKCOL)        \
-  XX(11, MOVE,        MOVE)         \
-  XX(12, PROPFIND,    PROPFIND)     \
-  XX(13, PROPPATCH,   PROPPATCH)    \
-  XX(14, SEARCH,      SEARCH)       \
-  XX(15, UNLOCK,      UNLOCK)       \
-  XX(16, BIND,        BIND)         \
-  XX(17, REBIND,      REBIND)       \
-  XX(18, UNBIND,      UNBIND)       \
-  XX(19, ACL,         ACL)          \
-  /* subversion */                  \
-  XX(20, REPORT,      REPORT)       \
-  XX(21, MKACTIVITY,  MKACTIVITY)   \
-  XX(22, CHECKOUT,    CHECKOUT)     \
-  XX(23, MERGE,       MERGE)        \
-  /* upnp */                        \
-  XX(24, MSEARCH,     M-SEARCH)     \
-  XX(25, NOTIFY,      NOTIFY)       \
-  XX(26, SUBSCRIBE,   SUBSCRIBE)    \
-  XX(27, UNSUBSCRIBE, UNSUBSCRIBE)  \
-  /* RFC-5789 */                    \
-  XX(28, PATCH,       PATCH)        \
-  XX(29, PURGE,       PURGE)        \
-  /* CalDAV */                      \
-  XX(30, MKCALENDAR,  MKCALENDAR)   \
-  /* RFC-2068, section 19.6.1.2 */  \
-  XX(31, LINK,        LINK)         \
-  XX(32, UNLINK,      UNLINK)       \
+#define HTTP_METHOD_MAP(XX)                 \
+  XX(0,  DELETE,          DELETE)           \
+  XX(1,  GET,             GET)              \
+  XX(2,  HEAD,            HEAD)             \
+  XX(3,  POST,            POST)             \
+  XX(4,  PUT,             PUT)              \
+  /* pathological */                        \
+  XX(5,  CONNECT,         CONNECT)          \
+  XX(6,  OPTIONS,         OPTIONS)          \
+  XX(7,  TRACE,           TRACE)            \
+  /* WebDAV */                              \
+  XX(8,  COPY,            COPY)             \
+  XX(9,  LOCK,            LOCK)             \
+  XX(10, MKCOL,           MKCOL)            \
+  XX(11, MOVE,            MOVE)             \
+  XX(12, PROPFIND,        PROPFIND)         \
+  XX(13, PROPPATCH,       PROPPATCH)        \
+  XX(14, SEARCH,          SEARCH)           \
+  XX(15, UNLOCK,          UNLOCK)           \
+  XX(16, BIND,            BIND)             \
+  XX(17, REBIND,          REBIND)           \
+  XX(18, UNBIND,          UNBIND)           \
+  XX(19, ACL,             ACL)              \
+  /* subversion */                          \
+  XX(20, REPORT,          REPORT)           \
+  XX(21, MKACTIVITY,      MKACTIVITY)       \
+  XX(22, CHECKOUT,        CHECKOUT)         \
+  XX(23, MERGE,           MERGE)            \
+  /* upnp */                                \
+  XX(24, MSEARCH,         M-SEARCH)         \
+  XX(25, NOTIFY,          NOTIFY)           \
+  XX(26, SUBSCRIBE,       SUBSCRIBE)        \
+  XX(27, UNSUBSCRIBE,     UNSUBSCRIBE)      \
+  /* RFC-5789 */                            \
+  XX(28, PATCH,           PATCH)            \
+  XX(29, PURGE,           PURGE)            \
+  /* CalDAV */                              \
+  XX(30, MKCALENDAR,      MKCALENDAR)       \
+  /* RFC-2068, section 19.6.1.2 */          \
+  XX(31, LINK,            LINK)             \
+  XX(32, UNLINK,          UNLINK)           \
+  /* WebDAV extensions */                   \
+  XX(33, VERSIONCONTROL,  VERSION-CONTROL)  \
+  XX(34, CHECKIN,         CHECKIN)          \
+  XX(35, UNCHECKOUT,      UNCHECKOUT)       \
+  XX(36, MKWORKSPACE,     MKWORKSPACE)      \
+  XX(37, UPDATE,          UPDATE)           \
+  XX(38, LABEL,           LABEL)            \
+  XX(39, BASELINECONTROL, BASELINE-CONTROL) \
+  XX(40, GETLIB,          GETLIB)           \
 
 enum http_method
   {


### PR DESCRIPTION
### Affected core subsystem(s)

* http

### Description of change

As described in [RFC2518](https://tools.ietf.org/html/rfc2518), [RFC4709](https://tools.ietf.org/html/rfc4709), [RFC5397](https://tools.ietf.org/html/rfc5397), [RFC5689](https://tools.ietf.org/html/rfc5689) and [RFC3744](https://tools.ietf.org/html/rfc3744) there are a couple of request methods available that [haven't been implemented yet](https://github.com/nodejs/node/blob/master/deps/http_parser/http_parser.h#L89,L129).

I did [find](https://github.com/nodejs/http-parser/pull/158) [other](https://github.com/nodejs/node/issues/1081) [issues](https://github.com/nodejs/node/pull/1457) discussing this, but until then I created a PR. I'm confident I made a mistake, as this is my first contribution to node, so give me hell :)

```
Running main() from gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from UtilTest
[ RUN      ] UtilTest.ListHead
[       OK ] UtilTest.ListHead (0 ms)
[----------] 1 test from UtilTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 1 test.
/Applications/Xcode.app/Contents/Developer/usr/bin/make jslint
./node tools/eslint/bin/eslint.js benchmark lib src test tools/doc \
	  tools/eslint-rules --rulesdir tools/eslint-rules
/Applications/Xcode.app/Contents/Developer/usr/bin/make cpplint
Total errors found: 0
/usr/local/opt/python/bin/python2.7 tools/test.py --mode=release message parallel sequential -J
[00:56|% 100|+ 1046|-   0]: Done
```