### PR TITLE
test,tools: enable linting for undefined vars in tests

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,8 +1,6 @@
 ## Test-specific linter rules
 
 rules:
-  ## allow undeclared variables
-  no-undef: 0
   ## common module is mandatory in tests
   required-modules: [2, "common"]
 

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -5,6 +5,7 @@ process.nextTick(function() {
   process.nextTick(function() {
     process.nextTick(function() {
       process.nextTick(function() {
+        // eslint-disable-next-line
         undefined_reference_error_maker;
       });
     });

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -2,5 +2,6 @@
 require('../common');
 
 setTimeout(function() {
+  // eslint-disable-next-line no-undef
   undefined_reference_error_maker;
 });

--- a/test/parallel/test-domain-exit-dispose-again.js
+++ b/test/parallel/test-domain-exit-dispose-again.js
@@ -56,7 +56,7 @@ setTimeout(function firstTimer() {
     // Make V8 throw an unreferenced error. As a result, the domain's error
     // handler is called, which disposes the domain "d" and should prevent the
     // nested timer that is attached to it from running.
-    err3();
+    err3(); // eslint-disable-line no-undef
   });
 }, TIMEOUT_DURATION);
 

--- a/test/parallel/test-domain-exit-dispose.js
+++ b/test/parallel/test-domain-exit-dispose.js
@@ -29,7 +29,7 @@ function err() {
     });
 
     // this function doesn't exist, and throws an error as a result.
-    err3();
+    err3(); // eslint-disable-line no-undef
   }
 
   function handle(e) {

--- a/test/parallel/test-exception-handler2.js
+++ b/test/parallel/test-exception-handler2.js
@@ -1,22 +1,14 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 
 process.on('uncaughtException', function(err) {
   console.log('Caught exception: ' + err);
 });
 
-var timeoutFired = false;
-setTimeout(function() {
+setTimeout(common.mustCall(function() {
   console.log('This will still run.');
-  timeoutFired = true;
-}, 500);
-
-process.on('exit', function() {
-  assert.ok(timeoutFired);
-});
+}), 50);
 
 // Intentionally cause an exception, but don't catch it.
-nonexistentFunc();
-console.log('This will not run.');
-
+nonexistentFunc(); // eslint-disable-line no-undef
+common.fail('This will not run.');

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -4,12 +4,14 @@ var assert = require('assert');
 
 common.globalCheck = false;
 
-baseFoo = 'foo';
+baseFoo = 'foo'; // eslint-disable-line no-undef
 global.baseBar = 'bar';
 
 assert.equal('foo', global.baseFoo, 'x -> global.x in base level not working');
 
-assert.equal('bar', baseBar, 'global.x -> x in base level not working');
+assert.equal('bar',
+             baseBar, // eslint-disable-line no-undef
+             'global.x -> x in base level not working');
 
 var module = require('../fixtures/global/plain');
 const fooBar = module.fooBar;

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
-  intentionally_not_defined();
+  intentionally_not_defined(); // eslint-disable-line no-undef
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('Thank you, come again.');
   res.end();

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -21,7 +21,6 @@ if (common.isWindows) {
 switch (process.argv[2]) {
   case 'master': return master();
   case 'worker': return worker();
-  case 'parent': return parent();
 }
 
 var ok;

--- a/test/parallel/test-next-tick-errors.js
+++ b/test/parallel/test-next-tick-errors.js
@@ -10,7 +10,7 @@ let exceptionHandled = false;
 process.nextTick(function() {
   order.push('A');
   // cause an error
-  what();
+  what(); // eslint-disable-line no-undef
 });
 
 // This nextTick function should remain in the queue when the first one

--- a/test/parallel/test-regress-GH-2245.js
+++ b/test/parallel/test-regress-GH-2245.js
@@ -3,7 +3,7 @@ require('../common');
 var assert = require('assert');
 
 /*
-in node 0.10 a bug existed that caused strict functions to not capture
+In Node.js 0.10, a bug existed that caused strict functions to not capture
 their environment when evaluated. When run in 0.10 `test()` fails with a
 `ReferenceError`. See https://github.com/nodejs/node/issues/2245 for details.
 */
@@ -21,7 +21,7 @@ function test() {
 
   eval(code);
 
-  return bar();
+  return bar(); // eslint-disable-line no-undef
 
 }
 

--- a/test/parallel/test-timers-reset-process-domain-on-throw.js
+++ b/test/parallel/test-timers-reset-process-domain-on-throw.js
@@ -22,7 +22,7 @@ function err() {
 
   function err2() {
     // this function doesn't exist, and throws an error as a result.
-    err3();
+    err3(); // eslint-disable-line no-undef
   }
 
   function handleDomainError(e) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -301,7 +301,7 @@ errors.forEach(function(err) {
   assert.equal(util.inspect(err), err.stack);
 });
 try {
-  undef();
+  undef(); // eslint-disable-line no-undef
 } catch (e) {
   assert.equal(util.inspect(e), e.stack);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test tools
##### Description of change

<!-- provide a description of the change below this comment -->

The test directory had linting for undefined variables disabled. It is
enabled everywhere else in the code base. Let's disable the fule for
individual lines in the handful of tests that use undefined variables.