### PR TITLE
test: ensure win32.isAbsolute() is consistent

### DIFF
--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -344,8 +344,18 @@ resolveTests.forEach(function(test) {
 assert.equal(failures.length, 0, failures.join(''));
 
 // path.isAbsolute tests
+assert.equal(path.win32.isAbsolute('/'), true);
+assert.equal(path.win32.isAbsolute('//'), true);
+assert.equal(path.win32.isAbsolute('//server'), true);
 assert.equal(path.win32.isAbsolute('//server/file'), true);
 assert.equal(path.win32.isAbsolute('\\\\server\\file'), true);
+assert.equal(path.win32.isAbsolute('\\\\server'), true);
+assert.equal(path.win32.isAbsolute('\\\\'), true);
+assert.equal(path.win32.isAbsolute('c'), false);
+assert.equal(path.win32.isAbsolute('c:'), false);
+assert.equal(path.win32.isAbsolute('c:\\'), true);
+assert.equal(path.win32.isAbsolute('c:/'), true);
+assert.equal(path.win32.isAbsolute('c://'), true);
 assert.equal(path.win32.isAbsolute('C:/Users/'), true);
 assert.equal(path.win32.isAbsolute('C:\\Users\\'), true);
 assert.equal(path.win32.isAbsolute('C:cwd/another'), false);


### PR DESCRIPTION
Adds test cases to ensure win32.isAbsolute is consistent.

This is a backport from 3072546feb

ref: https://github.com/nodejs/node/pull/6028