### PR TITLE
doc: fix multiline return comments in querystring

### DIFF
--- a/doc/api/querystring.markdown
+++ b/doc/api/querystring.markdown
@@ -28,15 +28,13 @@ Example:
 
 ```js
 querystring.parse('foo=bar&baz=qux&baz=quux&corge')
-// returns
-{ foo: 'bar', baz: ['qux', 'quux'], corge: '' }
+// returns { foo: 'bar', baz: ['qux', 'quux'], corge: '' }
 
 // Suppose gbkDecodeURIComponent function already exists,
 // it can decode `gbk` encoding string
 querystring.parse('w=%D6%D0%CE%C4&foo=bar', null, null,
   { decodeURIComponent: gbkDecodeURIComponent })
-// returns
-{ w: '中文', foo: 'bar' }
+// returns { w: '中文', foo: 'bar' }
 ```
 
 ## querystring.stringify(obj[, sep][, eq][, options])
@@ -52,19 +50,16 @@ Example:
 
 ```js
 querystring.stringify({ foo: 'bar', baz: ['qux', 'quux'], corge: '' })
-// returns
-'foo=bar&baz=qux&baz=quux&corge='
+// returns 'foo=bar&baz=qux&baz=quux&corge='
 
 querystring.stringify({foo: 'bar', baz: 'qux'}, ';', ':')
-// returns
-'foo:bar;baz:qux'
+// returns 'foo:bar;baz:qux'
 
 // Suppose gbkEncodeURIComponent function already exists,
 // it can encode string with `gbk` encoding
 querystring.stringify({ w: '中文', foo: 'bar' }, null, null,
   { encodeURIComponent: gbkEncodeURIComponent })
-// returns
-'w=%D6%D0%CE%C4&foo=bar'
+// returns 'w=%D6%D0%CE%C4&foo=bar'
 ```
 
 ## querystring.unescape


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

_Please provide a description of the change here._

Changes the multiline return example commments in querystring
which have the example out-of-comment, into single comment
lines to remain consistent with other docs.

See #5670