### PR TITLE
async_wrap,lib: Firing async-wrap callbacks for next-tick callbacks

### DIFF
--- a/lib/async_wrap.js
+++ b/lib/async_wrap.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const async_wrap = process.binding('async_wrap');
+
+const nextIdArray = async_wrap.getNextAsyncIdArray();
+const currentIdArray = async_wrap.getCurrentAsyncIdArray();
+const fieldsArray = async_wrap.getAsyncHookFields();
+const asyncCallbacks = async_wrap.getAsyncCallbacks();
+
+function getLittleEndian(a) {
+  return a[0] + a[1] * 0x100000000;
+}
+
+function getBigEndian(a) {
+  return a[1] + a[0] * 0x100000000;
+}
+
+function setLittleEndian(a, val) {
+
+  if (val < 0) {
+    throw new Error('Negative value not supported');
+  }
+
+  var lword = val & 0xffffffff;
+  var hword = 0;
+  if (val > 0xffffffff) {
+    // effectively we're doing shift-right by 32 bits.  Javascript bit
+    // operators convert operands to 32 bits, so we lose the
+    // high-order bits if we try to use >>> or >>.
+    hword = Math.floor((val / 0x100000000));
+  }
+  a[0] = lword;
+  a[1] = hword;
+}
+
+function setBigEndian(a, val) {
+
+  if (val < 0) {
+    throw new Error('Negative value not supported');
+  }
+
+  var lword = val & 0xffffffff;
+  var hword = 0;
+  if (val > 0xffffffff) {
+    // effectively we're doing shift-right by 32 bits.  Javascript bit
+    // operators convert operands to 32 bits, so we lose the
+    // high-order bits if we try to use >>> or >>.
+    hword = Math.floor((val / 0x100000000));
+  }
+  a[1] = lword;
+  a[0] = hword;
+}
+
+function incrementLittleEndian(a) {
+  // carry-over if lsb is maxed out
+  if (a[0] === 0xffffffff) {
+    a[0] = 0;
+    a[1]++;
+  }
+  a[0]++;
+  return a[0] + a[1] * 0x100000000;
+}
+
+function incrementBigEndian(a) {
+  // carry-over if lsb is maxed out
+  if (a[1] === 0xffffffff) {
+    a[1] = 0;
+    a[0]++;
+  }
+  a[1]++;
+  return a[1] + a[0] * 0x100000000;
+}
+
+function getCurrentIdLittleEndian() {
+  return getLittleEndian(currentIdArray);
+}
+
+function getCurrentIdBigEndian() {
+  return getBigEndian(currentIdArray);
+}
+
+function setCurrentIdLittleEndian(val) {
+  return setLittleEndian(currentIdArray, val);
+}
+
+function setCurrentIdBigEndian(val) {
+  return setBigEndian(currentIdArray, val);
+}
+
+function incrementNextIdLittleEndian() {
+  return incrementLittleEndian(nextIdArray);
+}
+
+function incrementNextIdBigEndian() {
+  return incrementBigEndian(nextIdArray);
+}
+
+// must match enum definitions in AsyncHook class in env.h
+const kEnableCallbacks = 0;
+
+function callbacksEnabled() {
+  return (fieldsArray[kEnableCallbacks] !== 0 ? true : false);
+}
+
+const getCurrentAsyncId =
+    process.binding('os').isBigEndian ?
+      getCurrentIdBigEndian : getCurrentIdLittleEndian;
+
+const setCurrentAsyncId =
+    process.binding('os').isBigEndian ?
+      setCurrentIdBigEndian : setCurrentIdLittleEndian;
+
+const incrementNextAsyncId =
+    process.binding('os').isBigEndian ?
+      incrementNextIdBigEndian : incrementNextIdLittleEndian;
+
+function notifyAsyncEnqueue(asyncId) {
+  if (callbacksEnabled()) {
+    const asyncState = {};
+    for (let i = 0; i < asyncCallbacks.length; i++) {
+      if (asyncCallbacks[i].init) {
+        /* init(asyncId, provider, parentId, parentObject) */
+        asyncCallbacks[i].init.call(asyncState, asyncId,
+         async_wrap.Providers.NEXTTICK, undefined, undefined);
+      }
+    }
+    return asyncState;
+  }
+  return undefined;
+}
+
+function notifyAsyncStart(asyncId, asyncState) {
+  setCurrentAsyncId(asyncId);
+  if (asyncState) {
+    for (let i = 0; i < asyncCallbacks.length; i++) {
+      if (asyncCallbacks[i].pre) {
+        /* pre(asyncId); */
+        asyncCallbacks[i].pre.call(asyncState, asyncId);
+      }
+    }
+  }
+}
+
+function notifyAsyncEnd(asyncId, asyncState, callbackThrew) {
+  if (asyncState) {
+    for (let i = 0; i < asyncCallbacks.length; i++) {
+      if (asyncCallbacks[i].post) {
+        /* post(asyncId, didUserCodeThrow); */
+        asyncCallbacks[i].post.call(asyncState, asyncId, callbackThrew);
+      }
+    }
+
+    setCurrentAsyncId(0);
+
+    for (let i = 0; i < asyncCallbacks.length; i++) {
+      if (asyncCallbacks[i].destroy) {
+        /* destroy(asyncId); */
+        asyncCallbacks[i].destroy.call(undefined, asyncId);
+      }
+    }
+  }
+}
+
+module.exports.incrementNextAsyncId = incrementNextAsyncId;
+module.exports.getCurrentAsyncId = getCurrentAsyncId;
+module.exports.setCurrentAsyncId = setCurrentAsyncId;
+module.exports.callbacksEnabled = callbacksEnabled;
+module.exports.notifyAsyncEnqueue = notifyAsyncEnqueue;
+module.exports.notifyAsyncStart = notifyAsyncStart;
+module.exports.notifyAsyncEnd = notifyAsyncEnd;

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -3,8 +3,8 @@
 exports.setup = setupNextTick;
 
 function setupNextTick() {
+  const async_wrap = require('async_wrap');
 
-  var asyncWrap = process.binding('async_wrap');
   const promises = require('internal/process/promises');
   const emitPendingUnhandledRejections = promises.setup(scheduleMicrotasks);
   var nextTickQueue = [];
@@ -95,26 +95,32 @@ function setupNextTick() {
         tock = nextTickQueue[tickInfo[kIndex]++];
         callback = tock.callback;
 
-        asyncWrap.notifyAsyncStart(
-          tock.ranInitCallback, tock.asyncId, tock.asyncState);
-
         args = tock.args;
-        var callbackThrew = true;
-        try {
-          // Using separate callback execution functions allows direct
-          // callback invocation with small numbers of arguments to avoid the
-          // performance hit associated with using `fn.apply()`
+        if (!tock.asyncState) {
+          async_wrap.setCurrentAsyncId(tock.asyncId);
           _combinedTickCallback(args, callback);
-          callbackThrew = false;
+          async_wrap.setCurrentAsyncId(0);
         }
-        finally {
-          asyncWrap.notifyAsyncEnd(
-            tock.ranInitCallback, tock.asyncId,
-            tock.asyncState, callbackThrew);
+        else {
+          var callbackThrew = true;
+          try {
+            async_wrap.notifyAsyncStart(tock.asyncId, tock.asyncState);
+
+            // Using separate callback execution functions allows direct
+            // callback invocation with small numbers of arguments to avoid the
+            // performance hit associated with using `fn.apply()`
+            _combinedTickCallback(args, callback);
+            callbackThrew = false;
+          }
+          finally {
+            async_wrap.notifyAsyncEnd(
+              tock.asyncId, tock.asyncState, callbackThrew);
+          }
         }
 
         if (1e4 < tickInfo[kIndex])
           tickDone();
+
       }
       tickDone();
       _runMicrotasks();
@@ -133,10 +139,29 @@ function setupNextTick() {
         args = tock.args;
         if (domain)
           domain.enter();
-        // Using separate callback execution functions allows direct
-        // callback invocation with small numbers of arguments to avoid the
-        // performance hit associated with using `fn.apply()`
-        _combinedTickCallback(args, callback);
+
+        if (!tock.asyncState) {
+          async_wrap.setCurrentAsyncId(tock.asyncId);
+          _combinedTickCallback(args, callback);
+          async_wrap.setCurrentAsyncId(0);
+        }
+        else {
+          var callbackThrew = true;
+          try {
+            async_wrap.notifyAsyncStart(tock.asyncId, tock.asyncState);
+
+            // Using separate callback execution functions allows direct
+            // callback invocation with small numbers of arguments to avoid the
+            // performance hit associated with using `fn.apply()`
+            _combinedTickCallback(args, callback);
+            callbackThrew = false;
+          }
+          finally {
+            async_wrap.notifyAsyncEnd(
+              tock.asyncId, tock.asyncState, callbackThrew);
+          }
+        }
+
         if (1e4 < tickInfo[kIndex])
           tickDone();
         if (domain)
@@ -152,12 +177,10 @@ function setupNextTick() {
     this.callback = c;
     this.domain = process.domain || null;
     this.args = args;
-    this.parentAsyncId = asyncWrap.getCurrentAsyncId();
-    this.asyncId = asyncWrap.getNextAsyncId();
-    this.asyncState = {};
-    this.ranInitCallback = asyncWrap.notifyAsyncEnqueue(
-        this.asyncId, this.asyncState, undefined, undefined,
-        asyncWrap.Providers.NEXTTICK);
+    this.asyncId = async_wrap.incrementNextAsyncId();
+    if (async_wrap.callbacksEnabled()) {
+      this.asyncState = async_wrap.notifyAsyncEnqueue(this.asyncId);
+    }
   }
 
   function nextTick(callback) {
@@ -177,4 +200,5 @@ function setupNextTick() {
     nextTickQueue.push(new TickObject(callback, args));
     tickInfo[kLength]++;
   }
+
 }

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -3,6 +3,8 @@
 exports.setup = setupNextTick;
 
 function setupNextTick() {
+
+  var asyncWrap = process.binding('async_wrap');
   const promises = require('internal/process/promises');
   const emitPendingUnhandledRejections = promises.setup(scheduleMicrotasks);
   var nextTickQueue = [];
@@ -85,17 +87,32 @@ function setupNextTick() {
   // Run callbacks that have no domain.
   // Using domains will cause this to be overridden.
   function _tickCallback() {
+
     var callback, args, tock;
 
     do {
       while (tickInfo[kIndex] < tickInfo[kLength]) {
         tock = nextTickQueue[tickInfo[kIndex]++];
         callback = tock.callback;
+
+        asyncWrap.notifyAsyncStart(
+          tock.ranInitCallback, tock.asyncId, tock.asyncState);
+
         args = tock.args;
-        // Using separate callback execution functions allows direct
-        // callback invocation with small numbers of arguments to avoid the
-        // performance hit associated with using `fn.apply()`
-        _combinedTickCallback(args, callback);
+        var callbackThrew = true;
+        try {
+          // Using separate callback execution functions allows direct
+          // callback invocation with small numbers of arguments to avoid the
+          // performance hit associated with using `fn.apply()`
+          _combinedTickCallback(args, callback);
+          callbackThrew = false;
+        }
+        finally {
+          asyncWrap.notifyAsyncEnd(
+            tock.ranInitCallback, tock.asyncId,
+            tock.asyncState, callbackThrew);
+        }
+
         if (1e4 < tickInfo[kIndex])
           tickDone();
       }
@@ -135,6 +152,12 @@ function setupNextTick() {
     this.callback = c;
     this.domain = process.domain || null;
     this.args = args;
+    this.parentAsyncId = asyncWrap.getCurrentAsyncId();
+    this.asyncId = asyncWrap.getNextAsyncId();
+    this.asyncState = {};
+    this.ranInitCallback = asyncWrap.notifyAsyncEnqueue(
+        this.asyncId, this.asyncState, undefined, undefined,
+        asyncWrap.Providers.NEXTTICK);
   }
 
   function nextTick(callback) {

--- a/node.gyp
+++ b/node.gyp
@@ -21,6 +21,7 @@
       'lib/_debug_agent.js',
       'lib/_debugger.js',
       'lib/assert.js',
+      'lib/async_wrap.js',
       'lib/buffer.js',
       'lib/child_process.js',
       'lib/console.js',

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -18,7 +18,7 @@ inline AsyncWrap::AsyncWrap(Environment* env,
                             ProviderType provider,
                             AsyncWrap* parent)
     : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1),
-      uid_(env->get_next_async_wrap_uid()) {
+      uid_(env->async_hooks()->get_next_async_wrap_uid()) {
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -18,69 +18,22 @@ inline AsyncWrap::AsyncWrap(Environment* env,
                             ProviderType provider,
                             AsyncWrap* parent)
     : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1),
-      uid_(env->get_async_wrap_uid()) {
+      uid_(env->get_next_async_wrap_uid()) {
   CHECK_NE(provider, PROVIDER_NONE);
   CHECK_GE(object->InternalFieldCount(), 1);
 
   // Shift provider value over to prevent id collision.
   persistent().SetWrapperClassId(NODE_ASYNC_ID_OFFSET + provider);
 
-  v8::Local<v8::Function> init_fn = env->async_hooks_init_function();
-
-  // No init callback exists, no reason to go on.
-  if (init_fn.IsEmpty())
-    return;
-
-  // If async wrap callbacks are disabled and no parent was passed that has
-  // run the init callback then return.
-  if (!env->async_wrap_callbacks_enabled() &&
-      (parent == nullptr || !parent->ran_init_callback()))
-    return;
-
-  v8::HandleScope scope(env->isolate());
-
-  v8::Local<v8::Value> argv[] = {
-    v8::Integer::New(env->isolate(), get_uid()),
-    v8::Int32::New(env->isolate(), provider),
-    Null(env->isolate()),
-    Null(env->isolate())
-  };
-
-  if (parent != nullptr) {
-    argv[2] = v8::Integer::New(env->isolate(), parent->get_uid());
-    argv[3] = parent->object();
+  if (AsyncWrap::FireAsyncInitCallbacks(env, get_uid(), object, provider, parent)) {
+      bits_ |= 1;  // ran_init_callback() is true now.
   }
-
-  v8::TryCatch try_catch(env->isolate());
-
-  v8::MaybeLocal<v8::Value> ret =
-      init_fn->Call(env->context(), object, arraysize(argv), argv);
-
-  if (ret.IsEmpty()) {
-    ClearFatalExceptionHandlers(env);
-    FatalException(env->isolate(), try_catch);
-  }
-
-  bits_ |= 1;  // ran_init_callback() is true now.
 }
 
 
 inline AsyncWrap::~AsyncWrap() {
-  if (!ran_init_callback())
-    return;
-
-  v8::Local<v8::Function> fn = env()->async_hooks_destroy_function();
-  if (!fn.IsEmpty()) {
-    v8::HandleScope scope(env()->isolate());
-    v8::Local<v8::Value> uid = v8::Integer::New(env()->isolate(), get_uid());
-    v8::TryCatch try_catch(env()->isolate());
-    v8::MaybeLocal<v8::Value> ret =
-        fn->Call(env()->context(), v8::Null(env()->isolate()), 1, &uid);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(env()->isolate(), try_catch);
-    }
-  }
+  v8::HandleScope scope(env()->isolate());
+  FireAsyncDestroyCallbacks(env(), ran_init_callback(), v8::Integer::New(env()->isolate(), get_uid()));
 }
 
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -34,7 +34,8 @@ namespace node {
   V(UDPWRAP)                                                                  \
   V(UDPSENDWRAP)                                                              \
   V(WRITEWRAP)                                                                \
-  V(ZLIB)
+  V(ZLIB)                                                                     \
+  V(NEXTTICK)
 
 class Environment;
 
@@ -46,6 +47,11 @@ class AsyncWrap : public BaseObject {
     NODE_ASYNC_PROVIDER_TYPES(V)
 #undef V
   };
+
+  static bool FireAsyncInitCallbacks(Environment* env,int64_t uid,v8::Local<v8::Object> object,AsyncWrap::ProviderType provider,AsyncWrap* parent);
+  static void FireAsyncPreCallbacks(Environment* env, bool ranInitCallback, v8::Local<v8::Number> uid, v8::Local<v8::Object> obj);
+  static void FireAsyncPostCallbacks(Environment* env, bool ranInitCallback, v8::Local<v8::Number> uid, v8::Local<v8::Object> obj, v8::Local<v8::Boolean> didUserCodeThrow);
+  static void FireAsyncDestroyCallbacks(Environment* env, bool ranInitCallbacks, v8::Local<v8::Number> uid);
 
   inline AsyncWrap(Environment* env,
                    v8::Local<v8::Object> object,
@@ -71,9 +77,11 @@ class AsyncWrap : public BaseObject {
 
   virtual size_t self_size() const = 0;
 
+  inline bool ran_init_callback() const;
+
  private:
   inline AsyncWrap();
-  inline bool ran_init_callback() const;
+
 
   // When the async hooks init JS function is called from the constructor it is
   // expected the context object will receive a _asyncQueue object property

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -221,7 +221,8 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       printed_error_(false),
       trace_sync_io_(false),
       makecallback_cntr_(0),
-      async_wrap_uid_(0),
+      async_wrap_counter_uid_(0),
+      async_wrap_current_uid_(0),
       debugger_agent_(this),
       http_parser_buffer_(nullptr),
       context_(context->GetIsolate(), context) {
@@ -372,8 +373,16 @@ inline void Environment::set_trace_sync_io(bool value) {
   trace_sync_io_ = value;
 }
 
-inline int64_t Environment::get_async_wrap_uid() {
-  return ++async_wrap_uid_;
+inline int64_t Environment::get_next_async_wrap_uid() {
+  return ++async_wrap_counter_uid_;
+}
+
+inline int64_t Environment::get_current_async_wrap_uid() {
+    return this->async_wrap_current_uid_;
+}
+
+inline void Environment::set_current_async_wrap_uid(int64_t value) {
+    this->async_wrap_current_uid_ = value;
 }
 
 inline uint32_t* Environment::heap_statistics_buffer() const {

--- a/src/env.h
+++ b/src/env.h
@@ -473,7 +473,9 @@ class Environment {
   void PrintSyncTrace() const;
   inline void set_trace_sync_io(bool value);
 
-  inline int64_t get_async_wrap_uid();
+  inline int64_t get_next_async_wrap_uid();
+  inline int64_t get_current_async_wrap_uid();
+  inline void set_current_async_wrap_uid(int64_t value);
 
   inline uint32_t* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(uint32_t* pointer);
@@ -577,7 +579,8 @@ class Environment {
   bool printed_error_;
   bool trace_sync_io_;
   size_t makecallback_cntr_;
-  int64_t async_wrap_uid_;
+  int64_t async_wrap_counter_uid_;
+  int64_t async_wrap_current_uid_;
   debugger::Agent debugger_agent_;
 
   HandleWrapQueue handle_wrap_queue_;

--- a/test/parallel/test-async-wrap-nextTick.js
+++ b/test/parallel/test-async-wrap-nextTick.js
@@ -4,13 +4,14 @@ require('../common');
 require('console');
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
+const async_wrap_module = require('async_wrap');
 
 const storage = new Map();
 async_wrap.setupHooks({ init, pre, post, destroy });
 async_wrap.enable();
 
 function init(uid) {
-  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.notStrictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   storage.set(uid, {
     init: true,
     pre: false,
@@ -23,24 +24,24 @@ function init(uid) {
 }
 
 function pre(uid) {
-  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.strictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   assert.strictEqual(this.uid, uid);
   storage.get(uid).pre = true;
 }
 
 function post(uid) {
-  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.strictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   assert.strictEqual(this.uid, uid);
   storage.get(uid).post = true;
 }
 
 function destroy(uid) {
-  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.notStrictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   storage.get(uid).destroy = true;
 }
 
 function validateAsyncCallbacksDuringNextTickCallback() {
-  const currentAsyncId = async_wrap.getCurrentAsyncId();
+  const currentAsyncId = async_wrap_module.getCurrentAsyncId();
   assert.strictEqual(storage.get(currentAsyncId).init, true);
   assert.strictEqual(storage.get(currentAsyncId).pre, true);
   assert.strictEqual(storage.get(currentAsyncId).post, false);
@@ -54,19 +55,19 @@ let id4 = 0;
 
 process.nextTick(function tick1() {
 
-  id1 = async_wrap.getCurrentAsyncId();
+  id1 = async_wrap_module.getCurrentAsyncId();
   assert.notStrictEqual(id1, 0);
   assert.strictEqual(storage.size, 1);
   validateAsyncCallbacksDuringNextTickCallback();
 
   process.nextTick(function tick2() {
-    id2 = async_wrap.getCurrentAsyncId();
+    id2 = async_wrap_module.getCurrentAsyncId();
     assert.notStrictEqual(id2, 0);
     assert.notStrictEqual(id1, id2);
     validateAsyncCallbacksDuringNextTickCallback();
 
     process.nextTick(function tick3() {
-      id3 = async_wrap.getCurrentAsyncId();
+      id3 = async_wrap_module.getCurrentAsyncId();
       assert.notStrictEqual(id3, 0);
       assert.notStrictEqual(id1, id3);
       assert.notStrictEqual(id2, id3);
@@ -76,7 +77,7 @@ process.nextTick(function tick1() {
       // so init shouldn't fire
       process.nextTick(function tick4() {
         // but currentAsyncId should still be set up
-        id4 = async_wrap.getCurrentAsyncId();
+        id4 = async_wrap_module.getCurrentAsyncId();
         assert.notStrictEqual(id4, 0);
         assert.notStrictEqual(id1, id4);
         assert.notStrictEqual(id2, id4);
@@ -89,11 +90,11 @@ process.nextTick(function tick1() {
     async_wrap.disable();
 
     assert.strictEqual(storage.size, 3);
-    assert.strictEqual(id2, async_wrap.getCurrentAsyncId());
+    assert.strictEqual(id2, async_wrap_module.getCurrentAsyncId());
   });
 
   assert.strictEqual(storage.size, 2);
-  assert.strictEqual(id1, async_wrap.getCurrentAsyncId());
+  assert.strictEqual(id1, async_wrap_module.getCurrentAsyncId());
 });
 
 process.once('exit', function() {

--- a/test/parallel/test-async-wrap-nextTick.js
+++ b/test/parallel/test-async-wrap-nextTick.js
@@ -1,0 +1,114 @@
+'use strict';
+
+require('../common');
+require('console');
+const assert = require('assert');
+const async_wrap = process.binding('async_wrap');
+
+const storage = new Map();
+async_wrap.setupHooks({ init, pre, post, destroy });
+async_wrap.enable();
+
+function init(uid) {
+  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
+  storage.set(uid, {
+    init: true,
+    pre: false,
+    post: false,
+    destroy: false
+  });
+  // track uid on the this pointer to confirm the same object is being pased
+  // to subsequent callbacks
+  this.uid = uid;
+}
+
+function pre(uid) {
+  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.strictEqual(this.uid, uid);
+  storage.get(uid).pre = true;
+}
+
+function post(uid) {
+  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.strictEqual(this.uid, uid);
+  storage.get(uid).post = true;
+}
+
+function destroy(uid) {
+  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
+  storage.get(uid).destroy = true;
+}
+
+function validateAsyncCallbacksDuringNextTickCallback() {
+  const currentAsyncId = async_wrap.getCurrentAsyncId();
+  assert.strictEqual(storage.get(currentAsyncId).init, true);
+  assert.strictEqual(storage.get(currentAsyncId).pre, true);
+  assert.strictEqual(storage.get(currentAsyncId).post, false);
+  assert.strictEqual(storage.get(currentAsyncId).destroy, false);
+}
+
+let id1 = 0;
+let id2 = 0;
+let id3 = 0;
+let id4 = 0;
+
+process.nextTick(function tick1() {
+
+  id1 = async_wrap.getCurrentAsyncId();
+  assert.notStrictEqual(id1, 0);
+  assert.strictEqual(storage.size, 1);
+  validateAsyncCallbacksDuringNextTickCallback();
+
+  process.nextTick(function tick2() {
+    id2 = async_wrap.getCurrentAsyncId();
+    assert.notStrictEqual(id2, 0);
+    assert.notStrictEqual(id1, id2);
+    validateAsyncCallbacksDuringNextTickCallback();
+
+    process.nextTick(function tick3() {
+      id3 = async_wrap.getCurrentAsyncId();
+      assert.notStrictEqual(id3, 0);
+      assert.notStrictEqual(id1, id3);
+      assert.notStrictEqual(id2, id3);
+      validateAsyncCallbacksDuringNextTickCallback();
+
+      // async-wrap callbacks should be disabled when this is enqueued
+      // so init shouldn't fire
+      process.nextTick(function tick4() {
+        // but currentAsyncId should still be set up
+        id4 = async_wrap.getCurrentAsyncId();
+        assert.notStrictEqual(id4, 0);
+        assert.notStrictEqual(id1, id4);
+        assert.notStrictEqual(id2, id4);
+        assert.notStrictEqual(id3, id4);
+        assert.strictEqual(!storage.get(id4), true);
+        assert.strictEqual(storage.size, 3);
+      });
+    });
+
+    async_wrap.disable();
+
+    assert.strictEqual(storage.size, 3);
+    assert.strictEqual(id2, async_wrap.getCurrentAsyncId());
+  });
+
+  assert.strictEqual(storage.size, 2);
+  assert.strictEqual(id1, async_wrap.getCurrentAsyncId());
+});
+
+process.once('exit', function() {
+
+  assert.strictEqual(storage.size, 3);
+
+  for (const item of storage) {
+    const uid = item[0];
+    const value = item[1];
+    assert.strictEqual(typeof uid, 'number');
+    assert.deepStrictEqual(value, {
+      init: true,
+      pre: true,
+      post: true,
+      destroy: true
+    });
+  }
+});

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -10,6 +10,7 @@ async_wrap.setupHooks({ init, pre, post, destroy });
 async_wrap.enable();
 
 function init(uid) {
+  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
   storage.set(uid, {
     init: true,
     pre: false,
@@ -19,14 +20,17 @@ function init(uid) {
 }
 
 function pre(uid) {
+  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
   storage.get(uid).pre = true;
 }
 
 function post(uid) {
+  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
   storage.get(uid).post = true;
 }
 
 function destroy(uid) {
+  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
   storage.get(uid).destroy = true;
 }
 
@@ -55,3 +59,8 @@ process.once('exit', function() {
     });
   }
 });
+
+// verify each call to next ID produces an increasing uid.
+var nextId = async_wrap.getNextAsyncId();
+var nextId2 = async_wrap.getNextAsyncId();
+assert.strictEqual(nextId + 1, nextId2);

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -4,13 +4,14 @@ require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
+const async_wrap_module = require('async_wrap');
 
 const storage = new Map();
 async_wrap.setupHooks({ init, pre, post, destroy });
 async_wrap.enable();
 
 function init(uid) {
-  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.notStrictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   storage.set(uid, {
     init: true,
     pre: false,
@@ -20,17 +21,17 @@ function init(uid) {
 }
 
 function pre(uid) {
-  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.strictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   storage.get(uid).pre = true;
 }
 
 function post(uid) {
-  assert.strictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.strictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   storage.get(uid).post = true;
 }
 
 function destroy(uid) {
-  assert.notStrictEqual(async_wrap.getCurrentAsyncId(), uid);
+  assert.notStrictEqual(async_wrap_module.getCurrentAsyncId(), uid);
   storage.get(uid).destroy = true;
 }
 
@@ -61,6 +62,36 @@ process.once('exit', function() {
 });
 
 // verify each call to next ID produces an increasing uid.
-var nextId = async_wrap.getNextAsyncId();
-var nextId2 = async_wrap.getNextAsyncId();
+var nextId = async_wrap_module.incrementNextAsyncId();
+var nextId2 = async_wrap_module.incrementNextAsyncId();
 assert.strictEqual(nextId + 1, nextId2);
+
+// verify getCurrentAsyncId() & setCurrentAsyncId() work as expected
+var expectedId = 0;
+async_wrap_module.setCurrentAsyncId(expectedId);
+assert.strictEqual(async_wrap_module.getCurrentAsyncId(), expectedId);
+
+expectedId = 1;
+async_wrap_module.setCurrentAsyncId(expectedId);
+assert.strictEqual(async_wrap_module.getCurrentAsyncId(), expectedId);
+
+// low-order 32 bits set
+expectedId = 0xFFFFFFFF;
+async_wrap_module.setCurrentAsyncId(expectedId);
+assert.strictEqual(async_wrap_module.getCurrentAsyncId(), expectedId);
+
+// low-order 36 bits set
+expectedId = 0xFFFFFFFFF;
+async_wrap_module.setCurrentAsyncId(expectedId);
+assert.strictEqual(async_wrap_module.getCurrentAsyncId(), expectedId);
+
+// negative numbers should throw
+var didThrow = false;
+try {
+  async_wrap_module.setCurrentAsyncId(-1);
+}
+catch (err) {
+  didThrow = true;
+}
+assert.strictEqual(async_wrap_module.getCurrentAsyncId(), expectedId);
+assert.strictEqual(didThrow, true);


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines

Caveats:
- seeing the following test failures on windows that occur without my changes:
  - parallel/test-path (fix is part of PR #6067)
  - parallel/test-tls-server-verify - intermittent failures without my changes.
  - addons/load-long-path/test.  See error message "The data area passed to a system call is too small".  I'll need to dig a bit more to see if this repros without my changes. 
  -   test\sequential\test-regress-GH-746.js - this times out intermittently without my changes.
- I'm not sure if there are docs that need updated here.  Please let me know
- I'm not sure if there are relevant benchmarks that I should run.  Please let me know.
##### Affected core subsystem(s)

async_wrap;lib
##### Description of change

This change updates nextTick() callback processing to call back into
the node runtime to notify the runtime of async state transitions.
Currently, the runtime will track the active async ID and fire any
registered async-wrap callbacks. This gives async-wrap consistent user
semantics for nextTick() callbacks.

I anticipate some concerns around impact to perf. Rough measurements
show an approximate 2x increase in time to process 1,000,000 nextTick()
callbacks.  These went from an average of 1094 ms per million
nextTick() callbacks to 2133 ms per million with the changes in this PR.

I'm open to alternative suggestions around implementation here. :) It's
not lost on me that the implementation of next_tick.js is making an
effort to minimize transitions from JS to the runtime, and this change
increases those transitions by a factor of three. One of the goals
here was to have basic entry-points for javascript code to notify the
runtime of async transitions (namely, "enqueue", "start", and "end").
This allows a future where async call graph information can be tracked
by the runtime and eliminates a number of cases where users will
require the async-wrap callbacks.  For example, continuation-local
storage can be implemented on such an API, without callbacks, assuming
each node in the graph contains a tuple of (unique ID, parent ID,
pending child callback count, state), and where state is one of
enqueued, running, or completed.
