### PR TITLE
repl: Copying tab characters into the repl calls tabComplete

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -357,10 +357,12 @@ a `'resize'` event on the `output` if/when the columns ever change
 
 Move cursor to the specified position in a given TTY stream.
 
-## readline.emitKeypressEvents(stream)
+## readline.emitKeypressEvents(stream[, interface])
 
 Causes `stream` to begin emitting `'keypress'` events corresponding to its
 input.
+Optionally, `interface` specifies a `readline.Interface` instance for which
+autocompletion is disabled when copy-pasted input is detected.
 
 ## readline.moveCursor(stream, dx, dy)
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -40,6 +40,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   this._sawReturn = false;
+  this.isCompletionEnabled = true;
 
   EventEmitter.call(this);
   var historySize;
@@ -129,7 +130,7 @@ function Interface(input, output, completer, terminal) {
 
   } else {
 
-    emitKeypressEvents(input);
+    emitKeypressEvents(input, this);
 
     // input usually refers to stdin
     input.on('keypress', onkeypress);
@@ -878,7 +879,7 @@ Interface.prototype._ttyWrite = function(s, key) {
 
       case 'tab':
         // If tab completion enabled, do that...
-        if (typeof this.completer === 'function') {
+        if (typeof this.completer === 'function' && this.isCompletionEnabled) {
           this._tabComplete();
           break;
         }
@@ -912,7 +913,7 @@ exports.Interface = Interface;
 const KEYPRESS_DECODER = Symbol('keypress-decoder');
 const ESCAPE_DECODER = Symbol('escape-decoder');
 
-function emitKeypressEvents(stream) {
+function emitKeypressEvents(stream, iface) {
   if (stream[KEYPRESS_DECODER]) return;
   var StringDecoder = require('string_decoder').StringDecoder; // lazy load
   stream[KEYPRESS_DECODER] = new StringDecoder('utf8');
@@ -925,6 +926,10 @@ function emitKeypressEvents(stream) {
       var r = stream[KEYPRESS_DECODER].write(b);
       if (r) {
         for (var i = 0; i < r.length; i++) {
+          if (r[i] === '\t' && typeof r[i + 1] === 'string' && iface) {
+            iface.isCompletionEnabled = false;
+          }
+
           try {
             stream[ESCAPE_DECODER].next(r[i]);
           } catch (err) {
@@ -933,6 +938,10 @@ function emitKeypressEvents(stream) {
             stream[ESCAPE_DECODER] = emitKeys(stream);
             stream[ESCAPE_DECODER].next();
             throw err;
+          } finally {
+            if (iface) {
+              iface.isCompletionEnabled = true;
+            }
           }
         }
       }

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -229,7 +229,9 @@ function isWarned(emitter) {
     assert.strictEqual(called, false);
     called = true;
   });
-  fi.emit('data', '\tfo\to\t');
+  for (var character of '\tfo\to\t') {
+    fi.emit('data', character);
+  }
   fi.emit('data', '\n');
   assert.ok(called);
   rli.close();


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

repl

### Description of change

Issue - https://github.com/nodejs/node/issues/5954

When you are copying tab-indented code into the repl, repl calls tabComplete function.
There is no actual pressing the button, so we need to ignore it.