### PR TITLE
fix FIPS regression in 4.x

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -19,7 +19,13 @@ const defaultSessionIdContext = getDefaultSessionIdContext();
 function getDefaultSessionIdContext() {
   var defaultText = process.argv.join(' ');
   /* SSL_MAX_SID_CTX_LENGTH is 128 bits */
-  if (process.config.variables.openssl_fips) {
+  if (
+    process.config &&
+    'variables' in process.config &&
+    process.config.variables &&
+    'openssl_fips' in process.config.variables &&
+    process.config.variables.openssl_fips
+  ) {
     return crypto.createHash('sha1')
       .update(defaultText)
       .digest('hex').slice(0, 32);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->


##### Affected core subsystem(s)

tiny change to lib/_tls_wrap.js

##### Description of change

This fixes a regression introduced in 4.2.4 where under certain circumstances (I believe mocha test framework, but didn't isolate) the code in getDefaultSessionIdContext() would throw an exception because process.config.variables was undefined and thus doesn't have attributes to access.

Why the project's libs in use were mucking about in process.config like that we'll never know, but this defensive patch makes it work again (like in 4.2.3).

https://github.com/nodejs/node/pull/3755#issuecomment-207066246