### PR TITLE
module: the node_modules paths always should be placed below the current directory

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -203,6 +203,7 @@ Module._nodeModulePaths = function(from) {
   // guarantee that 'from' is absolute.
   from = path.resolve(from);
 
+
   // note: this approach *only* works when the path is guaranteed
   // to be absolute.  Doing a fully-edge-case-correct path.split
   // that works on both Windows and Posix is non-trivial.
@@ -216,7 +217,7 @@ Module._nodeModulePaths = function(from) {
     paths.push(dir);
   }
 
-  return paths;
+  return [from].concat(paths);
 };
 
 
@@ -250,7 +251,7 @@ Module._resolveLookupPaths = function(request, parent) {
   if (!parent || !parent.id || !parent.filename) {
     // make require('./path/to/foo') work - normally the path is taken
     // from realpath(__filename) but with eval there is no filename
-    var mainPaths = ['.'].concat(modulePaths);
+    var mainPaths = modulePaths;
     mainPaths = Module._nodeModulePaths('.').concat(mainPaths);
     return [request, mainPaths];
   }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

repl

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change
Fix #5684. The result of the `require("module")._resolveLookupPaths('./')` in repl

Before:
```
[ './',
  [ '/Users/watilde/Development/tmp/repro/node_modules',
    '/Users/watilde/Development/tmp/node_modules',
    '/Users/watilde/Development/node_modules',
    '/Users/watilde/node_modules',
    '/Users/node_modules',
    '/node_modules',
    '.',
    '/Users/watilde/.node_modules',
    '/Users/watilde/.node_libraries',
    '/Users/watilde/.nodebrew/node/v5.4.0/lib/node' ] ]
```

After:
```
[ './',
  [ '/Users/watilde/Development/tmp/repro',
    '/Users/watilde/Development/tmp/repro/node_modules',
    '/Users/watilde/Development/tmp/node_modules',
    '/Users/watilde/Development/node_modules',
    '/Users/watilde/node_modules',
    '/Users/node_modules',
    '/node_modules',
    '/Users/watilde/.node_modules',
    '/Users/watilde/.node_libraries',
    '/Users/watilde/Development/node/out/lib/node' ] ]
```

will update test/parallel/test-repl.js