### PR TITLE
v8: warn in Template::Set() on improper use

### DIFF
--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -939,6 +939,17 @@ void Template::Set(v8::Local<Name> name, v8::Local<Data> value,
   i::Isolate* isolate = templ->GetIsolate();
   ENTER_V8(isolate);
   i::HandleScope scope(isolate);
+  auto value_obj = Utils::OpenHandle(*value);
+  if (i::FLAG_warn_template_set &&
+      value_obj->IsJSReceiver() &&
+      !value_obj->IsTemplateInfo()) {
+    base::OS::PrintError(
+        "(node) v8::%sTemplate::Set() with non-primitive values is deprecated\n"
+        "(node) and will stop working in the next major release.\n",
+        templ->IsFunctionTemplateInfo() ? "Function" : "Object");
+    isolate->PrintStack(stderr, i::Isolate::kPrintStackConcise);
+    base::DumpBacktrace();
+  }
   // TODO(dcarney): split api to allow values of v8::Value or v8::TemplateInfo.
   i::ApiNatives::AddDataProperty(isolate, templ, Utils::OpenHandle(*name),
                                  Utils::OpenHandle(*value),

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -172,6 +172,9 @@ struct MaybeBoolFlag {
 //
 #define FLAG FLAG_FULL
 
+DEFINE_BOOL(warn_template_set, true,
+            "warn on deprecated v8::Template::Set() use")
+
 DEFINE_BOOL(experimental_extras, false,
             "enable code compiled in via v8_experimental_extra_library_files")
 


### PR DESCRIPTION
The next major release will make it a fatal error to use non-primitive
values in function templates and object templates.

Print a warning that includes the C and JS stack trace to tell people to
upgrade their add-ons.  The C stack trace is only printed on platforms
that support it (the BSDs, OS X and Linux+glibc.)

Refs: #6216

Speculative - I'd like some input whether other collaborators think it's a good approach.  It can get pretty noisy when native code abuses `v8::Template::Set()` a lot but OTOH, hopefully that means it gets fixed quickly.

CI: https://ci.nodejs.org/job/node-test-pull-request/2319/