### PR TITLE
collaborator_guide: clarify commit message rules

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -93,13 +93,16 @@ information regarding the change process:
 
 - A `Reviewed-By: Name <email>` line for yourself and any
   other Collaborators who have reviewed the change.
-- A `PR-URL:` line that references the full GitHub URL of the original
+- A `PR-URL:` line that references the *full* GitHub URL of the original
   pull request being merged so it's easy to trace a commit back to the
   conversation that led up to that change.
-- A `Fixes: X` line, where _X_ is either includes the full GitHub URL
+- A `Fixes: X` line, where _X_ is either includes the *full* GitHub URL
   for an issue, and/or the hash and commit message if the commit fixes
   a bug in a previous commit. Multiple `Fixes:` lines may be added if
   appropriate.
+
+Review the commit message to ensure that it adheres to the guidelines
+outlined in the [contributing](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit) guide.
 
 See the commit log for examples such as
 [this one](https://github.com/nodejs/node/commit/b636ba8186) if unsure

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -96,7 +96,7 @@ information regarding the change process:
 - A `PR-URL:` line that references the *full* GitHub URL of the original
   pull request being merged so it's easy to trace a commit back to the
   conversation that led up to that change.
-- A `Fixes: X` line, where _X_ is either includes the *full* GitHub URL
+- A `Fixes: X` line, where _X_ either includes the *full* GitHub URL
   for an issue, and/or the hash and commit message if the commit fixes
   a bug in a previous commit. Multiple `Fixes:` lines may be added if
   appropriate.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

None, just the contributing_guide

### Description of change

Italicize the full URL being required in metadata.  I have added commits to core that lacked the full URL, as have others in the past.  I want to make it more obvious for future contributors.