### PR TITLE
deps: cherry-pick 1383d00 from v8 upstream

### DIFF
--- a/deps/v8/tools/tickprocessor.js
+++ b/deps/v8/tools/tickprocessor.js
@@ -757,8 +757,11 @@ inherits(MacCppEntriesProvider, UnixCppEntriesProvider);
 MacCppEntriesProvider.prototype.loadSymbols = function(libName) {
   this.parsePos = 0;
   libName = this.targetRootFS + libName;
+
+  // It seems that in OS X `nm` thinks that `-f` is a format option, not a
+  // "flat" display option flag.
   try {
-    this.symbols = [os.system(this.nmExec, ['-n', '-f', libName], -1, -1), ''];
+    this.symbols = [os.system(this.nmExec, ['-n', libName], -1, -1), ''];
   } catch (e) {
     // If the library cannot be found on this system let's not panic.
     this.symbols = '';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

v8

##### Description of change

deps: cherry-pick 1383d00 from v8 upstream

Original commit message:

    tools: fix tickprocessor Cpp symbols on mac

    Despite man page documentation:

        -f Display the symbol table of a dynamic library flat (as one
           file not separate modules).

    `nm` on mac treats `-f` as a shorthand for `-format`. The `-f` argument
    does not seem to be required, so just remove it completely.

    (For `-format` documentation - see `nm --help` on mac).

    BUG=

    Review URL: https://codereview.chromium.org/1840633002

    Cr-Commit-Position: refs/heads/master@{#35445}

Fix: #5903