### PR TITLE
util: don't apply any object for util.format() as this

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -99,7 +99,7 @@ exports.debuglog = function(set) {
     if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
       var pid = process.pid;
       debugs[set] = function() {
-        var msg = exports.format.apply(exports, arguments);
+        var msg = exports.format.apply(null, arguments);
         console.error('%s %d: %s', set, pid, msg);
       };
     } else {
@@ -803,7 +803,7 @@ function timestamp() {
 
 // log is just a thin wrapper to console.log that prepends a timestamp
 exports.log = function() {
-  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
+  console.log('%s - %s', timestamp(), exports.format.apply(null, arguments));
 };
 
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

util

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change
The util.format() is stateless.