### PR TITLE
child_process: refactor self=this in socket_list

### DIFF
--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -58,13 +58,11 @@ SocketListSend.prototype.getConnections = function getConnections(callback) {
 function SocketListReceive(slave, key) {
   EventEmitter.call(this);
 
-  var self = this;
-
   this.connections = 0;
   this.key = key;
   this.slave = slave;
 
-  function onempty() {
+  function onempty(self) {
     if (!self.slave.connected) return;
 
     self.slave.send({
@@ -73,21 +71,21 @@ function SocketListReceive(slave, key) {
     });
   }
 
-  this.slave.on('internalMessage', function(msg) {
-    if (msg.key !== self.key) return;
+  this.slave.on('internalMessage', (msg) => {
+    if (msg.key !== this.key) return;
 
     if (msg.cmd === 'NODE_SOCKET_NOTIFY_CLOSE') {
       // Already empty
-      if (self.connections === 0) return onempty();
+      if (this.connections === 0) return onempty(this);
 
       // Wait for sockets to get closed
-      self.once('empty', onempty);
+      this.once('empty', onempty);
     } else if (msg.cmd === 'NODE_SOCKET_GET_COUNT') {
-      if (!self.slave.connected) return;
-      self.slave.send({
+      if (!this.slave.connected) return;
+      this.slave.send({
         cmd: 'NODE_SOCKET_COUNT',
-        key: self.key,
-        count: self.connections
+        key: this.key,
+        count: this.connections
       });
     }
   });
@@ -95,14 +93,12 @@ function SocketListReceive(slave, key) {
 util.inherits(SocketListReceive, EventEmitter);
 
 SocketListReceive.prototype.add = function(obj) {
-  var self = this;
-
   this.connections++;
 
   // Notify previous owner of socket about its state change
-  obj.socket.once('close', function() {
-    self.connections--;
+  obj.socket.once('close', () => {
+    this.connections--;
 
-    if (self.connections === 0) self.emit('empty');
+    if (this.connections === 0) this.emit('empty', this);
   });
 };


### PR DESCRIPTION
### Pull Request check-list

### Affected core subsystem(s)

child_process
### Description of change

The socket list module (used by child_process) currently uses the `var self = this;` pattern for context in several places, this PR replaces this with arrow functions or passing a parameter in where appropriate.

Note that the `var self = this` in the _request is intentionally left in place since it is not trivial to refactor it and the current pattern isn't bad given the use case.
