### PR TITLE
doc: add note for platform specific flags `fs.open()`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -795,6 +795,23 @@ On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
+_Note: The behavior of `fs.open()` is platform specific for some flags. As such,
+opening a directory on OS X and Linux with the `'a+'` flag - see example below -
+will return an error. Whereas on Windows and FreeBSD a file descriptor will be
+returned._
+
+```js
+// OS X and Linux
+fs.open('<directory>', 'a+', (err, fd) => {
+  // => [Error: EISDIR: illegal operation on a directory, open <directory>]
+})
+
+// Windows and FreeBSD
+fs.open('<directory>', 'a+', (err, fd) => {
+  // => null, <fd>
+})
+```
+
 ## fs.openSync(path, flags[, mode])
 
 * `path` {String | Buffer}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
`doc`

##### Description of change
add note for platform specific flags `fs.open()`

closes #3643
E.g. fs.open('<directory>', 'a+', console.log)