### PR TITLE
buffer: backport --zero-fill-buffers command line option

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -53,6 +53,23 @@ While more efficient, it introduces subtle incompatibilities with the typed
 arrays specification.  `ArrayBuffer#slice()` makes a copy of the slice while
 `Buffer#slice()` creates a view.
 
+## The `--zero-fill-buffers` command line option
+
+Node.js can be started using the `--zero-fill-buffers` command line option to
+force all newly allocated `Buffer` and `SlowBuffer` instances created using
+either `new Buffer(size)` and `new SlowBuffer(size)` to be *automatically 
+zero-filled* upon creation. Use of this flag *changes the default behavior* of 
+these methods and *can have a significant impact* on performance. Use of the 
+`--zero-fill-buffers` option is recommended only when absolutely necessary to 
+enforce that newly allocated `Buffer` instances cannot contain potentially 
+sensitive data.
+
+```
+$ node --zero-fill-buffers
+> Buffer(5);
+<Buffer 00 00 00 00 00>
+```
+
 ## Class: Buffer
 
 The Buffer class is a global type for dealing with binary data directly.

--- a/doc/node.1
+++ b/doc/node.1
@@ -58,6 +58,9 @@ and servers.
 
   --throw-deprecation    throw errors on deprecations
 
+  --zero-fill-buffers    Automatically zero-fills all newly allocated Buffer 
+                         and SlowBuffer instances.
+
   --v8-options           print v8 command line options
 
   --max-stack-size=val   set max v8 stack size (bytes)

--- a/src/node.cc
+++ b/src/node.cc
@@ -186,6 +186,8 @@ void* ArrayBufferAllocator::Allocate(size_t length) {
 
 
 void* ArrayBufferAllocator::AllocateUninitialized(size_t length) {
+  if (zero_fill_all_buffers)
+    return ArrayBufferAllocator::Allocate(length);
   if (length > kMaxLength)
     return NULL;
   return new char[length];
@@ -3003,6 +3005,8 @@ static void PrintHelp() {
          "function is used\n"
          "  --trace-deprecation  show stack traces on deprecations\n"
          "  --v8-options         print v8 command line options\n"
+         "  --zero-fill-buffers   automatically zero-fill all newly allocated\n"
+         "                        Buffer and SlowBuffer instances\n"
          "  --max-stack-size=val set max v8 stack size (bytes)\n"
 #if defined(NODE_HAVE_I18N_SUPPORT)
          "  --icu-data-dir=dir   set ICU data load path to dir\n"
@@ -3137,6 +3141,8 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--v8-options") == 0) {
       new_v8_argv[new_v8_argc] = "--help";
       new_v8_argc += 1;
+    } else if (strcmp(arg, "--zero-fill-buffers") == 0) {
+      zero_fill_all_buffers = true;
 #if defined(NODE_HAVE_I18N_SUPPORT)
     } else if (strncmp(arg, "--icu-data-dir=", 15) == 0) {
       icu_data_dir = arg + 15;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -152,7 +152,7 @@ Local<Object> New(Environment* env, size_t length) {
   // approach if v8 provided one.
   char* data;
   if (length > 0) {
-    data = static_cast<char*>(malloc(length));
+    data = static_cast<char*>(BUFFER_MALLOC(length));
     if (data == NULL)
       FatalError("node::Buffer::New(size_t)", "Out Of Memory");
   } else {

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -34,6 +34,10 @@
 #define ALLOC_ID (0xA10C)
 
 namespace node {
+
+// if true, all Buffer and SlowBuffer instances will automatically zero-fill
+bool zero_fill_all_buffers = false;
+
 namespace smalloc {
 
 using v8::Context;
@@ -329,7 +333,7 @@ void Alloc(Environment* env,
   if (length == 0)
     return Alloc(env, obj, NULL, length, type);
 
-  char* data = static_cast<char*>(malloc(length));
+  char* data = static_cast<char*>(BUFFER_MALLOC(length));
   if (data == NULL) {
     FatalError("node::smalloc::Alloc(v8::Handle<v8::Object>, size_t,"
                " v8::ExternalArrayType)", "Out Of Memory");

--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -27,6 +27,10 @@
 
 namespace node {
 
+#define BUFFER_MALLOC(length)                                               \
+  zero_fill_all_buffers ? calloc(length, 1) : malloc(length)
+extern bool zero_fill_all_buffers;
+
 // Forward declaration
 class Environment;
 

--- a/test/simple/test-buffer-zero-fill-cli.js
+++ b/test/simple/test-buffer-zero-fill-cli.js
@@ -1,0 +1,29 @@
+// Flags: --zero-fill-buffers
+
+// when using --zero-fill-buffers, every Buffer and SlowBuffer
+// instance must be zero filled upon creation
+
+require('../common');
+var SlowBuffer = require('buffer').SlowBuffer;
+var assert = require('assert');
+
+function isZeroFilled(buf) {
+  for (var n = 0; n < buf.length; n++)
+    if (buf[n] > 0) return false;
+  return true;
+}
+
+// This can be somewhat unreliable because the
+// allocated memory might just already happen to
+// contain all zeroes. The test is run multiple
+// times to improve the reliability.
+for (var i = 0; i < 50; i++) {
+  var bufs = [
+    SlowBuffer(20),
+    Buffer(20),
+    new SlowBuffer(20)
+  ];
+  for (var buf of bufs) {
+    assert(isZeroFilled(buf));
+  }
+}


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

buffer

### Description of change

This backports the --zero-fill-buffers command line flag introduced in master. When used, all Buffer and SlowBuffer instances will zero fill by default.

This does *not* backport any of the other Buffer API or behavior changes.

Note: My intent is to open similar backports for `--zero-fill-buffer` in v5, v4, and v0.10

/cc @trevnorris @nodejs/lts 