### PR TITLE
deps: completely upgrade npm in LTS to 2.15.1

### DIFF
--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -352,3 +352,6 @@ Scott Plumlee <scott@plumlee.org>
 gnerkus <ifeanyioraelosi@gmail.com>
 Robert Ludwig <rob.ludwig@rideamigos.com>
 Adam Byrne <misterbyrne@gmail.com>
+GriffinSchneider <griffinschneider@gmail.com>
+doug.wade <doug.wade@redfin.com>
+rhgb <kaiserdaemon@gmail.com>

--- a/deps/npm/html/doc/README.html
+++ b/deps/npm/html/doc/README.html
@@ -127,5 +127,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@2.15.0</p>
+<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-bin.html
+++ b/deps/npm/html/doc/api/npm-bin.html
@@ -28,5 +28,5 @@ to the <code>npm.bin</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@2.15.0</p>
+<p id="footer">npm-bin &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-bugs.html
+++ b/deps/npm/html/doc/api/npm-bugs.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@2.15.0</p>
+<p id="footer">npm-bugs &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-cache.html
+++ b/deps/npm/html/doc/api/npm-cache.html
@@ -42,5 +42,5 @@ incrementation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@2.15.0</p>
+<p id="footer">npm-cache &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-commands.html
+++ b/deps/npm/html/doc/api/npm-commands.html
@@ -36,5 +36,5 @@ usage, or <code>man 3 npm-&lt;command&gt;</code> for programmatic usage.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-commands &mdash; npm@2.15.0</p>
+<p id="footer">npm-commands &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-config.html
+++ b/deps/npm/html/doc/api/npm-config.html
@@ -57,5 +57,5 @@ functions instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.15.0</p>
+<p id="footer">npm-config &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-deprecate.html
+++ b/deps/npm/html/doc/api/npm-deprecate.html
@@ -47,5 +47,5 @@ a deprecation warning to all who attempt to install it.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@2.15.0</p>
+<p id="footer">npm-deprecate &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-docs.html
+++ b/deps/npm/html/doc/api/npm-docs.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@2.15.0</p>
+<p id="footer">npm-docs &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-edit.html
+++ b/deps/npm/html/doc/api/npm-edit.html
@@ -36,5 +36,5 @@ and how this is used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@2.15.0</p>
+<p id="footer">npm-edit &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-explore.html
+++ b/deps/npm/html/doc/api/npm-explore.html
@@ -31,5 +31,5 @@ sure to use <code>npm rebuild &lt;pkg&gt;</code> if you make any changes.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@2.15.0</p>
+<p id="footer">npm-explore &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-help-search.html
+++ b/deps/npm/html/doc/api/npm-help-search.html
@@ -44,5 +44,5 @@ Name of the file that matched</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@2.15.0</p>
+<p id="footer">npm-help-search &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-init.html
+++ b/deps/npm/html/doc/api/npm-init.html
@@ -39,5 +39,5 @@ then go ahead and use this programmatically.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@2.15.0</p>
+<p id="footer">npm-init &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-install.html
+++ b/deps/npm/html/doc/api/npm-install.html
@@ -32,5 +32,5 @@ installed or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@2.15.0</p>
+<p id="footer">npm-install &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-link.html
+++ b/deps/npm/html/doc/api/npm-link.html
@@ -42,5 +42,5 @@ the package in the current working directory</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@2.15.0</p>
+<p id="footer">npm-link &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-load.html
+++ b/deps/npm/html/doc/api/npm-load.html
@@ -37,5 +37,5 @@ config object.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-load &mdash; npm@2.15.0</p>
+<p id="footer">npm-load &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-ls.html
+++ b/deps/npm/html/doc/api/npm-ls.html
@@ -63,5 +63,5 @@ dependency will only be output once.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@2.15.0</p>
+<p id="footer">npm-ls &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-outdated.html
+++ b/deps/npm/html/doc/api/npm-outdated.html
@@ -28,5 +28,5 @@ currently outdated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@2.15.0</p>
+<p id="footer">npm-outdated &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-owner.html
+++ b/deps/npm/html/doc/api/npm-owner.html
@@ -47,5 +47,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@2.15.0</p>
+<p id="footer">npm-owner &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-pack.html
+++ b/deps/npm/html/doc/api/npm-pack.html
@@ -33,5 +33,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@2.15.0</p>
+<p id="footer">npm-pack &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-ping.html
+++ b/deps/npm/html/doc/api/npm-ping.html
@@ -29,4 +29,4 @@ to npm registries.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ping &mdash; npm@2.15.0</p>
+<p id="footer">npm-ping &mdash; npm@2.15.1</p>

