### PR TITLE
lib: remove Object from global's prototype

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -208,7 +208,6 @@
 
   function setupGlobalVariables() {
     global.process = process;
-    global.global = global;
     const util = NativeModule.require('util');
 
     // Deprecate GLOBAL and root
@@ -246,8 +245,10 @@
   }
 
   function setupGlobalConsole() {
-    global.__defineGetter__('console', function() {
-      return NativeModule.require('console');
+    Object.defineProperty(global, 'console', {
+      get() {
+        return NativeModule.require('console');
+      }
     });
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -4195,6 +4195,12 @@ static void StartNodeInstance(void* arg) {
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     Local<Context> context = Context::New(isolate);
+    // note that Global() returns the proxy, which has a prototype
+    // that is the actual global
+    Local<Object> global_obj =
+        context->Global()->GetPrototype().As<Object>();
+    global_obj->SetPrototype(context, Null(isolate));
+
     Environment* env = CreateEnvironment(isolate, context, instance_data);
     array_buffer_allocator->set_env(env);
     Context::Scope context_scope(context);

--- a/test/common.js
+++ b/test/common.js
@@ -260,7 +260,6 @@ var knownGlobals = [setTimeout,
                     clearInterval,
                     clearImmediate,
                     console,
-                    constructor, // Enumerable in V8 3.21.
                     Buffer,
                     process,
                     global];


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

lib

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Removes some strange behavior from having Object in the global object's
prototype chain. No longer introducing global variables coming from
`Object.prototype`.

These globals have strange warts from existing but we should throw this in CITGM this to see if anything is affected. The only thing I really am suspicious of is `toString` might be used by some people via type coercion like `var_that_refs_global+''`.

This would be a breaking change.