### PR TITLE
child_process: Add nullptr checks after allocations

### DIFF
--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -166,6 +166,7 @@ class ProcessWrap : public HandleWrap {
       for (int i = 0; i < argc; i++) {
         node::Utf8Value arg(env->isolate(), js_argv->Get(i));
         options.args[i] = strdup(*arg);
+        CHECK_NE(options.args[i], nullptr);
       }
       options.args[argc] = nullptr;
     }
@@ -187,6 +188,7 @@ class ProcessWrap : public HandleWrap {
       for (int i = 0; i < envc; i++) {
         node::Utf8Value pair(env->isolate(), env_opt->Get(i));
         options.env[i] = strdup(*pair);
+        CHECK_NE(options.env[i], nullptr);
       }
       options.env[envc] = nullptr;
     }


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

child_process

##### Description of change

* Add checks against null pointers after allocations made when spawning child processes for arguments, environment variables, etc.
* ~~Make sure that the out-of-range tests for setting the uid/gid work when `uid_t`/`gid_t` are unsigned types (e.g. Linux) and the supplied value is negative, to the degree to which that is possible.~~