### PR TITLE
process: make process.config read-only

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -473,21 +473,23 @@ An example of the possible output looks like:
   variables:
    {
      host_arch: 'x64',
-     node_install_npm: 'true',
+     node_install_npm: true,
      node_prefix: '',
-     node_shared_cares: 'false',
-     node_shared_http_parser: 'false',
-     node_shared_libuv: 'false',
-     node_shared_zlib: 'false',
-     node_use_dtrace: 'false',
-     node_use_openssl: 'true',
-     node_shared_openssl: 'false',
-     strict_aliasing: 'true',
+     node_shared_cares: false,
+     node_shared_http_parser: false,
+     node_shared_libuv: false,
+     node_shared_zlib: false,
+     node_use_dtrace: false,
+     node_use_openssl: true,
+     node_shared_openssl: false,
+     strict_aliasing: true,
      target_arch: 'x64',
-     v8_use_snapshot: 'true'
+     v8_use_snapshot: true
    }
 }
 ```
+
+The `process.config` object is read-only and cannot be modified or extended.
 
 ## process.connected
 

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -60,10 +60,30 @@ function setupConfig(_source) {
       .replace(/"/g, '\\"')
       .replace(/'/g, '"');
 
-  process.config = JSON.parse(config, function(key, value) {
-    if (value === 'true') return true;
-    if (value === 'false') return false;
-    return value;
+  // Use a lazy getter and freeze the config object on parse.
+  // This makes it slower but ensures that userland cannot
+  // overwrite the config.
+  var _config;
+  Object.defineProperty(process, 'config', {
+    configurable: false,
+    enumerable: true,
+    get: function() {
+      if (!_config) {
+        _config = JSON.parse(config, (key, value) => {
+          if (value === 'true') return true;
+          if (value === 'false') return false;
+          if (typeof value === 'object')
+            Object.freeze(value);
+          return value;
+        });
+      }
+      return _config;
+    },
+    set: function set(val) {
+      const err = TypeError('process.config is read-only.');
+      Error.captureStackTrace(err, set);
+      throw err;
+    }
   });
 }
 

--- a/test/parallel/test-process-config-readonly.js
+++ b/test/parallel/test-process-config-readonly.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const config = process.config;
+
+assert(config);
+assert(config.variables);
+
+// These throw because the objects are frozen.
+assert.throws(() => process.config = {}, TypeError);
+assert.throws(() => process.config.a = 1, TypeError);
+assert.throws(() => process.config.variables.a = 1, TypeError);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

process

##### Description of change

Makes `process.config` read-only using a getter/setter and freezing the objects on JSON.parse. Does result in a perf hit but `process.config` is not used in any critical paths (or *any* path in core) for that matter. There are apparently some places in user land where this is being extended and it causes problems when we want to add new configuration options (see #6115 for an example).

Refs: https://github.com/nodejs/node/pull/6115

/cc @Fishrock123 