### PR TITLE
zlib: Fix use after null when calling .close

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -467,7 +467,10 @@ function _close(engine, callback) {
 
   engine._closed = true;
 
-  engine._handle.close();
+  // Caller may invoke .close after a zlib error (which will null _handle).
+  if (engine._handle) {
+    engine._handle.close();
+  }
 }
 
 function emitCloseNT(self) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

- zlib

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

An internal zlib error may cause _handle to be set to null.
Close now will check if there is a _handle prior to calling .close on
it.