--- a/deps/npm/html/doc/api/npm-prefix.html
+++ b/deps/npm/html/doc/api/npm-prefix.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@2.15.0</p>
+<p id="footer">npm-prefix &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-prune.html
+++ b/deps/npm/html/doc/api/npm-prune.html
@@ -30,5 +30,5 @@ package&#39;s dependencies list.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@2.15.0</p>
+<p id="footer">npm-prune &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-publish.html
+++ b/deps/npm/html/doc/api/npm-publish.html
@@ -46,5 +46,5 @@ the registry.  Overwrites when the &quot;force&quot; environment variable is set
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@2.15.0</p>
+<p id="footer">npm-publish &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-rebuild.html
+++ b/deps/npm/html/doc/api/npm-rebuild.html
@@ -30,5 +30,5 @@ the new binary. If no &#39;packages&#39; parameter is specify, every package wil
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@2.15.0</p>
+<p id="footer">npm-rebuild &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-repo.html
+++ b/deps/npm/html/doc/api/npm-repo.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@2.15.0</p>
+<p id="footer">npm-repo &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-restart.html
+++ b/deps/npm/html/doc/api/npm-restart.html
@@ -52,5 +52,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@2.15.0</p>
+<p id="footer">npm-restart &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-root.html
+++ b/deps/npm/html/doc/api/npm-root.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@2.15.0</p>
+<p id="footer">npm-root &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-run-script.html
+++ b/deps/npm/html/doc/api/npm-run-script.html
@@ -41,5 +41,5 @@ assumed to be the command to run. All other elements are ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@2.15.0</p>
+<p id="footer">npm-run-script &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-search.html
+++ b/deps/npm/html/doc/api/npm-search.html
@@ -53,5 +53,5 @@ like).</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@2.15.0</p>
+<p id="footer">npm-search &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/api/npm-shrinkwrap.html
@@ -33,5 +33,5 @@ been saved.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@2.15.0</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-start.html
+++ b/deps/npm/html/doc/api/npm-start.html
@@ -28,5 +28,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@2.15.0</p>
+<p id="footer">npm-start &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-stop.html
+++ b/deps/npm/html/doc/api/npm-stop.html
@@ -28,5 +28,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@2.15.0</p>
+<p id="footer">npm-stop &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-tag.html
+++ b/deps/npm/html/doc/api/npm-tag.html
@@ -36,5 +36,5 @@ used. For more information about how to set this config, check
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@2.15.0</p>
+<p id="footer">npm-tag &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-test.html
+++ b/deps/npm/html/doc/api/npm-test.html
@@ -30,5 +30,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@2.15.0</p>
+<p id="footer">npm-test &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-uninstall.html
+++ b/deps/npm/html/doc/api/npm-uninstall.html
@@ -30,5 +30,5 @@ uninstalled or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@2.15.0</p>
+<p id="footer">npm-uninstall &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-unpublish.html
+++ b/deps/npm/html/doc/api/npm-unpublish.html
@@ -33,5 +33,5 @@ the root package entry is removed from the registry entirely.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@2.15.0</p>
+<p id="footer">npm-unpublish &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-update.html
+++ b/deps/npm/html/doc/api/npm-update.html
@@ -33,5 +33,5 @@ parameter will be called when done or when an error occurs.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@2.15.0</p>
+<p id="footer">npm-update &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-version.html
+++ b/deps/npm/html/doc/api/npm-version.html
@@ -32,5 +32,5 @@ not have exactly one element. The only element should be a version number.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@2.15.0</p>
+<p id="footer">npm-version &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-view.html
+++ b/deps/npm/html/doc/api/npm-view.html
@@ -81,5 +81,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@2.15.0</p>
+<p id="footer">npm-view &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm-whoami.html
+++ b/deps/npm/html/doc/api/npm-whoami.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@2.15.0</p>
+<p id="footer">npm-whoami &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/api/npm.html
+++ b/deps/npm/html/doc/api/npm.html
@@ -23,7 +23,7 @@ npm.load([configObject, ]function (er, npm) {
   npm.commands.install([&quot;package&quot;], cb)
 })
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.15.0</p>
+<p>2.15.1</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>This is the API documentation for npm.
 To find documentation of the command line
