### PR TITLE
src: try to open `man 1 node` on Unix for --help

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -43,6 +43,9 @@
     _process.setupKillAndExit();
     _process.setupSignalHandlers();
 
+    const manual = NativeModule._source.manual;
+    delete NativeModule._source.manual;
+
     // Do not initialize channel in debugger agent, it deletes env variable
     // and the main thread won't see it.
     if (process.argv[1] !== '--debug-agent')
@@ -64,6 +67,31 @@
       process.nextTick(function() {
         NativeModule.require('_third_party_main');
       });
+
+    } else if (process.openManPage) {
+      // Attempt to spawn `man 1 node`.
+      const cp = NativeModule.require('child_process');
+      const fs = NativeModule.require('fs');
+      const os = NativeModule.require('os');
+      const path = NativeModule.require('path');
+
+      const manualPath = path.join(os.tmpdir(), 'node.1');
+
+      try {
+        // Write out the bundled manual page to a tmp file.
+        // (Not all versions of `man` can open pages from stdin.)
+        fs.writeFileSync(manualPath, manual);
+
+        const out = cp.spawnSync('man', [manualPath], { stdio: 'inherit' });
+        if (out.status === 0)
+          return process.exit(0);
+      } catch (er) {
+        console.error(`(${process.release.name}:${process.pid}) ${er.message}`);
+      } finally {
+        // Fall back to the C++ PrintHelp
+        process.printHelp();
+        process.exit(0);
+      }
 
     } else if (process.argv[1] == 'debug') {
       // Start the debugger agent

--- a/node.gyp
+++ b/node.gyp
@@ -102,6 +102,7 @@
       'deps/v8/tools/tickprocessor.js',
       'deps/v8/tools/SourceMap.js',
       'deps/v8/tools/tickprocessor-driver.js',
+      'doc/node.1',
     ],
     'conditions': [
       [ 'node_shared=="true"', {

--- a/test/parallel/test-help-option.js
+++ b/test/parallel/test-help-option.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+
+
+const help = cp.spawnSync(process.execPath, ['-h']);
+
+const manualPath = path.join(__dirname, '..', '..', 'doc', 'node.1');
+const man = cp.spawnSync('man', [manualPath]);
+
+if (man.status === 0) {
+  assert.strictEqual(help.stdout.toString(), man.stdout.toString());
+} else {
+  const raw = cp.spawnSync(process.execPath, ['--raw-help']);
+  assert.strictEqual(help.stdout.toString(), raw.stdout.toString());
+}

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -255,6 +255,9 @@ def JS2C(source, target):
     else:
       id = s
 
+    if id.endswith('node.1'):
+      id = id.replace('node.1', 'manual')
+
     if '.' in id:
       id = id.split('.', 1)[0]
 


### PR DESCRIPTION
### Pull Request check-list
- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit)?
### Affected core subsystem(s)

src,node
### Description of change

Make `node -h` attempt to open `man 1 node` on Unix.

I've seen this in some other programs, and quite frankly the man page is **way** better than the printed help, since man has syntax formatting and adapts to the terminal's width.

~~WIP, will fix everything up if people like it.~~ mostly done

cc @nodejs/ctc?
