### PR TITLE
doc, tls: deprecate createSecurePair

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -168,6 +168,8 @@ the total bytes written to the socket, *including the TLS overhead*.
 
 ## Class: SecurePair
 
+    Stability: 0 - Deprecated: Use [`tls.TLSSocket`][] instead.
+
 Returned by tls.createSecurePair.
 
 ### Event: 'secure'
@@ -379,9 +381,9 @@ Construct a new TLSSocket object from an existing TCP socket.
 
   - `server`: An optional [`net.Server`][] instance
 
-  - `requestCert`: Optional, see [`tls.createSecurePair()`][]
+  - `requestCert`: Optional, see [`tls.createServer()`][]
 
-  - `rejectUnauthorized`: Optional, see [`tls.createSecurePair()`][]
+  - `rejectUnauthorized`: Optional, see [`tls.createServer()`][]
 
   - `NPNProtocols`: Optional, see [`tls.createServer()`][]
 
@@ -745,6 +747,8 @@ publicly trusted list of CAs as given in
 
 ## tls.createSecurePair([context][, isServer][, requestCert][, rejectUnauthorized][, options])
 
+    Stability: 0 - Deprecated: Use [`tls.TLSSocket`][] instead.
+
 Creates a new secure pair object with two streams, one of which reads and writes
 the encrypted data and the other of which reads and writes the cleartext data.
 Generally, the encrypted stream is piped to/from an incoming encrypted data
@@ -769,6 +773,19 @@ stream.
 `encrypted` stream properties.
 
 NOTE: `cleartext` has the same API as [`tls.TLSSocket`][]
+
+**Deprecated** `tls.createSecurePair()` is now deprecated in favor of
+`tls.TLSSocket()`. For example:
+```
+pair = tls.createSecurePair( ... );
+pair.encrypted.pipe(socket);
+socket.pipe(pair.encrypted);
+```
+can be replaced with:
+```
+secure_socket = tls.TLSSocket(socket, options);
+```
+where `secure_socket` has the same API as `pair.cleartext`.
 
 ## tls.createServer(options[, secureConnectionListener])
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [ ] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

_Please provide affected core subsystem(s) (like buffer, cluster, crypto, etc)_

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

createSecurePair uses tls_legacy and the legacy Connection from
node_crypto.cc. Deprecate them in favor of TLSSocket.

See #5924 