### PR TITLE
module: prioritize current directory for local lookup

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -250,8 +250,7 @@ Module._resolveLookupPaths = function(request, parent) {
   if (!parent || !parent.id || !parent.filename) {
     // make require('./path/to/foo') work - normally the path is taken
     // from realpath(__filename) but with eval there is no filename
-    var mainPaths = ['.'].concat(modulePaths);
-    mainPaths = Module._nodeModulePaths('.').concat(mainPaths);
+    var mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
     return [request, mainPaths];
   }
 

--- a/test/fixtures/baz.js
+++ b/test/fixtures/baz.js
@@ -1,0 +1,1 @@
+module.exports = 'perhaps I work';

--- a/test/parallel/test-module-relative-lookup.js
+++ b/test/parallel/test-module-relative-lookup.js
@@ -1,0 +1,10 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const _module = require('module'); // avoid collision with global.module
+const lookupResults = _module._resolveLookupPaths('./lodash');
+const paths = lookupResults[1];
+
+assert.strictEqual(paths[0], '.',
+  'Current directory is prioritized before node_modules for local modules');

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -23,11 +23,11 @@ server.listen(options, function() {
   const conn = net.connect(options);
   conn.setEncoding('utf8');
   conn.on('data', (data) => answer += data);
-  conn.write('require("baz")\n.exit\n');
+  conn.write('require("baz")\nrequire("./baz")\n.exit\n');
 });
 
 process.on('exit', function() {
   assert.strictEqual(false, /Cannot find module/.test(answer));
   assert.strictEqual(false, /Error/.test(answer));
-  assert.strictEqual(true, /eye catcher/.test(answer));
+  assert.strictEqual(answer, '\'eye catcher\'\n\'perhaps I work\'\n');
 });


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

module, test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This fixes an issue reported in #5684 about module in `node_modules` being preferred over a local file with the same name, when resolved in repl (or --eval mode). The bug originates from the fact that `Module._resolveLookupPaths()` puts node_modules *before* the current directory when run from repl or --eval.

Previous results from `Module._resolveLookupPaths('./lodash')`:
```js
[ './lodash',
  [ '/Users/phillipj/Dev/repl-lookup-test/node_modules',
    '/Users/phillipj/Dev/node_modules',
    '/Users/phillipj/node_modules',
    '/Users/node_modules',
    '/node_modules',
    '.',
    '/Users/phillipj/.node_modules',
    '/Users/phillipj/.node_libraries',
    '/Users/phillipj/Dev/node/out/lib/node' ] ]
```

Fixed results from `Module._resolveLookupPaths('./lodash')`:
```js
[ './lodash',
  [ '.',
    '/Users/phillipj/Dev/repl-lookup-test/node_modules',
    '/Users/phillipj/Dev/node_modules',
    '/Users/phillipj/node_modules',
    '/Users/node_modules',
    '/node_modules',
    '/Users/phillipj/.node_modules',
    '/Users/phillipj/.node_libraries',
    '/Users/phillipj/Dev/node/out/lib/node' ] ]
```
