### PR TITLE
crypto: better error message when calling digest twice on a hash

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -538,6 +538,7 @@ class Hash : public BaseObject {
   EVP_MD_CTX mdctx_; /* coverity[member_decl] */
   const EVP_MD* md_; /* coverity[member_decl] */
   bool initialised_;
+  bool finalized_;
 };
 
 class SignBase : public BaseObject {

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -98,3 +98,15 @@ assert.equal(
 assert.notEqual(
     hutf8,
     crypto.createHash('sha512').update('УТФ-8 text', 'binary').digest('hex'));
+
+var h3 = crypto.createHash('sha256');
+h3.digest();
+assert.throws(function() {
+  h3.digest();
+},
+  /Digest already called/);
+
+assert.throws(function() {
+  h3.update('foo');
+},
+  /Digest already called/);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?

I'm getting an error on the test-tick-processor test, seems unrelated

- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

calling digest twice on a hash used to give an unhelpful error about the hash not being initialized, this fixes that
