### PR TITLE
fs: add Buffer support in fs methods

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -101,10 +101,23 @@ Objects returned from `fs.watch()` are of this type.
 ### Event: 'change'
 
 * `event` {String} The type of fs change
-* `filename` {String} The filename that changed (if relevant/available)
+* `filename` {String | Buffer} The filename that changed (if relevant/available)
 
 Emitted when something changes in a watched directory or file.
 See more details in [`fs.watch()`][].
+
+The `filename` argument may not be provided depending on operating system
+support. If `filename` is provided, it will be provided as a `Buffer` if
+`fs.watch()` is called with it's `encoding` option set to `'buffer'`, otherwise
+`filename` will be a string.
+
+```js
+fs.watch('./tmp', {encoding: 'buffer'}, (event, filename) => {
+  if (filename)
+    console.log(filename);
+    // Prints: <Buffer ...>
+});
+```
 
 ### Event: 'error'
 
@@ -128,7 +141,10 @@ Emitted when the ReadStream's file is opened.
 
 ### readStream.path
 
-The path to the file the stream is reading from.
+The path to the file the stream is reading from as specified in the first
+argument to `fs.createReadStream()`. If `path` is passed as a string, then
+`readStream.path` will be a string. If `path` is passed as a `Buffer`, then
+`readStream.path` will be a `Buffer`.
 
 ## Class: fs.Stats
 
@@ -217,11 +233,14 @@ for writing.
 
 ### writeStream.path
 
-The path to the file the stream is writing to.
+The path to the file the stream is writing to as specified in the first
+argument to `fs.createWriteStream()`. If `path` is passed as a string, then
+`writeStream.path` will be a string. If `path` is passed as a `Buffer`, then
+`writeStream.path` will be a `Buffer`.
 
 ## fs.access(path[, mode], callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -251,7 +270,7 @@ fs.access('/etc/passwd', fs.R_OK | fs.W_OK, (err) => {
 
 ## fs.accessSync(path[, mode])
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 
 Synchronous version of [`fs.access()`][]. This throws if any accessibility checks
@@ -259,7 +278,7 @@ fail, and does nothing otherwise.
 
 ## fs.appendFile(file, data[, options], callback)
 
