### PR TITLE
src: add process.binding('config')

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -489,6 +489,10 @@ An example of the possible output looks like:
 }
 ```
 
+*Note: the `process.config` property is **not** read-only and there are existing
+modules in the ecosystem that are known to extend, modify, or entirely replace
+the value of `process.config`.*
+
 ## process.connected
 
 * {Boolean} Set to false after `process.disconnect()` is called

--- a/node.gyp
+++ b/node.gyp
@@ -130,6 +130,7 @@
         'src/js_stream.cc',
         'src/node.cc',
         'src/node_buffer.cc',
+        'src/node_config.cc',
         'src/node_constants.cc',
         'src/node_contextify.cc',
         'src/node_file.cc',

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,0 +1,36 @@
+#include "node.h"
+#include "env.h"
+#include "env-inl.h"
+#include "util.h"
+#include "util-inl.h"
+
+
+namespace node {
+
+using v8::Context;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+using v8::ReadOnly;
+
+// The config binding is used to provide an internal view of compile or runtime
+// config options that are required internally by lib/*.js code. This is an
+// alternative to dropping additional properties onto the process object as
+// has been the practice previously in node.cc.
+
+#define READONLY_BOOLEAN_PROPERTY(str)                                        \
+  do {                                                                        \
+    target->DefineOwnProperty(env->context(),                                 \
+                              OneByteString(env->isolate(), str),             \
+                              True(env->isolate()), ReadOnly).FromJust();     \
+  } while (0)
+
+void InitConfig(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
+  // Environment* env = Environment::GetCurrent(context);
+}
+
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(config, node::InitConfig)

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,4 +1,5 @@
 #include "node.h"
+#include "node_i18n.h"
 #include "env.h"
 #include "env-inl.h"
 #include "util.h"
@@ -28,7 +29,18 @@ using v8::ReadOnly;
 void InitConfig(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
-  // Environment* env = Environment::GetCurrent(context);
+  Environment* env = Environment::GetCurrent(context);
+
+#ifdef NODE_HAVE_I18N_SUPPORT
+  READONLY_BOOLEAN_PROPERTY("hasIntl");
+
+#ifdef NODE_HAVE_SMALL_ICU
+  READONLY_BOOLEAN_PROPERTY("hasSmallICU");
+#endif  // NODE_HAVE_SMALL_ICU
+
+  if (flag_icu_data_dir)
+    READONLY_BOOLEAN_PROPERTY("usingICUDataDir");
+#endif  // NODE_HAVE_I18N_SUPPORT
 }
 
 }  // namespace node

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -42,10 +42,14 @@ extern "C" const char U_DATA_API SMALL_ICUDATA_ENTRY_POINT[];
 #endif
 
 namespace node {
+
+bool flag_icu_data_dir = false;
+
 namespace i18n {
 
 bool InitializeICUDirectory(const char* icu_data_path) {
   if (icu_data_path != nullptr) {
+    flag_icu_data_dir = true;
     u_setDataDirectory(icu_data_path);
     return true;  // no error
   } else {

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -6,6 +6,9 @@
 #if defined(NODE_HAVE_I18N_SUPPORT)
 
 namespace node {
+
+extern bool flag_icu_data_dir;
+
 namespace i18n {
 
 bool InitializeICUDirectory(const char* icu_data_path);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

process

##### Description of change

~~It turns out that userland likes to override process.config with their own stuff. If we want to be able to depend on it in any way, we need our own internal reference. It's still not read-only but that should be ok.~~

* Documents that `process.config` can and likely will be overwritten
* Adds `process.binding('config')`
* Adds the icu/intl configs as flags

/cc @Fishrock123 @srl295 