### PR TITLE
node: Make builtin libs available for `--eval`

### DIFF
--- a/doc/api/cli.markdown
+++ b/doc/api/cli.markdown
@@ -36,7 +36,8 @@ The output of this option is less detailed than this document.
 
 ### `-e`, `--eval "script"`
 
-Evaluate the following argument as JavaScript.
+Evaluate the following argument as JavaScript. The modules which are
+predefined in the REPL can also be used in `script`.
 
 
 ### `-p`, `--print "script"`

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -105,6 +105,9 @@
         // User passed '-e' or '--eval' arguments to Node without '-i' or
         // '--interactive'
         preloadModules();
+
+        const internalModule = NativeModule.require('internal/module');
+        internalModule.addBuiltinLibsToObject(global);
         evalScript('[eval]');
       } else if (process.argv[1]) {
         // make process.argv[1] into a full path

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -59,21 +59,36 @@ exports.builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
 function addBuiltinLibsToObject(object) {
   // Make built-in modules available directly (loaded lazily).
   exports.builtinLibs.forEach((name) => {
+    // Goals of this mechanism are:
+    // - Lazy loading of built-in modules
+    // - Having all built-in modules available as non-enumerable properties
+    // - Allowing the user to re-assign these variables as if there were no
+    //   pre-existing globals with the same name.
+
+    const setReal = (val) => {
+      // Deleting the property before re-assigning it disables the
+      // getter/setter mechanism.
+      delete object[name];
+      object[name] = val;
+    };
+
     Object.defineProperty(object, name, {
       get: () => {
         const lib = require(name);
-        // This implicitly invokes the setter, so that this getter is only
-        // invoked at most once and does not overwrite anything.
-        object[name] = lib;
+
+        // Disable the current getter/setter and set up a new
+        // non-enumerable property.
+        delete object[name];
+        Object.defineProperty(object, name, {
+          get: () => lib,
+          set: setReal,
+          configurable: true,
+          enumerable: false
+        });
+
         return lib;
       },
-      // Allow the creation of other globals with this name.
-      set: (val) => {
-        // Deleting the property before re-assigning it disables the
-        // getter/setter mechanism.
-        delete object[name];
-        object[name] = val;
-      },
+      set: setReal,
       configurable: true,
       enumerable: false
     });

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -1,6 +1,10 @@
 'use strict';
 
-exports = module.exports = { makeRequireFunction, stripBOM };
+exports = module.exports = {
+  makeRequireFunction,
+  stripBOM,
+  addBuiltinLibsToObject
+};
 
 exports.requireDepth = 0;
 
@@ -45,4 +49,33 @@ function stripBOM(content) {
     content = content.slice(1);
   }
   return content;
+}
+
+exports.builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
+  'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net',
+  'os', 'path', 'punycode', 'querystring', 'readline', 'repl', 'stream',
+  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'];
+
+function addBuiltinLibsToObject(object) {
+  // Make built-in modules available directly (loaded lazily).
+  exports.builtinLibs.forEach((name) => {
+    Object.defineProperty(object, name, {
+      get: () => {
+        const lib = require(name);
+        // This implicitly invokes the setter, so that this getter is only
+        // invoked at most once and does not overwrite anything.
+        object[name] = lib;
+        return lib;
+      },
+      // Allow the creation of other globals with this name.
+      set: (val) => {
+        // Deleting the property before re-assigning it disables the
+        // getter/setter mechanism.
+        delete object[name];
+        object[name] = val;
+      },
+      configurable: true,
+      enumerable: false
+    });
+  });
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -64,10 +64,7 @@ function hasOwnProperty(obj, prop) {
 // This is the default "writer" value if none is passed in the REPL options.
 exports.writer = util.inspect;
 
-exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
-  'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net',
-  'os', 'path', 'punycode', 'querystring', 'readline', 'stream',
-  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'];
+exports._builtinLibs = internalModule.builtinLibs;
 
 
 const BLOCK_SCOPED_ERROR = 'Block-scoped declarations (let, ' +
@@ -565,23 +562,7 @@ REPLServer.prototype.createContext = function() {
   this.lines = [];
   this.lines.level = [];
 
-  // make built-in modules available directly
-  // (loaded lazily)
-  exports._builtinLibs.forEach((name) => {
-    Object.defineProperty(context, name, {
-      get: () => {
-        var lib = require(name);
-        this.last = context[name] = lib;
-        return lib;
-      },
-      // allow the creation of other globals with this name
-      set: (val) => {
-        delete context[name];
-        context[name] = val;
-      },
-      configurable: true
-    });
-  });
+  internalModule.addBuiltinLibsToObject(context);
 
   Object.defineProperty(context, '_', {
     configurable: true,

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -53,6 +53,13 @@ child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
       assert.equal(status.code, 42);
     });
 
+// Check that builtin modules are pre-defined.
+child.exec(nodejs + ' --print "os.platform()"',
+    function(status, stdout, stderr) {
+      assert.strictEqual(stderr, '');
+      assert.strictEqual(stdout.trim(), require('os').platform());
+    });
+
 // module path resolve bug, regression test
 child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
     function(status, stdout, stderr) {


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

cli

##### Description of change

Make the builtin libraries available for the `--eval` and `--print` CLI options, using the same mechanism that the REPL uses.

This renders workarounds like `node -e 'require("fs").doStuff()'` unnecessary which I find myself often using.