### PR TITLE
Doc typo fix. decipher.setAuthPadding -> decipher.setAutoPadding

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -301,7 +301,7 @@ cipher text should be discarded due to failed authentication.
 ### decipher.setAutoPadding(auto_padding=true)
 
 When data has been encrypted without standard block padding, calling
-`decipher.setAuthPadding(false)` will disable automatic padding to prevent
+`decipher.setAutoPadding(false)` will disable automatic padding to prevent
 [`decipher.final()`][] from checking for and removing padding.
 
 Turning auto padding off will only work if the input data's length is a


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [n/a] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [n/a] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [n/a] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

`decipher.setAuthPadding(false)` changed to `decipher.setAutoPadding(false)`