### PR TITLE
Rimraf npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ config.gypi: configure
 	fi
 
 install: all
+	-rm -rf '$PREFIX'/lib/node_modules/npm
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ config.gypi: configure
 	fi
 
 install: all
-	-rm -rf '$PREFIX'/lib/node_modules/npm
+	-rm -rf $(PREFIX)/lib/node_modules/npm
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
 
 uninstall:


### PR DESCRIPTION
build: remove npm on make install

Different versions of npm potentially have different trees. We should
be cleaning the version of npm on every install.

This implements the removal naively by calling
`rm -rf $PREFIX/lib/node_modules/npm` in the `make install` command.

This does not implement similar functions for the windows installer,
nor does it implement the removal in the double click installers.

This can be implemented as part of this PR or as part of another.