### PR TITLE
module: expose `Module._runInThisContext`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -461,6 +461,10 @@ Module.prototype.require = function(path) {
 var resolvedArgv;
 
 
+// Overridable method, may be useful for caching compilation results
+Module._runInThisContext = runInThisContext;
+
+
 // Run the file contents in the correct scope or sandbox. Expose
 // the correct helper variables (require, module, exports) to
 // the file.
@@ -497,7 +501,7 @@ Module.prototype._compile = function(content, filename) {
   // create wrapper function
   var wrapper = Module.wrap(content);
 
-  var compiledWrapper = runInThisContext(wrapper, {
+  var compiledWrapper = Module._runInThisContext(wrapper, {
     filename: filename,
     lineOffset: 0,
     displayErrors: true

--- a/test/fixtures/empty.js
+++ b/test/fixtures/empty.js
@@ -1,0 +1,1 @@
+// Intentionally empty

--- a/test/parallel/test-module-run-in-this-context.js
+++ b/test/parallel/test-module-run-in-this-context.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const vm = require('vm');
+const path = require('path');
+const Module = require('module');
+
+let counter = 0;
+
+Module._runInThisContext = function runInThisContext(source, options) {
+  counter++;
+  return vm.runInThisContext(source, options);
+};
+
+const empty = require(path.join(common.fixturesDir, 'empty.js'));
+
+assert.equal(counter, 1);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

module
##### Description of change

<!-- provide a description of the change below this comment -->

`Module._runInThisContext` can be overridden to store/load cached
compilation artifacts when embedding node.js .

cc @nodejs/collaborators @zcbenz
