### PR TITLE
Doc: remove non-standard use of hyphens in doc/api/tls.markdown

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -56,10 +56,10 @@ openssl pkcs12 -export -in agent5-cert.pem -inkey agent5-key.pem \
 
 ALPN (Application-Layer Protocol Negotiation Extension), NPN (Next
 Protocol Negotiation) and SNI (Server Name Indication) are TLS
-handshake extensions allowing you:
+handshake extensions:
 
-  * ALPN/NPN - to use one TLS server for multiple protocols (HTTP, SPDY, HTTP/2)
-  * SNI - to use one TLS server for multiple hostnames with different SSL
+  * ALPN/NPN - Allows the use of one TLS server for multiple protocols (HTTP, SPDY, HTTP/2)
+  * SNI - Allows the use of one TLS server for multiple hostnames with different SSL
     certificates.
 
 ## Client-initiated renegotiation attack mitigation
@@ -187,8 +187,8 @@ connections using TLS or SSL.
 
 `function (exception, tlsSocket) { }`
 
-When a client connection emits an `'error'` event before secure connection is
-established - it will be forwarded here.
+When a client connection emits an `'error'` event before a secure connection is
+established it will be forwarded here.
 
 `tlsSocket` is the [`tls.TLSSocket`][] that the error originated from.
 
@@ -370,7 +370,7 @@ Construct a new TLSSocket object from existing TCP socket.
   - `secureContext`: An optional TLS context object from
      [`tls.createSecureContext()`][]
 
-  - `isServer`: If `true` - TLS socket will be instantiated in server-mode.
+  - `isServer`: If `true` the TLS socket will be instantiated in server-mode.
     Default: `false`
 
   - `server`: An optional [`net.Server`][] instance
@@ -387,9 +387,9 @@ Construct a new TLSSocket object from existing TCP socket.
 
   - `session`: Optional, a `Buffer` instance, containing TLS session
 
-  - `requestOCSP`: Optional, if `true` - OCSP status request extension would
-    be added to client hello, and `'OCSPResponse'` event will be emitted on socket
-    before establishing secure communication
+  - `requestOCSP`: Optional, if `true` the OCSP status request extension will
+    be added to the client hello, and an `'OCSPResponse'` event will be emitted 
+    on the socket before establishing a secure communication
 
 ### Event: 'OCSPResponse'
 
@@ -408,7 +408,7 @@ The listener will be called no matter if the server's certificate was
 authorized or not. It is up to the user to test `tlsSocket.authorized`
 to see if the server certificate was signed by one of the specified CAs.
 If `tlsSocket.authorized === false` then the error can be found in
-`tlsSocket.authorizationError`. Also if ALPN or NPN was used - you can
+`tlsSocket.authorizationError`. Also, if ALPN or NPN was used you can
 check `tlsSocket.alpnProtocol` or `tlsSocket.npnProtocol` for the
 negotiated protocol.
 
@@ -463,8 +463,8 @@ Example:
 
 Returns an object representing the peer's certificate. The returned object has
 some properties corresponding to the field of the certificate. If `detailed`
-argument is `true` - the full chain with `issuer` property will be returned,
-if `false` - only the top certificate without `issuer` property.
+argument is `true` the full chain with `issuer` property will be returned,
+if `false` only the top certificate without `issuer` property.
 
 Example:
 
@@ -876,7 +876,7 @@ automatically set as a listener for the [`'secureConnection'`][] event.  The
     and `cb`. `SNICallback` should invoke `cb(null, ctx)`, where `ctx` is a
     SecureContext instance.
     (You can use `tls.createSecureContext(...)` to get proper
-    SecureContext). If `SNICallback` wasn't provided - default callback with
+    SecureContext). If `SNICallback` wasn't provided the default callback with
     high-level API will be used (see below).
 
   - `sessionTimeout`: An integer specifying the seconds after which TLS


### PR DESCRIPTION
## Affected core subsystem(s)
Doc, TLS

## Description of change

Fixes #5672. Removes the non-idiomatic usages of the '-' character. ~~I also tidied up some of the phrasing, grammar, typos and punctuation throughout the whole file. If I should have done this in a separate PR, I'm happy to pull them out and leave only the hyphen changes.~~

Also, there seems to be an inconsistent use of 'can', 'could' and 'may' throughout the document but I decided against changing that as I don't really know what the house style is.