### PR TITLE
fix a typo in Buffer example code

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -222,7 +222,7 @@ function:
 Buffers can be iterated over using the ECMAScript 2015 (ES6) `for..of` syntax:
 
 ```js
-const buf = Buffer(.from[1, 2, 3]);
+const buf = Buffer.from([1, 2, 3]);
 
 for (var b of buf)
   console.log(b)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Description of change

<!-- provide a description of the change below this comment -->

it shows `Buffer(.from[1, 2, 3]);` but that doesn't run; should be a typo

1. https://nodejs.org/api/buffer.html#buffer_buffers_and_es6_iteration
1. https://nodejs.org/dist/latest-v5.x/docs/api/buffer.html#buffer_buffers_and_es6_iteration

resolve comment in https://github.com/nodejs/node/commit/c1534e7#commitcomment-17228215; verified the same doc in master 85ab4a5 is correct.