### PR TITLE
console: check that stderr is writable

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -48,8 +48,8 @@ myConsole.warn(`Danger ${name}! Danger!`);
 ```
 
 While the API for the `Console` class is designed fundamentally around the
-Web browser `console` object, the `Console` in Node.js is *not* intended to
-duplicate the browsers functionality exactly.
+browser `console` object, the `Console` in Node.js is *not* intended to
+duplicate the browser's functionality exactly.
 
 ## Asynchronous vs Synchronous Consoles
 
@@ -75,8 +75,8 @@ const Console = console.Console;
 
 Creates a new `Console` by passing one or two writable stream instances.
 `stdout` is a writable stream to print log or info output. `stderr`
-is used for warning or error output. If `stderr` isn't passed, the warning
-and error output will be sent to the `stdout`.
+is used for warning or error output. If `stderr` isn't passed, warning and error
+output will be sent to `stdout`.
 
 ```js
 const output = fs.createWriteStream('./stdout.log');

--- a/lib/console.js
+++ b/lib/console.js
@@ -11,7 +11,10 @@ function Console(stdout, stderr) {
   }
   if (!stderr) {
     stderr = stdout;
+  } else if (typeof stderr.write !== 'function') {
+    throw new TypeError('Console expects writable stream instances');
   }
+
   var prop = {
     writable: true,
     enumerable: false,

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -1,9 +1,12 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var Stream = require('stream');
-var Console = require('console').Console;
+const assert = require('assert');
+const Stream = require('stream');
+const Console = require('console').Console;
 var called = false;
+
+const out = new Stream();
+const err = new Stream();
 
 // ensure the Console instance doesn't write to the
 // process' "stdout" or "stderr" streams
@@ -20,9 +23,13 @@ assert.throws(function() {
   new Console();
 }, /Console expects a writable stream/);
 
-var out = new Stream();
-var err = new Stream();
-out.writable = err.writable = true;
+// Console constructor should throw if stderr exists but is not writable
+assert.throws(function() {
+  out.write = function() {};
+  err.write = undefined;
+  new Console(out, err);
+}, /Console expects writable stream instances/);
+
 out.write = err.write = function(d) {};
 
 var c = new Console(out, err);


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

`console`

### Description of change

`Console` constructor checks that `stdout.write()` is a function but 
does not do an equivalent check for `stderr.write()`. If `stderr` is not 
specified in the constructor, then `stderr` is set to be `stdout`. 
However, if `stderr` is specified, but `stderr.write()` is not a 
function, then an exception is not thrown until `console.error()` is 
called.

This change mirrors the check already there for `stdout` for `stderr`.
If `stderr` fails the check, then a `TypeError` is thrown.

Quite possibly `semver-major` on the grounds that code out there could
be dependent on the current behavior.

Took the opportunity to copyedit the `console` doc a little too.