### PR TITLE
zlib: Support for reading/writing Gzip headers

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -350,6 +350,22 @@ function Zlib(opts, mode) {
     }
   }
 
+  var gzipHeader = opts.gzipHeader || null;
+
+  if (gzipHeader) {
+    if (mode === binding.GZIP) {
+      // gzipping: write header information into the gzip file
+      gzipHeader = normalizeGzipHeader(gzipHeader);
+    } else if (mode === binding.GUNZIP || mode === binding.UNZIP) {
+      // unzipping: the user should supplay a boolean that indicates whether
+      // the `header` event should be emitted
+      gzipHeader = !!gzipHeader;
+    } else {
+      // providing gzip-specific options to non-gzip modes is pointless
+      gzipHeader = null;
+    }
+  }
+
   this._handle = new binding.Zlib(mode);
 
   var self = this;
@@ -376,7 +392,8 @@ function Zlib(opts, mode) {
                     level,
                     opts.memLevel || exports.Z_DEFAULT_MEMLEVEL,
                     strategy,
-                    opts.dictionary);
+                    opts.dictionary,
+                    gzipHeader);
 
   this._buffer = Buffer.allocUnsafe(this._chunkSize);
   this._offset = 0;
@@ -560,9 +577,13 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
   req.buffer = chunk;
   req.callback = callback;
 
-  function callback(availInAfter, availOutAfter) {
+  function callback(availInAfter, availOutAfter, gzipHeader) {
     if (self._hadError)
       return;
+
+    if (gzipHeader) {
+      self.emit('header', decodeGzipHeader(gzipHeader));
+    }
 
     var have = availOutBefore - availOutAfter;
     assert(have >= 0, 'have should not go down');
@@ -631,3 +652,135 @@ util.inherits(Gunzip, Zlib);
 util.inherits(DeflateRaw, Zlib);
 util.inherits(InflateRaw, Zlib);
 util.inherits(Unzip, Zlib);
+
+function decodeGzipHeader(header) {
+  const extraFields = [];
+
+  header.extraRaw = header.extra;
+
+  try {
+    for (let offset = 0; header.extra && offset < header.extra.length;) {
+      const id = header.extra.slice(offset, offset + 2);
+      const length = header.extra.readUInt16LE(offset + 2);
+      offset += 4;
+
+      const content = header.extra.slice(offset, offset + length);
+      offset += length;
+      extraFields.push({ id, content });
+    }
+
+    header.extra = extraFields;
+  } catch (e) {
+    // This can happen when invalid offsets were specified in the gzip file
+    // and readUInt16LE fails accordingly.
+    if (e.name !== 'RangeError') {
+      throw e;
+    }
+  }
+
+  return header;
+}
+
+function normalizeGzipHeader(header) {
+  if (typeof header !== 'object') {
+    throw new TypeError('When encoding gzipHeader needs to be object if set');
+  }
+
+  header = Object.assign({}, header);
+  if (!~['boolean', 'number', 'undefined'].indexOf(typeof header.text)) {
+    throw new TypeError('Invalid gzip header text flag: ' + header.text);
+  }
+
+  header.text = +!!header.text; // normalize to 0/1, default 0
+
+  if (typeof header.time !== 'number') {
+    if (typeof header.time === 'undefined' || header.time === null) {
+      header.time = 0;
+    } else if (header.time instanceof Date) {
+      header.time = parseInt(header.time.getTime() / 1000);
+    } else {
+      throw new TypeError('Invalid gzip header time field: ' + header.time);
+    }
+  }
+
+  if (typeof header.os !== 'number') {
+    header.os = 255; // unknown OS
+  }
+
+  header.extra = header.extra || header.extraRaw;
+  if (header.extra) {
+    if (Array.isArray(header.extra)) {
+      const buffers = [];
+
+      for (let i = 0; i < header.extra.length; i++) {
+        const subfield = header.extra[i];
+        const contentLength = Buffer.byteLength(subfield.content);
+
+        if (Buffer.byteLength(subfield.id) !== 2) {
+          throw new TypeError('Invalid subfield id: ' + subfield.id);
+        }
+
+        const subfieldHeader = Buffer.allocUnsafe(4);
+
+        if (Buffer.isBuffer(subfield.id)) {
+          subfield.id.copy(subfieldHeader);
+        } else {
+          subfieldHeader.write(subfield.id);
+        }
+
+        subfieldHeader.writeUInt16LE(contentLength, 2);
+        buffers.push(subfieldHeader);
+
+        buffers.push(Buffer.from(subfield.content));
+      }
+
+      header.extra = Buffer.concat(buffers);
+    }
+
+    if (!Buffer.isBuffer(header.extra)) {
+      header.extra = Buffer.from(header.extra);
+    }
+  } else {
+    header.extra = null;
+  }
+
+  if (header.name) {
+    header.name = normalizeToZeroTerminatedBuffer(header.name, 'name');
+  } else {
+    header.name = null;
+  }
+
+  if (header.comment) {
+    header.comment = normalizeToZeroTerminatedBuffer(header.comment, 'comment');
+  } else {
+    header.comment = null;
+  }
+
+  if (!~['boolean', 'number', 'undefined'].indexOf(typeof header.hcrc)) {
+    throw new TypeError('Invalid gzip header hcrc flag: ' + header.text);
+  }
+
+  header.hcrc = +!!header.hcrc;
+
+  return header;
+}
+
+function normalizeToZeroTerminatedBuffer(input, name) {
+  if (Buffer.isBuffer(input)) {
+    if (input[input.length - 1] == 0) {
+      return input;
+    } else {
+      // Append 1 zero byte.
+      return Buffer.concat([input, Buffer.alloc(1)]);
+    }
+  }
+
+  if (typeof input !== 'string') {
+    throw new TypeError(`Cannot convert ${name} to zero-terminated string`);
+  }
+
+  const buf = Buffer.allocUnsafe(Buffer.byteLength(input) + 1);
+  buf.write(input);
+  buf[buf.length - 1] = 0;
+  return buf;
+}

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -579,14 +579,21 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
       }
     }
 
