### PR TITLE
dns: Use object without protoype for map

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -243,7 +243,7 @@ function resolver(bindingName) {
 }
 
 
-var resolveMap = {};
+var resolveMap = Object.create(null);
 exports.resolve4 = resolveMap.A = resolver('queryA');
 exports.resolve6 = resolveMap.AAAA = resolver('queryAaaa');
 exports.resolveCname = resolveMap.CNAME = resolver('queryCname');

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -27,6 +27,11 @@ assert.throws(function() {
   dns.resolve('www.google.com', 'HI');
 }, /Unknown type/);
 
+// Try calling resolve with an unsupported type that's an object key
+assert.throws(function() {
+  dns.resolve('www.google.com', 'toString');
+}, /Unknown type/);
+
 // Windows doesn't usually have an entry for localhost 127.0.0.1 in
 // C:\Windows\System32\drivers\etc\hosts
 // so we disable this test on Windows.


### PR DESCRIPTION
### Pull Request check-list

### Affected core subsystem(s)

dns

### Description of change

_Please provide a description of the change here._

Currently we use `{}` for the `lookup` function to find the relevant
resolver to the dns.resolve function. It is preferable to use an
object without a Object.prototype, currently for example you can do
something like:

```js
dns.resolve("google.com", "toString", console.log);
```

And get `[Object undefined]` logged and the callback would never be
called. This is unexpected and strange behavior in my opinion.
In addition, if someone adds a property to `Object.prototype` might
also create unexpected results.

I recalled a client actually ran into this issue in production a while ago so now that I'm touching a bunch of dns I figured I might as well fix it :) 

This pull request fixes it, with it an appropriate error is thrown.

I tagged this semver-major to be on the safe side since an error is thrown where strange behavior currently happens. This is more likely a bug fix but I figured I'd error on the safe side - this is more like a bug fix.

Please advise.