### PR TITLE
node: call set_trace_sync_io before bootstrap

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4279,12 +4279,13 @@ static void StartNodeInstance(void* arg) {
     if (instance_data->use_debug_agent())
       StartDebug(env, debug_wait_connect);
 
+    env->set_trace_sync_io(trace_sync_io);
+
     {
       Environment::AsyncCallbackScope callback_scope(env);
       LoadEnvironment(env);
     }
 
-    env->set_trace_sync_io(trace_sync_io);
 
     // Enable debugger
     if (instance_data->use_debug_agent())


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

node --trace-sync-io

### Description of change

`env->set_trace_sync_io` was previously being called after `node::LoadEnvironment` so it wasn't in effect for the initial script.