### PR TITLE
test,vm: enable strict mode for vm tests

### DIFF
--- a/test/parallel/test-vm-new-script-new-context.js
+++ b/test/parallel/test-vm-new-script-new-context.js
@@ -1,15 +1,15 @@
-/* eslint-disable strict */
-var common = require('../common');
-var assert = require('assert');
-var Script = require('vm').Script;
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const Script = require('vm').Script;
 
 common.globalCheck = false;
 
 console.error('run a string');
 var script = new Script('\'passed\';');
 console.error('script created');
-var result1 = script.runInNewContext();
-var result2 = script.runInNewContext();
+const result1 = script.runInNewContext();
+const result2 = script.runInNewContext();
 assert.equal('passed', result1);
 assert.equal('passed', result2);
 
@@ -27,31 +27,31 @@ assert.throws(function() {
 }, /not defined/);
 
 
-hello = 5;
+global.hello = 5;
 script = new Script('hello = 2');
 script.runInNewContext();
-assert.equal(5, hello);
+assert.equal(5, global.hello);
 
 
 console.error('pass values in and out');
-code = 'foo = 1;' +
-       'bar = 2;' +
-       'if (baz !== 3) throw new Error(\'test fail\');';
-foo = 2;
-obj = { foo: 0, baz: 3 };
-script = new Script(code);
+global.code = 'foo = 1;' +
+              'bar = 2;' +
+              'if (baz !== 3) throw new Error(\'test fail\');';
+global.foo = 2;
+global.obj = { foo: 0, baz: 3 };
+script = new Script(global.code);
 /* eslint-disable no-unused-vars */
-var baz = script.runInNewContext(obj);
+var baz = script.runInNewContext(global.obj);
 /* eslint-enable no-unused-vars */
-assert.equal(1, obj.foo);
-assert.equal(2, obj.bar);
-assert.equal(2, foo);
+assert.equal(1, global.obj.foo);
+assert.equal(2, global.obj.bar);
+assert.equal(2, global.foo);
 
 console.error('call a function by reference');
 script = new Script('f()');
-function changeFoo() { foo = 100; }
+function changeFoo() { global.foo = 100; }
 script.runInNewContext({ f: changeFoo });
-assert.equal(foo, 100);
+assert.equal(global.foo, 100);
 
 console.error('modify an object by reference');
 script = new Script('f.a = 2');

--- a/test/parallel/test-vm-new-script-this-context.js
+++ b/test/parallel/test-vm-new-script-this-context.js
@@ -1,13 +1,13 @@
-/* eslint-disable strict */
-var common = require('../common');
-var assert = require('assert');
-var Script = require('vm').Script;
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const Script = require('vm').Script;
 
 common.globalCheck = false;
 
 console.error('run a string');
 var script = new Script('\'passed\';');
-var result = script.runInThisContext(script);
+const result = script.runInThisContext(script);
 assert.equal('passed', result);
 
 console.error('thrown error');
@@ -16,26 +16,26 @@ assert.throws(function() {
   script.runInThisContext(script);
 });
 
-hello = 5;
+global.hello = 5;
 script = new Script('hello = 2');
 script.runInThisContext(script);
-assert.equal(2, hello);
+assert.equal(2, global.hello);
 
 
 console.error('pass values');
-code = 'foo = 1;' +
-       'bar = 2;' +
-       'if (typeof baz !== \'undefined\') throw new Error(\'test fail\');';
-foo = 2;
-obj = { foo: 0, baz: 3 };
-script = new Script(code);
+global.code = 'foo = 1;' +
+              'bar = 2;' +
+              'if (typeof baz !== "undefined") throw new Error("test fail");';
+global.foo = 2;
+global.obj = { foo: 0, baz: 3 };
+script = new Script(global.code);
 script.runInThisContext(script);
-assert.equal(0, obj.foo);
-assert.equal(2, bar);
-assert.equal(1, foo);
+assert.equal(0, global.obj.foo);
+assert.equal(2, global.bar);
+assert.equal(1, global.foo);
 
 console.error('call a function');
-f = function() { foo = 100; };
+global.f = function() { global.foo = 100; };
 script = new Script('f()');
 script.runInThisContext(script);
-assert.equal(100, foo);
+assert.equal(100, global.foo);

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -1,16 +1,16 @@
-/* eslint-disable strict */
+'use strict';
 // Flags: --expose-gc
 
-var common = require('../common');
-var assert = require('assert');
-var vm = require('vm');
+const common = require('../common');
+const assert = require('assert');
+const vm = require('vm');
 
 assert.equal(typeof gc, 'function', 'Run this test with --expose-gc');
 
 common.globalCheck = false;
 
 console.error('run a string');
-var result = vm.runInNewContext('\'passed\';');
+const result = vm.runInNewContext('\'passed\';');
 assert.equal('passed', result);
 
 console.error('thrown error');
@@ -18,28 +18,28 @@ assert.throws(function() {
   vm.runInNewContext('throw new Error(\'test\');');
 });
 
-hello = 5;
+global.hello = 5;
 vm.runInNewContext('hello = 2');
-assert.equal(5, hello);
+assert.equal(5, global.hello);
 
 
 console.error('pass values in and out');
-code = 'foo = 1;' +
-       'bar = 2;' +
-       'if (baz !== 3) throw new Error(\'test fail\');';
-foo = 2;
-obj = { foo: 0, baz: 3 };
+global.code = 'foo = 1;' +
+              'bar = 2;' +
+              'if (baz !== 3) throw new Error(\'test fail\');';
+global.foo = 2;
+global.obj = { foo: 0, baz: 3 };
 /* eslint-disable no-unused-vars */
-var baz = vm.runInNewContext(code, obj);
+var baz = vm.runInNewContext(global.code, global.obj);
 /* eslint-enable no-unused-vars */
-assert.equal(1, obj.foo);
-assert.equal(2, obj.bar);
-assert.equal(2, foo);
+assert.equal(1, global.obj.foo);
+assert.equal(2, global.obj.bar);
+assert.equal(2, global.foo);
 
 console.error('call a function by reference');
-function changeFoo() { foo = 100; }
+function changeFoo() { global.foo = 100; }
 vm.runInNewContext('f()', { f: changeFoo });
-assert.equal(foo, 100);
+assert.equal(global.foo, 100);
 
 console.error('modify an object by reference');
 var f = { a: 1 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

test vm

##### Description of change

Some vm tests are not in strict mode because they need to create and use global variables. By using `global.foo` instead of just `foo`, we can still enable strict mode.

