### PR TITLE
node: --no-dom-globals CLI flag

### DIFF
--- a/configure
+++ b/configure
@@ -373,6 +373,12 @@ parser.add_option('--enable-static',
     dest='enable_static',
     help='build as static library')
 
+parser.add_option('--no-browser-globals',
+    action='store_true',
+    dest='no_browser_globals',
+    help='do not export browser globals like setTimeout, console, etc. ' +
+         '(This mode is not officially supported for regular applications)')
+
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -761,6 +767,8 @@ def configure_node(o):
 
   if options.enable_static:
     o['variables']['node_target_type'] = 'static_library'
+
+  o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -40,8 +40,10 @@
     setupProcessFatal();
 
     setupGlobalVariables();
-    setupGlobalTimeouts();
-    setupGlobalConsole();
+    if (!process._noBrowserGlobals) {
+      setupGlobalTimeouts();
+      setupGlobalConsole();
+    }
 
     const _process = NativeModule.require('internal/process');
 

--- a/node.gyp
+++ b/node.gyp
@@ -5,6 +5,7 @@
     'node_use_lttng%': 'false',
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',
+    'node_no_browser_globals%': 'false',
     'node_has_winsdk%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
@@ -365,6 +366,9 @@
             'src/node_counters.h',
             'tools/msvs/genfiles/node_perfctr_provider.rc',
           ]
+        } ],
+        [ 'node_no_browser_globals=="true"', {
+          'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
         } ],
         [ 'v8_postmortem_support=="true"', {
           'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],

--- a/src/node.cc
+++ b/src/node.cc
@@ -3058,6 +3058,11 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "throwDeprecation", True(env->isolate()));
   }
 
+#ifdef NODE_NO_BROWSER_GLOBALS
+  // configure --no-browser-globals
+  READONLY_PROPERTY(process, "_noBrowserGlobals", True(env->isolate()));
+#endif  // NODE_NO_BROWSER_GLOBALS
+
   // --prof-process
   if (prof_process) {
     READONLY_PROPERTY(process, "profProcess", True(env->isolate()));


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Introduce `--no-dom-globals` CLI flag. With this flag set, following
globals won't be exported:

- `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`,
  `setImmediate`, `clearImmediate`
- `console`

These are provided by the DOM implementation in browser, so the
`--no-dom-globals` flag may be helpful when embedding node.js within
chromium/webkit.

Inspired-By: https://github.com/atom/node/commit/82e10ce94f3c90234dac187f04a47d4d357ffd31