### PR TITLE
console: only require assert module once in Console.prototype.assert

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const util = require('util');
 
 function Console(stdout, stderr) {
@@ -91,7 +92,7 @@ Console.prototype.trace = function trace(...args) {
 
 Console.prototype.assert = function(expression, ...args) {
   if (!expression) {
-    require('assert').ok(false, util.format.apply(null, args));
+    assert.ok(false, util.format.apply(null, args));
   }
 };
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Description of change

Only `require` the `assert` module once at the head of the file, to reduce  the multiple `require` spending.
