### PR TITLE
http: correct error message for invalid trailer

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -519,7 +519,7 @@ OutgoingMessage.prototype.addTrailers = function(headers) {
         'Trailer name must be a valid HTTP Token ["' + field + '"]');
     }
     if (common._checkInvalidHeaderChar(value) === true) {
-      throw new TypeError('The header content contains invalid characters');
+      throw new TypeError('The trailer content contains invalid characters');
     }
     this._trailer += field + ': ' + escapeHeaderValue(value) + CRLF;
   }


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

http

##### Description of change

Prevent misleading error messages when trailers are invalid.

