### PR TITLE
crypto: fix error in deprecation message

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -671,4 +671,4 @@ exports.__defineGetter__('createCredentials',
 exports.__defineGetter__('Credentials', internalUtil.deprecate(function() {
   return require('tls').SecureContext;
 }, 'crypto.Credentials is deprecated. ' +
-   'Use tls.createSecureContext instead.'));
+   'Use tls.SecureContext instead.'));

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+const crypto = require('crypto');
+const tls = require('tls');
+
+process.on('warning', common.mustCall((warning) => {
+  assert.strictEqual(warning.name, 'DeprecationWarning');
+  assert.notStrictEqual(expected.indexOf(warning.message), -1,
+                        `unexpected error message: "${warning.message}"`);
+  // Remove a warning message after it is seen so that we guarantee that we get
+  // each message only once.
+  expected.splice(expected.indexOf(warning.message), 1);
+}, 2));
+
+var expected = [
+  'crypto.Credentials is deprecated. Use tls.SecureContext instead.',
+  'crypto.createCredentials is deprecated. Use tls.createSecureContext instead.'
+];
+
+// Accessing the deprecated function is enough to trigger the warning event.
+// It does not need to be called. So the assert serves the purpose of both
+// triggering the warning event and confirming that the deprected function is
+// mapped to the correct non-deprecated function.
+assert.strictEqual(crypto.Credentials, tls.SecureContext);
+assert.strictEqual(crypto.createCredentials, tls.createSecureContext);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

crypto test

##### Description of change

<!-- provide a description of the change below this comment -->

The deprecation message for `crypto.Credentials` says to use
`tls.createSecureContext` but the correct property to use is
`tls.SecureContext()`.

Fix the deprecation message and add a test that checks the mappings of
deprecated properties and their warning messages.

@nodejs/crypto