### PR TITLE
etw: fix descriptors of events 9 and 23

### DIFF
--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -244,7 +244,7 @@ void NODE_V8SYMBOL_ADD(LPCSTR symbol,
                                   line,
                                   col,
                                   symbuf,
-                                  symbol_len * sizeof(symbuf[0]));
+                                  (symbol_len + 1) * sizeof(symbuf[0]));
     ETW_WRITE_EVENT(MethodLoad, descriptors);
   }
 }

--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -94,6 +94,13 @@ extern int events_enabled;
                              dataDescriptors);                                \
   CHECK_EQ(status, ERROR_SUCCESS);
 
+#define ETW_WRITE_EMPTY_EVENT(eventDescriptor)                                \
+  DWORD status = event_write(node_provider,                                   \
+                             &eventDescriptor,                                \
+                             0,                                               \
+                             NULL);                                           \
+  CHECK_EQ(status, ERROR_SUCCESS);
+
 
 void NODE_HTTP_SERVER_REQUEST(node_dtrace_http_server_request_t* req,
     node_dtrace_connection_t* conn, const char *remote, int port,
@@ -189,10 +196,7 @@ void NODE_V8SYMBOL_MOVE(const void* addr1, const void* addr2) {
 
 void NODE_V8SYMBOL_RESET() {
   if (events_enabled > 0) {
-    int val = 0;
-    EVENT_DATA_DESCRIPTOR descriptors[1];
-    ETW_WRITE_INT32_DATA(descriptors, &val);
-    ETW_WRITE_EVENT(NODE_V8SYMBOL_RESET_EVENT, descriptors);
+    ETW_WRITE_EMPTY_EVENT(NODE_V8SYMBOL_RESET_EVENT);
   }
 }
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

ETW

### Description of change

A log of ETW events can be produced with:

```
logman start NodejsDCS -p NodeJS-ETW-provider -o node_log.etl -ets
:: Do something with node.exe
logman stop NodejsDCS -ets
```

The resulting `etl` file can be open in Event Viewer. However, ETW events 9 and 23 fail to display the `EventData` (under the _Details_ tab), having instead a `ProcessingErrorData` section with the data in raw hexadecimal. This happens because the events are not generated correctly.

- Event 9: The last event descriptor is a string, but the string is published without the zero terminator. This seems to have been a mistake introduced when reviewing the [original pull request](https://github.com/nodejs/node-v0.x-archive/pull/4219), because [the original code seems to include the terminator](https://github.com/nodejs/node-v0.x-archive/pull/4219/files/4e3ed92f7dc2384e22d5dd07034ac43eb45610c6#diff-b3465f24c6d7c62d7cd8f677deadb179R57).

- Event 23: The event [has no descriptors in the manifest](https://github.com/nodejs/node/blob/f9e6191f8582e0ec6f1ff64da454988423e0cb89/src/res/node_etw_provider.man#L145-L148) (no `template` attribute), but is generated from node with a dummy integer descriptor, always equal to 0.

There are two commits for easy review, I plan to squash and use the following commit message:

```
etw: fix descriptors of events 9 and 23

Event 9 must include the string terminator in the last descriptor.
Event 23 must be published with no descriptors, in accordance with
the manifest.
```

cc @nodejs/platform-windows 
