### PR TITLE
doc: clarify fs.watch and inodes on linux, os x

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -1157,6 +1157,16 @@ reliably or at all.
 You can still use `fs.watchFile`, which uses stat polling, but it is slower and
 less reliable.
 
+#### Inodes
+
+<!--type=misc-->
+
+On Linux and OS X systems, `fs.watch()` resolves the path to an [inode][] and
+watches the inode. If the watched path is deleted and recreated, it is assigned
+a new inode. The watch will emit an event for the delete but will continue
+watching the *original* inode. Events for the new inode will not be emitted.
+This is expected behavior.
+
 #### Filename Argument
 
 <!--type=misc-->
@@ -1378,3 +1388,4 @@ Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 [MDN-Date]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
+[inode]: http://www.linux.org/threads/intro-to-inodes.4130


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

On Linux and OS X systems, `fs.watch` resolves the watched path to an
inode. This clarifies that `fs.watch` watches the inode and not the
path. If the inode of the path subsequently changes, `fs.watch` will
continue watching the original inode and events for the path will no
longer be emitted. This is expected behavior.

Fixes: https://github.com/nodejs/node/issues/5039