### PR TITLE
stream: Support writing null to stream.Transform

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -162,7 +162,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 Transform.prototype._read = function(n) {
   var ts = this._transformState;
 
-  if (ts.writechunk !== null && ts.writecb && !ts.transforming) {
+  if (ts.writecb && !ts.transforming) {
     ts.transforming = true;
     this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
   } else {

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -302,6 +302,31 @@ test('can write strings as objects', function(t) {
   w.end();
 });
 
+test('can write falsey values', function(t) {
+  var w = new Writable({
+    objectMode: true
+  });
+  var list = [];
+
+  w._write = function(chunk, encoding, cb) {
+    list.push(chunk);
+    process.nextTick(cb);
+  };
+
+  w.on('finish', function() {
+    assert.deepEqual(list, [false, 0, '', null, undefined]);
+
+    t.end();
+  });
+
+  w.write(false);
+  w.write(0);
+  w.write('');
+  w.write(null);
+  w.write(undefined);
+  w.end();
+});
+
 test('buffers finish until cb is called', function(t) {
   var w = new Writable({
     objectMode: true

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -131,7 +131,7 @@ test('simple transform', function(t) {
 test('simple object transform', function(t) {
   var pt = new Transform({ objectMode: true });
   pt._transform = function(c, e, cb) {
-    pt.push(JSON.stringify(c));
+    pt.push(JSON.stringify(c) || 'undefined');
     cb();
   };
 
@@ -142,6 +142,8 @@ test('simple object transform', function(t) {
   pt.write('foo');
   pt.write('');
   pt.write({ a: 'b'});
+  pt.write(null);
+  pt.write(undefined);
   pt.end();
 
   t.equal(pt.read(), '1');
@@ -151,6 +153,8 @@ test('simple object transform', function(t) {
   t.equal(pt.read(), '"foo"');
   t.equal(pt.read(), '""');
   t.equal(pt.read(), '{"a":"b"}');
+  t.equal(pt.read(), 'null');
+  t.equal(pt.read(), 'undefined');
   t.end();
 });
 


### PR DESCRIPTION
Here's a proposed fix for #5711, which passes `null` to `._transform`, like other falsey values.

It updates the falsey value test for `Transform` to include `null` (and `undefined`, which was previously omitted) and adds a test for the falsey value behavior of `Writable` in `objectMode`, as requested in https://github.com/nodejs/node/issues/5711#issuecomment-197046130

Let me know what you think @mcollina and @calvinmetcalf (and anyone else interested, of course).

Fixes: #5711