### PR TITLE
lib: remove bootstrap global context indirection

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -8,7 +8,6 @@
 'use strict';
 
 (function(process) {
-  this.global = this;
 
   function startup() {
     var EventEmitter = NativeModule.require('events');
@@ -211,7 +210,6 @@
 
   function setupGlobalVariables() {
     global.process = process;
-    global.global = global;
     const util = NativeModule.require('util');
 
     // Deprecate GLOBAL and root

--- a/src/node.cc
+++ b/src/node.cc
@@ -118,6 +118,7 @@ using v8::Locker;
 using v8::MaybeLocal;
 using v8::Message;
 using v8::Name;
+using v8::Null;
 using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -3321,8 +3322,12 @@ void LoadEnvironment(Environment* env) {
 
   env->SetMethod(env->process_object(), "_rawDebug", RawDebug);
 
+  // Expose the global object as a property on itself
+  // (Allows you to set stuff on `global` from anywhere in JavaScript.)
+  global->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global);
+
   Local<Value> arg = env->process_object();
-  f->Call(global, 1, &arg);
+  f->Call(Null(env->isolate()), ARRAY_SIZE(&arg), &arg);
 }
 
 static void PrintHelp();


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

lib,bootstrap

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

From an irc discussion with @bmeck, this is less confusing than relying on what the "this" context is.
