### PR TITLE
buffer: standardize array index check

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -169,7 +169,7 @@ inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
     return true;
   }
 
-  int32_t tmp_i = arg->Uint32Value();
+  int64_t tmp_i = arg->IntegerValue();
 
   if (tmp_i < 0)
     return false;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1440,3 +1440,9 @@ assert.equal(Buffer.prototype.parent, undefined);
 assert.equal(Buffer.prototype.offset, undefined);
 assert.equal(SlowBuffer.prototype.parent, undefined);
 assert.equal(SlowBuffer.prototype.offset, undefined);
+
+
+// Test that ParseArrayIndex handles full uint32
+assert.throws(function() {
+  Buffer.from(new ArrayBuffer(0), -1 >>> 0);
+}, /RangeError: 'offset' is out of bounds/);


### PR DESCRIPTION
### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

ParseArrayIndex() was requesting a Uint32Value(), but assigning it to an
in32_t. This caused slight differences in error message reported in edge
cases of argument parsing. Fixed by getting the IntegerValue() before
checking if the value is < 0. Added test of API that was affected.

R=@bnoordhuis 
R=@jasnell 

CI: https://ci.nodejs.org/job/node-test-pull-request/2179/