### PR TITLE
test: Add zlib close-after-error regression test

### DIFF
--- a/test/parallel/test-zlib-close-after-error.js
+++ b/test/parallel/test-zlib-close-after-error.js
@@ -1,0 +1,14 @@
+'use strict';
+// https://github.com/nodejs/node/issues/6034
+
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+const decompress = zlib.createGunzip(15);
+
+decompress.on('error', common.mustCall((err) => {
+  assert.doesNotThrow(() => decompress.close());
+}));
+
+decompress.write('something invalid');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

zlib, test

##### Description of change

Add a regression test based on the report in https://github.com/nodejs/node/issues/6034. The bug itself has been fixed in #5982.