### PR TITLE
querystring: don't stringify bad surrogate pair

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -141,7 +141,7 @@ QueryString.escape = function(str) {
     if (i < str.length)
       c2 = str.charCodeAt(i) & 0x3FF;
     else
-      c2 = 0;
+      throw new URIError('URI malformed');
     lastPos = i + 1;
     c = 0x10000 + (((c & 0x3FF) << 10) | c2);
     out += hexTable[0xF0 | (c >> 18)] +

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -139,6 +139,11 @@ qsWeirdObjects.forEach(function(testCase) {
   assert.equal(testCase[1], qs.stringify(testCase[0]));
 });
 
+// invalid surrogate pair throws URIError
+assert.throws(function() {
+  qs.stringify({ foo: '\udc00' });
+}, URIError);
+
 // coerce numbers to string
 assert.strictEqual('foo=0', qs.stringify({ foo: 0 }));
 assert.strictEqual('foo=0', qs.stringify({ foo: -0 }));


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [X] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

* querystring

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Fixes: https://github.com/nodejs/node/issues/3702