### PR TITLE
tools: remove disabling of already-disabled rule

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,8 +3,6 @@
 rules:
   ## allow undeclared variables
   no-undef: 0
-  ## allow global Buffer usage
-  require-buffer: 0
   ## common module is mandatory in tests
   required-modules: [2, "common"]
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test tools buffer

### Description of change

`require-buffer` is only enabled in the `lib` directory. There is no
need to disable it in `test`.