### PR TITLE
http: fix incorrect header check

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -287,7 +287,7 @@ exports._checkIsHttpToken = checkIsHttpToken;
 function checkInvalidHeaderChar(val) {
   val = '' + val;
   for (var i = 0; i < val.length; i++) {
-    const ch = val.charCodeAt(i);
+    var ch = val.charCodeAt(i);
     if (ch === 9) continue;
     if (ch <= 31 || ch > 255 || ch === 127) return true;
   }


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

http


##### Description of change

The **const** in `checkInvalidHeaderChar` should be **var**:

```javascript
var invalid = checkInvalidHeaderChar("Mozilla/5.0 (compatible; 㘥)");
// before: invalid == false
// after: invalid == true
```