### PR TITLE
test: make arch available in status files

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1523,10 +1523,15 @@ def Main():
         if not exists(vm):
           print "Can't find shell executable: '%s'" % vm
           continue
+        archEngineContext = Execute([vm, "-p", "process.arch"], context)
+        vmArch = archEngineContext.stdout.rstrip()
+        if archEngineContext.exit_code is not 0 or vmArch == "undefined":
+          print "Can't determine the arch of: '%s'" % vm
+          continue
         env = {
           'mode': mode,
           'system': utils.GuessOS(),
-          'arch': arch,
+          'arch': vmArch,
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

The value is retrieved from `process.arch` in node itself.

Thanks to @joaocgreis for providing a similar [implementation](https://github.com/janeasystems/node-chakracore/commit/64b2b9b8a5dc7aae4b1e80dd4b776984e655ebb5) (mostly equal)

/cc @Trott 

