### PR TITLE
punycode: update to 1.4.1

### DIFF
--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -1,4 +1,4 @@
-/*! https://mths.be/punycode v1.3.2 by @mathias */
+/*! https://mths.be/punycode v1.4.1 by @mathias */
 ;(function(root) {
 
 	/** Detect free variables */
@@ -486,7 +486,7 @@
 		 * @memberOf punycode
 		 * @type String
 		 */
-		'version': '1.3.2',
+		'version': '1.4.1',
 		/**
 		 * An object of methods to convert from JavaScript's internal character
 		 * representation (UCS-2) to Unicode code points, and back.
@@ -516,14 +516,17 @@
 			return punycode;
 		});
 	} else if (freeExports && freeModule) {
-		if (module.exports == freeExports) { // in Node.js or RingoJS v0.8.0+
+		if (module.exports == freeExports) {
+			// in Node.js, io.js, or RingoJS v0.8.0+
 			freeModule.exports = punycode;
-		} else { // in Narwhal or RingoJS v0.7.0-
+		} else {
+			// in Narwhal or RingoJS v0.7.0-
 			for (key in punycode) {
 				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
 			}
 		}
-	} else { // in Rhino or a web browser
+	} else {
+		// in Rhino or a web browser
 		root.punycode = punycode;
 	}
 


### PR DESCRIPTION
### Affected core subsystem(s)

punycode

### Description of change

Update punycode to the latest released version. This is mainly in order to reduce the maintenance burden. In https://github.com/nodejs/node/pull/1246 a fix introducing `new` to errors was introduced and it has since been ported back to the punycode library.

This puts Node back in sync with the library itself so it can receive future fixes and updates directly.