### PR TITLE
cares: Support malloc(0) scenarios for AIX

### DIFF
--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -12,6 +12,10 @@
       [ 'OS=="aix"', {
         'include_dirs': [ 'config/aix' ],
         'sources': [ 'config/aix/ares_config.h' ],
+        'defines': [
+          # Support for malloc(0)
+          '_LINUX_SOURCE_COMPAT=1',
+          '_ALL_SOURCE=1'],
       }],
       ['OS=="solaris"', {
         'defines': [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change

<!-- provide a description of the change below this comment -->

Many places in cares library, when the stream data arrives
from the network with respect to dns and reverse dns
resolution, they are populated into data structures created
dymaically based on the size of the data. Malloc is heavily
used for such cases.

Often, based on the data length, malloc(0) is invoked. Linux
behavior on zero byte allocation is to return a valid pointer
where in AIX, it always return NULL.

This manifestst as test failure of test/internet/test-dns.js

Solution is to build cares with Linux compatible malloc behavior