### PR TITLE
docs: add steps for running addons + npm tests

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,6 +50,21 @@ To run the tests:
 $ make test
 ```
 
+To run the native module tests:
+
+```text
+$ make test-addons
+```
+
+To run the npm test suite:
+
+*note: to run the suite on node v4 or earlier you must first*
+*run `make install`*
+
+```
+$ make test-npm
+```
+
 To build the documentation:
 
 ```text


### PR DESCRIPTION
Currently we do not document how to run the test suite for native
modules or for npm. This commit updates BUILDING.md with the
information needed to do so. It includes a caveat about Node v4
and earlier requiring `make install` to be run before running the npm
test suite.