### PR TITLE
test: v8-flags is sensitive to script caching

### DIFF
--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -4,10 +4,13 @@ var assert = require('assert');
 var v8 = require('v8');
 var vm = require('vm');
 
+// Note: changing V8 flags after an isolate started is not guaranteed to work.
+// Specifically here, V8 may cache compiled scripts between the flip of the
+// flag. We use a different script each time to work around this problem.
 v8.setFlagsFromString('--allow_natives_syntax');
 assert(eval('%_IsSmi(42)'));
-assert(vm.runInThisContext('%_IsSmi(42)'));
+assert(vm.runInThisContext('%_IsSmi(43)'));
 
 v8.setFlagsFromString('--noallow_natives_syntax');
-assert.throws(function() { eval('%_IsSmi(42)'); }, SyntaxError);
-assert.throws(function() { vm.runInThisContext('%_IsSmi(42)'); }, SyntaxError);
+assert.throws(function() { eval('%_IsSmi(44)'); }, SyntaxError);
+assert.throws(function() { vm.runInThisContext('%_IsSmi(45)'); }, SyntaxError);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test

##### Description of change

<!-- provide a description of the change below this comment -->

V8 may cache compiled scripts, and it is not safe to assume that the
V8 flags may be changed after an isolate has been created. In this
particular case, since we are using the same script multiple times,
the test would fail if V8 cached the result of the compilation.

This PR, along with #6280 is need to fix the [Node.js integration builds](https://uberchromegw.corp.google.com/i/client.v8.fyi/builders/V8%20-%20node.js%20integration%20-%20lkgr) that V8 is running against V8 tip-of-tree.

Ref: https://github.com/nodejs/node/issues/6280
Fixes: https://github.com/nodejs/node/issues/6258

R=@bnoordhuis @jeisinger
CI: https://ci.nodejs.org/job/node-test-pull-request/2349/