### PR TITLE
dns: use template literals

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -25,7 +25,8 @@ function errnoException(err, syscall, hostname) {
   }
   var ex = null;
   if (typeof err === 'string') {  // c-ares error code.
-    ex = new Error(syscall + ' ' + err + (hostname ? ' ' + hostname : ''));
+    const errHost = hostname ? ' ' + hostname : '';
+    ex = new Error(`${syscall} ${err}${errHost}`);
     ex.code = err;
     ex.errno = err;
     ex.syscall = syscall;
@@ -272,7 +273,7 @@ exports.resolve = function(hostname, type_, callback_) {
   if (typeof resolver === 'function') {
     return resolver(hostname, callback);
   } else {
-    throw new Error('Unknown type "' + type_ + '"');
+    throw new Error(`Unknown type "${type_}"`);
   }
 };
 
@@ -310,7 +311,7 @@ exports.setServers = function(servers) {
     if (ver)
       return newSet.push([ver, s]);
 
-    throw new Error('IP address is not properly formatted: ' + serv);
+    throw new Error(`IP address is not properly formatted: ${serv}`);
   });
 
   var r = cares.setServers(newSet);
@@ -320,8 +321,7 @@ exports.setServers = function(servers) {
     cares.setServers(orig.join(','));
 
     var err = cares.strerror(r);
-    throw new Error('c-ares failed to set servers: "' + err +
-                    '" [' + servers + ']');
+    throw new Error(`c-ares failed to set servers: "${err}" [${servers}]`);
   }
 };
 


### PR DESCRIPTION
### Affected core subsystem(s)

dns

### Description of change

Prefer the use of template string literals over string concatenation in the dns module, makes dns consistent with other modules basically doing https://github.com/nodejs/node/pull/5778 for it.


(ci https://ci.nodejs.org/job/node-test-pull-request/1976/ )