### PR TITLE
build: introduce ci targets for lint/benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -584,6 +584,8 @@ bench-all: bench bench-misc bench-array bench-buffer bench-url bench-events benc
 
 bench: bench-net bench-http bench-fs bench-tls
 
+bench-ci: bench
+
 bench-http-simple:
 	benchmark/http_simple_bench.sh
 
@@ -630,10 +632,12 @@ lint:
 		"$ git clone https://github.com/nodejs/node.git"
 endif
 
+lint-ci: lint
+
 .PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean \
 	check uninstall install install-includes install-bin all staticlib \
 	dynamiclib test test-all test-addons build-addons website-upload pkg \
 	blog blogclean tar binary release-only bench-http-simple bench-idle \
 	bench-all bench bench-misc bench-array bench-buffer bench-net \
 	bench-http bench-fs bench-tls cctest run-ci test-v8 test-v8-intl \
-	test-v8-benchmarks test-v8-all v8
+	test-v8-benchmarks test-v8-all v8 lint-ci

--- a/Makefile
+++ b/Makefile
@@ -640,4 +640,4 @@ lint-ci: lint
 	blog blogclean tar binary release-only bench-http-simple bench-idle \
 	bench-all bench bench-misc bench-array bench-buffer bench-net \
 	bench-http bench-fs bench-tls cctest run-ci test-v8 test-v8-intl \
-	test-v8-benchmarks test-v8-all v8 lint-ci
+	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to CONTRIBUTING.md?

### Affected core subsystem(s)

build

### Description of change

Introduce two new targets we will populate with actions once merged into all branches we need to support through CI. Refs #5638. 

The gist of the problem is that we can't call makefile targets through CI that doesn't exist in all branches we test on. Meaning, the quicker we get it in, the easier it will be to expand on changes to linting, testing and benchmarking (making sure we call respective `-ci` targets from CI).

`vcbuild.bat` changes are missing, but linting and benchmarking needs more improvements than just ci - and we don't invoke linting/benchmarking stuff from Windows just yet.

/cc @nodejs/build, @mscdex 

