### PR TITLE
querystring: avoid conflicts with Object.prototype and __proto__

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -4,6 +4,7 @@
 
 const QueryString = exports;
 const Buffer = require('buffer').Buffer;
+const defineProperty = Object.defineProperty;
 
 
 // a safe fast alternative to decodeURIComponent
@@ -267,20 +268,37 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
           key = decodeStr(key, decode);
         if (valEncoded)
           value = decodeStr(value, decode);
-        // Use a key array lookup instead of using hasOwnProperty(), which is
-        // slower
-        if (keys.indexOf(key) === -1) {
-          obj[key] = value;
-          keys[keys.length] = key;
+        // most common case is to define unique keys per query string
+        // using the `in` operator we speed up the assignment of unique values
+        // instead of performing an indexOf each time.
+        // On top of that, we are sure the property is not conflicting
+        // with those in Object.prototype so it's also safer.
+        // However, if the object had already a key, even as own property
+        // we need to check the indexOf instantly after.
+        if (key in obj) {
+          // Use a key array lookup instead of using hasOwnProperty(),
+          // which is slower
+          if (keys.indexOf(key) === -1) {
+            keys[keys.length] = key;
+            defineProperty(obj, key, {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: value
+            });
+          } else {
+            const curValue = obj[key];
+            // `instanceof Array` is used instead of Array.isArray() because it
+            // is ~15-20% faster with v8 4.7 and is safe to use because we are
+            // using it with values being created within this function
+            if (curValue instanceof Array)
+              curValue[curValue.length] = value;
+            else
+              obj[key] = [curValue, value];
+          }
         } else {
-          const curValue = obj[key];
-          // `instanceof Array` is used instead of Array.isArray() because it
-          // is ~15-20% faster with v8 4.7 and is safe to use because we are
-          // using it with values being created within this function
-          if (curValue instanceof Array)
-            curValue[curValue.length] = value;
-          else
-            obj[key] = [curValue, value];
+          keys[keys.length] = key;
+          obj[key] = value;
         }
         if (--pairs === 0)
           break;
@@ -370,20 +388,37 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
       key = decodeStr(key, decode);
     if (valEncoded)
       value = decodeStr(value, decode);
-    // Use a key array lookup instead of using hasOwnProperty(), which is
-    // slower
-    if (keys.indexOf(key) === -1) {
-      obj[key] = value;
-      keys[keys.length] = key;
+    // most common case is to define unique keys per query string
+    // using the `in` operator we speed up the assignment of unique values
+    // instead of performing an indexOf each time.
+    // On top of that, we are sure the property is not conflicting
+    // with those in Object.prototype so it's also safer.
+    // However, if the object had already a key, even as own property
+    // we need to check the indexOf instantly after.
+    if (key in obj) {
+      // Use a key array lookup instead of using hasOwnProperty(),
+      // which is slower
+      if (keys.indexOf(key) === -1) {
+        keys[keys.length] = key;
+        defineProperty(obj, key, {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: value
+        });
+      } else {
+        const curValue = obj[key];
+        // `instanceof Array` is used instead of Array.isArray() because it
+        // is ~15-20% faster with v8 4.7 and is safe to use because we are
+        // using it with values being created within this function
+        if (curValue instanceof Array)
+          curValue[curValue.length] = value;
+        else
+          obj[key] = [curValue, value];
+      }
     } else {
-      const curValue = obj[key];
-      // `instanceof Array` is used instead of Array.isArray() because it
-      // is ~15-20% faster with v8 4.7 and is safe to use because we are
-      // using it with values being created within this function
-      if (curValue instanceof Array)
-        curValue[curValue.length] = value;
-      else
-        obj[key] = [curValue, value];
+      keys[keys.length] = key;
+      obj[key] = value;
     }
   }
 

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -9,6 +9,9 @@ var qs = require('querystring');
 // {{{
 // [ wonkyQS, canonicalQS, obj ]
 var qsTestCases = [
+  ['__proto__=1',
+   '__proto__=1',
+   JSON.parse('{"__proto__":"1"}')],
   ['foo=918854443121279438895193',
    'foo=918854443121279438895193',
    {'foo': '918854443121279438895193'}],


### PR DESCRIPTION
Currently, the literal returned object is swallowing all
methods and properties inherited from the Object.prototype.
This includes the `__proto__` special case and this PR
aim is to fix all these inherited properties at once,
using the `in` operator before checking the array of
known keys.

This PR has been previously described and tested in #5650
and it has been made from scratch to avoid confusion.

The benchmark shows overall 4 out of 5 tests are 2% up to 22%
faster and one test, the worst case scenario with many pairs,
slower between 3% and 14% than before.