### PR TITLE
Fix make tar-headers for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ doc-upload: tar
 	scp -pr out/doc/ $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs/
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs.done"
 
-$(TARBALL)-headers: config.gypi release-only
+$(TARBALL)-headers: release-only
 	$(PYTHON) ./configure \
 		--prefix=/ \
 		--dest-cpu=$(DESTCPU) \
@@ -492,7 +492,7 @@ $(TARBALL)-headers: config.gypi release-only
 		--release-urlbase=$(RELEASE_URLBASE) \
 		$(CONFIG_FLAGS) $(BUILD_RELEASE_FLAGS)
 	HEADERS_ONLY=1 $(PYTHON) tools/install.py install '$(TARNAME)' '/'
-	find $(TARNAME)/ -type l | xargs rm # annoying on windows
+	find $(TARNAME)/ -type l | xargs rm -f
 	tar -cf $(TARNAME)-headers.tar $(TARNAME)
 	rm -rf $(TARNAME)
 	gzip -c -f -9 $(TARNAME)-headers.tar > $(TARNAME)-headers.tar.gz
@@ -658,4 +658,5 @@ endif
 	blog blogclean tar binary release-only bench-http-simple bench-idle \
 	bench-all bench bench-misc bench-array bench-buffer bench-net \
 	bench-http bench-fs bench-tls cctest run-ci test-v8 test-v8-intl \
-	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci
+	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci \
+	$(TARBALL)-headers


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] ~~If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?~~
- [x] ~~Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?~~

### Affected core subsystem(s)
build
[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit
### Description of change
The make tar-headers target currently fails on Linux due to the command `find $(TARNAME)/ -type l | xargs rm` as the find is unable to find any links, so the rm fails with a no arguments error. The simplest solution is to simply remove this line (assuming we aren't expecting an links). If anyone thinks they can still appear, then I can do something like:
```shell
if [ `find $(TARNAME)/ -type l` ]; then
  find $(TARNAME)/ -type l | xargs rm
fi
```

I also removed the dependency on config.gypi, as the tar-headers target runs configure itself.


Related Issue: #4149  (see [this comment](https://github.com/nodejs/node/pull/4149#issuecomment-161875369))