### PR TITLE
dgram: pass null as error on successful send()

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -392,7 +392,10 @@ function doSend(ex, self, ip, buffer, address, port, callback) {
 function afterSend(err, sent) {
   if (err) {
     err = exceptionWithHostPort(err, 'send', this.address, this.port);
+  } else {
+    err = null;
   }
+
   this.callback(err, sent);
 }
 

--- a/test/parallel/test-dgram-send-callback-buffer.js
+++ b/test/parallel/test-dgram-send-callback-buffer.js
@@ -9,6 +9,7 @@ const client = dgram.createSocket('udp4');
 const buf = Buffer.allocUnsafe(256);
 
 const onMessage = common.mustCall(function(err, bytes) {
+  assert.strictEqual(err, null);
   assert.equal(bytes, buf.length);
   clearTimeout(timer);
   client.close();


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

dgram

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Prior to c9fd9e21622abb7b3893af457f6aaafb2363ab46, UDP sockets would callback with a `null` error on successful `send()` calls. The current behavior is to pass 0 as the error. This commit restores the previous, more expected behavior.