### PR TITLE
build,android: Added option to compile for Android with -fPIE flag

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -15,4 +15,6 @@ export LINK=$TOOLCHAIN/bin/arm-linux-androideabi-g++
 
 ./configure \
     --dest-cpu=arm \
-    --dest-os=android
+    --dest-os=android \
+    --cflag-pie=true \
+    --without-snapshot

--- a/common.gypi
+++ b/common.gypi
@@ -68,6 +68,10 @@
             'cflags': [ '-gxcoff' ],
             'ldflags': [ '-Wl,-bbigtoc' ],
           }],
+          ['cflag_pie=="true"', {
+            'cflags': [ '-fPIE' ],
+            'ldflags': [ '-fPIE', '-pie' ],
+          }],
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
@@ -100,6 +104,10 @@
           }],
           ['OS!="mac" and OS!="win"', {
             'cflags': [ '-fno-omit-frame-pointer' ],
+          }],
+          ['cflag_pie=="true"', {
+            'cflags': [ '-fPIE' ],
+            'ldflags': [ '-fPIE', '-pie' ],
           }],
         ],
         'msvs_settings': {

--- a/configure
+++ b/configure
@@ -373,6 +373,13 @@ parser.add_option('--enable-static',
     dest='enable_static',
     help='build as static library')
 
+parser.add_option('--cflag-pie',
+    action='store',
+    choices=('true', 'false'),
+    default='false',
+    dest='cflag_pie',
+    help='add cflags -fPIE')
+
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -666,6 +673,9 @@ def configure_mips(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
+
+  o['variables']['cflag_pie'] = options.cflag_pie
+
   o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'


### PR DESCRIPTION
### Description of change
Hi,

Node for Android wasn't executable using the actual android-configure file. I made this PR using @kikijhu proposition and it  builds fine on Linux (see #3581).

The created executable is PIE, and thus working on Android L & M (both tested).

I welcome any improvement you can make to this PR.


