### PR TITLE
test: skip cluster-disconnect-race on Windows

### DIFF
--- a/test/simple/test-cluster-disconnect-race.js
+++ b/test/simple/test-cluster-disconnect-race.js
@@ -9,6 +9,11 @@ var net = require('net');
 var cluster = require('cluster');
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
+if (process.platform === 'win32') {
+  console.log('1..0 # Skipped: This test does not apply to Windows.');
+  return;
+}
+
 if (cluster.isMaster) {
   var worker1, worker2;
 


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?


### Affected core subsystem(s)

test

### Description of change
See issue #5603 .   
Skips [simple/cluster-disconnect-race](https://github.com/nodejs/node/blob/v0.12-staging/test/simple/test-cluster-disconnect-race.js) on Windows. This was already done in #4457 for V4, but the fix is slightly different for v0.12.

@rvagg presumably `process.platform === 'win32'` covers 64bit as well as 32bit windows?