### PR TITLE
doc: DCO anchor that doesn't change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,7 @@ to address, apply your changes in a separate commit and push that to your
 feature branch. Post a comment in the pull request afterwards; GitHub does
 not send out notifications when you add commits.
 
+<a id="developers-certificate-of-origin"></a>
 ## Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Description of change

The DCO (Developer's Certificate of Origin) has a version number in it so whenever there is an update to the version, the hash (#) links break. This change just adds an anchor without the version number on it.

