### PR TITLE
console: timeEnd() doesn't throw an error if no matching label

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -67,9 +67,10 @@ Console.prototype.time = function(label) {
 
 
 Console.prototype.timeEnd = function(label) {
-  var time = this._times.get(label);
+  const time = this._times.get(label);
   if (!time) {
-    throw new Error(`No such label: ${label}`);
+    process.emitWarning(`No such label '${label}' for console.timeEnd()`);
+    return;
   }
   const duration = process.hrtime(time);
   const ms = duration[0] * 1000 + duration[1] / 1e6;

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 assert.ok(process.stdout.writable);
 assert.ok(process.stderr.writable);
@@ -8,7 +8,11 @@ assert.ok(process.stderr.writable);
 assert.equal('number', typeof process.stdout.fd);
 assert.equal('number', typeof process.stderr.fd);
 
-assert.throws(function() {
+assert.doesNotThrow(function() {
+  process.once('warning', common.mustCall((warning) => {
+    assert(/no such label/.test(warning.message));
+  }));
+
   console.timeEnd('no such label');
 });
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

console

### Description of change

Based on #3514 discussion, I've removed throw an error in timeEnd() method, if there is no matching label.