### PR TITLE
tools: remove simplejson dependency

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 
 import errno
-
-try:
-  import json
-except ImportError:
-  import simplejson as json
-
+import json
 import os
 import re
 import shutil


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

tools

##### Description of change

As Node.js expects either Python 2.6 or 2.7 installed to work properly,
simplejson module is no longer necessary. It was included in Python 2.6
as the json module.