### PR TITLE
doc: clarifies http.serverResponse implementation

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -638,7 +638,7 @@ connections.
 This object is created internally by a HTTP server--not by the user. It is
 passed as the second parameter to the `'request'` event.
 
-The response implements the [Writable Stream][] interface. This is an
+The response implements, but does not inherit from, the [Writable Stream][] interface. This is an
 [`EventEmitter`][] with the following events:
 
 ### Event: 'close'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

Since http.serverResponse does not inherit from Stream.writable
it does not pass the test `serverResponse instanceof stream.Writable`.
This commit clarifies that serverResponse does not inherit from
stream.Writable and therefore should not be expected to pass the above
test

- fixes nodejs/node#6046