@@ -109,5 +109,5 @@ method names.  Use the <code>npm.deref</code> method to find the real name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@2.15.0</p>
+<p id="footer">npm &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-access.html
+++ b/deps/npm/html/doc/cli/npm-access.html
@@ -84,5 +84,5 @@ with an HTTP 402 status code (logically enough), unless you use
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-access &mdash; npm@2.15.0</p>
+<p id="footer">npm-access &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-adduser.html
+++ b/deps/npm/html/doc/cli/npm-adduser.html
@@ -72,5 +72,5 @@ over any global configuration.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-adduser &mdash; npm@2.15.0</p>
+<p id="footer">npm-adduser &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-bin.html
+++ b/deps/npm/html/doc/cli/npm-bin.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@2.15.0</p>
+<p id="footer">npm-bin &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-bugs.html
+++ b/deps/npm/html/doc/cli/npm-bugs.html
@@ -56,5 +56,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@2.15.0</p>
+<p id="footer">npm-bugs &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-build.html
+++ b/deps/npm/html/doc/cli/npm-build.html
@@ -40,5 +40,5 @@ directly, run:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-build &mdash; npm@2.15.0</p>
+<p id="footer">npm-build &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-bundle.html
+++ b/deps/npm/html/doc/cli/npm-bundle.html
@@ -31,5 +31,5 @@ install packages into the local space.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bundle &mdash; npm@2.15.0</p>
+<p id="footer">npm-bundle &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-cache.html
+++ b/deps/npm/html/doc/cli/npm-cache.html
@@ -81,5 +81,5 @@ they do not make an HTTP request to the registry.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@2.15.0</p>
+<p id="footer">npm-cache &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-completion.html
+++ b/deps/npm/html/doc/cli/npm-completion.html
@@ -42,5 +42,5 @@ completions based on the arguments.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-completion &mdash; npm@2.15.0</p>
+<p id="footer">npm-completion &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-config.html
+++ b/deps/npm/html/doc/cli/npm-config.html
@@ -68,5 +68,5 @@ global config.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.15.0</p>
+<p id="footer">npm-config &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-dedupe.html
+++ b/deps/npm/html/doc/cli/npm-dedupe.html
@@ -65,5 +65,5 @@ versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dedupe &mdash; npm@2.15.0</p>
+<p id="footer">npm-dedupe &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-deprecate.html
+++ b/deps/npm/html/doc/cli/npm-deprecate.html
@@ -38,5 +38,5 @@ something like this:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@2.15.0</p>
+<p id="footer">npm-deprecate &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-dist-tag.html
+++ b/deps/npm/html/doc/cli/npm-dist-tag.html
@@ -87,5 +87,5 @@ begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dist-tag &mdash; npm@2.15.0</p>
+<p id="footer">npm-dist-tag &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-docs.html
+++ b/deps/npm/html/doc/cli/npm-docs.html
@@ -56,5 +56,5 @@ the current folder and use the <code>name</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@2.15.0</p>
+<p id="footer">npm-docs &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-edit.html
+++ b/deps/npm/html/doc/cli/npm-edit.html
@@ -49,5 +49,5 @@ or <code>&quot;notepad&quot;</code> on Windows.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@2.15.0</p>
+<p id="footer">npm-edit &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-explore.html
+++ b/deps/npm/html/doc/cli/npm-explore.html
@@ -49,5 +49,5 @@ Windows</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@2.15.0</p>
+<p id="footer">npm-explore &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-help-search.html
+++ b/deps/npm/html/doc/cli/npm-help-search.html
@@ -46,5 +46,5 @@ where the terms were found in the documentation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@2.15.0</p>
+<p id="footer">npm-help-search &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-help.html
+++ b/deps/npm/html/doc/cli/npm-help.html
@@ -52,5 +52,5 @@ matches are equivalent to specifying a topic name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help &mdash; npm@2.15.0</p>
+<p id="footer">npm-help &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-init.html
+++ b/deps/npm/html/doc/cli/npm-init.html
@@ -48,5 +48,5 @@ defaults and not prompt you for any options.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@2.15.0</p>
+<p id="footer">npm-init &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-install.html
+++ b/deps/npm/html/doc/cli/npm-install.html
@@ -279,5 +279,5 @@ affects a real use-case, it will be investigated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@2.15.0</p>
+<p id="footer">npm-install &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-link.html
+++ b/deps/npm/html/doc/cli/npm-link.html
@@ -73,5 +73,5 @@ include that scope, e.g.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@2.15.0</p>
+<p id="footer">npm-link &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-logout.html
+++ b/deps/npm/html/doc/cli/npm-logout.html
@@ -51,5 +51,5 @@ it takes precedence.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-logout &mdash; npm@2.15.0</p>
+<p id="footer">npm-logout &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-ls.html
+++ b/deps/npm/html/doc/cli/npm-ls.html
@@ -22,7 +22,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
-<pre><code>npm@2.15.0 /path/to/npm
+<pre><code>npm@2.15.1 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre><p>It will print out extraneous, missing, and invalid packages.</p>
@@ -97,5 +97,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@2.15.0</p>
+<p id="footer">npm-ls &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-outdated.html
+++ b/deps/npm/html/doc/cli/npm-outdated.html
@@ -116,5 +116,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@2.15.0</p>
+<p id="footer">npm-outdated &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-owner.html
+++ b/deps/npm/html/doc/cli/npm-owner.html
@@ -51,5 +51,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@2.15.0</p>
+<p id="footer">npm-owner &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-pack.html
+++ b/deps/npm/html/doc/cli/npm-pack.html
@@ -41,5 +41,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@2.15.0</p>
+<p id="footer">npm-pack &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-ping.html
+++ b/deps/npm/html/doc/cli/npm-ping.html
@@ -32,4 +32,4 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ping &mdash; npm@2.15.0</p>
+<p id="footer">npm-ping &mdash; npm@2.15.1</p>

