### PR TITLE
debugger: fix stuck debugger when debuggee exits

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -36,6 +36,10 @@ exports.start = function start() {
       process.removeListener('SIGWINCH', fn);
     });
 
+    // Disconnect all currently connected clients.
+    // Without this, the debugger agent loop will not unblock
+    // and the debuggee will get stuck.
+    agent.destroyAllClients();
     agent.close();
   };
 
@@ -79,6 +83,12 @@ Agent.prototype.notifyWait = function notifyWait() {
   if (this.first)
     this.binding.notifyWait();
   this.first = false;
+};
+
+Agent.prototype.destroyAllClients = function destroyAllClients() {
+  this.clients.forEach(function(client) {
+    client.destroy();
+  });
 };
 
 function Client(agent, socket) {

--- a/test/fixtures/debugger-stuck-regression-fixture.js
+++ b/test/fixtures/debugger-stuck-regression-fixture.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log('debug');

--- a/test/parallel/test-debugger-stuck-regression.js
+++ b/test/parallel/test-debugger-stuck-regression.js
@@ -16,7 +16,7 @@ const args = [
   fixture
 ];
 
-const TEST_TIMEOUT_MS = 4000;
+const TEST_TIMEOUT_MS = common.platformTimeout(4000);
 
 function onTestTimeout() {
   common.fail('The debuggee did not terminate.');

--- a/test/parallel/test-debugger-stuck-regression.js
+++ b/test/parallel/test-debugger-stuck-regression.js
@@ -1,0 +1,93 @@
+'use strict';
+const path = require('path');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
+
+const common = require('../common');
+
+const fixture = path.join(
+  common.fixturesDir,
+  'debugger-stuck-regression-fixture.js'
+);
+
+const args = [
+  'debug',
+  `--port=${common.PORT}`,
+  fixture
+];
+
+const TEST_TIMEOUT_MS = 4000;
+
+function onTestTimeout() {
+  common.fail('The debuggee did not terminate.');
+}
+
+const testTimeout = setTimeout(onTestTimeout, TEST_TIMEOUT_MS);
+
+const proc = spawn(process.execPath, args, { stdio: 'pipe' });
+proc.stdout.setEncoding('utf8');
+proc.stderr.setEncoding('utf8');
+
+const STATE_WAIT_BREAK = 0;
+const STATE_WAIT_PROC_TERMINATED = 1;
+const STATE_EXIT = 2;
+
+let stdout = '';
+let stderr = '';
+let state = 0;
+let cycles = 2;
+
+proc.stdout.on('data', (data) => {
+  stdout += data;
+
+  switch (state) {
+    case STATE_WAIT_BREAK:
+      // check if the debugger stopped at line 1
+      if (stdout.includes('> 1')) {
+        stdout = '';
+
+        // send continue to the debugger
+        proc.stdin.write('c\n');
+        state = STATE_WAIT_PROC_TERMINATED;
+      }
+      break;
+    case STATE_WAIT_PROC_TERMINATED:
+      // check if the debuggee has terminated
+      if (stdout.includes('program terminated')) {
+        stdout = '';
+
+        // If cycles is greater than 0,
+        // we re-run the debuggee.
+        // Otherwise exit the debugger.
+        if (cycles > 0) {
+          --cycles;
+          state = STATE_WAIT_BREAK;
+          proc.stdin.write('run\n');
+        } else {
+          // cancel the test timeout
+          clearTimeout(testTimeout);
+          state = STATE_EXIT;
+          proc.stdin.write('.exit\n');
+        }
+
+      }
+      break;
+    case STATE_EXIT:
+      // fall through
+    default:
+      break;
+  }
+});
+
+proc.stderr.on('data', (data) => {
+  stderr += data;
+});
+
+proc.stdin.on('error', (err) => {
+  console.error(err);
+});
+
+process.on('exit', (code) => {
+  assert.equal(code, 0, 'the program should exit cleanly');
+  assert.equal(stderr, '', 'stderr should be empty');
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

debugger
##### Description of change

Referencing PR [#27778](https://github.com/nodejs/node/pull/2778)

The debuggee node process will never exit because the execution
is blocked inside node::debugger::Agent::Stop,
joining the agent thread.
The debug agent thread is blocked inside uv_run.

To fix this, the debug agent has to close all client connections
in _debug_agent.js (process._debugAPI.onclose).

Additionally all remaining opened handles have to be closed
before calling uv_loop_close.
Otherwise uv_loop_close will fail with UV_EBUSY.

Assume the following script (debug.js):

``` js
console.log('debug');
```

Calling _node debug debug.js_ produces the following output:

``` bash
< Debugger listening on port 5858
connecting to 127.0.0.1:5858 ... ok
break in debug.js:1
> 1 console.log('debug');
  2 
  3 });
debug> c
< debug
program terminated
debug> 
```

Both

``` js
node --debug -e 0
```

and

``` js
node --debug-brk -e 0
```

exit immediately.
