### PR TITLE
url: use "empty" object for empty query strings

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -60,6 +60,12 @@ const slashedProtocol = {
 };
 const querystring = require('querystring');
 
+// This constructor is used to store parsed query string values. Instantiating
+// this is faster than explicitly calling `Object.create(null)` to get a
+// "clean" empty object (tested with v8 v4.9).
+function ParsedQueryString() {}
+ParsedQueryString.prototype = Object.create(null);
+
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url instanceof Url) return url;
 
@@ -168,7 +174,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
         }
       } else if (parseQueryString) {
         this.search = '';
-        this.query = {};
+        this.query = new ParsedQueryString();
       }
       return this;
     }
@@ -358,7 +364,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   } else if (parseQueryString) {
     // no query string, but parseQueryString still requested
     this.search = '';
-    this.query = {};
+    this.query = new ParsedQueryString();
   }
 
   var firstIdx = (questionIdx !== -1 &&

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -927,7 +927,7 @@ var parseTestsWithQueryString = {
     path: '/example',
     href: '/example'
   },
-  '/example?query=value':{
+  '/example?query=value': {
     protocol: null,
     slashes: null,
     auth: null,
@@ -950,6 +950,8 @@ for (const u in parseTestsWithQueryString) {
       expected[i] = null;
     }
   }
+
+  assert.notStrictEqual(Object.getPrototypeOf(actual.query), Object.prototype);
 
   assert.deepEqual(actual, expected);
 }


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes
- [X] a test and/or benchmark is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

* url


##### Description of change

This makes things consistent with the way that the `querystring` module creates parsed results.