### PR TITLE
tools,doc: fix json result of grouped optional params

### DIFF
--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -272,21 +272,30 @@ function parseSignature(text, sig) {
   var params = text.match(paramExpr);
   if (!params) return;
   params = params[1];
-  // the [ is irrelevant. ] indicates optionalness.
-  params = params.replace(/\[/g, '');
   params = params.split(/,/);
+  var optionalLevel = 0;
+  var optionalCharDict = {'[': 1, ' ': 0, ']': -1};
   params.forEach(function(p, i, _) {
     p = p.trim();
     if (!p) return;
     var param = sig.params[i];
     var optional = false;
     var def;
-    // [foo] -> optional
-    if (p.charAt(p.length - 1) === ']') {
-      optional = true;
-      p = p.replace(/\]/g, '');
-      p = p.trim();
+
+    // for grouped optional params such as someMethod(a[, b[, c]])
+    var pos;
+    for (pos = 0; pos < p.length; pos++) {
+      if (optionalCharDict[p[pos]] === undefined) { break; }
+      optionalLevel += optionalCharDict[p[pos]];
     }
+    p = p.substring(pos);
+    optional = (optionalLevel > 0);
+    for (pos = p.length - 1; pos >= 0; pos--) {
+      if (optionalCharDict[p[pos]] === undefined) { break; }
+      optionalLevel += optionalCharDict[p[pos]];
+    }
+    p = p.substring(0, pos + 1);
+
     var eq = p.indexOf('=');
     if (eq !== -1) {
       def = p.substr(eq + 1);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] <del>If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?</del>
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

* tools, doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

fixes #5976