### PR TITLE
tools,test: enforce deepStrictEqual over deepEqual

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,9 +85,10 @@ rules:
   prefer-const: 2
 
   # Custom rules in tools/eslint-rules
+  align-multiline-assignment: 2
   assert-fail-single-argument: 2
   new-with-error: [2, "Error", "RangeError", "TypeError", "SyntaxError", "ReferenceError"]
-  align-multiline-assignment: 2
+  no-deepEqual: 2
 
 # Global scoped method and vars
 globals:

--- a/benchmark/assert/deepequal-prims-and-objs-big-array.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array.js
@@ -1,3 +1,4 @@
+/* eslint no-deepEqual: 0 */
 'use strict';
 var common = require('../common.js');
 var assert = require('assert');

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -1,3 +1,4 @@
+/* eslint no-deepEqual: 0 */
 'use strict';
 var common = require('../common.js');
 var assert = require('assert');

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -1,3 +1,4 @@
+/* eslint no-deepEqual: 0 */
 'use strict';
 var common = require('../common.js');
 var assert = require('assert');

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -1,3 +1,4 @@
+/* eslint no-deepEqual: 0 */
 'use strict';
 
 require('../common');

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1,3 +1,4 @@
+/* eslint no-deepEqual: 0 */
 'use strict';
 require('../common');
 var assert = require('assert');

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -32,7 +32,9 @@ assert.strictEqual(0, d.length);
 
 var ui32 = new Uint32Array(4).fill(42);
 var e = Buffer.from(ui32);
-assert.deepEqual(ui32, e);
+for (const [index, value] of e.entries()) {
+  assert.strictEqual(value, ui32[index]);
+}
 
 // First check Buffer#fill() works as expected.
 
@@ -463,32 +465,32 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
   assert.equal(d[0], 23);
   assert.equal(d[1], 42);
   assert.equal(d[2], 255);
