### PR TITLE
handle_wrap: expose {un}refed check to JS

### DIFF
--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -9,6 +9,7 @@
 
 namespace node {
 
+using v8::Boolean;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
@@ -34,6 +35,15 @@ void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
     uv_unref(wrap->handle__);
     wrap->flags_ |= kUnref;
   }
+}
+
+
+void HandleWrap::IsRefed(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
+
+  bool refed = IsAlive(wrap) && (wrap->flags_ & kUnref) == 0;
+  args.GetReturnValue().Set(refed);
 }
 
 

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -35,6 +35,7 @@ class HandleWrap : public AsyncWrap {
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Ref(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Unref(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void IsRefed(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static inline bool IsAlive(const HandleWrap* wrap) {
     return wrap != nullptr && wrap->GetHandle() != nullptr;

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -81,6 +81,7 @@ void PipeWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
+  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
 
   StreamWrap::AddMethods(env, t);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -40,6 +40,7 @@ class ProcessWrap : public HandleWrap {
 
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
+    env->SetProtoMethod(constructor, "isRefed", HandleWrap::IsRefed);
 
     target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Process"),
                 constructor->GetFunction());

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -32,6 +32,7 @@ class SignalWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
+    env->SetProtoMethod(constructor, "isRefed", HandleWrap::IsRefed);
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -88,6 +88,7 @@ void TCPWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
+  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
 
   StreamWrap::AddMethods(env, t, StreamBase::kFlagHasWritev);
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -39,6 +39,7 @@ class TimerWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
+    env->SetProtoMethod(constructor, "isRefed", HandleWrap::IsRefed);
 
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -37,6 +37,7 @@ void TTYWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
+  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
 
   StreamWrap::AddMethods(env, t, StreamBase::kFlagNoShutdown);
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -108,6 +108,7 @@ void UDPWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
+  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "UDP"), t->GetFunction());
   env->set_udp_constructor_function(t->GetFunction());

--- a/test/parallel/test-handle-wrap-isrefed-tty.js
+++ b/test/parallel/test-handle-wrap-isrefed-tty.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const strictEqual = require('assert').strictEqual;
+const spawn = require('child_process').spawn;
+
+function makeAssert(message) {
+  return function(actual, expected) {
+    strictEqual(actual, expected, message);
+  };
+}
+const assert = makeAssert('isRefed() not working on tty_wrap');
+
+if (process.argv[2] === 'child') {
+  // Test tty_wrap in piped child to guarentee stdin being a TTY.
+  const ReadStream = require('tty').ReadStream;
+  const tty = new ReadStream(0);
+  assert(Object.getPrototypeOf(tty._handle).hasOwnProperty('isRefed'), true);
+  assert(tty._handle.isRefed(), true);
+  tty.unref();
+  assert(tty._handle.isRefed(), false);
+  return;
+}
+
+// Use spawn so that we can be sure that stdin has a _handle property.
+// Refs: https://github.com/nodejs/node/pull/5916
+const proc = spawn(process.execPath, [__filename, 'child'], { stdio: 'pipe' });
+proc.stderr.pipe(process.stderr);
+proc.on('exit', common.mustCall(function(exitCode) {
+  process.exitCode = exitCode;
+}));

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const common = require('../common');
+const strictEqual = require('assert').strictEqual;
+
+function makeAssert(message) {
+  return function(actual, expected) {
+    strictEqual(actual, expected, message);
+  };
+}
+
+
+// child_process
+{
+  const assert = makeAssert('isRefed() not working on process_wrap');
+  const spawn = require('child_process').spawn;
+  const cmd = common.isWindows ? 'rundll32' : 'ls';
+  const cp = spawn(cmd);
+  assert(Object.getPrototypeOf(cp._handle).hasOwnProperty('isRefed'), true);
+  assert(cp._handle.isRefed(), true);
+  cp.unref();
+  assert(cp._handle.isRefed(), false);
+  cp.ref();
+  assert(cp._handle.isRefed(), true);
+  cp.unref();
+}
+
+
+// dgram
+{
+  const assert = makeAssert('isRefed() not working on udp_wrap');
+  const dgram = require('dgram');
+
+  const sock4 = dgram.createSocket('udp4');
+  assert(Object.getPrototypeOf(sock4._handle).hasOwnProperty('isRefed'), true);
+  assert(sock4._handle.isRefed(), true);
+  sock4.unref();
+  assert(sock4._handle.isRefed(), false);
+  sock4.ref();
+  assert(sock4._handle.isRefed(), true);
+  sock4.unref();
+
+  const sock6 = dgram.createSocket('udp6');
+  assert(Object.getPrototypeOf(sock6._handle).hasOwnProperty('isRefed'), true);
+  assert(sock6._handle.isRefed(), true);
+  sock6.unref();
+  assert(sock6._handle.isRefed(), false);
+  sock6.ref();
+  assert(sock6._handle.isRefed(), true);
+  sock6.unref();
+}
+
+
+// pipe
+{
+  const assert = makeAssert('isRefed() not working on pipe_wrap');
+  const Pipe = process.binding('pipe_wrap').Pipe;
+  const handle = new Pipe();
+  assert(Object.getPrototypeOf(handle).hasOwnProperty('isRefed'), true);
+  assert(handle.isRefed(), true);
+  handle.unref();
+  assert(handle.isRefed(), false);
+  handle.ref();
+  assert(handle.isRefed(), true);
+  handle.unref();
+}
+
+
+// tcp
+{
+  const assert = makeAssert('isRefed() not working on tcp_wrap');
+  const net = require('net');
+  const server = net.createServer(() => {}).listen(common.PORT);
+  assert(Object.getPrototypeOf(server._handle).hasOwnProperty('isRefed'), true);
+  assert(server._handle.isRefed(), true);
+  assert(server._unref, false);
+  server.unref();
+  assert(server._handle.isRefed(), false);
+  assert(server._unref, true);
+  server.ref();
+  assert(server._handle.isRefed(), true);
+  assert(server._unref, false);
+  server.unref();
+}
+
+
+// timers
+{
+  const assert = makeAssert('isRefed() not working on timer_wrap');
+  const timer = setTimeout(() => {}, 500);
+  timer.unref();
+  assert(Object.getPrototypeOf(timer._handle).hasOwnProperty('isRefed'), true);
+  assert(timer._handle.isRefed(), false);
+  timer.ref();
+  assert(timer._handle.isRefed(), true);
+  timer.unref();
+}


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

handle_wrap

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Give tools a consistent way to check if a handle is unrefed that works for all of our APIs that expose handles. E.g. would be very helpful to see which handles are umrefed in @AndreasMadsen's [https://github.com/AndreasMadsen/dprof](dprof)

(Some APIs, like timers, do not normally expose handles and are not addressed at that level here)

Refs: https://github.com/nodejs/node/pull/5828
Refs: https://github.com/nodejs/node/pull/5827

R= @trevnorris 
cc @thlorenz 