-* `file` {String | Number} filename or file descriptor
+* `file` {String | Buffer | Number} filename or file descriptor
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`
@@ -291,11 +310,18 @@ _Note: Specified file descriptors will not be closed automatically._
 
 ## fs.appendFileSync(file, data[, options])
 
+* `file` {String | Buffer}
+* `data` {String | Buffer}
+* `options` {Object | String}
+  * `encoding` {String | Null} default = `'utf8'`
+  * `mode` {Integer} default = `0o666`
+  * `flag` {String} default = `'a'`
+
 The synchronous version of [`fs.appendFile()`][]. Returns `undefined`.
 
 ## fs.chmod(path, mode, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -304,14 +330,14 @@ to the completion callback.
 
 ## fs.chmodSync(path, mode)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 
 Synchronous chmod(2). Returns `undefined`.
 
 ## fs.chown(path, uid, gid, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 * `callback` {Function}
@@ -321,7 +347,7 @@ to the completion callback.
 
 ## fs.chownSync(path, uid, gid)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 
@@ -343,7 +369,7 @@ Synchronous close(2). Returns `undefined`.
 
 ## fs.createReadStream(path[, options])
 
-* `path` {String}
+* `path` {String | Buffer}
 * `options` {String | Object}
   * `flags` {String}
   * `encoding` {String}
@@ -399,7 +425,7 @@ If `options` is a string, then it specifies the encoding.
 
 ## fs.createWriteStream(path[, options])
 
-* `path` {String}
+* `path` {String | Buffer}
 * `options` {String | Object}
   * `flags` {String}
   * `defaultEncoding` {String}
@@ -444,7 +470,7 @@ If `options` is a string, then it specifies the encoding.
 
     Stability: 0 - Deprecated: Use [`fs.stat()`][] or [`fs.access()`][] instead.
 
-* `path` {String}
+* `path` {String | Buffer}
 * `callback` {Function}
 
 Test whether or not the given path exists by checking with the file system.
@@ -466,7 +492,7 @@ non-existent.
 
     Stability: 0 - Deprecated: Use [`fs.statSync()`][] or [`fs.accessSync()`][] instead.
 
-* `path` {String}
+* `path` {String | Buffer}
 
 Synchronous version of [`fs.exists()`][].
 Returns `true` if the file exists, `false` otherwise.
@@ -584,7 +610,7 @@ Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 
 ## fs.lchmod(path, mode, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -595,14 +621,14 @@ Only available on Mac OS X.
 
 ## fs.lchmodSync(path, mode)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 
 Synchronous lchmod(2). Returns `undefined`.
 
 ## fs.lchown(path, uid, gid, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 * `callback` {Function}
@@ -612,7 +638,7 @@ to the completion callback.
 
 ## fs.lchownSync(path, uid, gid)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 
@@ -620,8 +646,8 @@ Synchronous lchown(2). Returns `undefined`.
 
 ## fs.link(srcpath, dstpath, callback)
 
-* `srcpath` {String}
-* `dstpath` {String}
+* `srcpath` {String | Buffer}
+* `dstpath` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous link(2). No arguments other than a possible exception are given to
@@ -629,14 +655,14 @@ the completion callback.
 
 ## fs.linkSync(srcpath, dstpath)
 
-* `srcpath` {String}
-* `dstpath` {String}
+* `srcpath` {String | Buffer}
+* `dstpath` {String | Buffer}
 
 Synchronous link(2). Returns `undefined`.
 
 ## fs.lstat(path, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
@@ -646,13 +672,13 @@ refers to.
 
 ## fs.lstatSync(path)
 
-* `path` {String}
+* `path` {String | Buffer}
 
 Synchronous lstat(2). Returns an instance of `fs.Stats`.
 
 ## fs.mkdir(path[, mode], callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -661,7 +687,7 @@ to the completion callback. `mode` defaults to `0o777`.
 
 ## fs.mkdirSync(path[, mode])
 
-* `path` {String}
+* `path` {String | Buffer}
 * `mode` {Integer}
 
 Synchronous mkdir(2). Returns `undefined`.
@@ -692,7 +718,7 @@ folder path.
 
 ## fs.open(path, flags[, mode], callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `flags` {String | Number}
 * `mode` {Integer}
 * `callback` {Function}
@@ -759,7 +785,7 @@ the end of the file.
 
 ## fs.openSync(path, flags[, mode])
 
-* `path` {String}
+* `path` {String | Buffer}
 * `flags` {String | Number}
 * `mode` {Integer}
 
@@ -788,7 +814,12 @@ If `position` is `null`, data will be read from the current file position.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.
 
-## fs.readdir(path, callback)
+## fs.readdir(path[, options], callback)
+
+* `path` {String | Buffer}
+* `options` {String | Object}
+  * `encoding` {String} default = `'utf8'`
+* `callback` {Function}
 
 * `path` {String}
 * `callback` {Function}
@@ -797,16 +828,30 @@ Asynchronous readdir(3).  Reads the contents of a directory.
 The callback gets two arguments `(err, files)` where `files` is an array of
 the names of the files in the directory excluding `'.'` and `'..'`.
 
-## fs.readdirSync(path)
+The optional `options` argument can be a string specifying an encoding, or an
+object with an `encoding` property specifying the character encoding to use for
+the filenames passed to the callback. If the `encoding` is set to `'buffer'`,
+the filenames returned will be passed as `Buffer` objects.
+
+## fs.readdirSync(path[, options])
+
+* `path` {String | Buffer}
+* `options` {String | Object}
+  * `encoding` {String} default = `'utf8'`
 
 * `path` {String}
 
 Synchronous readdir(3). Returns an array of filenames excluding `'.'` and
 `'..'`.
 
+The optional `options` argument can be a string specifying an encoding, or an
+object with an `encoding` property specifying the character encoding to use for
+the filenames passed to the callback. If the `encoding` is set to `'buffer'`,
+the filenames returned will be passed as `Buffer` objects.
+
 ## fs.readFile(file[, options], callback)
 
-* `file` {String | Integer} filename or file descriptor
+* `file` {String | Buffer | Integer} filename or file descriptor
 * `options` {Object | String}
   * `encoding` {String | Null} default = `null`
   * `flag` {String} default = `'r'`
@@ -838,7 +883,7 @@ _Note: Specified file descriptors will not be closed automatically._
 
 ## fs.readFileSync(file[, options])
 
-* `file` {String | Integer} filename or file descriptor
+* `file` {String | Buffer | Integer} filename or file descriptor
 * `options` {Object | String}
   * `encoding` {String | Null} default = `null`
   * `flag` {String} default = `'r'`
@@ -848,7 +893,12 @@ Synchronous version of [`fs.readFile`][]. Returns the contents of the `file`.
 If the `encoding` option is specified then this function returns a
 string. Otherwise it returns a buffer.
 
-## fs.readlink(path, callback)
+## fs.readlink(path[, options], callback)
+
+* `path` {String | Buffer}
+* `options` {String | Object}
+  * `encoding` {String} default = `'utf8'`
+* `callback` {Function}
 
 * `path` {String}
 * `callback` {Function}
@@ -856,15 +906,29 @@ string. Otherwise it returns a buffer.
 Asynchronous readlink(2). The callback gets two arguments `(err,
 linkString)`.
 
-## fs.readlinkSync(path)
+The optional `options` argument can be a string specifying an encoding, or an
+object with an `encoding` property specifying the character encoding to use for
+the link path passed to the callback. If the `encoding` is set to `'buffer'`,
+the link path returned will be passed as a `Buffer` object.
+
+## fs.readlinkSync(path[, options])
+
+* `path` {String | Buffer}
+* `options` {String | Object}
+  * `encoding` {String} default = `'utf8'`
 
 * `path` {String}
 
 Synchronous readlink(2). Returns the symbolic link's string value.
 
+The optional `options` argument can be a string specifying an encoding, or an
+object with an `encoding` property specifying the character encoding to use for
+the link path passed to the callback. If the `encoding` is set to `'buffer'`,
+the link path returned will be passed as a `Buffer` object.
+
 ## fs.realpath(path[, cache], callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `cache` {Object}
 * `callback` {Function}
 
@@ -895,7 +959,7 @@ Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 
 ## fs.realpathSync(path[, cache])
 
-* `path` {String}
+* `path` {String | Buffer};
 * `cache` {Object}
 
 Synchronous realpath(2). Returns the resolved path. `cache` is an
@@ -904,8 +968,8 @@ resolution or avoid additional `fs.stat` calls for known real paths.
 
 ## fs.rename(oldPath, newPath, callback)
 
-* `oldPath` {String}
-* `newPath` {String}
+* `oldPath` {String | Buffer}
+* `newPath` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous rename(2). No arguments other than a possible exception are given
@@ -913,14 +977,14 @@ to the completion callback.
 
 ## fs.renameSync(oldPath, newPath)
 
-* `oldPath` {String}
-* `newPath` {String}
+* `oldPath` {String | Buffer}
+* `newPath` {String | Buffer}
 
 Synchronous rename(2). Returns `undefined`.
 
 ## fs.rmdir(path, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous rmdir(2). No arguments other than a possible exception are given
@@ -928,13 +992,13 @@ to the completion callback.
 
 ## fs.rmdirSync(path)
 
-* `path` {String}
+* `path` {String | Buffer}
 
 Synchronous rmdir(2). Returns `undefined`.
 
 ## fs.stat(path, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
@@ -943,14 +1007,14 @@ information.
 
 ## fs.statSync(path)
 
-* `path` {String}
+* `path` {String | Buffer}
 
 Synchronous stat(2). Returns an instance of [`fs.Stats`][].
 
 ## fs.symlink(target, path[, type], callback)
 
-* `target` {String}
-* `path` {String}
+* `target` {String | Buffer}
+* `path` {String | Buffer}
 * `type` {String}
 * `callback` {Function}
 
@@ -971,15 +1035,15 @@ It creates a symbolic link named "new-port" that points to "foo".
 
 ## fs.symlinkSync(target, path[, type])
 
-* `target` {String}
-* `path` {String}
+* `target` {String | Buffer}
+* `path` {String | Buffer}
 * `type` {String}
 
 Synchronous symlink(2). Returns `undefined`.
 
 ## fs.truncate(path, len, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `len` {Integer}
 * `callback` {Function}
 
@@ -989,14 +1053,14 @@ first argument. In this case, `fs.ftruncate()` is called.
 
 ## fs.truncateSync(path, len)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `len` {Integer}
 
 Synchronous truncate(2). Returns `undefined`.
 
 ## fs.unlink(path, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous unlink(2). No arguments other than a possible exception are given
@@ -1004,13 +1068,13 @@ to the completion callback.
 
 ## fs.unlinkSync(path)
 
-* `path` {String}
+* `path` {String | Buffer}
 
 Synchronous unlink(2). Returns `undefined`.
 
 ## fs.unwatchFile(filename[, listener])
 
-* `filename` {String}
+* `filename` {String | Buffer}
 * `listener` {Function}
 
 Stop watching for changes on `filename`. If `listener` is specified, only that
@@ -1026,7 +1090,7 @@ when possible._
 
 ## fs.utimes(path, atime, mtime, callback)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `atime` {Integer}
 * `mtime` {Integer}
 * `callback` {Function}
@@ -1043,7 +1107,7 @@ follow the below rules:
 
 ## fs.utimesSync(path, atime, mtime)
 
-* `path` {String}
+* `path` {String | Buffer}
 * `atime` {Integer}
 * `mtime` {Integer}
 
@@ -1051,18 +1115,23 @@ Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
 
 ## fs.watch(filename[, options][, listener])
 
-* `filename` {String}
-* `options` {Object}
+* `filename` {String | Buffer}
+* `options` {String | Object}
   * `persistent` {Boolean} Indicates whether the process should continue to run
     as long as files are being watched. default = `true`
   * `recursive` {Boolean} Indicates whether all subdirectories should be
     watched, or only the current directory. The applies when a directory is
     specified, and only on supported platforms (See [Caveats][]). default =
     `false`
+  * `encoding` {String} Specifies the character encoding to be used for the
+     filename passed to the listener. default = `'utf8'`
 * `listener` {Function}
 
 Watch for changes on `filename`, where `filename` is either a file or a
 directory.  The returned object is a [`fs.FSWatcher`][].
+
+The second argument is optional. If `options` is provided as a string, it
+specifies the `encoding`. Otherwise `options` should be passed as an object.
 
 The listener callback gets two arguments `(event, filename)`.  `event` is either
 `'rename'` or `'change'`, and `filename` is the name of the file which triggered
@@ -1120,7 +1189,7 @@ fs.watch('somedir', (event, filename) => {
 
 ## fs.watchFile(filename[, options], listener)
 
-* `filename` {String}
+* `filename` {String | Buffer}
 * `options` {Object}
   * `persistent` {Boolean}
   * `interval` {Integer}
@@ -1224,7 +1293,7 @@ the end of the file.
 
 ## fs.writeFile(file, data[, options], callback)
 
-* `file` {String | Integer} filename or file descriptor
+* `file` {String | Buffer | Integer} filename or file descriptor
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`
@@ -1263,7 +1332,7 @@ _Note: Specified file descriptors will not be closed automatically._
 
 ## fs.writeFileSync(file, data[, options])
 
