### PR TITLE
Prevent multiple calls to Server.listen

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1083,6 +1083,7 @@ function Server(options, connectionListener) {
     throw new TypeError('options must be an object');
   }
 
+  this._listenHasBeenCalled = false;
   this._connections = 0;
 
   Object.defineProperty(this, 'connections', {
@@ -1300,6 +1301,11 @@ function listen(self, address, port, addressType, backlog, fd, exclusive) {
 Server.prototype.listen = function() {
   var self = this;
 
+  if (self._listenHasBeenCalled) 
+    throw new Error('listen() cannot be called multiple times.');
+
+  self._listenHasBeenCalled = true;
+  
   var lastArg = arguments[arguments.length - 1];
   if (typeof lastArg === 'function') {
     self.once('listening', lastArg);

--- a/test/parallel/test-net-listen-multiple-calls.js
+++ b/test/parallel/test-net-listen-multiple-calls.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const server = net.createServer();
+
+server.on('error', () => {
+  console.error('server had an error');
+});
+
+assert.throws(function() {
+  server.listen(common.PORT).listen(common.PORT+1);
+}, /listen\(\) cannot be called multiple times/i);
+  
+process.on('exit', () => {
+  // Is this needed? assert.equal(server.address().port, 8080);
+  const key = server._connectionKey;
+  assert.equal(key.substr(key.lastIndexOf(':')+1), common.PORT);
+});
+
+server.close();


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

net
##### Description of change

Minimal attempt to resolve https://github.com/nodejs/node/issues/6190 

Added `_listenHasBeenCalled` as suggested by @trevnorris 
