### PR TITLE
src: allow combination of -i and -e cli flags

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -98,8 +98,9 @@
         delete process.env.NODE_UNIQUE_ID;
       }
 
-      if (process._eval != null) {
-        // User passed '-e' or '--eval' arguments to Node.
+      if (process._eval != null && !process._forceRepl) {
+        // User passed '-e' or '--eval' arguments to Node without '-i' or
+        // '--interactive'
         startup.preloadModules();
         evalScript('[eval]');
       } else if (process.argv[1]) {
@@ -171,6 +172,11 @@
               process.exit();
             });
           });
+
+          if (process._eval != null) {
+            // User passed '-e' or '--eval'
+            evalScript('[eval]');
+          }
         } else {
           // Read all of stdin - execute it.
           process.stdin.setEncoding('utf8');

--- a/test/sequential/test-force-repl-with-eval.js
+++ b/test/sequential/test-force-repl-with-eval.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+// spawn a node child process in "interactive" mode (force the repl) and eval
+const cp = spawn(process.execPath, ['-i', '-e', 'console.log("42")']);
+var gotToEnd = false;
+const timeoutId = setTimeout(function() {
+  throw new Error('timeout!');
+}, common.platformTimeout(1000)); // give node + the repl 1 second to boot up
+
+cp.stdout.setEncoding('utf8');
+
+var output = '';
+cp.stdout.on('data', function(b) {
+  output += b;
+  if (output === '> 42\n') {
+    clearTimeout(timeoutId);
+    gotToEnd = true;
+    cp.kill();
+  }
+});
+
+process.on('exit', function() {
+  assert(gotToEnd);
+});


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

repl

### Description of change

If both -i and -e flags are specified, do not ignore the -i. Instead,
launch the interactive REPL and start by evaluating the passed string.

Fixes: https://github.com/nodejs/node/issues/1197