### PR TITLE
doc: note assert.throws() pitfall

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -361,8 +361,13 @@ If the values are not strictly equal, an `AssertionError` is thrown with a
 
 ## assert.throws(block[, error][, message])
 
-Expects the function `block` to throw an error. If specified, `error` can be a
-constructor, [`RegExp`][], or validation function.
+Expects the function `block` to throw an error.
+
+If specified, `error` can be a constructor, [`RegExp`][], or validation
+function.
+
+If specified, `message` will be the message provided by the `AssertionError` if
+the block fails to throw.
 
 Validate instanceof using constructor:
 
@@ -400,6 +405,18 @@ assert.throws(
   },
   'unexpected error'
 );
+```
+
+Note that `error` can not be a string. If a string is provided as the second
+argument, then `error` is assumed to be omitted and the string will be used for
+`message` instead. This can lead to easy-to-miss mistakes:
+
+```js
+// THIS IS A MISTAKE! DO NOT DO THIS!
+assert.throws(myFunction, 'missing foo', 'did not throw with expected message');
+
+// Do this instead.
+assert.throws(myFunction, /missing foo/, 'did not throw with expected message');
 ```
 
 [Locked]: documentation.html#documentation_stability_index


### PR DESCRIPTION
### Pull Request check-list

- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

### Affected core subsystem(s)

doc assert

### Description of change

`assert.throws()` has a pitfall where you may think you are checking error message text when you are not. Document it.
