### PR TITLE
test: ensure existence of _handle property

### DIFF
--- a/test/parallel/test-stdout-close-unref.js
+++ b/test/parallel/test-stdout-close-unref.js
@@ -1,16 +1,30 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
 
-var errs = 0;
+if (process.argv[2] === 'child') {
+  var errs = 0;
 
-process.stdin.resume();
-process.stdin._handle.close();
-process.stdin._handle.unref();  // Should not segfault.
-process.stdin.on('error', function(err) {
-  errs++;
-});
+  process.stdin.resume();
+  process.stdin._handle.close();
+  process.stdin._handle.unref();  // Should not segfault.
+  process.stdin.on('error', function(err) {
+    errs++;
+  });
 
-process.on('exit', function() {
-  assert.strictEqual(errs, 1);
-});
+  process.on('exit', function() {
+    assert.strictEqual(errs, 1);
+  });
+  return;
+}
+
+// Use spawn so that we can be sure that stdin has a _handle property.
+// Refs: https://github.com/nodejs/node/pull/5916
+const proc = spawn(process.execPath, [__filename, 'child'], { stdio: 'pipe' });
+
+proc.stderr.pipe(process.stderr);
+proc.on('exit', common.mustCall(function(exitCode) {
+  if (exitCode !== 0)
+    process.exitCode = exitCode;
+}));


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

test

### Description of change

`test-stdtout-close-unref.js` will fail if `process.stdin._handle` does
not exist. On UNIX-like operating systems, you can see this failure this
way:

    ./node test/parallel/test-stdout-close-unref.js < /dev/null

This issue has been experienced by @bengl and @drewfish in a Docker
container. I'm not sure why they are experiencing it in their
environment, but since it is possible that the `_handle` property does
not exist, perhaps it should be checked.

@nodejs/testing 