### PR TITLE
gitignore: ignore VS 2015 *.VC.opendb files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ _UpgradeReport_Files/
 ipch/
 *.sdf
 *.opensdf
+*.VC.opendb
 
 /config.mk
 /config.gypi

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ ipch/
 *.sdf
 *.opensdf
 *.VC.opendb
+.vs/
 
 /config.mk
 /config.gypi


### PR DESCRIPTION

- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

gitignore

##### Description of change

*.VC.opendb files are created by VS 2015 and should be ignored by git.
