### PR TITLE
benchmarks: add microbenchmarks for new ES6 features

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -255,3 +255,15 @@ Benchmark.prototype.getHeading = function() {
     }).join(',');
   }
 };
+
+exports.v8ForceOptimization = function(method, ...args) {
+  if (typeof method !== 'function')
+    return;
+  const v8 = require('v8');
+  v8.setFlagsFromString('--allow_natives_syntax');
+  method.apply(null, args);
+  eval('%OptimizeFunctionOnNextCall(method)');
+  method.apply(null, args);
+  return eval('%GetOptimizationStatus(method)');
+};
+

--- a/benchmark/es/defaultparams-bench.js
+++ b/benchmark/es/defaultparams-bench.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  method: ['withoutdefaults', 'withdefaults'],
+  millions: [100]
+});
+
+function oldStyleDefaults(x, y) {
+  x = x || 1;
+  y = y || 2;
+  assert.strictEqual(x, 1);
+  assert.strictEqual(y, 2);
+}
+
+function defaultParams(x = 1, y = 2) {
+  assert.strictEqual(x, 1);
+  assert.strictEqual(y, 2);
+}
+
+function runOldStyleDefaults(n) {
+
+  common.v8ForceOptimization(oldStyleDefaults);
+
+  var i = 0;
+  bench.start();
+  for (; i < n; i++)
+    oldStyleDefaults();
+  bench.end(n / 1e6);
+}
+
+function runDefaultParams(n) {
+
+  common.v8ForceOptimization(defaultParams);
+
+  var i = 0;
+  bench.start();
+  for (; i < n; i++)
+    defaultParams();
+  bench.end(n / 1e6);
+}
+
+function main(conf) {
+  const n = +conf.millions * 1e6;
+
+  switch (conf.method) {
+    case 'withoutdefaults':
+      runOldStyleDefaults(n);
+      break;
+    case 'withdefaults':
+      runDefaultParams(n);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  method: ['swap', 'destructure'],
+  millions: [100]
+});
+
+function runSwapManual(n) {
+  var i = 0, x, y, r;
+  bench.start();
+  for (; i < n; i++) {
+    x = 1, y = 2;
+    r = x;
+    x = y;
+    y = r;
+    assert.strictEqual(x, 2);
+    assert.strictEqual(y, 1);
+  }
+  bench.end(n / 1e6);
+}
+
+function runSwapDestructured(n) {
+  var i = 0, x, y;
+  bench.start();
+  for (; i < n; i++) {
+    x = 1, y = 2;
+    [x, y] = [y, x];
+    assert.strictEqual(x, 2);
+    assert.strictEqual(y, 1);
+  }
+  bench.end(n / 1e6);
+}
+
+function main(conf) {
+  const n = +conf.millions * 1e6;
+
+  switch (conf.method) {
+    case 'swap':
+      runSwapManual(n);
+      break;
+    case 'destructure':
+      runSwapDestructured(n);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  method: ['copy', 'rest', 'arguments'],
+  millions: [100]
+});
+
+function copyArguments() {
+  var len = arguments.length;
+  var args = new Array(len);
+  for (var i = 0; i < len; i++)
+    args[i] = arguments[i];
+  assert.strictEqual(args[0], 1);
+  assert.strictEqual(args[1], 2);
+  assert.strictEqual(args[2], 'a');
+  assert.strictEqual(args[3], 'b');
+}
+
+function restArguments(...args) {
+  assert.strictEqual(args[0], 1);
+  assert.strictEqual(args[1], 2);
+  assert.strictEqual(args[2], 'a');
+  assert.strictEqual(args[3], 'b');
+}
+
+function useArguments() {
+  assert.strictEqual(arguments[0], 1);
+  assert.strictEqual(arguments[1], 2);
+  assert.strictEqual(arguments[2], 'a');
+  assert.strictEqual(arguments[3], 'b');
+}
+
+function runCopyArguments(n) {
+
+  common.v8ForceOptimization(copyArguments, 1, 2, 'a', 'b');
+
+  var i = 0;
+  bench.start();
+  for (; i < n; i++)
+    copyArguments(1, 2, 'a', 'b');
+  bench.end(n / 1e6);
+}
+
+function runRestArguments(n) {
+
+  common.v8ForceOptimization(restArguments, 1, 2, 'a', 'b');
+
+  var i = 0;
+  bench.start();
+  for (; i < n; i++)
+    restArguments(1, 2, 'a', 'b');
+  bench.end(n / 1e6);
+}
+
+function runUseArguments(n) {
+
+  common.v8ForceOptimization(useArguments, 1, 2, 'a', 'b');
+
+  var i = 0;
+  bench.start();
+  for (; i < n; i++)
+    useArguments(1, 2, 'a', 'b');
+  bench.end(n / 1e6);
+}
+
+function main(conf) {
+  const n = +conf.millions * 1e6;
+
+  switch (conf.method) {
+    case 'copy':
+      runCopyArguments(n);
+      break;
+    case 'rest':
+      runRestArguments(n);
+      break;
+    case 'arguments':
+      runUseArguments(n);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}


### PR DESCRIPTION
##### Checklist

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] the commit message follows commit guidelines

##### Affected core subsystem(s)

benchmarks

##### Description of change

Adds new microbenchmarks for destructuring, rest params and default params.

Now that v8 v5 has landed, it makes sense to track the perf of various new language features. These are very simple raw micro-benchmarks.

Current results from master:

```
bash-3.2$ ./node benchmark/misc/restparams-bench.js 
misc/restparams-bench.js method=old millions=100: 11.42148
misc/restparams-bench.js method=new millions=100: 23.56694
misc/restparams-bench.js method=arguments millions=100: 14.49330

bash-3.2$ ./node benchmark/misc/defaultparams-bench.js 
misc/defaultparams-bench.js method=old millions=100: 26.88026
misc/defaultparams-bench.js method=new millions=100: 25.99777

bash-3.2$ ./node benchmark/misc/destructuring-bench.js 
misc/destructuring-bench.js method=old millions=100: 2230.47279
misc/destructuring-bench.js method=new millions=100: 15.22549
bash-3.2$ 
```

( Note how much slower the new destructuring assignment is for a simple var swap :-/ )

