### PR TITLE
build: updated android-configure script for npm

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# In order to cross-compile node for Android using NDK, run:
+#   source android-configure <path_to_ndk> [arch]
+#
+# By running android-configure with source, will allow environment variables to
+# be persistent in current session. This is useful for installing native node
+# modules with npm. Also, don't forget to set the arch in npm config using
+# 'npm config set arch=<arch>'
+
+
 if [ -z "$2" ]; then
     ARCH=arm
 else
@@ -42,8 +51,16 @@ export CC=$TOOLCHAIN/bin/$SUFFIX-gcc
 export CXX=$TOOLCHAIN/bin/$SUFFIX-g++
 export LINK=$TOOLCHAIN/bin/$SUFFIX-g++
 
-./configure \
-    --dest-cpu=$DEST_CPU \
-    --dest-os=android \
-    --without-snapshot \
-    --openssl-no-asm
+GYP_DEFINES="target_arch=$ARCH"
+GYP_DEFINES+=" v8_target_arch=$ARCH"
+GYP_DEFINES+=" android_target_arch=$ARCH"
+GYP_DEFINES+=" host_os=linux OS=android"
+export GYP_DEFINES
+
+if [ -f "configure" ]; then
+    ./configure \
+        --dest-cpu=$DEST_CPU \
+        --dest-os=android \
+        --without-snapshot \
+        --openssl-no-asm
+fi


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
build

##### Description of change

<!-- provide a description of the change below this comment -->

Now, that we can cross-compile node for Android, we also need to take
care of native node modules installed with npm. Since there is no way to
install and run npm on an Android device, we could instal node on host
and setup an environment for installing node modules and cross-compile the
native sources using Android NDK.
The changes to this script will allow npm, when installing a module, to
compile it using NDK.

In order to do this, the developer should do the following steps:
1. Compile and install node on host, using: configure, make and make
install
2. Build node for Android, using: source android-configure <path_to_ndk>
arch and make
3. Push node binary to Android device
4. Using the same session, configure npm arch using: npm config set
arch=<arch>
5. Install desired node modules using: npm install
6. Push installed node modules to Android device

Signed-off-by: Robert Chiras <robert.chiras@intel.com>