### PR TITLE
docs: Fix documentation and browser back button issue

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -16,7 +16,6 @@ body {
   color: #333;
   background: #fff;
   overflow: hidden;
-  height: 100%;
   display: block;
 }
 

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -4,8 +4,6 @@ html {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-variant-ligatures: none;
           font-variant-ligatures: none;
-  height: 100%;
-  overflow: hidden;
 }
 
 body {
@@ -15,7 +13,6 @@ body {
   padding: 0;
   color: #333;
   background: #fff;
-  overflow: hidden;
   display: block;
 }
 
@@ -25,10 +22,8 @@ pre, tt, code, .pre, span.type, a.type {
 
 #content {
   font-size: 1.8em;
-  overflow: hidden;
   display: block;
   position: relative;
-  height: 100%;
 }
 
 a, a:link, a:active {
@@ -372,15 +367,13 @@ a code {
   margin-left: 234px;
   padding: 0 2em;
   -webkit-padding-start: 1.5em;
-  height: 100%;
   position: relative;
-  overflow-y: scroll;
 }
 
 #column2.interior {
   width: 234px;
   background: #333;
-  position: absolute;
+  position: fixed;
   left: 0;
   top: 0;
   bottom: 0;


### PR DESCRIPTION
I couldn't find any other issue or discussion thread but I'm new to Node and therefore spending a lot of time with the docs. It's quite annoying that the browser back button is not working when one has jumped to an anchor within a page and then wanting to go back to the index with the browser back functionality. Removing the suggested line fixes the issue. I don't really know what it's good for, so if anyone could tell me and propose a different fix I'd be happy too.