### PR TITLE
repl: Don’t complete non-simple expressions

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -647,7 +647,7 @@ ArrayStream.prototype.write = function() {};
 
 const requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
 const simpleExpressionRE =
-    /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
+    /^\s*(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
 
 function intFilter(item) {
   // filters out anything not starting with A-Z, a-z, $ or _

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -249,3 +249,11 @@ testMe.complete('obj.', common.mustCall(function(error, data) {
   assert.strictEqual(data[0].indexOf('obj.1a'), -1);
   assert.notStrictEqual(data[0].indexOf('obj.a'), -1);
 }));
+
+// Don't try to complete results of non-simple expressions
+putIn.run(['.clear']);
+putIn.run(['function a() {}']);
+
+testMe.complete('a().b.', common.mustCall((error, data) => {
+  assert.deepEqual(data, [[], undefined]);
+}));


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

repl

##### Description of change

Change the regular expression that recognizes “simple” JS expressions to requiring that the full line needs to match it.

Previously, in terms like `a().b.`, `b.` would be a partial match. This meant that completion would evaluate `b` and either fail with a `ReferenceError` or, if `b` was some global, return the properties of the global `b` object.