### PR TITLE
Revert "build: run lint before tests"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,9 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH) $(V8_BUILD_OPTIONS)
 
 test: | cctest  # Depends on 'all'.
+	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
 	$(MAKE) jslint
 	$(MAKE) cpplint
-	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
 
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

The reverted commit seems to have been mildly controversial. Revert it for now. If the change or something similar is highly desirable, a wider conversation can happen.

/cc @bnoordhuis @jbergstroem @evanlucas @Fishrock123 @jasnell @TheAlphaNerd 