### PR TITLE
stream: make null an invalid chunk to write in object mode

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -177,13 +177,19 @@ function writeAfterEnd(stream, cb) {
 // how many bytes or characters.
 function validChunk(stream, state, chunk, cb) {
   var valid = true;
-
-  if (!(chunk instanceof Buffer) &&
+  var er = false;
+  // Always throw error if a null is written
+  // if we are not in object mode then throw
+  // if it is not a buffer, string, or undefined.
+  if (chunk === null) {
+    er = new TypeError('May not write null values to stream');
+  } else if (!(chunk instanceof Buffer) &&
       typeof chunk !== 'string' &&
-      chunk !== null &&
       chunk !== undefined &&
       !state.objectMode) {
-    var er = new TypeError('Invalid non-string/buffer chunk');
+    er = new TypeError('Invalid non-string/buffer chunk');
+  }
+  if (er) {
     stream.emit('error', er);
     process.nextTick(cb, er);
     valid = false;

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -1,0 +1,56 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const stream = require('stream');
+const util = require('util');
+
+function MyWritable(options) {
+  stream.Writable.call(this, options);
+}
+
+util.inherits(MyWritable, stream.Writable);
+
+MyWritable.prototype._write = function(chunk, encoding, callback) {
+  assert.notStrictEqual(chunk, null);
+  callback();
+};
+
+assert.throws(() => {
+  var m = new MyWritable({objectMode: true});
+  m.write(null, (err) => assert.ok(err));
+}, TypeError, 'May not write null values to stream');
+assert.doesNotThrow(() => {
+  var m = new MyWritable({objectMode: true}).on('error', (e) => {
+    assert.ok(e);
+  });
+  m.write(null, (err) => {
+    assert.ok(err);
+  });
+});
+
+assert.throws(() => {
+  var m = new MyWritable();
+  m.write(false, (err) => assert.ok(err));
+}, TypeError, 'Invalid non-string/buffer chunk');
+assert.doesNotThrow(() => {
+  var m = new MyWritable().on('error', (e) => {
+    assert.ok(e);
+  });
+  m.write(false, (err) => {
+    assert.ok(err);
+  });
+});
+
+assert.doesNotThrow(() => {
+  var m = new MyWritable({objectMode: true});
+  m.write(false, (err) => assert.ifError(err));
+});
+assert.doesNotThrow(() => {
+  var m = new MyWritable({objectMode: true}).on('error', (e) => {
+    assert.ifError(e || new Error('should not get here'));
+  });
+  m.write(false, (err) => {
+    assert.ifError(err);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added (current documentation implies this behavior)
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change

<!-- provide a description of the change below this comment -->
as discussed by @nodejs/streams 

this harmonizes behavior between readable, writable, and transform
streams so that they all handle nulls in object mode the same way by
considering them invalid chunks.