### PR TITLE
tools,benchmark: increase lint compliance

### DIFF
--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -43,7 +43,7 @@ function main(conf) {
     var r = Buffer.byteLength(strings[index], encoding);
 
     if (r !== results[index])
-      throw Error('incorrect return value');
+      throw new Error('incorrect return value');
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -21,10 +21,10 @@ function main(conf) {
 
   buff.writeDoubleLE(0, 0, noAssert);
   var testFunction = new Function('buff', [
-    "for (var i = 0; i !== " + len + "; i++) {",
-    "  buff." + fn + "(0, " + JSON.stringify(noAssert) + ");",
-    "}"
-  ].join("\n"));
+    'for (var i = 0; i !== ' + len + '; i++) {',
+    '  buff.' + fn + '(0, ' + JSON.stringify(noAssert) + ');',
+    '}'
+  ].join('\n'));
   bench.start();
   testFunction(buff);
   bench.end(len / 1e6);

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -48,10 +48,10 @@ function main(conf) {
 function benchInt(buff, fn, len, noAssert) {
   var m = mod[fn];
   var testFunction = new Function('buff', [
-    "for (var i = 0; i !== " + len + "; i++) {",
-    "  buff." + fn + "(i & " + m + ", 0, " + JSON.stringify(noAssert) + ");",
-    "}"
-  ].join("\n"));
+    'for (var i = 0; i !== ' + len + '; i++) {',
+    '  buff.' + fn + '(i & ' + m + ', 0, ' + JSON.stringify(noAssert) + ');',
+    '}'
+  ].join('\n'));
   bench.start();
   testFunction(buff);
   bench.end(len / 1e6);
