### PR TITLE
zlib: remove internal-ish unused event

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -463,13 +463,7 @@ Zlib.prototype.close = function(callback) {
   this._closed = true;
 
   this._handle.close();
-
-  process.nextTick(emitCloseNT, this);
 };
-
-function emitCloseNT(self) {
-  self.emit('close');
-}
 
 Zlib.prototype._transform = function(chunk, encoding, cb) {
   var flushFlag;


### PR DESCRIPTION
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

zlib

### Description of change

WIP, probably less desirable than the other proposed fix, which also
might be undesirable, but letting people comment just in case.

Still needs a test.

Refs: https://github.com/nodejs/node/issues/1668