### PR TITLE
contextify: tie lifetimes of context & sandbox

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -50,7 +50,8 @@ namespace node {
 #define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                              \
   V(alpn_buffer_private_symbol, "node:alpnBuffer")                            \
   V(arrow_message_private_symbol, "node:arrowMessage")                        \
-  V(contextify_private_symbol, "node:contextify")                             \
+  V(contextify_context_private_symbol, "node:contextify:context")             \
+  V(contextify_global_private_symbol, "node:contextify:global")               \
   V(decorated_private_symbol, "node:decorated")                               \
   V(npn_buffer_private_symbol, "node:npnBuffer")                              \
   V(processed_private_symbol, "node:processed")                               \

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-gc
 require('../common');
 var assert = require('assert');
 
@@ -18,3 +19,11 @@ console.error('test updating context');
 result = vm.runInContext('var foo = 3;', context);
 assert.equal(3, context.foo);
 assert.equal('lala', context.thing);
+
+// https://github.com/nodejs/node/issues/5768
+console.error('run in contextified sandbox without referencing the context');
+var sandbox = {x: 1};
+vm.createContext(sandbox);
+gc();
+vm.runInContext('x = 2', sandbox);
+// Should not crash.


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

contextify

### Description of change

When the previous set of changes (bfff07b4) it was possible to have the
context get garbage collected while sandbox was still live. We need to
tie the lifetime of the context to the lifetime of the sandbox.

Fixes: https://github.com/nodejs/node/issues/5768
R=@bnoordhuis
/cc @evanlucas @cjihrig 

Note that this is not trivially back-portable to 5.x. `SetPrivate` doesn't exist on 5.x, but I can create a new PR once this lands on master. This does continue to address the memory growth issue reported in #3113, but we should get this vetted before backporting.

CI: https://ci.nodejs.org/job/node-test-pull-request/1960/