### PR TITLE
test: fix test-vm-cached-data to work with old v8

### DIFF
--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -14,10 +14,11 @@ function produce(source, count) {
     count = 1;
 
   const out = spawnSync(process.execPath, [ '-e', `
+    'use strict';
     var assert = require('assert');
     var vm = require('vm');
 
-    let data;
+    var data;
     for (var i = 0; i < ${count}; i++) {
       var script = new vm.Script(process.argv[1], {
         produceCachedData: true


### PR DESCRIPTION
while `let` no longer needs to run in `strict mode` in v8 5.x it throws
in v8 4. This modification will make the test-vm-cached-data work in
older version of node.

I am under the impression that these changes were made to test features that will only be available in v8 5. So perhaps we don't care to support older versions. Either way it might be nice to be explicit with the code being shelled out.

I've currently marked https://github.com/nodejs/node/pull/6280 as `dont-land-on-v5.x`, but we can change that if this lands

/cc @jasnell @indutny 