### PR TITLE
streams: support unlimited synchronous cork/uncork cycles

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -112,10 +112,9 @@ function WritableState(options, stream) {
   // count buffered requests
   this.bufferedRequestCount = 0;
 
-  // create the two objects needed to store the corked requests
-  // they are not a linked list, as no new elements are inserted in there
+  // allocate the first CorkedRequest, there is always
+  // one allocated and free to use, and we maintain at most two
   this.corkedRequestsFree = new CorkedRequest(this);
-  this.corkedRequestsFree.next = new CorkedRequest(this);
 }
 
 WritableState.prototype.getBuffer = function writableStateGetBuffer() {
@@ -387,12 +386,16 @@ function clearBuffer(stream, state) {
 
     doWrite(stream, state, true, state.length, buffer, '', holder.finish);
 
-    // doWrite is always async, defer these to save a bit of time
+    // doWrite is almost always async, defer these to save a bit of time
     // as the hot path ends with doWrite
     state.pendingcb++;
     state.lastBufferedRequest = null;
-    state.corkedRequestsFree = holder.next;
-    holder.next = null;
+    if (holder.next) {
+      state.corkedRequestsFree = holder.next;
+      holder.next = null;
+    } else {
+      state.corkedRequestsFree = new CorkedRequest(state);
+    }
   } else {
     // Slow case, write chunks one-by-one
     while (entry) {

--- a/test/parallel/test-net-sync-cork.js
+++ b/test/parallel/test-net-sync-cork.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const server = net.createServer(handle);
+
+const N = 100;
+const buf = Buffer.alloc(2, 'a');
+
+server.listen(common.PORT, function() {
+  const conn = net.connect(common.PORT);
+
+  conn.on('connect', () => {
+    let res = true;
+    let i = 0;
+    for (; i < N && res; i++) {
+      conn.cork();
+      conn.write(buf);
+      res = conn.write(buf);
+      conn.uncork();
+    }
+    assert.equal(i, N);
+    conn.end();
+  });
+});
+
+process.on('exit', function() {
+  assert.equal(server.connections, 0);
+});
+
+function handle(socket) {
+  socket.resume();
+
+  socket.on('error', function(err) {
+    socket.destroy();
+  }).on('close', function() {
+    server.close();
+  });
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included


##### Affected core subsystem(s)

streams, writable

##### Description of change

net streams can request multiple chunks to be written in a synchronous
fashion. If this is combined with cork/uncork, en error is currently
thrown because of a regression introduced in:
https://github.com/nodejs/node/commit/89aeab901ac9e34c79be3854f1aa41f2a4fb6888
(https://github.com/nodejs/node/pull/4354).

I am not creating a full linked list anyway, because that is not needed in any "normal" operation of the stream, and I think multiple cork/uncork synchronously it is a very edge case: we can possibly waste some objects and callbacks. 
Just to clarify, we are supporting a "feature" that can easily lead to event loop starvation and memory leaks, because for each synchronous cork/uncork cycle, we are adding a task in the `nextTick` queue:  https://github.com/nodejs/node/blob/819b2d36bcffdb9f33e0e4497ac818d64fe5711d/lib/_stream_writable.js#L344.

Fixes: https://github.com/nodejs/node/issues/6154.