### PR TITLE
buffer: fix buffer alignment restriction

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -13,10 +13,6 @@ namespace Buffer {
 static const unsigned int kMaxLength =
     sizeof(int32_t) == sizeof(intptr_t) ? 0x3fffffff : 0x7fffffff;
 
-// Buffers have two internal fields, the first of which is reserved for use by
-// Node.
-static const unsigned int kBufferInternalFieldIndex = 0;
-
 NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
 
 NODE_EXTERN bool HasInstance(v8::Local<v8::Value> val);

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -13,9 +13,16 @@ static void FreeCallback(char* data, void* hint) {
 void Alloc(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   alive++;
+
+  uintptr_t alignment = args[1]->IntegerValue();
+  uintptr_t offset = args[2]->IntegerValue();
+
+  uintptr_t static_offset = reinterpret_cast<uintptr_t>(buf) % alignment;
+  char* aligned = buf + (alignment - static_offset) + offset;
+
   args.GetReturnValue().Set(node::Buffer::New(
         isolate,
-        buf,
+        aligned,
         args[0]->IntegerValue(),
         FreeCallback,
         nullptr).ToLocalChecked());

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -4,8 +4,8 @@
 require('../../common');
 var binding = require('./build/Release/binding');
 
-function check(size) {
-  var buf = binding.alloc(size);
+function check(size, alignment, offset) {
+  var buf = binding.alloc(size, alignment, offset);
   var slice = buf.slice(size >>> 1);
 
   buf = null;
@@ -16,7 +16,20 @@ function check(size) {
   gc();
 }
 
-check(64);
+check(64, 1, 0);
+
+// Buffers can have weird sizes.
+check(97, 1, 0);
+
+// Buffers can be unaligned
+check(64,  8, 0);
+check(64, 16, 0);
+check(64,  8, 1);
+check(64, 16, 1);
+check(97,  8, 1);
+check(97, 16, 1);
+check(97,  8, 3);
+check(97, 16, 3);
 
 // Empty ArrayBuffer does not allocate data, worth checking
-check(0);
+check(0, 1, 0);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?


### Affected core subsystem(s)

buffer

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

@addaleax [recently reported](https://github.com/nodejs/node/commit/ebbbc5a790db6900653ad9c697c60861dc518589#commitcomment-16738830) that recent phantom weakness changes (ebbbc5a) to buffer break `node-ffi` and possibly other modules that use create unaligned buffers.

It turns out there is a simpler solution possible that doesn't introduce an alignment restriction. This also eliminates the need for Node-core to reserve the first internal field on buffers.

Ref: https://github.com/nodejs/node/pull/5204
R=@bnoordhuis, @trevnorris 

Marking with `dont-land-on-*` as the pre-requisite change is also marked likewise.