### PR TITLE
test: fix flaky test-cluster-shared-leak

### DIFF
--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -40,6 +40,11 @@ if (cluster.isMaster) {
 }
 
 const server = net.createServer(function(c) {
+  c.on('error', function(e) {
+    // ECONNRESET is OK, so we don't exit with code !== 0
+    if (e.code !== 'ECONNRESET')
+      throw e;
+  });
   c.end('bye');
 });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

_Please provide a description of the change here._

Test was flaky on centos7-64 due to an uncaught ECONNRESET on the worker code. This catches the error so the process will exit with code 0.

Fixes: https://github.com/nodejs/node/issues/5604

PS: I did consider retrying but `ECONNRESET` was already being disregarded on the cluster-master side of things, and the test itself is concerned with a particular assertion in `cluster`, but I'd still like some feedback on this.
You can reproduce the error by adding a timeout like this:
```
//...
conn.on('error', function(e) {
  // ECONNRESET is OK
  if (e.code !== 'ECONNRESET')
    throw e;
});
// add this and run the test a couple times:
setTimeout(function(){
  conn.destroy();
}, 5);
//...
```