### PR TITLE
test: move the debugger tests back to parallel

### DIFF
--- a/test/parallel/test-debugger-repeat-last.js
+++ b/test/parallel/test-debugger-repeat-last.js
@@ -12,6 +12,7 @@ const fixture = path.join(
 
 const args = [
   'debug',
+  `--port=${common.PORT}`,
   fixture
 ];
 

--- a/test/parallel/test-debugger-util-regression.js
+++ b/test/parallel/test-debugger-util-regression.js
@@ -12,6 +12,7 @@ const fixture = path.join(
 
 const args = [
   'debug',
+  `--port=${common.PORT}`,
   fixture
 ];
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
test

##### Description of change

<!-- provide a description of the change below this comment -->

Run the debugger with `--port=common.PORT` to avoid the use of the same
port.

/cc @nodejs/testing 