### PR TITLE
test: fix test-net-settimeout flakiness

### DIFF
--- a/test/parallel/test-net-settimeout.js
+++ b/test/parallel/test-net-settimeout.js
@@ -8,22 +8,24 @@ const assert = require('assert');
 
 const T = 100;
 
-const server = net.createServer(function(c) {
+const server = net.createServer(common.mustCall((c) => {
   c.write('hello');
-});
+}));
+
 server.listen(common.PORT);
 
 const socket = net.createConnection(common.PORT, 'localhost');
 
-const s = socket.setTimeout(T, function() {
+const s = socket.setTimeout(T, () => {
   common.fail('Socket timeout event is not expected to fire');
 });
 assert.ok(s instanceof net.Socket);
 
+socket.on('data', common.mustCall(() => {
+  setTimeout(function() {
+    socket.destroy();
+    server.close();
+  }, T * 2);
+}));
+
 socket.setTimeout(0);
-
-setTimeout(function() {
-  socket.destroy();
-  server.close();
-}, T * 2);
-


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
test


##### Description of change

<!-- provide a description of the change below this comment -->

Wait for the data to be received by the socket before creating the
clean-up timer. This way, a possible (though unlikely) `ECONNRESET`
error can be avoided.

Failure in CI: https://ci.nodejs.org/job/node-test-binary-arm/RUN_SUBSET=6,nodes=pi1-raspbian-wheezy/1686/
```
1) test-net-settimeout.js
----------------------------------------------
# events.js:154
#       throw er; // Unhandled 'error' event
#       ^
# 
# Error: read ECONNRESET
#     at exports._errnoException (util.js:893:11)
#     at TCP.onread (net.js:550:26)

==============================================

```