### PR TITLE
tools: remove obsolete lint config file

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,6 +1,0 @@
-rules:
-  # ECMAScript-6
-  # http://eslint.org/docs/rules/#ecmascript-6
-  prefer-template: 2
-  # Custom rules in tools/eslint-rules
-  buffer-constructor: 2


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

tools, src

### Description of change

All JS files have been moved out of the `src` directory so the
`.eslintrc` file in that directory can also be removed.