### PR TITLE
doc: add copy about how to curl SHA256.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ documentation of the latest stable version.
 
 Stable, LTS and Nightly download directories all contain a *SHASUM256.txt*
 file that lists the SHA checksums for each file available for
-download. To check that a downloaded file matches the checksum, run
+download.
+
+The *SHASUM256.txt* can be downloaded using curl.
+
+```
+$ curl -O https://nodejs.org/dist/vx.y.z/SHASUMS256.txt
+```
+
+To check that a downloaded file matches the checksum, run
 it through `sha256sum` with a command such as:
 
 ```


### PR DESCRIPTION
Currently we include instructions on how to check the sha of a
downloaded tar-ball, but do not include instruction on how to
get the `SHA256.txt` file. This has led to confusion with people
thinking that the SHA256.txt is included in that tarball.

This commit includes instructions on how to use curl to download the
`SHA256.txt` prior to the instructions on how to verify the sha.

ref: https://github.com/nodejs/help/issues/113
ref: https://github.com/nodejs/help/issues/137