### PR TITLE
buffer: Reverting change in let to fix regressions in buffer operations

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -185,7 +185,7 @@ function fromString(string, encoding) {
 function fromArrayLike(obj) {
   const length = obj.length;
   const b = allocate(length);
-  for (let i = 0; i < length; i++)
+  for (var i = 0; i < length; i++)
     b[i] = obj[i] & 255;
   return b;
 }
@@ -276,6 +276,7 @@ Buffer.isEncoding = function(encoding) {
 
 
 Buffer.concat = function(list, length) {
+  var i;
   if (!Array.isArray(list))
     throw new TypeError('"list" argument must be an Array of Buffers');
 
@@ -284,7 +285,7 @@ Buffer.concat = function(list, length) {
 
   if (length === undefined) {
     length = 0;
-    for (let i = 0; i < list.length; i++)
+    for (i = 0; i < list.length; i++)
       length += list[i].length;
   } else {
     length = length >>> 0;
@@ -292,7 +293,7 @@ Buffer.concat = function(list, length) {
 
   var buffer = Buffer.allocUnsafe(length);
   var pos = 0;
-  for (let i = 0; i < list.length; i++) {
+  for (i = 0; i < list.length; i++) {
     var buf = list[i];
     if (!Buffer.isBuffer(buf))
       throw new TypeError('"list" argument must be an Array of Buffers');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

buffer

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change


Using let in for loops showed a regression in 4.4.0. @ofrobots suggested
that we avoid using let in for loops until TurboFan becomes the default
optimiser.

As discussed in https://github.com/nodejs/benchmarking/issues/38