### PR TITLE
test: fix flaky test-net-socket-timeout

### DIFF
--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -41,7 +41,7 @@ server.listen(common.PORT, function() {
   });
   var timer = setTimeout(function() {
     process.exit(1);
-  }, 200);
+  }, common.platformTimeout(200));
 });
 
 process.on('exit', function() {


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

* test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Fixes a flaky test due to short timeouts on slow systems.

Fixes: https://github.com/nodejs/node/pull/5902

Stress test: https://ci.nodejs.org/job/node-stress-single-test/569
CI: https://ci.nodejs.org/job/node-test-pull-request/2064/