### PR TITLE
doc: path.format provide more examples

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -95,7 +95,7 @@ and the `base` property.
 If the `dir` property is not supplied, the `root` property will be used as the
 `dir` property. However, it will be assumed that the `root` property already
 ends with the platform-dependent path separator. In this case, the returned
-string will be the concatenation fo the `root` property and the `base` property.
+string will be the concatenation of the `root` property and the `base` property.
 
 If both the `dir` and the `root` properties are not supplied, then the returned
 string will be the contents of the `base` property.
@@ -105,28 +105,41 @@ and the `ext` property will be used as the `base` property.
 
 Examples:
 
-An example on Posix systems:
+Some Posix system examples:
 
 ```js
+// If `dir` and `base` are provided, `dir` + platform separator + `base`
+// will be returned.
 path.format({
-    root : "/",
-    dir : "/home/user/dir",
-    base : "file.txt",
-    ext : ".txt",
-    name : "file"
+    dir: '/home/user/dir',
+    base: 'file.txt'
 });
 // returns '/home/user/dir/file.txt'
 
-// `root` will be used if `dir` is not specified and `name` + `ext` will be used
-// if `base` is not specified
+// `root` will be used if `dir` is not specified.
+// `name` + `ext` will be used if `base` is not specified.
+// If only `root` is provided or `dir` is equal to `root` then the
+// platform separator will not be included.
 path.format({
-    root : "/",
-    ext : ".txt",
-    name : "file"
-})
+    root: '/',
+    base: 'file.txt'
+});
 // returns '/file.txt'
-```
 
+path.format({
+    dir: '/',
+    root: '/',
+    name: 'file',
+    ext: '.txt'
+});
+// returns '/file.txt'
+
+// `base` will be returned if `dir` or `root` are not provided.
+path.format({
+    base: 'file.txt'
+});
+// returns 'file.txt'
+```
 An example on Windows:
 
 ```js


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [X] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

path

### Description of change

Added examples for all cases of path.format for V5.9.0 on Linux.

Fixes #5747