### PR TITLE
gyp: add missing `openssl_fips%` to common.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -14,6 +14,8 @@
     'node_tag%': '',
     'uv_library%': 'static_library',
 
+    'openssl_fips%': '',
+
     # Default to -O0 for debug builds.
     'v8_optimized_debug%': 0,
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_gyp_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

No comments, it just should be there in some rare cases.

See: atom/node@cba512d493d968afb203e28ed01e8d345fc9c9f4