### PR TITLE
net: support DNS hints in createConnection()

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -375,6 +375,8 @@ For TCP sockets, `options` argument should be an object which specifies:
 
   - `family` : Version of IP stack. Defaults to `4`.
 
+  - `hints`: [`dns.lookup()` hints][]. Defaults to `0`.
+
   - `lookup` : Custom lookup function. Defaults to `dns.lookup`.
 
 For local domain sockets, `options` argument should be an object which
@@ -720,6 +722,7 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`connect()`]: #net_socket_connect_options_connectlistener
 [`destroy()`]: #net_socket_destroy
 [`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
+[`dns.lookup()` hints]: #dns_supported_getaddrinfo_flags
 [`end()`]: #net_socket_end_data_encoding
 [`EventEmitter`]: events.html#events_class_events_eventemitter
 [`net.Socket`]: #net_class_net_socket

--- a/lib/net.js
+++ b/lib/net.js
@@ -944,10 +944,10 @@ function lookupAndConnect(self, options) {
 
   var dnsopts = {
     family: options.family,
-    hints: 0
+    hints: options.hints || 0
   };
 
-  if (dnsopts.family !== 4 && dnsopts.family !== 6) {
+  if (dnsopts.family !== 4 && dnsopts.family !== 6 && dnsopts.hints === 0) {
     dnsopts.hints = dns.ADDRCONFIG;
     // The AI_V4MAPPED hint is not supported on FreeBSD or Android,
     // and getaddrinfo returns EAI_BADFLAGS. However, it seems to be

--- a/test/parallel/test-net-create-connection.js
+++ b/test/parallel/test-net-create-connection.js
@@ -1,14 +1,15 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const dns = require('dns');
+const net = require('net');
 
-var tcpPort = common.PORT;
-var expectedConnections = 7;
+const tcpPort = common.PORT;
+const expectedConnections = 7;
 var clientConnected = 0;
 var serverConnected = 0;
 
-var server = net.createServer(function(socket) {
+const server = net.createServer(function(socket) {
   socket.end();
   if (++serverConnected === expectedConnections) {
     server.close();
@@ -87,6 +88,10 @@ server.listen(tcpPort, 'localhost', function() {
   fail({
     port: 65536
   }, RangeError, '"port" option should be >= 0 and < 65536: 65536');
+
+  fail({
+    hints: (dns.ADDRCONFIG | dns.V4MAPPED) + 42,
+  }, TypeError, 'Invalid argument: hints must use valid flags');
 });
 
 // Try connecting to random ports, but do so once the server is closed


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

net

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This commit adds support for passing DNS lookup hints to `createConnection()`.

This PR is semver minor, but I'd like to toss out the idea of a semver major change where no DNS hints are implicitly set. Instead, users could specify hints if necessary. My motivation is a number of issues related to varying support of `V4MAPPED`. Thoughts @bnoordhuis / @indutny?