### PR TITLE
build: allow test-ci to run tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ PREFIX ?= /usr/local
 FLAKY_TESTS ?= run
 TEST_CI_ARGS ?=
 STAGINGSERVER ?= node-www
-
 OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
+
+ifdef JOBS
+  PARALLEL_ARGS = -j $(JOBS)
+endif
 
 ifdef QUICKCHECK
   QUICKCHECK_ARG := --quickcheck
@@ -168,7 +171,8 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci: | build-addons
-	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release --flaky-tests=$(FLAKY_TESTS) \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) addons message parallel sequential
 
 test-release: test-build
@@ -607,8 +611,9 @@ jslint:
 	  tools/eslint-rules tools/jslint.js
 
 jslint-ci:
-	$(NODE) tools/jslint.js -f tap -o test-eslint.tap benchmark lib src test \
-	  tools/doc tools/eslint-rules tools/jslint.js
+	$(NODE) tools/jslint.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
+		benchmark lib src test tools/doc \
+		tools/eslint-rules tools/jslint.js
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

build

##### Description of change


Run tests in parallel if the environment variable JOBS (which should contain a number of parallel jobs) is set.

I'd like to expand this to the actual build steps as well (and possibly even outside of the `ci` scope), but it requires careful testing since it seems to break here and there for some jobs.

/cc=@nodejs/build, @Trott, @bnoordhuis.