### PR TITLE
docs: Add note that process.send and child.send use JSON.stringify()

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -902,6 +902,8 @@ tracking when the socket is destroyed. To indicate this, the `.connections`
 property becomes `null`. It is recommended not to use `.maxConnections` when
 this occurs.
 
+*Note: this function uses [`JSON.stringify()`][] internally to serialize the `message`.*
+
 ### child.stderr
 
 * {Stream}
@@ -996,3 +998,4 @@ to the same value.
 [`options.stdio`]: #child_process_options_stdio
 [`stdio`]: #child_process_options_stdio
 [synchronous counterparts]: #child_process_synchronous_process_creation
+[`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -841,6 +841,8 @@ When Node.js is spawned with an IPC channel attached, it can send messages to it
 parent process using `process.send()`. Each will be received as a
 [`'message'`][] event on the parent's `ChildProcess` object.
 
+*Note: this function uses [`JSON.stringify()`][] internally to serialize the `message`.*
+
 If Node.js was not spawned with an IPC channel, `process.send()` will be undefined.
 
 ## process.setegid(id)
@@ -1096,3 +1098,4 @@ Will print something like:
 [Signal Events]: #process_signal_events
 [Stream compatibility]: stream.html#stream_compatibility_with_older_node_js_versions
 [the tty docs]: tty.html#tty_tty
+[`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [X] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [X] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit
docs
### Description of change

_Please provide a description of the change here._

Explicitly call out that the send method on both process and child uses JSON.stringify to serialize the message
Fixes #5453