### PR TITLE
doc: fix typo in fs writeSync param list

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -1342,7 +1342,7 @@ The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 ## fs.writeSync(fd, data[, position[, encoding]])
 
 * `fd` {Integer}
-* `buffer` {String | Buffer}
+* `data` {String | Buffer}
 * `position` {Integer}
 * `encoding` {String}
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] <del>If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?</del>
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

* doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Change `buffer` to `data` in the param list of `fs.writeSync(fd, data[, position[, encoding]])`