### PR TITLE
test: fix test-dns.js flakiness

### DIFF
--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -1,8 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var dns = require('dns');
+const dns = require('dns');
 
 var existing = dns.getServers();
 assert(existing.length);
@@ -121,27 +121,27 @@ assert.doesNotThrow(function() {
 });
 
 assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
+  dns.lookup('', {
     family: 4,
     hints: 0
   }, noop);
 });
 
 assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
+  dns.lookup('', {
     family: 6,
     hints: dns.ADDRCONFIG
   }, noop);
 });
 
 assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
+  dns.lookup('', {
     hints: dns.V4MAPPED
   }, noop);
 });
 
 assert.doesNotThrow(function() {
-  dns.lookup('www.google.com', {
+  dns.lookup('', {
     hints: dns.ADDRCONFIG | dns.V4MAPPED
   }, noop);
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test, dns

### Description of change

Use empty string instead of `www.google.com` for tests where we are just
doing parameter evaluation. This will avoid DNS lookups which appear to
be causing flakiness on Raspberry Pi devices in CI.

Fixes: https://github.com/nodejs/node/issues/5554