### PR TITLE
timers: give Timeouts a constructor name

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -439,7 +439,7 @@ exports.clearInterval = function(timer) {
 };
 
 
-const Timeout = function(after) {
+function Timeout(after) {
   this._called = false;
   this._idleTimeout = after;
   this._idlePrev = this;

--- a/test/message/timeout_throw.out
+++ b/test/message/timeout_throw.out
@@ -2,6 +2,6 @@
   undefined_reference_error_maker;
   ^
 ReferenceError: undefined_reference_error_maker is not defined
-    at ._onTimeout (*test*message*timeout_throw.js:*:*)
+    at Timeout._onTimeout (*test*message*timeout_throw.js:*:*)
     at tryOnTimeout (timers.js:*:*)
     at Timer.listOnTimeout (timers.js:*:*)


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

timers

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Refs: https://github.com/nodejs/node/pull/5792

No functional difference, this is for clarity only.