### PR TITLE
readline: Allow history to be disabled

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -300,7 +300,8 @@ the following values:
    treated like a TTY, and have ANSI/VT100 escape codes written to it.
    Defaults to checking `isTTY` on the `output` stream upon instantiation.
 
- - `historySize` - maximum number of history lines retained. Defaults to `30`.
+ - `historySize` - maximum number of history lines retained. To disable the
+   history set this value to `0`. Defaults to `30`.
 
 The `completer` function is given the current line entered by the user, and
 is supposed to return an Array with 2 entries:

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -53,10 +53,13 @@ function Interface(input, output, completer, terminal) {
     historySize = input.historySize;
     input = input.input;
   }
-  historySize = historySize || kHistorySize;
 
   if (completer && typeof completer !== 'function') {
     throw new TypeError('Argument "completer" must be a function');
+  }
+
+  if (historySize === undefined) {
+    historySize = kHistorySize;
   }
 
   if (typeof historySize !== 'number' ||
@@ -227,6 +230,9 @@ Interface.prototype._writeToOutput = function _writeToOutput(stringToWrite) {
 
 Interface.prototype._addHistory = function() {
   if (this.line.length === 0) return '';
+
+  // if the history is disabled then return the line
+  if (this.historySize === 0) return this.line;
 
   if (this.history.length === 0 || this.history[0] !== this.line) {
     this.history.unshift(this.line);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -32,12 +32,18 @@ function isWarned(emitter) {
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal,
                               historySize: 0 });
   assert.strictEqual(rli.historySize, 0);
+
+  fi.emit('data', 'asdf\n');
+  assert.deepStrictEqual(rli.history, terminal ? [] : undefined);
   rli.close();
 
   // default history size 30
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
   assert.strictEqual(rli.historySize, 30);
+
+  fi.emit('data', 'asdf\n');
+  assert.deepStrictEqual(rli.history, terminal ? ['asdf'] : undefined);
   rli.close();
 
   // sending a full line

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -27,6 +27,19 @@ function isWarned(emitter) {
   var rli;
   var called;
 
+  // disable history
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal,
+                              historySize: 0 });
+  assert.strictEqual(rli.historySize, 0);
+  rli.close();
+
+  // default history size 30
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
+  assert.strictEqual(rli.historySize, 30);
+  rli.close();
+
   // sending a full line
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

readline

##### Description of change

<!-- provide a description of the change below this comment -->

Fixes #6336
1.  The `historySize` to default to `30` only if `undefined`.
2.  If `historySize` is set to 0, then disable caching the line.
3.  Added unit tests.
4.  Updated documentation.