### PR TITLE
net: remove implicit setting of DNS hints

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -949,17 +949,6 @@ function lookupAndConnect(self, options) {
     hints: options.hints || 0
   };
 
-  if (dnsopts.family !== 4 && dnsopts.family !== 6 && dnsopts.hints === 0) {
-    dnsopts.hints = dns.ADDRCONFIG;
-    // The AI_V4MAPPED hint is not supported on FreeBSD or Android,
-    // and getaddrinfo returns EAI_BADFLAGS. However, it seems to be
-    // supported on most other systems. See
-    // http://lists.freebsd.org/pipermail/freebsd-bugs/2008-February/028260.html
-    // for more information on the lack of support for FreeBSD.
-    if (process.platform !== 'freebsd' && process.platform !== 'android')
-      dnsopts.hints |= dns.V4MAPPED;
-  }
-
   debug('connect: find host ' + host);
   debug('connect: dns options', dnsopts);
   self._host = host;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This commit removes the implicit setting of the `V4MAPPED` and `ADDRCONFIG` DNS flags in `createConnection()`. As of 39de601e1c3eda92eb2e37eca4e6aa960f206f39, users that need these
flags can set them explicitly.

Refs: https://github.com/nodejs/node/pull/6000
CI: https://ci.nodejs.org/job/node-test-pull-request/2136/
CI Retry: https://ci.nodejs.org/job/node-test-pull-request/2137/
CI Retry 2: https://ci.nodejs.org/job/node-test-pull-request/2138/
CITGM: https://ci.nodejs.org/job/thealphanerd-smoker/176/