### PR TITLE
net: improve socket.write() error message

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -619,8 +619,10 @@ Socket.prototype.__defineGetter__('localPort', function() {
 
 
 Socket.prototype.write = function(chunk, encoding, cb) {
-  if (typeof chunk !== 'string' && !(chunk instanceof Buffer))
-    throw new TypeError('Invalid data');
+  if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
+    throw new TypeError(
+      'Invalid data, chunk must be a string or buffer, not ' + typeof chunk);
+  }
   return stream.Duplex.prototype.write.apply(this, arguments);
 };
 

--- a/test/parallel/test-net-socket-write-error.js
+++ b/test/parallel/test-net-socket-write-error.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const server = net.createServer().listen(common.PORT, connectToServer);
+
+function connectToServer() {
+  const client = net.createConnection(common.PORT, () => {
+    assert.throws(() => {
+      client.write(1337);
+    }, /Invalid data, chunk must be a string or buffer, not number/);
+
+    client.end();
+  })
+  .on('end', () => server.close());
+}


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

net

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Informative error messages are very important for developers and could possibly save hours of debugging and frustration. This improves the error message thrown when writing invalid data into a socket, by communicating what's expected compared to what the developer just tried to write.

When passing anything other than a string or buffer to `socket.write()`, a TypeError with saying `Invalid data` gets thrown. E.g:

```bash
TypeError: Invalid data
    at Socket.write (net.js:623:11)
    at Socket.net.createConnection (/Users/phillipj/my-awesome-sock-script.js:5:12)
    at Socket.g (events.js:271:16)
    at emitNone (events.js:85:20)
    at Socket.emit (events.js:179:7)
```

This has bit me more than once as it doesn't really say much about what was expected or what I did wrong, other than some data being invalid.

Getting something like this would be a lot more helpful:
```bash
TypeError: Invalid data, chunk must be a string or a buffer, not number
    at Socket.write (net.js:623:11)
    at Socket.net.createConnection (/Users/phillipj/my-awesome-sock-script.js:5:12)
    at Socket.g (events.js:271:16)
    at emitNone (events.js:85:20)
    at Socket.emit (events.js:179:7)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1048:10)```
```