### PR TITLE
stream,win: fix ghost keypress events

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -738,7 +738,8 @@ Readable.prototype.pause = function() {
   if (false !== this._readableState.flowing) {
     debug('pause');
     this._readableState.flowing = false;
-    this.emit('pause');
+    // Emit 'pause' on next tick as we do for 'resume'
+    process.nextTick(() => this.emit('pause'));
   }
   return this;
 };

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -17,17 +17,23 @@ function ReadStream(fd, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(fd, options);
 
+  // pauseOnCreate to avoid reading from the sytem buffer
   options = util._extend({
     highWaterMark: 0,
     readable: true,
     writable: false,
-    handle: new TTY(fd, true)
+    handle: new TTY(fd, true),
+    pauseOnCreate: true
   }, options);
 
   net.Socket.call(this, options);
 
   this.isRaw = false;
   this.isTTY = true;
+
+  // Let the stream resume automatically when 'data' event handlers
+  // are added, even though it was paused on creation
+  this._readableState.flowing = null;
 }
 inherits(ReadStream, net.Socket);
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)
stream, win

### Description of change

**First commit:**
The tty.ReadStream constructor initializes this as a socket,
which causes a read to be initiated. Even though during stdin
initalization we call readStop shortly after, the read operation
can consume keypress events from the system buffers.

Fixes: https://github.com/nodejs/node/issues/5384

**Second commit:**
The change in the first commit change surfaces an issue with readable streams, which causes test\parallel\test-stdin-resume-pause.js (and a few others) to fail. The second commit addresses that issue.

R: @nodejs/streams @silverwind @cjihrig 

