### PR TITLE
promise: Add --throw-unhandled-rejection and --trace-unhandled-rejection 

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -186,6 +186,12 @@ this, you can either attach a dummy `.catch(() => { })` handler to
 `resource.loaded`, preventing the `'unhandledRejection'` event from being
 emitted, or you can use the [`'rejectionHandled'`][] event.
 
+When `'--throw-unhandled-rejection'` option is on, Node process throws 
+an exception if `unhandledRejection` listener is not exist.
+
+And `'--trace-unhandled-rejection'` option is on, Node outputs stderr message
+an exception if `unhandledRejection` listener is not exist.
+
 ## Event: 'warning'
 
 Emitted whenever Node.js emits a process warning.

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -3,6 +3,9 @@
 const promiseRejectEvent = process._promiseRejectEvent;
 const hasBeenNotifiedProperty = new WeakMap();
 const pendingUnhandledRejections = [];
+const traceUnhandledRejection = process.traceUnhandledRejection;
+const throwUnhandledRejection = process.throwUnhandledRejection;
+const prefix = `(${process.release.name}:${process.pid}) `;
 
 exports.setup = setupPromises;
 
@@ -44,6 +47,18 @@ function setupPromises(scheduleMicrotasks) {
         if (!process.emit('unhandledRejection', reason, promise)) {
           // Nobody is listening.
           // TODO(petkaantonov) Take some default action, see #830
+
+          if (traceUnhandledRejection) {
+            if (reason && reason.stack) {
+              console.error(`${prefix}${reason.stack}`);
+            } else {
+              console.error(`${prefix}${reason}`);
+            }
+          }
+
+          if (throwUnhandledRejection) {
+            throw reason;
+          }
         } else {
           hadListeners = true;
         }

--- a/src/node.cc
+++ b/src/node.cc
@@ -143,6 +143,8 @@ static bool trace_deprecation = false;
 static bool throw_deprecation = false;
 static bool trace_sync_io = false;
 static bool track_heap_objects = false;
+static bool trace_unhandled_rejection = false;
+static bool throw_unhandled_rejection = false;
 static const char* eval_string = nullptr;
 static unsigned int preload_module_count = 0;
 static const char** preload_modules = nullptr;
@@ -3142,6 +3144,18 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
   }
 
+  // --trace-unhandled-rejection
+  if (trace_unhandled_rejection) {
+    READONLY_PROPERTY(
+        process, "traceUnhandledRejection", True(env->isolate()));
+  }
+
+  // --throw-unhandled-rejection
+  if (throw_unhandled_rejection) {
+    READONLY_PROPERTY(
+        process, "throwUnhandledRejection", True(env->isolate()));
+  }
+
   // --security-revert flags
 #define V(code, _, __)                                                        \
   do {                                                                        \
@@ -3571,6 +3585,10 @@ static void ParseArgs(int* argc,
     } else if (strncmp(arg, "--icu-data-dir=", 15) == 0) {
       icu_data_dir = arg + 15;
 #endif
+    } else if (strcmp(arg, "--trace-unhandled-rejection") == 0) {
+      trace_unhandled_rejection = true;
+    } else if (strcmp(arg, "--throw-unhandled-rejection") == 0) {
+      throw_unhandled_rejection = true;
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js

--- a/test/parallel/test-throw-default-error-unhandled-rejections.js
+++ b/test/parallel/test-throw-default-error-unhandled-rejections.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const node = process.execPath;
+
+if (process.argv[2] === 'child') {
+  const rejectPromise = () => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error('Reject Promise')), 100);
+    });
+  };
+  rejectPromise();
+} else {
+  run('--throw-unhandled-rejection');
+}
+
+function run(flags) {
+  const args = [__filename, 'child'];
+  if (flags)
+    args.unshift(flags);
+
+  const child = spawn(node, args);
+  let message = '';
+  child.stderr.on('data', (data) => {
+    message += data;
+  });
+  child.stderr.on('end', common.mustCall(() => {
+    assert(message.match(/Reject Promise/));
+  }));
+  child.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 1);
+  }));
+}
+

--- a/test/parallel/test-trace-default-error-unhandled-rejections.js
+++ b/test/parallel/test-trace-default-error-unhandled-rejections.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const node = process.execPath;
+
+if (process.argv[2] === 'child') {
+  const rejectPromise = () => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error('Reject Promise')), 100);
+    });
+  };
+  rejectPromise();
+} else {
+  run('--trace-unhandled-rejection');
+}
+
+function run(flags) {
+  const args = [__filename, 'child'];
+  if (flags)
+    args.unshift(flags);
+
+  const child = spawn(node, args);
+  let errorMessage = '';
+  child.stderr.on('data', (data) => {
+    errorMessage += data;
+  });
+  child.stderr.on('end', common.mustCall(() => {
+    assert(errorMessage.match(/Reject Promise/));
+  }));
+  child.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+}
+
+

--- a/test/parallel/test-trace-null-unhandled-rejections.js
+++ b/test/parallel/test-trace-null-unhandled-rejections.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const node = process.execPath;
+
+if (process.argv[2] === 'child') {
+  const rejectPromise = () => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => reject(null), 100);
+    });
+  };
+  rejectPromise();
+} else {
+  run('--trace-unhandled-rejection');
+}
+
+function run(flags) {
+  const args = [__filename, 'child'];
+  if (flags)
+    args.unshift(flags);
+
+  const child = spawn(node, args);
+  let message = '';
+  child.stderr.on('data', (data) => {
+    message += data;
+  });
+  child.stderr.on('end', common.mustCall(() => {
+    assert(message.match(/null/));
+  }));
+  child.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+}
+
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
promise

##### Description of change

<!-- provide a description of the change below this comment -->

We are writing a lots of Promise modules and test these modules in our development environment. When `process.on('unhandledRejection')` error is occurred, default node behavior does not send any message, no warnings, no exceptions.  So we have to prepare the following code and add tests.

```js
process.on('unhandledRejection', (reason) => {
  throw reason;
});
```

This is not so easy for Promise / Node beginner. So I would like to propose the following 2 options.

1. `--throw-unhandled-rejection` option will throw Exception when no unhandledRejection listener
2. `--trace-unhandled-rejection` option will output stderr when no unhandledRejection listener

I know the default unhandledRejection behavior is discussing here
https://github.com/nodejs/promises/issues/26

But I would like to add these options to help our developments.
