### PR TITLE
test: fix failing test in test-tick-processor

### DIFF
--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -35,7 +35,7 @@ if (common.isWindows ||
   console.log('1..0 # Skipped: C++ symbols are not mapped for this os.');
   return;
 }
-runTest(/RunInDebugContext/,
+runTest(/RunInDebugContext/i,
   `function f() {
      require(\'vm\').runInDebugContext(\'Debug\');
      setImmediate(function() { f(); });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test

### Description of change

Fixes #5903 

The problem in /RunInDebugContext/ regular expression. After investigating the isolate logs for this test-case, I've found nothing that satisfy this expression.

Possible solution can be flag `i` that fixes it.

Though, I think that it's just a typo in regular expression and there is should be lower-cased first letter.