### PR TITLE
path: fixing a test that breaks on some machines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ _UpgradeReport_Files/
 ipch/
 *.sdf
 *.opensdf
+node.VC.opendb
 
 /config.mk
 /config.gypi

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ _UpgradeReport_Files/
 ipch/
 *.sdf
 *.opensdf
-node.VC.opendb
 
 /config.mk
 /config.gypi

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -561,8 +561,9 @@ if (common.isWindows) {
                '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
   assert.equal(path.win32._makeLong('foo/bar').toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
-  assert.equal(path.win32._makeLong('C:').toLowerCase(),
-               '\\\\?\\' + process.cwd().toLowerCase());
+  const currentDeviceLetter = path.parse(process.cwd()).root.substring(0, 2);
+  assert.equal(path.win32._makeLong(currentDeviceLetter).toLowerCase(),
+                 '\\\\?\\' + process.cwd().toLowerCase());
   assert.equal(path.win32._makeLong('C').toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase() + '\\c');
 }

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -563,7 +563,7 @@ if (common.isWindows) {
                '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
   const currentDeviceLetter = path.parse(process.cwd()).root.substring(0, 2);
   assert.equal(path.win32._makeLong(currentDeviceLetter).toLowerCase(),
-                 '\\\\?\\' + process.cwd().toLowerCase());
+               '\\\\?\\' + process.cwd().toLowerCase());
   assert.equal(path.win32._makeLong('C').toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase() + '\\c');
 }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `make -j8 test` (UNIX) or `vcbuild test nosign` (Windows) pass with
  this change (including linting)?
- [x] Is the commit message formatted according to [CONTRIBUTING.md][0]?
- [x] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)?

Caveats:

- didn't run the unix tests, as this change doesn't impact them.
- seeing two non-related test failures on windows.  I haven't investigated these
  -  addons/load-long-path/test - seeing "Error: The data area passed to a system call is too small."
  -  test\parallel\test-tls-server-verify.js - seeing a timeout. 



### Affected core subsystem(s)

path

[0]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit

### Description of change

A win32-only test was verifying that path.win32._makeLong('C:')
would return the current working directory.  This would only work if
current working directory was also on the C: device.  Fix is to grab
the device letter for current working directory, and pass that to
_makeLong().