### PR TITLE
http: disallow sending obviously invalid status codes

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -187,6 +187,10 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
     headers = obj;
   }
 
+  statusCode |= 0;
+  if (statusCode < 100 || statusCode > 999)
+    throw new RangeError(`Invalid status code: ${statusCode}`);
+
   var statusLine = 'HTTP/1.1 ' + statusCode.toString() + ' ' +
                    this.statusMessage + CRLF;
 

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -1,0 +1,92 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const MAX_REQUESTS = 12;
+var reqNum = 0;
+
+const server = http.Server(common.mustCall(function(req, res) {
+  switch (reqNum) {
+    case 0:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(-1);
+      }, /invalid status code/i));
+      break;
+    case 1:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(Infinity);
+      }, /invalid status code/i));
+      break;
+    case 2:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(NaN);
+      }, /invalid status code/i));
+      break;
+    case 3:
+      assert.throws(common.mustCall(() => {
+        res.writeHead({});
+      }, /invalid status code/i));
+      break;
+    case 4:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(99);
+      }, /invalid status code/i));
+      break;
+    case 5:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(1000);
+      }, /invalid status code/i));
+      break;
+    case 6:
+      assert.throws(common.mustCall(() => {
+        res.writeHead('1000');
+      }, /invalid status code/i));
+      break;
+    case 7:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(null);
+      }, /invalid status code/i));
+      break;
+    case 8:
+      assert.throws(common.mustCall(() => {
+        res.writeHead(true);
+      }, /invalid status code/i));
+      break;
+    case 9:
+      assert.throws(common.mustCall(() => {
+        res.writeHead([]);
+      }, /invalid status code/i));
+      break;
+    case 10:
+      assert.throws(common.mustCall(() => {
+        res.writeHead('this is not valid');
+      }, /invalid status code/i));
+      break;
+    case 11:
+      assert.throws(common.mustCall(() => {
+        res.writeHead('404 this is not valid either');
+      }, /invalid status code/i));
+      this.close();
+      break;
+    default:
+      throw new Error('Unexpected request');
+  }
+  res.statusCode = 200;
+  res.end();
+}, MAX_REQUESTS));
+server.listen();
+
+server.on('listening', function makeRequest() {
+  http.get({
+    port: this.address().port
+  }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.on('end', () => {
+      if (++reqNum < MAX_REQUESTS)
+        makeRequest.call(this);
+    });
+    res.resume();
+  });
+});
+


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes
- [X] a test and/or benchmark is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

* http


##### Description of change

Disallows sending of invalid status codes.