### PR TITLE
win,build: support Visual C++ Build Tools 2015

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -187,7 +187,9 @@ echo Project files generated.
 if defined nobuild goto sign
 
 @rem Build the sln with msbuild.
-msbuild node.sln /m /t:%target% /p:Configuration=%config% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
+set "msbplatform=Win32"
+if "%target_arch%"=="x64" set "msbplatform=x64"
+msbuild node.sln /m /t:%target% /p:Configuration=%config% /p:Platform=%msbplatform% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 if "%target%" == "Clean" goto exit
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

`win`, `build`

### Description of change

To build with [Microsoft Visual C++ Build Tools 2015 Technical Preview Update 2 RC](https://www.visualstudio.com/downloads/update2-prereleases), `msbuild` should be invoked with a parameter specifying the platform (`/p:Platform=`). This is necessary because `vcvarsall.bat` sets a default platform that is not present in the solution generated by Gyp, failing the build.

CI machines run a previous version of VCBT, with a version of `vcvarsall.bat` modified to be able to build node. With the updated version in Update 2, only this change is needed to build with unmodified VCBT.

This is a trivial cherry-pick for `v4-staging`, `v0.12-staging` and `v0.10-staging`.

cc @nodejs/platform-windows 