### PR TITLE
child_process: Check the command argument in normalizeSpawnArguments

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -304,6 +304,10 @@ function _convertCustomFds(options) {
 function normalizeSpawnArguments(file /*, args, options*/) {
   var args, options;
 
+  if (typeof file !== 'string') {
+    throw new TypeError('"command" argument must be a string');
+  }
+
   if (Array.isArray(arguments[1])) {
     args = arguments[1].slice(0);
     options = arguments[2];

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -36,7 +36,11 @@ assert.doesNotThrow(function() {
 // verify that invalid argument combinations throw
 assert.throws(function() {
   spawn();
-}, /Bad argument/);
+}, /"command" argument must be a string/);
+
+assert.throws(function() {
+  spawn(undefined, { shell: true });
+}, /"command" argument must be a string/);
 
 assert.throws(function() {
   spawn(cmd, null);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change

<!-- provide a description of the change below this comment -->

Throws '"command" argument must be an object' TypeError when command
argument is not of type string.

Fix #6127.