### PR TITLE
doc: update build instructions for OS X

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ If you consistently can reproduce a test failure, search for it in the
 file a new issue.
 
 
-### Unix / Macintosh
+### Unix / OS X
 
 Prerequisites:
 
@@ -17,7 +17,16 @@ Prerequisites:
 * `clang` and `clang++` 3.4 or newer
 * Python 2.6 or 2.7
 * GNU Make 3.81 or newer
+
+On OS X, you will also need:
+* [Xcode](https://developer.apple.com/xcode/download/)
+  * You also need to install the `Command Line Tools` via Xcode. You can find 
+    this under the menu `Xcode -> Preferences -> Downloads`
+  * This step will install `gcc` and the related toolchain containing `make`
+
+On FreeBSD and OpenBSD, you may also need:
 * libexecinfo (FreeBSD and OpenBSD only)
+
 
 ```text
 $ ./configure
@@ -118,7 +127,7 @@ This option will build with "small" (English only) support, but
 the full `Intl` (ECMA-402) APIs.  With `--download=all` it will
 download the ICU library as needed.
 
-##### Unix / Macintosh:
+##### Unix / OS X:
 
 ```text
 $ ./configure --with-intl=small-icu --download=all
@@ -141,7 +150,7 @@ data at runtime.
 With the `--download=all`, this may download ICU if you don't have an
 ICU in `deps/icu`.
 
-##### Unix / Macintosh:
+##### Unix / OS X:
 
 ```text
 $ ./configure --with-intl=full-icu --download=all
@@ -158,7 +167,7 @@ $ ./configure --with-intl=full-icu --download=all
 The `Intl` object will not be available. This is the default at
 present, so this option is not normally needed.
 
-##### Unix / Macintosh:
+##### Unix / OS X:
 
 ```text
 $ ./configure --with-intl=none
@@ -170,7 +179,7 @@ $ ./configure --with-intl=none
 > vcbuild intl-none
 ```
 
-#### Use existing installed ICU (Unix / Macintosh only):
+#### Use existing installed ICU (Unix / OS X only):
 
 ```text
 $ pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
@@ -186,7 +195,7 @@ You can find other ICU releases at
 Download the file named something like `icu4c-**##.#**-src.tgz` (or
 `.zip`).
 
-##### Unix / Macintosh
+##### Unix / OS X
 
 ```text
 # from an already-unpacked ICU:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc build

##### Description of change

<!-- provide a description of the change below this comment -->

Building Node.js on OS X requires XCode (because node-gyp requires
XCode). Add that information to BUILDING.md.

Additionally, this changes references to `Macintosh` in BUILDING.md to
refer to `OS X`. This is consistent with the way other references are to
operating system families (`Unix`, `Windows`) and not brand names or
hardware architectures.