### PR TITLE
test,repl: use deepStrictEqual for false-y values

### DIFF
--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -176,7 +176,7 @@ var spaceTimeout = setTimeout(function() {
 }, 1000);
 
 testMe.complete(' ', common.mustCall(function(error, data) {
-  assert.deepEqual(data, [[], undefined]);
+  assert.deepStrictEqual(data, [[], undefined]);
   clearTimeout(spaceTimeout);
 }));
 
@@ -255,5 +255,5 @@ putIn.run(['.clear']);
 putIn.run(['function a() {}']);
 
 testMe.complete('a().b.', common.mustCall((error, data) => {
-  assert.deepEqual(data, [[], undefined]);
+  assert.deepStrictEqual(data, [[], undefined]);
 }));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc,repl

##### Description of change

<!-- provide a description of the change below this comment -->

Refs: https://github.com/nodejs/node/commit/0b66b8f2d2c3aceba5e65c4b4ba428b7fabd3cb5#commitcomment-17104918, https://github.com/nodejs/node/pull/6192


... Should we just change this throughout all of our testes, except the assert ones themselves?

As a note, I'm not sure how much it matters for this test, but testing false-y values with `deepEqual()` can easily miss problems.

cc @nodejs/testing 