--- a/deps/npm/html/doc/cli/npm-prefix.html
+++ b/deps/npm/html/doc/cli/npm-prefix.html
@@ -38,5 +38,5 @@ to contain a package.json file unless <code>-g</code> is also specified.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@2.15.0</p>
+<p id="footer">npm-prefix &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-prune.html
+++ b/deps/npm/html/doc/cli/npm-prune.html
@@ -41,5 +41,5 @@ negate <code>NODE_ENV</code> being set to <code>production</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@2.15.0</p>
+<p id="footer">npm-prune &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-publish.html
+++ b/deps/npm/html/doc/cli/npm-publish.html
@@ -69,5 +69,5 @@ it is removed with <a href="../cli/npm-unpublish.html">npm-unpublish(1)</a>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@2.15.0</p>
+<p id="footer">npm-publish &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-rebuild.html
+++ b/deps/npm/html/doc/cli/npm-rebuild.html
@@ -38,5 +38,5 @@ the new binary.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@2.15.0</p>
+<p id="footer">npm-rebuild &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-repo.html
+++ b/deps/npm/html/doc/cli/npm-repo.html
@@ -42,5 +42,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@2.15.0</p>
+<p id="footer">npm-repo &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-restart.html
+++ b/deps/npm/html/doc/cli/npm-restart.html
@@ -53,5 +53,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@2.15.0</p>
+<p id="footer">npm-restart &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-rm.html
+++ b/deps/npm/html/doc/cli/npm-rm.html
@@ -39,5 +39,5 @@ on its behalf.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rm &mdash; npm@2.15.0</p>
+<p id="footer">npm-rm &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-root.html
+++ b/deps/npm/html/doc/cli/npm-root.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@2.15.0</p>
+<p id="footer">npm-root &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-run-script.html
+++ b/deps/npm/html/doc/cli/npm-run-script.html
@@ -57,5 +57,5 @@ you should write:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@2.15.0</p>
+<p id="footer">npm-run-script &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-search.html
+++ b/deps/npm/html/doc/cli/npm-search.html
@@ -57,5 +57,5 @@ Pass a different registry url such as the default above in order to override thi
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@2.15.0</p>
+<p id="footer">npm-search &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/cli/npm-shrinkwrap.html
@@ -168,5 +168,5 @@ contents rather than versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@2.15.0</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-star.html
+++ b/deps/npm/html/doc/cli/npm-star.html
@@ -36,5 +36,5 @@ a vaguely positive way to show that you care.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-star &mdash; npm@2.15.0</p>
+<p id="footer">npm-star &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-stars.html
+++ b/deps/npm/html/doc/cli/npm-stars.html
@@ -37,5 +37,5 @@ you will most certainly enjoy this command.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stars &mdash; npm@2.15.0</p>
+<p id="footer">npm-stars &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-start.html
+++ b/deps/npm/html/doc/cli/npm-start.html
@@ -39,5 +39,5 @@ more details.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@2.15.0</p>
+<p id="footer">npm-start &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-stop.html
+++ b/deps/npm/html/doc/cli/npm-stop.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@2.15.0</p>
+<p id="footer">npm-stop &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-tag.html
+++ b/deps/npm/html/doc/cli/npm-tag.html
@@ -62,5 +62,5 @@ that do not begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@2.15.0</p>
+<p id="footer">npm-tag &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-team.html
+++ b/deps/npm/html/doc/cli/npm-team.html
@@ -67,4 +67,4 @@ use the <code>npm access</code> command to grant or revoke the appropriate permi
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-team &mdash; npm@2.15.0</p>
+<p id="footer">npm-team &mdash; npm@2.15.1</p>