@@ -59,10 +59,10 @@ function benchInt(buff, fn, len, noAssert) {
 
 function benchFloat(buff, fn, len, noAssert) {
   var testFunction = new Function('buff', [
-    "for (var i = 0; i !== " + len + "; i++) {",
-    "  buff." + fn + "(i, 0, " + JSON.stringify(noAssert) + ");",
-    "}"
-  ].join("\n"));
+    'for (var i = 0; i !== ' + len + '; i++) {',
+    '  buff.' + fn + '(i, 0, ' + JSON.stringify(noAssert) + ');',
+    '}'
+  ].join('\n'));
   bench.start();
   testFunction(buff);
   bench.end(len / 1e6);

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -27,7 +27,7 @@ if (module === require.main) {
   var tests = fs.readdirSync(dir);
 
   if (testFilter) {
-    var filteredTests = tests.filter(function(item){
+    var filteredTests = tests.filter(function(item) {
       if (item.lastIndexOf(testFilter) >= 0) {
         return item;
       }
@@ -48,7 +48,7 @@ function hasWrk() {
   if (result.error && result.error.code === 'ENOENT') {
     console.error('Couldn\'t locate `wrk` which is needed for running ' +
       'benchmarks. Check benchmark/README.md for further instructions.');
-      process.exit(-1);
+    process.exit(-1);
   }
 }
 
@@ -86,7 +86,7 @@ function Benchmark(fn, options) {
   this.options = options;
   this.config = parseOpts(options);
   this._name = require.main.filename.split(/benchmark[\/\\]/).pop();
-  this._start = [0,0];
+  this._start = [0, 0];
   this._started = false;
 
   var self = this;
@@ -120,7 +120,7 @@ Benchmark.prototype.http = function(p, args, cb) {
 
     if (code) {
       console.error('wrk failed with ' + code);
-      process.exit(code)
+      process.exit(code);
     }
     var match = out.match(regexp);
     var qps = match && +match[1];
@@ -140,8 +140,6 @@ Benchmark.prototype._run = function() {
   // some options weren't set.
   // run with all combinations
   var main = require.main.filename;
-  var settings = [];
-  var queueLen = 1;
   var options = this.options;
 
   var queue = Object.keys(options).reduce(function(set, key) {
@@ -203,7 +201,7 @@ function parseOpts(options) {
     });
   }
   return num === 0 ? conf : null;
-};
+}
 
 Benchmark.prototype.start = function() {
   if (this._started)
@@ -221,8 +219,8 @@ Benchmark.prototype.end = function(operations) {
   if (typeof operations !== 'number')
     throw new Error('called end() without specifying operation count');
 
-  var time = elapsed[0] + elapsed[1]/1e9;
-  var rate = operations/time;
+  var time = elapsed[0] + elapsed[1] / 1e9;
+  var rate = operations / time;
   this.report(rate);
 };
 

--- a/benchmark/crypto/aes-gcm-throughput.js
+++ b/benchmark/crypto/aes-gcm-throughput.js
@@ -30,7 +30,7 @@ function AEAD_Bench(cipher, message, associate_data, key, iv, n, len) {
     var bob = crypto.createDecipheriv(cipher, key, iv);
     bob.setAuthTag(tag);
     bob.setAAD(associate_data);
-    var clear = bob.update(enc);
+    bob.update(enc);
     bob.final();
   }
 

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -95,7 +95,6 @@ function legacyWrite(alice, bob, message, encoding, writes) {
   written += dec.length;
   dec = bob.final();
   written += dec.length;
-  var bits = written * 8;
   var gbits = written / (1024 * 1024 * 1024);
   bench.end(gbits);
 }

--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -20,9 +20,6 @@ function main(conf) {
     api = 'legacy';
   }
 
-  var crypto = require('crypto');
-  var assert = require('assert');
-
   var message;
   var encoding;
   switch (conf.type) {

--- a/benchmark/crypto/hash-stream-throughput.js
+++ b/benchmark/crypto/hash-stream-throughput.js
@@ -19,9 +19,6 @@ function main(conf) {
     api = 'legacy';
   }
 
-  var crypto = require('crypto');
-  var assert = require('assert');
-
   var message;
   var encoding;
   switch (conf.type) {

--- a/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
+++ b/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
@@ -22,7 +22,6 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var crypto = require('crypto');
   var message = (new Buffer(conf.len)).fill('b');
 
   bench.start();
@@ -38,7 +37,7 @@ function StreamWrite(algo, keylen, message, n, len) {
   var publicKey = RSA_PublicPem[keylen];
   for (var i = 0; i < n; i++) {
     var enc = crypto.privateEncrypt(privateKey, message);
-    var clear = crypto.publicDecrypt(publicKey, enc);
+    crypto.publicDecrypt(publicKey, enc);
   }
 
   bench.end(kbits);

--- a/benchmark/crypto/rsa-sign-verify-throughput.js
+++ b/benchmark/crypto/rsa-sign-verify-throughput.js
@@ -23,7 +23,6 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var crypto = require('crypto');
   var message = (new Buffer(conf.len)).fill('b');
 
   bench.start();
@@ -36,7 +35,6 @@ function StreamWrite(algo, keylen, message, writes, len) {
   var kbits = bits / (1024);
 
   var privateKey = RSA_PrivatePem[keylen];
-  var publicKey = RSA_PublicPem[keylen];
   var s = crypto.createSign(algo);
   var v = crypto.createVerify(algo);
 
@@ -45,7 +43,7 @@ function StreamWrite(algo, keylen, message, writes, len) {
     v.update(message);
   }
 
-  var sign = s.sign(privateKey, 'binary');
+  s.sign(privateKey, 'binary');
   s.end();
   v.end();
 

--- a/benchmark/events/ee-emit-multi-args.js
+++ b/benchmark/events/ee-emit-multi-args.js
@@ -7,7 +7,6 @@ function main(conf) {
   var n = conf.n | 0;
 
   var ee = new EventEmitter();
-  var listeners = [];
 
   for (var k = 0; k < 10; k += 1)
     ee.on('dummy', function() {});

--- a/benchmark/events/ee-listener-count-on-prototype.js
+++ b/benchmark/events/ee-listener-count-on-prototype.js
@@ -13,7 +13,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var r = ee.listenerCount('dummy');
+    ee.listenerCount('dummy');
   }
   bench.end(n);
 }

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -14,7 +14,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var r = ee.listeners('dummy');
+    ee.listeners('dummy');
   }
   bench.end(n);
 }

--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -13,7 +13,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var r = ee.listeners('dummy');
+    ee.listeners('dummy');
   }
   bench.end(n);
 }

--- a/benchmark/fs-write-stream-throughput.js
+++ b/benchmark/fs-write-stream-throughput.js
@@ -49,14 +49,13 @@ function runTest(dur, size, type) {
       break;
   }
 
-  var writes = 0;
   var fs = require('fs');
   try { fs.unlinkSync('write_stream_throughput'); } catch (e) {}
 
-  var start
+  var start;
   var end;
   function done() {
-    var time = end[0] + end[1]/1E9;
+    var time = end[0] + end[1] / 1E9;
     var written = fs.statSync('write_stream_throughput').size / 1024;
     var rate = (written / time).toFixed(2);
     console.log('fs_write_stream_dur_%d_size_%d_type_%s: %d',

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -11,7 +11,7 @@ var type, encoding, size;
 
 var bench = common.createBenchmark(main, {
   type: ['buf', 'asc', 'utf'],
-  size: [1024, 4096, 65535, 1024*1024]
+  size: [1024, 4096, 65535, 1024 * 1024]
 });
 
 function main(conf) {

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -28,7 +28,7 @@ function main(conf) {
       encoding = 'ascii';
       break;
     case 'utf':
-      chunk = new Array(Math.ceil(size/2) + 1).join('ü');
+      chunk = new Array(Math.ceil(size / 2) + 1).join('ü');
       encoding = 'utf8';
       break;
     default:

--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -15,7 +15,6 @@ var bench = common.createBenchmark(main, {
 function main(conf) {
   var len = +conf.len;
   var num = +conf.num;
-  var type = conf.type;
   var todo = [];
   var headers = [];
   // Chose 7 because 9 showed "Connection error" / "Connection closed"
@@ -24,7 +23,7 @@ function main(conf) {
     headers.push(Array(i + 1).join('o'));
 
   function WriteHTTPHeaders(channel, has_keep_alive, extra_header_count) {
-    todo = []
+    todo = [];
     todo.push('GET / HTTP/1.1');
     todo.push('Host: localhost');
     todo.push('Connection: keep-alive');
@@ -63,7 +62,7 @@ function main(conf) {
   var socket = net.connect(PIPE, function() {
     bench.start();
     WriteHTTPHeaders(socket, 1, len);
-    socket.setEncoding('utf8')
+    socket.setEncoding('utf8');
     socket.on('data', function(d) {
       var did = false;
       var pattern = 'HTTP/1.1 200 OK\r\n';
@@ -73,7 +72,7 @@ function main(conf) {
         success += 1;
         did = true;
       } else {
-        pattern = 'HTTP/1.1 '
+        pattern = 'HTTP/1.1 ';
         if ((d.length === pattern.length && d === pattern) ||
             (d.length > pattern.length &&
              d.slice(0, pattern.length) === pattern)) {

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -8,7 +8,6 @@
 // Verify that our assumptions are valid.
 
 var common = require('../common.js');
-var PORT = common.PORT;
 
 var bench = common.createBenchmark(main, {
   num: [1, 4, 8, 16],

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -8,7 +8,6 @@
 // Verify that our assumptions are valid.
 
 var common = require('../common.js');
-var PORT = common.PORT;
 
 var bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],

--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -4,8 +4,8 @@ var path = require('path');
 var http = require('http');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
-var common = require('../common.js')
-var test = require('../../test/common.js')
+require('../common.js');
+var test = require('../../test/common.js');
 var pep = path.dirname(process.argv[1]) + '/_chunky_http_client.js';
 var PIPE = test.PIPE;
 
@@ -38,17 +38,17 @@ try {
   child = spawn(process.execPath, [pep], { });
 
   child.on('error', function(err) {
-    throw new Error('spawn error: ' + err );
+    throw new Error('spawn error: ' + err);
   });
 
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);
 
-  child.on('close', function (exitCode) {
+  child.on('close', function(exitCode) {
     server.close();
   });
 
-} catch(e) {
-  throw new Error('error: ' + e );
+} catch (e) {
+  throw new Error('error: ' + e);
 }
 

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -11,7 +11,6 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   process.env.PORT = PORT;
-  var spawn = require('child_process').spawn;
   var server = require('../http_simple.js');
   setTimeout(function() {
     var path = '/' + conf.type + '/' + conf.length + '/' + conf.chunks;

--- a/benchmark/http_bench.js
+++ b/benchmark/http_bench.js
@@ -20,10 +20,10 @@ for (var i = 2; i < process.argv.length; ++i) {
 }
 
 switch (options.mode) {
-case 'master': startMaster(); break;
-case 'server': startServer(); break;
-case 'client': startClient(); break;
-default: throw new Error('Bad mode: ' + options.mode);
+  case 'master': startMaster(); break;
+  case 'server': startServer(); break;
+  case 'client': startClient(); break;
+  default: throw new Error('Bad mode: ' + options.mode);
 }
 
 process.title = 'http_bench[' + options.mode + ']';
@@ -47,7 +47,7 @@ function startMaster() {
 
   var forkCount = 0;
 
-  cluster.on('online', function () {
+  cluster.on('online', function() {
     forkCount = forkCount + 1;
     if (forkCount === ~~options.servers) {
       var args = [

--- a/benchmark/http_server_lag.js
+++ b/benchmark/http_server_lag.js
@@ -6,7 +6,7 @@ http.createServer(function(req, res) {
   res.writeHead(200, { 'content-type': 'text/plain',
                        'content-length': '2' });
 
-  var lag = parseInt(req.url.split("/").pop(), 10) || defaultLag;
+  var lag = parseInt(req.url.split('/').pop(), 10) || defaultLag;
   setTimeout(function() {
     res.end('ok');
   }, lag);

--- a/benchmark/http_simple.js
+++ b/benchmark/http_simple.js
@@ -1,13 +1,13 @@
-var path = require('path'),
-    exec = require('child_process').exec,
-    http = require('http');
+'use strict';
+
+var http = require('http');
 
 var port = parseInt(process.env.PORT || 8000);
 
 var fixed = makeString(20 * 1024, 'C'),
-    storedBytes = {},
-    storedBuffer = {},
-    storedUnicode = {};
+  storedBytes = {},
+  storedBuffer = {},
+  storedUnicode = {};
 
 var useDomains = process.env.NODE_USE_DOMAINS;
 
@@ -22,7 +22,7 @@ if (useDomains) {
   gdom.enter();
 }
 
-var server = module.exports = http.createServer(function (req, res) {
+var server = module.exports = http.createServer(function(req, res) {
   if (useDomains) {
     var dom = domain.create();
     dom.add(req);
@@ -39,7 +39,7 @@ var server = module.exports = http.createServer(function (req, res) {
   if (command == 'bytes') {
     var n = ~~arg;
     if (n <= 0)
-      throw new Error('bytes called with n <= 0')
+      throw new Error('bytes called with n <= 0');
     if (storedBytes[n] === undefined) {
       storedBytes[n] = makeString(n, 'C');
     }
@@ -114,7 +114,7 @@ function makeString(size, c) {
   return s;
 }
 
-server.listen(port, function () {
+server.listen(port, function() {
   if (module === require.main)
-    console.error('Listening at http://127.0.0.1:'+port+'/');
+    console.error('Listening at http://127.0.0.1:' + port + '/');
 });

--- a/benchmark/http_simple_auto.js
+++ b/benchmark/http_simple_auto.js
@@ -7,74 +7,73 @@
 //   <target> Target to benchmark, e.g. `bytes/1024` or `buffer/8192`.
 //
 
-var path = require("path");
-var http = require("http");
-var spawn = require("child_process").spawn;
+var http = require('http');
+var spawn = require('child_process').spawn;
 
 var port = parseInt(process.env.PORT || 8000);
 
-var fixed = ""
-for (var i = 0; i < 20*1024; i++) {
-  fixed += "C";
+var fixed = '';
+for (var i = 0; i < 20 * 1024; i++) {
+  fixed += 'C';
 }
 
 var stored = {};
 var storedBuffer = {};
 
-var server = http.createServer(function (req, res) {
-  var commands = req.url.split("/");
+var server = http.createServer(function(req, res) {
+  var commands = req.url.split('/');
   var command = commands[1];
-  var body = "";
+  var body = '';
   var arg = commands[2];
   var n_chunks = parseInt(commands[3], 10);
   var status = 200;
 
-  if (command == "bytes") {
-    var n = parseInt(arg, 10)
+  if (command == 'bytes') {
+    var n = parseInt(arg, 10);
     if (n <= 0)
-      throw "bytes called with n <= 0"
+      throw new Error('bytes called with n <= 0');
     if (stored[n] === undefined) {
-      stored[n] = "";
+      stored[n] = '';
       for (var i = 0; i < n; i++) {
-        stored[n] += "C"
+        stored[n] += 'C';
       }
     }
     body = stored[n];
 
-  } else if (command == "buffer") {
-    var n = parseInt(arg, 10)
-    if (n <= 0) throw new Error("bytes called with n <= 0");
+  } else if (command == 'buffer') {
+    var n = parseInt(arg, 10);
+    if (n <= 0) throw new Error('bytes called with n <= 0');
     if (storedBuffer[n] === undefined) {
       storedBuffer[n] = new Buffer(n);
       for (var i = 0; i < n; i++) {
-        storedBuffer[n][i] = "C".charCodeAt(0);
+        storedBuffer[n][i] = 'C'.charCodeAt(0);
       }
     }
     body = storedBuffer[n];
 
-  } else if (command == "quit") {
+  } else if (command == 'quit') {
     res.connection.server.close();
-    body = "quitting";
+    body = 'quitting';
 
-  } else if (command == "fixed") {
+  } else if (command == 'fixed') {
     body = fixed;
 
-  } else if (command == "echo") {
-    res.writeHead(200, { "Content-Type": "text/plain",
-                         "Transfer-Encoding": "chunked" });
+  } else if (command == 'echo') {
+    res.writeHead(200, { 'Content-Type': 'text/plain',
+                         'Transfer-Encoding': 'chunked' });
     req.pipe(res);
     return;
 
   } else {
     status = 404;
-    body = "not found\n";
+    body = 'not found\n';
   }
 
   // example: http://localhost:port/bytes/512/4
   // sends a 512 byte body in 4 chunks of 128 bytes
   if (n_chunks > 0) {
-    res.writeHead(status, { "Content-Type": "text/plain",
-                            "Transfer-Encoding": "chunked" });
+    res.writeHead(status, { 'Content-Type': 'text/plain',
+                            'Transfer-Encoding': 'chunked' });
     // send body in chunks
     var len = body.length;
     var step = Math.floor(len / n_chunks) || 1;
@@ -86,14 +85,14 @@ var server = http.createServer(function (req, res) {
   } else {
     var content_length = body.length.toString();
 
-    res.writeHead(status, { "Content-Type": "text/plain",
-                            "Content-Length": content_length });
+    res.writeHead(status, { 'Content-Type': 'text/plain',
+                            'Content-Length': content_length });
     res.end(body);
   }
 
 });
 
-server.listen(port, function () {
+server.listen(port, function() {
   var url = 'http://127.0.0.1:' + port + '/';
 
   var n = process.argv.length - 1;

--- a/benchmark/idle_clients.js
+++ b/benchmark/idle_clients.js
@@ -2,26 +2,24 @@ net = require('net');
 
 var errors = 0, connections = 0;
 
-var lastClose = 0;
-
-function connect () {
-  process.nextTick(function () {
+function connect() {
+  process.nextTick(function() {
     var s = net.Stream();
     var gotConnected = false;
     s.connect(9000);
 
-    s.on('connect', function () {
+    s.on('connect', function() {
       gotConnected = true;
       connections++;
       connect();
     });
 
-    s.on('close', function () {
+    s.on('close', function() {
       if (gotConnected) connections--;
       lastClose = new Date();
     });
 
-    s.on('error', function () {
+    s.on('error', function() {
       errors++;
     });
   });
@@ -35,15 +33,15 @@ var oldConnections, oldErrors;
 // Try to start new connections every so often
 setInterval(connect, 5000);
 
-setInterval(function () {
+setInterval(function() {
   if (oldConnections != connections) {
     oldConnections = connections;
-    console.log("CLIENT %d connections: %d", process.pid, connections);
+    console.log('CLIENT %d connections: %d', process.pid, connections);
   }
 
   if (oldErrors != errors) {
     oldErrors = errors;
-    console.log("CLIENT %d errors: %d", process.pid, errors);
+    console.log('CLIENT %d errors: %d', process.pid, errors);
   }
 }, 1000);
 

--- a/benchmark/idle_server.js
+++ b/benchmark/idle_server.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const net = require('net');
-var connections = 0;
 var errors = 0;
 
-var server = net.Server(function (socket) {
+var server = net.Server(function(socket) {
 
-  socket.on('error', function () {
+  socket.on('error', function() {
     errors++;
   });
 
@@ -18,14 +17,14 @@ server.listen(9000);
 
 var oldConnections, oldErrors;
 
-setInterval(function () {
+setInterval(function() {
   if (oldConnections != server.connections) {
     oldConnections = server.connections;
-    console.log("SERVER %d connections: %d", process.pid, server.connections);
+    console.log('SERVER %d connections: %d', process.pid, server.connections);
   }
 
   if (oldErrors != errors) {
     oldErrors = errors;
-    console.log("SERVER %d errors: %d", process.pid, errors);
+    console.log('SERVER %d errors: %d', process.pid, errors);
   }
 }, 1000);

--- a/benchmark/misc/domain-fn-args.js
+++ b/benchmark/misc/domain-fn-args.js
@@ -13,6 +13,7 @@ function main(conf) {
 
   var args, ret, n = +conf.n;
   var arguments = gargs.slice(0, conf.arguments);
+
   bench.start();
 
   bdomain.enter();

--- a/benchmark/misc/function_call/index.js
+++ b/benchmark/misc/function_call/index.js
@@ -27,7 +27,7 @@ assert(js() === cxx());
 
 var bench = common.createBenchmark(main, {
   type: ['js', 'cxx'],
-  millions: [1,10,50]
+  millions: [1, 10, 50]
 });
 
 function main(conf) {

--- a/benchmark/misc/module-loader.js
+++ b/benchmark/misc/module-loader.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var common = require('../common.js');
-var packageJson = '{"main": "index.js"}';
 
 var tmpDirectory = path.join(__dirname, '..', 'tmp');
 var benchmarkDirectory = path.join(tmpDirectory, 'nodejs-benchmark-module');
@@ -38,7 +37,7 @@ function rmrf(location) {
     var things = fs.readdirSync(location);
     things.forEach(function(thing) {
       var cur = path.join(location, thing),
-          isDirectory = fs.statSync(cur).isDirectory();
+        isDirectory = fs.statSync(cur).isDirectory();
       if (isDirectory) {
         rmrf(cur);
         return;

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -2,9 +2,6 @@ var common = require('../common.js');
 var spawn = require('child_process').spawn;
 var path = require('path');
 var emptyJsFile = path.resolve(__dirname, '../../test/fixtures/semicolon.js');
-var starts = 100;
-var i = 0;
-var start;
 
 var bench = common.createBenchmark(startNode, {
   dur: [1]
@@ -14,7 +11,6 @@ function startNode(conf) {
   var dur = +conf.dur;
   var go = true;
   var starts = 0;
-  var open = 0;
 
   setTimeout(function() {
     go = false;

--- a/benchmark/misc/string-creation.js
+++ b/benchmark/misc/string-creation.js
@@ -2,7 +2,7 @@
 var common = require('../common.js');
 var bench = common.createBenchmark(main, {
   millions: [100]
-})
+});
 
 function main(conf) {
   var n = +conf.millions * 1e6;
@@ -10,7 +10,7 @@ function main(conf) {
   var s;
   for (var i = 0; i < n; i++) {
     s = '01234567890';
-    s[1] = "a";
+    s[1] = 'a';
   }
   bench.end(n / 1e6);
 }

--- a/benchmark/net/dgram.js
+++ b/benchmark/net/dgram.js
@@ -18,7 +18,6 @@ var len;
 var num;
 var type;
 var chunk;
-var encoding;
 
 function main(conf) {
   dur = +conf.dur;

--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -35,7 +35,6 @@ function main(conf) {
       break;
     default:
       throw new Error('invalid type: ' + type);
-      break;
   }
 
   server();
@@ -77,8 +76,8 @@ function server() {
     socket.on('connect', function() {
       bench.start();
 
-      socket.on('drain', send)
-      send()
+      socket.on('drain', send);
+      send();
 
       setTimeout(function() {
         var bytes = writer.received;
@@ -88,7 +87,7 @@ function server() {
 
       function send() {
         socket.cork();
-        while(socket.write(chunk, encoding)) {}
+        while (socket.write(chunk, encoding)) {}
         socket.uncork();
       }
     });

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -35,7 +35,6 @@ function main(conf) {
       break;
     default:
       throw new Error('invalid type: ' + type);
-      break;
   }
 
   server();

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -35,7 +35,6 @@ function main(conf) {
       break;
     default:
       throw new Error('invalid type: ' + type);
-      break;
   }
 
   server();

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -35,7 +35,6 @@ function main(conf) {
       break;
     default:
       throw new Error('invalid type: ' + type);
-      break;
   }
 
   server();

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -89,7 +89,6 @@ function client() {
       break;
     default:
       throw new Error('invalid type: ' + type);
-      break;
   }
 
   var clientHandle = new TCP();

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -87,7 +87,6 @@ function client() {
       break;
     default:
       throw new Error('invalid type: ' + type);
-      break;
   }
 
   var clientHandle = new TCP();

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -61,7 +61,6 @@ function server() {
         break;
       default:
         throw new Error('invalid type: ' + type);
-        break;
     }
 
     clientHandle.readStart();

--- a/benchmark/static_http_server.js
+++ b/benchmark/static_http_server.js
@@ -3,7 +3,7 @@ var http = require('http');
 var concurrency = 30;
 var port = 12346;
 var n = 700;
-var bytes = 1024*5;
+var bytes = 1024 * 5;
 
 var requests = 0;
 var responses = 0;
@@ -19,7 +19,7 @@ var server = http.createServer(function(req, res) {
     'Content-Length': body.length
   });
   res.end(body);
-})
+});
 
 server.listen(port, function() {
   var agent = new http.Agent();

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -30,7 +30,7 @@ function main(conf) {
       encoding = 'ascii';
       break;
     case 'utf':
-      chunk = new Array(size/2 + 1).join('ü');
+      chunk = new Array(size / 2 + 1).join('ü');
       encoding = 'utf8';
       break;
     default:
@@ -53,7 +53,6 @@ function main(conf) {
     });
 
     function write() {
-      var i = 0;
       while (false !== conn.write(chunk, encoding));
     }
   });

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -1,7 +1,7 @@
-var assert = require('assert'),
-    fs = require('fs'),
-    path = require('path'),
-    tls = require('tls');
+'use strict';
+var fs = require('fs'),
+  path = require('path'),
+  tls = require('tls');
 
 var common = require('../common.js');
 var bench = common.createBenchmark(main, {
@@ -21,10 +21,10 @@ function main(conf) {
   concurrency = +conf.concurrency;
 
   var cert_dir = path.resolve(__dirname, '../../test/fixtures'),
-      options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
-                  cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
-                  ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
-                  ciphers: 'AES256-GCM-SHA384' };
+    options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
+                cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
+                ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+                ciphers: 'AES256-GCM-SHA384' };
 
   server = tls.createServer(options, onConnection);
   server.listen(common.PORT, onListening);

--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -9,7 +9,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var r = util.inspect({a: 'a', b: 'b', c: 'c', d: 'd'});
+    util.inspect({a: 'a', b: 'b', c: 'c', d: 'd'});
   }
   bench.end(n);
 }


### PR DESCRIPTION
Backport for v4.x.

### Pull Request check-list

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

benchmark, tools

### Description of change

In the hopes of soon having the benchmark code linted, this change
groups all the likely non-controversial lint-compliance changes such as
indentation, semi-colon usage, and single-vs.-double quotation marks.

Other lint rules may have subtle performance implications in the V8
currently shipped with Node.js. Those changes will require more careful
review and will be in a separate change.