-* `file` {String | Integer} filename or file descriptor
+* `file` {String | Buffer | Integer} filename or file descriptor
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -122,7 +122,7 @@ Stop watching for changes on the given `fs.FSWatcher`.
 
 ### Event: 'open'
 
-* `fd` {Number} Integer file descriptor used by the ReadStream.
+* `fd` {Integer} Integer file descriptor used by the ReadStream.
 
 Emitted when the ReadStream's file is opened.
 
@@ -206,7 +206,7 @@ on Unix systems, it never was.
 
 ### Event: 'open'
 
-* `fd` {Number} Integer file descriptor used by the WriteStream.
+* `fd` {Integer} Integer file descriptor used by the WriteStream.
 
 Emitted when the WriteStream's file is opened.
 
@@ -220,6 +220,10 @@ for writing.
 The path to the file the stream is writing to.
 
 ## fs.access(path[, mode], callback)
+
+* `path` {String}
+* `mode` {Integer}
+* `callback` {Function}
 
 Tests a user's permissions for the file specified by `path`. `mode` is an
 optional integer that specifies the accessibility checks to be performed. The
@@ -247,16 +251,19 @@ fs.access('/etc/passwd', fs.R_OK | fs.W_OK, (err) => {
 
 ## fs.accessSync(path[, mode])
 
+* `path` {String}
+* `mode` {Integer}
+
 Synchronous version of [`fs.access()`][]. This throws if any accessibility checks
 fail, and does nothing otherwise.
 
 ## fs.appendFile(file, data[, options], callback)
 
-* `file` {String|Number} filename or file descriptor
-* `data` {String|Buffer}
-* `options` {Object|String}
-  * `encoding` {String|Null} default = `'utf8'`
-  * `mode` {Number} default = `0o666`
+* `file` {String | Number} filename or file descriptor
+* `data` {String | Buffer}
+* `options` {Object | String}
+  * `encoding` {String | Null} default = `'utf8'`
+  * `mode` {Integer} default = `0o666`
   * `flag` {String} default = `'a'`
 * `callback` {Function}
 
@@ -288,32 +295,63 @@ The synchronous version of [`fs.appendFile()`][]. Returns `undefined`.
 
 ## fs.chmod(path, mode, callback)
 
+* `path` {String}
+* `mode` {Integer}
+* `callback` {Function}
+
 Asynchronous chmod(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.chmodSync(path, mode)
 
+* `path` {String}
+* `mode` {Integer}
+
 Synchronous chmod(2). Returns `undefined`.
 
 ## fs.chown(path, uid, gid, callback)
+
+* `path` {String}
+* `uid` {Integer}
+* `gid` {Integer}
+* `callback` {Function}
 
 Asynchronous chown(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.chownSync(path, uid, gid)
 
+* `path` {String}
+* `uid` {Integer}
+* `gid` {Integer}
+
 Synchronous chown(2). Returns `undefined`.
 
 ## fs.close(fd, callback)
+
+* `fd` {Integer}
+* `callback` {Function}
 
 Asynchronous close(2).  No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.closeSync(fd)
 
+* `fd` {Integer}
+
 Synchronous close(2). Returns `undefined`.
 
 ## fs.createReadStream(path[, options])
+
+* `path` {String}
+* `options` {String | Object}
+  * `flags` {String}
+  * `encoding` {String}
+  * `fd` {Integer}
+  * `mode` {Integer}
+  * `autoClose` {Boolean}
+  * `start` {Integer}
+  * `end` {Integer}
 
 Returns a new [`ReadStream`][] object. (See [Readable Stream][]).
 
@@ -361,6 +399,15 @@ If `options` is a string, then it specifies the encoding.
 
 ## fs.createWriteStream(path[, options])
 
+* `path` {String}
+* `options` {String | Object}
+  * `flags` {String}
+  * `defaultEncoding` {String}
+  * `fd` {Integer}
+  * `mode` {Integer}
+  * `autoClose` {Boolean}
+  * `start` {Integer}
+
 Returns a new [`WriteStream`][] object. (See [Writable Stream][]).
 
 `options` is an object or string with the following defaults:
@@ -397,6 +444,9 @@ If `options` is a string, then it specifies the encoding.
 
     Stability: 0 - Deprecated: Use [`fs.stat()`][] or [`fs.access()`][] instead.
 
+* `path` {String}
+* `callback` {Function}
+
 Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
 
@@ -416,37 +466,63 @@ non-existent.
 
     Stability: 0 - Deprecated: Use [`fs.statSync()`][] or [`fs.accessSync()`][] instead.
 
+* `path` {String}
+
 Synchronous version of [`fs.exists()`][].
 Returns `true` if the file exists, `false` otherwise.
 
 ## fs.fchmod(fd, mode, callback)
+
+* `fd` {Integer}
+* `mode` {Integer}
+* `callback` {Function}
 
 Asynchronous fchmod(2). No arguments other than a possible exception
 are given to the completion callback.
 
 ## fs.fchmodSync(fd, mode)
 
+* `fd` {Integer}
+* `mode` {Integer}
+
 Synchronous fchmod(2). Returns `undefined`.
 
 ## fs.fchown(fd, uid, gid, callback)
+
+* `fd` {Integer}
+* `uid` {Integer}
+* `gid` {Integer}
+* `callback` {Function}
 
 Asynchronous fchown(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.fchownSync(fd, uid, gid)
 
+* `fd` {Integer}
+* `uid` {Integer}
+* `gid` {Integer}
+
 Synchronous fchown(2). Returns `undefined`.
 
 ## fs.fdatasync(fd, callback)
+
+* `fd` {Integer}
+* `callback` {Function}
 
 Asynchronous fdatasync(2). No arguments other than a possible exception are
 given to the completion callback.
 
 ## fs.fdatasyncSync(fd)
 
+* `fd` {Integer}
+
 Synchronous fdatasync(2). Returns `undefined`.
 
 ## fs.fstat(fd, callback)
+
+* `fd` {Integer}
+* `callback` {Function}
 
 Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a `fs.Stats` object. `fstat()` is identical to [`stat()`][], except that
@@ -454,36 +530,63 @@ the file to be stat-ed is specified by the file descriptor `fd`.
 
 ## fs.fstatSync(fd)
 
+* `fd` {Integer}
+
 Synchronous fstat(2). Returns an instance of `fs.Stats`.
 
 ## fs.fsync(fd, callback)
+
+* `fd` {Integer}
+* `callback` {Function}
 
 Asynchronous fsync(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.fsyncSync(fd)
 
+* `fd` {Integer}
+
 Synchronous fsync(2). Returns `undefined`.
 
 ## fs.ftruncate(fd, len, callback)
+
+* `fd` {Integer}
+* `len` {Integer}
+* `callback` {Function}
 
 Asynchronous ftruncate(2). No arguments other than a possible exception are
 given to the completion callback.
 
 ## fs.ftruncateSync(fd, len)
 
+* `fd` {Integer}
+* `len` {Integer}
+
 Synchronous ftruncate(2). Returns `undefined`.
 
 ## fs.futimes(fd, atime, mtime, callback)
+
+* `fd` {Integer}
+* `atime` {Integer}
+* `mtime` {Integer}
+* `callback` {Function}
 
 Change the file timestamps of a file referenced by the supplied file
 descriptor.
 
 ## fs.futimesSync(fd, atime, mtime)
 
+* `fd` {Integer}
+* `atime` {Integer}
+* `mtime` {Integer}
+
 Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 
 ## fs.lchmod(path, mode, callback)
+
+* `path` {String}
+* `mode` {Integer}
+* `callback` {Function}
 
 Asynchronous lchmod(2). No arguments other than a possible exception
 are given to the completion callback.
@@ -492,27 +595,49 @@ Only available on Mac OS X.
 
 ## fs.lchmodSync(path, mode)
 
+* `path` {String}
+* `mode` {Integer}
+
 Synchronous lchmod(2). Returns `undefined`.
 
 ## fs.lchown(path, uid, gid, callback)
+
+* `path` {String}
+* `uid` {Integer}
+* `gid` {Integer}
+* `callback` {Function}
 
 Asynchronous lchown(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.lchownSync(path, uid, gid)
 
+* `path` {String}
+* `uid` {Integer}
+* `gid` {Integer}
+
 Synchronous lchown(2). Returns `undefined`.
 
 ## fs.link(srcpath, dstpath, callback)
+
+* `srcpath` {String}
+* `dstpath` {String}
+* `callback` {Function}
 
 Asynchronous link(2). No arguments other than a possible exception are given to
 the completion callback.
 
 ## fs.linkSync(srcpath, dstpath)
 
+* `srcpath` {String}
+* `dstpath` {String}
+
 Synchronous link(2). Returns `undefined`.
 
 ## fs.lstat(path, callback)
+
+* `path` {String}
+* `callback` {Function}
 
 Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a `fs.Stats` object. `lstat()` is identical to `stat()`, except that if
@@ -521,14 +646,23 @@ refers to.
 
 ## fs.lstatSync(path)
 
+* `path` {String}
+
 Synchronous lstat(2). Returns an instance of `fs.Stats`.
 
 ## fs.mkdir(path[, mode], callback)
+
+* `path` {String}
+* `mode` {Integer}
+* `callback` {Function}
 
 Asynchronous mkdir(2). No arguments other than a possible exception are given
 to the completion callback. `mode` defaults to `0o777`.
 
 ## fs.mkdirSync(path[, mode])
+
+* `path` {String}
+* `mode` {Integer}
 
 Synchronous mkdir(2). Returns `undefined`.
 
@@ -557,6 +691,11 @@ The synchronous version of [`fs.mkdtemp()`][]. Returns the created
 folder path.
 
 ## fs.open(path, flags[, mode], callback)
+
+* `path` {String}
+* `flags` {String | Number}
+* `mode` {Integer}
+* `callback` {Function}
 
 Asynchronous file open. See open(2). `flags` can be:
 
@@ -620,10 +759,21 @@ the end of the file.
 
 ## fs.openSync(path, flags[, mode])
 
+* `path` {String}
+* `flags` {String | Number}
+* `mode` {Integer}
+
 Synchronous version of [`fs.open()`][]. Returns an integer representing the file
 descriptor.
 
 ## fs.read(fd, buffer, offset, length, position, callback)
+
+* `fd` {Integer}
+* `buffer` {String | Buffer}
+* `offset` {Integer}
+* `length` {Integer}
+* `position` {Integer}
+* `callback` {Function}
 
 Read data from the file specified by `fd`.
 
@@ -640,11 +790,16 @@ The callback is given the three arguments, `(err, bytesRead, buffer)`.
 
 ## fs.readdir(path, callback)
 
+* `path` {String}
+* `callback` {Function}
+
 Asynchronous readdir(3).  Reads the contents of a directory.
 The callback gets two arguments `(err, files)` where `files` is an array of
 the names of the files in the directory excluding `'.'` and `'..'`.
 
 ## fs.readdirSync(path)
+
+* `path` {String}
 
 Synchronous readdir(3). Returns an array of filenames excluding `'.'` and
 `'..'`.
@@ -683,6 +838,11 @@ _Note: Specified file descriptors will not be closed automatically._
 
 ## fs.readFileSync(file[, options])
 
+* `file` {String | Integer} filename or file descriptor
+* `options` {Object | String}
+  * `encoding` {String | Null} default = `null`
+  * `flag` {String} default = `'r'`
+
 Synchronous version of [`fs.readFile`][]. Returns the contents of the `file`.
 
 If the `encoding` option is specified then this function returns a
@@ -690,14 +850,23 @@ string. Otherwise it returns a buffer.
 
 ## fs.readlink(path, callback)
 
+* `path` {String}
+* `callback` {Function}
+
 Asynchronous readlink(2). The callback gets two arguments `(err,
 linkString)`.
 
 ## fs.readlinkSync(path)
 
+* `path` {String}
+
 Synchronous readlink(2). Returns the symbolic link's string value.
 
 ## fs.realpath(path[, cache], callback)
+
+* `path` {String}
+* `cache` {Object}
+* `callback` {Function}
 
 Asynchronous realpath(2). The `callback` gets two arguments `(err,
 resolvedPath)`. May use `process.cwd` to resolve relative paths. `cache` is an
@@ -716,9 +885,18 @@ fs.realpath('/etc/passwd', cache, (err, resolvedPath) => {
 
 ## fs.readSync(fd, buffer, offset, length, position)
 
+* `fd` {Integer}
+* `buffer` {String | Buffer}
+* `offset` {Integer}
+* `length` {Integer}
+* `position` {Integer}
+
 Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 
 ## fs.realpathSync(path[, cache])
+
+* `path` {String}
+* `cache` {Object}
 
 Synchronous realpath(2). Returns the resolved path. `cache` is an
 object literal of mapped paths that can be used to force a specific path
@@ -726,23 +904,38 @@ resolution or avoid additional `fs.stat` calls for known real paths.
 
 ## fs.rename(oldPath, newPath, callback)
 
+* `oldPath` {String}
+* `newPath` {String}
+* `callback` {Function}
+
 Asynchronous rename(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.renameSync(oldPath, newPath)
 
+* `oldPath` {String}
+* `newPath` {String}
+
 Synchronous rename(2). Returns `undefined`.
 
 ## fs.rmdir(path, callback)
+
+* `path` {String}
+* `callback` {Function}
 
 Asynchronous rmdir(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.rmdirSync(path)
 
+* `path` {String}
+
 Synchronous rmdir(2). Returns `undefined`.
 
 ## fs.stat(path, callback)
+
+* `path` {String}
+* `callback` {Function}
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 `stats` is a [`fs.Stats`][] object.  See the [`fs.Stats`][] section for more
@@ -750,9 +943,16 @@ information.
 
 ## fs.statSync(path)
 
+* `path` {String}
+
 Synchronous stat(2). Returns an instance of [`fs.Stats`][].
 
 ## fs.symlink(target, path[, type], callback)
+
+* `target` {String}
+* `path` {String}
+* `type` {String}
+* `callback` {Function}
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
 to the completion callback.
@@ -771,9 +971,17 @@ It creates a symbolic link named "new-port" that points to "foo".
 
 ## fs.symlinkSync(target, path[, type])
 
+* `target` {String}
+* `path` {String}
+* `type` {String}
+
 Synchronous symlink(2). Returns `undefined`.
 
 ## fs.truncate(path, len, callback)
+
+* `path` {String}
+* `len` {Integer}
+* `callback` {Function}
 
 Asynchronous truncate(2). No arguments other than a possible exception are
 given to the completion callback. A file descriptor can also be passed as the
@@ -781,18 +989,29 @@ first argument. In this case, `fs.ftruncate()` is called.
 
 ## fs.truncateSync(path, len)
 
+* `path` {String}
+* `len` {Integer}
+
 Synchronous truncate(2). Returns `undefined`.
 
 ## fs.unlink(path, callback)
+
+* `path` {String}
+* `callback` {Function}
 
 Asynchronous unlink(2). No arguments other than a possible exception are given
 to the completion callback.
 
 ## fs.unlinkSync(path)
 
+* `path` {String}
+
 Synchronous unlink(2). Returns `undefined`.
 
 ## fs.unwatchFile(filename[, listener])
+
+* `filename` {String}
+* `listener` {Function}
 
 Stop watching for changes on `filename`. If `listener` is specified, only that
 particular listener is removed. Otherwise, *all* listeners are removed and you
@@ -807,6 +1026,11 @@ when possible._
 
 ## fs.utimes(path, atime, mtime, callback)
 
+* `path` {String}
+* `atime` {Integer}
+* `mtime` {Integer}
+* `callback` {Function}
+
 Change file timestamps of the file referenced by the supplied path.
 
 Note: the arguments `atime` and `mtime` of the following related functions does
@@ -819,21 +1043,26 @@ follow the below rules:
 
 ## fs.utimesSync(path, atime, mtime)
 
+* `path` {String}
+* `atime` {Integer}
+* `mtime` {Integer}
+
 Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
 
 ## fs.watch(filename[, options][, listener])
 
+* `filename` {String}
+* `options` {Object}
+  * `persistent` {Boolean} Indicates whether the process should continue to run
+    as long as files are being watched. default = `true`
+  * `recursive` {Boolean} Indicates whether all subdirectories should be
+    watched, or only the current directory. The applies when a directory is
+    specified, and only on supported platforms (See [Caveats][]). default =
+    `false`
+* `listener` {Function}
+
 Watch for changes on `filename`, where `filename` is either a file or a
 directory.  The returned object is a [`fs.FSWatcher`][].
-
-The second argument is optional. The `options` if provided should be an object.
-The supported boolean members are `persistent` and `recursive`. `persistent`
-indicates whether the process should continue to run as long as files are being
-watched. `recursive` indicates whether all subdirectories should be watched, or
-only the current directory. This applies when a directory is specified, and only
-on supported platforms (See [Caveats][]).
-
-The default is `{ persistent: true, recursive: false }`.
 
 The listener callback gets two arguments `(event, filename)`.  `event` is either
 `'rename'` or `'change'`, and `filename` is the name of the file which triggered
@@ -891,6 +1120,12 @@ fs.watch('somedir', (event, filename) => {
 
 ## fs.watchFile(filename[, options], listener)
 
+* `filename` {String}
+* `options` {Object}
+  * `persistent` {Boolean}
+  * `interval` {Integer}
+* `listener` {Function}
+
 Watch for changes on `filename`. The callback `listener` will be called each
 time the file is accessed.
 
@@ -928,6 +1163,13 @@ when possible._
 
 ## fs.write(fd, buffer, offset, length[, position], callback)
 
+* `fd` {Integer}
+* `buffer` {String | Buffer}
+* `offset` {Integer}
+* `length` {Integer}
+* `position` {Integer}
+* `callback` {Function}
+
 Write `buffer` to the file specified by `fd`.
 
 `offset` and `length` determine the part of the buffer to be written.
@@ -948,6 +1190,12 @@ The kernel ignores the position argument and always appends the data to
 the end of the file.
 
 ## fs.write(fd, data[, position[, encoding]], callback)
+
+* `fd` {Integer}
+* `data` {String | Buffer}
+* `position` {Integer}
+* `encoding` {String}
+* `callback` {Function}
 
 Write `data` to the file specified by `fd`.  If `data` is not a Buffer instance
 then the value will be coerced to a string.
@@ -980,7 +1228,7 @@ the end of the file.
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`
-  * `mode` {Number} default = `0o666`
+  * `mode` {Integer} default = `0o666`
   * `flag` {String} default = `'w'`
 * `callback` {Function}
 
@@ -1015,11 +1263,29 @@ _Note: Specified file descriptors will not be closed automatically._
 
 ## fs.writeFileSync(file, data[, options])
 
+* `file` {String | Integer} filename or file descriptor
+* `data` {String | Buffer}
+* `options` {Object | String}
+  * `encoding` {String | Null} default = `'utf8'`
+  * `mode` {Integer} default = `0o666`
+  * `flag` {String} default = `'w'`
+
 The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 
 ## fs.writeSync(fd, buffer, offset, length[, position])
 
+* `fd` {Integer}
+* `buffer` {String | Buffer}
+* `offset` {Integer}
+* `length` {Integer}
+* `position` {Integer}
+
 ## fs.writeSync(fd, data[, position[, encoding]])
+
+* `fd` {Integer}
+* `buffer` {String | Buffer}
+* `position` {Integer}
+* `encoding` {String}
 
 Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -903,17 +903,32 @@ fs.mkdirSync = function(path, mode) {
                        modeNum(mode, 0o777));
 };
 
-fs.readdir = function(path, callback) {
+fs.readdir = function(path, options, callback) {
+  options = options || {};
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  } else if (typeof options === 'string') {
+    options = {encoding: options};
+  }
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
+
   callback = makeCallback(callback);
   if (!nullCheck(path, callback)) return;
   var req = new FSReqWrap();
   req.oncomplete = callback;
-  binding.readdir(pathModule._makeLong(path), req);
+  binding.readdir(pathModule._makeLong(path), options.encoding, req);
 };
 
-fs.readdirSync = function(path) {
+fs.readdirSync = function(path, options) {
+  options = options || {};
+  if (typeof options === 'string')
+    options = {encoding: options};
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
   nullCheck(path);
-  return binding.readdir(pathModule._makeLong(path));
+  return binding.readdir(pathModule._makeLong(path), options.encoding);
 };
 
 fs.fstat = function(fd, callback) {
@@ -952,17 +967,31 @@ fs.statSync = function(path) {
   return binding.stat(pathModule._makeLong(path));
 };
 
-fs.readlink = function(path, callback) {
+fs.readlink = function(path, options, callback) {
+  options = options || {};
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  } else if (typeof options === 'string') {
+    options = {encoding: options};
+  }
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
   callback = makeCallback(callback);
   if (!nullCheck(path, callback)) return;
   var req = new FSReqWrap();
   req.oncomplete = callback;
-  binding.readlink(pathModule._makeLong(path), req);
+  binding.readlink(pathModule._makeLong(path), options.encoding, req);
 };
 
-fs.readlinkSync = function(path) {
+fs.readlinkSync = function(path, options) {
+  options = options || {};
+  if (typeof options === 'string')
+    options = {encoding: options};
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
   nullCheck(path);
-  return binding.readlink(pathModule._makeLong(path));
+  return binding.readlink(pathModule._makeLong(path), options.encoding);
 };
 
 function preprocessSymlinkDestination(path, type, linkPath) {
@@ -1363,11 +1392,15 @@ function FSWatcher() {
 }
 util.inherits(FSWatcher, EventEmitter);
 
-FSWatcher.prototype.start = function(filename, persistent, recursive) {
+FSWatcher.prototype.start = function(filename,
+                                     persistent,
+                                     recursive,
+                                     encoding) {
   nullCheck(filename);
   var err = this._handle.start(pathModule._makeLong(filename),
                                persistent,
-                               recursive);
+                               recursive,
+                               encoding);
   if (err) {
     this._handle.close();
     const error = errnoException(err, `watch ${filename}`);
@@ -1380,25 +1413,27 @@ FSWatcher.prototype.close = function() {
   this._handle.close();
 };
 
-fs.watch = function(filename) {
+fs.watch = function(filename, options, listener) {
   nullCheck(filename);
-  var watcher;
-  var options;
-  var listener;
 
-  if (arguments[1] !== null && typeof arguments[1] === 'object') {
-    options = arguments[1];
-    listener = arguments[2];
-  } else {
+  options = options || {};
+  if (typeof options === 'function') {
+    listener = options;
     options = {};
-    listener = arguments[1];
+  } else if (typeof options === 'string') {
+    options = {encoding: options};
   }
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
 
   if (options.persistent === undefined) options.persistent = true;
   if (options.recursive === undefined) options.recursive = false;
 
-  watcher = new FSWatcher();
-  watcher.start(filename, options.persistent, options.recursive);
+  const watcher = new FSWatcher();
+  watcher.start(filename,
+                options.persistent,
+                options.recursive,
+                options.encoding);
 
   if (listener) {
     watcher.addListener('change', listener);
@@ -2139,10 +2174,19 @@ SyncWriteStream.prototype.destroy = function() {
 
 SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
 
-fs.mkdtemp = function(prefix, callback) {
-  if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+fs.mkdtemp = function(prefix, options, callback) {
+  if (!prefix || typeof prefix !== 'string')
+    throw new TypeError('filename prefix is required');
+
+  options = options || {};
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  } else if (typeof options === 'string') {
+    options = {encoding: options};
   }
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
 
   if (!nullCheck(prefix, callback)) {
     return;
@@ -2151,11 +2195,19 @@ fs.mkdtemp = function(prefix, callback) {
   var req = new FSReqWrap();
   req.oncomplete = callback;
 
-  binding.mkdtemp(prefix + 'XXXXXX', req);
+  binding.mkdtemp(prefix + 'XXXXXX', options.encoding, req);
 };
 
-fs.mkdtempSync = function(prefix) {
+fs.mkdtempSync = function(prefix, options) {
+  if (!prefix || typeof prefix !== 'string')
+    throw new TypeError('filename prefix is required');
+
+  options = options || {};
+  if (typeof options === 'string')
+    options = {encoding: options};
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
   nullCheck(prefix);
 
-  return binding.mkdtemp(prefix + 'XXXXXX');
+  return binding.mkdtemp(prefix + 'XXXXXX', options.encoding);
 };

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1382,7 +1382,10 @@ function FSWatcher() {
   this._handle.onchange = function(status, event, filename) {
     if (status < 0) {
       self._handle.close();
-      const error = errnoException(status, `watch ${filename}`);
+      const error = !filename ?
+          errnoException(status, 'Error watching file for changes:') :
+          errnoException(status,
+                         `Error watching file ${filename} for changes:`);
       error.filename = filename;
       self.emit('error', error);
     } else {

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -6,6 +6,7 @@
 #include "util-inl.h"
 #include "node.h"
 #include "handle_wrap.h"
+#include "string_bytes.h"
 
 #include <stdlib.h>
 
@@ -41,6 +42,7 @@ class FSEventWrap: public HandleWrap {
 
   uv_fs_event_t handle_;
   bool initialized_;
+  enum encoding encoding_;
 };
 
 
@@ -86,15 +88,19 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
 
   FSEventWrap* wrap = Unwrap<FSEventWrap>(args.Holder());
 
-  if (args.Length() < 1 || !args[0]->IsString()) {
-    return env->ThrowTypeError("filename must be a valid string");
-  }
+  static const char kErrMsg[] = "filename must be a string or Buffer";
+  if (args.Length() < 1)
+    return env->ThrowTypeError(kErrMsg);
 
-  node::Utf8Value path(env->isolate(), args[0]);
+  BufferValue path(env->isolate(), args[0]);
+  if (*path == nullptr)
+    return env->ThrowTypeError(kErrMsg);
 
   unsigned int flags = 0;
   if (args[2]->IsTrue())
     flags |= UV_FS_EVENT_RECURSIVE;
+
+  wrap->encoding_ = ParseEncoding(env->isolate(), args[3], UTF8);
 
   int err = uv_fs_event_init(wrap->env()->event_loop(), &wrap->handle_);
   if (err == 0) {
@@ -156,7 +162,18 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
   };
 
   if (filename != nullptr) {
-    argv[2] = OneByteString(env->isolate(), filename);
+    Local<Value> fn = StringBytes::Encode(env->isolate(),
+                                          filename,
+                                          wrap->encoding_);
+    if (fn.IsEmpty()) {
+      argv[0] = Integer::New(env->isolate(), UV_EINVAL);
+      argv[2] = StringBytes::Encode(env->isolate(),
+                                    filename,
+                                    strlen(filename),
+                                    BUFFER);
+    } else {
+      argv[2] = fn;
+    }
   }
 
   wrap->MakeCallback(env->onchange_string(), ARRAY_SIZE(argv), argv);

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -106,6 +106,10 @@ class StringBytes {
                                      const uint16_t* buf,
                                      size_t buflen);
 
+  static v8::Local<v8::Value> Encode(v8::Isolate* isolate,
+                                     const char* buf,
+                                     enum encoding encoding);
+
   // Deprecated legacy interface
 
   NODE_DEPRECATED("Use IsValidString(isolate, ...)",

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,37 +1,48 @@
 #include "util.h"
 #include "string_bytes.h"
+#include "node_buffer.h"
+#include <stdio.h>
 
 namespace node {
 
-Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value)
+using v8::Isolate;
+using v8::String;
+using v8::Local;
+using v8::Value;
+
+static int MakeUtf8String(Isolate* isolate,
+                          Local<Value> value,
+                          char** dst,
+                          const size_t size) {
+  Local<String> string = value->ToString(isolate);
+  if (string.IsEmpty())
+    return 0;
+  size_t len = StringBytes::StorageSize(isolate, string, UTF8) + 1;
+  if (len > size) {
+    *dst = static_cast<char*>(malloc(len));
+    CHECK_NE(*dst, nullptr);
+  }
+  const int flags =
+      String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8;
+  const int length = string->WriteUtf8(*dst, len, 0, flags);
+  (*dst)[length] = '\0';
+  return length;
+}
+
+Utf8Value::Utf8Value(Isolate* isolate, Local<Value> value)
     : length_(0), str_(str_st_) {
   if (value.IsEmpty())
     return;
-
-  v8::Local<v8::String> string = value->ToString(isolate);
-  if (string.IsEmpty())
-    return;
-
-  // Allocate enough space to include the null terminator
-  size_t len = StringBytes::StorageSize(isolate, string, UTF8) + 1;
-  if (len > sizeof(str_st_)) {
-    str_ = static_cast<char*>(malloc(len));
-    CHECK_NE(str_, nullptr);
-  }
-
-  const int flags =
-      v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
-  length_ = string->WriteUtf8(str_, len, 0, flags);
-  str_[length_] = '\0';
+  length_ = MakeUtf8String(isolate, value, &str_, sizeof(str_st_));
 }
 
 
-TwoByteValue::TwoByteValue(v8::Isolate* isolate, v8::Local<v8::Value> value)
+TwoByteValue::TwoByteValue(Isolate* isolate, Local<Value> value)
     : length_(0), str_(str_st_) {
   if (value.IsEmpty())
     return;
 
-  v8::Local<v8::String> string = value->ToString(isolate);
+  Local<String> string = value->ToString(isolate);
   if (string.IsEmpty())
     return;
 
@@ -43,9 +54,31 @@ TwoByteValue::TwoByteValue(v8::Isolate* isolate, v8::Local<v8::Value> value)
   }
 
   const int flags =
-      v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
+      String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8;
   length_ = string->Write(str_, 0, len, flags);
   str_[length_] = '\0';
+}
+
+BufferValue::BufferValue(Isolate* isolate, Local<Value> value)
+    : str_(str_st_), fail_(true) {
+  // Slightly different take on Utf8Value. If value is a String,
+  // it will return a Utf8 encoded string. If value is a Buffer,
+  // it will copy the data out of the Buffer as is.
+  if (value.IsEmpty())
+    return;
+  if (value->IsString()) {
+    MakeUtf8String(isolate, value, &str_, sizeof(str_st_));
+    fail_ = false;
+  } else if (Buffer::HasInstance(value)) {
+    size_t len = Buffer::Length(value) + 1;
+    if (len > sizeof(str_st_)) {
+      str_ = static_cast<char*>(malloc(len));
+      CHECK_NE(str_, nullptr);
+    }
+    memcpy(str_, Buffer::Data(value), len);
+    str_[len - 1] = '\0';
+    fail_ = false;
+  }
 }
 
 }  // namespace node

--- a/src/util.h
+++ b/src/util.h
@@ -232,6 +232,25 @@ class TwoByteValue {
     uint16_t str_st_[1024];
 };
 
+class BufferValue {
+  public:
+    explicit BufferValue(v8::Isolate* isolate, v8::Local<v8::Value> value);
+
+    ~BufferValue() {
+      if (str_ != str_st_)
+        free(str_);
+    }
+
+    const char* operator*() const {
+      return fail_ ? nullptr : str_;
+    };
+
+  private:
+    char* str_;
+    char str_st_[1024];
+    bool fail_;
+};
+
 }  // namespace node
 
 #endif  // SRC_UTIL_H_

--- a/test/common.js
+++ b/test/common.js
@@ -57,8 +57,14 @@ function rmdirSync(p, originalEr) {
     if (e.code === 'ENOTDIR')
       throw originalEr;
     if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
-      fs.readdirSync(p).forEach(function(f) {
-        rimrafSync(path.join(p, f));
+      const enc = process.platform === 'linux' ? 'buffer' : 'utf8';
+      fs.readdirSync(p, enc).forEach((f) => {
+        if (f instanceof Buffer) {
+          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
+          rimrafSync(buf);
+        } else {
+          rimrafSync(path.join(p, f));
+        }
       });
       fs.rmdirSync(p);
     }

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -92,7 +92,7 @@ fs.access(readOnlyFile, fs.W_OK, function(err) {
 
 assert.throws(function() {
   fs.access(100, fs.F_OK, function(err) {});
-}, /path must be a string/);
+}, /path must be a string or Buffer/);
 
 assert.throws(function() {
   fs.access(__filename, fs.F_OK);

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+common.refreshTmpDir();
+
+assert.doesNotThrow(() => {
+  fs.access(Buffer.from(common.tmpDir), common.mustCall((err) => {
+    if (err) throw err;
+  }));
+});
+
+assert.doesNotThrow(() => {
+  const buf = Buffer.from(path.join(common.tmpDir, 'a.txt'));
+  fs.open(buf, 'w+', common.mustCall((err, fd) => {
+    if (err) throw err;
+    assert(fd);
+    fs.close(fd, common.mustCall(() => {
+      fs.unlinkSync(buf);
+    }));
+  }));
+});
+
+assert.throws(() => {
+  fs.accessSync(true);
+}, /path must be a string or Buffer/);
+
+const dir = Buffer.from(common.fixturesDir);
+fs.readdir(dir, 'hex', common.mustCall((err, list) => {
+  if (err) throw err;
+  list = list.map((i) => {
+    return Buffer.from(i, 'hex').toString();
+  });
+  fs.readdir(dir, common.mustCall((err, list2) => {
+    if (err) throw err;
+    assert.deepStrictEqual(list, list2);
+  }));
+}));

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -25,12 +25,12 @@ assert.throws(
   function() {
     fs.link();
   },
-  /src path/
+  /src must be a string or Buffer/
 );
 
 assert.throws(
   function() {
     fs.link('abc');
   },
-  /dest path/
+  /dest must be a string or Buffer/
 );

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+
+if (process.platform !== 'linux') {
+  console.log('1..0 # Skipped: Test is linux specific.');
+  return;
+}
+
+common.refreshTmpDir();
+const filename = '\uD83D\uDC04';
+const root = Buffer.from(`${common.tmpDir}${path.sep}`);
+const filebuff = Buffer.from(filename, 'ucs2');
+const fullpath = Buffer.concat([root, filebuff]);
+
+fs.closeSync(fs.openSync(fullpath, 'w+'));
+
+fs.readdir(common.tmpDir, 'ucs2', (err, list) => {
+  if (err) throw err;
+  assert.equal(1, list.length);
+  const fn = list[0];
+  assert.deepStrictEqual(filebuff, Buffer.from(fn, 'ucs2'));
+  assert.strictEqual(fn, filename);
+});
+
+process.on('exit', () => {
+  fs.unlinkSync(fullpath);
+});

--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+if (common.isFreeBSD) {
+  console.log('1..0 # Skipped: Test currently not working on FreeBSD');
+  return;
+}
+
+const fn = '新建文夹件.txt';
+const a = path.join(common.tmpDir, fn);
+
+const watcher1 = fs.watch(
+  common.tmpDir,
+  {encoding: 'hex'},
+  (event, filename) => {
+    if (filename)
+      assert.equal(filename, 'e696b0e5bbbae69687e5a4b9e4bbb62e747874');
+    watcher1.close();
+  }
+);
+
+const watcher2 = fs.watch(
+  common.tmpDir,
+  (event, filename) => {
+    if (filename)
+      assert.equal(filename, fn);
+    watcher2.close();
+  }
+);
+
+const watcher3 = fs.watch(
+  common.tmpDir,
+  {encoding: 'buffer'},
+  (event, filename) => {
+    if (filename) {
+      assert(filename instanceof Buffer);
+      assert.equal(filename.toString('utf8'), fn);
+    }
+    watcher3.close();
+  }
+);
+
+const fd = fs.openSync(a, 'w+');
+fs.closeSync(fd);
+
+process.on('exit', () => {
+  fs.unlink(a);
+});

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -247,7 +247,7 @@ assert.deepEqual(children, {
 assert.throws(function() {
   console.error('require non-string');
   require({ foo: 'bar' });
-}, 'path must be a string');
+}, 'path must be a string or Buffer');
 
 assert.throws(function() {
   console.error('require empty string');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

fs (/cc @trevnorris @bnoordhuis )

### Description of change

*Updated*: Reworked the implementation based on @trevnorris feedback. This now does several things:

* Buffer accepted as Path on all fs methods that accept a Path
* {encoding: '...'} option accepted on fs.readdir, fs.readdirSync, fs.readlink, fs.readlinkSync, and fs.watch
* Documentation updates

Fixes: https://github.com/nodejs/node/issues/2088
Ref: https://github.com/nodejs/node/issues/3519
See Also: https://github.com/nodejs/node/pull/3401