### PR TITLE
[backport v4.x] querystring: don't stringify bad surrogate pair

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -138,7 +138,12 @@ QueryString.escape = function(str) {
     }
     // Surrogate pair
     ++i;
-    c = 0x10000 + (((c & 0x3FF) << 10) | (str.charCodeAt(i) & 0x3FF));
+    var c2;
+    if (i < str.length)
+      c2 = str.charCodeAt(i) & 0x3FF;
+    else
+      throw new URIError('URI malformed');
+    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
     out += hexTable[0xF0 | (c >> 18)] +
            hexTable[0x80 | ((c >> 12) & 0x3F)] +
            hexTable[0x80 | ((c >> 6) & 0x3F)] +

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -139,6 +139,11 @@ qsWeirdObjects.forEach(function(testCase) {
   assert.equal(testCase[1], qs.stringify(testCase[0]));
 });
 
+// invalid surrogate pair throws URIError
+assert.throws(function() {
+  qs.stringify({ foo: '\udc00' });
+}, URIError);
+
 // coerce numbers to string
 assert.strictEqual('foo=0', qs.stringify({ foo: 0 }));
 assert.strictEqual('foo=0', qs.stringify({ foo: -0 }));


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes
- [X] a test and/or benchmark is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

* querystring


##### Description of change

Fixes: https://github.com/nodejs/node/issues/3702