### PR TITLE
test: explicitly set global in test-repl

### DIFF
--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -24,7 +24,7 @@ var moduleFilename = require('path').join(common.fixturesDir, 'a');
 console.error('repl test');
 
 // function for REPL to run
-invoke_me = function(arg) {
+global.invoke_me = function(arg) {
   return 'invoked ' + arg;
 };
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

test repl

### Description of change

The test intentionally assigns a global. Use `global` namespace to make it clear that it is intentional and not an accidental leak.
