### PR TITLE
handle_wrap: IsRefed -> Unrefed, no isAlive check

### DIFF
--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -37,11 +37,11 @@ void HandleWrap::Unref(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void HandleWrap::IsRefed(const FunctionCallbackInfo<Value>& args) {
+void HandleWrap::Unrefed(const FunctionCallbackInfo<Value>& args) {
   HandleWrap* wrap = Unwrap<HandleWrap>(args.Holder());
 
-  bool refed = IsAlive(wrap) && (wrap->flags_ & kUnref) == 0;
-  args.GetReturnValue().Set(refed);
+  bool unrefed = wrap->flags_ & kUnref == 1;
+  args.GetReturnValue().Set(unrefed);
 }
 
 

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -35,7 +35,7 @@ class HandleWrap : public AsyncWrap {
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Ref(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Unref(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void IsRefed(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Unrefed(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static inline bool IsAlive(const HandleWrap* wrap) {
     return wrap != nullptr && wrap->GetHandle() != nullptr;

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -80,7 +80,7 @@ void PipeWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
-  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
+  env->SetProtoMethod(t, "unrefed", HandleWrap::Unrefed);
 
   StreamWrap::AddMethods(env, t);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -40,7 +40,7 @@ class ProcessWrap : public HandleWrap {
 
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(constructor, "isRefed", HandleWrap::IsRefed);
+    env->SetProtoMethod(constructor, "unrefed", HandleWrap::Unrefed);
 
     target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Process"),
                 constructor->GetFunction());

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -32,7 +32,7 @@ class SignalWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(constructor, "isRefed", HandleWrap::IsRefed);
+    env->SetProtoMethod(constructor, "unrefed", HandleWrap::Unrefed);
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -87,7 +87,7 @@ void TCPWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
+  env->SetProtoMethod(t, "unrefed", HandleWrap::Unrefed);
 
   StreamWrap::AddMethods(env, t, StreamBase::kFlagHasWritev);
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -39,7 +39,7 @@ class TimerWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
-    env->SetProtoMethod(constructor, "isRefed", HandleWrap::IsRefed);
+    env->SetProtoMethod(constructor, "unrefed", HandleWrap::Unrefed);
 
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -36,7 +36,7 @@ void TTYWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
+  env->SetProtoMethod(t, "unrefed", HandleWrap::Unrefed);
 
   StreamWrap::AddMethods(env, t, StreamBase::kFlagNoShutdown);
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -108,7 +108,7 @@ void UDPWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
-  env->SetProtoMethod(t, "isRefed", HandleWrap::IsRefed);
+  env->SetProtoMethod(t, "unrefed", HandleWrap::Unrefed);
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "UDP"), t->GetFunction());
   env->set_udp_constructor_function(t->GetFunction());

--- a/test/parallel/test-handle-wrap-isrefed-tty.js
+++ b/test/parallel/test-handle-wrap-isrefed-tty.js
@@ -9,16 +9,18 @@ function makeAssert(message) {
     strictEqual(actual, expected, message);
   };
 }
-const assert = makeAssert('isRefed() not working on tty_wrap');
+const assert = makeAssert('unrefed() not working on tty_wrap');
 
 if (process.argv[2] === 'child') {
   // Test tty_wrap in piped child to guarentee stdin being a TTY.
   const ReadStream = require('tty').ReadStream;
   const tty = new ReadStream(0);
-  assert(Object.getPrototypeOf(tty._handle).hasOwnProperty('isRefed'), true);
-  assert(tty._handle.isRefed(), true);
+  assert(Object.getPrototypeOf(tty._handle).hasOwnProperty('unrefed'), true);
+  assert(tty._handle.unrefed(), false);
   tty.unref();
-  assert(tty._handle.isRefed(), false);
+  assert(tty._handle.unrefed(), true);
+  tty._handle.close();
+  assert(tty._handle.unrefed(), true);
   return;
 }
 

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -12,86 +12,92 @@ function makeAssert(message) {
 
 // child_process
 {
-  const assert = makeAssert('isRefed() not working on process_wrap');
+  const assert = makeAssert('unrefed() not working on process_wrap');
   const spawn = require('child_process').spawn;
   const cmd = common.isWindows ? 'rundll32' : 'ls';
   const cp = spawn(cmd);
-  assert(Object.getPrototypeOf(cp._handle).hasOwnProperty('isRefed'), true);
-  assert(cp._handle.isRefed(), true);
+  assert(Object.getPrototypeOf(cp._handle).hasOwnProperty('unrefed'), true);
+  assert(cp._handle.unrefed(), false);
   cp.unref();
-  assert(cp._handle.isRefed(), false);
+  assert(cp._handle.unrefed(), true);
   cp.ref();
-  assert(cp._handle.isRefed(), true);
-  cp.unref();
+  assert(cp._handle.unrefed(), false);
+  cp._handle.close();
+  assert(cp._handle.unrefed(), false);
 }
 
 
 // dgram
 {
-  const assert = makeAssert('isRefed() not working on udp_wrap');
+  const assert = makeAssert('unrefed() not working on udp_wrap');
   const dgram = require('dgram');
 
   const sock4 = dgram.createSocket('udp4');
-  assert(Object.getPrototypeOf(sock4._handle).hasOwnProperty('isRefed'), true);
-  assert(sock4._handle.isRefed(), true);
+  assert(Object.getPrototypeOf(sock4._handle).hasOwnProperty('unrefed'), true);
+  assert(sock4._handle.unrefed(), false);
   sock4.unref();
-  assert(sock4._handle.isRefed(), false);
+  assert(sock4._handle.unrefed(), true);
   sock4.ref();
-  assert(sock4._handle.isRefed(), true);
-  sock4.unref();
+  assert(sock4._handle.unrefed(), false);
+  sock4._handle.close();
+  assert(sock4._handle.unrefed(), false);
 
   const sock6 = dgram.createSocket('udp6');
-  assert(Object.getPrototypeOf(sock6._handle).hasOwnProperty('isRefed'), true);
-  assert(sock6._handle.isRefed(), true);
+  assert(Object.getPrototypeOf(sock6._handle).hasOwnProperty('unrefed'), true);
+  assert(sock6._handle.unrefed(), false);
   sock6.unref();
-  assert(sock6._handle.isRefed(), false);
+  assert(sock6._handle.unrefed(), true);
   sock6.ref();
-  assert(sock6._handle.isRefed(), true);
-  sock6.unref();
+  assert(sock6._handle.unrefed(), false);
+  sock6._handle.close();
+  assert(sock6._handle.unrefed(), false);
 }
 
 
 // pipe
 {
-  const assert = makeAssert('isRefed() not working on pipe_wrap');
+  const assert = makeAssert('unrefed() not working on pipe_wrap');
   const Pipe = process.binding('pipe_wrap').Pipe;
   const handle = new Pipe();
-  assert(Object.getPrototypeOf(handle).hasOwnProperty('isRefed'), true);
-  assert(handle.isRefed(), true);
+  assert(Object.getPrototypeOf(handle).hasOwnProperty('unrefed'), true);
+  assert(handle.unrefed(), false);
   handle.unref();
-  assert(handle.isRefed(), false);
+  assert(handle.unrefed(), true);
   handle.ref();
-  assert(handle.isRefed(), true);
-  handle.unref();
+  assert(handle.unrefed(), false);
+  handle.close();
+  assert(handle.unrefed(), false);
 }
 
 
 // tcp
 {
-  const assert = makeAssert('isRefed() not working on tcp_wrap');
+  const assert = makeAssert('unrefed() not working on tcp_wrap');
   const net = require('net');
   const server = net.createServer(() => {}).listen(common.PORT);
-  assert(Object.getPrototypeOf(server._handle).hasOwnProperty('isRefed'), true);
-  assert(server._handle.isRefed(), true);
+  assert(Object.getPrototypeOf(server._handle).hasOwnProperty('unrefed'), true);
+  assert(server._handle.unrefed(), false);
   assert(server._unref, false);
   server.unref();
-  assert(server._handle.isRefed(), false);
+  assert(server._handle.unrefed(), true);
   assert(server._unref, true);
   server.ref();
-  assert(server._handle.isRefed(), true);
+  assert(server._handle.unrefed(), false);
   assert(server._unref, false);
-  server.unref();
+  server._handle.close();
+  assert(server._handle.unrefed(), false);
 }
 
 
 // timers
 {
-  const assert = makeAssert('isRefed() not working on timer_wrap');
+  const assert = makeAssert('unrefed() not working on timer_wrap');
   const timer = setTimeout(() => {}, 500);
   timer.unref();
-  assert(Object.getPrototypeOf(timer._handle).hasOwnProperty('isRefed'), true);
-  assert(timer._handle.isRefed(), false);
+  assert(Object.getPrototypeOf(timer._handle).hasOwnProperty('unrefed'), true);
+  assert(timer._handle.unrefed(), true);
   timer.ref();
-  assert(timer._handle.isRefed(), true);
-  timer.unref();
+  assert(timer._handle.unrefed(), false);
+  timer.close();
+  assert(timer._handle.unrefed(), false);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

handle_wrap

##### Description of change

<!-- provide a description of the change below this comment -->

This fixes my perceived usability issues with https://github.com/nodejs/node/pull/5834, which has not landed in any release except v6 RCs. **This should not be considered a breaking change due to that.**

It is useful if you have a handle, even if it has been closed, to be able to inspect whether that handle was unrefed or not. As such, I have renamed the method accordingly. If people need to check a handle's aliveness, that is a separate API we should consider exposing.

cc @trevnorris, @jasnell, @cjihrig 