### PR TITLE
net: refactor self=this to arrow functions

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -444,17 +444,17 @@ Socket.prototype.destroySoon = function() {
 Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');
 
-  function fireErrorCallbacks() {
+  function fireErrorCallbacks(self) {
     if (cb) cb(exception);
-    if (exception && !this._writableState.errorEmitted) {
-      process.nextTick(emitErrorNT, this, exception);
-      this._writableState.errorEmitted = true;
+    if (exception && !self._writableState.errorEmitted) {
+      process.nextTick(emitErrorNT, self, exception);
+      self._writableState.errorEmitted = true;
     }
   }
 
   if (this.destroyed) {
     debug('already destroyed, fire error callbacks');
-    fireErrorCallbacks.call(this);
+    fireErrorCallbacks(this);
     return;
   }
 
@@ -483,7 +483,7 @@ Socket.prototype._destroy = function(exception, cb) {
   // to make it re-entrance safe in case Socket.prototype.destroy()
   // is called within callbacks
   this.destroyed = true;
-  fireErrorCallbacks.call(this);
+  fireErrorCallbacks(this);
 
   if (this._server) {
     COUNTER_NET_SERVER_CONNECTION_CLOSE(this);

--- a/lib/net.js
+++ b/lib/net.js
@@ -444,23 +444,21 @@ Socket.prototype.destroySoon = function() {
 Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');
 
-  var self = this;
-
   function fireErrorCallbacks() {
     if (cb) cb(exception);
-    if (exception && !self._writableState.errorEmitted) {
-      process.nextTick(emitErrorNT, self, exception);
-      self._writableState.errorEmitted = true;
+    if (exception && !this._writableState.errorEmitted) {
+      process.nextTick(emitErrorNT, this, exception);
+      this._writableState.errorEmitted = true;
     }
   }
 
   if (this.destroyed) {
     debug('already destroyed, fire error callbacks');
-    fireErrorCallbacks();
+    fireErrorCallbacks.call(this);
     return;
   }
 
-  self._connecting = false;
+  this._connecting = false;
 
   this.readable = this.writable = false;
 
@@ -472,9 +470,9 @@ Socket.prototype._destroy = function(exception, cb) {
     if (this !== process.stderr)
       debug('close handle');
     var isException = exception ? true : false;
-    this._handle.close(function() {
+    this._handle.close(() => {
       debug('emit close');
-      self.emit('close', isException);
+      this.emit('close', isException);
     });
     this._handle.onread = noop;
     this._handle = null;
@@ -485,7 +483,7 @@ Socket.prototype._destroy = function(exception, cb) {
   // to make it re-entrance safe in case Socket.prototype.destroy()
   // is called within callbacks
   this.destroyed = true;
-  fireErrorCallbacks();
+  fireErrorCallbacks.call(this);
 
   if (this._server) {
     COUNTER_NET_SERVER_CONNECTION_CLOSE(this);
@@ -1080,17 +1078,15 @@ function Server(options, connectionListener) {
 
   EventEmitter.call(this);
 
-  var self = this;
-
   if (typeof options === 'function') {
     connectionListener = options;
     options = {};
-    self.on('connection', connectionListener);
+    this.on('connection', connectionListener);
   } else if (options == null || typeof options === 'object') {
     options = options || {};
 
     if (typeof connectionListener === 'function') {
-      self.on('connection', connectionListener);
+      this.on('connection', connectionListener);
     }
   } else {
     throw new TypeError('options must be an object');
@@ -1099,16 +1095,16 @@ function Server(options, connectionListener) {
   this._connections = 0;
 
   Object.defineProperty(this, 'connections', {
-    get: internalUtil.deprecate(function() {
+    get: internalUtil.deprecate(() => {
 
-      if (self._usingSlaves) {
+      if (this._usingSlaves) {
         return null;
       }
-      return self._connections;
+      return this._connections;
     }, 'Server.connections property is deprecated. ' +
        'Use Server.getConnections method instead.'),
-    set: internalUtil.deprecate(function(val) {
-      return (self._connections = val);
+    set: internalUtil.deprecate((val) => {
+      return (this._connections = val);
     }, 'Server.connections property is deprecated.'),
     configurable: true, enumerable: false
   });


### PR DESCRIPTION
### Affected core subsystem(s)

net

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Refactor unused `self=this` code to code without without this pattern
making it more consistent with the rest of our code.

There were PRs to do this code-base wide but they all seem to have stalled so I figured I'd do this in the least objectionable way one change at a time. 

CI: https://ci.nodejs.org/job/node-test-pull-request/2037/console