### PR TITLE
path: refactor path.format() repeated code

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -140,6 +140,18 @@ function normalizeStringPosix(path, allowAboveRoot) {
   return res;
 }
 
+function _format(sep, pathObject) {
+  const dir = pathObject.dir || pathObject.root;
+  const base = pathObject.base ||
+    ((pathObject.name || '') + (pathObject.ext || ''));
+  if (!dir) {
+    return base;
+  }
+  if (dir === pathObject.root) {
+    return dir + base;
+  }
+  return dir + sep + base;
+}
 
 const win32 = {
   // path.resolve([from ...], to)
@@ -970,20 +982,10 @@ const win32 = {
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
       throw new TypeError(
-          'Parameter "pathObject" must be an object, not ' + typeof pathObject
+        `Parameter "pathObject" must be an object, not ${typeof pathObject}`
       );
     }
-
-    var dir = pathObject.dir || pathObject.root;
-    var base = pathObject.base ||
-      ((pathObject.name || '') + (pathObject.ext || ''));
-    if (!dir) {
-      return base;
-    }
-    if (dir === pathObject.root) {
-      return dir + base;
-    }
-    return dir + win32.sep + base;
+    return _format('\\', pathObject);
   },
 
 
@@ -1525,20 +1527,10 @@ const posix = {
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
       throw new TypeError(
-          'Parameter "pathObject" must be an object, not ' + typeof pathObject
+        `Parameter "pathObject" must be an object, not ${typeof pathObject}`
       );
     }
-
-    var dir = pathObject.dir || pathObject.root;
-    var base = pathObject.base ||
-               ((pathObject.name || '') + (pathObject.ext || ''));
-    if (!dir) {
-      return base;
-    }
-    if (dir === pathObject.root) {
-      return dir + base;
-    }
-    return dir + posix.sep + base;
+    return _format('/', pathObject);
   },
 
 


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

path

### Description of change

Refactor repeated code into a separate function.
