### PR TITLE
tls: deprecate `newSession`/`resumeSession` events

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -194,6 +194,9 @@ established it will be forwarded here.
 
 ### Event: 'newSession'
 
+Stability: 0 - Deprecated: Use synchronous `newSession` option-callback of
+[`tls.createServer`][] instead.
+
 `function (sessionId, sessionData, callback) { }`
 
 Emitted on creation of TLS session. May be used to store sessions in external
@@ -242,6 +245,9 @@ NOTE: you may want to use some npm module like [asn1.js] to parse the
 certificates.
 
 ### Event: 'resumeSession'
+
+Stability: 0 - Deprecated: Use synchronous `resumeSession` option-callback of
+[`tls.createServer`][] instead.
 
 `function (sessionId, callback) { }`
 
@@ -897,6 +903,13 @@ automatically set as a listener for the [`'secureConnection'`][] event.  The
   - `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
     SSL version 3. The possible values depend on your installation of
     OpenSSL and are defined in the constant [SSL_METHODS][].
+
+  - `newSession`: A callback to invoke when creating new TLS session
+    (Signature: `newSession(sessionId, sessionData)`).
+
+  - `resumeSession`: A callback to invoke when client attempts to resume some
+    TLS session by id (Signature: `resumeSession(sessionId)`, should return
+    `undefined` or `Buffer` instance with `sessionData` from `newSession`).
 
 Here is a simple example echo server:
 

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -173,3 +173,14 @@ exports.translatePeerCertificate = function translatePeerCertificate(c) {
   }
   return c;
 };
+
+exports.deprecateAsyncSessionAPI = function deprecateAsyncSessionAPI(server) {
+  const asyncSessionWarning = internalUtil.deprecate(() => {},
+      'server.on(\'newSession\')/server.on(\'resumeSession\') are deprecated.' +
+          ' Please upgrade to synchronous API and pass these callbacks in ' +
+          'options.newSession (options.resumeSession).');
+  server.on('newListener', (type) => {
+    if (/^(new|resume)Session$/.test(type))
+      asyncSessionWarning();
+  });
+};

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -72,10 +72,16 @@ function loadSession(self, hello, cb) {
     cb(null, ret);
   }
 
-  if (hello.sessionId.length <= 0 ||
-      hello.tlsTicket ||
-      self.server &&
-      !self.server.emit('resumeSession', hello.sessionId, onSession)) {
+  if (hello.sessionId.length <= 0 || hello.tlsTicket) {
+    return cb(null);
+  }
+
+  assert(self.server);
+  if (self.server.onResumeSession) {
+    return onSession(null, self.server.onResumeSession(hello.sessionId));
+  }
+
+  if (!self.server.emit('resumeSession', hello.sessionId, onSession)) {
     cb(null);
   }
 }
@@ -183,6 +189,12 @@ function onnewsession(key, session) {
   var once = false;
 
   this._newSessionPending = true;
+  if (this.server.onNewSession) {
+    this.server.onNewSession(key, session);
+    done();
+    return;
+  }
+
   if (!this.server.emit('newSession', key, session, done))
     done();
 
@@ -398,7 +410,9 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.handshakes = 0;
 
     if (this.server) {
-      if (this.server.listenerCount('resumeSession') > 0 ||
+      if (this.server.onNewSession ||
+          this.server.onResumeSession ||
+          this.server.listenerCount('resumeSession') > 0 ||
           this.server.listenerCount('newSession') > 0) {
         ssl.enableSessionCallbacks();
       }
@@ -828,6 +842,8 @@ function Server(/* [options], listener */) {
   if (listener) {
     this.on('secureConnection', listener);
   }
+
+  common.deprecateAsyncSessionAPI(this);
 }
 
 util.inherits(Server, net.Server);
@@ -902,6 +918,9 @@ Server.prototype.setOptions = function(options) {
                                   .digest('hex')
                                   .slice(0, 32);
   }
+
+  if (options.newSession) this.onNewSession = options.newSession;
+  if (options.resumeSession) this.onResumeSession = options.resumeSession;
 };
 
 // SNI Contexts High-Level API


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit)?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
### Affected core subsystem(s)

tls
### Description of change

Deprecate asynchronous `newSession`/`resumeSession` events, introduce a
synchronous APIs via `newSession`/`resumeSession` option-callback for
`tls.createServer`.

The reason for this transition is rather simple. There is a quite big
amount of code that was added to support this construction, and not that
much users of it. Additionally, that code chunk is running in front of
OpenSSL, so it makes the process of asynchronous session resumption
twice as ineffective.

See: #1462
