### PR TITLE
test,tools: limit lint tolerance of gc global

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,6 +3,3 @@
 rules:
   ## common module is mandatory in tests
   required-modules: [2, "common"]
-
-globals:
-  gc: false

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose-gc
+/* global gc:false */
 
 require('../../common');
 var binding = require('./build/Release/binding');

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -1,6 +1,5 @@
 'use strict';
 // Flags: --expose-gc
-/* global gc:false */
 
 require('../../common');
 var binding = require('./build/Release/binding');
@@ -12,9 +11,9 @@ function check(size, alignment, offset) {
   buf = null;
   binding.check(slice);
   slice = null;
-  gc();
-  gc();
-  gc();
+  global.gc();
+  global.gc();
+  global.gc();
 }
 
 check(64, 1, 0);

--- a/test/common.js
+++ b/test/common.js
@@ -275,7 +275,7 @@ var knownGlobals = [setTimeout,
                     global];
 
 if (global.gc) {
-  knownGlobals.push(gc);
+  knownGlobals.push(global.gc);
 }
 
 if (global.DTRACE_HTTP_SERVER_RESPONSE) {

--- a/test/gc/.eslintrc
+++ b/test/gc/.eslintrc
@@ -1,0 +1,2 @@
+globals:
+  gc: false

--- a/test/gc/.eslintrc
+++ b/test/gc/.eslintrc
@@ -1,2 +1,0 @@
-globals:
-  gc: false

--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -53,13 +53,13 @@ function afterGC() {
 
 var timer;
 function statusLater() {
-  gc();
+  global.gc();
   if (timer) clearTimeout(timer);
   timer = setTimeout(status, 1);
 }
 
 function status() {
-  gc();
+  global.gc();
   console.log('Done: %d/%d', done, todo);
   console.log('Collected: %d/%d', countGC, count);
   if (done === todo) {

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -61,13 +61,13 @@ function afterGC() {
 
 var timer;
 function statusLater() {
-  gc();
+  global.gc();
   if (timer) clearTimeout(timer);
   timer = setTimeout(status, 1);
 }
 
 function status() {
-  gc();
+  global.gc();
   console.log('Done: %d/%d', done, todo);
   console.log('Collected: %d/%d', countGC, count);
   if (done === todo) {

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -62,13 +62,13 @@ function afterGC() {
 
 var timer;
 function statusLater() {
-  gc();
+  global.gc();
   if (timer) clearTimeout(timer);
   timer = setTimeout(status, 1);
 }
 
 function status() {
-  gc();
+  global.gc();
   console.log('Done: %d/%d', done, todo);
   console.log('Collected: %d/%d', countGC, count);
   if (done === todo) {

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -31,7 +31,7 @@ function getall() {
       res.resume();
       console.error('in cb');
       done += 1;
-      res.on('end', gc);
+      res.on('end', global.gc);
     }
 
     var req = http.get({
@@ -57,7 +57,7 @@ function afterGC() {
 setInterval(status, 1000).unref();
 
 function status() {
-  gc();
+  global.gc();
   console.log('Done: %d/%d', done, todo);
   console.log('Collected: %d/%d', countGC, count);
   if (done === todo) {

--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -43,7 +43,7 @@ function getall() {
       //console.log('timeout (expected)')
       req.destroy();
       done++;
-      gc();
+      global.gc();
     });
 
     count++;
@@ -63,13 +63,13 @@ function afterGC() {
 setInterval(status, 100).unref();
 
 function status() {
-  gc();
+  global.gc();
   console.log('Done: %d/%d', done, todo);
   console.log('Collected: %d/%d', countGC, count);
   if (done === todo) {
     /* Give libuv some time to make close callbacks. */
     setTimeout(function() {
-      gc();
+      global.gc();
       console.log('All should be collected now.');
       console.log('Collected: %d/%d', countGC, count);
       assert(count === countGC);

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -3,7 +3,6 @@
 // problem.
 
 // Flags: --expose_gc
-/* global gc:false */
 
 require('../common');
 var assert = require('assert');
@@ -19,7 +18,7 @@ var messagesComplete = 0;
 
 function flushPool() {
   Buffer.allocUnsafe(Buffer.poolSize - 1);
-  gc();
+  global.gc();
 }
 
 function demoBug(part1, part2) {

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -3,6 +3,7 @@
 // problem.
 
 // Flags: --expose_gc
+/* global gc:false */
 
 require('../common');
 var assert = require('assert');

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,6 +1,5 @@
 'use strict';
 // Flags: --expose-gc
-/* global gc:false */
 require('../common');
 var assert = require('assert');
 
@@ -25,6 +24,6 @@ assert.equal('lala', context.thing);
 console.error('run in contextified sandbox without referencing the context');
 var sandbox = {x: 1};
 vm.createContext(sandbox);
-gc();
+global.gc();
 vm.runInContext('x = 2', sandbox);
 // Should not crash.

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose-gc
+/* global gc:false */
 require('../common');
 var assert = require('assert');
 

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose-gc
+/* global gc:false */
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -1,12 +1,11 @@
 'use strict';
 // Flags: --expose-gc
-/* global gc:false */
 
 const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-assert.equal(typeof gc, 'function', 'Run this test with --expose-gc');
+assert.equal(typeof global.gc, 'function', 'Run this test with --expose-gc');
 
 common.globalCheck = false;
 
@@ -49,6 +48,6 @@ assert.equal(f.a, 2);
 
 console.error('use function in context without referencing context');
 var fn = vm.runInNewContext('(function() { obj.p = {}; })', { obj: {} });
-gc();
+global.gc();
 fn();
 // Should not crash

--- a/test/pummel/test-net-connect-memleak.js
+++ b/test/pummel/test-net-connect-memleak.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose-gc
+/* global gc:false */
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/pummel/test-net-connect-memleak.js
+++ b/test/pummel/test-net-connect-memleak.js
@@ -1,30 +1,29 @@
 'use strict';
 // Flags: --expose-gc
-/* global gc:false */
 
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
+assert(typeof global.gc === 'function', 'Run this test with --expose-gc');
 net.createServer(function() {}).listen(common.PORT);
 
 var before = 0;
 (function() {
   // 2**26 == 64M entries
-  gc();
+  global.gc();
   for (var i = 0, junk = [0]; i < 26; ++i) junk = junk.concat(junk);
   before = process.memoryUsage().rss;
 
   net.createConnection(common.PORT, '127.0.0.1', function() {
     assert(junk.length != 0);  // keep reference alive
     setTimeout(done, 10);
-    gc();
+    global.gc();
   });
 })();
 
 function done() {
-  gc();
+  global.gc();
   var after = process.memoryUsage().rss;
   var reclaimed = (before - after) / 1024;
   console.log('%d kB reclaimed', reclaimed);

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -1,6 +1,5 @@
 'use strict';
 // Flags: --expose_gc
-/* global gc:false */
 
 function newBuffer(size, value) {
   var buffer = Buffer.allocUnsafe(size);
@@ -39,7 +38,7 @@ var timeToQuit = Date.now() + 8e3; //Test during no more than this seconds.
 
   if (PASS) {
     fs.write(testFileFD, newBuffer(kBufSize, 0x61), 0, kBufSize, -1, cb);
-    gc();
+    global.gc();
     var nuBuf = Buffer.allocUnsafe(kBufSize);
     neverWrittenBuffer.copy(nuBuf);
     if (bufPool.push(nuBuf) > 100) {

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose_gc
+/* global gc:false */
 
 function newBuffer(size, value) {
   var buffer = Buffer.allocUnsafe(size);

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -1,6 +1,5 @@
 'use strict';
 // Flags: --expose_gc
-/* global gc:false */
 
 var common = require('../common');
 
@@ -45,12 +44,12 @@ function writer() {
       }, 555);
     } else {
       fs.write(testFD, newBuffer(kBufSize, 0x61), 0, kBufSize, -1, writerCB);
-      gc();
-      gc();
-      gc();
-      gc();
-      gc();
-      gc();
+      global.gc();
+      global.gc();
+      global.gc();
+      global.gc();
+      global.gc();
+      global.gc();
       var nuBuf = Buffer.allocUnsafe(kBufSize);
       neverWrittenBuffer.copy(nuBuf);
       if (bufPool.push(nuBuf) > 100) {

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose_gc
+/* global gc:false */
 
 var common = require('../common');
 

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -1,5 +1,6 @@
 'use strict';
 // Flags: --expose-gc
+/* global gc:false */
 
 var common = require('../common');
 var assert = require('assert');

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -1,6 +1,5 @@
 'use strict';
 // Flags: --expose-gc
-/* global gc:false */
 
 var common = require('../common');
 var assert = require('assert');
@@ -13,7 +12,7 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
+assert(typeof global.gc === 'function', 'Run this test with --expose-gc');
 
 tls.createServer({
   cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
@@ -28,13 +27,13 @@ tls.createServer({
   tls.connect(common.PORT, '127.0.0.1', options, function() {
     assert(junk.length != 0);  // keep reference alive
     setTimeout(done, 10);
-    gc();
+    global.gc();
   });
 })();
 
 function done() {
   var before = process.memoryUsage().rss;
-  gc();
+  global.gc();
   var after = process.memoryUsage().rss;
   var reclaimed = (before - after) / 1024;
   console.log('%d kB reclaimed', reclaimed);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test tools
##### Description of change

<!-- provide a description of the change below this comment -->

Lint rules permitted the `gc` global in any test file. This change
limits it to just the files that need it.