### PR TITLE
deps: reintroduce supporting shared c-ares builds

### DIFF
--- a/configure
+++ b/configure
@@ -202,6 +202,27 @@ shared_optgroup.add_option('--shared-zlib-libpath',
     dest='shared_zlib_libpath',
     help='a directory to search for the shared zlib DLL')
 
+shared_optgroup.add_option('--shared-cares',
+    action='store_true',
+    dest='shared_libcares',
+    help='link to a shared cares DLL instead of static linking')
+
+shared_optgroup.add_option('--shared-cares-includes',
+    action='store',
+    dest='shared_libcares_includes',
+    help='directory containing cares header files')
+
+shared_optgroup.add_option('--shared-cares-libname',
+    action='store',
+    dest='shared_libcares_libname',
+    default='cares',
+    help='alternative lib name to link to [default: %default]')
+
+shared_optgroup.add_option('--shared-cares-libpath',
+    action='store',
+    dest='shared_libcares_libpath',
+    help='a directory to search for the shared cares DLL')
+
 parser.add_option_group(shared_optgroup)
 
 parser.add_option('--systemtap-includes',
@@ -1125,6 +1146,10 @@ configure_node(output)
 configure_library('zlib', output)
 configure_library('http_parser', output)
 configure_library('libuv', output)
+configure_library('libcares', output)
+# stay backwards compatible with shared cares builds
+output['variables']['node_shared_cares'] = \
+    output['variables'].pop('node_shared_libcares')
 configure_v8(output)
 configure_openssl(output)
 configure_intl(output)

--- a/node.gyp
+++ b/node.gyp
@@ -8,6 +8,7 @@
     'node_no_browser_globals%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
+    'node_shared_cares%': 'false',
     'node_shared_libuv%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
@@ -107,7 +108,6 @@
 
       'dependencies': [
         'node_js2c#host',
-        'deps/cares/cares.gyp:cares',
         'deps/v8/tools/gyp/v8.gyp:v8',
         'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
       ],
@@ -389,6 +389,10 @@
 
         [ 'node_shared_http_parser=="false"', {
           'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
+        }],
+
+        [ 'node_shared_cares=="false"', {
+          'dependencies': [ 'deps/cares/cares.gyp:cares' ],
         }],
 
         [ 'node_shared_libuv=="false"', {

--- a/tools/install.py
+++ b/tools/install.py
@@ -164,8 +164,10 @@ def headers(action):
   if sys.platform.startswith('aix'):
     action(['out/Release/node.exp'], 'include/node/')
 
-  subdir_files('deps/cares/include', 'include/node/', action)
   subdir_files('deps/v8/include', 'include/node/', action)
+
+  if 'false' == variables.get('node_shared_cares'):
+    subdir_files('deps/cares/include', 'include/node/', action)
 
   if 'false' == variables.get('node_shared_libuv'):
     subdir_files('deps/uv/include', 'include/node/', action)


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to CONTRIBUTING.md?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

build, deps

### Description of change

As of cc192f0e we've now in sync with upstream which means that we also can allow our users to build against a shared version of c-ares.

Note: It is still up to users to make sure that the library version is on par with what Node.js bundles.

This "reverts" commit 25fa5c4c79fccf2fdfa7f6ad8ffb9d596a5d49f4.

Tested on gentoo with a shared version c-ares. Tests pass.

/CC @indutny, @bnoordhuis