### PR TITLE
src: add SIGINFO to supported signals

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -704,6 +704,12 @@ const char *signo_string(int signo) {
 # endif
 #endif
 
+#ifdef SIGINFO
+# if !defined(SIGPWR) || SIGINFO != SIGPWR
+  SIGNO_CASE(SIGINFO);
+# endif
+#endif
+
 #ifdef SIGSYS
   SIGNO_CASE(SIGSYS);
 #endif

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -716,6 +716,10 @@ void DefineSignalConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, SIGPWR);
 #endif
 
+#ifdef SIGINFO
+  NODE_DEFINE_CONSTANT(target, SIGINFO);
+#endif
+
 #ifdef SIGSYS
   NODE_DEFINE_CONSTANT(target, SIGSYS);
 #endif


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

Exposed through `process` module, change in `constants` within `src`.


##### Description of change

Though not a POSIX signal, SIGINFO is supported by [BSD systems](https://www.freebsd.org/cgi/man.cgi?query=termios&sektion=4&manpath=freebsd-release-ports) (including Mac OS X) and is amongst the few signals that can be triggered in a terminal via a simple key combination (CTRL-T).

Supporting SIGINFO on these systems will enable the use case where long-running terminal applications can report their status upon receiving the signal, and the signal can be triggered with a keystroke, instead of requiring the use of `kill`.

A brief examination of `src/node_constants.cc` indicates that there's no philosophical decision to support only POSIX signals, so I assume SIGINFO was an oversight. (SIGPWR, SIGLOST, and SIGWINCH are all present and non-POSIX). It's worth noting that on Linux, SIGINFO [is an alias](http://man7.org/linux/man-pages/man7/signal.7.html) for SIGPWR, which is why I employed defensive conditionals in `src/node.cc`.