### PR TITLE
debugger: run last command on pressing enter

### DIFF
--- a/doc/api/debugger.markdown
+++ b/doc/api/debugger.markdown
@@ -84,6 +84,9 @@ The `repl` command allows code to be evaluated remotely. The `next` command
 steps over to the next line. Type `help` to see what other commands are
 available.
 
+Pressing `enter` without typing a command will repeat the previous debugger
+command.
+
 ## Watchers
 
 It is possible to watch expression and variable values while debugging. On

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -674,6 +674,9 @@ var helpMessage = 'Commands: ' + commands.map(function(group) {
   return group.join(', ');
 }).join(',\n');
 
+// Previous command received. Initialize to empty command.
+var lastCommand = '\n';
+
 
 function SourceUnderline(sourceText, position, repl) {
   if (!sourceText) return '';
@@ -945,10 +948,10 @@ Interface.prototype.requireConnection = function() {
 Interface.prototype.controlEval = function(code, context, filename, callback) {
   try {
     // Repeat last command if empty line are going to be evaluated
-    if (this.repl.rli.history && this.repl.rli.history.length > 0) {
-      if (code === '\n') {
-        code = this.repl.rli.history[0] + '\n';
-      }
+    if (code === '\n') {
+      code = lastCommand;
+    } else {
+      lastCommand = code;
     }
 
     // exec process.title => exec("process.title");

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -224,6 +224,10 @@ function REPLServer(prompt,
   function defaultEval(code, context, file, cb) {
     var err, result, retry = false, input = code, wrappedErr;
     // first, create the Script object to check the syntax
+
+    if (code === '\n')
+      return cb(null);
+
     while (true) {
       try {
         if (!/^\s*$/.test(code) &&
@@ -421,30 +425,23 @@ function REPLServer(prompt,
       }
     }
 
-    // self.context.setBreakpoint exists we are in the debugger.
-    // If we are in the debugger, then we should process empty lines as they are
-    // a shortcut for "repeat the previous debugging command".
-    if (cmd || self.bufferedCommand || self.context.setBreakpoint) {
-      var evalCmd = self.bufferedCommand + cmd;
-      if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
-        // It's confusing for `{ a : 1 }` to be interpreted as a block
-        // statement rather than an object literal.  So, we first try
-        // to wrap it in parentheses, so that it will be interpreted as
-        // an expression.
-        evalCmd = '(' + evalCmd + ')\n';
-        self.wrappedCmd = true;
-      } else {
-        // otherwise we just append a \n so that it will be either
-        // terminated, or continued onto the next expression if it's an
-        // unexpected end of input.
-        evalCmd = evalCmd + '\n';
-      }
-
-      debug('eval %j', evalCmd);
-      self.eval(evalCmd, self.context, 'repl', finish);
+    var evalCmd = self.bufferedCommand + cmd;
+    if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
+      // It's confusing for `{ a : 1 }` to be interpreted as a block
+      // statement rather than an object literal.  So, we first try
+      // to wrap it in parentheses, so that it will be interpreted as
+      // an expression.
+      evalCmd = '(' + evalCmd + ')\n';
+      self.wrappedCmd = true;
     } else {
-      finish(null);
+      // otherwise we just append a \n so that it will be either
+      // terminated, or continued onto the next expression if it's an
+      // unexpected end of input.
+      evalCmd = evalCmd + '\n';
     }
+
+    debug('eval %j', evalCmd);
+    self.eval(evalCmd, self.context, 'repl', finish);
 
     function finish(e, ret) {
       debug('finish', e, ret);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -421,7 +421,10 @@ function REPLServer(prompt,
       }
     }
 
-    if (cmd || self.bufferedCommand) {
+    // self.context.setBreakpoint exists we are in the debugger.
+    // If we are in the debugger, then we should process empty lines as they are
+    // a shortcut for "repeat the previous debugging command".
+    if (cmd || self.bufferedCommand || self.context.setBreakpoint) {
       var evalCmd = self.bufferedCommand + cmd;
       if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
         // It's confusing for `{ a : 1 }` to be interpreted as a block

--- a/test/fixtures/debugger-repeat-last.js
+++ b/test/fixtures/debugger-repeat-last.js
@@ -1,0 +1,7 @@
+var a = 1;
+
+var b = 2;
+
+var c = 3;
+
+b = c;

--- a/test/parallel/test-debugger-repeat-last.js
+++ b/test/parallel/test-debugger-repeat-last.js
@@ -1,0 +1,46 @@
+'use strict';
+const path = require('path');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
+
+const common = require('../common');
+
+const fixture = path.join(
+  common.fixturesDir,
+  'debugger-repeat-last.js'
+);
+
+const args = [
+  'debug',
+  fixture
+];
+
+const proc = spawn(process.execPath, args, { stdio: 'pipe' });
+proc.stdout.setEncoding('utf8');
+
+var stdout = '';
+
+var sentCommand = false;
+var sentEmpty = false;
+var sentExit = false;
+
+proc.stdout.on('data', (data) => {
+  stdout += data;
+  if (!sentCommand && stdout.includes('> 1')) {
+    setImmediate(() => {proc.stdin.write('n\n');});
+    return sentCommand = true;
+  }
+  if (!sentEmpty && stdout.includes('> 3')) {
+    setImmediate(() => {proc.stdin.write('\n');});
+    return sentEmpty = true;
+  }
+  if (!sentExit && sentCommand && sentEmpty) {
+    setTimeout(() => {proc.stdin.write('\n\n\n.exit\n\n\n');}, 1);
+    return sentExit = true;
+  }
+});
+
+process.on('exit', (exitCode) => {
+  assert.strictEqual(exitCode, 0);
+  console.log(stdout);
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

debugger

##### Description of change

<!-- provide a description of the change below this comment -->

In earlier versions of Node.js, pressing enter in the debugger resulted in the previous command running again. At some point, this was (accidentally, it appears) removed. This reinstates that behavior. 

Not sure about the semver-ness of this. *Could* be a bug fix. *Could* be a new feature. *Could* be a breaking change. Inclined to just shrug/table-flip and make it `semver-major`. The Peoples won't see it until October, then, but The Peoples have been without it for more than a year now, so I think The Peoples will be OK.

Fixes: https://github.com/nodejs/node/issues/2895