### PR TITLE
Reduce tarball size, v2

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -261,8 +261,14 @@ goto jslint
 
 :jslint
 if not defined jslint goto exit
+if not exist tools\eslint\bin\eslint.js goto no-lint
 echo running jslint
 %config%\node tools\eslint\bin\eslint.js benchmark lib src test tools\doc tools\eslint-rules --rulesdir tools\eslint-rules
+goto exit
+
+:no-lint
+echo Linting is not available through the source tarball.
+echo Use the git repo instead: $ git clone https://github.com/nodejs/node.git
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to CONTRIBUTING.md?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

build, deps, tools

### Description of change

Reduce the nodejs tarball size with another ~10% (it's grown pretty fast over the last year). The distinction we're making here is that developers should opt for git instead of tarballs, but the test suite should still be able to run (therefore verifying the generated binary). This means that stuff like linters or  test suites in `deps/` should go.