### PR TITLE
doc: fix doc for Buffer.readInt32LE()

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -1049,7 +1049,7 @@ buf.readInt16LE(1);
 ### buf.readInt32BE(offset[, noAssert])
 ### buf.readInt32LE(offset[, noAssert])
 
-* `offset` {Number} `0 <= offset < buf.length - 4`
+* `offset` {Number} `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Default: false
 * Return: {Number}
 
@@ -1069,6 +1069,8 @@ buf.readInt32BE();
   // returns 33424132
 buf.readInt32LE();
   // returns 67370497
+buf.readInt32LE(1);
+  // throws RangeError: Index out of range
 ```
 
 ### buf.readIntBE(offset, byteLength[, noAssert])

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -1049,7 +1049,7 @@ buf.readInt16LE(1);
 ### buf.readInt32BE(offset[, noAssert])
 ### buf.readInt32LE(offset[, noAssert])
 
-* `offset` {Number} `0 <= offset <= buf.length - 4`
+* `offset` {Number} `0 <= offset < buf.length - 4`
 * `noAssert` {Boolean} Default: false
 * Return: {Number}
 
@@ -1067,7 +1067,7 @@ const buf = Buffer.from([1,-2,3,4]);
 
 buf.readInt32BE();
   // returns 33424132
-buf.readInt32LE(1);
+buf.readInt32LE();
   // returns 67370497
 ```
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

doc

### Description of change

Update example and signature for readInt32LE method. It fixes #5889.