### PR TITLE
net: stricter checking for internal/net isLegalPort

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -5,7 +5,8 @@ module.exports = { isLegalPort };
 // Check that the port number is not NaN when coerced to a number,
 // is an integer and that it falls within the legal range of port numbers.
 function isLegalPort(port) {
-  if (typeof port === 'string' && port.trim() === '')
+  if ((typeof port !== 'number' && typeof port !== 'string') ||
+      (typeof port === 'string' && port.trim().length === 0))
     return false;
-  return +port === (port >>> 0) && port >= 0 && port <= 0xFFFF;
+  return +port === (+port >>> 0) && port <= 0xFFFF;
 }

--- a/test/parallel/test-net-internal.js
+++ b/test/parallel/test-net-internal.js
@@ -4,12 +4,17 @@
 
 require('../common');
 const assert = require('assert');
-const net = require('internal/net');
+const isLegalPort = require('internal/net').isLegalPort;
 
-assert.strictEqual(net.isLegalPort(''), false);
-assert.strictEqual(net.isLegalPort('0'), true);
-assert.strictEqual(net.isLegalPort(0), true);
-assert.strictEqual(net.isLegalPort(65536), false);
-assert.strictEqual(net.isLegalPort('65535'), true);
-assert.strictEqual(net.isLegalPort(undefined), false);
-assert.strictEqual(net.isLegalPort(null), true);
+for (var n = 0; n <= 0xFFFF; n++) {
+  assert(isLegalPort(n));
+  assert(isLegalPort('' + n));
+  assert(`0x${n.toString(16)}`);
+  assert(`0o${n.toString(8)}`);
+  assert(`0b${n.toString(2)}`);
+}
+
+const bad = [-1, 'a', {}, [], false, true, 0xFFFF + 1, Infinity,
+             -Infinity, NaN, undefined, null, '', ' ', 1.1, '0x',
+             '-0x1', '-0o1', '-0b1', '0o', '0b'];
+bad.forEach((i) => assert(!isLegalPort(i)));


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

net

### Description of change

_Please provide a description of the change here._

Add stricter testing for the isLegalPort method in internal/net.
This ensures that odd inputs such as isLegalPort(true) and
isLegalPort([1]) aren't acceptable as valid port inputs.

Refs: https://github.com/nodejs/node/pull/5732