### PR TITLE
tools: lint rule for assert.fail()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,6 +85,7 @@ rules:
   prefer-const: 2
 
   # Custom rules in tools/eslint-rules
+  assert-fail-single-argument: 2
   new-with-error: [2, "Error", "RangeError", "TypeError", "SyntaxError", "ReferenceError"]
 
 

--- a/tools/eslint-rules/assert-fail-single-argument.js
+++ b/tools/eslint-rules/assert-fail-single-argument.js
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Prohibit use of a single argument only in `assert.fail()`. It
+ * is almost always an error.
+ * @author Rich Trott
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const msg = 'assert.fail() message should be third argument';
+
+function isAssert(node) {
+  return node.callee.object && node.callee.object.name === 'assert';
+}
+
+function isFail(node) {
+  return node.callee.property && node.callee.property.name === 'fail';
+}
+
+module.exports = function(context) {
+  return {
+    'CallExpression': function(node) {
+      if (isAssert(node) && isFail(node) && node.arguments.length === 1) {
+        context.report(node, msg);
+      }
+    }
+  };
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

assert tools

##### Description of change

<!-- provide a description of the change below this comment -->

`assert.fail()` is often mistakenly used with a single argument even in
Node.js core. (See fixes to previous instances in
b7f4b1ba4cca320cf576aa73fae15902fd801190,
28e9a022df3ef89a0ea21e4ad86655eb408a8d96. and
676e61872f54dd546e324599c7871c20b798386a.)

This commit adds a linting rule to identify instances of this issue.