### PR TITLE
http: trim whitespace from header field name

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -121,7 +121,7 @@ IncomingMessage.prototype._addHeaderLines = function(headers, n) {
 // and drop the second. Extended header fields (those beginning with 'x-') are
 // always joined.
 IncomingMessage.prototype._addHeaderLine = function(field, value, dest) {
-  field = field.toLowerCase();
+  field = field.toLowerCase().trim();
   switch (field) {
     // Array headers:
     case 'set-cookie':

--- a/test/parallel/test-http-header-ws-trim.js
+++ b/test/parallel/test-http-header-ws-trim.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  // The http-parser tolerates whitespace in the header field name
+  // when parsing, but should trim that when it passes it off to
+  // the headers.
+  assert(req.headers['foo']);
+  req.on('data', common.mustCall(() => {}));
+  req.on('end', common.mustCall(() => {
+    assert(req.trailers['baz']);
+    res.end('ok');
+    server.close();
+  }));
+}));
+server.listen(common.PORT, common.mustCall(() => {
+  // Have to use net client because the HTTP client does not
+  // permit sending whitespace in header field names.
+  const client = net.connect({port: common.PORT}, common.mustCall(() => {
+    client.write('GET / HTTP/1.1\r\n' +
+                 'Host: localhost\r\n' +
+                 'Connection: close\r\n' +
+                 'Foo : test\r\n' +
+                 'Trailer: Baz\r\n' +
+                 'Transfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\n' +
+                 'Baz   : test\r\n\r\n');
+  }));
+  client.on('close', common.mustCall(() => {
+    client.end();
+  }));
+}));


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

http

### Description of change

The http-parser tolerates extraneous whitespace in header field
names on incoming messages. This whitespace should be trimmed
when those header fields are passed on to IncomingMessage.

/cc @indutny @nodejs/http 
