### PR TITLE
child_process: refactor var to const

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -57,7 +57,7 @@ exports.fork = function(modulePath /*, args, options*/) {
 
 exports._forkChild = function(fd) {
   // set process.send()
-  var p = new Pipe(true);
+  const p = new Pipe(true);
   p.open(fd);
   p.unref();
   const control = setupChannel(process, p);
@@ -95,7 +95,7 @@ function normalizeExecArgs(command /*, options, callback*/) {
 
 
 exports.exec = function(command /*, options, callback*/) {
-  var opts = normalizeExecArgs.apply(null, arguments);
+  const opts = normalizeExecArgs.apply(null, arguments);
   return exports.execFile(opts.file,
                           opts.options,
                           opts.callback);
@@ -358,8 +358,8 @@ function normalizeSpawnArguments(file /*, args, options*/) {
 
 
 var spawn = exports.spawn = function(/*file, args, options*/) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
-  var options = opts.options;
+  const opts = normalizeSpawnArguments.apply(null, arguments);
+  const options = opts.options;
   var child = new ChildProcess();
 
   debug('spawn', opts.args, options);
@@ -392,9 +392,9 @@ function lookupSignal(signal) {
 
 
 function spawnSync(/*file, args, options*/) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
+  const opts = normalizeSpawnArguments.apply(null, arguments);
 
-  var options = opts.options;
+  const options = opts.options;
 
   var i;
 
@@ -478,7 +478,7 @@ function checkExecSyncError(ret) {
 
 
 function execFileSync(/*command, args, options*/) {
-  var opts = normalizeSpawnArguments.apply(null, arguments);
+  const opts = normalizeSpawnArguments.apply(null, arguments);
   var inheritStderr = !opts.options.stdio;
 
   var ret = spawnSync(opts.file, opts.args.slice(1), opts.options);
@@ -497,7 +497,7 @@ exports.execFileSync = execFileSync;
 
 
 function execSync(command /*, options*/) {
-  var opts = normalizeExecArgs.apply(null, arguments);
+  const opts = normalizeExecArgs.apply(null, arguments);
   var inheritStderr = opts.options ? !opts.options.stdio : true;
 
   var ret = spawnSync(opts.file, opts.options);


### PR DESCRIPTION
### Affected core subsystem(s)

child_process

### Description of change

In several places in the code we use `var` for options objects. This pull request replaces usages of `var` with `const` where appropriate in `child_process` - mainly for consistency and because
it makes it explicit that the object reference is not replaced.