### PR TITLE
test: Add test for piping large input from stdin

### DIFF
--- a/test/parallel/test-stdin-pipe-large.js
+++ b/test/parallel/test-stdin-pipe-large.js
@@ -1,0 +1,23 @@
+'use strict';
+// See https://github.com/nodejs/node/issues/5927
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+if (process.argv[2] === 'child') {
+  process.stdin.pipe(process.stdout);
+  return;
+}
+
+const child = spawn(process.execPath, [__filename, 'child'], { stdio: 'pipe' });
+
+const expectedBytes = 1024 * 1024;
+let readBytes = 0;
+
+child.stdin.end(Buffer.alloc(expectedBytes));
+
+child.stdout.on('data', (chunk) => readBytes += chunk.length);
+child.stdout.on('end', common.mustCall(() => {
+  assert.strictEqual(readBytes, expectedBytes);
+}));


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included? (This *is* a regression test)

<!-- - [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)? -->

### Affected core subsystem(s)

test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Check that piping a large chunk of data from `process.stdin` into `process.stdout` does not lose any data by verifying that the output has the same size as the input.

This is a regression test for #5927 and fails for the commits in the range [ace100945..89abe8680).