### PR TITLE
test: fix offending max-len linter error

### DIFF
--- a/test/known_issues/test-stdin-is-always-net.socket.js
+++ b/test/known_issues/test-stdin-is-always-net.socket.js
@@ -11,7 +11,7 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const proc = spawn(process.execPath, [__filename, 'child'], { stdio: 'ignore' });
+const proc = spawn(process.execPath, [__filename, 'child'], {stdio: 'ignore'});
 // To double-check this test, set stdio to 'pipe' and uncomment the line below.
 // proc.stderr.pipe(process.stderr);
 proc.on('exit', common.mustCall(function(exitCode) {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

fix offending max-len linter error