### PR TITLE
doc: fix http response event, Agent#getName

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -152,6 +152,13 @@ connection can be reused.  In the http agent, this returns
 CA, cert, ciphers, and other HTTPS/TLS-specific options that determine
 socket reusability.
 
+Options:
+
+- `host`: A domain name or IP address of the server to issue the request to.
+- `port`: Port of remote server.
+- `localAddress`: Local interface to bind for network connections when issuing
+  the request.
+
 ### agent.maxFreeSockets
 
 By default set to 256.  For Agents supporting HTTP KeepAlive, this
@@ -302,12 +309,6 @@ the client should send the request body.
 
 Emitted when a response is received to this request. This event is emitted only
 once. The `response` argument will be an instance of [`http.IncomingMessage`][].
-
-Options:
-
-- `host`: A domain name or IP address of the server to issue the request to.
-- `port`: Port of remote server.
-- `socketPath`: Unix Domain Socket (use one of host:port or socketPath)
 
 ### Event: 'socket'
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [X] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [X] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

doc

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Removes the options block from the http 'response' event and attaches
it to Agent#getName where it belongs. Removes socketPath and documents
localAddress option.

Fixes #4586