### PR TITLE
tls: rejectUnauthorized is treated to true by default

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -712,7 +712,10 @@ added: v0.11.8
 -->
 
 * `options` {Object}
-  * `rejectUnauthorized` {boolean}
+  * `rejectUnauthorized` {boolean} If not `false`, the server certificate is verified
+    against the list of supplied CAs. An `'error'` event is emitted if
+    verification fails; `err.code` contains the OpenSSL error code. Defaults to
+    `true`.
   * `requestCert`
 * `callback` {Function} A function that will be called when the renegotiation
   request has been completed.
@@ -769,7 +772,7 @@ changes:
     connection/disconnection/destruction of `socket` is the user's
     responsibility, calling `tls.connect()` will not cause `net.connect()` to be
     called.
-  * `rejectUnauthorized` {boolean} If `true`, the server certificate is verified
+  * `rejectUnauthorized` {boolean} If not `false`, the server certificate is verified
     against the list of supplied CAs. An `'error'` event is emitted if
     verification fails; `err.code` contains the OpenSSL error code. Defaults to
     `true`.
@@ -1012,7 +1015,7 @@ changes:
   * `requestCert` {boolean} If `true` the server will request a certificate from
     clients that connect and attempt to verify that certificate. Defaults to
     `false`.
-  * `rejectUnauthorized` {boolean} If `true` the server will reject any
+  * `rejectUnauthorized` {boolean} If not `false` the server will reject any
     connection which is not authorized with the list of supplied CAs. This
     option only has an effect if `requestCert` is `true`. Defaults to `true`.
   * `NPNProtocols` {string[]|Buffer} An array of strings or a `Buffer` naming
@@ -1190,9 +1193,8 @@ changes:
   opened as a server.
 * `requestCert` {boolean} `true` to specify whether a server should request a
   certificate from a connecting client. Only applies when `isServer` is `true`.
-* `rejectUnauthorized` {boolean} `true` to specify whether a server should
-  automatically reject clients with invalid certificates. Only applies when
-  `isServer` is `true`.
+* `rejectUnauthorized` {boolean} If not `false` a server automatically reject clients
+   with invalid certificates. Only applies when `isServer` is `true`.
 * `options`
   * `secureContext`: An optional TLS context object from
      [`tls.createSecureContext()`][]

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1014,7 +1014,7 @@ changes:
     `false`.
   * `rejectUnauthorized` {boolean} If `true` the server will reject any
     connection which is not authorized with the list of supplied CAs. This
-    option only has an effect if `requestCert` is `true`. Defaults to `false`.
+    option only has an effect if `requestCert` is `true`. Defaults to `true`.
   * `NPNProtocols` {string[]|Buffer} An array of strings or a `Buffer` naming
     possible NPN protocols. (Protocols should be ordered by their priority.)
   * `ALPNProtocols` {string[]|Buffer} An array of strings or a `Buffer` naming

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -920,17 +920,8 @@ Server.prototype.setTicketKeys = function setTicketKeys(keys) {
 
 
 Server.prototype.setOptions = function(options) {
-  if (typeof options.requestCert === 'boolean') {
-    this.requestCert = options.requestCert;
-  } else {
-    this.requestCert = false;
-  }
-
-  if (typeof options.rejectUnauthorized === 'boolean') {
-    this.rejectUnauthorized = options.rejectUnauthorized;
-  } else {
-    this.rejectUnauthorized = false;
-  }
+  this.requestCert = options.requestCert === true;
+  this.rejectUnauthorized = options.rejectUnauthorized !== false;
 
   if (options.pfx) this.pfx = options.pfx;
   if (options.key) this.key = options.key;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1062,7 +1062,7 @@ exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
     secureContext: context,
     isServer: false,
     requestCert: true,
-    rejectUnauthorized: options.rejectUnauthorized,
+    rejectUnauthorized: options.rejectUnauthorized !== false,
     session: options.session,
     NPNProtocols: NPN.NPNProtocols,
     ALPNProtocols: ALPN.ALPNProtocols,

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -42,7 +42,8 @@ const https = require('https');
 const options = {
   key: fs.readFileSync(common.fixturesDir + '/agent.key'),
   cert: fs.readFileSync(common.fixturesDir + '/agent.crt'),
-  requestCert: true
+  requestCert: true,
+  rejectUnauthorized: false
 };
 
 const modulus = 'A6F44A9C25791431214F5C87AF9E040177A8BB89AC803F7E09BBC3A5519F' +

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -56,7 +56,8 @@ function doTest(testOptions, callback) {
     key: key,
     cert: cert,
     ca: [cert],
-    requestCert: true
+    requestCert: true,
+    rejectUnauthorized: false
   };
   let requestCount = 0;
   let resumeCount = 0;


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
### Affected core subsystem(s)

tls
### Description of change

Improves usability as described here - #5917 

tls.connect treats rejectUnauthorized as a false value, when we need to treat it only when rejectUnauthorized is really set to false.
