### PR TITLE
repl: Don’t complete expressions when eval() failed

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -628,7 +628,7 @@ ArrayStream.prototype.write = function() {};
 
 const requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
 const simpleExpressionRE =
-    /^\s*(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
+    /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
 
 function intFilter(item) {
   // filters out anything not starting with A-Z, a-z, $ or _
@@ -806,7 +806,8 @@ REPLServer.prototype.complete = function(line, callback) {
           });
         }
       } else {
-        this.eval(expr, this.context, 'repl', function(e, obj) {
+        const evalExpr = `try { ${expr} } catch (e) {}`;
+        this.eval(evalExpr, this.context, 'repl', function(e, obj) {
           // if (e) console.log(e);
 
           if (obj != null) {


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

repl

##### Description of change

Instead of changing the way “simple” expressions are detected, switch to ignoring errors when completing. This approach is more generic than the previous one from 0b66b8f, but also changes the way errors are thrown when completing.

Fixes: #6325

This includes a revert of the regular expression change in #6192.
This is also a completely inappropriate solution if it is *intended* that trying to complete expressions like `a = b.c.d` with `b` not defined throw a `ReferenceError`; the test file seems to be laid out to expect that behaviour. I can’t imagine how that might be even remotely desirable, though.