### PR TITLE
test: fix `test-cluster-worker-kill`

### DIFF
--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -60,8 +60,6 @@ if (cluster.isWorker) {
     results.cluster_exitCode = worker.process.exitCode;
     results.cluster_signalCode = worker.process.signalCode;
     results.cluster_emitExit += 1;
-    assert.ok(results.cluster_emitDisconnect,
-        "cluster: 'exit' event before 'disconnect' event");
   });
 
   // Check worker events and properties
@@ -77,26 +75,11 @@ if (cluster.isWorker) {
     results.worker_signalCode = signalCode;
     results.worker_emitExit += 1;
     results.worker_died = !alive(worker.process.pid);
-    assert.ok(results.worker_emitDisconnect,
-        "worker: 'exit' event before 'disconnect' event");
-
-    process.nextTick(function() { finish_test(); });
   });
 
-  var finish_test = function() {
-    try {
-      checkResults(expected_results, results);
-    } catch (exc) {
-      console.error('FAIL: ' + exc.message);
-      if (exc.name != 'AssertionError') {
-        console.trace(exc);
-      }
-
-      process.exit(1);
-      return;
-    }
-    process.exit(0);
-  };
+  process.on('exit', function() {
+    checkResults(expected_results, results);
+  });
 }
 
 // some helper functions ...


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)
test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change
Don't check that the `disconnect` event is emitted before the `exit`
event as the order is not guaranteed.
See failing test @ https://ci.nodejs.org/job/node-test-commit-linux/nodes=centos5-32/2648/tapTestReport/test.tap-133/
```
not ok 133 test-cluster-worker-kill.js
# 
# assert.js:89
# throw new assert.AssertionError({
# ^
# AssertionError: worker: 'exit' event before 'disconnect' event
# at Worker.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux/nodes/centos5-32/test/parallel/test-cluster-worker-kill.js:80:12)
# at Worker.g (events.js:273:16)
# at emitTwo (events.js:100:13)
# at Worker.emit (events.js:185:7)
# at ChildProcess.<anonymous> (cluster.js:361:14)
# at ChildProcess.g (events.js:273:16)
# at emitTwo (events.js:100:13)
# at ChildProcess.emit (events.js:185:7)
# at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
```