--- a/deps/npm/html/doc/cli/npm-test.html
+++ b/deps/npm/html/doc/cli/npm-test.html
@@ -38,5 +38,5 @@ true.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@2.15.0</p>
+<p id="footer">npm-test &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-uninstall.html
+++ b/deps/npm/html/doc/cli/npm-uninstall.html
@@ -57,5 +57,5 @@ npm uninstall dtrace-provider --save-optional
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@2.15.0</p>
+<p id="footer">npm-uninstall &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-unpublish.html
+++ b/deps/npm/html/doc/cli/npm-unpublish.html
@@ -47,5 +47,5 @@ package again, a new version number must be used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@2.15.0</p>
+<p id="footer">npm-unpublish &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-update.html
+++ b/deps/npm/html/doc/cli/npm-update.html
@@ -117,5 +117,5 @@ be <em>downgraded</em>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@2.15.0</p>
+<p id="footer">npm-update &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-version.html
+++ b/deps/npm/html/doc/cli/npm-version.html
@@ -95,5 +95,5 @@ and tag up to the server, and deletes the <code>build/temp</code> directory.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@2.15.0</p>
+<p id="footer">npm-version &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-view.html
+++ b/deps/npm/html/doc/cli/npm-view.html
@@ -85,5 +85,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@2.15.0</p>
+<p id="footer">npm-view &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm-whoami.html
+++ b/deps/npm/html/doc/cli/npm-whoami.html
@@ -33,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@2.15.0</p>
+<p id="footer">npm-whoami &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/cli/npm.html
+++ b/deps/npm/html/doc/cli/npm.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <pre><code>npm &lt;command&gt; [args]
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.15.0</p>
+<p>2.15.1</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -126,7 +126,7 @@ will no doubt tell you to put the output in a gist or email.</p>
 <p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
 <a href="https://github.com/isaacs/">isaacs</a> ::
 <a href="http://twitter.com/izs">@izs</a> ::
-<a href="&#109;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#105;&#64;&#105;&#122;&#115;&#46;&#109;&#x65;">&#105;&#64;&#105;&#122;&#115;&#46;&#109;&#x65;</a></p>
+<a href="&#x6d;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#109;&#x65;">&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#109;&#x65;</a></p>
 <h2 id="see-also">SEE ALSO</h2>
 <ul>
 <li><a href="../cli/npm-help.html">npm-help(1)</a></li>
