### PR TITLE
test: enforce strict mode for test-domain-crypto

### DIFF
--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -1,4 +1,6 @@
-/* eslint-disable strict, required-modules */
+/* eslint-disable required-modules */
+'use strict';
+
 try {
   var crypto = require('crypto');
 } catch (e) {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?

### Affected core subsystem(s)

crypto domain test

### Description of change

The last change to this test landed before a nit about strict mode was
addressed, so this change addresses that.

Refs: https://github.com/nodejs/node/pull/6017

/cc @bnoordhuis @jasnell 