### PR TITLE
debugger: Reduce global variables and expose some APIs for the debugger.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -146,9 +146,9 @@ static bool track_heap_objects = false;
 static const char* eval_string = nullptr;
 static unsigned int preload_module_count = 0;
 static const char** preload_modules = nullptr;
-static bool use_debug_agent = false;
-static bool debug_wait_connect = false;
-static int debug_port = 5858;
+// Keep a global of the debug port, as it's needed, for example, when starting
+// the debugger from within a signal handler.
+static int global_debug_port = 5858;
 static const int v8_default_thread_pool_size = 4;
 static int v8_thread_pool_size = v8_default_thread_pool_size;
 static bool prof_process = false;
@@ -2778,14 +2778,14 @@ static Local<Object> GetFeatures(Environment* env) {
 
 static void DebugPortGetter(Local<Name> property,
                             const PropertyCallbackInfo<Value>& info) {
-  info.GetReturnValue().Set(debug_port);
+  info.GetReturnValue().Set(global_debug_port);
 }
 
 
 static void DebugPortSetter(Local<Name> property,
                             Local<Value> value,
                             const PropertyCallbackInfo<void>& info) {
-  debug_port = value->Int32Value();
+  global_debug_port = value->Int32Value();
 }
 
 
@@ -3341,20 +3341,20 @@ void LoadEnvironment(Environment* env) {
 
 static void PrintHelp();
 
-static bool ParseDebugOpt(const char* arg) {
+static bool ParseDebugOpt(const char* arg, DebuggerSettings* settings) {
   const char* port = nullptr;
 
   if (!strcmp(arg, "--debug")) {
-    use_debug_agent = true;
+    settings->use_agent = true;
   } else if (!strncmp(arg, "--debug=", sizeof("--debug=") - 1)) {
-    use_debug_agent = true;
+    settings->use_agent = true;
     port = arg + sizeof("--debug=") - 1;
   } else if (!strcmp(arg, "--debug-brk")) {
-    use_debug_agent = true;
-    debug_wait_connect = true;
+    settings->use_agent = true;
+    settings->wait_connect = true;
   } else if (!strncmp(arg, "--debug-brk=", sizeof("--debug-brk=") - 1)) {
-    use_debug_agent = true;
-    debug_wait_connect = true;
+    settings->use_agent = true;
+    settings->wait_connect = true;
     port = arg + sizeof("--debug-brk=") - 1;
   } else if (!strncmp(arg, "--debug-port=", sizeof("--debug-port=") - 1)) {
     port = arg + sizeof("--debug-port=") - 1;
@@ -3363,12 +3363,13 @@ static bool ParseDebugOpt(const char* arg) {
   }
 
   if (port != nullptr) {
-    debug_port = atoi(port);
-    if (debug_port < 1024 || debug_port > 65535) {
+    int port_int = atoi(port);
+    if (port_int < 1024 || port_int > 65535) {
       fprintf(stderr, "Debug port must be in range 1024 to 65535.\n");
       PrintHelp();
       exit(12);
     }
+    settings->port = port_int;
   }
 
   return true;
@@ -3456,7 +3457,8 @@ static void ParseArgs(int* argc,
                       int* exec_argc,
                       const char*** exec_argv,
                       int* v8_argc,
-                      const char*** v8_argv) {
+                      const char*** v8_argv,
+                      DebuggerSettings* debugger_settings) {
   const unsigned int nargs = static_cast<unsigned int>(*argc);
   const char** new_exec_argv = new const char*[nargs];
   const char** new_v8_argv = new const char*[nargs];
@@ -3483,7 +3485,7 @@ static void ParseArgs(int* argc,
     const char* const arg = argv[index];
     unsigned int args_consumed = 1;
 
-    if (ParseDebugOpt(arg)) {
+    if (ParseDebugOpt(arg, debugger_settings)) {
       // Done, consumed by ParseDebugOpt().
     } else if (strcmp(arg, "--version") == 0 || strcmp(arg, "-v") == 0) {
       printf("%s\n", NODE_VERSION);
@@ -3622,7 +3624,7 @@ static void DispatchMessagesDebugAgentCallback(Environment* env) {
 }
 
 
-static void StartDebug(Environment* env, bool wait) {
+void StartDebug(Environment* env, int debug_port, bool wait) {
   CHECK(!debugger_running);
 
   env->debugger_agent()->set_dispatch_handler(
@@ -3637,7 +3639,7 @@ static void StartDebug(Environment* env, bool wait) {
 
 
 // Called from the main thread.
-static void EnableDebug(Environment* env) {
+void EnableDebug(Environment* env) {
   CHECK(debugger_running);
 
   // Send message to enable debug in workers
@@ -3684,7 +3686,7 @@ static void DispatchDebugMessagesAsyncCallback(uv_async_t* handle) {
     Environment* env = Environment::GetCurrent(isolate);
     Context::Scope context_scope(env->context());
 
-    StartDebug(env, false);
+    StartDebug(env, global_debug_port, false);
     EnableDebug(env);
   }
 
@@ -3974,7 +3976,8 @@ inline void PlatformInit() {
 void Init(int* argc,
           const char** argv,
           int* exec_argc,
-          const char*** exec_argv) {
+          const char*** exec_argv,
+          DebuggerSettings* debugger_settings) {
   // Initialize prog_start_time to get relative uptime.
   prog_start_time = static_cast<double>(uv_now(uv_default_loop()));
 
@@ -3998,7 +4001,8 @@ void Init(int* argc,
   // Parse a few arguments which are specific to Node.
   int v8_argc;
   const char** v8_argv;
-  ParseArgs(argc, argv, exec_argc, exec_argv, &v8_argc, &v8_argv);
+  ParseArgs(argc, argv, exec_argc, exec_argv, &v8_argc, &v8_argv,
+            debugger_settings);
 
   // TODO(bnoordhuis) Intercept --prof arguments and start the CPU profiler
   // manually?  That would give us a little more control over its runtime
@@ -4048,7 +4052,7 @@ void Init(int* argc,
     exit(9);
   }
 
-  if (debug_wait_connect) {
+  if (debugger_settings->wait_connect) {
     const char expose_debug_as[] = "--expose_debug_as=v8debug";
     V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
   }
@@ -4059,7 +4063,7 @@ void Init(int* argc,
   const char no_typed_array_heap[] = "--typed_array_max_size_in_heap=0";
   V8::SetFlagsFromString(no_typed_array_heap, sizeof(no_typed_array_heap) - 1);
 
-  if (!use_debug_agent) {
+  if (!debugger_settings->use_agent) {
     RegisterDebugSignalHandler();
   }
 
@@ -4256,11 +4260,16 @@ Environment* CreateEnvironment(Isolate* isolate,
   return env;
 }
 
+// Returns true if the isolate field was previously null, otherwise returns
+// false if there was another current main isolate value that was overwritten.
+bool SetMainIsolate(v8::Isolate* isolate) {
+  return node_isolate.exchange(isolate) == nullptr;
+}
 
 // Entry point for new node instances, also called directly for the main
 // node instance.
-static void StartNodeInstance(void* arg) {
-  NodeInstanceData* instance_data = static_cast<NodeInstanceData*>(arg);
+static void StartNodeInstance(NodeInstanceData* instance_data,
+                              DebuggerSettings* debugger_settings) {
   Isolate::CreateParams params;
   ArrayBufferAllocator* array_buffer_allocator = new ArrayBufferAllocator();
   params.array_buffer_allocator = array_buffer_allocator;
@@ -4272,10 +4281,12 @@ static void StartNodeInstance(void* arg) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
   }
 
-  // Fetch a reference to the main isolate, so we have a reference to it
+  const bool is_main = instance_data->is_main();
+
+  // Store a reference to the main isolate, so we have a reference to it
   // even when we need it to access it from another (debugger) thread.
-  if (instance_data->is_main())
-    CHECK_EQ(nullptr, node_isolate.exchange(isolate));
+  if (is_main)
+    CHECK(SetMainIsolate(isolate));
 
   {
     Locker locker(isolate);
@@ -4290,8 +4301,8 @@ static void StartNodeInstance(void* arg) {
         ShouldAbortOnUncaughtException);
 
     // Start debug agent when argv has --debug
-    if (instance_data->use_debug_agent())
-      StartDebug(env, debug_wait_connect);
+    if (is_main && debugger_settings->use_agent)
+      StartDebug(env, debugger_settings->port, debugger_settings->wait_connect);
 
     {
       Environment::AsyncCallbackScope callback_scope(env);
@@ -4301,7 +4312,7 @@ static void StartNodeInstance(void* arg) {
     env->set_trace_sync_io(trace_sync_io);
 
     // Enable debugger
-    if (instance_data->use_debug_agent())
+    if (is_main && debugger_settings->use_agent)
       EnableDebug(env);
 
     {
@@ -4363,7 +4374,10 @@ int Start(int argc, char** argv) {
   // optional, in case you're wondering.
   int exec_argc;
   const char** exec_argv;
-  Init(&argc, const_cast<const char**>(argv), &exec_argc, &exec_argv);
+  DebuggerSettings debugger_settings = {false, false, global_debug_port};
+  Init(&argc, const_cast<const char**>(argv), &exec_argc, &exec_argv,
+       &debugger_settings);
+  global_debug_port = debugger_settings.port;
 
 #if HAVE_OPENSSL
 #ifdef NODE_FIPS_MODE
@@ -4387,9 +4401,9 @@ int Start(int argc, char** argv) {
                                    argc,
                                    const_cast<const char**>(argv),
                                    exec_argc,
-                                   exec_argv,
-                                   use_debug_agent);
-    StartNodeInstance(&instance_data);
+                                   exec_argv);
+
+    StartNodeInstance(&instance_data, &debugger_settings);
     exit_code = instance_data.exit_code();
   }
   V8::Dispose();

--- a/src/node.h
+++ b/src/node.h
@@ -184,11 +184,22 @@ NODE_EXTERN extern bool enable_fips_crypto;
 NODE_EXTERN extern bool force_fips_crypto;
 #endif
 
+struct DebuggerSettings {
+  bool use_agent;
+  bool wait_connect;
+  int port;
+};
+
 NODE_EXTERN int Start(int argc, char *argv[]);
 NODE_EXTERN void Init(int* argc,
                       const char** argv,
                       int* exec_argc,
-                      const char*** exec_argv);
+                      const char*** exec_argv,
+                      DebuggerSettings* debugger_settings);
+
+NODE_EXTERN void EnableDebug(Environment* env);
+NODE_EXTERN void StartDebug(Environment* env, int debug_port, bool wait);
+NODE_EXTERN bool SetMainIsolate(v8::Isolate* isolate);
 
 class Environment;
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -221,16 +221,14 @@ class NodeInstanceData {
                      int argc,
                      const char** argv,
                      int exec_argc,
-                     const char** exec_argv,
-                     bool use_debug_agent_flag)
+                     const char** exec_argv)
         : node_instance_type_(node_instance_type),
           exit_code_(1),
           event_loop_(event_loop),
           argc_(argc),
           argv_(argv),
           exec_argc_(exec_argc),
-          exec_argv_(exec_argv),
-          use_debug_agent_flag_(use_debug_agent_flag) {
+          exec_argv_(exec_argv) {
       CHECK_NE(event_loop_, nullptr);
     }
 
@@ -272,10 +270,6 @@ class NodeInstanceData {
       return exec_argv_;
     }
 
-    bool use_debug_agent() {
-      return is_main() && use_debug_agent_flag_;
-    }
-
   private:
     const NodeInstanceType node_instance_type_;
     int exit_code_;
@@ -284,7 +278,6 @@ class NodeInstanceData {
     const char** argv_;
     const int exec_argc_;
     const char** exec_argv_;
-    const bool use_debug_agent_flag_;
 
     DISALLOW_COPY_AND_ASSIGN(NodeInstanceData);
 };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

Node embedding API / startup / command line handling.
##### Description of change

<!-- provide a description of the change below this comment -->

The debugger setup is a bit complicated because of all of the cross signal handler / thread / global state.  While I didn't completely remove all of the global state, I think this patch at least improves it and takes a step towards a cleaner API.  This is also exposes a few additional functions required to make the debugger work from an embedder of Node that does its own startup (not via node::Start).

Reduce the amount of global state relating to starting the debugger
to just the port number, which is needed by the SIGUSR1 handler.

Expose APIs so that embedders of Node can also have some control over
the debugger setup process.  SetMainIsolate is required to set the
global Isolate variable that the debugger related handlers use.
Expose StartDebug and EnableDebug for controlling the debug agent.

Remove the debug agent flag from NodeInstanceData and instead track via a
separate DebugSettings struct and plumb that through as much as possible to
remove the majority of reliance on global settings.
