### PR TITLE
crypto: fail early when loading crypto module w/o openssl

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -19,6 +19,21 @@ console.log(hash);
   //   c0fa1bc00531bd78ef38c628449c5102aeabd49b5dc3a2a516ea6ea959d6658e
 ```
 
+## Determining if crypto support is unavailable
+
+It is possible for Node.js to be built without including support for the 
+`crypto` module. In such cases, calling `require('crypto')` will result in an 
+error being thrown.
+
+```js
+var crypto;
+try {
+  crypto = require('crypto');
+} catch (err) {
+  console.log('crypto support is disabled!');
+}
+```
+
 ## Class: Certificate
 
 SPKAC is a Certificate Signing Request mechanism originally implemented by

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('internal/util').assertCrypto(exports);
+
 const assert = require('assert');
 const EventEmitter = require('events');
 const stream = require('stream');
@@ -9,12 +11,7 @@ const common = require('_tls_common');
 const debug = util.debuglog('tls-legacy');
 const Buffer = require('buffer').Buffer;
 const Timer = process.binding('timer_wrap').Timer;
-var Connection = null;
-try {
-  Connection = process.binding('crypto').Connection;
-} catch (e) {
-  throw new Error('Node.js is not compiled with openssl crypto support');
-}
+const Connection = process.binding('crypto').Connection;
 
 function SlabBuffer() {
   this.create();

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('internal/util').assertCrypto(exports);
+
 const assert = require('assert');
 const crypto = require('crypto');
 const net = require('net');

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -3,25 +3,23 @@
 
 'use strict';
 
+const internalUtil = require('internal/util');
+internalUtil.assertCrypto(exports);
+
 exports.DEFAULT_ENCODING = 'buffer';
 
-try {
-  var binding = process.binding('crypto');
-  var randomBytes = binding.randomBytes;
-  var getCiphers = binding.getCiphers;
-  var getHashes = binding.getHashes;
-  var getCurves = binding.getCurves;
-  var getFipsCrypto = binding.getFipsCrypto;
-  var setFipsCrypto = binding.setFipsCrypto;
-} catch (e) {
-  throw new Error('Node.js is not compiled with openssl crypto support');
-}
+const binding = process.binding('crypto');
+const randomBytes = binding.randomBytes;
+const getCiphers = binding.getCiphers;
+const getHashes = binding.getHashes;
+const getCurves = binding.getCurves;
+const getFipsCrypto = binding.getFipsCrypto;
+const setFipsCrypto = binding.setFipsCrypto;
 
 const Buffer = require('buffer').Buffer;
 const constants = require('constants');
 const stream = require('stream');
 const util = require('util');
-const internalUtil = require('internal/util');
 const LazyTransform = require('internal/streams/lazy_transform');
 
 const DH_GENERATOR = 2;

--- a/lib/https.js
+++ b/lib/https.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('internal/util').assertCrypto(exports);
+
 const tls = require('tls');
 const url = require('url');
 const http = require('http');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -96,3 +96,9 @@ exports.isError = function isError(e) {
 exports.objectToString = function objectToString(o) {
   return Object.prototype.toString.call(o);
 };
+
+const noCrypto = !process.versions.openssl;
+exports.assertCrypto = function(exports) {
+  if (noCrypto)
+    throw new Error('Node.js is not compiled with openssl crypto support');
+};

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('internal/util').assertCrypto(exports);
+
 const net = require('net');
 const url = require('url');
 const binding = process.binding('crypto');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

crypto, tls, https, process, src

### Description of change

*Updated*
Fail early in require('crypto'), require('tls'), require('https'), etc when crypto is not available
(rather than depending on an internal try/catch).

Add documentation for detecting when crypto is not available.

(this previously had a `process.noCrypto` flag that was removed)
```