### PR TITLE
document how to use crypto.sign() for algorithm+digest combinations without named constants

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -747,7 +747,7 @@ const sign = crypto.createSign('sha256');
 
 sign.update('some data to sign');
 
-const privateKey = '-----BEGIN EC PRIVATE KEY-----\n' +
+const private_key = '-----BEGIN EC PRIVATE KEY-----\n' +
         'MHcCAQEEIF+jnWY1D5kbVYDNvxxo/Y+ku2uJPDwS0r/VuPZQrjjVoAoGCCqGSM49\n' +
         'AwEHoUQDQgAEurOxfSxmqIRYzJVagdZfMMSjRNNhB8i3mXyIMq704m2m52FdfKZ2\n' +
         'pQhByd5eyj3lgZ7m7jbchtdgyOF8Io/1ng==\n' +

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -734,6 +734,28 @@ console.log(sign.sign(private_key, 'hex'));
   // Prints the calculated signature
 ```
 
+A [`sign`][] instance can also be created by just passing in the digest
+algorithm name, in which case OpenSSL will infer the full signature algorithm
+from the type of the PEM-formatted private key, including algorithms that
+do not have directly exposed name constants, e.g. 'ecdsa-with-SHA256'.
+
+Example: signing using ECDSA with SHA256
+
+```js
+const crypto = require('crypto');
+const sign = crypto.createSign('sha256');
+
+sign.update('some data to sign');
+
+const privateKey = '-----BEGIN EC PRIVATE KEY-----\n' +
+        'MHcCAQEEIF+jnWY1D5kbVYDNvxxo/Y+ku2uJPDwS0r/VuPZQrjjVoAoGCCqGSM49\n' +
+        'AwEHoUQDQgAEurOxfSxmqIRYzJVagdZfMMSjRNNhB8i3mXyIMq704m2m52FdfKZ2\n' +
+        'pQhByd5eyj3lgZ7m7jbchtdgyOF8Io/1ng==\n' +
+        '-----END EC PRIVATE KEY-----\n',
+
+console.log(sign.sign(private_key).toString('hex'));
+```
+
 ### sign.sign(private_key[, output_format])
 
 Calculates the signature on all the data passed through using either


### PR DESCRIPTION
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Description of change

Updates the crypto API documentation to demonstrate how to use signature algorithms supported by OpenSSL but not exposed as named constants, e.g. "ecdsa-with-SHA256".

