### PR TITLE
test: exclude new fs watch test for AIX

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -24,3 +24,4 @@ test-tick-processor           : PASS,FLAKY
 # regressions until this work is complete
 [$system==aix]
 test-fs-watch-enoent                 : FAIL, PASS
+test-fs-watch-encoding               : FAIL, PASS


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

fs

### Description of change

As per https://github.com/nodejs/node/issues/5085
exclude new test from AIX until we have fixes for
libuv for fs watching on AIX.  Excluding test
so AIX tests are green and we don't miss
other regressions