### PR TITLE
events: make eventNames() use Reflect.ownKeys()

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -437,12 +437,7 @@ function listenerCount(type) {
 }
 
 EventEmitter.prototype.eventNames = function eventNames() {
-  if (this._eventsCount > 0) {
-    const events = this._events;
-    return Object.keys(events).concat(
-      Object.getOwnPropertySymbols(events));
-  }
-  return [];
+  return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
 };
 
 // About 1.5x faster than the two-arg version of Array#splice().


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to CONTRIBUTING.md?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

events

### Description of change

Use [`Reflect.ownKeys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys) instead of [`Object.keys()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) and [`Object.getOwnPropertySymbols()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols).