### PR TITLE
test: stdin is not always a net.Socket

### DIFF
--- a/test/known_issues/test-stdin-is-always-net.socket.js
+++ b/test/known_issues/test-stdin-is-always-net.socket.js
@@ -1,0 +1,19 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/pull/5916
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const net = require('net');
+
+if (process.argv[2] === 'child') {
+  assert(process.stdin instanceof net.Socket);
+  return;
+}
+
+const proc = spawn(process.execPath, [__filename, 'child'], { stdio: 'ignore' });
+// To double-check this test, set stdio to 'pipe' and uncomment the line below.
+// proc.stderr.pipe(process.stderr);
+proc.on('exit', common.mustCall(function(exitCode) {
+  process.exitCode = exitCode;
+}));


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Refs: https://github.com/nodejs/node/pull/5916#issuecomment-202126418

> `<`-ing a file into stdin actually results in a [`fs.ReadStream`](https://github.com/nodejs/node/blob/293fd0453591ef0d87437a265ff515916d35d715/lib/fs.js#L1791), rather an a `tty.ReadStream`, and as such does not [inherit from `net.Socket`](https://github.com/nodejs/node/blob/293fd0453591ef0d87437a265ff515916d35d715/lib/tty.js#L29), unlike the other possible `stdin` options: https://github.com/nodejs/node/blob/293fd0453591ef0d87437a265ff515916d35d715/lib/internal/process/stdio.js#L54-L57

cc @Trott I think this should cover the known issue.

