### PR TITLE
test: don't assume IPv6 in test-regress-GH-5727

### DIFF
--- a/test/parallel/test-regress-GH-5727.js
+++ b/test/parallel/test-regress-GH-5727.js
@@ -7,7 +7,10 @@ const invalidPort = -1 >>> 0;
 const errorMessage = /"port" argument must be \>= 0 and \< 65536/;
 
 net.Server().listen(common.PORT, function() {
-  assert.equal(this._connectionKey, '6::::' + common.PORT);
+  const address = this.address();
+  const key = `${address.family.slice(-1)}:${address.address}:${common.PORT}`;
+
+  assert.equal(this._connectionKey, key);
   this.close();
 });
 


### PR DESCRIPTION

##### Checklist

- [x] tests and code linting passes

##### Affected core subsystem(s)

test

##### Description of change

`test/parallel/test-regress-GH-5727` assumed that one of the servers would be listening on IPv6. This breaks when the machine running the test doesn't have IPv6. This commit builds the connection key that is compared dynamically.

Refs https://github.com/nodejs/node/pull/5732

R= @Trott 