### PR TITLE
test: reduce brittleness of tab complete test

### DIFF
--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -226,97 +226,26 @@ putIn.run([
   'var proxy = new Proxy({}, {ownKeys: () => { throw new Error(); }});'
 ]);
 
-const proxyElements = [ [
-  'proxy.__defineGetter__',
-  'proxy.__defineSetter__',
-  'proxy.__lookupGetter__',
-  'proxy.__lookupSetter__',
-  'proxy.__proto__',
-  'proxy.constructor',
-  'proxy.hasOwnProperty',
-  'proxy.isPrototypeOf',
-  'proxy.propertyIsEnumerable',
-  'proxy.toLocaleString',
-  'proxy.toString',
-  'proxy.valueOf' ],
-  'proxy.' ];
-
 testMe.complete('proxy.', common.mustCall(function(error, data) {
   assert.strictEqual(error, null);
-  assert.deepEqual(data, proxyElements);
 }));
 
 // Make sure tab completion does not include integer members of an Array
-var array_elements = [ [
-  'ary.__defineGetter__',
-  'ary.__defineSetter__',
-  'ary.__lookupGetter__',
-  'ary.__lookupSetter__',
-  'ary.__proto__',
-  'ary.constructor',
-  'ary.hasOwnProperty',
-  'ary.isPrototypeOf',
-  'ary.propertyIsEnumerable',
-  'ary.toLocaleString',
-  'ary.toString',
-  'ary.valueOf',
-  '',
-  'ary.concat',
-  'ary.copyWithin',
-  'ary.entries',
-  'ary.every',
-  'ary.fill',
-  'ary.filter',
-  'ary.find',
-  'ary.findIndex',
-  'ary.forEach',
-  'ary.includes',
-  'ary.indexOf',
-  'ary.join',
-  'ary.keys',
-  'ary.lastIndexOf',
-  'ary.length',
-  'ary.map',
-  'ary.pop',
-  'ary.push',
-  'ary.reduce',
-  'ary.reduceRight',
-  'ary.reverse',
-  'ary.shift',
-  'ary.slice',
-  'ary.some',
-  'ary.sort',
-  'ary.splice',
-  'ary.unshift' ],
-  'ary.'];
-
 putIn.run(['.clear']);
 
 putIn.run(['var ary = [1,2,3];']);
 testMe.complete('ary.', common.mustCall(function(error, data) {
-  assert.deepEqual(data, array_elements);
+  assert.strictEqual(data[0].indexOf('ary.0'), -1);
+  assert.strictEqual(data[0].indexOf('ary.1'), -1);
+  assert.strictEqual(data[0].indexOf('ary.2'), -1);
 }));
 
 // Make sure tab completion does not include integer keys in an object
-var obj_elements = [ [
-  'obj.__defineGetter__',
-  'obj.__defineSetter__',
-  'obj.__lookupGetter__',
-  'obj.__lookupSetter__',
-  'obj.__proto__',
-  'obj.constructor',
-  'obj.hasOwnProperty',
-  'obj.isPrototypeOf',
-  'obj.propertyIsEnumerable',
-  'obj.toLocaleString',
-  'obj.toString',
-  'obj.valueOf',
-  '',
-  'obj.a' ],
-  'obj.' ];
 putIn.run(['.clear']);
 putIn.run(['var obj = {1:"a","1a":"b",a:"b"};']);
 
 testMe.complete('obj.', common.mustCall(function(error, data) {
-  assert.deepEqual(data, obj_elements);
+  assert.strictEqual(data[0].indexOf('obj.1'), -1);
+  assert.strictEqual(data[0].indexOf('obj.1a'), -1);
+  assert.notStrictEqual(data[0].indexOf('obj.a'), -1);
 }));


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

_Please provide a description of the change here._

test-repl-tab-complete includes tests that ensure that certain keys do
not appear in tab completions or that completion does not crash the
repl. It performed these tests by comparing completion output to a
hardcoded list of expected keys. This list is made incorrect by any api
changes that occur when new versions of V8 are introduced.

With this change, we assert that the specific keys to be avoided are
not present in the output instead.