### PR TITLE
src,tools: use template literals

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,3 +1,6 @@
 rules:
+  # ECMAScript-6
+  # http://eslint.org/docs/rules/#ecmascript-6
+  prefer-template: 2
   # Custom rules in tools/eslint-rules
   buffer-constructor: 2

--- a/src/node.js
+++ b/src/node.js
@@ -566,19 +566,19 @@
     module.paths = Module._nodeModulePaths(cwd);
     var script = process._eval;
     var body = script;
-    script = 'global.__filename = ' + JSON.stringify(name) + ';\n' +
+    script = `global.__filename = ${JSON.stringify(name)};\n` +
              'global.exports = exports;\n' +
              'global.module = module;\n' +
              'global.__dirname = __dirname;\n' +
              'global.require = require;\n' +
              'return require("vm").runInThisContext(' +
-             JSON.stringify(body) + ', { filename: ' +
-             JSON.stringify(name) + ', displayErrors: true });\n';
+             `${JSON.stringify(body)}, { filename: ` +
+             `${JSON.stringify(name)}, displayErrors: true });\n`;
     // Defer evaluation for a tick.  This is a workaround for deferred
     // events not firing when evaluating scripts from the command line,
     // see https://github.com/nodejs/node/issues/1600.
     process.nextTick(function() {
-      var result = module._compile(script, name + '-wrapper');
+      var result = module._compile(script, `${name}-wrapper`);
       if (process._print_eval) console.log(result);
     });
   }
@@ -770,7 +770,7 @@
             sig.slice(0, 3) === 'SIG') {
           err = process._kill(pid, startup.lazyConstants()[sig]);
         } else {
-          throw new Error('Unknown signal: ' + sig);
+          throw new Error(`Unknown signal: ${sig}`);
         }
       }
 
@@ -875,7 +875,7 @@
   }
 
   function NativeModule(id) {
-    this.filename = id + '.js';
+    this.filename = `${id}.js`;
     this.id = id;
     this.exports = {};
     this.loaded = false;
@@ -895,10 +895,10 @@
     }
 
     if (!NativeModule.exists(id)) {
-      throw new Error('No such native module ' + id);
+      throw new Error(`No such native module ${id}`);
     }
 
-    process.moduleLoadList.push('NativeModule ' + id);
+    process.moduleLoadList.push(`NativeModule ${id}`);
 
     var nativeModule = new NativeModule(id);
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

src, tools

### Description of change

Convert string concatenation to template literals. Enforce with lint
rule.

This came out of the conversation around https://github.com/nodejs/node/pull/5762. If this is not objectionable, then the idea would be to enable the `prefer-template` rule on other parts of the codebase, moving it incrementally to using template literals instead of string concatenation.