### PR TITLE
src: don't set non-primitive values on templates

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const FreeList = require('internal/freelist').FreeList;
-const HTTPParser = process.binding('http_parser').HTTPParser;
+const binding = process.binding('http_parser');
+const methods = binding.methods;
+const HTTPParser = binding.HTTPParser;
 
+const FreeList = require('internal/freelist').FreeList;
 const incoming = require('_http_incoming');
 const IncomingMessage = incoming.IncomingMessage;
 const readStart = incoming.readStart;
@@ -14,7 +16,7 @@ exports.debug = debug;
 exports.CRLF = '\r\n';
 exports.chunkExpression = /chunk/i;
 exports.continueExpression = /100-continue/i;
-exports.methods = HTTPParser.methods;
+exports.methods = methods;
 
 const kOnHeaders = HTTPParser.kOnHeaders | 0;
 const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
@@ -71,7 +73,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
 
   if (typeof method === 'number') {
     // server only
-    parser.incoming.method = HTTPParser.methods[method];
+    parser.incoming.method = methods[method];
   } else {
     // client only
     parser.incoming.statusCode = statusCode;

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -507,27 +507,25 @@ inline void Environment::SetProtoMethod(v8::Local<v8::FunctionTemplate> that,
                                         const char* name,
                                         v8::FunctionCallback callback) {
   v8::Local<v8::Signature> signature = v8::Signature::New(isolate(), that);
-  v8::Local<v8::Function> function =
-      NewFunctionTemplate(callback, signature)->GetFunction();
+  v8::Local<v8::FunctionTemplate> t = NewFunctionTemplate(callback, signature);
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->PrototypeTemplate()->Set(name_string, function);
-  function->SetName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
+  that->PrototypeTemplate()->Set(name_string, t);
+  t->SetClassName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
 }
 
 inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
                                            const char* name,
                                            v8::FunctionCallback callback) {
-  v8::Local<v8::Function> function =
-      NewFunctionTemplate(callback)->GetFunction();
+  v8::Local<v8::FunctionTemplate> t = NewFunctionTemplate(callback);
   // kInternalized strings are created in the old space.
   const v8::NewStringType type = v8::NewStringType::kInternalized;
   v8::Local<v8::String> name_string =
       v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked();
-  that->Set(name_string, function);
-  function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
+  that->Set(name_string, t);
+  t->SetClassName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 
 inline v8::Local<v8::Object> Environment::NewInternalFieldObject() {

--- a/src/node.h
+++ b/src/node.h
@@ -240,8 +240,20 @@ NODE_EXTERN void RunAtExit(Environment* env);
   while (0)
 
 // Used to be a macro, hence the uppercase name.
-template <typename TypeName>
-inline void NODE_SET_METHOD(const TypeName& recv,
+inline void NODE_SET_METHOD(v8::Local<v8::Template> recv,
+                            const char* name,
+                            v8::FunctionCallback callback) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate,
+                                                                callback);
+  v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
+  t->SetClassName(fn_name);
+  recv->Set(fn_name, t);
+}
+
+// Used to be a macro, hence the uppercase name.
+inline void NODE_SET_METHOD(v8::Local<v8::Object> recv,
                             const char* name,
                             v8::FunctionCallback callback) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
@@ -265,10 +277,9 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
   v8::Local<v8::Signature> s = v8::Signature::New(isolate, recv);
   v8::Local<v8::FunctionTemplate> t =
       v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), s);
-  v8::Local<v8::Function> fn = t->GetFunction();
-  recv->PrototypeTemplate()->Set(v8::String::NewFromUtf8(isolate, name), fn);
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
-  fn->SetName(fn_name);
+  t->SetClassName(fn_name);
+  recv->PrototypeTemplate()->Set(v8::String::NewFromUtf8(isolate, name), t);
 }
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -759,7 +759,7 @@ void InitHttpParser(Local<Object> target,
     methods->Set(num, FIXED_ONE_BYTE_STRING(env->isolate(), #string));
   HTTP_METHOD_MAP(V)
 #undef V
-  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "methods"), methods);
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "methods"), methods);
 
   env->SetProtoMethod(t, "close", Parser::Close);
   env->SetProtoMethod(t, "execute", Parser::Execute);

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -2,13 +2,13 @@
 require('../common');
 var assert = require('assert');
 
-var HTTPParser = process.binding('http_parser').HTTPParser;
+const binding = process.binding('http_parser');
+const methods = binding.methods;
+const HTTPParser = binding.HTTPParser;
 
 var CRLF = '\r\n';
 var REQUEST = HTTPParser.REQUEST;
 var RESPONSE = HTTPParser.RESPONSE;
-
-var methods = HTTPParser.methods;
 
 var kOnHeaders = HTTPParser.kOnHeaders | 0;
 var kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;


### PR DESCRIPTION
V8 is going to disallow non-primitive values on v8::FunctionTemplate
and v8::ObjectTemplate because those can't be shared across contexts.
Hide such properties behind a getter.

Fixes: #6216

R=@nodejs/v8 @jeisinger

CI: https://ci.nodejs.org/job/node-test-pull-request/2279/