### PR TITLE
tools: do not rewrite npm shebang in install.py

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -79,12 +79,6 @@ def try_remove(path, dst):
 def install(paths, dst): map(lambda path: try_copy(path, dst), paths)
 def uninstall(paths, dst): map(lambda path: try_remove(path, dst), paths)
 
-def update_shebang(path, shebang):
-  print 'updating shebang of %s to %s' % (path, shebang)
-  s = open(path, 'r').read()
-  s = re.sub(r'#!.*\n', '#!' + shebang + '\n', s)
-  open(path, 'w').write(s)
-
 def npm_files(action):
   target_path = 'lib/node_modules/npm/'
 
@@ -105,16 +99,6 @@ def npm_files(action):
     action([link_path], 'bin/npm')
   elif action == install:
     try_symlink('../lib/node_modules/npm/bin/npm-cli.js', link_path)
-    if os.environ.get('PORTABLE'):
-      # This crazy hack is necessary to make the shebang execute the copy
-      # of node relative to the same directory as the npm script. The precompiled
-      # binary tarballs use a prefix of "/" which gets translated to "/bin/node"
-      # in the regular shebang modifying logic, which is incorrect since the
-      # precompiled bundle should be able to be extracted anywhere and "just work"
-      shebang = '/bin/sh\n// 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"'
-    else:
-      shebang = os.path.join(node_prefix or '/', 'bin/node')
-    update_shebang(link_path, shebang)
   else:
     assert(0) # unhandled action type
 


### PR DESCRIPTION
##### Checklist

- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

tools


##### Description of change

It violates user expectations among other things.

The shebang in npm.js is kept as #!/usr/bin/env node.

See https://github.com/nodejs/node/issues/6095 for more details