### PR TITLE
Backport 5786 to v5.x

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -209,7 +209,17 @@ class ContextifyContext {
 
     CHECK(!ctx.IsEmpty());
     ctx->SetSecurityToken(env->context()->GetSecurityToken());
+
+    // We need to tie the lifetime of the sandbox object with the lifetime of
+    // newly created context. We do this by making them hold references to each
+    // other. The context can directly hold a reference to the sandbox as an
+    // embedder data field. However, we cannot hold a reference to a v8::Context
+    // directly in an Object, we instead hold onto the new context's global
+    // object instead (which then has a reference to the context).
     ctx->SetEmbedderData(kSandboxObjectIndex, sandbox_obj);
+    sandbox_obj->SetHiddenValue(
+        FIXED_ONE_BYTE_STRING(env->isolate(), "_contextifyHiddenGlobal"),
+        ctx->Global());
 
     env->AssignToContext(ctx);
 

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-gc
 require('../common');
 var assert = require('assert');
 
@@ -18,3 +19,11 @@ console.error('test updating context');
 result = vm.runInContext('var foo = 3;', context);
 assert.equal(3, context.foo);
 assert.equal('lala', context.thing);
+
+// https://github.com/nodejs/node/issues/5768
+console.error('run in contextified sandbox without referencing the context');
+var sandbox = {x: 1};
+vm.createContext(sandbox);
+gc();
+vm.runInContext('x = 2', sandbox);
+// Should not crash.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to CONTRIBUTING.md?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

contextify

### Description of change

Backport of #5786 to `v5.x`. The implementation is slightly different from `master` because `SetPrivate` is not available in `v5.x`. This fixes the contextify regression in 5.9.0 (#5768).

R=@bnoordhuis
/cc @nodejs/release 
CI: https://ci.nodejs.org/job/node-test-pull-request/1969/