### PR TITLE
dns: Refactor forEach to map

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -285,41 +285,37 @@ exports.getServers = function() {
 exports.setServers = function(servers) {
   // cache the original servers because in the event of an error setting the
   // servers cares won't have any servers available for resolution
-  var orig = cares.getServers();
+  const orig = cares.getServers();
 
-  var newSet = [];
+  const newSet = servers.map((serv) => {
+    var ipVersion = isIP(serv);
+    if (ipVersion !== 0)
+      return [ipVersion, serv];
 
-  servers.forEach(function(serv) {
-    var ver = isIP(serv);
-
-    if (ver)
-      return newSet.push([ver, serv]);
-
-    var match = serv.match(/\[(.*)\](:\d+)?/);
-
+    const match = serv.match(/\[(.*)\](:\d+)?/);
     // we have an IPv6 in brackets
     if (match) {
-      ver = isIP(match[1]);
-      if (ver)
-        return newSet.push([ver, match[1]]);
+      ipVersion = isIP(match[1]);
+      if (ipVersion !== 0)
+        return [ipVersion, match[1]];
     }
 
-    var s = serv.split(/:\d+$/)[0];
-    ver = isIP(s);
+    const s = serv.split(/:\d+$/)[0];
+    ipVersion = isIP(s);
 
-    if (ver)
-      return newSet.push([ver, s]);
+    if (ipVersion !== 0)
+      return [ipVersion, s];
 
     throw new Error(`IP address is not properly formatted: ${serv}`);
   });
 
-  var r = cares.setServers(newSet);
+  const errorNumber = cares.setServers(newSet);
 
-  if (r) {
+  if (errorNumber !== 0) {
     // reset the servers to the old servers, because ares probably unset them
     cares.setServers(orig.join(','));
 
-    var err = cares.strerror(r);
+    var err = cares.strerror(errorNumber);
     throw new Error(`c-ares failed to set servers: "${err}" [${servers}]`);
   }
 };


### PR DESCRIPTION
### Pull Request check-list
### Affected core subsystem(s)

dns

### Description of change

This is (as suggested) a more modular take on - https://github.com/nodejs/node/pull/5762/ , adding the changes one by one and making sure they're less objectionable. Making more smaller PRs.

Refactor a forEach to a `map` in the `setServers` function of the
dns module - simplifying the code. In addition, use more descriptive
variable names and `const` over `var` where possible.