+    // Not done yet with the current chunk of input if:
+    // - The output buffer is full and more output might be pending in the
+    //   zlib state, OR
+    // - There is more data waiting to be processed and progress is possible.
+    const notDoneYet = availOutAfter === 0 ||
+                       (availInAfter !== 0 && availInAfter !== availInBefore);
+
     // exhausted the output buffer, or used all the input create a new one.
-    if (availOutAfter === 0 || self._offset >= self._chunkSize) {
+    if (notDoneYet || self._offset >= self._chunkSize) {
       availOutBefore = self._chunkSize;
       self._offset = 0;
       self._buffer = Buffer.allocUnsafe(self._chunkSize);
     }
 
-    if (availOutAfter === 0) {
+    if (notDoneYet) {
       // Not actually done.  Need to reprocess.
       // Also, update the availInBefore to the availInAfter value,
       // so that if we have to hit it a third (fourth, etc.) time,

--- a/src/env.h
+++ b/src/env.h
@@ -77,6 +77,7 @@ namespace node {
   V(cached_data_rejected_string, "cachedDataRejected")                        \
   V(callback_string, "callback")                                              \
   V(change_string, "change")                                                  \
+  V(comment_string, "comment")                                                \
   V(oncertcb_string, "oncertcb")                                              \
   V(onclose_string, "_onclose")                                               \
   V(code_string, "code")                                                      \
@@ -92,6 +93,7 @@ namespace node {
   V(domain_string, "domain")                                                  \
   V(emitting_top_level_domain_error_string, "_emittingTopLevelDomainError")   \
   V(exchange_string, "exchange")                                              \
+  V(extra_string, "extra")                                                    \
   V(idle_string, "idle")                                                      \
   V(irq_string, "irq")                                                        \
   V(enter_string, "enter")                                                    \
@@ -119,6 +121,7 @@ namespace node {
   V(fsevent_string, "FSEvent")                                                \
   V(gid_string, "gid")                                                        \
   V(handle_string, "handle")                                                  \
+  V(hcrc_string, "hcrc")                                                      \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
   V(hostmaster_string, "hostmaster")                                          \
@@ -177,6 +180,7 @@ namespace node {
   V(onwrite_string, "onwrite")                                                \
   V(output_string, "output")                                                  \
   V(order_string, "order")                                                    \
+  V(os_string, "os")                                                          \
   V(owner_string, "owner")                                                    \
   V(parse_error_string, "Parse Error")                                        \
   V(path_string, "path")                                                      \
@@ -218,10 +222,12 @@ namespace node {
   V(subjectaltname_string, "subjectaltname")                                  \
   V(sys_string, "sys")                                                        \
   V(syscall_string, "syscall")                                                \
+  V(text_string, "text")                                                      \
   V(tick_callback_string, "_tickCallback")                                    \
   V(tick_domain_cb_string, "_tickDomainCallback")                             \
   V(ticketkeycallback_string, "onticketkeycallback")                          \
   V(timeout_string, "timeout")                                                \
+  V(time_string, "time")                                                      \
   V(times_string, "times")                                                    \
   V(timestamp_string, "timestamp")                                            \
   V(title_string, "title")                                                    \

--- a/test/parallel/test-zlib-gzip-header.js
+++ b/test/parallel/test-zlib-gzip-header.js
@@ -1,0 +1,133 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var zlib = require('zlib');
+
+const helloWorldIndexed = (n) => zlib.gzipSync(`Hello, World ${n}!\n`, {
+  gzipHeader: {
+    name: `hw-${n}.txt`
+  }
+});
+
+// No header events when not requested.
+const unzipWithoutHeaders = zlib.createUnzip();
+unzipWithoutHeaders.on('header', () => {
+  assert.fail(null, null, 'Unexpected "header" event');
+});
+unzipWithoutHeaders.on('finish', common.mustCall(() => {}));
+unzipWithoutHeaders.write(helloWorldIndexed(1));
+unzipWithoutHeaders.end(helloWorldIndexed(2));
+
+// Three header events for three separate files, multiple chunks style.
+const unzip = zlib.createUnzip({ gzipHeader: true });
+const seenFilenames = [];
+const expectedFilenames = ['hw-1.txt', 'hw-2.txt', 'hw-3.txt'];
+unzip.on('header', common.mustCall((header) => {
+  assert.ok(Buffer.isBuffer(header.name));
+
+  seenFilenames.push(header.name.toString());
+}, 3));
+unzip.write(helloWorldIndexed(1));
+unzip.write(helloWorldIndexed(2));
+unzip.end(helloWorldIndexed(3));
+
+process.on('exit', () => {
+  assert.deepStrictEqual(seenFilenames, expectedFilenames);
+});
+
+// Three header events for three separate files, multiple chunks style.
+const unzipSingleChunk = zlib.createUnzip({ gzipHeader: true });
+const seenFilenamesSingleChunk = [];
+unzipSingleChunk.on('header', common.mustCall((header) => {
+  assert.ok(Buffer.isBuffer(header.name));
+
+  seenFilenamesSingleChunk.push(header.name.toString());
+}, 3));
+unzipSingleChunk.end(Buffer.concat([
+  helloWorldIndexed(1),
+  helloWorldIndexed(2),
+  helloWorldIndexed(3)
+]));
+
+process.on('exit', () => {
+  assert.deepStrictEqual(seenFilenamesSingleChunk, expectedFilenames);
+});
+
+// Test that various types of header fields are passed through the data stream.
+const testHeader = {
+  text: true,
+  time: 1460335349,
+  os: 42,
+  hcrc: true,
+  extra: [
+    { id: Buffer.from('AA'), content: Buffer.from('foobar') },
+    { id: Buffer.from('AB'), content: Buffer.from('barbaz') },
+  ],
+  name: Buffer.from('original-filename'),
+  comment: Buffer.from('Some file comment')
+};
+
+const unzipCheckHeader = zlib.createGunzip({ gzipHeader: true });
+const gzipWithHeader = zlib.createGzip({ gzipHeader: testHeader });
+
+unzipCheckHeader.on('header', common.mustCall((header) => {
+  // The `.extraRaw` field is generated and duplicates the information from
+  // `.extra`.
+  assert.ok(Buffer.isBuffer(header.extraRaw));
+  delete header.extraRaw;
+
+  assert.deepStrictEqual(header, testHeader);
+}));
+
+gzipWithHeader.pipe(unzipCheckHeader);
+gzipWithHeader.end('some data');
+
+// Some argument type checks.
+assert.throws(() => {
+  zlib.gzipSync('foobar', {
+    gzipHeader: {
+      name: 42
+    }
+  });
+}, /Cannot convert name to zero-terminated string/);
+
+assert.throws(() => {
+  zlib.gzipSync('foobar', {
+    gzipHeader: {
+      comment: 42
+    }
+  });
+}, /Cannot convert comment to zero-terminated string/);
+
+assert.throws(() => {
+  zlib.gzipSync('foobar', {
+    gzipHeader: {
+      text: 'Yes'
+    }
+  });
+}, /Invalid gzip header text flag:/);
+
+assert.throws(() => {
+  zlib.gzipSync('foobar', {
+    gzipHeader: {
+      time: 'Yes'
+    }
+  });
+}, /Invalid gzip header time field:/);
+
+assert.throws(() => {
+  zlib.gzipSync('foobar', {
+    gzipHeader: 42
+  });
+}, /When encoding gzipHeader needs to be object if set/);
+
+// There is no gzip header for non-gzip input.
+const unzipCheckDeflate = zlib.createUnzip({ gzipHeader: true });
+const deflateWithHeader = zlib.createDeflate();
+
+unzipCheckDeflate.on('header', (header) => {
+  assert.fail(null, null, 'There should be no gzip header for non-gzip data.');
+});
+
+deflateWithHeader.pipe(unzipCheckDeflate);
+deflateWithHeader.end('some data');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

zlib

##### Description of change

So, I decided to try and work out a somewhat larger project on my own – if it is decided that this feature is not worthwhile, I can definitely live with that, but would appreciate feedback on the things which I have done Terribly Wrong™ either way. :smile:

---------------------------------------

Add support for reading and writing the Gzip headers using the functions provided by zlib.

The Gzip headers may contain additional information about a file, such as the original filename, the modification time of the original file, the OS on which the compressed file was generated, or even arbitrary additional machine-readable and human-readable information.

This patch adds an `gzipHeader` option to the Zlib constructors. In the case of compression, this option contains the data which will be written to the resulting Gzip stream. In the case of decompression, passing a truthy value will enable the emission of `header` events for each member of the underlying Gzip input.

As a side effect, this enables detecting whether the input of a `Unzip` stream with format auto-detection was, in fact, a Gzip file or not.
