### PR TITLE
querystring: don't inherit from Object.prototype

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -5,6 +5,12 @@
 const QueryString = exports;
 const Buffer = require('buffer').Buffer;
 
+// This constructor is used to store parsed query string values. Instantiating
+// this is faster than explicitly calling `Object.create(null)` to get a
+// "clean" empty object (tested with v8 v4.9).
+function ParsedQueryString() {}
+ParsedQueryString.prototype = Object.create(null);
+
 
 // a safe fast alternative to decodeURIComponent
 QueryString.unescapeBuffer = function(s, decodeSpaces) {
@@ -216,7 +222,7 @@ QueryString.parse = QueryString.decode = function(qs, sep, eq, options) {
   sep = sep || '&';
   eq = eq || '=';
 
-  const obj = {};
+  const obj = new ParsedQueryString();
 
   if (typeof qs !== 'string' || qs.length === 0) {
     return obj;

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -9,6 +9,12 @@ var qs = require('querystring');
 // {{{
 // [ wonkyQS, canonicalQS, obj ]
 var qsTestCases = [
+  ['__proto__=1',
+   '__proto__=1',
+   JSON.parse('{"__proto__":"1"}')],
+  ['__defineGetter__=asdf',
+   '__defineGetter__=asdf',
+   JSON.parse('{"__defineGetter__":"asdf"}')],
   ['foo=918854443121279438895193',
    'foo=918854443121279438895193',
    {'foo': '918854443121279438895193'}],


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [X] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [X] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Affected core subsystem(s)

* querystring

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

This commit safely allows querystring keys that are named the same as
properties that are ordinarily inherited from `Object.prototype` such
as \__proto\__. Additionally, this commit provides a bit of a speed
improvement (~25% in the querystring-parse 'manypairs' benchmark)
when there are many unique keys.

Fixes: https://github.com/nodejs/node/issues/5642