### PR TITLE
buffer: adds buffer.prototype.split / join

### DIFF
--- a/benchmark/buffers/buffer-indexes.js
+++ b/benchmark/buffers/buffer-indexes.js
@@ -1,13 +1,10 @@
+'use strict';
 var common = require('../common.js');
 var crypto = require('crypto');
-var assert = require('assert');
 
-const big = crypto.randomBytes(100000000 / 2).toString('hex') // 100mb
-const bigAssert = 100*1000*1000
-const small = `4320abc78a25ff6d9afbcb51924dcb4eef8ac424a0d7451b6e5001528c8a46` +
-              `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
-const smallAssert = `4320abc78a25ff6d9afbCB51924dCB4eef8ac424a0d7451b6e5001528c8a46` +
-                    `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
+const big = crypto.randomBytes(100000000 / 2).toString('hex'); // 100mb
+const small = '4320abc78a25ff6d9afbcb51924dcb4eef8ac424a0d7451b6e5001528c8a46' +
+              '5decff7d8e82e26176769b4266fdc05e4773bf'; // 100byte
 
 var bench = common.createBenchmark(main, {
   size: ['small', 'big'],
@@ -15,48 +12,44 @@ var bench = common.createBenchmark(main, {
   n: [1024]
 });
 
-var smallBuf = new Buffer(small)
-var bigBuf = new Buffer(big)
-var findStr = 'cb'
-var find = new Buffer(findStr)
-var indexing = null
-// var res = ''
-
+var smallBuf = new Buffer(small);
+var bigBuf = new Buffer(big);
+var findStr = 'cb';
+var find = new Buffer(findStr);
+var indexing = null;
 
 function main(conf) {
-  let buf = null
-  let len = null
+  let buf = null;
+  let len = null;
   var n = +conf.n;
 
   switch (conf.size) {
     case 'small':
-      buf = smallBuf
-      len = n * 1024
+      buf = smallBuf;
+      len = n * 1024;
       break;
     case 'big':
-      buf = bigBuf
-      len = 10
+      buf = bigBuf;
+      len = 10;
       break;
     default:
-      buf = smallBuf
-      len = n
+      buf = smallBuf;
+      len = n;
   }
   switch (conf.type) {
     case 'indexes':
-      indexing = function (buf) {
-        return buf.indexes(find)
-      }
+      indexing = function(buf) {
+        return buf.indexes(find);
+      };
       break;
   }
 
   bench.start();
-  let res = null
   for (var i = 0; i < len; i++) {
-    res = indexing(buf)
+    indexing(buf);
   }
 
-  res = null
-  buf = null
-  len = null
+  buf = null;
+  len = null;
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-indexes.js
+++ b/benchmark/buffers/buffer-indexes.js
@@ -1,0 +1,62 @@
+var common = require('../common.js');
+var crypto = require('crypto');
+var assert = require('assert');
+
+const big = crypto.randomBytes(100000000 / 2).toString('hex') // 100mb
+const bigAssert = 100*1000*1000
+const small = `4320abc78a25ff6d9afbcb51924dcb4eef8ac424a0d7451b6e5001528c8a46` +
+              `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
+const smallAssert = `4320abc78a25ff6d9afbCB51924dCB4eef8ac424a0d7451b6e5001528c8a46` +
+                    `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
+
+var bench = common.createBenchmark(main, {
+  size: ['small', 'big'],
+  type: ['indexes'],
+  n: [1024]
+});
+
+var smallBuf = new Buffer(small)
+var bigBuf = new Buffer(big)
+var findStr = 'cb'
+var find = new Buffer(findStr)
+var indexing = null
+// var res = ''
+
+
+function main(conf) {
+  let buf = null
+  let len = null
+  var n = +conf.n;
+
+  switch (conf.size) {
+    case 'small':
+      buf = smallBuf
+      len = n * 1024
+      break;
+    case 'big':
+      buf = bigBuf
+      len = 10
+      break;
+    default:
+      buf = smallBuf
+      len = n
+  }
+  switch (conf.type) {
+    case 'indexes':
+      indexing = function (buf) {
+        return buf.indexes(find)
+      }
+      break;
+  }
+
+  bench.start();
+  let res = null
+  for (var i = 0; i < len; i++) {
+    res = indexing(buf)
+  }
+
+  res = null
+  buf = null
+  len = null
+  bench.end(n);
+}

--- a/benchmark/buffers/buffer-split.js
+++ b/benchmark/buffers/buffer-split.js
@@ -12,7 +12,7 @@ const smallAssert = `4320abc78a25ff6d9afbCB51924dCB4eef8ac424a0d7451b6e5001528c8
 var bench = common.createBenchmark(main, {
   size: ['small', 'big'],
   assert: ['true', 'false'],
-  type: ['cpp', 'string'],
+  type: ['js_native', 'string'],
   n: [1024]
 });
 
@@ -23,47 +23,6 @@ var find = new Buffer(findStr)
 var replaceStr = 'CB'
 var replace = new Buffer(replaceStr)
 var splitAndJoin = null
-
-Buffer.prototype.replace = function replace(sub, newSub, encoding) {
-  // input must be buffer; else force convert it to one
-  // !(newSub instanceof Buffer) ? newSub = new Buffer(newSub) : 0
-  let indexes = [], i = -1; // target and index for occurences
-  let cursorOld = 0, cursorNew = 0, diff = 0 // cursors for replacing
-  // get all occurences of sub
-  while ((i = this.indexOf(sub, i + 1)) != -1) {
-    indexes.push(i);
-  }
-  // resulting buffer; shortly unallocated; destroy in error case
-  let res = Buffer.allocUnsafe(this.length -
-                               indexes.length * sub.length +
-                               indexes.length * newSub.length)
-
-  indexes.forEach((el, index, array) => {
-    // copy everthing until first occurence into new buffer. As consquence
-    // advance cursors (of the buffer reads) either according to the distances
-    // plus size of the insert
-    this.copy(res, cursorNew, cursorOld, el)
-    // calculate diff for the next jump mark of th cursor.
-    // First change requires a diff that is for both the same. This is different
-    // for first call where diffing begins at 0. Else note: diff between to
-    // occurences must be bumped up by 1
-    diff = el - (index > 0 ? array[index - 1] + 1 : 0)
-    cursorNew += diff
-    cursorOld += diff
-    // copy over the replacement for sub part of bufffer
-    newSub.copy(res, cursorNew, 0, newSub.length)
-    // advance cursor by replacement length
-    cursorNew += newSub.length
-    // advance cursor by one except for the last time. At last call we just want
-    // to copy until the end of the resulting buffer
-    index !== array.length ? cursorOld += sub.length : 0
-  })
-  // this doesn't need iteration since we just want to fill the rest of the
-  // buffer starting from the last occurence until computed end.
-  this.copy(res, cursorNew, cursorOld, res.length)
-
-  return res
-}
 
 
 function main(conf) {
@@ -85,18 +44,13 @@ function main(conf) {
       len = n
   }
   switch (conf.type) {
-    case 'js':
-      splitAndJoin = function (buf) {
-        return buf.replace(find, replace)
-      }
-      break;
     case 'string':
       splitAndJoin = function (buf) {
         let res = buf.toString().split(findStr)
         return res.join(replaceStr)
       }
       break;
-    case 'cpp':
+    case 'js_native':
       splitAndJoin = function (buf) {
         let res = buf.split(find)
         return Buffer.join(res, replace)

--- a/benchmark/buffers/buffer-split.js
+++ b/benchmark/buffers/buffer-split.js
@@ -1,0 +1,124 @@
+var common = require('../common.js');
+var crypto = require('crypto');
+var assert = require('assert');
+
+const big = crypto.randomBytes(100000000 / 2).toString('hex') // 100mb
+const bigAssert = 100*1000*1000
+const small = `4320abc78a25ff6d9afbcb51924dcb4eef8ac424a0d7451b6e5001528c8a46` +
+              `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
+const smallAssert = `4320abc78a25ff6d9afbCB51924dCB4eef8ac424a0d7451b6e5001528c8a46` +
+                    `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
+
+var bench = common.createBenchmark(main, {
+  size: ['small', 'big'],
+  assert: ['true', 'false'],
+  type: ['cpp', 'string'],
+  n: [1024]
+});
+
+var smallBuf = new Buffer(small)
+var bigBuf = new Buffer(big)
+var findStr = 'cb'
+var find = new Buffer(findStr)
+var replaceStr = 'CB'
+var replace = new Buffer(replaceStr)
+var splitAndJoin = null
+
+Buffer.prototype.replace = function replace(sub, newSub, encoding) {
+  // input must be buffer; else force convert it to one
+  // !(newSub instanceof Buffer) ? newSub = new Buffer(newSub) : 0
+  let indexes = [], i = -1; // target and index for occurences
+  let cursorOld = 0, cursorNew = 0, diff = 0 // cursors for replacing
+  // get all occurences of sub
+  while ((i = this.indexOf(sub, i + 1)) != -1) {
+    indexes.push(i);
+  }
+  // resulting buffer; shortly unallocated; destroy in error case
+  let res = Buffer.allocUnsafe(this.length -
+                               indexes.length * sub.length +
+                               indexes.length * newSub.length)
+
+  indexes.forEach((el, index, array) => {
+    // copy everthing until first occurence into new buffer. As consquence
+    // advance cursors (of the buffer reads) either according to the distances
+    // plus size of the insert
+    this.copy(res, cursorNew, cursorOld, el)
+    // calculate diff for the next jump mark of th cursor.
+    // First change requires a diff that is for both the same. This is different
+    // for first call where diffing begins at 0. Else note: diff between to
+    // occurences must be bumped up by 1
+    diff = el - (index > 0 ? array[index - 1] + 1 : 0)
+    cursorNew += diff
+    cursorOld += diff
+    // copy over the replacement for sub part of bufffer
+    newSub.copy(res, cursorNew, 0, newSub.length)
+    // advance cursor by replacement length
+    cursorNew += newSub.length
+    // advance cursor by one except for the last time. At last call we just want
+    // to copy until the end of the resulting buffer
+    index !== array.length ? cursorOld += sub.length : 0
+  })
+  // this doesn't need iteration since we just want to fill the rest of the
+  // buffer starting from the last occurence until computed end.
+  this.copy(res, cursorNew, cursorOld, res.length)
+
+  return res
+}
+
+
+function main(conf) {
+  let buf = null
+  let len = null
+  var n = +conf.n;
+
+  switch (conf.size) {
+    case 'small':
+      buf = smallBuf
+      len = n * 1024
+      break;
+    case 'big':
+      buf = bigBuf
+      len = 10
+      break;
+    default:
+      buf = smallBuf
+      len = n
+  }
+  switch (conf.type) {
+    case 'js':
+      splitAndJoin = function (buf) {
+        return buf.replace(find, replace)
+      }
+      break;
+    case 'string':
+      splitAndJoin = function (buf) {
+        let res = buf.toString().split(findStr)
+        return res.join(replaceStr)
+      }
+      break;
+    case 'cpp':
+      splitAndJoin = function (buf) {
+        let res = buf.split(find)
+        return Buffer.join(res, replace)
+      }
+      break;
+  }
+
+  bench.start();
+  let res = null
+  for (var i = 0; i < len; i++) {
+    res = splitAndJoin(buf)
+  }
+
+  if (conf.assert === 'true' && conf.size === 'small') {
+    assert(res.toString() === smallAssert)
+  }
+
+  if (conf.assert === 'true' && conf.size === 'big') {
+    assert(res.toString().length === bigAssert)
+  }
+  res = null
+  buf = null
+  len = null
+  bench.end(n);
+}

--- a/benchmark/buffers/buffer-split.js
+++ b/benchmark/buffers/buffer-split.js
@@ -1,13 +1,14 @@
+'use strict';
 var common = require('../common.js');
 var crypto = require('crypto');
 var assert = require('assert');
 
-const big = crypto.randomBytes(100000000 / 2).toString('hex') // 100mb
-const bigAssert = 100*1000*1000
-const small = `4320abc78a25ff6d9afbcb51924dcb4eef8ac424a0d7451b6e5001528c8a46` +
-              `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
-const smallAssert = `4320abc78a25ff6d9afbCB51924dCB4eef8ac424a0d7451b6e5001528c8a46` +
-                    `5decff7d8e82e26176769b4266fdc05e4773bf` // 100byte
+const big = crypto.randomBytes(100000000 / 2).toString('hex'); // 100mb
+const bigAssert = 100 * 1000 * 1000;
+const small = '4320abc78a25ff6d9afbcb51924dcb4eef8ac424a0d7451b6e5001528c8a46' +
+              '5decff7d8e82e26176769b4266fdc05e4773bf'; // 100byte
+const smallAssert = '4320abc78a25ff6d9afbCB51924dCB4eef8ac424a0d7451b6e500152' +
+                    '8c8a465decff7d8e82e26176769b4266fdc05e4773bf'; // 100byte
 
 var bench = common.createBenchmark(main, {
   size: ['small', 'big'],
@@ -16,63 +17,63 @@ var bench = common.createBenchmark(main, {
   n: [1024]
 });
 
-var smallBuf = new Buffer(small)
-var bigBuf = new Buffer(big)
-var findStr = 'cb'
-var find = new Buffer(findStr)
-var replaceStr = 'CB'
-var replace = new Buffer(replaceStr)
-var splitAndJoin = null
+var smallBuf = new Buffer(small);
+var bigBuf = new Buffer(big);
+var findStr = 'cb';
+var find = new Buffer(findStr);
+var replaceStr = 'CB';
+var replace = new Buffer(replaceStr);
+var splitAndJoin = null;
 
 
 function main(conf) {
-  let buf = null
-  let len = null
+  let buf = null;
+  let len = null;
   var n = +conf.n;
 
   switch (conf.size) {
     case 'small':
-      buf = smallBuf
-      len = n * 1024
+      buf = smallBuf;
+      len = n * 1024;
       break;
     case 'big':
-      buf = bigBuf
-      len = 10
+      buf = bigBuf;
+      len = 10;
       break;
     default:
-      buf = smallBuf
-      len = n
+      buf = smallBuf;
+      len = n;
   }
   switch (conf.type) {
     case 'string':
-      splitAndJoin = function (buf) {
-        let res = buf.toString().split(findStr)
-        return res.join(replaceStr)
-      }
+      splitAndJoin = function(buf) {
+        const res = buf.toString().split(findStr);
+        return res.join(replaceStr);
+      };
       break;
     case 'js_native':
-      splitAndJoin = function (buf) {
-        let res = buf.split(find)
-        return Buffer.join(res, replace)
-      }
+      splitAndJoin = function(buf) {
+        const res = buf.split(find);
+        return Buffer.join(res, replace);
+      };
       break;
   }
 
   bench.start();
-  let res = null
+  let res = null;
   for (var i = 0; i < len; i++) {
-    res = splitAndJoin(buf)
+    res = splitAndJoin(buf);
   }
 
   if (conf.assert === 'true' && conf.size === 'small') {
-    assert(res.toString() === smallAssert)
+    assert(res.toString() === smallAssert);
   }
 
   if (conf.assert === 'true' && conf.size === 'big') {
-    assert(res.toString().length === bigAssert)
+    assert(res.toString().length === bigAssert);
   }
-  res = null
-  buf = null
-  len = null
+  res = null;
+  buf = null;
+  len = null;
   bench.end(n);
 }

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -589,6 +589,71 @@ console.log(bufA.length);
 // 42
 ```
 
+### Class Method: Buffer.split([separator])
+
+* `separator` {Buffer} A separator that gets matched against the input buffer
+* Return: {Array} Array of Buffers
+
+`Buffer.split()` behaves similar to `String.prototype.split`, as such it matches
+an input against a source buffer, splits the source buffer, removes the input
+and returns the number of resulting buffers in an array.
+
+```js
+const buf = new Buffer('Hello World');
+const res = buf.split(new Buffer(' '))
+
+console.log(res);
+// [ <Buffer 48 65 6c 6c 6f>, <Buffer 57 6f 72 6c 64> ]
+```
+
+It is also possible to split with an empty buffer, which results in an array
+with the single bytes of buffer contents wrapped in new buffers.
+
+```js
+const buf = new Buffer('Hello');
+const res = buf.split(new Buffer(''))
+
+console.log(res);
+// [ <Buffer 48>, <Buffer 65>, <Buffer 6c>, <Buffer 6c>, <Buffer 6f> ]
+```
+
+### Class Method: Buffer.join(array[, insert])
+
+* `array` {Array} Array of buffers that will be joined together
+* `insert` {Buffer} Buffer that gets inserted between the subjects
+* Return: {Buffer}
+
+`Buffer.join()` behaves similar to `Array.prototype.join`, as such it matches
+takes an array of buffers and generate new buffer with the concatenated buffers.
+Optionally it takes a an `insert` as argument that will be inserted between the
+buffers.
+
+```js
+const res = Buffer.join([
+  new Buffer('Hello'),
+  new Buffer('World'),
+], new Buffer('\n'));
+
+console.log(res);
+// <Buffer 48 65 6c 6c 6f 0a 57 6f 72 6c 64>
+console.log(res.toString());
+// Hello
+// World
+```
+
+_Note: `Array.prototype.join` would fill in commas if no insert will be
+provided. `Buffer.join()` though will simply concat against the next buffer._
+
+```js
+const res = Buffer.join([
+  new Buffer('Hello'),
+  new Buffer('World'),
+]);
+
+console.log(res.toString());
+// HelloWorld
+```
+
 ### Class Method: Buffer.from(array)
 
 * `array` {Array}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -658,6 +658,28 @@ Buffer.prototype.includes = function includes(val, byteOffset, encoding) {
   return this.indexOf(val, byteOffset, encoding) !== -1;
 };
 
+// Limit currently not implemented; reserved
+Buffer.prototype.split = function split(sep, limit) {
+  if (!limit)
+    limit = null;
+  if (!sep)
+    return [this];
+  if (!Buffer.isBuffer(sep))
+    throw new TypeError('First argument must be a buffer.');
+
+  return binding.split(this, sep, limit);
+};
+
+// not overriding prototype here, because of Uint8Array, REVIEW
+Buffer.join = function join(array, insert) {
+  if (!insert)
+    insert = null;
+  if (!Array.isArray(array) || !Buffer.isBuffer(array[0]))
+    throw new TypeError('First argument must be an array of buffers with ' +
+                                                        'at least one buffer.');
+
+  return binding.join(array, array.length, insert);
+};
 
 // Usage:
 //    buffer.fill(number[, offset[, end]])

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -659,7 +659,14 @@ Buffer.prototype.includes = function includes(val, byteOffset, encoding) {
 };
 
 Buffer.prototype.indexes = function indexes(match) {
-  return binding.indexes(this, match);
+  if (!Buffer.isBuffer(match))
+    throw new TypeError('argument must be a Buffer')
+  let indexes = [], i = -1;
+
+  while ((i = this.indexOf(match, i + 1)) != -1) {
+    indexes.push(i);
+  }
+  return indexes;
 };
 
 // Limit currently not implemented; reserved

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -670,8 +670,12 @@ Buffer.prototype.indexes = function indexes(match) {
   return indexes;
 };
 
-// Limit currently not implemented; reserved
-Buffer.prototype.split = function split(sep, limit) {
+Buffer.prototype.split = function split(sep, encoding, limit) {
+  if (!limit && typeof encondig === 'number')
+    limit = encoding
+  if (sep)
+    sep = Buffer.from(sep, encoding); // allows all constructor APIs
+
   const res = [];
   const sepLen = sep ? sep.byteLength : undefined;
   const indexes = sep ? this.indexes(sep) : [];

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -658,13 +658,15 @@ Buffer.prototype.includes = function includes(val, byteOffset, encoding) {
   return this.indexOf(val, byteOffset, encoding) !== -1;
 };
 
-Buffer.prototype.indexes = function indexes(match) {
+Buffer.prototype.indexes = function indexes(match, limit) {
   if (!Buffer.isBuffer(match))
     throw new TypeError('argument must be a Buffer');
   const indexes = [];
   let i = -1;
 
   while ((i = this.indexOf(match, i + 1)) != -1) {
+    if (i > limit)
+      break;
     indexes.push(i);
   }
   return indexes;
@@ -672,7 +674,7 @@ Buffer.prototype.indexes = function indexes(match) {
 
 Buffer.prototype.split = function split(sep, encoding, limit) {
   if (!limit && typeof encondig === 'number')
-    limit = encoding
+    limit = encoding;
   if (sep)
     sep = Buffer.from(sep, encoding); // allows all constructor APIs
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -660,8 +660,9 @@ Buffer.prototype.includes = function includes(val, byteOffset, encoding) {
 
 Buffer.prototype.indexes = function indexes(match) {
   if (!Buffer.isBuffer(match))
-    throw new TypeError('argument must be a Buffer')
-  let indexes = [], i = -1;
+    throw new TypeError('argument must be a Buffer');
+  const indexes = [];
+  let i = -1;
 
   while ((i = this.indexOf(match, i + 1)) != -1) {
     indexes.push(i);
@@ -671,30 +672,30 @@ Buffer.prototype.indexes = function indexes(match) {
 
 // Limit currently not implemented; reserved
 Buffer.prototype.split = function split(sep, limit) {
-  let res = [];
+  const res = [];
   const sepLen = sep ? sep.byteLength : undefined;
   const indexes = sep ? this.indexes(sep) : [];
 
   if (sepLen > 0) {
     let cursor = 0;
-    let len = indexes.length;
+    const len = indexes.length;
     // push from index to index; catch last case after loop
     for (let i = 0; i < len; i++) {
-      res.push(this.slice(cursor, indexes[i]))
+      res.push(this.slice(cursor, indexes[i]));
       cursor += indexes[i] - cursor + sepLen;
     }
-    res.push(this.slice(cursor))
+    res.push(this.slice(cursor));
 
   } else if (sepLen === 0) {
-    let len = this.byteLength;
+    const len = this.byteLength;
     // slice through from start to end
     for (let i = 0; i < len; i++) {
-      res.push(this.slice(i, i + 1))
+      res.push(this.slice(i, i + 1));
     }
 
   } else if (sepLen === undefined) {
     // compliance to String.prototype.split; return array of one buffer
-    res.push(this)
+    res.push(this);
   }
 
   return res;
@@ -702,14 +703,14 @@ Buffer.prototype.split = function split(sep, limit) {
 
 // not overriding prototype here, because of Uint8Array, REVIEW
 Buffer.join = function join(array, insert) {
-  if (array.length ===0)
+  if (array.length === 0)
     throw new TypeError('first argument must be an array of Buffers');
   if (array.length === 1)
     return Buffer.concat(array);
 
   const len = array.length * (insert ? 2 : 1);
   const minusLastOrNot = insert ? 1 : 0;
-  let arr = new Array(len - minusLastOrNot);
+  const arr = new Array(len - minusLastOrNot);
   let i = 0;
   let j = 0;
 
@@ -725,7 +726,7 @@ Buffer.join = function join(array, insert) {
     }
   }
 
-  return Buffer.concat(arr)
+  return Buffer.concat(arr);
 };
 
 // Usage:

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -673,14 +673,15 @@ Buffer.prototype.indexes = function indexes(match, limit) {
 };
 
 Buffer.prototype.split = function split(sep, encoding, limit) {
-  if (!limit && typeof encondig === 'number')
+  if (!limit && typeof encoding === 'number')
     limit = encoding;
   if (sep)
     sep = Buffer.from(sep, encoding); // allows all constructor APIs
 
   const res = [];
+  // false case: return Array of 1 Buffer
   const sepLen = sep ? sep.byteLength : undefined;
-  const indexes = sep ? this.indexes(sep) : [];
+  const indexes = sep ? this.indexes(sep, limit) : [];
 
   if (sepLen > 0) {
     let cursor = 0;
@@ -690,11 +691,13 @@ Buffer.prototype.split = function split(sep, encoding, limit) {
       res.push(this.slice(cursor, indexes[i]));
       cursor += indexes[i] - cursor + sepLen;
     }
-    res.push(this.slice(cursor));
+    // push to the end when no limit is given or when cursor is still below it
+    if (!limit || cursor < limit)
+      res.push(this.slice(cursor));
 
   } else if (sepLen === 0) {
     const len = this.byteLength;
-    // slice through from start to end
+    // slice through from start to end, byte by byte
     for (let i = 0; i < len; i++) {
       res.push(this.slice(i, i + 1));
     }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -664,10 +664,12 @@ Buffer.prototype.indexes = function indexes(match, limit) {
   const indexes = [];
   let i = -1;
 
+  let len = 0
   while ((i = this.indexOf(match, i + 1)) != -1) {
-    if (i > limit)
-      break;
     indexes.push(i);
+    len++;
+    if (len >= limit)
+      break;
   }
   return indexes;
 };
@@ -692,7 +694,7 @@ Buffer.prototype.split = function split(sep, encoding, limit) {
       cursor += indexes[i] - cursor + sepLen;
     }
     // push to the end when no limit is given or when cursor is still below it
-    if (!limit || cursor < limit)
+    if (!limit || cursor <= limit)
       res.push(this.slice(cursor));
 
   } else if (sepLen === 0) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -664,14 +664,33 @@ Buffer.prototype.indexes = function indexes(match) {
 
 // Limit currently not implemented; reserved
 Buffer.prototype.split = function split(sep, limit) {
-  if (!limit)
-    limit = null;
-  if (!sep)
-    return [this];
-  if (!Buffer.isBuffer(sep))
-    throw new TypeError('First argument must be a buffer.');
+  let res = [];
+  const sepLen = sep ? sep.byteLength : undefined;
+  const indexes = sep ? this.indexes(sep) : [];
 
-  return binding.split(this, sep, limit);
+  if (sepLen > 0) {
+    let cursor = 0;
+    let len = indexes.length;
+    // push from index to index; catch last case after loop
+    for (let i = 0; i < len; i++) {
+      res.push(this.slice(cursor, indexes[i]))
+      cursor += indexes[i] - cursor + sepLen;
+    }
+    res.push(this.slice(cursor))
+
+  } else if (sepLen === 0) {
+    let len = this.byteLength;
+    // slice through from start to end
+    for (let i = 0; i < len; i++) {
+      res.push(this.slice(i, i + 1))
+    }
+
+  } else if (sepLen === undefined) {
+    // compliance to String.prototype.split; return array of one buffer
+    res.push(this)
+  }
+
+  return res;
 };
 
 // not overriding prototype here, because of Uint8Array, REVIEW

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -695,13 +695,30 @@ Buffer.prototype.split = function split(sep, limit) {
 
 // not overriding prototype here, because of Uint8Array, REVIEW
 Buffer.join = function join(array, insert) {
-  if (!insert)
-    insert = null;
-  if (!Array.isArray(array) || !Buffer.isBuffer(array[0]))
-    throw new TypeError('First argument must be an array of buffers with ' +
-                                                        'at least one buffer.');
+  if (array.length ===0)
+    throw new TypeError('first argument must be an array of Buffers');
+  if (array.length === 1)
+    return Buffer.concat(array);
 
-  return binding.join(array, array.length, insert);
+  const len = array.length * (insert ? 2 : 1);
+  const minusLastOrNot = insert ? 1 : 0;
+  let arr = new Array(len - minusLastOrNot);
+  let i = 0;
+  let j = 0;
+
+  while (i < len) {
+    arr[i] = array[j];
+    j++;
+    i++;
+    if (i == len - minusLastOrNot)
+      break;
+    if (insert) {
+      arr[i] = insert;
+      i++;
+    }
+  }
+
+  return Buffer.concat(arr)
 };
 
 // Usage:

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -658,6 +658,10 @@ Buffer.prototype.includes = function includes(val, byteOffset, encoding) {
   return this.indexOf(val, byteOffset, encoding) !== -1;
 };
 
+Buffer.prototype.indexes = function indexes(match) {
+  return binding.indexes(this, match);
+};
+
 // Limit currently not implemented; reserved
 Buffer.prototype.split = function split(sep, limit) {
   if (!limit)

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1359,6 +1359,9 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "readFloatBE", ReadFloatBE);
   env->SetMethod(target, "readFloatLE", ReadFloatLE);
 
+  env->SetMethod(target, "split", Split);
+  env->SetMethod(target, "join", Join);
+
   env->SetMethod(target, "writeDoubleBE", WriteDoubleBE);
   env->SetMethod(target, "writeDoubleLE", WriteDoubleLE);
   env->SetMethod(target, "writeFloatBE", WriteFloatBE);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1191,6 +1191,11 @@ void Split(const FunctionCallbackInfo<Value>& args) {
 
   res_buffers = v8::Array::New(env->isolate(), index_arr.size());
   len = (size_t)index_arr.size();
+  if (len == 0) {
+    obj = Buffer::New(env->isolate(), buf, js_buf_length).ToLocalChecked();
+    res_buffers->Set(0, obj);
+    goto return_array;
+  }
 
   for (size_t i = 0; i < len + 1; i++) {
     size_t index = index_arr[i] - cursor;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1142,55 +1142,6 @@ void IndexOfNumber(const FunctionCallbackInfo<Value>& args) {
                                 : -1);
 }
 
-void Indexes(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
-  THROW_AND_RETURN_UNLESS_BUFFER(env, args[1]);
-  SPREAD_ARG(args[0], js_buf);
-  SPREAD_ARG(args[1], js_sep_buf);
-
-  Local<v8::Array> res;
-  std::vector<size_t> index_arr;
-  size_t res_length = 0;
-
-  char* buf = js_buf_data;
-  size_t sep_buf_len = js_sep_buf_length;
-  char *sep_buf = js_sep_buf_data;
-  unsigned char first_match_byte = (unsigned char) sep_buf[0];
-
-  // bail early
-  if (sep_buf_len == 0 || sep_buf_len > js_buf_length) {
-    res = v8::Array::New(env->isolate(), 0);
-    goto return_array;
-  }
-
-  for (size_t i = 0; i < js_buf_length; ++i) {
-    unsigned char byte = (unsigned char)buf[i];
-    // check first occurence...
-    // ...and if separator > 1 check consecutive bytes for equalness.
-    if (sep_buf_len == 1 && byte == first_match_byte) {
-      index_arr.push_back(i);
-    } else if (byte == first_match_byte) {
-      for (size_t j = 0; j < sep_buf_len; ++j) {
-        unsigned char sep_byte = (unsigned char)buf[i + j];
-        // only push to array when the whole separator got compared
-        if (sep_byte == sep_buf[j] && j == sep_buf_len - 1) {
-          index_arr.push_back(i);
-        }
-      }
-    }
-  }
-
-  res = v8::Array::New(env->isolate(), index_arr.size());
-  for (size_t i = 0; i < index_arr.size(); i++) {
-    res->Set(i, v8::Integer::New(env->isolate(), index_arr[i]));
-  }
-
-return_array:
-  return args.GetReturnValue().Set(res);
-}
-
 void Swap16(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   THROW_AND_RETURN_UNLESS_BUFFER(env, args.This());
@@ -1269,8 +1220,6 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "indexOfBuffer", IndexOfBuffer);
   env->SetMethod(target, "indexOfNumber", IndexOfNumber);
   env->SetMethod(target, "indexOfString", IndexOfString);
-
-  env->SetMethod(target, "indexes", Indexes);
 
   env->SetMethod(target, "readDoubleBE", ReadDoubleBE);
   env->SetMethod(target, "readDoubleLE", ReadDoubleLE);

--- a/test/parallel/test-buffer-indexes.js
+++ b/test/parallel/test-buffer-indexes.js
@@ -2,14 +2,14 @@
 const assert = require('assert');
 const common = require('../common');
 
-const TEST_BUF = Buffer.from('Hello World, the day of tomorrows past')
+const TEST_BUF = Buffer.from('Hello World, the day of tomorrows past');
 
 assert(common);
 
-assert(TEST_BUF.indexes(new Buffer('or')).length === 2)
-assert(TEST_BUF.indexes(new Buffer('o')).length === 6)
-assert(TEST_BUF.indexes(new Buffer('k')).length === 0)
-assert(TEST_BUF.indexes(new Buffer('')).length === 0)
+assert(TEST_BUF.indexes(new Buffer('or')).length === 2);
+assert(TEST_BUF.indexes(new Buffer('o')).length === 6);
+assert(TEST_BUF.indexes(new Buffer('k')).length === 0);
+assert(TEST_BUF.indexes(new Buffer('')).length === 0);
 
-assert(new Buffer('short').indexes(new Buffer('veeeerylong')).length === 0)
-assert(new Buffer('short').indexes(new Buffer('shortnotshort')).length === 0)
+assert(new Buffer('short').indexes(new Buffer('veeeerylong')).length === 0);
+assert(new Buffer('short').indexes(new Buffer('shortnotshort')).length === 0);

--- a/test/parallel/test-buffer-indexes.js
+++ b/test/parallel/test-buffer-indexes.js
@@ -11,5 +11,7 @@ assert(TEST_BUF.indexes(new Buffer('o')).length === 6);
 assert(TEST_BUF.indexes(new Buffer('k')).length === 0);
 assert(TEST_BUF.indexes(new Buffer('')).length === 0);
 
+assert(new Buffer('oooo').indexes(new Buffer('o'), 2).length === 3);
+
 assert(new Buffer('short').indexes(new Buffer('veeeerylong')).length === 0);
 assert(new Buffer('short').indexes(new Buffer('shortnotshort')).length === 0);

--- a/test/parallel/test-buffer-indexes.js
+++ b/test/parallel/test-buffer-indexes.js
@@ -1,0 +1,15 @@
+'use strict';
+const assert = require('assert');
+const common = require('../common');
+
+const TEST_BUF = Buffer.from('Hello World, the day of tomorrows past')
+
+assert(common);
+
+assert(TEST_BUF.indexes(new Buffer('or')).length === 2)
+assert(TEST_BUF.indexes(new Buffer('o')).length === 6)
+assert(TEST_BUF.indexes(new Buffer('k')).length === 0)
+assert(TEST_BUF.indexes(new Buffer('')).length === 0)
+
+assert(new Buffer('short').indexes(new Buffer('veeeerylong')).length === 0)
+assert(new Buffer('short').indexes(new Buffer('shortnotshort')).length === 0)

--- a/test/parallel/test-buffer-split-join.js
+++ b/test/parallel/test-buffer-split-join.js
@@ -1,0 +1,159 @@
+'use strict';
+const assert = require('assert');
+const common = require('../common');
+
+assert(common);
+
+/*
+  gatekeepers
+ */
+assert.throws(() => {
+  const buf = new Buffer('Hello World, the day of tomorrows past');
+  buf.split('o');
+}, TypeError);
+
+assert.doesNotThrow(() => {
+  const buf = new Buffer('Hello World, the day of tomorrows past');
+  buf.split(new Buffer('o'));
+}, TypeError);
+
+assert.throws(() => {
+  Buffer.join(['String']);
+}, TypeError);
+
+assert.doesNotThrow(() => {
+  const buf = new Buffer('Buffer from String');
+  Buffer.join([buf]);
+}, TypeError);
+
+assert.doesNotThrow(() => {
+  Buffer.join([new Buffer('Buffer from String')]);
+}, Error);
+
+/*
+  e2e
+ */
+{
+  const buf = new Buffer('Hello World, the day of tomorrows past');
+  const res = buf.split(new Buffer('o'));
+
+  assert(res.length === 7);
+
+  assert(Buffer.compare(res[0], new Buffer('Hell')) === 0);
+  assert(Buffer.compare(res[1], new Buffer(' W')) === 0);
+  assert(Buffer.compare(res[2], new Buffer('rld, the day ')) === 0);
+  assert(Buffer.compare(res[3], new Buffer('f t')) === 0);
+  assert(Buffer.compare(res[4], new Buffer('m')) === 0);
+  assert(Buffer.compare(res[5], new Buffer('rr')) === 0);
+  assert(Buffer.compare(res[6], new Buffer('ws past')) === 0);
+}
+
+/*
+  edge cases
+ */
+{
+  // Returns empty buffers for edges
+  const buf = new Buffer('ABCdEF');
+  const res_1 = buf.split(new Buffer('F'));
+  const res_2 = buf.split(new Buffer('A'));
+
+  assert(res_1.length === 2);
+  assert(res_2.length === 2);
+
+  assert(Buffer.compare(res_1[0], new Buffer('ABCdE')) === 0);
+  assert(Buffer.compare(res_1[1], new Buffer('')) === 0);
+  assert(Buffer.compare(res_2[1], new Buffer('BCdEF')) === 0);
+  assert(Buffer.compare(res_2[0], new Buffer('')) === 0);
+}
+
+{
+  // Returns array of == buffer.length when sep buffer is empty
+  const buf = new Buffer('ABCdEF');
+  const res = buf.split(new Buffer(''));
+  assert(res.length === 6);
+
+  assert(Buffer.compare(res[0], new Buffer('A')) === 0);
+  assert(Buffer.compare(res[1], new Buffer('B')) === 0);
+  assert(Buffer.compare(res[2], new Buffer('C')) === 0);
+  assert(Buffer.compare(res[3], new Buffer('d')) === 0);
+  assert(Buffer.compare(res[4], new Buffer('E')) === 0);
+  assert(Buffer.compare(res[5], new Buffer('F')) === 0);
+}
+
+{
+  // Returns array of with the the buffer
+  const buf = new Buffer('ABCdEF');
+  const res = buf.split();
+  assert(res.length === 1);
+
+  assert(Buffer.compare(res[0], new Buffer('ABCdEF')) === 0);
+}
+
+{
+  const res = Buffer.join([
+    new Buffer('Hello'),
+    new Buffer(' World')
+  ]);
+  assert(Buffer.compare(res, new Buffer('Hello World')) === 0);
+}
+
+{
+  const res = Buffer.join([
+    new Buffer('Hello'),
+    new Buffer('World'),
+    new Buffer(','),
+    new Buffer('the day of tomorrows past')
+  ], new Buffer('\n'));
+  assert(Buffer.compare(res, new Buffer('Hello\nWorld\n,\nthe day of ' +
+                                                      'tomorrows past')) === 0);
+}
+
+assert.throws(() => {
+  Buffer.join([
+    new Buffer('Hello'),
+    ' ',
+    new Buffer('World')
+  ]);
+}, TypeError);
+
+{
+  const res = Buffer.join([
+    new Buffer('Hello')
+  ]);
+  assert(Buffer.compare(res, new Buffer('Hello')) === 0);
+}
+
+{
+  const res = Buffer.join([
+    new Buffer('Hello')
+  ], new Buffer('\n'));
+  assert(Buffer.compare(res, new Buffer('Hello')) === 0);
+}
+
+assert.throws(() => {
+  Buffer.join([]);
+}, TypeError);
+
+/*
+  Non-string buffers
+ */
+{
+  const res = Buffer.from([1, 2, 3, 4, 5, 6, 10, 100]).split(new Buffer([10]));
+  assert(res.length === 2);
+  assert(Buffer.compare(res[0], new Buffer([1, 2, 3, 4, 5, 6])) === 0);
+  assert(Buffer.compare(res[1], new Buffer([100])) === 0);
+
+  const res_2 = Buffer.join(res, new Buffer([11]));
+  assert(Buffer.compare(res_2, new Buffer([1, 2, 3, 4, 5, 6, 11, 100])) === 0);
+}
+
+{
+  const buf = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64'); // 'hello world'
+  const buf_2 = Buffer.alloc(1, 'IA==', 'base64')     ;    // ' '
+  const res_1 = buf.split(buf_2);                          // ['hello', 'world']
+  assert(Buffer.compare(res_1[0], new Buffer('hello')) === 0);
+  assert(Buffer.compare(res_1[1], new Buffer('world')) === 0);
+
+  const res_2 = Buffer.join(res_1, Buffer.alloc(1, 'Cg==', 'base64')); // '\n'
+  assert(Buffer.compare(res_2, new Buffer('hello\nworld')) === 0);
+}

--- a/test/parallel/test-buffer-split-join.js
+++ b/test/parallel/test-buffer-split-join.js
@@ -48,6 +48,14 @@ assert.doesNotThrow(() => {
   assert(Buffer.compare(res[6], new Buffer('ws past')) === 0);
 }
 
+{
+  const buf = new Buffer('Hello World, the day of tomorrows past');
+  let res = buf.split(new Buffer('or'));
+  res = Buffer.join(res, new Buffer('01'))
+  let comp = new Buffer('Hello W01ld, the day of tom01rows past')
+  assert(Buffer.compare(res, comp) === 0);
+}
+
 /*
   edge cases
  */

--- a/test/parallel/test-buffer-split-join.js
+++ b/test/parallel/test-buffer-split-join.js
@@ -51,8 +51,8 @@ assert.doesNotThrow(() => {
 {
   const buf = new Buffer('Hello World, the day of tomorrows past');
   let res = buf.split(new Buffer('or'));
-  res = Buffer.join(res, new Buffer('01'))
-  let comp = new Buffer('Hello W01ld, the day of tom01rows past')
+  res = Buffer.join(res, new Buffer('01'));
+  const comp = new Buffer('Hello W01ld, the day of tom01rows past');
   assert(Buffer.compare(res, comp) === 0);
 }
 

--- a/test/parallel/test-buffer-split-join.js
+++ b/test/parallel/test-buffer-split-join.js
@@ -7,10 +7,6 @@ assert(common);
 /*
   gatekeepers
  */
-assert.throws(() => {
-  const buf = new Buffer('Hello World, the day of tomorrows past');
-  buf.split('o');
-}, TypeError);
 
 assert.doesNotThrow(() => {
   const buf = new Buffer('Hello World, the day of tomorrows past');

--- a/test/parallel/test-buffer-split-join.js
+++ b/test/parallel/test-buffer-split-join.js
@@ -94,8 +94,9 @@ assert.doesNotThrow(() => {
 }
 
 {
+  // conexecutive matches reult in empty buffers, limit to three results
   const buf = new Buffer('Heeello');
-  const res = buf.split('e', 4);
+  const res = buf.split('e', 3);
 
   assert(res.length === 3);
 
@@ -105,8 +106,9 @@ assert.doesNotThrow(() => {
 }
 
 {
+  // conexecutive matches reult in empty buffers
   const buf = new Buffer('Heeello');
-  const res = buf.split('e', 5);
+  const res = buf.split('e', 4);
 
   assert(res.length === 4);
 
@@ -114,6 +116,38 @@ assert.doesNotThrow(() => {
   assert(Buffer.compare(res[1], new Buffer('')) === 0);
   assert(Buffer.compare(res[2], new Buffer('')) === 0);
   assert(Buffer.compare(res[3], new Buffer('llo')) === 0);
+}
+
+{
+  // isolated: split limit
+  const buf = new Buffer('ABABABA');
+  const res = buf.split('B', 2);
+
+  assert(res.length === 2);
+
+  assert(Buffer.compare(res[0], new Buffer('A')) === 0);
+  assert(Buffer.compare(res[1], new Buffer('A')) === 0);
+}
+
+{
+  // octets as input
+  const buf = new Buffer('ABCdEF');
+  const res = buf.split([0x43, 0x64]);
+
+  assert(res.length === 2);
+
+  assert(Buffer.compare(res[0], new Buffer('AB')) === 0);
+  assert(Buffer.compare(res[1], new Buffer('EF')) === 0);
+}
+
+{
+  // string input with encoding
+  const buf = new Buffer('this is a tést, tést', 'ascii');
+  const res = buf.split('é', 'ascii', 2);
+  assert(res.length === 2);
+
+  assert(Buffer.compare(res[0], new Buffer('this is a t')) === 0);
+  assert(Buffer.compare(res[1], new Buffer('st, t')) === 0);
 }
 
 {

--- a/test/parallel/test-buffer-split-join.js
+++ b/test/parallel/test-buffer-split-join.js
@@ -94,6 +94,29 @@ assert.doesNotThrow(() => {
 }
 
 {
+  const buf = new Buffer('Heeello');
+  const res = buf.split('e', 4);
+
+  assert(res.length === 3);
+
+  assert(Buffer.compare(res[0], new Buffer('H')) === 0);
+  assert(Buffer.compare(res[1], new Buffer('')) === 0);
+  assert(Buffer.compare(res[2], new Buffer('')) === 0);
+}
+
+{
+  const buf = new Buffer('Heeello');
+  const res = buf.split('e', 5);
+
+  assert(res.length === 4);
+
+  assert(Buffer.compare(res[0], new Buffer('H')) === 0);
+  assert(Buffer.compare(res[1], new Buffer('')) === 0);
+  assert(Buffer.compare(res[2], new Buffer('')) === 0);
+  assert(Buffer.compare(res[3], new Buffer('llo')) === 0);
+}
+
+{
   const res = Buffer.join([
     new Buffer('Hello'),
     new Buffer(' World')


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

`buffer`
##### Description of change

<!-- provide a description of the change below this comment -->

> **WIP**
> - benchmarks
> - one less copy (had problems persisting the input buffer in `.split()`)
> - general `c++` related review induced changes, style etc.

**Description/ Motivation**
This PR introduces two additions to the `buffer` API, `.split()` and `.join()`. Motivation is too handle buffers directly (say in streams) and having higher efficiency to what would be possible in userland js. This continues the discussion from https://github.com/nodejs/node/issues/5683 whereas as a `.replace()` API seemed too high level, but can be easily implemented with the methods here. 

**Comparison**
In string scenarios the methods are 1.5x to 3x times slower, whereas a similar JS implementation would be 10x to 20x slower. Detailed benchmarks are yet to be written and also the currently implementation makes at least one copy too much (WIP).

**Usage**
The potential usage is bot only string manipulation, but having a general byte manipulation interface with efficient copying. 

 **For docs:**
##### Class Method: Buffer.split([separator])
- `separator` {Buffer} A separator that gets matched against the input buffer
- Return: {Array} Array of Buffers

`Buffer.split()` behaves similar to `String.prototype.split`, as such it matches
an input against a source buffer, splits the source buffer, removes the input
and returns the number of resulting buffers in an array.

``` js
const buf = new Buffer('Hello World');
const res = buf.split(new Buffer(' '))

console.log(res);
// [ <Buffer 48 65 6c 6c 6f>, <Buffer 57 6f 72 6c 64> ]
```

It is also possible to split with an empty buffer, which results in an array
with the single bytes of buffer contents wrapped in new buffers.

``` js
const buf = new Buffer('Hello');
const res = buf.split(new Buffer(''))

console.log(res);
// [ <Buffer 48>, <Buffer 65>, <Buffer 6c>, <Buffer 6c>, <Buffer 6f> ]
```
##### Class Method: Buffer.join(array[, insert])
- `array` {Array} Array of buffers that will be joined together
- `insert` {Buffer} Buffer that gets inserted between the subjects
- Return: {Buffer}

`Buffer.join()` behaves similar to `Array.prototype.join`, as such it matches
takes an array of buffers and generate new buffer with the concatenated buffers.
Optionally it takes a an `insert` as argument that will be inserted between the
buffers.

``` js
const res = Buffer.join([
  new Buffer('Hello'),
  new Buffer('World'),
], new Buffer('\n'));

console.log(res);
// <Buffer 48 65 6c 6c 6f 0a 57 6f 72 6c 64>
console.log(res.toString());
// Hello
// World
```

_Note: `Array.prototype.join` would fill in commas if no insert will be
provided. `Buffer.join()` though will simply concat against the next buffer._

``` js
const res = Buffer.join([
  new Buffer('Hello'),
  new Buffer('World'),
]);

console.log(res.toString());
// HelloWorld
```
