### PR TITLE
assert: Check typed array view type in deepEqual

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,6 +29,7 @@ const compare = process.binding('buffer').compare;
 const util = require('util');
 const Buffer = require('buffer').Buffer;
 const pSlice = Array.prototype.slice;
+const pToString = (obj) => Object.prototype.toString.call(obj);
 
 // 1. The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
@@ -170,10 +171,18 @@ function _deepEqual(actual, expected, strict) {
              (expected === null || typeof expected !== 'object')) {
     return strict ? actual === expected : actual == expected;
 
-  // If both values are instances of typed arrays, wrap them in
-  // a Buffer each to increase performance
-  } else if (ArrayBuffer.isView(actual) && ArrayBuffer.isView(expected)) {
-    return compare(Buffer.from(actual), Buffer.from(expected)) === 0;
+  // If both values are instances of typed arrays, wrap their underlying
+  // ArrayBuffers in a Buffer each to increase performance
+  // This optimization requires the arrays to have the same type as checked by
+  // Object.prototype.toString (aka pToString). Never perform binary
+  // comparisons for Float*Arrays, though, since e.g. +0 === -0 but their
+  // bit patterns are not identical.
+  } else if (ArrayBuffer.isView(actual) && ArrayBuffer.isView(expected) &&
+             pToString(actual) === pToString(expected) &&
+             !(actual instanceof Float32Array ||
+               actual instanceof Float64Array)) {
+    return compare(Buffer.from(actual.buffer),
+                   Buffer.from(expected.buffer)) === 0;
 
   // 7.5 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -20,13 +20,25 @@ const equalArrayPairs = [
   [new Int16Array(1e5), new Int16Array(1e5)],
   [new Int32Array(1e5), new Int32Array(1e5)],
   [new Float32Array(1e5), new Float32Array(1e5)],
-  [new Float64Array(1e5), new Float64Array(1e5)]
+  [new Float64Array(1e5), new Float64Array(1e5)],
+  [new Int16Array(256), new Uint16Array(256)],
+  [new Int16Array([256]), new Uint16Array([256])],
+  [new Float32Array([+0.0]), new Float32Array([-0.0])],
+  [new Float64Array([+0.0]), new Float32Array([-0.0])],
+  [new Float64Array([+0.0]), new Float64Array([-0.0])]
 ];
 
 const notEqualArrayPairs = [
   [new Uint8Array(2), new Uint8Array(3)],
   [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
-  [new Uint8ClampedArray([300, 2, 3]), new Uint8Array([300, 2, 3])]
+  [new Uint8ClampedArray([300, 2, 3]), new Uint8Array([300, 2, 3])],
+  [new Uint16Array([2]), new Uint16Array([3])],
+  [new Uint16Array([0]), new Uint16Array([256])],
+  [new Int16Array([0]), new Uint16Array([256])],
+  [new Int16Array([-256]), new Uint16Array([0xff00])], // same bits
+  [new Int32Array([-256]), new Uint32Array([0xffffff00])], // ditto
+  [new Float32Array([0.1]), new Float32Array([0.0])],
+  [new Float64Array([0.1]), new Float64Array([0.0])]
 ];
 
 equalArrayPairs.forEach((arrayPair) => {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

assert

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Do not convert typed arrays to `Buffer` for deepEqual since their values may not be accurately represented by 8-bit ints. Instead perform binary comparison of underlying `ArrayBuffer`s, but only when the array types match.

Never apply any kind of optimization for floating-point typed arrays since bit pattern equality is not the right kind of check for them.

Fixes: #5907 (introduced in #4330)