### PR TITLE
src: fix 1-byte out-of-bounds write in TwoByteValue

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -47,7 +47,9 @@ TwoByteValue::TwoByteValue(Isolate* isolate, Local<Value> value)
     return;
 
   // Allocate enough space to include the null terminator
-  size_t len = StringBytes::StorageSize(isolate, string, UCS2) + 1;
+  size_t len =
+      StringBytes::StorageSize(isolate, string, UCS2) +
+      sizeof(uint16_t);
   if (len > sizeof(str_st_)) {
     str_ = static_cast<uint16_t*>(malloc(len));
     CHECK_NE(str_, nullptr);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

src, buffer (`Buffer.fill` is the only place where `TwoByteValue` is being used)

##### Description of change

Plan 2 bytes instead of 1 byte for the final zero terminator for UTF-16. This is unlikely to cause real-world problems, but that ultimately depends on the `malloc` implementation.

The issue can be uncovered by running e.g.
`valgrind node -e "Buffer(65536).fill('a'.repeat(4096), 'utf16le')"`.

CI: https://ci.nodejs.org/job/node-test-commit/3010/