### PR TITLE
test: be explicit about polluting of `global`

### DIFF
--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -6,8 +6,9 @@ try {
   return;
 }
 
-// the missing var keyword is intentional
-domain = require('domain');
+// Pollution of global is intentional as part of test.
+// See https://github.com/nodejs/node/commit/d1eff9ab
+global.domain = require('domain');
 
 // should not throw a 'TypeError: undefined is not a function' exception
 crypto.randomBytes(8);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test crypto domain

### Description of change

There was a comment in `test-domain-crypto.js` indicating that the
pollution of the `global` object with a `domain` property was
intentional. Provide more information in the comment so someone may
easily determine why. Use `global.domain` rather than declaring `domain`
without the `var` keyword to more clearly signal that the pollution is
intentional.