### PR TITLE
zlib: do not emit event on *Sync() methods

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -454,7 +454,7 @@ Zlib.prototype.flush = function(kind, callback) {
 };
 
 Zlib.prototype.close = function(callback, options) {
-  options = options || {};
+  options = Object.assign({sync: false}, options);
 
   if (callback)
     process.nextTick(callback);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -453,7 +453,9 @@ Zlib.prototype.flush = function(kind, callback) {
   }
 };
 
-Zlib.prototype.close = function(callback) {
+Zlib.prototype.close = function(callback, options) {
+  options = options || {};
+
   if (callback)
     process.nextTick(callback);
 
@@ -464,7 +466,9 @@ Zlib.prototype.close = function(callback) {
 
   this._handle.close();
 
-  process.nextTick(emitCloseNT, this);
+  if (!options.sync) {
+    process.nextTick(emitCloseNT, this);
+  }
 };
 
 function emitCloseNT(self) {
@@ -535,12 +539,12 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
     }
 
     if (nread >= kMaxLength) {
-      this.close();
+      this.close(null, {sync: true});
       throw new RangeError(kRangeErrorMessage);
     }
 
     var buf = Buffer.concat(buffers, nread);
-    this.close();
+    this.close(null, {sync: true});
 
     return buf;
   }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -453,23 +453,22 @@ Zlib.prototype.flush = function(kind, callback) {
   }
 };
 
-Zlib.prototype.close = function(callback, options) {
-  options = Object.assign({sync: false}, options);
+Zlib.prototype.close = function(callback) {
+  _close(this, callback);
+  process.nextTick(emitCloseNT, this);
+};
 
+function _close(engine, callback) {
   if (callback)
     process.nextTick(callback);
 
-  if (this._closed)
+  if (engine._closed)
     return;
 
-  this._closed = true;
+  engine._closed = true;
 
-  this._handle.close();
-
-  if (!options.sync) {
-    process.nextTick(emitCloseNT, this);
-  }
-};
+  engine._handle.close();
+}
 
 function emitCloseNT(self) {
   self.emit('close');
@@ -539,12 +538,12 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
     }
 
     if (nread >= kMaxLength) {
-      this.close(null, {sync: true});
+      _close(this);
       throw new RangeError(kRangeErrorMessage);
     }
 
     var buf = Buffer.concat(buffers, nread);
-    this.close(null, {sync: true});
+    _close(this);
 
     return buf;
   }

--- a/test/parallel/test-zlib-sync-no-event.js
+++ b/test/parallel/test-zlib-sync-no-event.js
@@ -1,9 +1,21 @@
 'use strict';
 require('../common');
 const zlib = require('zlib');
+const assert = require('assert');
+
+const shouldNotBeCalled = () => { throw new Error('unexpected event'); };
+
+const message = 'Come on, Fhqwhgads.';
 
 const zipper = new zlib.Gzip();
-zipper.on('close', () => { throw new Error('unexpected `close` event'); });
+zipper.on('close', shouldNotBeCalled);
 
-const buffer = new Buffer('hello world');
-zipper._processChunk(buffer, zlib.Z_FINISH);
+const buffer = new Buffer(message);
+const zipped = zipper._processChunk(buffer, zlib.Z_FINISH);
+
+const unzipper = new zlib.Gunzip();
+unzipper.on('close', shouldNotBeCalled);
+
+const unzipped = unzipper._processChunk(zipped, zlib.Z_FINISH);
+assert.notEqual(zipped.toString(), message);
+assert.strictEqual(unzipped.toString(), message);

--- a/test/parallel/test-zlib-sync-no-event.js
+++ b/test/parallel/test-zlib-sync-no-event.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../common');
+const zlib = require('zlib');
+
+const zipper = new zlib.Gzip();
+zipper.on('close', () => { throw new Error('unexpected `close` event'); });
+
+const buffer = new Buffer('hello world');
+zipper._processChunk(buffer, zlib.Z_FINISH);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

zlib

### Description of change

WIP right now, still need to do it for more methods than just
gunzipSync().

Needs a test, too.

Refs: https://github.com/nodejs/node/issues/1668