### PR TITLE
querystring: allow querystring parse to handle __proto__

### DIFF
--- a/benchmark/querystring/querystring-parse-proto.js
+++ b/benchmark/querystring/querystring-parse-proto.js
@@ -1,0 +1,25 @@
+'use strict';
+var common = require('../common.js');
+var querystring = require('querystring');
+var v8 = require('v8');
+
+var bench = common.createBenchmark(main, {
+  n: [1e6],
+});
+
+function main(conf) {
+  var n = conf.n | 0;
+
+  const input = 'a=b&__proto__=1';
+
+  v8.setFlagsFromString('--allow_natives_syntax');
+  querystring.parse(input);
+  eval('%OptimizeFunctionOnNextCall(querystring.parse)');
+  querystring.parse(input);
+
+  var i;
+  bench.start();
+  for (i = 0; i < n; i += 1)
+    querystring.parse(input);
+  bench.end(n);
+}

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -212,11 +212,12 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   sep = sep || '&';
   eq = eq || '=';
 
-  const obj = {};
-
   if (typeof qs !== 'string' || qs.length === 0) {
-    return obj;
+    return {};
   }
+
+  var obj = {};
+  Object.setPrototypeOf(obj, null);
 
   if (typeof sep !== 'string')
     sep += '';
@@ -387,6 +388,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
     }
   }
 
+  Object.setPrototypeOf(obj, Object.prototype);
   return obj;
 };
 

--- a/test/parallel/test-querystring-proto.js
+++ b/test/parallel/test-querystring-proto.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-proto */
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const qs = require('querystring');
+
+const obj = qs.parse('a=b&__proto__=1');
+
+assert.equal(obj.a, 'b');
+assert.equal(obj.__proto__, 1);
+assert(typeof Object.getPrototypeOf(obj) === 'object');
+assert.strictEqual(Object.getPrototypeOf(obj), Object.prototype);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

querystring

### Description of change

Per #5642, using querystring.parse to parse `'a=b&__proto__=1'` causes the `__proto__` to be swallowed and ignored. This works around the limitation by temporarily setting the prototype of the parsed obj to null during the parse, then setting it back before returning. 

The rest of the existing implementation remains the same.

Fixes: https://github.com/nodejs/node/issues/5642

/cc @mscdex @WebReflection 