### PR TITLE
buffer: replace SlowBuffer with Buffer.allocUnsafeSlow(size)

### DIFF
--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -8,6 +8,7 @@ const bench = common.createBenchmark(main, {
     'fast-alloc',
     'fast-alloc-fill',
     'fast-allocUnsafe',
+    'slow-allocUnsafe',
     'slow',
     'buffer()'],
   len: [10, 1024, 2048, 4096, 8192],
@@ -36,6 +37,13 @@ function main(conf) {
       bench.start();
       for (let i = 0; i < n * 1024; i++) {
         Buffer.allocUnsafe(len);
+      }
+      bench.end(n);
+      break;
+    case 'slow-allocUnsafe':
+      bench.start();
+      for (let i = 0; i < n * 1024; i++) {
+        Buffer.allocUnsafeSlow(len);
       }
       bench.end(n);
       break;

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -103,14 +103,13 @@ use the shared internal memory pool.
 ### The `--zero-fill-buffers` command line option
 
 Node.js can be started using the `--zero-fill-buffers` command line option to
-force all newly allocated `Buffer` and `SlowBuffer` instances created using
-either `new Buffer(size)`, `Buffer.allocUnsafe(size)`,
-`Buffer.allocUnsafeSlow(size)` or `new SlowBuffer(size)` to be *automatically
-zero-filled* upon creation. Use of this flag *changes the default behavior* of
-these methods and *can have a significant impact* on performance. Use of the
-`--zero-fill-buffers` option is recommended only when absolutely necessary to
-enforce that newly allocated `Buffer` instances cannot contain potentially
-sensitive data.
+force all newly allocated `Buffer` instances created using either
+`new Buffer(size)`, `Buffer.allocUnsafe(size)`, `Buffer.allocUnsafeSlow(size)`
+or `new SlowBuffer(size)` to be *automatically zero-filled* upon creation. Use
+of this flag *changes the default behavior* of these methods and *can have a
+significant impact* on performance. Use of the `--zero-fill-buffers` option is
+recommended only when absolutely necessary to enforce that newly allocated
+`Buffer` instances cannot contain potentially sensitive data.
 
 ```
 $ node --zero-fill-buffers
@@ -342,8 +341,8 @@ console.log(buf);
 Allocates a new `Buffer` of `size` bytes.  The `size` must be less than
 or equal to the value of `require('buffer').kMaxLength` (on 64-bit
 architectures, `kMaxLength` is `(2^31)-1`). Otherwise, a [`RangeError`][] is
-thrown. If a `size` less than 0 is specified, a zero-length Buffer will be
-created.
+thrown. A zero-length Buffer will be created if a `size` less than or equal to
+0 is specified.
 
 Unlike `ArrayBuffers`, the underlying memory for `Buffer` instances created in
 this way is *not initialized*. The contents of a newly created `Buffer` are
@@ -400,8 +399,8 @@ console.log(buf);
 
 The `size` must be less than or equal to the value of
 `require('buffer').kMaxLength` (on 64-bit architectures, `kMaxLength` is
-`(2^31)-1`). Otherwise, a [`RangeError`][] is thrown. If a `size` less than 0
-is specified, a zero-length `Buffer` will be created.
+`(2^31)-1`). Otherwise, a [`RangeError`][] is thrown. A zero-length Buffer will
+be created if a `size` less than or equal to 0 is specified.
 
 If `fill` is specified, the allocated `Buffer` will be initialized by calling
 `buf.fill(fill)`. See [`buf.fill()`][] for more information.
@@ -434,8 +433,8 @@ A `TypeError` will be thrown if `size` is not a number.
 Allocates a new *non-zero-filled* `Buffer` of `size` bytes.  The `size` must
 be less than or equal to the value of `require('buffer').kMaxLength` (on 64-bit
 architectures, `kMaxLength` is `(2^31)-1`). Otherwise, a [`RangeError`][] is
-thrown. If a `size` less than 0 is specified, a zero-length `Buffer` will be
-created.
+thrown. A zero-length Buffer will be created if a `size` less than or equal to
+0 is specified.
 
 The underlying memory for `Buffer` instances created in this way is *not
 initialized*. The contents of the newly created `Buffer` are unknown and
@@ -476,8 +475,8 @@ additional performance that `Buffer.allocUnsafe(size)` provides.
 Allocates a new *non-zero-filled* and non-pooled `Buffer` of `size` bytes.  The
 `size` must be less than or equal to the value of
 `require('buffer').kMaxLength` (on 64-bit architectures, `kMaxLength` is
-`(2^31)-1`). Otherwise, a [`RangeError`][] is thrown. If a `size` less than 0
-is specified, a zero-length `Buffer` will be created.
+`(2^31)-1`). Otherwise, a [`RangeError`][] is thrown. A zero-length Buffer will
+be created if a `size` less than or equal to 0 is specified.
 
 The underlying memory for `Buffer` instances created in this way is *not
 initialized*. The contents of the newly created `Buffer` are unknown and
@@ -1824,8 +1823,8 @@ has observed undue memory retention in their applications.
 Allocates a new `SlowBuffer` of `size` bytes.  The `size` must be less than
 or equal to the value of `require('buffer').kMaxLength` (on 64-bit
 architectures, `kMaxLength` is `(2^31)-1`). Otherwise, a [`RangeError`][] is
-thrown. If a `size` less than 0 is specified, a zero-length `SlowBuffer` will be
-created.
+thrown. A zero-length Buffer will be created if a `size` less than or equal to
+0 is specified.
 
 The underlying memory for `SlowBuffer` instances is *not initialized*. The
 contents of a newly created `SlowBuffer` are unknown and could contain

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -1783,6 +1783,9 @@ Note that this is a property on the `buffer` module as returned by
 
 ## Class: SlowBuffer
 
+    Stability: 0 - Deprecated: Use
+    [`Buffer.allocUnsafeSlow(size)`][buffer_allocunsafeslow] instead.
+
 Returns an un-pooled `Buffer`.
 
 In order to avoid the garbage collection overhead of creating many individually
@@ -1812,6 +1815,9 @@ Use of `SlowBuffer` should be used only as a last resort *after* a developer
 has observed undue memory retention in their applications.
 
 ### new SlowBuffer(size)
+
+    Stability: 0 - Deprecated: Use
+    [`Buffer.allocUnsafeSlow(size)`][buffer_allocunsafeslow] instead.
 
 * `size` Number
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -133,13 +133,23 @@ Buffer.from = function(value, encodingOrOffset, length) {
 Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
 Object.setPrototypeOf(Buffer, Uint8Array);
 
+function assertSize(size) {
+  if (typeof size !== 'number') {
+    const err = new TypeError('"size" argument must be a number');
+    // The following hides the 'assertSize' method from the
+    // callstack. This is done simply to hide the internal
+    // details of the implementation from bleeding out to users.
+    Error.captureStackTrace(err, assertSize);
+    throw err;
+  }
+}
+
 /**
  * Creates a new filled Buffer instance.
  * alloc(size[, fill[, encoding]])
  **/
 Buffer.alloc = function(size, fill, encoding) {
-  if (typeof size !== 'number')
-    throw new TypeError('"size" argument must be a number');
+  assertSize(size);
   if (size <= 0)
     return createBuffer(size);
   if (fill !== undefined) {
@@ -161,9 +171,20 @@ Buffer.alloc = function(size, fill, encoding) {
  * instance. If `--zero-fill-buffers` is set, will zero-fill the buffer.
  **/
 Buffer.allocUnsafe = function(size) {
-  if (typeof size !== 'number')
-    throw new TypeError('"size" argument must be a number');
+  assertSize(size);
   return allocate(size);
+};
+
+/**
+ * Equivalent to SlowBuffer(num), by default creates a non-zero-filled
+ * Buffer instance that is not allocated off the pre-initialized pool.
+ * If `--zero-fill-buffers` is set, will zero-fill the buffer.
+ **/
+Buffer.allocUnsafeSlow = function(size) {
+  assertSize(size);
+  if (size > 0)
+    flags[kNoZeroFill] = 1;
+  return createBuffer(size);
 };
 
 // If --zero-fill-buffers command line argument is set, a zero-filled

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-const SlowBuffer = require('buffer').SlowBuffer;
 const util = require('util');
 const pathModule = require('path');
 
@@ -321,7 +320,7 @@ ReadFileContext.prototype.read = function() {
   var length;
 
   if (this.size === 0) {
-    buffer = this.buffer = SlowBuffer(kReadFileBufferLength);
+    buffer = this.buffer = Buffer.allocUnsafeSlow(kReadFileBufferLength);
     offset = 0;
     length = kReadFileBufferLength;
   } else {
@@ -389,7 +388,7 @@ function readFileAfterStat(err, st) {
     return context.close(err);
   }
 
-  context.buffer = SlowBuffer(size);
+  context.buffer = Buffer.allocUnsafeSlow(size);
   context.read();
 }
 

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 
 var Buffer = require('buffer').Buffer;
-var SlowBuffer = require('buffer').SlowBuffer;
 
 // counter to ensure unique value is always copied
 var cntr = 0;
@@ -428,7 +427,7 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 
 {
   // also from a non-pooled instance
-  const b = new SlowBuffer(5);
+  const b = Buffer.allocUnsafeSlow(5);
   const c = b.slice(0, 4);
   const d = c.slice(0, 2);
   assert.equal(c.parent, d.parent);
@@ -1305,7 +1304,7 @@ assert.throws(function() {
 
   // try to slice a zero length Buffer
   // see https://github.com/joyent/node/issues/5881
-  SlowBuffer(0).slice(0, 1);
+  Buffer.alloc(0).slice(0, 1);
 })();
 
 // Regression test for #5482: should throw but not assert in C++ land.
@@ -1336,7 +1335,7 @@ assert.throws(function() {
 }, RangeError);
 
 assert.throws(function() {
-  SlowBuffer((-1 >>> 0) + 1);
+  Buffer.allocUnsafeSlow((-1 >>> 0) + 1);
 }, RangeError);
 
 if (common.hasCrypto) {
@@ -1435,14 +1434,13 @@ assert.throws(function() {
 }, regErrorMsg);
 
 
-// Test prototype getters don't throw
-assert.equal(Buffer.prototype.parent, undefined);
-assert.equal(Buffer.prototype.offset, undefined);
-assert.equal(SlowBuffer.prototype.parent, undefined);
-assert.equal(SlowBuffer.prototype.offset, undefined);
-
-
 // Test that ParseArrayIndex handles full uint32
 assert.throws(function() {
   Buffer.from(new ArrayBuffer(0), -1 >>> 0);
 }, /RangeError: 'offset' is out of bounds/);
+
+// Unpooled buffer (replaces SlowBuffer)
+const ubuf = Buffer.allocUnsafeSlow(10);
+assert(ubuf);
+assert(ubuf.buffer);
+assert.equal(ubuf.buffer.byteLength, 10);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

buffer

### Description of change

* Adds `Buffer.allocUnsafeSlow()` as a replacement for `SlowBuffer`
* Soft-deprecate `SlowBuffer`

Essentially, this aligns the functionality of `SlowBuffer` with the new constructor API

Refs: https://github.com/nodejs/node/issues/5799

/cc @ChALkeR @trevnorris 