### PR TITLE
http: unref socket timer on parser execute

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -365,6 +365,7 @@ function connectionListener(socket) {
   }
 
   function onParserExecute(ret, d) {
+    socket._unrefTimer();
     debug('SERVER socketOnParserExecute %d', ret);
     onParserExecuteCommon(ret, undefined);
   }

--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  server.close();
+
+  res.writeHead(200);
+  res.flushHeaders();
+
+  req.setTimeout(100, () => {
+    assert(false, 'Should not happen');
+  });
+  req.resume();
+  req.once('end', () => {
+    res.end();
+  });
+});
+
+server.listen(common.PORT, () => {
+  const req = http.request({
+    port: common.PORT,
+    method: 'POST'
+  }, (res) => {
+    const interval = setInterval(() => {
+      req.write('a');
+    }, 25);
+    setTimeout(() => {
+      clearInterval(interval);
+      req.end();
+    }, 150);
+  });
+  req.write('.');
+});

--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -10,7 +10,7 @@ const server = http.createServer((req, res) => {
   res.writeHead(200);
   res.flushHeaders();
 
-  req.setTimeout(100, () => {
+  req.setTimeout(200, () => {
     assert(false, 'Should not happen');
   });
   req.resume();
@@ -30,7 +30,7 @@ server.listen(common.PORT, () => {
     setTimeout(() => {
       clearInterval(interval);
       req.end();
-    }, 150);
+    }, 400);
   });
   req.write('.');
 });

--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -10,27 +10,27 @@ const server = http.createServer((req, res) => {
   res.writeHead(200);
   res.flushHeaders();
 
-  req.setTimeout(200, () => {
+  req.setTimeout(common.platformTimeout(200), () => {
     assert(false, 'Should not happen');
   });
   req.resume();
-  req.once('end', () => {
+  req.once('end', common.mustCall(() => {
     res.end();
-  });
+  }));
 });
 
-server.listen(common.PORT, () => {
+server.listen(common.PORT, common.mustCall(() => {
   const req = http.request({
     port: common.PORT,
     method: 'POST'
   }, (res) => {
     const interval = setInterval(() => {
       req.write('a');
-    }, 25);
+    }, common.platformTimeout(25));
     setTimeout(() => {
       clearInterval(interval);
       req.end();
-    }, 400);
+    }, common.platformTimeout(400));
   });
   req.write('.');
-});
+}));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

http

##### Description of change

<!-- provide a description of the change below this comment -->

When underlying `net.Socket` instance is consumed in http server - no
`data` events are emitted, and thus `socket.setTimeout` fires the
callback even if the data is constantly flowing into the socket.

Fix this by calling `socket._unrefTimer()` on every `onParserExecute`
call.

Fix: #5899