### PR TITLE
dns: use isIp consistently

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const net = require('net');
 const util = require('util');
 
 const cares = process.binding('cares_wrap');
@@ -11,7 +10,7 @@ const GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
 const GetNameInfoReqWrap = cares.GetNameInfoReqWrap;
 const QueryReqWrap = cares.QueryReqWrap;
 
-const isIp = net.isIP;
+const isIP = cares.isIP;
 const isLegalPort = internalNet.isLegalPort;
 
 
@@ -148,7 +147,7 @@ exports.lookup = function lookup(hostname, options, callback) {
     return {};
   }
 
-  var matchedFamily = net.isIP(hostname);
+  var matchedFamily = isIP(hostname);
   if (matchedFamily) {
     if (all) {
       callback(null, [{address: hostname, family: matchedFamily}]);
@@ -188,7 +187,7 @@ exports.lookupService = function(host, port, callback) {
   if (arguments.length !== 3)
     throw new Error('Invalid arguments');
 
-  if (cares.isIP(host) === 0)
+  if (isIP(host) === 0)
     throw new TypeError('"host" argument needs to be a valid IP address');
 
   if (port == null || !isLegalPort(port))
@@ -290,7 +289,7 @@ exports.setServers = function(servers) {
   var newSet = [];
 
   servers.forEach(function(serv) {
-    var ver = isIp(serv);
+    var ver = isIP(serv);
 
     if (ver)
       return newSet.push([ver, serv]);
@@ -299,13 +298,13 @@ exports.setServers = function(servers) {
 
     // we have an IPv6 in brackets
     if (match) {
-      ver = isIp(match[1]);
+      ver = isIP(match[1]);
       if (ver)
         return newSet.push([ver, match[1]]);
     }
 
     var s = serv.split(/:\d+$/)[0];
-    ver = isIp(s);
+    ver = isIP(s);
 
     if (ver)
       return newSet.push([ver, s]);


### PR DESCRIPTION

### Affected core subsystem(s)

dns

### Description of change

This is a more modular take on https://github.com/nodejs/node/pull/5762/ ,

Currently the DNS module imports isIP from both cares and `net` and
uses both of them both throughout the code base. This PR removes the
direct dependency `dns` has on `net` and uses `isIp` from c-ares all
the time. Note that both functions do the same thing.

