### PR TITLE
etw: add event messages

### DIFF
--- a/src/res/node_etw_provider.man
+++ b/src/res/node_etw_provider.man
@@ -175,7 +175,7 @@
                 <string id="NodeJS-ETW-provider.event.6.message" value="Node.js Net Stream End%nRemote: %3%nPort: %2"/>
                 <string id="NodeJS-ETW-provider.event.7.message" value="Node.js Garbage Collection Start"/>
                 <string id="NodeJS-ETW-provider.event.8.message" value="Node.js Garbage Collection Done"/>
-                <string id="NodeJS-ETW-provider.event.9.message" value="Node.js Method Load: %10"/>
+                <string id="NodeJS-ETW-provider.event.9.message" value="Node.js Function Compiled: %10"/>
                 <string id="NodeJS-ETW-provider.event.21.message" value="Node.js V8 Symbol Remove"/>
                 <string id="NodeJS-ETW-provider.event.22.message" value="Node.js V8 Symbol Move"/>
                 <string id="NodeJS-ETW-provider.event.23.message" value="Node.js V8 Symbol Reset"/>

--- a/src/res/node_etw_provider.man
+++ b/src/res/node_etw_provider.man
@@ -7,6 +7,7 @@
             <provider name="NodeJS-ETW-provider"
                 guid="{77754E9B-264B-4D8D-B981-E4135C1ECB0C}"
                 symbol="NODE_ETW_PROVIDER"
+                message="$(string.NodeJS-ETW-provider.name)"
                 resourceFileName="node.exe"
                 messageFileName="node.exe">
 
@@ -90,64 +91,95 @@
                         opcode="NODE_HTTP_SERVER_REQUEST"
                         template="node_http_server_request"
                         symbol="NODE_HTTP_SERVER_REQUEST_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.1.message)"
                         level="win:Informational"/>
                     <event value="2"
                         opcode="NODE_HTTP_SERVER_RESPONSE"
                         template="node_connection"
                         symbol="NODE_HTTP_SERVER_RESPONSE_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.2.message)"
                         level="win:Informational"/>
                     <event value="3"
                         opcode="NODE_HTTP_CLIENT_REQUEST"
                         template="node_http_client_request"
                         symbol="NODE_HTTP_CLIENT_REQUEST_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.3.message)"
                         level="win:Informational"/>
                     <event value="4"
                         opcode="NODE_HTTP_CLIENT_RESPONSE"
                         template="node_connection"
                         symbol="NODE_HTTP_CLIENT_RESPONSE_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.4.message)"
                         level="win:Informational"/>
                     <event value="5"
                         opcode="NODE_NET_SERVER_CONNECTION"
                         template="node_connection"
                         symbol="NODE_NET_SERVER_CONNECTION_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.5.message)"
                         level="win:Informational"/>
                     <event value="6"
                         opcode="NODE_NET_STREAM_END"
                         template="node_connection"
                         symbol="NODE_NET_STREAM_END_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.6.message)"
                         level="win:Informational"/>
                     <event value="7"
                         opcode="NODE_GC_START"
                         template="node_gc"
                         symbol="NODE_GC_START_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.7.message)"
                         level="win:Informational"/>
                     <event value="8"
                         opcode="NODE_GC_DONE"
                         template="node_gc"
                         symbol="NODE_GC_DONE_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.8.message)"
                         level="win:Informational"/>
                     <event value="9"
                         level="win:Informational"
                         opcode="MethodLoad"
                         symbol="MethodLoad"
+                        message="$(string.NodeJS-ETW-provider.event.9.message)"
                         task="MethodRuntime"
                         template="MethodLoadUnload"/>
                     <event value="21"
                         opcode="NODE_V8SYMBOL_REMOVE"
                         template="V8AddressChange"
                         symbol="NODE_V8SYMBOL_REMOVE_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.21.message)"
                         level="win:Informational" />
                     <event value="22"
                         opcode="NODE_V8SYMBOL_MOVE"
                         template="V8AddressChange"
                         symbol="NODE_V8SYMBOL_MOVE_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.22.message)"
                         level="win:Informational" />
                     <event value="23"
                         opcode="NODE_V8SYMBOL_RESET"
                         symbol="NODE_V8SYMBOL_RESET_EVENT"
+                        message="$(string.NodeJS-ETW-provider.event.23.message)"
                         level="win:Informational" />
                 </events>
             </provider>
         </events>
     </instrumentation>
+    <localization>
+        <resources culture="en-US">
+            <stringTable>
+                <string id="NodeJS-ETW-provider.name" value="Node.js ETW Provider"/>
+                <string id="NodeJS-ETW-provider.event.1.message" value="Node.js HTTP Server Request%nMethod: %2%nRemote: %6%nPort: %5%nURL: %1"/>
+                <string id="NodeJS-ETW-provider.event.2.message" value="Node.js HTTP Server Response%nRemote: %3%nPort: %2"/>
+                <string id="NodeJS-ETW-provider.event.3.message" value="Node.js HTTP Client Request%nMethod: %2%nRemote: %5%nPort: %4%nURL: %1"/>
+                <string id="NodeJS-ETW-provider.event.4.message" value="Node.js HTTP Client Response%nRemote: %3%nPort: %2"/>
+                <string id="NodeJS-ETW-provider.event.5.message" value="Node.js Net Server Connection%nRemote: %3%nPort: %2"/>
+                <string id="NodeJS-ETW-provider.event.6.message" value="Node.js Net Stream End%nRemote: %3%nPort: %2"/>
+                <string id="NodeJS-ETW-provider.event.7.message" value="Node.js Garbage Collection Start"/>
+                <string id="NodeJS-ETW-provider.event.8.message" value="Node.js Garbage Collection Done"/>
+                <string id="NodeJS-ETW-provider.event.9.message" value="Node.js Method Load: %10"/>
+                <string id="NodeJS-ETW-provider.event.21.message" value="Node.js V8 Symbol Remove"/>
+                <string id="NodeJS-ETW-provider.event.22.message" value="Node.js V8 Symbol Move"/>
+                <string id="NodeJS-ETW-provider.event.23.message" value="Node.js V8 Symbol Reset"/>
+            </stringTable>
+        </resources>
+    </localization>
 </instrumentationManifest>


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

ETW

### Description of change

Note: https://github.com/nodejs/node/pull/5657 should land before this, because this does not include the generated files.

A log of ETW events can be produced with:

```
logman start NodejsDCS -p NodeJS-ETW-provider -o node_log.etl -ets
:: Do something with node.exe
logman stop NodejsDCS -ets
```

The resulting `etl` file can be open in Event Viewer.

Without this change, the description box shows an error message:

```
The description for Event ID 23 from source NodeJS-ETW-provider cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer.

If the event originated on another computer, the display information had to be saved with the event.

The following information was included with the event: 


The message id for the desired message could not be found
```

This adds descriptions to all events, replacing the error message in the Event Viewer.

![etw](https://cloud.githubusercontent.com/assets/134460/14086133/6df740c6-f51b-11e5-9fc4-bb4357036e99.png)

cc @nodejs/platform-windows 