### PR TITLE
test: split out hints from test-dns

### DIFF
--- a/test/parallel/test-dns-lookup-hints-family.js
+++ b/test/parallel/test-dns-lookup-hints-family.js
@@ -1,0 +1,23 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const dns = require('dns');
+
+function noop() {}
+
+dns.setServers([]);
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    family: 4,
+    hints: 0
+  }, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    family: 6,
+    hints: dns.ADDRCONFIG
+  }, noop);
+});

--- a/test/parallel/test-dns-lookup-hints.js
+++ b/test/parallel/test-dns-lookup-hints.js
@@ -40,20 +40,6 @@ assert.doesNotThrow(function() {
 
 assert.doesNotThrow(function() {
   dns.lookup('www.google.com', {
-    family: 4,
-    hints: 0
-  }, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
-    family: 6,
-    hints: dns.ADDRCONFIG
-  }, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
     hints: dns.V4MAPPED
   }, noop);
 });

--- a/test/parallel/test-dns-lookup-hints.js
+++ b/test/parallel/test-dns-lookup-hints.js
@@ -1,8 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var dns = require('dns');
+const dns = require('dns');
 
 function noop() {}
 

--- a/test/parallel/test-dns-lookup-hints.js
+++ b/test/parallel/test-dns-lookup-hints.js
@@ -1,0 +1,65 @@
+'use strict';
+require('../common');
+var assert = require('assert');
+
+var dns = require('dns');
+
+function noop() {}
+
+dns.setServers([]);
+
+/*
+ * Make sure that dns.lookup throws if hints does not represent a valid flag.
+ * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:
+ * - it's different from dns.V4MAPPED and dns.ADDRCONFIG.
+ * - it's different from them bitwise ored.
+ * - it's different from 0.
+ * - it's an odd number different than 1, and thus is invalid, because
+ * flags are either === 1 or even.
+ */
+assert.throws(function() {
+  dns.lookup('www.google.com', { hints: (dns.V4MAPPED | dns.ADDRCONFIG) + 1 },
+    noop);
+});
+
+assert.throws(function() {
+  dns.lookup('www.google.com');
+}, 'invalid arguments: callback must be passed');
+
+assert.throws(function() {
+  dns.lookup('www.google.com', 4);
+}, 'invalid arguments: callback must be passed');
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', 6, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {}, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    family: 4,
+    hints: 0
+  }, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    family: 6,
+    hints: dns.ADDRCONFIG
+  }, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    hints: dns.V4MAPPED
+  }, noop);
+});
+
+assert.doesNotThrow(function() {
+  dns.lookup('www.google.com', {
+    hints: dns.ADDRCONFIG | dns.V4MAPPED
+  }, noop);
+});

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -90,62 +90,6 @@ assert.doesNotThrow(function() {
   dns.lookup(NaN, noop);
 });
 
-/*
- * Make sure that dns.lookup throws if hints does not represent a valid flag.
- * (dns.V4MAPPED | dns.ADDRCONFIG) + 1 is invalid because:
- * - it's different from dns.V4MAPPED and dns.ADDRCONFIG.
- * - it's different from them bitwise ored.
- * - it's different from 0.
- * - it's an odd number different than 1, and thus is invalid, because
- * flags are either === 1 or even.
- */
-assert.throws(function() {
-  dns.lookup('www.google.com', { hints: (dns.V4MAPPED | dns.ADDRCONFIG) + 1 },
-    noop);
-});
-
-assert.throws(function() {
-  dns.lookup('www.google.com');
-}, 'invalid arguments: callback must be passed');
-
-assert.throws(function() {
-  dns.lookup('www.google.com', 4);
-}, 'invalid arguments: callback must be passed');
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', 6, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {}, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
-    family: 4,
-    hints: 0
-  }, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
-    family: 6,
-    hints: dns.ADDRCONFIG
-  }, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
-    hints: dns.V4MAPPED
-  }, noop);
-});
-
-assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
-    hints: dns.ADDRCONFIG | dns.V4MAPPED
-  }, noop);
-});
-
 assert.throws(function() {
   dns.lookupService('0.0.0.0');
 }, /Invalid arguments/);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test, dns

### Description of change

A few of the hints tests were flaky in CI on pi2-raspbian-wheezy. Moving
them to their own file fixes it. It could be that there is an unnoticed
interaction with other tests in the file, or it could be that there is a
cumulative threshold on some resource that is reached that causes Pi2 to
sometimes stall out. (The test was timing out.)

Fixes: https://github.com/nodejs/node/issues/5554