### PR TITLE
util: deprecate most of util.is*()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -715,42 +715,51 @@ function reduceToSingleString(output, base, braces) {
 
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
-exports.isArray = Array.isArray;
+exports.isArray = internalUtil.deprecate(Array.isArray,
+    'util.isArray() is deprecated. Use Array.isArray instead.');
 
 function isBoolean(arg) {
   return typeof arg === 'boolean';
 }
-exports.isBoolean = isBoolean;
+exports.isBoolean = internalUtil.deprecate(isBoolean,
+    'util.isBoolean() is deprecated. Use typeof arg === \'boolean\' instead.');
 
 function isNull(arg) {
   return arg === null;
 }
-exports.isNull = isNull;
+exports.isNull = internalUtil.deprecate(isNull,
+    'util.isNull() is deprecated. Use arg === null instead.');
 
 function isNullOrUndefined(arg) {
   return arg === null || arg === undefined;
 }
-exports.isNullOrUndefined = isNullOrUndefined;
+exports.isNullOrUndefined = internalUtil.deprecate(isNullOrUndefined,
+  'util.isNullOrUndefined() is deprecated. Use the following instead:\n' +
+  'arg === null || arg === undefined');
 
 function isNumber(arg) {
   return typeof arg === 'number';
 }
-exports.isNumber = isNumber;
+exports.isNumber = internalUtil.deprecate(isNumber,
+    'util.isNumber() is deprecated. Use typeof arg === \'number\' instead.');
 
 function isString(arg) {
   return typeof arg === 'string';
 }
-exports.isString = isString;
+exports.isString = internalUtil.deprecate(isString,
+    'util.isString() is deprecated. Use typeof arg === \'string\' instead.');
 
 function isSymbol(arg) {
   return typeof arg === 'symbol';
 }
-exports.isSymbol = isSymbol;
+exports.isSymbol = internalUtil.deprecate(isSymbol,
+    'util.isSymbol() is deprecated. Use typeof arg === \'symbol\' instead');
 
 function isUndefined(arg) {
   return arg === undefined;
 }
-exports.isUndefined = isUndefined;
+exports.isUndefined = internalUtil.deprecate(isUndefined,
+    'util.isUndefined() is deprecated. Use arg === undefined instead.');
 
 function isRegExp(re) {
   return binding.isRegExp(re);
@@ -760,7 +769,9 @@ exports.isRegExp = isRegExp;
 function isObject(arg) {
   return arg !== null && typeof arg === 'object';
 }
-exports.isObject = isObject;
+exports.isObject = internalUtil.deprecate(isObject,
+    'util.isObject() is deprecated. Use the following instead:\n' +
+    'arg !== null && typeof arg === \'object\'');
 
 function isDate(d) {
   return binding.isDate(d);
@@ -772,15 +783,17 @@ exports.isError = isError;
 function isFunction(arg) {
   return typeof arg === 'function';
 }
-exports.isFunction = isFunction;
+exports.isFunction = internalUtil.deprecate(isFunction,
+    'util.isFunction() is deprecated. ' +
+    'Use typeof arg === \'function\' instead.');
 
 function isPrimitive(arg) {
-  return arg === null ||
-         typeof arg !== 'object' && typeof arg !== 'function';
+  return binding.isPrimitive(arg);
 }
 exports.isPrimitive = isPrimitive;
 
-exports.isBuffer = Buffer.isBuffer;
+exports.isBuffer = internalUtil.deprecate(Buffer.isBuffer,
+    'util.isBuffer() is deprecated. Use Buffer.isBuffer() instead.');
 
 
 function pad(n) {

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -38,6 +38,11 @@ using v8::Value;
 #undef V
 
 
+static void IsPrimitive(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(!args[0]->IsObject() && !args[0]->IsExternal());
+}
+
+
 static void GetHiddenValue(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -84,6 +89,7 @@ void Initialize(Local<Object> target,
 
   env->SetMethod(target, "getHiddenValue", GetHiddenValue);
   env->SetMethod(target, "setHiddenValue", SetHiddenValue);
+  env->SetMethod(target, "isPrimitive", IsPrimitive);
 }
 
 }  // namespace util


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

util
##### Description of change

<!-- provide a description of the change below this comment -->

Supersedes https://github.com/nodejs/node/pull/1301

This deprecates most of util.is except some stuff for which v8 has internal functions for and primitives.

**To be quite honest, I don't really know what to do here, if this is remotely right, etc.**

cc @nodejs/ctc I guess

_note: the tests currently log a ton of warnings but I can't be bothered to fix them until we decide on what is the best path forward_
