### PR TITLE
stream: remove unnecessary wrapping of chunks in object mode

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -379,10 +379,18 @@ function clearBuffer(stream, state) {
     holder.entry = entry;
 
     var count = 0;
-    while (entry) {
-      buffer[count] = entry;
-      entry = entry.next;
-      count += 1;
+    if (state.objectMode) {
+      while (entry) {
+        buffer[count] = entry.chunk;
+        entry = entry.next;
+        count += 1;
+      }
+    } else {
+      while (entry) {
+        buffer[count] = entry;
+        entry = entry.next;
+        count += 1;
+      }
     }
 
     doWrite(stream, state, true, state.length, buffer, '', holder.finish);

--- a/test/parallel/test-stream-writev-object-mode.js
+++ b/test/parallel/test-stream-writev-object-mode.js
@@ -1,0 +1,79 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+var queue = [];
+for (var uncork = 0; uncork < 2; uncork++) {
+  for (var multi = 0; multi < 2; multi++) {
+    queue.push([!!uncork, !!multi]);
+  }
+}
+
+run();
+
+function run() {
+  var t = queue.pop();
+  if (t)
+    test(t[0], t[1], run);
+}
+
+function test(uncork, multi, next) {
+  var counter = 0;
+  var expectCount = 0;
+  function cnt(msg) {
+    expectCount++;
+    var expect = expectCount;
+    return function(er) {
+      if (er)
+        throw er;
+      counter++;
+      assert.equal(counter, expect);
+    };
+  }
+
+  var w = new stream.Writable({ objectMode: true });
+  w._write = function(chunk, e, cb) {
+    assert(false, 'Should not call _write');
+  };
+
+  var expectChunks = [
+    { text: 'hello, ' },
+    'world',
+    [33],
+    { prop: { name: 'qwerty'} }
+  ];
+
+  var actualChunks;
+  w._writev = function(chunks, cb) {
+    actualChunks = chunks;
+    cb();
+  };
+
+  w.cork();
+  w.write({ text: 'hello, ' }, cnt('simple object'));
+  w.write('world', cnt('world'));
+
+  if (multi)
+    w.cork();
+
+  w.write([33], cnt('array'));
+
+  if (multi)
+    w.uncork();
+
+  w.write({ prop: { name: 'qwerty'} }, cnt('complex object'));
+
+  if (uncork)
+    w.uncork();
+
+  w.end(cnt('end'));
+
+  w.on('finish', function() {
+    // make sure finish comes after all the write cb
+    cnt('finish')();
+    assert.deepEqual(expectChunks, actualChunks);
+    next();
+  });
+}


### PR DESCRIPTION
### Affected core subsystem(s)

stream
### Description of change

When you are using writable stream in object mode information
about the encoding is completely useless. In addition, it is necessary
to go throw whole chunks array to obtaining useful information
(for example, var data = chunks.map((c) => c.chunk)), which greatly
reduces the performance for  large buffer size.
It makes buffer contains only chunks data without additional information 
from WriteReq.
