### PR TITLE
doc: use Buffer.from() instead of new Buffer()

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -93,7 +93,7 @@ The `spkac` argument must be a Node.js [`Buffer`][].
 ```js
 const cert = require('crypto').Certificate();
 const spkac = getSpkacSomehow();
-console.log(cert.verifySpkac(new Buffer(spkac)));
+console.log(cert.verifySpkac(Buffer.from(spkac)));
   // Prints true or false
 ```
 

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -233,7 +233,7 @@ Example of sending a UDP packet to a random port on `localhost`;
 
 ```js
 const dgram = require('dgram');
-const message = new Buffer('Some bytes');
+const message = Buffer.from('Some bytes');
 const client = dgram.createSocket('udp4');
 client.send(message, 41234, 'localhost', (err) => {
   client.close();
@@ -244,8 +244,8 @@ Example of sending a UDP packet composed of multiple buffers to a random port on
 
 ```js
 const dgram = require('dgram');
-const buf1 = new Buffer('Some ');
-const buf2 = new Buffer('bytes');
+const buf1 = Buffer.from('Some ');
+const buf2 = Buffer.from('bytes');
 const client = dgram.createSocket('udp4');
 client.send([buf1, buf2], 41234, 'localhost', (err) => {
   client.close();

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -490,7 +490,7 @@ function parseHeader(stream, callback) {
         var split = str.split(/\n\n/);
         header += split.shift();
         var remaining = split.join('\n\n');
-        var buf = new Buffer(remaining, 'utf8');
+        var buf = Buffer.from(remaining, 'utf8');
         if (buf.length)
           stream.unshift(buf);
         stream.removeListener('error', callback);
@@ -985,7 +985,7 @@ Counter.prototype._read = function() {
     this.push(null);
   else {
     var str = '' + i;
-    var buf = new Buffer(str, 'ascii');
+    var buf = Buffer.from(str, 'ascii');
     this.push(buf);
   }
 };

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -10,10 +10,10 @@ additional support for utf8.
 const StringDecoder = require('string_decoder').StringDecoder;
 const decoder = new StringDecoder('utf8');
 
-const cent = new Buffer([0xC2, 0xA2]);
+const cent = Buffer.from([0xC2, 0xA2]);
 console.log(decoder.write(cent));
 
-const euro = new Buffer([0xE2, 0x82, 0xAC]);
+const euro = Buffer.from([0xE2, 0x82, 0xAC]);
 console.log(decoder.write(euro));
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -297,7 +297,7 @@ util.isBuffer({ length: 0 })
   // false
 util.isBuffer([])
   // false
-util.isBuffer(new Buffer('hello world'))
+util.isBuffer(Buffer.from('hello world'))
   // true
 ```
 

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -37,7 +37,7 @@ zlib.deflate(input, (err, buffer) => {
   }
 });
 
-const buffer = new Buffer('eJzT0yMAAGTvBe8=', 'base64');
+const buffer = Buffer.from('eJzT0yMAAGTvBe8=', 'base64');
 zlib.unzip(buffer, (err, buffer) => {
   if (!err) {
     console.log(buffer.toString());
@@ -117,7 +117,7 @@ method that is used to compressed the last chunk of input data:
 
 ```js
 // This is a truncated version of the buffer from the above examples
-const buffer = new Buffer('eJzT0yMA', 'base64');
+const buffer = Buffer.from('eJzT0yMA', 'base64');
 
 zlib.unzip(buffer, { finishFlush: zlib.Z_SYNC_FLUSH }, (err, buffer) => {
   if (!err) {

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -58,8 +58,8 @@ const StringDecoder = exports.StringDecoder = function(encoding) {
 // returned when calling write again with the remaining bytes.
 //
 // Note: Converting a Buffer containing an orphan surrogate to a String
-// currently works, but converting a String to a Buffer (via `new Buffer`, or
-// Buffer#write) will replace incomplete surrogates with the unicode
+// currently works, but converting a String to a Buffer (via `Buffer.from()`,
+// or Buffer#write) will replace incomplete surrogates with the unicode
 // replacement character. See https://codereview.chromium.org/121173009/ .
 StringDecoder.prototype.write = function(buffer) {
   var charStr = '';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

Use new API of Buffer to developers in most documents.