### PR TITLE
benchmark: refactor to eliminate redeclared vars

### DIFF
--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -6,9 +6,10 @@ function main(conf) {
   var N = 64 * 1024 * 1024;
   var b = Buffer(N);
   var s = '';
-  for (var i = 0; i < 256; ++i) s += String.fromCharCode(i);
-  for (var i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
+  var i;
+  for (i = 0; i < 256; ++i) s += String.fromCharCode(i);
+  for (i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
   bench.start();
-  for (var i = 0; i < 32; ++i) b.toString('base64');
+  for (i = 0; i < 32; ++i) b.toString('base64');
   bench.end(64);
 }

--- a/benchmark/buffers/buffer-tostring.js
+++ b/benchmark/buffers/buffer-tostring.js
@@ -14,12 +14,13 @@ function main(conf) {
   const n = conf.n | 0;
   const buf = Buffer(len).fill(42);
 
+  var i;
   bench.start();
   if (arg) {
-    for (var i = 0; i < n; i += 1)
+    for (i = 0; i < n; i += 1)
       buf.toString('utf8');
   } else {
-    for (var i = 0; i < n; i += 1)
+    for (i = 0; i < n; i += 1)
       buf.toString();
   }
   bench.end(n);

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -36,18 +36,19 @@ for (var i = 2; i < process.argv.length; i++) {
   }
 }
 
+var start, green, red, reset, end;
 if (!html) {
-  var start = '';
-  var green = '\033[1;32m';
-  var red = '\033[1;31m';
-  var reset = '\033[m';
-  var end = '';
+  start = '';
+  green = '\u001b[1;32m';
+  red = '\u001b[1;31m';
+  reset = '\u001b[m';
+  end = '';
 } else {
-  var start = '<pre style="background-color:#333;color:#eee">';
-  var green = '<span style="background-color:#0f0;color:#000">';
-  var red = '<span style="background-color:#f00;color:#fff">';
-  var reset = '</span>';
-  var end = '</pre>';
+  start = '<pre style="background-color:#333;color:#eee">';
+  green = '<span style="background-color:#0f0;color:#000">';
+  red = '<span style="background-color:#f00;color:#fff">';
+  reset = '</span>';
+  end = '</pre>';
 }
 
 var runBench = process.env.NODE_BENCH || 'bench';
@@ -136,7 +137,7 @@ function compare() {
 
     var r0 = util.format('%s%s: %d%s', g, nodes[0], n0.toPrecision(5), g ? reset : '');
     var r1 = util.format('%s%s: %d%s', r, nodes[1], n1.toPrecision(5), r ? reset : '');
-    var pct = c + pct + '%' + reset;
+    pct = c + pct + '%' + reset;
     var l = util.format('%s: %s %s', bench, r0, r1);
     maxLen = Math.max(l.length + pct.length, maxLen);
     return [l, pct];

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -85,13 +85,14 @@ function streamWrite(alice, bob, message, encoding, writes) {
 
 function legacyWrite(alice, bob, message, encoding, writes) {
   var written = 0;
+  var enc, dec;
   for (var i = 0; i < writes; i++) {
-    var enc = alice.update(message, encoding);
-    var dec = bob.update(enc);
+    enc = alice.update(message, encoding);
+    dec = bob.update(enc);
     written += dec.length;
   }
-  var enc = alice.final();
-  var dec = bob.update(enc);
+  enc = alice.final();
+  dec = bob.update(enc);
   written += dec.length;
   dec = bob.final();
   written += dec.length;

--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -9,14 +9,15 @@ function main(conf) {
   var ee = new events.EventEmitter();
   var listeners = [];
 
-  for (var k = 0; k < 10; k += 1)
+  var k;
+  for (k = 0; k < 10; k += 1)
     listeners.push(function() {});
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    for (var k = listeners.length; --k >= 0; /* empty */)
+    for (k = listeners.length; --k >= 0; /* empty */)
       ee.on('dummy', listeners[k]);
-    for (var k = listeners.length; --k >= 0; /* empty */)
+    for (k = listeners.length; --k >= 0; /* empty */)
       ee.removeListener('dummy', listeners[k]);
   }
   bench.end(n);

--- a/benchmark/fs-write-stream-throughput.js
+++ b/benchmark/fs-write-stream-throughput.js
@@ -39,12 +39,13 @@ function parent() {
 function runTest(dur, size, type) {
   if (type !== 'string')
     type = 'buffer';
+  var chunk;
   switch (type) {
     case 'string':
-      var chunk = new Array(size + 1).join('a');
+      chunk = new Array(size + 1).join('a');
       break;
     case 'buffer':
-      var chunk = new Buffer(size);
+      chunk = new Buffer(size);
       chunk.fill('a');
       break;
   }

--- a/benchmark/http_simple.js
+++ b/benchmark/http_simple.js
@@ -36,8 +36,9 @@ var server = module.exports = http.createServer(function (req, res) {
   var n_chunks = parseInt(commands[3], 10);
   var status = 200;
 
+  var n, i;
   if (command == 'bytes') {
-    var n = ~~arg;
+    n = ~~arg;
     if (n <= 0)
       throw new Error('bytes called with n <= 0')
     if (storedBytes[n] === undefined) {
@@ -46,19 +47,19 @@ var server = module.exports = http.createServer(function (req, res) {
     body = storedBytes[n];
 
   } else if (command == 'buffer') {
-    var n = ~~arg;
+    n = ~~arg;
     if (n <= 0)
       throw new Error('buffer called with n <= 0');
     if (storedBuffer[n] === undefined) {
       storedBuffer[n] = new Buffer(n);
-      for (var i = 0; i < n; i++) {
+      for (i = 0; i < n; i++) {
         storedBuffer[n][i] = 'C'.charCodeAt(0);
       }
     }
     body = storedBuffer[n];
 
   } else if (command == 'unicode') {
-    var n = ~~arg;
+    n = ~~arg;
     if (n <= 0)
       throw new Error('unicode called with n <= 0');
     if (storedUnicode[n] === undefined) {
@@ -93,7 +94,7 @@ var server = module.exports = http.createServer(function (req, res) {
     var len = body.length;
     var step = Math.floor(len / n_chunks) || 1;
 
-    for (var i = 0, n = (n_chunks - 1); i < n; ++i) {
+    for (i = 0, n = (n_chunks - 1); i < n; ++i) {
       res.write(body.slice(i * step, i * step + step));
     }
     res.end(body.slice((n_chunks - 1) * step));

--- a/benchmark/http_simple_auto.js
+++ b/benchmark/http_simple_auto.js
@@ -13,9 +13,10 @@ var spawn = require("child_process").spawn;
 
 var port = parseInt(process.env.PORT || 8000);
 
-var fixed = ""
-for (var i = 0; i < 20*1024; i++) {
-  fixed += "C";
+var fixed = '';
+var i;
+for (i = 0; i < 20 * 1024; i++) {
+  fixed += 'C';
 }
 
 var stored = {};
@@ -28,26 +29,26 @@ var server = http.createServer(function (req, res) {
   var arg = commands[2];
   var n_chunks = parseInt(commands[3], 10);
   var status = 200;
+  var n;
 
-  if (command == "bytes") {
-    var n = parseInt(arg, 10)
+  if (command == 'bytes') {
+    n = parseInt(arg, 10);
     if (n <= 0)
       throw "bytes called with n <= 0"
     if (stored[n] === undefined) {
-      stored[n] = "";
-      for (var i = 0; i < n; i++) {
-        stored[n] += "C"
+      stored[n] = '';
+      for (i = 0; i < n; i++) {
+        stored[n] += 'C';
       }
     }
     body = stored[n];
-
-  } else if (command == "buffer") {
-    var n = parseInt(arg, 10)
-    if (n <= 0) throw new Error("bytes called with n <= 0");
+  } else if (command == 'buffer') {
+    n = parseInt(arg, 10);
+    if (n <= 0) throw new Error('bytes called with n <= 0');
     if (storedBuffer[n] === undefined) {
       storedBuffer[n] = new Buffer(n);
-      for (var i = 0; i < n; i++) {
-        storedBuffer[n][i] = "C".charCodeAt(0);
+      for (i = 0; i < n; i++) {
+        storedBuffer[n][i] = 'C'.charCodeAt(0);
       }
     }
     body = storedBuffer[n];
@@ -79,7 +80,7 @@ var server = http.createServer(function (req, res) {
     var len = body.length;
     var step = Math.floor(len / n_chunks) || 1;
 
-    for (var i = 0, n = (n_chunks - 1); i < n; ++i) {
+    for (i = 0, n = (n_chunks - 1); i < n; ++i) {
       res.write(body.slice(i * step, i * step + step));
     }
     res.end(body.slice((n_chunks - 1) * step));

--- a/benchmark/misc/string-decoder.js
+++ b/benchmark/misc/string-decoder.js
@@ -21,6 +21,7 @@ function main(conf) {
   var chunks = [];
   var str = '';
   var isBase64 = (encoding === 'base64-ascii' || encoding === 'base64-utf8');
+  var i;
 
   if (encoding === 'ascii' || encoding === 'base64-ascii')
     alpha = ASC_ALPHA;
@@ -31,7 +32,7 @@ function main(conf) {
 
   var sd = new StringDecoder(isBase64 ? 'base64' : encoding);
 
-  for (var i = 0; i < inLen; ++i) {
+  for (i = 0; i < inLen; ++i) {
     if (i > 0 && (i % chunkLen) === 0 && !isBase64) {
       chunks.push(new Buffer(str, encoding));
       str = '';
@@ -52,7 +53,7 @@ function main(conf) {
   var nChunks = chunks.length;
 
   bench.start();
-  for (var i = 0; i < n; ++i) {
+  for (i = 0; i < n; ++i) {
     for (var j = 0; j < nChunks; ++j)
       sd.write(chunks[j]);
   }

--- a/benchmark/querystring/querystring-parse.js
+++ b/benchmark/querystring/querystring-parse.js
@@ -27,8 +27,16 @@ function main(conf) {
   v8.setFlagsFromString('--allow_natives_syntax');
   eval('%OptimizeFunctionOnNextCall(querystring.parse)');
 
-  bench.start();
-  for (var i = 0; i < n; i += 1)
-    querystring.parse(input);
-  bench.end(n);
+  var i;
+  if (type !== 'multicharsep') {
+    bench.start();
+    for (i = 0; i < n; i += 1)
+      querystring.parse(input);
+    bench.end(n);
+  } else {
+    bench.start();
+    for (i = 0; i < n; i += 1)
+      querystring.parse(input, '&&&&&&&&&&');
+    bench.end(n);
+  }
 }


### PR DESCRIPTION
Backport for v4.x

### Pull Request check-list


- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

benchmark

### Description of change

In order to comply with linting rules used in the rest of the code base,
eliminate redeclared variables. A conservative approach is used so as to
avoid unintentional performance issues (for example, as might be seen in
some situations when using `let` instead of `var`).