### PR TITLE
src: fix -Wunused-result warning in e38bade

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3229,7 +3229,8 @@ void SetupProcessObject(Environment* env,
 
   // pre-set _events object for faster emit checks
   Local<Object> events_obj = Object::New(env->isolate());
-  events_obj->SetPrototype(env->context(), Null(env->isolate()));
+  maybe = events_obj->SetPrototype(env->context(), Null(env->isolate()));
+  CHECK(maybe.FromJust());
   process->Set(env->events_string(), events_obj);
 }
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

src

##### Description of change

This patch fixes the warning introduced by the changes in e38bade.

cc @Fishrock123 @jasnell @mscdex 

Ref: https://github.com/nodejs/node/pull/6092