@@ -152,5 +152,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@2.15.0</p>
+<p id="footer">npm &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/files/npm-folders.html
+++ b/deps/npm/html/doc/files/npm-folders.html
@@ -183,5 +183,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@2.15.0</p>
+<p id="footer">npm-folders &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/files/npm-global.html
+++ b/deps/npm/html/doc/files/npm-global.html
@@ -183,5 +183,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html">packa
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@2.15.0</p>
+<p id="footer">npm-folders &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/files/npm-json.html
+++ b/deps/npm/html/doc/files/npm-json.html
@@ -581,5 +581,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@2.15.0</p>
+<p id="footer">package.json &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/files/npmrc.html
+++ b/deps/npm/html/doc/files/npmrc.html
@@ -83,5 +83,5 @@ manner.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npmrc &mdash; npm@2.15.0</p>
+<p id="footer">npmrc &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/files/package.json.html
+++ b/deps/npm/html/doc/files/package.json.html
@@ -581,5 +581,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@2.15.0</p>
+<p id="footer">package.json &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/index.html
+++ b/deps/npm/html/doc/index.html
@@ -242,5 +242,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@2.15.0</p>
+<p id="footer">npm-index &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-coding-style.html
+++ b/deps/npm/html/doc/misc/npm-coding-style.html
@@ -147,5 +147,5 @@ set to anything.&quot;</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-coding-style &mdash; npm@2.15.0</p>
+<p id="footer">npm-coding-style &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-config.html
+++ b/deps/npm/html/doc/misc/npm-config.html
@@ -806,5 +806,5 @@ exit successfully.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.15.0</p>
+<p id="footer">npm-config &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-developers.html
+++ b/deps/npm/html/doc/misc/npm-developers.html
@@ -195,5 +195,5 @@ from a fresh checkout.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-developers &mdash; npm@2.15.0</p>
+<p id="footer">npm-developers &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-disputes.html
+++ b/deps/npm/html/doc/misc/npm-disputes.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <ol>
 <li>Get the author email with <code>npm owner ls &lt;pkgname&gt;</code></li>
-<li>Email the author, CC <a href="&#x6d;&#97;&#105;&#108;&#116;&#x6f;&#58;&#x73;&#117;&#112;&#112;&#x6f;&#x72;&#x74;&#x40;&#110;&#112;&#109;&#x6a;&#115;&#46;&#99;&#x6f;&#109;">&#x73;&#117;&#112;&#112;&#x6f;&#x72;&#x74;&#x40;&#110;&#112;&#109;&#x6a;&#115;&#46;&#99;&#x6f;&#109;</a></li>
+<li>Email the author, CC <a href="&#109;&#97;&#105;&#x6c;&#116;&#x6f;&#x3a;&#x73;&#117;&#x70;&#112;&#111;&#114;&#x74;&#x40;&#110;&#112;&#x6d;&#x6a;&#x73;&#x2e;&#99;&#x6f;&#x6d;">&#x73;&#117;&#x70;&#112;&#111;&#114;&#x74;&#x40;&#110;&#112;&#x6d;&#x6a;&#x73;&#x2e;&#99;&#x6f;&#x6d;</a></li>
 <li>After a few weeks, if there&#39;s no resolution, we&#39;ll sort it out.</li>
 </ol>
 <p>Don&#39;t squat on package names.  Publish code or move out of the way.</p>
@@ -51,12 +51,12 @@ Joe&#39;s appropriate course of action in each case is the same.</p>
 owner (Bob).</li>
 <li>Joe emails Bob, explaining the situation <strong>as respectfully as
 possible</strong>, and what he would like to do with the module name.  He
-adds the npm support staff <a href="&#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#x3a;&#x73;&#117;&#112;&#112;&#x6f;&#x72;&#x74;&#x40;&#x6e;&#x70;&#x6d;&#106;&#115;&#x2e;&#x63;&#x6f;&#x6d;">&#x73;&#117;&#112;&#112;&#x6f;&#x72;&#x74;&#x40;&#x6e;&#x70;&#x6d;&#106;&#115;&#x2e;&#x63;&#x6f;&#x6d;</a> to the CC list of
+adds the npm support staff <a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#58;&#x73;&#117;&#x70;&#112;&#x6f;&#x72;&#x74;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#115;&#x2e;&#x63;&#111;&#109;">&#x73;&#117;&#x70;&#112;&#x6f;&#x72;&#x74;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#115;&#x2e;&#x63;&#111;&#109;</a> to the CC list of
 the email.  Mention in the email that Bob can run <code>npm owner add
 joe foo</code> to add Joe as an owner of the <code>foo</code> package.</li>
 <li>After a reasonable amount of time, if Bob has not responded, or if
 Bob and Joe can&#39;t come to any sort of resolution, email support
