### PR TITLE
tools: add buffer-constructor eslint rule

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,5 +1,4 @@
 rules:
   # Custom rules in tools/eslint-rules
-  require-buffer: 2
   buffer-constructor: 2
 

--- a/tools/eslint-rules/buffer-constructor.js
+++ b/tools/eslint-rules/buffer-constructor.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Require use of new Buffer constructor methods in lib
+ * @author James M Snell
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+const msg = 'Use of the Buffer() constructor has been deprecated. ' +
+            'Please use either Buffer.alloc(), Buffer.allocUnsafe(), ' +
+            'or Buffer.from()';
+
+function test(context, node) {
+  if (node.callee.name === 'Buffer') {
+    context.report(node, msg);
+  }
+}
+
+module.exports = function(context) {
+  return {
+    'NewExpression': (node) => test(context, node),
+    'CallExpression': (node) => test(context, node)
+  };
+};


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

tools (eslint)

### Description of change

Now that the Buffer.alloc, allocUnsafe, and from methods have landed,
add a linting rule that requires their use within lib. Tests and
benchmarks are explicitly excluded by the rule.

Requires: https://github.com/nodejs/node/pull/4682

/cc @Trott @ChALkeR @nodejs/testing