-  assert.deepEqual(d, Buffer.from(d));
+  assert.deepStrictEqual(d, Buffer.from(d));
 }
 
 {
   const e = Buffer.from('über');
   console.error('uber: \'%s\'', e.toString());
-  assert.deepEqual(e, Buffer.from([195, 188, 98, 101, 114]));
+  assert.deepStrictEqual(e, Buffer.from([195, 188, 98, 101, 114]));
 }
 
 {
   const f = Buffer.from('über', 'ascii');
   console.error('f.length: %d     (should be 4)', f.length);
-  assert.deepEqual(f, Buffer.from([252, 98, 101, 114]));
+  assert.deepStrictEqual(f, Buffer.from([252, 98, 101, 114]));
 }
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
   {
     const f = Buffer.from('über', encoding);
     console.error('f.length: %d     (should be 8)', f.length);
-    assert.deepEqual(f, Buffer.from([252, 0, 98, 0, 101, 0, 114, 0]));
+    assert.deepStrictEqual(f, Buffer.from([252, 0, 98, 0, 101, 0, 114, 0]));
   }
 
   {
     const f = Buffer.from('привет', encoding);
     console.error('f.length: %d     (should be 12)', f.length);
-    assert.deepEqual(f,
+    assert.deepStrictEqual(f,
       Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
     assert.equal(f.toString(encoding), 'привет');
   }
@@ -499,23 +501,23 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
     const size = f.write('あいうえお', encoding);
     console.error('bytes written to buffer: %d     (should be 4)', size);
     assert.equal(size, 4);
-    assert.deepEqual(f, Buffer.from([0x42, 0x30, 0x44, 0x30, 0x00]));
+    assert.deepStrictEqual(f, Buffer.from([0x42, 0x30, 0x44, 0x30, 0x00]));
   }
 });
 
 {
   const f = Buffer.from('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
   assert.equal(f.length, 4);
-  assert.deepEqual(f, Buffer.from('3DD84DDC', 'hex'));
+  assert.deepStrictEqual(f, Buffer.from('3DD84DDC', 'hex'));
 }
 
 
 var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
 var g = Buffer.from(arrayIsh);
-assert.deepEqual(g, Buffer.from([0, 1, 2, 3]));
+assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
 var strArrayIsh = {0: '0', 1: '1', 2: '2', 3: '3', length: 4};
 g = Buffer.from(strArrayIsh);
-assert.deepEqual(g, Buffer.from([0, 1, 2, 3]));
+assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
 
 
 //
@@ -526,10 +528,10 @@ assert.equal('TWFu', (Buffer.from('Man')).toString('base64'));
 {
   // test that regular and URL-safe base64 both work
   const expected = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff];
-  assert.deepEqual(Buffer.from('//++/++/++//', 'base64'),
-                   Buffer.from(expected));
-  assert.deepEqual(Buffer.from('__--_--_--__', 'base64'),
-                   Buffer.from(expected));
+  assert.deepStrictEqual(Buffer.from('//++/++/++//', 'base64'),
+                         Buffer.from(expected));
+  assert.deepStrictEqual(Buffer.from('__--_--_--__', 'base64'),
+                         Buffer.from(expected));
 }
 
 {
@@ -1021,7 +1023,7 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 
   assert.equal(string, '{"type":"Buffer","data":[116,101,115,116]}');
 
-  assert.deepEqual(buffer, JSON.parse(string, function(key, value) {
+  assert.deepStrictEqual(buffer, JSON.parse(string, function(key, value) {
     return value && value.type === 'Buffer'
       ? Buffer.from(value.data)
       : value;
@@ -1167,92 +1169,92 @@ assert.throws(function() {
 (function() {
   var buf = Buffer.allocUnsafe(3);
   buf.writeUIntLE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.equal(buf.readUIntLE(0, 3), 0x123456);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeUIntBE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
   assert.equal(buf.readUIntBE(0, 3), 0x123456);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.equal(buf.readIntLE(0, 3), 0x123456);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
   assert.equal(buf.readIntBE(0, 3), 0x123456);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(-0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
   assert.equal(buf.readIntLE(0, 3), -0x123456);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(-0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
   assert.equal(buf.readIntBE(0, 3), -0x123456);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(-0x123400, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x00, 0xcc, 0xed]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x00, 0xcc, 0xed]);
   assert.equal(buf.readIntLE(0, 3), -0x123400);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(-0x123400, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xed, 0xcc, 0x00]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcc, 0x00]);
   assert.equal(buf.readIntBE(0, 3), -0x123400);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(-0x120000, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x00, 0x00, 0xee]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x00, 0x00, 0xee]);
   assert.equal(buf.readIntLE(0, 3), -0x120000);
 
   buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(-0x120000, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xee, 0x00, 0x00]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xee, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 3), -0x120000);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeUIntLE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
   assert.equal(buf.readUIntLE(0, 5), 0x1234567890);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeUIntBE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
   assert.equal(buf.readUIntBE(0, 5), 0x1234567890);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeIntLE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
   assert.equal(buf.readIntLE(0, 5), 0x1234567890);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeIntBE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
   assert.equal(buf.readIntBE(0, 5), 0x1234567890);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeIntLE(-0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
   assert.equal(buf.readIntLE(0, 5), -0x1234567890);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeIntBE(-0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
   assert.equal(buf.readIntBE(0, 5), -0x1234567890);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeIntLE(-0x0012000000, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x00, 0x00, 0x00, 0xee, 0xff]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x00, 0x00, 0x00, 0xee, 0xff]);
   assert.equal(buf.readIntLE(0, 5), -0x0012000000);
 
   buf = Buffer.allocUnsafe(5);
   buf.writeIntBE(-0x0012000000, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 5), -0x0012000000);
 })();
 
@@ -1292,7 +1294,7 @@ assert.throws(function() {
   }
 
   var utf16Buf = Buffer.from('0123456789', 'utf16le');
-  assert.deepEqual(utf16Buf.slice(0, 6), Buffer.from('012', 'utf16le'));
+  assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer.from('012', 'utf16le'));
 
   assert.equal(buf.slice('0', '1'), '0');
   assert.equal(buf.slice('-5', '10'), '56789');

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -140,18 +140,25 @@ testBufs('Yci0Ysi1Y8i2', 12, 1, 'ucs2');
 
 
 // Buffer
+function deepStrictEqualValues(buf, arr) {
+  for (const [index, value] of buf.entries()) {
+    assert.deepStrictEqual(value, arr[index]);
+  }
+}
+
+
 const buf2Fill = Buffer.allocUnsafe(1).fill(2);
-assert.deepEqual(genBuffer(4, [buf2Fill]), [2, 2, 2, 2]);
-assert.deepEqual(genBuffer(4, [buf2Fill, 1]), [0, 2, 2, 2]);
-assert.deepEqual(genBuffer(4, [buf2Fill, 1, 3]), [0, 2, 2, 0]);
-assert.deepEqual(genBuffer(4, [buf2Fill, 1, 1]), [0, 0, 0, 0]);
-assert.deepEqual(genBuffer(4, [buf2Fill, 1, -1]), [0, 0, 0, 0]);
+deepStrictEqualValues(genBuffer(4, [buf2Fill]), [2, 2, 2, 2]);
+deepStrictEqualValues(genBuffer(4, [buf2Fill, 1]), [0, 2, 2, 2]);
+deepStrictEqualValues(genBuffer(4, [buf2Fill, 1, 3]), [0, 2, 2, 0]);
+deepStrictEqualValues(genBuffer(4, [buf2Fill, 1, 1]), [0, 0, 0, 0]);
+deepStrictEqualValues(genBuffer(4, [buf2Fill, 1, -1]), [0, 0, 0, 0]);
 const hexBufFill = Buffer.allocUnsafe(2).fill(0).fill('0102', 'hex');
-assert.deepEqual(genBuffer(4, [hexBufFill]), [1, 2, 1, 2]);
-assert.deepEqual(genBuffer(4, [hexBufFill, 1]), [0, 1, 2, 1]);
-assert.deepEqual(genBuffer(4, [hexBufFill, 1, 3]), [0, 1, 2, 0]);
-assert.deepEqual(genBuffer(4, [hexBufFill, 1, 1]), [0, 0, 0, 0]);
-assert.deepEqual(genBuffer(4, [hexBufFill, 1, -1]), [0, 0, 0, 0]);
+deepStrictEqualValues(genBuffer(4, [hexBufFill]), [1, 2, 1, 2]);
+deepStrictEqualValues(genBuffer(4, [hexBufFill, 1]), [0, 1, 2, 1]);
+deepStrictEqualValues(genBuffer(4, [hexBufFill, 1, 3]), [0, 1, 2, 0]);
+deepStrictEqualValues(genBuffer(4, [hexBufFill, 1, 1]), [0, 0, 0, 0]);
+deepStrictEqualValues(genBuffer(4, [hexBufFill, 1, -1]), [0, 0, 0, 0]);
 
 
 // Check exceptions

--- a/test/parallel/test-buffer-iterator.js
+++ b/test/parallel/test-buffer-iterator.js
@@ -13,7 +13,7 @@ arr = [];
 for (b of buffer)
   arr.push(b);
 
-assert.deepEqual(arr, [1, 2, 3, 4, 5]);
+assert.deepStrictEqual(arr, [1, 2, 3, 4, 5]);
 
 
 // buffer iterators should be iterable
@@ -23,7 +23,7 @@ arr = [];
 for (b of buffer[Symbol.iterator]())
   arr.push(b);
 
-assert.deepEqual(arr, [1, 2, 3, 4, 5]);
+assert.deepStrictEqual(arr, [1, 2, 3, 4, 5]);
 
 
 // buffer#values() should return iterator for values
@@ -33,7 +33,7 @@ arr = [];
 for (b of buffer.values())
   arr.push(b);
 
-assert.deepEqual(arr, [1, 2, 3, 4, 5]);
+assert.deepStrictEqual(arr, [1, 2, 3, 4, 5]);
 
 
 // buffer#keys() should return iterator for keys
@@ -43,7 +43,7 @@ arr = [];
 for (b of buffer.keys())
   arr.push(b);
 
-assert.deepEqual(arr, [0, 1, 2, 3, 4]);
+assert.deepStrictEqual(arr, [0, 1, 2, 3, 4]);
 
 
 // buffer#entries() should return iterator for entries
@@ -53,7 +53,7 @@ arr = [];
 for (b of buffer.entries())
   arr.push(b);
 
-assert.deepEqual(arr, [
+assert.deepStrictEqual(arr, [
   [0, 1],
   [1, 2],
   [2, 3],

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -13,7 +13,9 @@ let sb = SlowBuffer(4);
 assert(sb instanceof Buffer);
 assert.strictEqual(sb.length, 4);
 sb.fill(1);
-assert.deepEqual(sb, ones);
+for (const [key, value] of sb.entries()) {
+  assert.deepStrictEqual(value, ones[key]);
+}
 
 // underlying ArrayBuffer should have the same length
 assert.strictEqual(sb.buffer.byteLength, 4);
@@ -23,7 +25,9 @@ sb = SlowBuffer(4);
 assert(sb instanceof Buffer);
 assert.strictEqual(sb.length, 4);
 sb.fill(1);
-assert.deepEqual(sb, ones);
+for (const [key, value] of sb.entries()) {
+  assert.deepStrictEqual(value, ones[key]);
+}
 
 // should work with edge cases
 assert.strictEqual(SlowBuffer(0).length, 0);

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -33,7 +33,9 @@ assert.strictEqual(0, d.length);
 
 var ui32 = new Uint32Array(4).fill(42);
 var e = Buffer(ui32);
-assert.deepEqual(ui32, e);
+for (const [key, value] of e.entries()) {
+  assert.deepStrictEqual(value, ui32[key]);
+}
 
 // First check Buffer#fill() works as expected.
 
@@ -464,32 +466,33 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
   assert.equal(d[0], 23);
   assert.equal(d[1], 42);
   assert.equal(d[2], 255);
-  assert.deepEqual(d, new Buffer(d));
+  assert.deepStrictEqual(d, new Buffer(d));
 }
 
 {
   const e = new Buffer('über');
   console.error('uber: \'%s\'', e.toString());
-  assert.deepEqual(e, new Buffer([195, 188, 98, 101, 114]));
+  assert.deepStrictEqual(e, new Buffer([195, 188, 98, 101, 114]));
 }
 
 {
   const f = new Buffer('über', 'ascii');
   console.error('f.length: %d     (should be 4)', f.length);
-  assert.deepEqual(f, new Buffer([252, 98, 101, 114]));
+  assert.deepStrictEqual(f, new Buffer([252, 98, 101, 114]));
 }
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
   {
     const f = new Buffer('über', encoding);
     console.error('f.length: %d     (should be 8)', f.length);
-    assert.deepEqual(f, new Buffer([252, 0, 98, 0, 101, 0, 114, 0]));
+    assert.deepStrictEqual(f, new Buffer([252, 0, 98, 0, 101, 0, 114, 0]));
   }
 
   {
     const f = new Buffer('привет', encoding);
     console.error('f.length: %d     (should be 12)', f.length);
-    assert.deepEqual(f, new Buffer([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
+    const expected = new Buffer([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]);
+    assert.deepStrictEqual(f, expected);
     assert.equal(f.toString(encoding), 'привет');
   }
 
@@ -499,23 +502,23 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
     const size = f.write('あいうえお', encoding);
     console.error('bytes written to buffer: %d     (should be 4)', size);
     assert.equal(size, 4);
-    assert.deepEqual(f, new Buffer([0x42, 0x30, 0x44, 0x30, 0x00]));
+    assert.deepStrictEqual(f, new Buffer([0x42, 0x30, 0x44, 0x30, 0x00]));
   }
 });
 
 {
   const f = new Buffer('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
   assert.equal(f.length, 4);
-  assert.deepEqual(f, new Buffer('3DD84DDC', 'hex'));
+  assert.deepStrictEqual(f, new Buffer('3DD84DDC', 'hex'));
 }
 
 
 var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
 var g = new Buffer(arrayIsh);
-assert.deepEqual(g, new Buffer([0, 1, 2, 3]));
+assert.deepStrictEqual(g, new Buffer([0, 1, 2, 3]));
 var strArrayIsh = {0: '0', 1: '1', 2: '2', 3: '3', length: 4};
 g = new Buffer(strArrayIsh);
-assert.deepEqual(g, new Buffer([0, 1, 2, 3]));
+assert.deepStrictEqual(g, new Buffer([0, 1, 2, 3]));
 
 
 //
@@ -526,8 +529,8 @@ assert.equal('TWFu', (new Buffer('Man')).toString('base64'));
 {
   // test that regular and URL-safe base64 both work
   const expected = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff];
-  assert.deepEqual(Buffer('//++/++/++//', 'base64'), Buffer(expected));
-  assert.deepEqual(Buffer('__--_--_--__', 'base64'), Buffer(expected));
+  assert.deepStrictEqual(Buffer('//++/++/++//', 'base64'), Buffer(expected));
+  assert.deepStrictEqual(Buffer('__--_--_--__', 'base64'), Buffer(expected));
 }
 
 {
@@ -1013,7 +1016,7 @@ Buffer(Buffer(0), 0, 0);
 
   assert.equal(string, '{"type":"Buffer","data":[116,101,115,116]}');
 
-  assert.deepEqual(buffer, JSON.parse(string, function(key, value) {
+  assert.deepStrictEqual(buffer, JSON.parse(string, function(key, value) {
     return value && value.type === 'Buffer'
       ? new Buffer(value.data)
       : value;
@@ -1169,92 +1172,92 @@ assert.throws(function() {
 (function() {
   var buf = Buffer(3);
   buf.writeUIntLE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.equal(buf.readUIntLE(0, 3), 0x123456);
 
   buf = Buffer(3);
   buf.writeUIntBE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
   assert.equal(buf.readUIntBE(0, 3), 0x123456);
 
   buf = Buffer(3);
   buf.writeIntLE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.equal(buf.readIntLE(0, 3), 0x123456);
 
   buf = Buffer(3);
   buf.writeIntBE(0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
   assert.equal(buf.readIntBE(0, 3), 0x123456);
 
   buf = Buffer(3);
   buf.writeIntLE(-0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
   assert.equal(buf.readIntLE(0, 3), -0x123456);
 
   buf = Buffer(3);
   buf.writeIntBE(-0x123456, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
   assert.equal(buf.readIntBE(0, 3), -0x123456);
 
   buf = Buffer(3);
   buf.writeIntLE(-0x123400, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x00, 0xcc, 0xed]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x00, 0xcc, 0xed]);
   assert.equal(buf.readIntLE(0, 3), -0x123400);
 
   buf = Buffer(3);
   buf.writeIntBE(-0x123400, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xed, 0xcc, 0x00]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcc, 0x00]);
   assert.equal(buf.readIntBE(0, 3), -0x123400);
 
   buf = Buffer(3);
   buf.writeIntLE(-0x120000, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0x00, 0x00, 0xee]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x00, 0x00, 0xee]);
   assert.equal(buf.readIntLE(0, 3), -0x120000);
 
   buf = Buffer(3);
   buf.writeIntBE(-0x120000, 0, 3);
-  assert.deepEqual(buf.toJSON().data, [0xee, 0x00, 0x00]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xee, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 3), -0x120000);
 
   buf = Buffer(5);
   buf.writeUIntLE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
   assert.equal(buf.readUIntLE(0, 5), 0x1234567890);
 
   buf = Buffer(5);
   buf.writeUIntBE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
   assert.equal(buf.readUIntBE(0, 5), 0x1234567890);
 
   buf = Buffer(5);
   buf.writeIntLE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
   assert.equal(buf.readIntLE(0, 5), 0x1234567890);
 
   buf = Buffer(5);
   buf.writeIntBE(0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
   assert.equal(buf.readIntBE(0, 5), 0x1234567890);
 
   buf = Buffer(5);
   buf.writeIntLE(-0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
   assert.equal(buf.readIntLE(0, 5), -0x1234567890);
 
   buf = Buffer(5);
   buf.writeIntBE(-0x1234567890, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
   assert.equal(buf.readIntBE(0, 5), -0x1234567890);
 
   buf = Buffer(5);
   buf.writeIntLE(-0x0012000000, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0x00, 0x00, 0x00, 0xee, 0xff]);
+  assert.deepStrictEqual(buf.toJSON().data, [0x00, 0x00, 0x00, 0xee, 0xff]);
   assert.equal(buf.readIntLE(0, 5), -0x0012000000);
 
   buf = Buffer(5);
   buf.writeIntBE(-0x0012000000, 0, 5);
-  assert.deepEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
+  assert.deepStrictEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 5), -0x0012000000);
 })();
 
@@ -1294,7 +1297,7 @@ assert.throws(function() {
   }
 
   var utf16Buf = new Buffer('0123456789', 'utf16le');
-  assert.deepEqual(utf16Buf.slice(0, 6), Buffer('012', 'utf16le'));
+  assert.deepStrictEqual(utf16Buf.slice(0, 6), Buffer('012', 'utf16le'));
 
   assert.equal(buf.slice('0', '1'), '0');
   assert.equal(buf.slice('-5', '10'), '56789');

--- a/test/parallel/test-child-process-fork-exec-argv.js
+++ b/test/parallel/test-child-process-fork-exec-argv.js
@@ -23,6 +23,6 @@ if (process.argv[2] === 'fork') {
   });
 
   child.on('exit', function() {
-    assert.deepEqual(JSON.parse(out), execArgv);
+    assert.deepStrictEqual(JSON.parse(out), execArgv);
   });
 }

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -32,7 +32,7 @@ else {
     env: envCopy
   });
   child.on('message', common.mustCall(function(recv) {
-    assert.deepEqual(msg, recv);
+    assert.deepStrictEqual(msg, recv);
   }));
   child.on('exit', common.mustCall(function(code) {
     fs.unlinkSync(copyPath);

--- a/test/parallel/test-child-process-fork-ref.js
+++ b/test/parallel/test-child-process-fork-ref.js
@@ -31,7 +31,7 @@ if (process.argv[2] === 'child') {
   });
 
   child.once('exit', function() {
-    assert.deepEqual(ipc, ['1', '2']);
+    assert.deepStrictEqual(ipc, ['1', '2']);
     assert.equal(stdout, '3');
   });
 }

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -5,7 +5,7 @@ var fork = require('child_process').fork;
 var args = ['foo', 'bar'];
 
 var n = fork(common.fixturesDir + '/child-process-spawn-node.js', args);
-assert.deepEqual(args, ['foo', 'bar']);
+assert.deepStrictEqual(args, ['foo', 'bar']);
 
 var messageCount = 0;
 

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -32,7 +32,7 @@ if (process.argv[2] === 'child') {
   });
 
   process.on('exit', function() {
-    assert.deepEqual(gotNormal, normal);
-    assert.deepEqual(gotInternal, internal);
+    assert.deepStrictEqual(gotNormal, normal);
+    assert.deepStrictEqual(gotInternal, internal);
   });
 }

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -15,7 +15,7 @@ enoentChild.on('error', function(err) {
   assert.equal(err.errno, 'ENOENT');
   assert.equal(err.syscall, 'spawn ' + enoentPath);
   assert.equal(err.path, enoentPath);
-  assert.deepEqual(err.spawnargs, spawnargs);
+  assert.deepStrictEqual(err.spawnargs, spawnargs);
   errors++;
 });
 

--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -27,8 +27,8 @@ function checkSpawnSyncRet(ret) {
 
 function verifyBufOutput(ret) {
   checkSpawnSyncRet(ret);
-  assert.deepEqual(ret.stdout, msgOutBuf);
-  assert.deepEqual(ret.stderr, msgErrBuf);
+  assert.deepStrictEqual(ret.stdout, msgOutBuf);
+  assert.deepStrictEqual(ret.stderr, msgErrBuf);
 }
 
 if (process.argv.indexOf('spawnchild') !== -1) {
@@ -77,8 +77,8 @@ options = {
 ret = spawnSync('cat', [], options);
 
 checkSpawnSyncRet(ret);
-assert.deepEqual(ret.stdout, options.input);
-assert.deepEqual(ret.stderr, Buffer.from(''));
+assert.deepStrictEqual(ret.stdout, options.input);
+assert.deepStrictEqual(ret.stderr, Buffer.from(''));
 
 verifyBufOutput(spawnSync(process.execPath, args));
 

--- a/test/parallel/test-child-process-spawnsync-maxbuf.js
+++ b/test/parallel/test-child-process-spawnsync-maxbuf.js
@@ -24,4 +24,4 @@ assert.ok(ret.error, 'maxBuffer should error');
 assert.strictEqual(ret.error.errno, 'ENOBUFS');
 // We can have buffers larger than maxBuffer because underneath we alloc 64k
 // that matches our read sizes
-assert.deepEqual(ret.stdout, msgOutBuf);
+assert.deepStrictEqual(ret.stdout, msgOutBuf);

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -16,7 +16,7 @@ assert.strictEqual(ret_err.code, 'ENOENT');
 assert.strictEqual(ret_err.errno, 'ENOENT');
 assert.strictEqual(ret_err.syscall, 'spawnSync command_does_not_exist');
 assert.strictEqual(ret_err.path, 'command_does_not_exist');
-assert.deepEqual(ret_err.spawnargs, ['bar']);
+assert.deepStrictEqual(ret_err.spawnargs, ['bar']);
 
 // Verify that the cwd option works - GH #7824
 (function() {

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -16,4 +16,4 @@ assert.equal(child.stderr, null);
 
 options = {stdio: 'ignore'};
 child = common.spawnSyncCat(options);
-assert.deepEqual(options, {stdio: 'ignore'});
+assert.deepStrictEqual(options, {stdio: 'ignore'});

--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -117,7 +117,7 @@ else if (cluster.isMaster) {
                          port: common.PORT,
                          addressType: 4,
                          fd: undefined };
-          assert.deepEqual(arguments[0], expect);
+          assert.deepStrictEqual(arguments[0], expect);
           break;
 
         default:

--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -8,6 +8,6 @@ if (cluster.isMaster) {
   fork(); // it is intentionally called `fork` instead of
   fork(); // `cluster.fork` to test that `this` is not used
   cluster.disconnect(common.mustCall(function() {
-    assert.deepEqual(Object.keys(cluster.workers), []);
+    assert.deepStrictEqual(Object.keys(cluster.workers), []);
   }));
 }

--- a/test/parallel/test-cluster-setup-master-cumulative.js
+++ b/test/parallel/test-cluster-setup-master-cumulative.js
@@ -5,11 +5,14 @@ var cluster = require('cluster');
 
 assert(cluster.isMaster);
 
-assert.deepEqual(cluster.settings, {},
-                 'cluster.settings should not be initialized until needed');
+assert.deepStrictEqual(
+  cluster.settings,
+  {},
+  'cluster.settings should not be initialized until needed'
+);
 
 cluster.setupMaster();
-assert.deepEqual(cluster.settings, {
+assert.deepStrictEqual(cluster.settings, {
   args: process.argv.slice(2),
   exec: process.argv[1],
   execArgv: process.execArgv,
@@ -23,16 +26,16 @@ console.log('ok overrids defaults');
 
 cluster.setupMaster({ args: ['foo', 'bar'] });
 assert.strictEqual(cluster.settings.exec, 'overridden');
-assert.deepEqual(cluster.settings.args, ['foo', 'bar']);
+assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
 
 cluster.setupMaster({ execArgv: ['baz', 'bang'] });
 assert.strictEqual(cluster.settings.exec, 'overridden');
-assert.deepEqual(cluster.settings.args, ['foo', 'bar']);
-assert.deepEqual(cluster.settings.execArgv, ['baz', 'bang']);
+assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
+assert.deepStrictEqual(cluster.settings.execArgv, ['baz', 'bang']);
 console.log('ok preserves unchanged settings on repeated calls');
 
 cluster.setupMaster();
-assert.deepEqual(cluster.settings, {
+assert.deepStrictEqual(cluster.settings, {
   args: ['foo', 'bar'],
   exec: 'overridden',
   execArgv: ['baz', 'bang'],

--- a/test/parallel/test-cluster-worker-events.js
+++ b/test/parallel/test-cluster-worker-events.js
@@ -46,7 +46,7 @@ function check(m) {
 
   if (messages.length < 2) return;
 
-  assert.deepEqual(messages[0], messages[1]);
+  assert.deepStrictEqual(messages[0], messages[1]);
 
   cluster.worker.once('error', function(e) {
     assert.equal(e, 'HI');

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -4,4 +4,4 @@ var assert = require('assert');
 
 common.globalCheck = false;
 global.gc = 42;  // Not a valid global unless --expose_gc is set.
-assert.deepEqual(common.leakedGlobals(), ['gc']);
+assert.deepStrictEqual(common.leakedGlobals(), ['gc']);

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -363,9 +363,11 @@ assert.equal(a3, '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
                  '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
              'Test SHA512 as assumed binary');
 
-assert.deepEqual(a4,
-                 Buffer.from('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
-                 'Test SHA1');
+assert.deepStrictEqual(
+  a4,
+  Buffer.from('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
+  'Test SHA1'
+);
 
 // Test multiple updates to same hash
 var h1 = crypto.createHash('sha1').update('Test123').digest('hex');

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -46,10 +46,10 @@ var privkey1 = dh1.getPrivateKey();
 dh3.setPublicKey(key1);
 dh3.setPrivateKey(privkey1);
 
-assert.deepEqual(dh1.getPrime(), dh3.getPrime());
-assert.deepEqual(dh1.getGenerator(), dh3.getGenerator());
-assert.deepEqual(dh1.getPublicKey(), dh3.getPublicKey());
-assert.deepEqual(dh1.getPrivateKey(), dh3.getPrivateKey());
+assert.deepStrictEqual(dh1.getPrime(), dh3.getPrime());
+assert.deepStrictEqual(dh1.getGenerator(), dh3.getGenerator());
+assert.deepStrictEqual(dh1.getPublicKey(), dh3.getPublicKey());
+assert.deepStrictEqual(dh1.getPrivateKey(), dh3.getPrivateKey());
 assert.equal(dh3.verifyError, 0);
 
 var secret3 = dh3.computeSecret(key2, 'hex', 'base64');

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -45,7 +45,7 @@ if (!common.hasFipsCrypto) {
 assert.equal(a1, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
 assert.equal(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
              'Test SHA256 as base64');
-assert.deepEqual(
+assert.deepStrictEqual(
   a3,
   Buffer.from(
     '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
@@ -55,13 +55,15 @@ assert.deepEqual(
     '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
     'binary'),
   'Test SHA512 as assumed buffer');
-assert.deepEqual(a4,
-                Buffer.from('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
-                 'Test SHA1');
+assert.deepStrictEqual(
+  a4,
+  Buffer.from('8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'hex'),
+  'Test SHA1'
+);
 
 // stream interface should produce the same result.
-assert.deepEqual(a5, a3, 'stream interface is consistent');
-assert.deepEqual(a6, a3, 'stream interface is consistent');
+assert.deepStrictEqual(a5, a3, 'stream interface is consistent');
+assert.deepStrictEqual(a6, a3, 'stream interface is consistent');
 assert.notEqual(a7, undefined, 'no data should return data');
 assert.notEqual(a8, undefined, 'empty string should generate data');
 

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -57,7 +57,7 @@ assert.throws(function() {
 function assertSorted(list) {
   // Array#sort() modifies the list in place so make a copy.
   var sorted = util._extend([], list).sort();
-  assert.deepEqual(list, sorted);
+  assert.deepStrictEqual(list, sorted);
 }
 
 // Assume that we have at least AES-128-CBC.

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -14,20 +14,20 @@ var goog = [
   '8.8.4.4',
 ];
 assert.doesNotThrow(function() { dns.setServers(goog); });
-assert.deepEqual(dns.getServers(), goog);
+assert.deepStrictEqual(dns.getServers(), goog);
 assert.throws(function() { dns.setServers(['foobar']); });
-assert.deepEqual(dns.getServers(), goog);
+assert.deepStrictEqual(dns.getServers(), goog);
 
 var goog6 = [
   '2001:4860:4860::8888',
   '2001:4860:4860::8844',
 ];
 assert.doesNotThrow(function() { dns.setServers(goog6); });
-assert.deepEqual(dns.getServers(), goog6);
+assert.deepStrictEqual(dns.getServers(), goog6);
 
 goog6.push('4.4.4.4');
 dns.setServers(goog6);
-assert.deepEqual(dns.getServers(), goog6);
+assert.deepStrictEqual(dns.getServers(), goog6);
 
 var ports = [
   '4.4.4.4:53',
@@ -38,10 +38,10 @@ var portsExpected = [
   '2001:4860:4860::8888',
 ];
 dns.setServers(ports);
-assert.deepEqual(dns.getServers(), portsExpected);
+assert.deepStrictEqual(dns.getServers(), portsExpected);
 
 assert.doesNotThrow(function() { dns.setServers([]); });
-assert.deepEqual(dns.getServers(), []);
+assert.deepStrictEqual(dns.getServers(), []);
 
 assert.throws(function() {
   dns.resolve('test.com', [], noop);

--- a/test/parallel/test-domain-enter-exit.js
+++ b/test/parallel/test-domain-enter-exit.js
@@ -19,21 +19,21 @@ var c = domain.create();
 c.name = 'c';
 
 a.enter(); // push
-assert.deepEqual(domain._stack, [a],
-                 'a not pushed: ' + names(domain._stack));
+assert.deepStrictEqual(domain._stack, [a],
+                       'a not pushed: ' + names(domain._stack));
 
 b.enter(); // push
-assert.deepEqual(domain._stack, [a, b],
-                 'b not pushed: ' + names(domain._stack));
+assert.deepStrictEqual(domain._stack, [a, b],
+                       'b not pushed: ' + names(domain._stack));
 
 c.enter(); // push
-assert.deepEqual(domain._stack, [a, b, c],
-                 'c not pushed: ' + names(domain._stack));
+assert.deepStrictEqual(domain._stack, [a, b, c],
+                       'c not pushed: ' + names(domain._stack));
 
 b.exit(); // pop
-assert.deepEqual(domain._stack, [a],
-                 'b and c not popped: ' + names(domain._stack));
+assert.deepStrictEqual(domain._stack, [a],
+                       'b and c not popped: ' + names(domain._stack));
 
 b.enter(); // push
-assert.deepEqual(domain._stack, [a, b],
-                 'b not pushed: ' + names(domain._stack));
+assert.deepStrictEqual(domain._stack, [a, b],
+                       'b not pushed: ' + names(domain._stack));

--- a/test/parallel/test-domain-safe-exit.js
+++ b/test/parallel/test-domain-safe-exit.js
@@ -10,7 +10,7 @@ var b = domain.create();
 
 a.enter(); // push
 b.enter(); // push
-assert.deepEqual(domain._stack, [a, b], 'b not pushed');
+assert.deepStrictEqual(domain._stack, [a, b], 'b not pushed');
 
 domain.create().exit(); // no-op
-assert.deepEqual(domain._stack, [a, b], 'stack mangled!');
+assert.deepStrictEqual(domain._stack, [a, b], 'stack mangled!');

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -29,7 +29,7 @@ function hello(a, b) {
 e.once('newListener', function(name, listener) {
   assert.equal(name, 'hello');
   assert.equal(listener, hello);
-  assert.deepEqual(this.listeners('hello'), []);
+  assert.deepStrictEqual(this.listeners('hello'), []);
 });
 e.on('hello', hello);
 
@@ -47,8 +47,8 @@ f.setMaxListeners(0);
 
 
 process.on('exit', function() {
-  assert.deepEqual(['hello', 'foo'], events_new_listener_emited);
-  assert.deepEqual([hello, foo], listeners_new_listener_emited);
+  assert.deepStrictEqual(['hello', 'foo'], events_new_listener_emited);
+  assert.deepStrictEqual([hello, foo], listeners_new_listener_emited);
   assert.equal(1, times_hello_emited);
 });
 
@@ -56,13 +56,13 @@ var listen1 = function listen1() {};
 var listen2 = function listen2() {};
 var e1 = new events.EventEmitter();
 e1.once('newListener', function() {
-  assert.deepEqual(e1.listeners('hello'), []);
+  assert.deepStrictEqual(e1.listeners('hello'), []);
   e1.once('newListener', function() {
-    assert.deepEqual(e1.listeners('hello'), []);
+    assert.deepStrictEqual(e1.listeners('hello'), []);
   });
   e1.on('hello', listen2);
 });
 e1.on('hello', listen1);
 // The order of listeners on an event is not always the order in which the
 // listeners were added.
-assert.deepEqual(e1.listeners('hello'), [listen2, listen1]);
+assert.deepStrictEqual(e1.listeners('hello'), [listen2, listen1]);

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -11,7 +11,8 @@ var fl;  // foo listeners
 fl = e.listeners('foo');
 assert(Array.isArray(fl));
 assert(fl.length === 0);
-assert.deepEqual(e._events, {});
+assert(!(e._events instanceof Object));
+assert.deepStrictEqual(Object.keys(e._events), []);
 
 e.on('foo', assert.fail);
 fl = e.listeners('foo');

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -10,23 +10,23 @@ function listener2() {}
 var e1 = new events.EventEmitter();
 e1.on('foo', listener);
 var fooListeners = e1.listeners('foo');
-assert.deepEqual(e1.listeners('foo'), [listener]);
+assert.deepStrictEqual(e1.listeners('foo'), [listener]);
 e1.removeAllListeners('foo');
-assert.deepEqual(e1.listeners('foo'), []);
-assert.deepEqual(fooListeners, [listener]);
+assert.deepStrictEqual(e1.listeners('foo'), []);
+assert.deepStrictEqual(fooListeners, [listener]);
 
 var e2 = new events.EventEmitter();
 e2.on('foo', listener);
 var e2ListenersCopy = e2.listeners('foo');
-assert.deepEqual(e2ListenersCopy, [listener]);
-assert.deepEqual(e2.listeners('foo'), [listener]);
+assert.deepStrictEqual(e2ListenersCopy, [listener]);
+assert.deepStrictEqual(e2.listeners('foo'), [listener]);
 e2ListenersCopy.push(listener2);
-assert.deepEqual(e2.listeners('foo'), [listener]);
-assert.deepEqual(e2ListenersCopy, [listener, listener2]);
+assert.deepStrictEqual(e2.listeners('foo'), [listener]);
+assert.deepStrictEqual(e2ListenersCopy, [listener, listener2]);
 
 var e3 = new events.EventEmitter();
 e3.on('foo', listener);
 var e3ListenersCopy = e3.listeners('foo');
 e3.on('foo', listener2);
-assert.deepEqual(e3.listeners('foo'), [listener, listener2]);
-assert.deepEqual(e3ListenersCopy, [listener]);
+assert.deepStrictEqual(e3.listeners('foo'), [listener, listener2]);
+assert.deepStrictEqual(e3ListenersCopy, [listener]);

--- a/test/parallel/test-event-emitter-modify-in-emit.js
+++ b/test/parallel/test-event-emitter-modify-in-emit.js
@@ -1,11 +1,11 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var events = require('events');
+const assert = require('assert');
+const events = require('events');
 
 var callbacks_called = [];
 
-var e = new events.EventEmitter();
+const e = new events.EventEmitter();
 
 function callback1() {
   callbacks_called.push('callback1');
@@ -29,15 +29,17 @@ assert.equal(1, e.listeners('foo').length);
 
 e.emit('foo');
 assert.equal(2, e.listeners('foo').length);
-assert.deepEqual(['callback1'], callbacks_called);
+assert.deepStrictEqual(['callback1'], callbacks_called);
 
 e.emit('foo');
 assert.equal(0, e.listeners('foo').length);
-assert.deepEqual(['callback1', 'callback2', 'callback3'], callbacks_called);
+assert.deepStrictEqual(['callback1', 'callback2', 'callback3'],
+                       callbacks_called);
 
 e.emit('foo');
 assert.equal(0, e.listeners('foo').length);
-assert.deepEqual(['callback1', 'callback2', 'callback3'], callbacks_called);
+assert.deepStrictEqual(['callback1', 'callback2', 'callback3'],
+                       callbacks_called);
 
 e.on('foo', callback1);
 e.on('foo', callback2);
@@ -53,5 +55,5 @@ e.on('foo', callback2);
 e.on('foo', callback3);
 assert.equal(2, e.listeners('foo').length);
 e.emit('foo');
-assert.deepEqual(['callback2', 'callback3'], callbacks_called);
+assert.deepStrictEqual(['callback2', 'callback3'], callbacks_called);
 assert.equal(0, e.listeners('foo').length);

--- a/test/parallel/test-event-emitter-num-args.js
+++ b/test/parallel/test-event-emitter-num-args.js
@@ -22,5 +22,5 @@ e.emit('numArgs', null, null, null, null);
 e.emit('numArgs', null, null, null, null, null);
 
 process.on('exit', function() {
-  assert.deepEqual([0, 1, 2, 3, 4, 5], num_args_emited);
+  assert.deepStrictEqual([0, 1, 2, 3, 4, 5], num_args_emited);
 });

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -7,7 +7,7 @@ var events = require('events');
 function expect(expected) {
   var actual = [];
   process.on('exit', function() {
-    assert.deepEqual(actual.sort(), expected.sort());
+    assert.deepStrictEqual(actual.sort(), expected.sort());
   });
   function listener(name) {
     actual.push(name);
@@ -28,14 +28,14 @@ var bazListeners = e1.listeners('baz');
 e1.on('removeListener', expect(['bar', 'baz', 'baz']));
 e1.removeAllListeners('bar');
 e1.removeAllListeners('baz');
-assert.deepEqual(e1.listeners('foo'), [listener]);
-assert.deepEqual(e1.listeners('bar'), []);
-assert.deepEqual(e1.listeners('baz'), []);
+assert.deepStrictEqual(e1.listeners('foo'), [listener]);
+assert.deepStrictEqual(e1.listeners('bar'), []);
+assert.deepStrictEqual(e1.listeners('baz'), []);
 // after calling removeAllListeners,
 // the old listeners array should stay unchanged
-assert.deepEqual(fooListeners, [listener]);
-assert.deepEqual(barListeners, [listener]);
-assert.deepEqual(bazListeners, [listener, listener]);
+assert.deepStrictEqual(fooListeners, [listener]);
+assert.deepStrictEqual(barListeners, [listener]);
+assert.deepStrictEqual(bazListeners, [listener, listener]);
 // after calling removeAllListeners,
 // new listeners arrays are different from the old
 assert.notEqual(e1.listeners('bar'), barListeners);
@@ -49,8 +49,8 @@ e2.on('removeListener', expect(['foo', 'bar', 'removeListener']));
 e2.on('removeListener', expect(['foo', 'bar']));
 e2.removeAllListeners();
 console.error(e2);
-assert.deepEqual([], e2.listeners('foo'));
-assert.deepEqual([], e2.listeners('bar'));
+assert.deepStrictEqual([], e2.listeners('foo'));
+assert.deepStrictEqual([], e2.listeners('bar'));
 
 var e3 = new events.EventEmitter();
 e3.on('removeListener', listener);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -30,13 +30,13 @@ e1.on('removeListener', common.mustCall(function(name, cb) {
   assert.equal(cb, listener1);
 }));
 e1.removeListener('hello', listener1);
-assert.deepEqual([], e1.listeners('hello'));
+assert.deepStrictEqual([], e1.listeners('hello'));
 
 var e2 = new events.EventEmitter();
 e2.on('hello', listener1);
 e2.on('removeListener', common.fail);
 e2.removeListener('hello', listener2);
-assert.deepEqual([listener1], e2.listeners('hello'));
+assert.deepStrictEqual([listener1], e2.listeners('hello'));
 
 var e3 = new events.EventEmitter();
 e3.on('hello', listener1);
@@ -44,17 +44,17 @@ e3.on('hello', listener2);
 e3.once('removeListener', common.mustCall(function(name, cb) {
   assert.equal(name, 'hello');
   assert.equal(cb, listener1);
-  assert.deepEqual([listener2], e3.listeners('hello'));
+  assert.deepStrictEqual([listener2], e3.listeners('hello'));
 }));
 e3.removeListener('hello', listener1);
-assert.deepEqual([listener2], e3.listeners('hello'));
+assert.deepStrictEqual([listener2], e3.listeners('hello'));
 e3.once('removeListener', common.mustCall(function(name, cb) {
   assert.equal(name, 'hello');
   assert.equal(cb, listener2);
-  assert.deepEqual([], e3.listeners('hello'));
+  assert.deepStrictEqual([], e3.listeners('hello'));
 }));
 e3.removeListener('hello', listener2);
-assert.deepEqual([], e3.listeners('hello'));
+assert.deepStrictEqual([], e3.listeners('hello'));
 
 var e4 = new events.EventEmitter();
 e4.on('removeListener', common.mustCall(function(name, cb) {
@@ -72,17 +72,17 @@ e5.on('hello', listener2);
 e5.once('removeListener', common.mustCall(function(name, cb) {
   assert.equal(name, 'hello');
   assert.equal(cb, listener1);
-  assert.deepEqual([listener2], e5.listeners('hello'));
+  assert.deepStrictEqual([listener2], e5.listeners('hello'));
   e5.once('removeListener', common.mustCall(function(name, cb) {
     assert.equal(name, 'hello');
     assert.equal(cb, listener2);
-    assert.deepEqual([], e5.listeners('hello'));
+    assert.deepStrictEqual([], e5.listeners('hello'));
   }));
   e5.removeListener('hello', listener2);
-  assert.deepEqual([], e5.listeners('hello'));
+  assert.deepStrictEqual([], e5.listeners('hello'));
 }));
 e5.removeListener('hello', listener1);
-assert.deepEqual([], e5.listeners('hello'));
+assert.deepStrictEqual([], e5.listeners('hello'));
 
 const e6 = new events.EventEmitter();
 

--- a/test/parallel/test-event-emitter-set-max-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-set-max-listeners-side-effects.js
@@ -5,6 +5,7 @@ var events = require('events');
 
 var e = new events.EventEmitter();
 
-assert.deepEqual(e._events, {});
+assert(!(e._events instanceof Object));
+assert.deepStrictEqual(Object.keys(e._events), []);
 e.setMaxListeners(5);
-assert.deepEqual(e._events, {});
+assert.deepStrictEqual(Object.keys(e._events), []);

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -30,7 +30,8 @@ assert.throws(function() {
 
 process.on('exit', function() {
   assert(called);
-  assert.deepEqual(myee._events, {});
+  assert(!(myee._events instanceof Object));
+  assert.deepStrictEqual(Object.keys(myee._events), []);
   console.log('ok');
 });
 

--- a/test/parallel/test-event-emitter-symbols.js
+++ b/test/parallel/test-event-emitter-symbols.js
@@ -9,15 +9,15 @@ const foo = Symbol('foo');
 const listener = common.mustCall(function() {});
 
 ee.on(foo, listener);
-assert.deepEqual(ee.listeners(foo), [listener]);
+assert.deepStrictEqual(ee.listeners(foo), [listener]);
 
 ee.emit(foo);
 
 ee.removeAllListeners();
-assert.deepEqual(ee.listeners(foo), []);
+assert.deepStrictEqual(ee.listeners(foo), []);
 
 ee.on(foo, listener);
-assert.deepEqual(ee.listeners(foo), [listener]);
+assert.deepStrictEqual(ee.listeners(foo), [listener]);
 
 ee.removeListener(foo, listener);
-assert.deepEqual(ee.listeners(foo), []);
+assert.deepStrictEqual(ee.listeners(foo), []);

--- a/test/parallel/test-fs-read-buffer-zero-length.js
+++ b/test/parallel/test-fs-read-buffer-zero-length.js
@@ -11,9 +11,9 @@ const bufferSync = Buffer.alloc(0);
 
 fs.read(fd, bufferAsync, 0, 0, 0, common.mustCall(function(err, bytesRead) {
   assert.equal(bytesRead, 0);
-  assert.deepEqual(bufferAsync, Buffer.alloc(0));
+  assert.deepStrictEqual(bufferAsync, Buffer.alloc(0));
 }));
 
 const r = fs.readSync(fd, bufferSync, 0, 0, 0);
-assert.deepEqual(bufferSync, Buffer.alloc(0));
+assert.deepStrictEqual(bufferSync, Buffer.alloc(0));
 assert.equal(r, 0);

--- a/test/parallel/test-fs-read-buffer.js
+++ b/test/parallel/test-fs-read-buffer.js
@@ -15,11 +15,11 @@ fs.read(fd, bufferAsync, 0, expected.length, 0, function(err, bytesRead) {
   readCalled++;
 
   assert.equal(bytesRead, expected.length);
-  assert.deepEqual(bufferAsync, Buffer.from(expected));
+  assert.deepStrictEqual(bufferAsync, Buffer.from(expected));
 });
 
 var r = fs.readSync(fd, bufferSync, 0, expected.length, 0);
-assert.deepEqual(bufferSync, Buffer.from(expected));
+assert.deepStrictEqual(bufferSync, Buffer.from(expected));
 assert.equal(r, expected.length);
 
 process.on('exit', function() {

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -16,12 +16,12 @@ files.forEach(function(currentFile) {
 });
 
 // Check the readdir Sync version
-assert.deepEqual(files, fs.readdirSync(readdirDir).sort());
+assert.deepStrictEqual(files, fs.readdirSync(readdirDir).sort());
 
 // Check the readdir async version
 fs.readdir(readdirDir, common.mustCall(function(err, f) {
   assert.ifError(err);
-  assert.deepEqual(files, f.sort());
+  assert.deepStrictEqual(files, f.sort());
 }));
 
 // readdir() on file should throw ENOTDIR

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -24,7 +24,7 @@ fs.open(filename, 'w', 0o644, function(err, fd) {
     fs.closeSync(fd);
 
     var found = fs.readFileSync(filename, 'utf8');
-    assert.deepEqual(expected.toString(), found);
+    assert.deepStrictEqual(expected.toString(), found);
     fs.unlinkSync(filename);
   });
 });

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -62,7 +62,7 @@ function second() {
 function remoteClose() {
   // mock remote server close the socket
   get('/remote_close', function(res) {
-    assert.deepEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.statusCode, 200);
     res.on('data', checkDataAndSockets);
     res.on('end', function() {
       assert.equal(agent.sockets[name].length, 1);

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -10,7 +10,7 @@ var server = http.createServer(function(req, res) {
   gotReq = true;
   assert.equal('GET', req.method);
   assert.equal('/blah', req.url);
-  assert.deepEqual({
+  assert.deepStrictEqual({
     host: 'mapdevel.trolologames.ru:443',
     origin: 'http://mapdevel.trolologames.ru',
     cookie: ''

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -10,7 +10,7 @@ var expectedHeadersMultipleWrites = {
 
 var expectedHeadersEndWithData = {
   'connection': 'close',
-  'content-length': 'hello world'.length,
+  'content-length': String('hello world'.length)
 };
 
 var expectedHeadersEndNoData = {
@@ -26,16 +26,16 @@ var server = http.createServer(function(req, res) {
 
   switch (req.url.substr(1)) {
     case 'multiple-writes':
-      assert.deepEqual(req.headers, expectedHeadersMultipleWrites);
+      assert.deepStrictEqual(req.headers, expectedHeadersMultipleWrites);
       res.write('hello');
       res.end('world');
       break;
     case 'end-with-data':
-      assert.deepEqual(req.headers, expectedHeadersEndWithData);
+      assert.deepStrictEqual(req.headers, expectedHeadersEndWithData);
       res.end('hello world');
       break;
     case 'empty':
-      assert.deepEqual(req.headers, expectedHeadersEndNoData);
+      assert.deepStrictEqual(req.headers, expectedHeadersEndNoData);
       res.end();
       break;
     default:
@@ -59,7 +59,7 @@ server.listen(common.PORT, function() {
   req.write('hello ');
   req.end('world');
   req.on('response', function(res) {
-    assert.deepEqual(res.headers, expectedHeadersMultipleWrites);
+    assert.deepStrictEqual(res.headers, expectedHeadersMultipleWrites);
   });
 
   req = http.request({
@@ -71,7 +71,7 @@ server.listen(common.PORT, function() {
   req.removeHeader('Host');
   req.end('hello world');
   req.on('response', function(res) {
-    assert.deepEqual(res.headers, expectedHeadersEndWithData);
+    assert.deepStrictEqual(res.headers, expectedHeadersEndWithData);
   });
 
   req = http.request({
@@ -83,7 +83,7 @@ server.listen(common.PORT, function() {
   req.removeHeader('Host');
   req.end();
   req.on('response', function(res) {
-    assert.deepEqual(res.headers, expectedHeadersEndNoData);
+    assert.deepStrictEqual(res.headers, expectedHeadersEndNoData);
   });
 
 });

--- a/test/parallel/test-http-methods.js
+++ b/test/parallel/test-http-methods.js
@@ -9,4 +9,4 @@ assert(http.METHODS.length > 0);
 assert(http.METHODS.indexOf('GET') !== -1);
 assert(http.METHODS.indexOf('HEAD') !== -1);
 assert(http.METHODS.indexOf('POST') !== -1);
-assert.deepEqual(util._extend([], http.METHODS), http.METHODS.sort());
+assert.deepStrictEqual(util._extend([], http.METHODS), http.METHODS.sort());

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -84,8 +84,8 @@ function nextTest() {
                      'testing');
         assert.equal(response.headers['x-test-array-header'],
                      [1, 2, 3].join(', '));
-        assert.deepEqual(cookies,
-                         response.headers['set-cookie']);
+        assert.deepStrictEqual(cookies,
+                               response.headers['set-cookie']);
         assert.equal(response.headers['x-test-header2'] !== undefined, false);
         // Make the next request
         test = 'contentLength';

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -156,7 +156,7 @@ function expectBody(expected) {
     assert.equal(method, undefined);
     assert.equal(statusCode, 200);
     assert.equal(statusMessage, 'Connection established');
-    assert.deepEqual(headers || parser.headers, []);
+    assert.deepStrictEqual(headers || parser.headers, []);
   };
 
   var parser = newParser(RESPONSE);
@@ -184,7 +184,8 @@ function expectBody(expected) {
 
   var onHeaders = function(headers, url) {
     assert.ok(seen_body); // trailers should come after the body
-    assert.deepEqual(headers, ['Vary', '*', 'Content-Type', 'text/plain']);
+    assert.deepStrictEqual(headers,
+                           ['Vary', '*', 'Content-Type', 'text/plain']);
   };
 
   var onHeadersComplete = function(versionMajor, versionMinor, headers, method,
@@ -228,7 +229,7 @@ function expectBody(expected) {
     assert.equal(method, methods.indexOf('GET'));
     assert.equal(versionMajor, 1);
     assert.equal(versionMinor, 0);
-    assert.deepEqual(
+    assert.deepStrictEqual(
         headers || parser.headers,
         ['X-Filler', '1337', 'X-Filler', '42', 'X-Filler2', '42']);
   };
@@ -486,7 +487,7 @@ function expectBody(expected) {
     assert.equal(url || parser.url, '/it');
     assert.equal(versionMajor, 1);
     assert.equal(versionMinor, 1);
-    assert.deepEqual(
+    assert.deepStrictEqual(
         headers || parser.headers,
         ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
   };
@@ -538,7 +539,7 @@ function expectBody(expected) {
     assert.equal(url, '/this');
     assert.equal(versionMajor, 1);
     assert.equal(versionMinor, 1);
-    assert.deepEqual(
+    assert.deepStrictEqual(
         headers,
         ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
   };
@@ -550,8 +551,10 @@ function expectBody(expected) {
     assert.equal(url, '/that');
     assert.equal(versionMajor, 1);
     assert.equal(versionMinor, 0);
-    assert.deepEqual(headers,
-                     ['Content-Type', 'text/plain', 'Content-Length', '4']);
+    assert.deepStrictEqual(
+      headers,
+      ['Content-Type', 'text/plain', 'Content-Length', '4']
+    );
   };
 
   var parser = newParser(REQUEST);

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -34,7 +34,7 @@ var proxy = http.createServer(function(req, res) {
 
     assert.equal('world', proxy_res.headers['hello']);
     assert.equal('text/plain', proxy_res.headers['content-type']);
-    assert.deepEqual(cookies, proxy_res.headers['set-cookie']);
+    assert.deepStrictEqual(cookies, proxy_res.headers['set-cookie']);
 
     res.writeHead(proxy_res.statusCode, proxy_res.headers);
 
@@ -65,7 +65,7 @@ function startReq() {
 
     assert.equal('world', res.headers['hello']);
     assert.equal('text/plain', res.headers['content-type']);
-    assert.deepEqual(cookies, res.headers['set-cookie']);
+    assert.deepStrictEqual(cookies, res.headers['set-cookie']);
 
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -36,12 +36,12 @@ http.createServer(function(req, res) {
 
   var expectTrailers = { 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
 
-  assert.deepEqual(req.rawHeaders, expectRawHeaders);
-  assert.deepEqual(req.headers, expectHeaders);
+  assert.deepStrictEqual(req.rawHeaders, expectRawHeaders);
+  assert.deepStrictEqual(req.headers, expectHeaders);
 
   req.on('end', function() {
-    assert.deepEqual(req.rawTrailers, expectRawTrailers);
-    assert.deepEqual(req.trailers, expectTrailers);
+    assert.deepStrictEqual(req.rawTrailers, expectRawTrailers);
+    assert.deepStrictEqual(req.trailers, expectTrailers);
   });
 
   req.resume();
@@ -83,8 +83,8 @@ http.createServer(function(req, res) {
     };
     res.rawHeaders[3] = null;
     res.headers.date = null;
-    assert.deepEqual(res.rawHeaders, expectRawHeaders);
-    assert.deepEqual(res.headers, expectHeaders);
+    assert.deepStrictEqual(res.rawHeaders, expectRawHeaders);
+    assert.deepStrictEqual(res.headers, expectHeaders);
     res.on('end', function() {
       var expectRawTrailers = [
         'x-fOo',
@@ -98,8 +98,8 @@ http.createServer(function(req, res) {
       ];
       var expectTrailers = { 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' };
 
-      assert.deepEqual(res.rawTrailers, expectRawTrailers);
-      assert.deepEqual(res.trailers, expectTrailers);
+      assert.deepStrictEqual(res.rawTrailers, expectRawTrailers);
+      assert.deepStrictEqual(res.trailers, expectTrailers);
       console.log('ok');
     });
     res.resume();

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -30,7 +30,7 @@ process.on('exit', function() {
 server.listen(common.PORT, function() {
   http.get({ port: common.PORT }, function(res) {
     assert.equal(200, res.statusCode);
-    assert.deepEqual(res.headers, { date : 'coffee o clock' });
+    assert.deepStrictEqual(res.headers, { date : 'coffee o clock' });
 
     res.setEncoding('ascii');
     res.on('data', function(chunk) {

--- a/test/parallel/test-http-set-cookies.js
+++ b/test/parallel/test-http-set-cookies.js
@@ -26,7 +26,7 @@ server.on('listening', function() {
   http.get({ port: common.PORT, path: '/one' }, function(res) {
     // set-cookie headers are always return in an array.
     // even if there is only one.
-    assert.deepEqual(['A'], res.headers['set-cookie']);
+    assert.deepStrictEqual(['A'], res.headers['set-cookie']);
     assert.equal('text/plain', res.headers['content-type']);
 
     res.on('data', function(chunk) {
@@ -43,7 +43,7 @@ server.on('listening', function() {
   // two set-cookie headers
 
   http.get({ port: common.PORT, path: '/two' }, function(res) {
-    assert.deepEqual(['A', 'B'], res.headers['set-cookie']);
+    assert.deepStrictEqual(['A', 'B'], res.headers['set-cookie']);
     assert.equal('text/plain', res.headers['content-type']);
 
     res.on('data', function(chunk) {

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -59,7 +59,7 @@ srv.listen(common.PORT, '127.0.0.1', function() {
     var expectedHeaders = { 'hello': 'world',
                             'connection': 'upgrade',
                             'upgrade': 'websocket' };
-    assert.deepEqual(expectedHeaders, res.headers);
+    assert.deepStrictEqual(expectedHeaders, res.headers);
 
     // Make sure this request got removed from the pool.
     assert(!http.globalAgent.sockets.hasOwnProperty(name));

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -53,7 +53,7 @@ srv.listen(common.PORT, '127.0.0.1', function() {
     var expectedHeaders = {'hello': 'world',
                             'connection': 'upgrade',
                             'upgrade': 'websocket' };
-    assert.deepEqual(expectedHeaders, res.headers);
+    assert.deepStrictEqual(expectedHeaders, res.headers);
 
     socket.end();
     srv.close();

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -79,9 +79,9 @@ server.listen(common.PORT, function() {
 
 process.on('exit', function() {
   // Confirm that all connections tried to send data...
-  assert.deepEqual(sent, [0, 1, 2, 3]);
+  assert.deepStrictEqual(sent, ['0', '1', '2', '3']);
   // ...but that only connections 0 and 2 were successful.
-  assert.deepEqual(received, [0, 2]);
+  assert.deepStrictEqual(received, ['0', '2']);
 });
 
 process.on('unhandledRejection', function() {

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -19,8 +19,8 @@ const server = net.createServer((socket) => {
 });
 
 server.on('close', common.mustCall(() => {
-  assert.deepEqual(clientLocalPorts, serverRemotePorts,
-                   'client and server should agree on the ports used');
+  assert.deepStrictEqual(clientLocalPorts, serverRemotePorts,
+                         'client and server should agree on the ports used');
   assert.strictEqual(2, conns);
 }));
 

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -48,6 +48,6 @@ process.on('uncaughtException', function() {
 });
 
 process.on('exit', function() {
-  assert.deepEqual(['A', 'B', 'C'], order);
+  assert.deepStrictEqual(['A', 'B', 'C'], order);
 });
 

--- a/test/parallel/test-next-tick-ordering2.js
+++ b/test/parallel/test-next-tick-ordering2.js
@@ -14,5 +14,5 @@ process.nextTick(function() {
 });
 
 process.on('exit', function() {
-  assert.deepEqual(order, ['nextTick', 'setTimeout']);
+  assert.deepStrictEqual(order, ['nextTick', 'setTimeout']);
 });

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -89,7 +89,7 @@ switch (platform) {
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                         mac: '00:00:00:00:00:00', family: 'IPv4',
                         internal: true }];
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       break;
     }
   case 'win32':
@@ -99,7 +99,7 @@ switch (platform) {
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                         mac: '00:00:00:00:00:00', family: 'IPv4',
                         internal: true }];
-      assert.deepEqual(actual, expected);
+      assert.deepStrictEqual(actual, expected);
       break;
     }
 }

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -586,6 +586,6 @@ assert.equal(path.win32._makeLong(emptyObj), emptyObj);
 
 
 if (common.isWindows)
-  assert.deepEqual(path, path.win32, 'should be win32 path module');
+  assert.deepStrictEqual(path, path.win32, 'should be win32 path module');
 else
-  assert.deepEqual(path, path.posix, 'should be posix path module');
+  assert.deepStrictEqual(path, path.posix, 'should be posix path module');

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -21,4 +21,4 @@ config = JSON.parse(config, function(key, value) {
   return value;
 });
 
-assert.deepEqual(config, process.config);
+assert.deepStrictEqual(config, process.config);

--- a/test/parallel/test-process-exec-argv.js
+++ b/test/parallel/test-process-exec-argv.js
@@ -16,6 +16,6 @@ if (process.argv[2] === 'child') {
   });
 
   child.on('exit', function() {
-    assert.deepEqual(JSON.parse(out), execArgv);
+    assert.deepStrictEqual(JSON.parse(out), execArgv);
   });
 }

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 var expected_keys = ['ares', 'http_parser', 'modules', 'node',
                      'uv', 'v8', 'zlib'];
@@ -13,4 +13,7 @@ if (typeof Intl !== 'undefined') {
   expected_keys.push('icu');
 }
 
-assert.deepEqual(Object.keys(process.versions).sort(), expected_keys.sort());
+expected_keys.sort();
+const actual_keys = Object.keys(process.versions).sort();
+
+assert.deepStrictEqual(actual_keys, expected_keys);

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -658,7 +658,7 @@ asyncTest('nextTick is immediately scheduled when called inside an event' +
     });
     setTimeout(function() {
       order.push(2);
-      assert.deepEqual([1, 2], order);
+      assert.deepStrictEqual([1, 2], order);
       done();
     }, 1);
   });

--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -4,10 +4,10 @@ const assert = require('assert');
 
 const qs = require('querystring');
 
-assert.deepEqual(qs.escape(5), '5');
-assert.deepEqual(qs.escape('test'), 'test');
-assert.deepEqual(qs.escape({}), '%5Bobject%20Object%5D');
-assert.deepEqual(qs.escape([5, 10]), '5%2C10');
+assert.deepStrictEqual(qs.escape(5), '5');
+assert.deepStrictEqual(qs.escape('test'), 'test');
+assert.deepStrictEqual(qs.escape({}), '%5Bobject%20Object%5D');
+assert.deepStrictEqual(qs.escape([5, 10]), '5%2C10');
 
 // using toString for objects
 assert.strictEqual(

--- a/test/parallel/test-querystring-multichar-separator.js
+++ b/test/parallel/test-querystring-multichar-separator.js
@@ -3,22 +3,20 @@ require('../common');
 const assert = require('assert');
 const qs = require('querystring');
 
-assert.deepEqual(
-  qs.parse('foo=>bar&&bar=>baz', '&&', '=>'),
-  {foo: 'bar', bar: 'baz'}
-);
+function check(actual, expected) {
+  assert(!(actual instanceof Object));
+  assert.deepStrictEqual(Object.keys(actual).sort(),
+                         Object.keys(expected).sort());
+  Object.keys(expected).forEach(function(key) {
+    assert.deepStrictEqual(actual[key], expected[key]);
+  });
+}
 
-assert.strictEqual(
-  qs.stringify({foo: 'bar', bar: 'baz'}, '&&', '=>'),
-  'foo=>bar&&bar=>baz'
-);
+check(qs.parse('foo=>bar&&bar=>baz', '&&', '=>'), {foo: 'bar', bar: 'baz'});
 
-assert.deepEqual(
-  qs.parse('foo==>bar, bar==>baz', ', ', '==>'),
-  {foo: 'bar', bar: 'baz'}
-);
+check(qs.stringify({foo: 'bar', bar: 'baz'}, '&&', '=>'), 'foo=>bar&&bar=>baz');
 
-assert.strictEqual(
-  qs.stringify({foo: 'bar', bar: 'baz'}, ', ', '==>'),
-  'foo==>bar, bar==>baz'
-);
+check(qs.parse('foo==>bar, bar==>baz', ', ', '==>'), {foo: 'bar', bar: 'baz'});
+
+check(qs.stringify({foo: 'bar', bar: 'baz'}, ', ', '==>'),
+      'foo==>bar, bar==>baz');

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -5,13 +5,20 @@ var assert = require('assert');
 // test using assert
 var qs = require('querystring');
 
+function createWithNoPrototype(properties) {
+  const noProto = Object.create(null);
+  properties.forEach((property) => {
+    noProto[property.key] = property.value;
+  });
+  return noProto;
+}
 // folding block, commented to pass gjslint
 // {{{
 // [ wonkyQS, canonicalQS, obj ]
 var qsTestCases = [
   ['__proto__=1',
    '__proto__=1',
-   JSON.parse('{"__proto__":"1"}')],
+   createWithNoPrototype([{key: '__proto__', value: '1'}])],
   ['__defineGetter__=asdf',
    '__defineGetter__=asdf',
    JSON.parse('{"__defineGetter__":"asdf"}')],
@@ -97,37 +104,64 @@ var qsNoMungeTestCases = [
 assert.strictEqual('918854443121279438895193',
                    qs.parse('id=918854443121279438895193').id);
 
+
+function check(actual, expected) {
+  assert(!(actual instanceof Object));
+  assert.deepStrictEqual(Object.keys(actual).sort(),
+                         Object.keys(expected).sort());
+  Object.keys(expected).forEach(function(key) {
+    assert.deepStrictEqual(actual[key], expected[key]);
+  });
+}
+
 // test that the canonical qs is parsed properly.
 qsTestCases.forEach(function(testCase) {
-  assert.deepEqual(testCase[2], qs.parse(testCase[0]));
+  check(qs.parse(testCase[0]), testCase[2]);
 });
 
 // test that the colon test cases can do the same
 qsColonTestCases.forEach(function(testCase) {
-  assert.deepEqual(testCase[2], qs.parse(testCase[0], ';', ':'));
+  check(qs.parse(testCase[0], ';', ':'), testCase[2]);
 });
 
 // test the weird objects, that they get parsed properly
 qsWeirdObjects.forEach(function(testCase) {
-  assert.deepEqual(testCase[2], qs.parse(testCase[1]));
+  check(qs.parse(testCase[1]), testCase[2]);
 });
 
 qsNoMungeTestCases.forEach(function(testCase) {
-  assert.deepEqual(testCase[0], qs.stringify(testCase[1], '&', '='));
+  assert.deepStrictEqual(testCase[0], qs.stringify(testCase[1], '&', '='));
 });
 
 // test the nested qs-in-qs case
 (function() {
-  var f = qs.parse('a=b&q=x%3Dy%26y%3Dz');
+  const f = qs.parse('a=b&q=x%3Dy%26y%3Dz');
+  check(f, createWithNoPrototype([
+    { key: 'a', value: 'b'},
+    {key: 'q', value: 'x=y&y=z'}
+  ]));
+
   f.q = qs.parse(f.q);
-  assert.deepEqual(f, { a: 'b', q: { x: 'y', y: 'z' } });
+  const expectedInternal = createWithNoPrototype([
+    { key: 'x', value: 'y'},
+    {key: 'y', value: 'z' }
+  ]);
+  check(f.q, expectedInternal);
 })();
 
 // nested in colon
 (function() {
-  var f = qs.parse('a:b;q:x%3Ay%3By%3Az', ';', ':');
+  const f = qs.parse('a:b;q:x%3Ay%3By%3Az', ';', ':');
+  check(f, createWithNoPrototype([
+    {key: 'a', value: 'b'},
+    {key: 'q', value: 'x:y;y:z'}
+  ]));
   f.q = qs.parse(f.q, ';', ':');
-  assert.deepEqual(f, { a: 'b', q: { x: 'y', y: 'z' } });
+  const expectedInternal = createWithNoPrototype([
+    { key: 'x', value: 'y'},
+    {key: 'y', value: 'z' }
+  ]);
+  check(f.q, expectedInternal);
 })();
 
 // now test stringifying
@@ -186,7 +220,7 @@ assert.doesNotThrow(function() {
   assert.equal(f, 'a:b;q:x%3Ay%3By%3Az');
 }
 
-assert.deepEqual({}, qs.parse());
+check(qs.parse(), {});
 
 
 // Test limiting
@@ -238,9 +272,8 @@ assert.equal(0xe6, b[19]);
 function demoDecode(str) {
   return str + str;
 }
-assert.deepEqual(
-  qs.parse('a=a&b=b&c=c', null, null, { decodeURIComponent: demoDecode }),
-  { aa: 'aa', bb: 'bb', cc: 'cc' });
+check(qs.parse('a=a&b=b&c=c', null, null, { decodeURIComponent: demoDecode }),
+      { aa: 'aa', bb: 'bb', cc: 'cc' });
 
 
 // Test custom encode
@@ -257,8 +290,8 @@ var prevUnescape = qs.unescape;
 qs.unescape = function(str) {
   return str.replace(/o/g, '_');
 };
-assert.deepEqual(qs.parse('foo=bor'), {f__: 'b_r'});
+check(qs.parse('foo=bor'), createWithNoPrototype([{key: 'f__', value: 'b_r'}]));
 qs.unescape = prevUnescape;
 
 // test separator and "equals" parsing order
-assert.deepEqual(qs.parse('foo&bar', '&', '&'), { foo: '', bar: '' });
+check(qs.parse('foo&bar', '&', '&'), { foo: '', bar: '' });

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -335,7 +335,7 @@ function isWarned(emitter) {
   assert.equal(readline.getStringWidth('\u001b[31m\u001b[39m'), 0);
   assert.equal(readline.getStringWidth('> '), 2);
 
-  assert.deepEqual(fi.listeners(terminal ? 'keypress' : 'data'), []);
+  assert.deepStrictEqual(fi.listeners(terminal ? 'keypress' : 'data'), []);
 
   // check EventEmitter memory leak
   for (var i = 0; i < 12; i++) {

--- a/test/parallel/test-readline-set-raw-mode.js
+++ b/test/parallel/test-readline-set-raw-mode.js
@@ -64,6 +64,6 @@ assert(rawModeCalled);
 assert(!resumeCalled);
 assert(pauseCalled);
 
-assert.deepEqual(stream.listeners('keypress'), []);
+assert.deepStrictEqual(stream.listeners('keypress'), []);
 // one data listener for the keypress events.
 assert.equal(stream.listeners('data').length, 1);

--- a/test/parallel/test-regress-GH-2245.js
+++ b/test/parallel/test-regress-GH-2245.js
@@ -25,4 +25,4 @@ function test() {
 
 }
 
-assert.deepEqual(test(), {m: 1});
+assert.deepStrictEqual(test(), {m: 1});

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -32,7 +32,7 @@ assert.equal(fs.readFileSync(saveFileName, 'utf8'), testFile.join('\n') + '\n');
 // make sure that the REPL data is "correct"
 // so when I load it back I know I'm good
 testMe.complete('inner.o', function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 });
 
 // clear the REPL
@@ -43,7 +43,7 @@ putIn.run(['.load ' + saveFileName]);
 
 // make sure that the REPL data is "correct"
 testMe.complete('inner.o', function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 });
 
 // clear the REPL

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -41,13 +41,13 @@ putIn.run([
 testMe.complete('inner.o', getDoNotCallFunction());
 
 testMe.complete('console.lo', common.mustCall(function(error, data) {
-  assert.deepEqual(data, [['console.log'], 'console.lo']);
+  assert.deepStrictEqual(data, [['console.log'], 'console.lo']);
 }));
 
 // Tab Complete will return globaly scoped variables
 putIn.run(['};']);
 testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 }));
 
 putIn.run(['.clear']);
@@ -68,7 +68,7 @@ putIn.run([
   'var inner = {one:1};'
 ]);
 testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 }));
 
 // When you close the function scope tab complete will not return the
@@ -86,7 +86,7 @@ putIn.run([
   '};'
 ]);
 testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 }));
 
 putIn.run(['.clear']);
@@ -100,7 +100,7 @@ putIn.run([
   '};'
 ]);
 testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 }));
 
 putIn.run(['.clear']);
@@ -115,7 +115,7 @@ putIn.run([
   '};'
 ]);
 testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.deepEqual(data, works);
+  assert.deepStrictEqual(data, works);
 }));
 
 putIn.run(['.clear']);
@@ -165,7 +165,7 @@ putIn.run([
   'var str = "test";'
 ]);
 testMe.complete('str.len', common.mustCall(function(error, data) {
-  assert.deepEqual(data, [['str.length'], 'str.len']);
+  assert.deepStrictEqual(data, [['str.length'], 'str.len']);
 }));
 
 putIn.run(['.clear']);
@@ -183,7 +183,7 @@ testMe.complete(' ', common.mustCall(function(error, data) {
 // tab completion should pick up the global "toString" object, and
 // any other properties up the "global" object's prototype chain
 testMe.complete('toSt', common.mustCall(function(error, data) {
-  assert.deepEqual(data, [['toString'], 'toSt']);
+  assert.deepStrictEqual(data, [['toString'], 'toSt']);
 }));
 
 // Tab complete provides built in libs for require()
@@ -215,7 +215,7 @@ putIn.run([
   'var custom = "test";'
 ]);
 testMe.complete('cus', common.mustCall(function(error, data) {
-  assert.deepEqual(data, [['custom'], 'cus']);
+  assert.deepStrictEqual(data, [['custom'], 'cus']);
 }));
 
 // Make sure tab completion doesn't crash REPL with half-baked proxy objects.

--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -29,6 +29,6 @@ child.on('close', function(code) {
     process.exit(1);
   }
 
-  assert.deepEqual(output, outputExpect);
+  assert.deepStrictEqual(output, outputExpect);
   console.log('ok');
 });

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -26,7 +26,7 @@ s.read(0);
 // ACTUALLY [1, 3, 5, 6, 4, 2]
 
 process.on('exit', function() {
-  assert.deepEqual(s._readableState.buffer,
-                   ['1', '2', '3', '4', '5', '6']);
+  assert.deepStrictEqual(s._readableState.buffer,
+                         ['1', '2', '3', '4', '5', '6']);
   console.log('ok');
 });

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -41,6 +41,6 @@ ms.on('readable', function() {
 var expect = [ 'first chunksecond to last chunk', 'last chunk' ];
 process.on('exit', function() {
   assert.equal(ms._chunks, -1);
-  assert.deepEqual(results, expect);
+  assert.deepStrictEqual(results, expect);
   console.log('ok');
 });

--- a/test/parallel/test-stream-transform-objectmode-falsey-value.js
+++ b/test/parallel/test-stream-transform-objectmode-falsey-value.js
@@ -12,7 +12,7 @@ var dest = new PassThrough({ objectMode: true });
 var expect = [ -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
 var results = [];
 process.on('exit', function() {
-  assert.deepEqual(results, expect);
+  assert.deepStrictEqual(results, expect);
   console.log('ok');
 });
 

--- a/test/parallel/test-stream-unshift-empty-chunk.js
+++ b/test/parallel/test-stream-unshift-empty-chunk.js
@@ -54,6 +54,6 @@ var expect =
     'yyyyy' ];
 
 r.on('end', function() {
-  assert.deepEqual(seen, expect);
+  assert.deepStrictEqual(seen, expect);
   console.log('ok');
 });

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -97,7 +97,7 @@ function test(decode, uncork, multi, next) {
   w.on('finish', function() {
     // make sure finish comes after all the write cb
     cnt('finish')();
-    assert.deepEqual(expectChunks, actualChunks);
+    assert.deepStrictEqual(expectChunks, actualChunks);
     next();
   });
 }

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -22,7 +22,7 @@ function run() {
   var fn = next[1];
   console.log('# %s', name);
   fn({
-    same: assert.deepEqual,
+    same: assert.deepStrictEqual,
     equal: assert.equal,
     end: function() {
       count--;
@@ -72,9 +72,9 @@ test('can read objects from stream', function(t) {
   var v2 = r.read();
   var v3 = r.read();
 
-  assert.deepEqual(v1, { one: '1' });
-  assert.deepEqual(v2, { two: '2' });
-  assert.deepEqual(v3, null);
+  assert.deepStrictEqual(v1, { one: '1' });
+  assert.deepStrictEqual(v2, { two: '2' });
+  assert.deepStrictEqual(v3, null);
 
   t.end();
 });
@@ -83,7 +83,7 @@ test('can pipe objects into stream', function(t) {
   var r = fromArray([{ one: '1'}, { two: '2' }]);
 
   r.pipe(toArray(function(list) {
-    assert.deepEqual(list, [
+    assert.deepStrictEqual(list, [
       { one: '1' },
       { two: '2' }
     ]);
@@ -97,7 +97,7 @@ test('read(n) is ignored', function(t) {
 
   var value = r.read(2);
 
-  assert.deepEqual(value, { one: '1' });
+  assert.deepStrictEqual(value, { one: '1' });
 
   t.end();
 });
@@ -111,7 +111,7 @@ test('can read objects from _read (sync)', function(t) {
   };
 
   r.pipe(toArray(function(list) {
-    assert.deepEqual(list, [
+    assert.deepStrictEqual(list, [
       { one: '1' },
       { two: '2' }
     ]);
@@ -131,7 +131,7 @@ test('can read objects from _read (async)', function(t) {
   };
 
   r.pipe(toArray(function(list) {
-    assert.deepEqual(list, [
+    assert.deepStrictEqual(list, [
       { one: '1' },
       { two: '2' }
     ]);
@@ -152,7 +152,7 @@ test('can read strings as objects', function(t) {
   r.push(null);
 
   r.pipe(toArray(function(array) {
-    assert.deepEqual(array, list);
+    assert.deepStrictEqual(array, list);
 
     t.end();
   }));
@@ -168,7 +168,7 @@ test('read(0) for object streams', function(t) {
   r.push(null);
 
   r.pipe(toArray(function(array) {
-    assert.deepEqual(array, ['foobar']);
+    assert.deepStrictEqual(array, ['foobar']);
 
     t.end();
   }));
@@ -186,7 +186,7 @@ test('falsey values', function(t) {
   r.push(null);
 
   r.pipe(toArray(function(array) {
-    assert.deepEqual(array, [false, 0, '']);
+    assert.deepStrictEqual(array, [false, 0, '']);
 
     t.end();
   }));
@@ -242,7 +242,7 @@ test('can write objects to stream', function(t) {
   var w = new Writable({ objectMode: true });
 
   w._write = function(chunk, encoding, cb) {
-    assert.deepEqual(chunk, { foo: 'bar' });
+    assert.deepStrictEqual(chunk, { foo: 'bar' });
     cb();
   };
 
@@ -264,7 +264,7 @@ test('can write multiple objects to stream', function(t) {
   };
 
   w.on('finish', function() {
-    assert.deepEqual(list, [0, 1, 2, 3, 4]);
+    assert.deepStrictEqual(list, [0, 1, 2, 3, 4]);
 
     t.end();
   });
@@ -289,7 +289,7 @@ test('can write strings as objects', function(t) {
   };
 
   w.on('finish', function() {
-    assert.deepEqual(list, ['0', '1', '2', '3', '4']);
+    assert.deepStrictEqual(list, ['0', '1', '2', '3', '4']);
 
     t.end();
   });

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -103,7 +103,7 @@ function data() {
 
 function finish() {
   console.error('finish');
-  assert.deepEqual(written, expectWritten);
+  assert.deepStrictEqual(written, expectWritten);
   console.log('ok');
 }
 

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -64,7 +64,7 @@ function test1() {
   flow();
 
   process.on('exit', function() {
-    assert.deepEqual(results, [ 'xxxxx', 'xxxxx', 'EOF' ]);
+    assert.deepStrictEqual(results, [ 'xxxxx', 'xxxxx', 'EOF' ]);
     console.log('ok');
   });
 }
@@ -92,7 +92,7 @@ function test2() {
   flow();
 
   process.on('exit', function() {
-    assert.deepEqual(results, [ 'eHh4', 'eHg=', 'EOF' ]);
+    assert.deepStrictEqual(results, [ 'eHh4', 'eHg=', 'EOF' ]);
     console.log('ok');
   });
 }

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -73,7 +73,7 @@ function runTest(highWaterMark, objectMode, produce) {
   function performAsserts() {
     assert(ended);
     assert(oldEnded);
-    assert.deepEqual(written, expected);
+    assert.deepStrictEqual(written, expected);
   }
 }
 

--- a/test/parallel/test-timers-args.js
+++ b/test/parallel/test-timers-args.js
@@ -11,7 +11,7 @@ function timeout(nargs) {
   setTimeout.apply(null, [callback, 1].concat(args));
 
   function callback() {
-    assert.deepEqual([].slice.call(arguments), args);
+    assert.deepStrictEqual([].slice.call(arguments), args);
     if (nargs < 128) timeout(nargs + 1);
   }
 }
@@ -22,7 +22,7 @@ function interval(nargs) {
 
   function callback() {
     clearInterval(timer);
-    assert.deepEqual([].slice.call(arguments), args);
+    assert.deepStrictEqual([].slice.call(arguments), args);
     if (nargs < 128) interval(nargs + 1);
   }
 }

--- a/test/parallel/test-timers-immediate.js
+++ b/test/parallel/test-timers-immediate.js
@@ -28,5 +28,5 @@ setImmediate(function(x, y, z) {
 process.on('exit', function() {
   assert.ok(immediateA, 'Immediate should happen after normal execution');
   assert.notStrictEqual(immediateB, true, 'immediateB should not fire');
-  assert.deepEqual(immediateC, [1, 2, 3], 'immediateC args should match');
+  assert.deepStrictEqual(immediateC, [1, 2, 3], 'immediateC args should match');
 });

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -43,7 +43,7 @@ var server = tls.createServer(options, function(conn) {
 });
 
 process.on('exit', function() {
-  assert.deepEqual(ciphers, [{
+  assert.deepStrictEqual(ciphers, [{
     name: 'ECDHE-ECDSA-AES256-GCM-SHA384',
     version: 'TLSv1/SSLv3'
   }, {

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -7,7 +7,7 @@ const tls = require('tls');
 const singles = 'C=US\nST=CA\nL=SF\nO=Node.js Foundation\nOU=Node.js\n' +
                 'CN=ca1\nemailAddress=ry@clouds.org';
 const singlesOut = tls.parseCertString(singles);
-assert.deepEqual(singlesOut, {
+assert.deepStrictEqual(singlesOut, {
   C: 'US',
   ST: 'CA',
   L: 'SF',
@@ -20,7 +20,7 @@ assert.deepEqual(singlesOut, {
 const doubles = 'OU=Domain Control Validated\nOU=PositiveSSL Wildcard\n' +
                 'CN=*.nodejs.org';
 const doublesOut = tls.parseCertString(doubles);
-assert.deepEqual(doublesOut, {
+assert.deepStrictEqual(doublesOut, {
   OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
   CN: '*.nodejs.org'
 });

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -28,8 +28,10 @@ server.listen(common.PORT, function() {
   }, function() {
     var peerCert = socket.getPeerCertificate();
     console.error(util.inspect(peerCert));
-    assert.deepEqual(peerCert.subject.OU,
-                     ['Information Technology', 'Engineering', 'Marketing']);
+    assert.deepStrictEqual(
+      peerCert.subject.OU,
+      ['Information Technology', 'Engineering', 'Marketing']
+    );
     verified = true;
     server.close();
   });

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -40,7 +40,7 @@ server.listen(common.PORT, function() {
     assert.equal(peerCert.exponent, '0x10001');
     assert.equal(peerCert.fingerprint,
                  '8D:06:3A:B3:E5:8B:85:29:72:4F:7D:1B:54:CD:95:19:3C:EF:6F:AA');
-    assert.deepEqual(peerCert.infoAccess['OCSP - URI'],
+    assert.deepStrictEqual(peerCert.infoAccess['OCSP - URI'],
                      [ 'http://ocsp.nodejs.org/' ]);
 
     var issuer = peerCert.issuerCertificate;

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -154,16 +154,18 @@ function startTest() {
 }
 
 process.on('exit', function() {
-  assert.deepEqual(serverResults, [
+  assert.deepStrictEqual(serverResults, [
     { sni: 'a.example.com', authorized: false },
     { sni: 'a.example.com', authorized: true },
     { sni: 'b.example.com', authorized: false },
     { sni: 'c.wrong.com', authorized: false },
     null
   ]);
-  assert.deepEqual(clientResults, [true, true, true, false, false]);
-  assert.deepEqual(clientErrors, [null, null, null, null, 'socket hang up']);
-  assert.deepEqual(serverErrors, [
+  assert.deepStrictEqual(clientResults, [true, true, true, false, false]);
+  assert.deepStrictEqual(clientErrors, [
+    null, null, null, null, 'socket hang up'
+  ]);
+  assert.deepStrictEqual(serverErrors, [
     null, null, null, null, 'Invalid SNI context'
   ]);
 });

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -109,9 +109,9 @@ function startTest() {
 }
 
 process.on('exit', function() {
-  assert.deepEqual(serverResults, [
+  assert.deepStrictEqual(serverResults, [
     'a.example.com', 'b.test.com', 'a.b.test.com', 'c.wrong.com',
     'chain.example.com'
   ]);
-  assert.deepEqual(clientResults, [true, true, false, false, true]);
+  assert.deepStrictEqual(clientResults, [true, true, false, false, true]);
 });

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -873,7 +873,7 @@ var parseTests = {
 for (const u in parseTests) {
   let actual = url.parse(u);
   const spaced = url.parse(`     \t  ${u}\n\t`);
-  let expected = parseTests[u];
+  let expected = Object.assign(new url.Url(), parseTests[u]);
 
   Object.keys(actual).forEach(function(i) {
     if (expected[i] === undefined && actual[i] === null) {
@@ -881,8 +881,8 @@ for (const u in parseTests) {
     }
   });
 
-  assert.deepEqual(actual, expected);
-  assert.deepEqual(spaced, expected);
+  assert.deepStrictEqual(actual, expected);
+  assert.deepStrictEqual(spaced, expected);
 
   expected = parseTests[u].href;
   actual = url.format(parseTests[u]);
@@ -891,14 +891,29 @@ for (const u in parseTests) {
                'format(' + u + ') == ' + u + '\nactual:' + actual);
 }
 
+function createWithNoPrototype(properties = []) {
+  const noProto = Object.create(null);
+  properties.forEach((property) => {
+    noProto[property.key] = property.value;
+  });
+  return noProto;
+}
+
+function check(actual, expected) {
+  assert.notStrictEqual(Object.getPrototypeOf(actual), Object.prototype);
+  assert.deepStrictEqual(Object.keys(actual).sort(),
+                         Object.keys(expected).sort());
+  Object.keys(expected).forEach(function(key) {
+    assert.deepStrictEqual(actual[key], expected[key]);
+  });
+}
+
 var parseTestsWithQueryString = {
   '/foo/bar?baz=quux#frag': {
     href: '/foo/bar?baz=quux#frag',
     hash: '#frag',
     search: '?baz=quux',
-    query: {
-      baz: 'quux'
-    },
+    query: createWithNoPrototype([{key: 'baz', value: 'quux'}]),
     pathname: '/foo/bar',
     path: '/foo/bar?baz=quux'
   },
@@ -908,7 +923,7 @@ var parseTestsWithQueryString = {
     slashes: true,
     host: 'example.com',
     hostname: 'example.com',
-    query: {},
+    query: createWithNoPrototype(),
     search: '',
     pathname: '/',
     path: '/'
@@ -916,13 +931,13 @@ var parseTestsWithQueryString = {
   '/example': {
     protocol: null,
     slashes: null,
-    auth: null,
+    auth: undefined,
     host: null,
     port: null,
     hostname: null,
     hash: null,
     search: '',
-    query: {},
+    query: createWithNoPrototype(),
     pathname: '/example',
     path: '/example',
     href: '/example'
@@ -930,13 +945,13 @@ var parseTestsWithQueryString = {
   '/example?query=value': {
     protocol: null,
     slashes: null,
-    auth: null,
+    auth: undefined,
     host: null,
     port: null,
     hostname: null,
     hash: null,
     search: '?query=value',
-    query: { query: 'value' },
+    query: createWithNoPrototype([{ key: 'query', value: 'value' }]),
     pathname: '/example',
     path: '/example?query=value',
     href: '/example?query=value'
@@ -944,16 +959,22 @@ var parseTestsWithQueryString = {
 };
 for (const u in parseTestsWithQueryString) {
   const actual = url.parse(u, true);
-  const expected = parseTestsWithQueryString[u];
+  const expected = Object.assign(new url.Url(), parseTestsWithQueryString[u]);
   for (const i in actual) {
     if (actual[i] === null && expected[i] === undefined) {
       expected[i] = null;
     }
   }
 
-  assert.notStrictEqual(Object.getPrototypeOf(actual.query), Object.prototype);
-
-  assert.deepEqual(actual, expected);
+  const properties = Object.keys(actual).sort();
+  assert.deepStrictEqual(properties, Object.keys(expected).sort());
+  properties.forEach((property) => {
+    if (property === 'query') {
+      check(actual[property], expected[property]);
+    } else {
+      assert.deepStrictEqual(actual[property], expected[property]);
+    }
+  });
 }
 
 // some extra formatting tests, just to verify
@@ -1536,7 +1557,7 @@ relativeTests.forEach(function(relativeTest) {
   var expected = url.parse(relativeTest[2]);
 
 
-  assert.deepEqual(actual, expected);
+  assert.deepStrictEqual(actual, expected);
 
   expected = relativeTest[2];
   actual = url.format(actual);
@@ -1563,7 +1584,7 @@ relativeTests2.forEach(function(relativeTest) {
   var actual = url.resolveObject(url.parse(relativeTest[1]), relativeTest[0]);
   var expected = url.parse(relativeTest[2]);
 
-  assert.deepEqual(actual, expected);
+  assert.deepStrictEqual(actual, expected);
 
   expected = relativeTest[2];
   actual = url.format(actual);

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -26,7 +26,7 @@ assert.throws(getHiddenValue(85, 'foo'), /obj must be an object/);
 assert.throws(getHiddenValue({}), /name must be a string/);
 assert.throws(getHiddenValue({}, null), /name must be a string/);
 assert.throws(getHiddenValue({}, []), /name must be a string/);
-assert.deepEqual(internalUtil.getHiddenValue({}, 'foo'), undefined);
+assert.deepStrictEqual(internalUtil.getHiddenValue({}, 'foo'), undefined);
 
 assert.throws(setHiddenValue(), /obj must be an object/);
 assert.throws(setHiddenValue(null, 'foo'), /obj must be an object/);

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -76,10 +76,10 @@ assert.equal(false, util.isBuffer('foo'));
 assert.equal(true, util.isBuffer(Buffer.from('foo')));
 
 // _extend
-assert.deepEqual(util._extend({a:1}),             {a:1});
-assert.deepEqual(util._extend({a:1}, []),         {a:1});
-assert.deepEqual(util._extend({a:1}, null),       {a:1});
-assert.deepEqual(util._extend({a:1}, true),       {a:1});
-assert.deepEqual(util._extend({a:1}, false),      {a:1});
-assert.deepEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
-assert.deepEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});
+assert.deepStrictEqual(util._extend({a:1}),             {a:1});
+assert.deepStrictEqual(util._extend({a:1}, []),         {a:1});
+assert.deepStrictEqual(util._extend({a:1}, null),       {a:1});
+assert.deepStrictEqual(util._extend({a:1}, true),       {a:1});
+assert.deepStrictEqual(util._extend({a:1}, false),      {a:1});
+assert.deepStrictEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
+assert.deepStrictEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -11,7 +11,7 @@ var keys = [
   'total_heap_size_executable',
   'total_physical_size',
   'used_heap_size'];
-assert.deepEqual(Object.keys(s).sort(), keys);
+assert.deepStrictEqual(Object.keys(s).sort(), keys);
 keys.forEach(function(key) {
   assert.equal(typeof s[key], 'number');
 });
@@ -26,7 +26,7 @@ const expectedHeapSpaces = [
 ];
 const heapSpaceStatistics = v8.getHeapSpaceStatistics();
 const actualHeapSpaceNames = heapSpaceStatistics.map((s) => s.space_name);
-assert.deepEqual(actualHeapSpaceNames.sort(), expectedHeapSpaces.sort());
+assert.deepStrictEqual(actualHeapSpaceNames.sort(), expectedHeapSpaces.sort());
 heapSpaceStatistics.forEach((heapSpace) => {
   assert.strictEqual(typeof heapSpace.space_name, 'string');
   assert.strictEqual(typeof heapSpace.space_size, 'number');

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -9,7 +9,7 @@ var result = vm.runInNewContext(
   'foo = "bar"; this.typeofProcess = typeof process; typeof Object;',
   sandbox
 );
-assert.deepEqual(sandbox, {
+assert.deepStrictEqual(sandbox, {
   foo: 'bar',
   typeofProcess: 'undefined',
 });
@@ -22,7 +22,7 @@ result = vm.runInContext(
   'baz = foo; this.typeofProcess = typeof process; typeof Object;',
   context
 );
-assert.deepEqual(sandbox2, {
+assert.deepStrictEqual(sandbox2, {
   foo: 'bar',
   baz: 'bar',
   typeofProcess: 'undefined'

--- a/test/parallel/test-vm-create-context-accessors.js
+++ b/test/parallel/test-vm-create-context-accessors.js
@@ -24,4 +24,5 @@ Object.defineProperty(ctx, 'setter', {
 ctx = vm.createContext(ctx);
 
 var result = vm.runInContext('setter = "test";[getter,setter]', ctx);
-assert.deepEqual(result, ['ok', 'ok=test']);
+assert.strictEqual(result[0], 'ok');
+assert.strictEqual(result[1], 'ok=test');

--- a/test/parallel/test-vm-global-define-property.js
+++ b/test/parallel/test-vm-global-define-property.js
@@ -23,4 +23,4 @@ assert(res);
 assert.equal(typeof res, 'object');
 assert.equal(res, x);
 assert.equal(o.f, res);
-assert.deepEqual(Object.keys(o), ['console', 'x', 'g', 'f']);
+assert.deepStrictEqual(Object.keys(o), ['console', 'x', 'g', 'f']);

--- a/test/parallel/test-zlib-flush.js
+++ b/test/parallel/test-zlib-flush.js
@@ -31,6 +31,6 @@ deflater.write(chunk, function() {
 });
 
 process.once('exit', function() {
-  assert.deepEqual(actualNone, expectedNone);
-  assert.deepEqual(actualFull, expectedFull);
+  assert.deepStrictEqual(actualNone, expectedNone);
+  assert.deepStrictEqual(actualFull, expectedFull);
 });

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -41,5 +41,5 @@ unzips.forEach(function(uz, i) {
 });
 
 process.on('exit', function() {
-  assert.deepEqual(hadError, [true, true, true, true], 'expect 4 errors');
+  assert.deepStrictEqual(hadError, [true, true, true, true], 'expect 4 errors');
 });

--- a/test/parallel/test-zlib-params.js
+++ b/test/parallel/test-zlib-params.js
@@ -30,5 +30,5 @@ deflater.write(chunk1, function() {
 });
 
 process.once('exit', function() {
-  assert.deepEqual(actual, expected);
+  assert.deepStrictEqual(actual, expected);
 });

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -49,5 +49,5 @@ for (const name in hashes) {
   group2.generateKeys();
   var key1 = group1.computeSecret(group2.getPublicKey());
   var key2 = group2.computeSecret(group1.getPublicKey());
-  assert.deepEqual(key1, key2);
+  assert.deepStrictEqual(key1, key2);
 }

--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -17,7 +17,7 @@ for (var i = 0; i < 2000; i++) {
   a.generateKeys();
   b.generateKeys();
 
-  assert.deepEqual(
+  assert.deepStrictEqual(
     a.computeSecret(b.getPublicKey()),
     b.computeSecret(a.getPublicKey()),
     'secrets should be equal!'

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -41,7 +41,7 @@ cmd = `"${process.execPath}" -e "console.log(\'${msg}\');"`;
 ret = execSync(cmd);
 
 assert.strictEqual(ret.length, msgBuf.length);
-assert.deepEqual(ret, msgBuf, 'execSync result buffer should match');
+assert.deepStrictEqual(ret, msgBuf, 'execSync result buffer should match');
 
 ret = execSync(cmd, { encoding: 'utf8' });
 
@@ -53,7 +53,7 @@ var args = [
 ];
 ret = execFileSync(process.execPath, args);
 
-assert.deepEqual(ret, msgBuf);
+assert.deepStrictEqual(ret, msgBuf);
 
 ret = execFileSync(process.execPath, args, { encoding: 'utf8' });
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -172,7 +172,7 @@ assert.equal(child.loaded, parent.loaded);
 
 // #1357 Loading JSON files with require()
 var json = require('../fixtures/packages/main/package.json');
-assert.deepEqual(json, {
+assert.deepStrictEqual(json, {
   name: 'package-name',
   version: '1.2.3',
   main: 'package-main-module'
@@ -190,7 +190,7 @@ var children = module.children.reduce(function red(set, child) {
   return set;
 }, {});
 
-assert.deepEqual(children, {
+assert.deepStrictEqual(children, {
   'common.js': {},
   'fixtures/not-main-module.js': {},
   'fixtures/a.js': {

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -40,7 +40,7 @@ var w = new TestWriter();
 w.on('results', function(res) {
   console.error(res, w.length);
   assert.equal(w.length, size);
-  assert.deepEqual(res.map(function(c) {
+  assert.deepStrictEqual(res.map(function(c) {
     return c.length;
   }), expectLengths);
   console.log('ok');

--- a/tools/eslint-rules/no-deepEqual.js
+++ b/tools/eslint-rules/no-deepEqual.js
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Prohibit use of assert.deepEqual()
+ * @author Rich Trott
+ *
+ * This rule is imperfect, but will find the most common forms of
+ * assert.deepEqual() usage.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const msg = 'assert.deepEqual() disallowed. Use assert.deepStrictEqual()';
+
+function isAssert(node) {
+  return node.callee.object && node.callee.object.name === 'assert';
+}
+
+function isDeepEqual(node) {
+  return node.callee.property && node.callee.property.name === 'deepEqual';
+}
+
+module.exports = function(context) {
+  return {
+    'CallExpression': function(node) {
+      if (isAssert(node) && isDeepEqual(node)) {
+        context.report(node, msg);
+      }
+    }
+  };
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools, test, benchmark
##### Description of change

<!-- provide a description of the change below this comment -->

Introduce a lint rule that enforces use of `assert.deepStrictEqual()`
over `assert.deepEqual()`.

This is a proof of concept inspired by @Fishrock123 wondering in https://github.com/nodejs/node/pull/6196#issuecomment-209998141:

> We could make a lint rule that requires strict assertions for the tests, but I feel people may be opposed to that?

I like it, but (like Fishrock123) I don't know if others will feel the same.

If this is deemed a good idea, it can optionally evolve from `no-deepEqual` to something that flags all non-strict assertions, perhaps only in the tests. Not going to bother, though, if there isn't consensus on this.