### PR TITLE
buffer: add fast Buffer.encode() for simple string conversion

### DIFF
--- a/benchmark/buffers/buffer-encode.js
+++ b/benchmark/buffers/buffer-encode.js
@@ -4,7 +4,7 @@ const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
   method: ['encode', 'tostring'],
-  enc: ['utf8', 'utf16', 'hex', 'base64'],
+  enc: ['utf8', 'ucs2', 'hex', 'base64'],
   size: [16, 512, 1024, 4096],
   millions: [1]
 });
@@ -44,7 +44,7 @@ function dotostring(str, target, iter) {
 
 function main(conf) {
   const iter = (conf.millions >>> 0) * 1e6;
-  const enc = conf.env;
+  const enc = conf.enc;
   const size = (conf.size >>> 0);
   const method = conf.method === 'encode' ?
       encode : tostring;

--- a/benchmark/buffers/buffer-encode.js
+++ b/benchmark/buffers/buffer-encode.js
@@ -1,0 +1,53 @@
+'use strict';
+const common = require('../common.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  method: ['encode', 'tostring'],
+  enc: ['utf8', 'utf16', 'hex', 'base64'],
+  size: [16, 512, 1024, 4096],
+  millions: [1]
+});
+
+function encode(str, target, iter) {
+  Buffer.encode(str, target);
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(Buffer.encode)');
+  Buffer.encode(str, target);
+  doencode(str, target, iter);
+}
+
+function doencode(str, target, iter) {
+  var i;
+  bench.start();
+  for (i = 0; i < iter; i++)
+    Buffer.encode(str, target);
+  bench.end(iter / 1e6);
+}
+
+function tostring(str, target, iter) {
+  Buffer.from(str).toString(target);
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(Buffer.from)');
+  eval('%OptimizeFunctionOnNextCall(Buffer.prototype.toString)');
+  Buffer.from(str).toString(target);
+  dotostring(str, target, iter);
+}
+
+function dotostring(str, target, iter) {
+  var i;
+  bench.start();
+  for (i = 0; i < iter; i++)
+    Buffer.from(str).toString(target);
+  bench.end(iter / 1e6);
+}
+
+function main(conf) {
+  const iter = (conf.millions >>> 0) * 1e6;
+  const enc = conf.env;
+  const size = (conf.size >>> 0);
+  const method = conf.method === 'encode' ?
+      encode : tostring;
+  const str = Buffer.alloc(size, 'a').toString();
+  method(str, enc, iter);
+}

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -541,6 +541,42 @@ console.log(bufA.length);
 // 42
 ```
 
+### Class Method: Buffer.encode(str[, str_encoding][, target_encoding])
+
+* `str` {String} A source string
+* `str_encoding` {String} The character encoding for `str`. Default = `'utf8'`
+* `target_encoding` {String} The target character encoding. Default = `'utf8'`
+
+Historically, a common use case for `Buffer` instances has been to convert
+text from one encoding to another. For instance, it is not uncommon to find 
+`Buffer` instances used to convert text to Hex or Base64 encodings:
+
+```js
+Buffer.from('test').toString('hex');
+  // Produces: 74657374
+```
+
+However, using `Buffer` objects in this way can create additional unnecessary
+overhead in allocating the `Buffer` and garbage collection.
+
+The `Buffer.encode()` method allows a simplified mechanism for converting text
+from one character encoding to another as a more efficient shortcut. While it
+uses the same mechanisms internally as `Buffer.prototype.toString()` to perform
+to character encoding, it does so without the overhead of creating a new
+`Buffer` instance.
+
+```js
+Buffer.encode('test', 'base64');
+  // Produces: dGVzdA==
+```
+
+To convert easily from one encoding to another:
+
+```js
+Buffer.encode('dGVzdA==', 'base64', 'hex');
+  // Produces: 74657374
+```
+
 ### Class Method: Buffer.from(array)
 
 * `array` {Array}

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -547,8 +547,8 @@ console.log(bufA.length);
 * `str_encoding` {String} The character encoding for `str`. Default = `'utf8'`
 * `target_encoding` {String} The target character encoding. Default = `'utf8'`
 
-Historically, a common use case for `Buffer` instances has been to convert
-text from one encoding to another. For instance, it is not uncommon to find 
+Historically, a common use case for `Buffer` instances has been to reinterpret
+text from one encoding into another. For instance, it is not uncommon to find 
 `Buffer` instances used to convert text to Hex or Base64 encodings:
 
 ```js
@@ -576,6 +576,11 @@ To convert easily from one encoding to another:
 Buffer.encode('dGVzdA==', 'base64', 'hex');
   // Produces: 74657374
 ```
+
+It's important to note that, with specific exception given to `'hex'` and
+`'base64'`, `Buffer.encode()` does not *convert* text from one character set 
+encoding to another. Rather, it reads the source text and *reinterprets* the
+bytes using the target encoding.
 
 ### Class Method: Buffer.from(array)
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -107,8 +107,8 @@ function ClientRequest(options, cb) {
 
   if (options.auth && !this.getHeader('Authorization')) {
     //basic auth
-    this.setHeader('Authorization', 'Basic ' +
-                   Buffer.from(options.auth).toString('base64'));
+    this.setHeader('Authorization',
+                   `Basic ${Buffer.encode(options.auth, 'base64')}`);
   }
 
   if (method === 'GET' ||

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -349,10 +349,18 @@ Buffer.concat = function(list, length) {
 };
 
 Buffer.encode = function(source, encoding, targetEncoding) {
+  if (typeof source !== 'string')
+    throw new TypeError('"source" argument must be a string');
   if (!targetEncoding) {
     targetEncoding = encoding;
     encoding = 'utf8';
   }
+  targetEncoding = targetEncoding || 'utf8';
+  encoding = encoding || 'utf8';
+  if (source === '' || encoding === targetEncoding)
+    return source;
+  if (encoding === 'hex' && source.length % 2 !== 0)
+    throw new TypeError('Invalid hex string');
   return binding.encode(source, encoding, targetEncoding);
 };
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -348,6 +348,13 @@ Buffer.concat = function(list, length) {
   return buffer;
 };
 
+Buffer.encode = function(source, encoding, targetEncoding) {
+  if (!targetEncoding) {
+    targetEncoding = encoding;
+    encoding = 'utf8';
+  }
+  return binding.encode(source, encoding, targetEncoding);
+};
 
 function base64ByteLength(str, bytes) {
   // Handle padding

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -675,6 +675,48 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+void StringWriteWithoutBuffer(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = args.GetIsolate();
+
+  if (!args[0]->IsString())
+    return env->ThrowTypeError("Source must be a string");
+  enum encoding source_encoding = ParseEncoding(isolate, args[1], UTF8);
+  enum encoding target_encoding = ParseEncoding(isolate, args[2], UTF8);
+
+  Local<String> str = args[0]->ToString(isolate);
+
+  if (source_encoding == HEX && str->Length() % 2 != 0)
+    return env->ThrowTypeError("Invalid hex string");
+
+  const size_t length = StringBytes::Size(isolate, str, source_encoding);
+  size_t actual = 0;
+  char* data = nullptr;
+
+  if (length > 0) {
+    data = static_cast<char*>(BUFFER_MALLOC(length));
+
+    if (data == nullptr)
+      return env->ThrowError("Unable to encode string");
+
+    actual = StringBytes::Write(isolate, data, length, str, source_encoding);
+    CHECK(actual <= length);
+
+    if (actual == 0) {
+      free(data);
+      data = nullptr;
+    } else if (actual < length) {
+      data = static_cast<char*>(realloc(data, actual));
+      CHECK_NE(data, nullptr);
+    }
+  }
+
+  args.GetReturnValue().Set(StringBytes::Encode(isolate,
+                                                data,
+                                                target_encoding));
+
+  free(data);
+}
 
 template <encoding encoding>
 void StringWrite(const FunctionCallbackInfo<Value>& args) {
@@ -1233,6 +1275,8 @@ void Initialize(Local<Object> target,
 
   env->SetMethod(target, "swap16", Swap16);
   env->SetMethod(target, "swap32", Swap32);
+
+  env->SetMethod(target, "encode", StringWriteWithoutBuffer);
 
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxLength"),

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -716,9 +716,11 @@ void StringWriteWithoutBuffer(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  args.GetReturnValue().Set(StringBytes::Encode(isolate,
-                                                data,
-                                                target_encoding));
+  Local<Value> ret = StringBytes::Encode(isolate, data, target_encoding);
+  if (target_encoding == UCS2 && ret.IsEmpty())
+    return env->ThrowError("Unable to encode UCS2 string");
+    
+  args.GetReturnValue().Set(ret);
 
   if (release)
     free(data);

--- a/test/parallel/test-buffer-encode.js
+++ b/test/parallel/test-buffer-encode.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(Buffer.encode('test', 'hex'), '74657374');
+
+assert.strictEqual(Buffer.encode('test', 'base64'), 'dGVzdA==');
+

--- a/test/parallel/test-buffer-encode.js
+++ b/test/parallel/test-buffer-encode.js
@@ -7,3 +7,4 @@ assert.strictEqual(Buffer.encode('test', 'hex'), '74657374');
 
 assert.strictEqual(Buffer.encode('test', 'base64'), 'dGVzdA==');
 
+assert.strictEqual(Buffer.encode('74657374', 'hex', 'base64'), 'dGVzdA==');


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines


##### Affected core subsystem(s)

buffer

##### Description of change

/cc @trevnorris 

Adds Buffer.encode(str, str_enc, target_enc) as a fast, simple replacement for the pattern `Buffer.from(str, str_enc).toString(target_enc)`. The implementation is at least twice as efficient and doesn't require creating a new Buffer instance for straightforward conversions.

```js
// Instead of:
Buffer.from('test').toString('base64');

// It's
Buffer.encode('test', 'base64');
```

Benchmark, test and doc included.

Benchmark numbers: 
```
buffers/buffer-encode.js method=encode enc=utf8 size=16 millions=1: 3.14952
buffers/buffer-encode.js method=encode enc=utf8 size=512 millions=1: 1.72794
buffers/buffer-encode.js method=encode enc=utf8 size=1024 millions=1: 1.27162
buffers/buffer-encode.js method=encode enc=utf8 size=4096 millions=1: 0.42907
buffers/buffer-encode.js method=encode enc=utf16 size=16 millions=1: 3.01668
buffers/buffer-encode.js method=encode enc=utf16 size=512 millions=1: 1.66038
buffers/buffer-encode.js method=encode enc=utf16 size=1024 millions=1: 1.26316
buffers/buffer-encode.js method=encode enc=utf16 size=4096 millions=1: 0.48477
buffers/buffer-encode.js method=encode enc=hex size=16 millions=1: 3.11447
buffers/buffer-encode.js method=encode enc=hex size=512 millions=1: 1.68086
buffers/buffer-encode.js method=encode enc=hex size=1024 millions=1: 1.34287
buffers/buffer-encode.js method=encode enc=hex size=4096 millions=1: 0.47781
buffers/buffer-encode.js method=encode enc=base64 size=16 millions=1: 3.02440
buffers/buffer-encode.js method=encode enc=base64 size=512 millions=1: 1.71211
buffers/buffer-encode.js method=encode enc=base64 size=1024 millions=1: 1.27482
buffers/buffer-encode.js method=encode enc=base64 size=4096 millions=1: 0.47746
buffers/buffer-encode.js method=tostring enc=utf8 size=16 millions=1: 1.20082
buffers/buffer-encode.js method=tostring enc=utf8 size=512 millions=1: 0.76192
buffers/buffer-encode.js method=tostring enc=utf8 size=1024 millions=1: 0.51062
buffers/buffer-encode.js method=tostring enc=utf8 size=4096 millions=1: 0.26153
buffers/buffer-encode.js method=tostring enc=utf16 size=16 millions=1: 1.32567
buffers/buffer-encode.js method=tostring enc=utf16 size=512 millions=1: 0.75700
buffers/buffer-encode.js method=tostring enc=utf16 size=1024 millions=1: 0.57700
buffers/buffer-encode.js method=tostring enc=utf16 size=4096 millions=1: 0.26391
buffers/buffer-encode.js method=tostring enc=hex size=16 millions=1: 1.28990
buffers/buffer-encode.js method=tostring enc=hex size=512 millions=1: 0.74679
buffers/buffer-encode.js method=tostring enc=hex size=1024 millions=1: 0.55791
buffers/buffer-encode.js method=tostring enc=hex size=4096 millions=1: 0.26711
buffers/buffer-encode.js method=tostring enc=base64 size=16 millions=1: 1.32528
buffers/buffer-encode.js method=tostring enc=base64 size=512 millions=1: 0.75487
buffers/buffer-encode.js method=tostring enc=base64 size=1024 millions=1: 0.52509
buffers/buffer-encode.js method=tostring enc=base64 size=4096 millions=1: 0.26081
```

Perfectly ok if this doesn't land in core but the perf difference is compelling.