### PR TITLE
events: make eventNames() return only enumerable properties

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -440,7 +440,9 @@ EventEmitter.prototype.eventNames = function eventNames() {
   if (this._eventsCount > 0) {
     const events = this._events;
     return Object.keys(events).concat(
-      Object.getOwnPropertySymbols(events));
+      Object.getOwnPropertySymbols(events)
+      .filter((s) => events.propertyIsEnumerable(s))
+    );
   }
   return [];
 };

--- a/test/parallel/test-events-list.js
+++ b/test/parallel/test-events-list.js
@@ -17,3 +17,5 @@ EE.on(s, m);
 assert.deepStrictEqual(['foo', s], EE.eventNames());
 EE.removeListener(s, m);
 assert.deepStrictEqual(['foo'], EE.eventNames());
+Object.defineProperty(EE._events, s, { value: 'bar' });
+assert.deepStrictEqual(['foo'], EE.eventNames());


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to CONTRIBUTING.md?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

events

### Description of change

Right now `eventNames()` returns all the symbol properties (enumerable or not) directly found in `_events`. This patch prevents non-enumerable symbol properties from being included in the returned array.