-<a href="&#109;&#97;&#105;&#108;&#116;&#x6f;&#x3a;&#x73;&#x75;&#x70;&#112;&#x6f;&#114;&#x74;&#x40;&#x6e;&#112;&#109;&#x6a;&#115;&#46;&#x63;&#111;&#109;">&#x73;&#x75;&#x70;&#112;&#x6f;&#114;&#x74;&#x40;&#x6e;&#112;&#109;&#x6a;&#115;&#46;&#x63;&#111;&#109;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
+<a href="&#109;&#x61;&#105;&#x6c;&#116;&#111;&#58;&#x73;&#x75;&#112;&#x70;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#x6d;&#106;&#x73;&#x2e;&#x63;&#x6f;&#x6d;">&#x73;&#x75;&#112;&#x70;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#x6d;&#106;&#x73;&#x2e;&#x63;&#x6f;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
 usually at least 4 weeks, but extra time is allowed around common
 holidays.)</li>
 </ol>
@@ -112,5 +112,5 @@ things into it.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-disputes &mdash; npm@2.15.0</p>
+<p id="footer">npm-disputes &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-index.html
+++ b/deps/npm/html/doc/misc/npm-index.html
@@ -242,5 +242,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@2.15.0</p>
+<p id="footer">npm-index &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-orgs.html
+++ b/deps/npm/html/doc/misc/npm-orgs.html
@@ -86,4 +86,4 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-orgs &mdash; npm@2.15.0</p>
+<p id="footer">npm-orgs &mdash; npm@2.15.1</p>

--- a/deps/npm/html/doc/misc/npm-registry.html
+++ b/deps/npm/html/doc/misc/npm-registry.html
@@ -70,5 +70,5 @@ effectively implement the entire CouchDB API anyway.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-registry &mdash; npm@2.15.0</p>
+<p id="footer">npm-registry &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-scope.html
+++ b/deps/npm/html/doc/misc/npm-scope.html
@@ -92,5 +92,5 @@ that registry instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scope &mdash; npm@2.15.0</p>
+<p id="footer">npm-scope &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/npm-scripts.html
+++ b/deps/npm/html/doc/misc/npm-scripts.html
@@ -207,5 +207,5 @@ scripts is for compilation which must be done on the target architecture.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scripts &mdash; npm@2.15.0</p>
+<p id="footer">npm-scripts &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/removing-npm.html
+++ b/deps/npm/html/doc/misc/removing-npm.html
@@ -57,5 +57,5 @@ modules.  To track those down, you can do the following:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">removing-npm &mdash; npm@2.15.0</p>
+<p id="footer">removing-npm &mdash; npm@2.15.1</p>
 

--- a/deps/npm/html/doc/misc/semver.html
+++ b/deps/npm/html/doc/misc/semver.html
@@ -302,5 +302,5 @@ range, use the <code>satisfies(version, range)</code> function.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">semver &mdash; npm@2.15.0</p>
+<p id="footer">semver &mdash; npm@2.15.1</p>
 

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -23,7 +23,7 @@ For example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@2.15.0 /path/to/npm
+npm@2.15.1 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SH VERSION
 .P
-2.15.0
+2.15.1
 .SH DESCRIPTION
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man3/npm.3
+++ b/deps/npm/man/man3/npm.3
@@ -20,7 +20,7 @@ npm\.load([configObject, ]function (er, npm) {
 .RE
 .SH VERSION
 .P
-2.15.0
+2.15.1
 .SH DESCRIPTION
 .P
 This is the API documentation for npm\.

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.15.0",
+  "version": "2.15.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [


### PR DESCRIPTION
This is the same as 55c3f804c4a077873a438846931fd0fcea0caba2, only it includes the version tag marking it as `npm@2.15.1` (instead of `npm@2.15.0`).

My apologies for the confusion.

**r**: @TheAlphaNerd 
**r**: @rvagg 