### PR TITLE
build: run lint jobs even if tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,11 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH) $(V8_BUILD_OPTIONS)
 
 test: | cctest  # Depends on 'all'.
-	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
-	$(MAKE) jslint
-	$(MAKE) cpplint
+    RC=0; \
+    $(PYTHON) tools/test.py --mode=release message parallel sequential -J || RC=$$?; \
+    $(MAKE) jslint || RC=$$?; \
+    $(MAKE) cpplint || RC=$$?; \
+    exit $$RC
 
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,11 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH) $(V8_BUILD_OPTIONS)
 
 test: | cctest  # Depends on 'all'.
-    RC=0; \
-    $(PYTHON) tools/test.py --mode=release message parallel sequential -J || RC=$$?; \
-    $(MAKE) jslint || RC=$$?; \
-    $(MAKE) cpplint || RC=$$?; \
-    exit $$RC
+	RC=0; \
+	$(PYTHON) tools/test.py --mode=release message parallel sequential -J || RC=$$?; \
+	$(MAKE) jslint || RC=$$?; \
+	$(MAKE) cpplint || RC=$$?; \
+	exit $$RC
 
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J


### PR DESCRIPTION


- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?



### Description of change

Reviewable version of Option 3 from #5607. If tests fail, lint still runs. Recipe exits with error if *any* tests or lint tasks don't run without incident.

This is a proof-of-concept for a small change but the small change has potentially enormous consequences. So, you know, don't merge casually. Added `in progress` label to try to make that clear.
