### PR TITLE
stream_base: expose `bytesRead` getter

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -111,6 +111,10 @@ function initSocketHandle(self) {
   }
 }
 
+
+const BYTES_READ = Symbol('bytesRead');
+
+
 function Socket(options) {
   if (!(this instanceof Socket)) return new Socket(options);
 
@@ -180,7 +184,7 @@ function Socket(options) {
   this._server = null;
 
   // Used after `.destroy()`
-  this._bytesRead = 0;
+  this[BYTES_READ] = 0;
 }
 util.inherits(Socket, stream.Duplex);
 
@@ -473,7 +477,7 @@ Socket.prototype._destroy = function(exception, cb) {
       debug('close handle');
     var isException = exception ? true : false;
     // `bytesRead` should be accessible after `.destroy()`
-    this._bytesRead = this._handle.bytesRead;
+    this[BYTES_READ] = this._handle.bytesRead;
 
     this._handle.close(() => {
       debug('emit close');
@@ -582,7 +586,7 @@ Socket.prototype._getpeername = function() {
 };
 
 Socket.prototype.__defineGetter__('bytesRead', function() {
-  return this._handle ? this._handle.bytesRead : this._bytesRead;
+  return this._handle ? this._handle.bytesRead : this[BYTES_READ];
 });
 
 Socket.prototype.__defineGetter__('remoteAddress', function() {

--- a/lib/net.js
+++ b/lib/net.js
@@ -585,19 +585,27 @@ Socket.prototype._getpeername = function() {
   return this._peername;
 };
 
-Socket.prototype.__defineGetter__('bytesRead', function() {
+function protoGetter(name, callback) {
+  Object.defineProperty(Socket.prototype, name, {
+    configurable: false,
+    enumerable: true,
+    get: callback
+  });
+}
+
+protoGetter('bytesRead', function bytesRead() {
   return this._handle ? this._handle.bytesRead : this[BYTES_READ];
 });
 
-Socket.prototype.__defineGetter__('remoteAddress', function() {
+protoGetter('remoteAddress', function remoteAddress() {
   return this._getpeername().address;
 });
 
-Socket.prototype.__defineGetter__('remoteFamily', function() {
+protoGetter('remoteFamily', function remoteFamily() {
   return this._getpeername().family;
 });
 
-Socket.prototype.__defineGetter__('remotePort', function() {
+protoGetter('remotePort', function remotePort() {
   return this._getpeername().port;
 });
 
@@ -616,12 +624,12 @@ Socket.prototype._getsockname = function() {
 };
 
 
-Socket.prototype.__defineGetter__('localAddress', function() {
+protoGetter('localAddress', function localAddress() {
   return this._getsockname().address;
 });
 
 
-Socket.prototype.__defineGetter__('localPort', function() {
+protoGetter('localPort', function localPort() {
   return this._getsockname().port;
 });
 
@@ -735,7 +743,7 @@ function createWriteReq(req, handle, data, encoding) {
 }
 
 
-Socket.prototype.__defineGetter__('bytesWritten', function() {
+protoGetter('bytesWritten', function bytesWritten() {
   var bytes = this._bytesDispatched;
   const state = this._writableState;
   const data = this._pendingData;

--- a/lib/net.js
+++ b/lib/net.js
@@ -97,7 +97,6 @@ exports._normalizeConnectArgs = normalizeConnectArgs;
 // called when creating new Socket, or when re-using a closed Socket
 function initSocketHandle(self) {
   self.destroyed = false;
-  self.bytesRead = 0;
   self._bytesDispatched = 0;
   self._sockname = null;
 
@@ -179,6 +178,9 @@ function Socket(options) {
   // Reserve properties
   this.server = null;
   this._server = null;
+
+  // Used after `.destroy()`
+  this._bytesRead = 0;
 }
 util.inherits(Socket, stream.Duplex);
 
@@ -470,6 +472,9 @@ Socket.prototype._destroy = function(exception, cb) {
     if (this !== process.stderr)
       debug('close handle');
     var isException = exception ? true : false;
+    // `bytesRead` should be accessible after `.destroy()`
+    this._bytesRead = this._handle.bytesRead;
+
     this._handle.close(() => {
       debug('emit close');
       this.emit('close', isException);
@@ -520,10 +525,6 @@ function onread(nread, buffer) {
     // In theory (and in practice) calling readStop right now
     // will prevent this from being called again until _read() gets
     // called again.
-
-    // if it's not enough data, we'll just call handle.readStart()
-    // again right away.
-    self.bytesRead += nread;
 
     // Optimization: emit the original buffer with end points
     var ret = self.push(buffer);
@@ -580,6 +581,9 @@ Socket.prototype._getpeername = function() {
   return this._peername;
 };
 
+Socket.prototype.__defineGetter__('bytesRead', function() {
+  return this._handle ? this._handle.bytesRead : this._bytesRead;
+});
 
 Socket.prototype.__defineGetter__('remoteAddress', function() {
   return this._getpeername().address;

--- a/src/env.h
+++ b/src/env.h
@@ -72,6 +72,7 @@ namespace node {
   V(buffer_string, "buffer")                                                  \
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
+  V(bytes_read_string, "bytesRead")                                           \
   V(cached_data_string, "cachedData")                                         \
   V(cached_data_produced_string, "cachedDataProduced")                        \
   V(cached_data_rejected_string, "cachedDataRejected")                        \

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -91,7 +91,7 @@ void StreamBase::GetBytesRead(Local<String> key,
                               const PropertyCallbackInfo<Value>& args) {
   StreamBase* wrap = Unwrap<Base>(args.Holder());
 
-  // int64_t -> double. 53bits is enough for all real cases.
+  // uint64_t -> double. 53bits is enough for all real cases.
   args.GetReturnValue().Set(static_cast<double>(wrap->bytes_read_));
 }
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -43,6 +43,13 @@ void StreamBase::AddMethods(Environment* env,
                                      v8::DEFAULT,
                                      attributes);
 
+  t->InstanceTemplate()->SetAccessor(env->bytes_read_string(),
+                                     GetBytesRead<Base>,
+                                     nullptr,
+                                     env->as_external(),
+                                     v8::DEFAULT,
+                                     attributes);
+
   env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
   env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);
   if ((flags & kFlagNoShutdown) == 0)
@@ -76,6 +83,15 @@ void StreamBase::GetFD(Local<String> key,
     return args.GetReturnValue().Set(UV_EINVAL);
 
   args.GetReturnValue().Set(wrap->GetFD());
+}
+
+
+template <class Base>
+void StreamBase::GetBytesRead(Local<String> key,
+                              const PropertyCallbackInfo<Value>& args) {
+  StreamBase* wrap = Unwrap<Base>(args.Holder());
+
+  args.GetReturnValue().Set(wrap->bytes_read_);
 }
 
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -91,7 +91,8 @@ void StreamBase::GetBytesRead(Local<String> key,
                               const PropertyCallbackInfo<Value>& args) {
   StreamBase* wrap = Unwrap<Base>(args.Holder());
 
-  args.GetReturnValue().Set(wrap->bytes_read_);
+  // int64_t -> double. 53bits is enough for all real cases.
+  args.GetReturnValue().Set(static_cast<double>(wrap->bytes_read_));
 }
 
 

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -164,7 +164,7 @@ class StreamResource {
                      const uv_buf_t* buf,
                      uv_handle_type pending = UV_UNKNOWN_HANDLE) {
     if (nread > 0)
-      bytes_read_ += nread;
+      bytes_read_ += static_cast<uint64_t>(nread);
     if (!read_cb_.is_empty())
       read_cb_.fn(nread, buf, pending, read_cb_.ctx);
   }
@@ -184,7 +184,7 @@ class StreamResource {
   Callback<AfterWriteCb> after_write_cb_;
   Callback<AllocCb> alloc_cb_;
   Callback<ReadCb> read_cb_;
-  int bytes_read_;
+  uint64_t bytes_read_;
 
   friend class StreamBase;
 };

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -136,7 +136,7 @@ class StreamResource {
                          uv_handle_type pending,
                          void* ctx);
 
-  StreamResource() {
+  StreamResource() : bytes_read_(0) {
   }
   virtual ~StreamResource() = default;
 
@@ -160,9 +160,11 @@ class StreamResource {
       alloc_cb_.fn(size, buf, alloc_cb_.ctx);
   }
 
-  inline void OnRead(size_t nread,
+  inline void OnRead(ssize_t nread,
                      const uv_buf_t* buf,
                      uv_handle_type pending = UV_UNKNOWN_HANDLE) {
+    if (nread > 0)
+      bytes_read_ += nread;
     if (!read_cb_.is_empty())
       read_cb_.fn(nread, buf, pending, read_cb_.ctx);
   }
@@ -182,6 +184,9 @@ class StreamResource {
   Callback<AfterWriteCb> after_write_cb_;
   Callback<AllocCb> alloc_cb_;
   Callback<ReadCb> read_cb_;
+  int bytes_read_;
+
+  friend class StreamBase;
 };
 
 class StreamBase : public StreamResource {
@@ -248,6 +253,10 @@ class StreamBase : public StreamResource {
   template <class Base>
   static void GetExternal(v8::Local<v8::String> key,
                           const v8::PropertyCallbackInfo<v8::Value>& args);
+
+  template <class Base>
+  static void GetBytesRead(v8::Local<v8::String> key,
+                           const v8::PropertyCallbackInfo<v8::Value>& args);
 
   template <class Base,
             int (StreamBase::*Method)(  // NOLINT(whitespace/parens)

--- a/test/parallel/test-net-bytes-read.js
+++ b/test/parallel/test-net-bytes-read.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const big = new Buffer(1024 * 1024);
+big.fill('-');
+
+const server = net.createServer((socket) => {
+  socket.end(big);
+  server.close();
+}).listen(common.PORT, () => {
+  let prev = 0;
+
+  function checkRaise(value) {
+    assert(value > prev);
+    prev = value;
+  }
+
+  const socket = net.connect(common.PORT, () => {
+    socket.on('data', (chunk) => {
+      checkRaise(socket.bytesRead);
+    });
+
+    socket.on('end', common.mustCall(() => {
+      assert.equal(socket.bytesRead, prev);
+      assert.equal(big.length, prev);
+    }));
+
+    socket.on('close', common.mustCall(() => {
+      assert(!socket._handle);
+      assert.equal(socket.bytesRead, prev);
+      assert.equal(big.length, prev);
+    }));
+  });
+  socket.end();
+});

--- a/test/parallel/test-net-bytes-read.js
+++ b/test/parallel/test-net-bytes-read.js
@@ -4,8 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const big = new Buffer(1024 * 1024);
-big.fill('-');
+const big = Buffer.alloc(1024 * 1024);
 
 const server = net.createServer((socket) => {
   socket.end(big);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

stream_base

##### Description of change

<!-- provide a description of the change below this comment -->

This will provide `bytesRead` data on consumed sockets.

Fix: #3021