### PR TITLE
child_process: tracking unrefdness of child_process

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -166,6 +166,7 @@ function ChildProcess() {
 
   this._handle = new Process();
   this._handle.owner = this;
+  this._unref = false;
 
   this._handle.onexit = function(exitCode, signalCode) {
     //
@@ -388,11 +389,13 @@ ChildProcess.prototype.kill = function(sig) {
 
 
 ChildProcess.prototype.ref = function() {
+  this._unref = false;
   if (this._handle) this._handle.ref();
 };
 
 
 ChildProcess.prototype.unref = function() {
+  this._unref = true;
   if (this._handle) this._handle.unref();
 };
 

--- a/test/parallel/test-child-process-ref-unref.js
+++ b/test/parallel/test-child-process-ref-unref.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const spawn = require('child_process').spawn;
+const cmd = common.isWindows ? 'rundll32' : 'ls';
+const assert = require('assert');
+
+const cp = spawn(cmd);
+assert.ok(cp.hasOwnProperty('_unref'));
+assert.ok(!cp._unref);
+cp.unref();
+assert.ok(cp._unref);
+cp.ref();
+assert.ok(!cp._unref);
+cp.unref();
+assert.ok(cp._unref);

--- a/test/parallel/test-child-process-ref-unref.js
+++ b/test/parallel/test-child-process-ref-unref.js
@@ -5,11 +5,11 @@ const cmd = common.isWindows ? 'rundll32' : 'ls';
 const assert = require('assert');
 
 const cp = spawn(cmd);
-assert.ok(cp.hasOwnProperty('_unref'));
-assert.ok(!cp._unref);
+assert.strictEqual(cp.hasOwnProperty('_unref'), true);
+assert.strictEqual(cp._unref, false);
 cp.unref();
-assert.ok(cp._unref);
+assert.strictEqual(cp._unref, true);
 cp.ref();
-assert.ok(!cp._unref);
+assert.strictEqual(cp._unref, false);
 cp.unref();
-assert.ok(cp._unref);
+assert.strictEqual(cp._unref, true);


### PR DESCRIPTION
### Affected core subsystem

child_process

### Description of change

- initializing `_unref` to `false` when child process is created
- updating that value each time either `unref()` or `ref()` is invoked
- this mirrors the implementation in `lib/net.js`
- adding test to check unrefdness tracking

R= @Fishrock123 
R= @trevnorris 