### PR TITLE
repl: eval empty lines, fixing debugger repeat

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -421,7 +421,7 @@ function REPLServer(prompt,
       }
     }
 
-    if (!skipCatchall && (cmd || (!cmd && self.bufferedCommand))) {
+    if (!skipCatchall) {
       var evalCmd = self.bufferedCommand + cmd;
       if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
         // It's confusing for `{ a : 1 }` to be interpreted as a block
@@ -483,7 +483,7 @@ function REPLServer(prompt,
           // immediately. We don't have to print anything else. So, only when
           // the second argument to this function is there, print it.
           arguments.length === 2 &&
-          (!self.ignoreUndefined || ret !== undefined)) {
+          (!(self.ignoreUndefined || evalCmd === '\n') || ret !== undefined)) {
         if (!self.underscoreAssigned) {
           self.last = ret;
         }

--- a/test/debugger/test-debugger-pid.js
+++ b/test/debugger/test-debugger-pid.js
@@ -23,8 +23,8 @@ interfacer.stderr.on('data', onData);
 
 interfacer.on('line', function(line) {
   line = line.replace(/^(debug> *)+/, '');
-  var expected = 'Target process: 655555 doesn\'t exist.';
-  assert.ok(expected == line, 'Got unexpected line: ' + line);
+  var expected = /Target process: 655555 doesn\'t exist./;
+  assert.ok(line.match(expected), 'Got unexpected line: ' + line);
 });
 
 interfacer.on('exit', function(code, signal) {

--- a/test/debugger/test-debugger-repl-break-in-module.js
+++ b/test/debugger/test-debugger-repl-break-in-module.js
@@ -7,7 +7,7 @@ repl.startDebugger('break-in-module/main.js');
 // -- SET BREAKPOINT --
 
 // Set breakpoint by file name + line number where the file is not loaded yet
-repl.addTest('sb("mod.js", 23)', [
+repl.addTest('sb("mod.js", 2)', [
   /Warning: script 'mod\.js' was not loaded yet\./,
   /1/, /2/, /3/, /4/, /5/, /6/
 ]);
@@ -20,8 +20,8 @@ repl.addTest('sb(")^$*+?}{|][(.js\\\\", 1)', [
 
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
-  /break in .*[\\\/]mod\.js:23/,
-  /21/, /22/, /23/, /24/, /25/
+  /break in .*[\\\/]mod\.js:2/,
+  /1/, /2/, /3/, /4/
 ]);
 
 // -- RESTORE BREAKPOINT ON RESTART --
@@ -33,7 +33,7 @@ repl.addTest('restart', [].concat(
   ],
   repl.handshakeLines,
   [
-    /Restoring breakpoint mod.js:23/,
+    /Restoring breakpoint mod.js:2/,
     /Warning: script 'mod\.js' was not loaded yet\./,
     /Restoring breakpoint \).*:\d+/,
     /Warning: script '\)[^']*' was not loaded yet\./
@@ -42,14 +42,14 @@ repl.addTest('restart', [].concat(
 
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
-  /break in .*[\\\/]mod\.js:23/,
-  /21/, /22/, /23/, /24/, /25/
+  /break in .*[\\\/]mod\.js:2/,
+  /1/, /2/, /3/, /4/
 ]);
 
 // -- CLEAR BREAKPOINT SET IN MODULE TO BE LOADED --
 
-repl.addTest('cb("mod.js", 23)', [
-  /18/, /./, /./, /./, /./, /./, /./, /./, /26/
+repl.addTest('cb("mod.js", 2)', [
+  /1/, /2/, /3/, /4/, /5/
 ]);
 
 repl.addTest('c', [

--- a/test/debugger/test-debugger-repl-term.js
+++ b/test/debugger/test-debugger-repl-term.js
@@ -22,16 +22,16 @@ addTest('', [
   /3/, /4/, /5/, /6/, /7/,
 ]);
 
-// continue
-addTest('c', [
-  /debug>.*c/,
+// out
+addTest('o', [
+  /debug>.*o/,
   /break in .*:12/,
   /10/, /11/, /12/, /13/, /14/
 ]);
 
-// should repeat continue
-addTest('', [
-  /debug>/,
+// continue
+addTest('c', [
+  /debug>.*c/,
   /break in .*:5/,
   /3/, /4/, /5/, /6/, /7/,
 ]);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_repl, debugger_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

Tweak the better empty line handling introduced in #2163 so that empty lines
are still passed to the eval function. This is required for the debugger to
repeat the last command on an empty line.

Fixes: https://github.com/nodejs/node/issues/6010