### PR TITLE
net: set ADDRCONFIG DNS hint in connections

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -949,6 +949,10 @@ function lookupAndConnect(self, options) {
     hints: options.hints || 0
   };
 
+  if (dnsopts.family !== 4 && dnsopts.family !== 6 && dnsopts.hints === 0) {
+    dnsopts.hints = dns.ADDRCONFIG;
+  }
+
   debug('connect: find host ' + host);
   debug('connect: dns options', dnsopts);
   self._host = host;


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes

##### Affected core subsystem(s)

net

##### Description of change

https://github.com/nodejs/node/commit/b85a50b6da5bbd7e9c8902a13dfbe1a142fd786a removed the implicit setting of DNS hints when creating a connection. Stress testing has shown that this caused the pi2 machines to become flaky. This commit restores the implicit `dns.ADDRCONFIG` hint, but not the more problematic `dns.V4MAPPED`. The stress test in https://ci.nodejs.org/job/node-stress-single-test/655/ has, so far, stopped being flaky with this change.

I'll update the commit message prior to landing.

Refs: https://github.com/nodejs/node/issues/6133

Likely also
Refs: https://github.com/nodejs/node/issues/6265
Refs: https://github.com/nodejs/node/issues/6134