### PR TITLE
test: test-tick-processor was failing on mac osx.

### DIFF
--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -35,7 +35,7 @@ if (common.isWindows ||
   console.log('1..0 # Skipped: C++ symbols are not mapped for this os.');
   return;
 }
-runTest(/RunInDebugContext/,
+runTest(/runInDebugContext/,
   `function f() {
      require(\'vm\').runInDebugContext(\'Debug\');
      setImmediate(function() { f(); });


### PR DESCRIPTION

##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

test

##### Description of change

Test was looking for "RunInDebugContext", but output had
"runInDebugContext".  Updated pattern to use lower-case r and test passes.