### PR TITLE
test: fix flaky test-repl

### DIFF
--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -15,7 +15,7 @@ const prompt_npm = 'npm should be run outside of the ' +
                    'node repl, in your normal shell.\n' +
                    '(Press Control-D to exit.)\n';
 const expect_npm = prompt_npm + prompt_unix;
-var server_tcp, server_unix, client_tcp, client_unix, timer, replServer;
+var server_tcp, server_unix, client_tcp, client_unix, replServer;
 
 
 // absolute path to test/fixtures/a.js
@@ -45,7 +45,6 @@ function send_expect(list) {
 function clean_up() {
   client_tcp.end();
   client_unix.end();
-  clearTimeout(timer);
 }
 
 function strict_mode_error_test() {
@@ -463,7 +462,3 @@ function unix_test() {
 }
 
 unix_test();
-
-timer = setTimeout(function() {
-  assert.fail(null, null, 'Timeout');
-}, 5000);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

* test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Fixes a flaky test on ARM due to too short of a timeout. Example failure: https://ci.nodejs.org/job/node-test-binary-arm/1494/RUN_SUBSET=3,nodes=pi1-raspbian-wheezy/console
CI: https://ci.nodejs.org/job/node-test-pull-request/2075/
Stress test: https://ci.nodejs.org/job/node-stress-single-test/572/