### PR TITLE
tools: enable linting for v8_prof_processor.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 lib/internal/v8_prof_polyfill.js
-lib/internal/v8_prof_processor.js
 lib/punycode.js
 test/addons/??_*/
 test/fixtures

--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -1,3 +1,4 @@
+/* eslint-disable strict */
 const scriptFiles = [
   'internal/v8_prof_polyfill',
   'v8/tools/splaytree',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools v8

##### Description of change

<!-- provide a description of the change below this comment -->

`lib/internal/v8_prof_processor.js` was being excluded from linting, but
the only lint issue it has is that it cannot run in strict mode. Disable
the `strict` rule with a comment and remove the file from
`.eslintignore`.