### PR TITLE
tools: allow separate component install w/ env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ $(TARBALL)-headers: config.gypi release-only
 		--tag=$(TAG) \
 		--release-urlbase=$(RELEASE_URLBASE) \
 		$(CONFIG_FLAGS) $(BUILD_RELEASE_FLAGS)
-	HEADERS_ONLY=1 $(PYTHON) tools/install.py install '$(TARNAME)' '/'
+	NODE_INSTALL_HEADERS_ONLY=1 $(PYTHON) tools/install.py install '$(TARNAME)' '/'
 	find $(TARNAME)/ -type l | xargs rm # annoying on windows
 	tar -cf $(TARNAME)-headers.tar $(TARNAME)
 	rm -rf $(TARNAME)

--- a/tools/install.py
+++ b/tools/install.py
@@ -37,6 +37,7 @@ def try_unlink(path):
 
 def try_symlink(source_path, link_path):
   print 'symlinking %s -> %s' % (source_path, link_path)
+  try_mkdir_r(os.path.dirname(link_path))
   try_unlink(link_path)
   os.symlink(source_path, link_path)
 
@@ -128,6 +129,18 @@ def subdir_files(path, dest, action):
     action(files, subdir + '/')
 
 def files(action):
+  if os.environ.get('NODE_INSTALL_HEADERS_ONLY'):
+    header_files(action)
+  elif os.environ.get('NODE_INSTALL_NODE_ONLY'):
+    node_files(action)
+  elif os.environ.get('NODE_INSTALL_NPM_ONLY'):
+    npm_files(action)
+  else:
+    node_files(action)
+    header_files(action)
+    if 'true' == variables.get('node_install_npm'): npm_files(action)
+
+def node_files(action):
   is_windows = sys.platform == 'win32'
 
   exeext = '.exe' if is_windows else ''
@@ -146,11 +159,7 @@ def files(action):
   else:
     action(['doc/node.1'], 'share/man/man1/')
 
-  if 'true' == variables.get('node_install_npm'): npm_files(action)
-
-  headers(action)
-
-def headers(action):
+def header_files(action):
   action([
     'common.gypi',
     'config.gypi',
@@ -205,12 +214,8 @@ def run(args):
 
   cmd = args[1] if len(args) > 1 else 'install'
 
-  if os.environ.get('HEADERS_ONLY'):
-    if cmd == 'install': return headers(install)
-    if cmd == 'uninstall': return headers(uninstall)
-  else:
-    if cmd == 'install': return files(install)
-    if cmd == 'uninstall': return files(uninstall)
+  if cmd == 'install': return files(install)
+  if cmd == 'uninstall': return files(uninstall)
 
   raise RuntimeError('Bad command: %s\n' % cmd)
 


### PR DESCRIPTION
Primary use cases are: headers tarball (previously using `HEADERS_ONLY`)
and OS X installer so it has npm files separate from core node + header
files. This is a component of #5656, a rework of the OS X installer, which now
has a working checkbox to optionally install npm.

* set `NODE_INSTALL_NODE_ONLY` for core node executable and associated
  extras (dtrace, systemtap, gdbinit, man page).
* set `NODE_INSTALL_HEADERS_ONLY` for header files as required for
  compiling native addons, previously `HEADERS_ONLY`, used for creating
  the headers tarball for distribution.
* set `NODE_INSTALL_NPM_ONLY` to install npm only, including executable
  symlink.

If none of these are set, install everything.

Options are mutually exclusive, run install.py multiple times to install
multiple components.

/cc @nodejs/build @fhemberger 

I'm also open to making this a semver-major change because of the change from `HEADERS_ONLY` to `NODE_INSTALL_HEADERS_ONLY` although I don't imagine anyone's actually using that in the wild (it's new and also pretty obscure for use outside of the Makefile).