### PR TITLE
governance: remove target size for CTC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -63,10 +63,9 @@ A guide for Collaborators is maintained in
 
 ## CTC Membership
 
-CTC seats are not time-limited.  There is no fixed size of the CTC.
-However, the expected target is between 6 and 12, to ensure adequate
-coverage of important areas of expertise, balanced with the ability to
-make decisions efficiently.
+CTC seats are not time-limited. There is no fixed size of the CTC. The CTC
+should be of such a size as to ensure adequate coverage of important areas of
+expertise balanced with the ability to make decisions efficiently.
 
 There is no specific set of requirements or qualifications for CTC
 membership beyond these rules.


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

doc

### Description of change

CTC target size of 6 to 12 seems out of date. Proposing increase to 9 to 15.

Refs: https://github.com/nodejs/node/issues/5866