### PR TITLE
test: fix flakiness of stringbytes-external

### DIFF
--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <node.h>
+#include <v8.h>
+
+void EnsureAllocation(const v8::FunctionCallbackInfo<v8::Value> &args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  uintptr_t size = args[0]->IntegerValue();
+  v8::Local<v8::Boolean> success;
+
+  void* buffer = malloc(size);
+  if (buffer) {
+    success = v8::Boolean::New(isolate, true);
+    free(buffer);
+  } else {
+    success = v8::Boolean::New(isolate, false);
+  }
+  args.GetReturnValue().Set(success);
+}
+
+void init(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "ensureAllocation", EnsureAllocation);
+}
+
+NODE_MODULE(binding, init);

--- a/test/addons/stringbytes-external-exceed-max/binding.gyp
+++ b/test/addons/stringbytes-external-exceed-max/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,9 +17,6 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = Buffer.allocUnsafe(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  Buffer.allocUnsafe(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Array buffer allocation failed') throw (e);
@@ -28,14 +24,12 @@ try {
   return;
 }
 
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
 assert.throws(function() {
-  buf.toString('binary');
+  buf.toString('base64');
 }, /"toString\(\)" failed/);
-
-var maxString = buf.toString('binary', 1);
-assert.equal(maxString.length, kStringMaxLength);
-// Free the memory early instead of at the end of the next assignment
-maxString = undefined;
-
-maxString = buf.toString('binary', 0, kStringMaxLength);
-assert.equal(maxString.length, kStringMaxLength);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,9 +17,6 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = Buffer.allocUnsafe(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  Buffer.allocUnsafe(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Array buffer allocation failed') throw (e);
@@ -28,10 +24,20 @@ try {
   return;
 }
 
-assert.throws(function() {
-  buf.toString();
-}, /"toString\(\)" failed|Array buffer allocation failed/);
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
 
 assert.throws(function() {
-  buf.toString('utf8');
+  buf.toString('binary');
 }, /"toString\(\)" failed/);
+
+var maxString = buf.toString('binary', 1);
+assert.equal(maxString.length, kStringMaxLength);
+// Free the memory early instead of at the end of the next assignment
+maxString = undefined;
+
+maxString = buf.toString('binary', 0, kStringMaxLength);
+assert.equal(maxString.length, kStringMaxLength);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,9 +17,6 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = Buffer.allocUnsafe(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  Buffer.allocUnsafe(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Array buffer allocation failed') throw (e);
@@ -28,6 +24,12 @@ try {
   return;
 }
 
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
 assert.throws(function() {
-  buf.toString('base64');
+  buf.toString('hex');
 }, /"toString\(\)" failed/);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,17 +10,13 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  var buf = Buffer.allocUnsafe(kStringMaxLength * 2 + 2);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  Buffer.allocUnsafe(2 * kStringMaxLength);
-  gc();
+  var buf = Buffer.allocUnsafe(kStringMaxLength + 1);
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Array buffer allocation failed') throw (e);
@@ -28,6 +24,16 @@ try {
   return;
 }
 
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
 assert.throws(function() {
-  buf.toString('utf16le');
+  buf.toString();
+}, /"toString\(\)" failed|Array buffer allocation failed/);
+
+assert.throws(function() {
+  buf.toString('utf8');
 }, /"toString\(\)" failed/);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,12 +17,15 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = Buffer.allocUnsafe(kStringMaxLength + 2);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  Buffer.allocUnsafe(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Array buffer allocation failed') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
   console.log(skipMessage);
   return;
 }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

test

### Description of change

The tests used to rely on precise timing of when a JavaScript object
would be garbage collected to ensure that there is enough memory
available on the system. Switch the test to use a malloc/free pair
instead.

Ref: https://github.com/nodejs/node/pull/5945
R=@bnoordhuis, @Trott 
~~CI: https://ci.nodejs.org/job/node-test-pull-request/2146/~~
~~CI: https://ci.nodejs.org/job/node-test-pull-request/2147/~~
CI: https://ci.nodejs.org/job/node-test-pull-request/2148/
