### PR TITLE
repl: Default `useGlobal` to false in CLI REPL.

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -22,8 +22,8 @@ function createRepl(env, opts, cb) {
   opts = opts || {
     ignoreUndefined: false,
     terminal: process.stdout.isTTY,
-    useGlobal: true,
-    breakEvalOnSigint: true
+    breakEvalOnSigint: true,
+    useGlobal: false
   };
 
   if (parseInt(env.NODE_NO_READLINE)) {

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -22,8 +22,8 @@ function createRepl(env, opts, cb) {
   opts = opts || {
     ignoreUndefined: false,
     terminal: process.stdout.isTTY,
-    breakEvalOnSigint: true,
-    useGlobal: false
+    useGlobal: false,
+    breakEvalOnSigint: true
   };
 
   if (parseInt(env.NODE_NO_READLINE)) {

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -48,19 +48,9 @@ const processTestCases = [false, undefined];
 const processTest = (useGlobal, cb) => (err, repl) => {
   if (err)
     return cb(err);
-  try {
-    // if useGlobal is false, then `let process` should work
-    repl.write('let process;\n');
-    assert.ok(!useGlobal);
-  } catch (e) {
-    // If useGlobal is true, then 'let process' will cause
-    // a TypeError to be thrown. Testing this is problematic
-    // however, because even though we end up in this catch
-    // clause, the test framework sees the exception and reports
-    // a failure.
-    assert.ok(useGlobal);
-    assert.equals(e.name, 'TypeError');
-  }
+  // if useGlobal is false, then `let process` should work
+  repl.write('let process;\n');
+  assert.ok(!useGlobal);
   repl.close();
   cb(null, 'OK');
 };

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Flags: --expose-internals
+
+const common = require('../common');
+const stream = require('stream');
+const REPL = require('internal/repl');
+const assert = require('assert');
+
+common.globalCheck = false;
+
+test();
+
+function test() {
+
+  runRepl(false, (err, output) => {
+    assert.ifError(err);
+    assert.strictEqual(output, 'undefined');
+
+    runRepl(true, (err, output) => {
+      assert.ifError(err);
+      assert.strictEqual(output, '\'tacos\'');
+    });
+  });
+}
+
+function runRepl(useGlobal, cb) {
+  const inputStream = new stream.PassThrough();
+  const outputStream = new stream.PassThrough();
+
+  const opts = {
+    input: inputStream,
+    output: outputStream,
+    useColors: false,
+    terminal: false,
+    prompt: ''
+  };
+
+  // Don't blindly set useGlobal, because we want to test
+  // the default case as well, where useGlobal is not provided.
+  if (useGlobal)
+    opts.useGlobal = true;
+
+  let output = '';
+
+  outputStream.on('data', (data) => {
+    output += data;
+  });
+
+  REPL.createInternalRepl(process.env, opts, function(err, repl) {
+
+    if (err)
+      return cb(err);
+
+    global.lunch = 'tacos';
+    repl.write('global.lunch;\n');
+    repl.close();
+    delete global.lunch;
+    cb(null, output.trim());
+  });
+}

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -4,25 +4,25 @@
 
 const common = require('../common');
 const stream = require('stream');
-const REPL = require('internal/repl');
+const repl = require('internal/repl');
 const assert = require('assert');
 
 common.globalCheck = false;
 
-test();
+runRepl(false, common.mustCall(function(err, output) {
+  assert.ifError(err);
+  assert.strictEqual(output, 'undefined');
 
-function test() {
-
-  runRepl(false, (err, output) => {
+  runRepl(true, common.mustCall(function(err, output) {
     assert.ifError(err);
-    assert.strictEqual(output, 'undefined');
+    assert.strictEqual(output, '\'tacos\'');
 
-    runRepl(true, (err, output) => {
+    runRepl(undefined, common.mustCall(function(err, output) {
       assert.ifError(err);
-      assert.strictEqual(output, '\'tacos\'');
-    });
-  });
-}
+      assert.strictEqual(output, 'undefined');
+    }));
+  }));
+}));
 
 function runRepl(useGlobal, cb) {
   const inputStream = new stream.PassThrough();
@@ -31,15 +31,11 @@ function runRepl(useGlobal, cb) {
   const opts = {
     input: inputStream,
     output: outputStream,
+    useGlobal: useGlobal,
     useColors: false,
     terminal: false,
     prompt: ''
   };
-
-  // Don't blindly set useGlobal, because we want to test
-  // the default case as well, where useGlobal is not provided.
-  if (useGlobal)
-    opts.useGlobal = true;
 
   let output = '';
 
@@ -47,8 +43,7 @@ function runRepl(useGlobal, cb) {
     output += data;
   });
 
-  REPL.createInternalRepl(process.env, opts, function(err, repl) {
-
+  repl.createInternalRepl(process.env, opts, function(err, repl) {
     if (err)
       return cb(err);
 

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -55,7 +55,6 @@ const processTest = (useGlobal, cb, output) => (err, repl) => {
   // if useGlobal is false, then `let process` should work
   repl.write('let process;\n');
   repl.write('21 * 2;\n');
-  assert.ok(!useGlobal);
   repl.close();
   cb(null, str.trim());
 };


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

repl

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This addresses https://github.com/nodejs/node/issues/5659. The
documentation for REPL states that the default value of `useGlobal` is
`false`. It makes no distinction between a REPL that is created
programmatically, and the one a user is dropped into on the command line
by executing `node` with no arguments. This change ensures that the CLI
REPL uses a default value of `false`.