### PR TITLE
test: fix flaky test-net-socket-timeout-unref

### DIFF
--- a/test/parallel/test-net-socket-timeout-unref.js
+++ b/test/parallel/test-net-socket-timeout-unref.js
@@ -1,39 +1,35 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
 
-var server = net.createServer(function(c) {
+// Test that unref'ed sockets with timeouts do not prevent exit.
+
+const common = require('../common');
+const net = require('net');
+
+const server = net.createServer(function(c) {
   c.write('hello');
   c.unref();
 });
 server.listen(common.PORT);
 server.unref();
 
-var timedout = false;
 var connections = 0;
-var sockets = [];
-var delays = [8, 5, 3, 6, 2, 4];
+const sockets = [];
+const delays = [8, 5, 3, 6, 2, 4];
 
 delays.forEach(function(T) {
-  var socket = net.createConnection(common.PORT, 'localhost');
-  socket.on('connect', function() {
+  const socket = net.createConnection(common.PORT, 'localhost');
+  socket.on('connect', common.mustCall(function() {
     if (++connections === delays.length) {
       sockets.forEach(function(s) {
-        s[0].setTimeout(s[1] * 1000, function() {
-          timedout = true;
-          s[0].destroy();
+        s.socket.setTimeout(s.timeout, function() {
+          s.socket.destroy();
+          throw new Error('socket timed out unexpectedly');
         });
 
-        s[0].unref();
+        s.socket.unref();
       });
     }
-  });
+  }));
 
-  sockets.push([socket, T]);
-});
-
-process.on('exit', function() {
-  assert.strictEqual(timedout, false,
-                     'Socket timeout should not hold loop open');
+  sockets.push({socket: socket, timeout: T * 1000});
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test, net

### Description of change

Throw immediately on socket timeout rather than checking boolean in exit
handler.

Fixes: https://github.com/nodejs/node/issues/5128