### PR TITLE
doc: remove redundant parameter comments from fs

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -821,9 +821,6 @@ The callback is given the three arguments, `(err, bytesRead, buffer)`.
   * `encoding` {String} default = `'utf8'`
 * `callback` {Function}
 
-* `path` {String}
-* `callback` {Function}
-
 Asynchronous readdir(3).  Reads the contents of a directory.
 The callback gets two arguments `(err, files)` where `files` is an array of
 the names of the files in the directory excluding `'.'` and `'..'`.
@@ -838,8 +835,6 @@ the filenames returned will be passed as `Buffer` objects.
 * `path` {String | Buffer}
 * `options` {String | Object}
   * `encoding` {String} default = `'utf8'`
-
-* `path` {String}
 
 Synchronous readdir(3). Returns an array of filenames excluding `'.'` and
 `'..'`.
@@ -900,9 +895,6 @@ string. Otherwise it returns a buffer.
   * `encoding` {String} default = `'utf8'`
 * `callback` {Function}
 
-* `path` {String}
-* `callback` {Function}
-
 Asynchronous readlink(2). The callback gets two arguments `(err,
 linkString)`.
 
@@ -916,8 +908,6 @@ the link path returned will be passed as a `Buffer` object.
 * `path` {String | Buffer}
 * `options` {String | Object}
   * `encoding` {String} default = `'utf8'`
-
-* `path` {String}
 
 Synchronous readlink(2). Returns the symbolic link's string value.
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] <del>If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?</del>
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

* doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Some old version parameter comments are left in the fs doc. Such as following `path` and `callback` at last:

```md
## fs.readdir(path[, options], callback)

* `path` {String | Buffer}
* `options` {String | Object}
  * `encoding` {String} default = `'utf8'`
* `callback` {Function}

* `path` {String}
* `callback` {Function}
```

This change removes them.

See commit 060e5f0c0064e578c2150f13e3f91ac15fdeed92 and #5943 for reference.