### PR TITLE
net: do not bind TCP server after close has run

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1112,6 +1112,7 @@ function Server(options, connectionListener) {
   }
 
   this._connections = 0;
+  this._lookup_state = {running: false};
 
   Object.defineProperty(this, 'connections', {
     get: internalUtil.deprecate(() => {
@@ -1391,13 +1392,26 @@ Server.prototype.listen = function() {
   }
 
   function listenAfterLookup(port, address, backlog, exclusive) {
-    require('dns').lookup(address, function(err, ip, addressType) {
-      if (err) {
-        self.emit('error', err);
-      } else {
-        addressType = ip ? addressType : 4;
-        listen(self, ip, port, addressType, backlog, undefined, exclusive);
-      }
+    const dns = require('dns');
+    const lookup_state = {running: true};
+    self._lookup_state = lookup_state;
+    process.nextTick(() => {
+      if (!lookup_state.running)
+        return;
+
+      dns.lookup(address, function(err, ip, addressType) {
+        if (!lookup_state.running)
+          return;
+
+        lookup_state.running = false;
+        if (err) {
+          self.emit('error', err);
+        } else {
+          addressType = ip ? addressType : 4;
+          listen(self, ip, port, addressType, backlog, undefined,
+                 exclusive);
+        }
+      });
     });
   }
 
@@ -1498,13 +1512,16 @@ Server.prototype.close = function(cb) {
   }
 
   if (typeof cb === 'function') {
-    if (!this._handle) {
+    if (this._handle || this._lookup_state.running) {
+      this._lookup_state.running = false;
+      this.once('close', cb);
+    } else {
       this.once('close', function() {
         cb(new Error('Not running'));
       });
-    } else {
-      this.once('close', cb);
     }
+  } else {
+    this._lookup_state.running = false;
   }
 
   if (this._handle) {

--- a/test/parallel/test-net-server-close-before-dns.js
+++ b/test/parallel/test-net-server-close-before-dns.js
@@ -1,0 +1,9 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+
+net.createServer(() => {}).listen(common.PORT, 'localhost', () => {
+  net.connect(common.PORT, () => {
+    throw new Error('a connection was made');
+  });
+}).close();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [ ] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)
- net

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
##### Description of change

<!-- provide a description of the change below this comment -->

Currently, calling listen() on a Server with a hostname, causes
the server to perform a DNS lookup. Calling close() on the Server,
before the DNS is complete and a handle is set, makes .close() a noop
and when the DNS lookup returns, it binds the TCP socket.

Instead, when close() is called on a Server, whose DNS request is
still in progress - mark the Server as closed, and do not store the
handle when the DNS request is complete.

Fixes #6188 
