### PR TITLE
doc: update release tweet template

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -266,7 +266,7 @@ Create a new blog post by running the [nodejs.org release-post.js script](https:
 
 The nodejs.org website will automatically rebuild and include the new version. You simply need to announce the build, preferably via Twitter with a message such as:
 
-> v5.3.0 of @nodejs is out @ https://nodejs.org/dist/latest/ changelog @ https://github.com/nodejs/node/blob/master/CHANGELOG.md#2015-12-16-version-530-stable-cjihrig … something here about notable changes
+> v5.8.0 of @nodejs is out: https://nodejs.org/en/blog/release/v5.8.0/ … something here about notable changes
 
 ### 16. Cleanup
 


### PR DESCRIPTION
### Pull Request check-list

- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]

### Affected core subsystem(s)

doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Now that we have such great release blog tooling, it is more user-friendly to link to the blogs rather than the raw sources, and gives more room for info in the tweet.

cc @nodejs/release 

