### PR TITLE
test: increase the platform timeout for AIX

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -245,6 +245,9 @@ exports.platformTimeout = function(ms) {
   if (process.config.target_defaults.default_configuration === 'Debug')
     ms = 2 * ms;
 
+  if (exports.isAix)
+    return 2 * ms; // default localhost speed is slower on AIX
+
   if (process.arch !== 'arm')
     return ms;
 


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

test

##### Description of change

There have been failures on AIX due to the slower
default loopback performance. So far I've resisted
updating the global timeout but seeing another
new failure in a newly added test I now think the
right thing is to just extending the platform
timeout for AIX. This commit does that.

addresses: https://github.com/nodejs/node/issues/6333