### PR TITLE
buffer: don't set `kNoZeroFill` flag in allocUnsafe

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -163,8 +163,6 @@ Buffer.alloc = function(size, fill, encoding) {
 Buffer.allocUnsafe = function(size) {
   if (typeof size !== 'number')
     throw new TypeError('"size" argument must be a number');
-  if (size > 0)
-    flags[kNoZeroFill] = 1;
   return allocate(size);
 };
 

--- a/test/parallel/test-buffer-safe-unsafe.js
+++ b/test/parallel/test-buffer-safe-unsafe.js
@@ -7,8 +7,18 @@ const safe = Buffer.alloc(10);
 
 function isZeroFilled(buf) {
   for (let n = 0; n < buf.length; n++)
-    if (buf[n] > 0) return false;
+    if (buf[n] !== 0) return false;
   return true;
 }
 
 assert(isZeroFilled(safe));
+
+// Test that unsafe allocations doesn't affect subsequent safe allocations
+Buffer.allocUnsafe(10);
+assert(isZeroFilled(new Float64Array(10)));
+
+new Buffer(10);
+assert(isZeroFilled(new Float64Array(10)));
+
+Buffer.allocUnsafe(10);
+assert(isZeroFilled(Buffer.alloc(10)));


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

buffer 
[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

If `kNoZeroFill` is set here, it won't be reset in case of
pooled allocation. In case of "slow" allocation it will be
set later anyway.

Fixes: https://github.com/nodejs/node/issues/6006