### PR TITLE
buffer: make Buffer.alloc() works with pool

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -13,8 +13,6 @@ const kFromErrorMsg = 'First argument must be a string, Buffer, ' +
                       'ArrayBuffer, Array, or array-like object.';
 
 Buffer.poolSize = 8 * 1024;
-var poolSize, poolOffset, allocPool;
-
 
 binding.setupBufferJS(Buffer.prototype, bindingObj);
 
@@ -68,23 +66,48 @@ function createBuffer(size) {
   return ui8;
 }
 
-function createPool() {
-  poolSize = Buffer.poolSize;
-  if (poolSize > 0)
-    flags[kNoZeroFill] = 1;
-  allocPool = createBuffer(poolSize);
-  poolOffset = 0;
-}
-createPool();
+var Pool = function(poolSize, zeroFill) {
+  this.poolSize = poolSize;
+  this.zeroFill = zeroFill;
+  this.init();
+};
 
+Pool.prototype.init = function() {
+  flags[kNoZeroFill] = this.zeroFill ? 0 : 1;
+  this.allocPool = createBuffer(this.poolSize);
+  this.poolOffset = 0;
+};
 
-function alignPool() {
+Pool.prototype.allocate = function(size) {
+  if (size > (this.poolSize - this.poolOffset))
+    this.init();
+
+  var b = this.allocPool.slice(this.poolOffset, this.poolOffset + size);
+  this.poolOffset += size;
+  this.alignPool();
+  return b;
+};
+
+Pool.prototype.fromString = function(string, length, encoding) {
+  if (length > (this.poolSize - this.poolOffset))
+    this.init();
+  var actual = this.allocPool.write(string, this.poolOffset, encoding);
+  var b = this.allocPool.slice(this.poolOffset, this.poolOffset + actual);
+  this.poolOffset += actual;
+  this.alignPool();
+  return b;
+};
+
+Pool.prototype.alignPool = function() {
   // Ensure aligned slices
-  if (poolOffset & 0x7) {
-    poolOffset |= 0x7;
-    poolOffset++;
+  if (this.poolOffset & 0x7) {
+    this.poolOffset |= 0x7;
+    this.poolOffset++;
   }
-}
+};
+
+var unsafePool = new Pool(Buffer.poolSize, false);
+var safePool = new Pool(Buffer.poolSize, true);
 
 /**
  * The Buffer() construtor is "soft deprecated" ... that is, it is deprecated
@@ -152,6 +175,7 @@ Buffer.alloc = function(size, fill, encoding) {
   assertSize(size);
   if (size <= 0)
     return createBuffer(size);
+
   if (fill !== undefined) {
     // Since we are filling anyway, don't zero fill initially.
     flags[kNoZeroFill] = 1;
@@ -162,6 +186,11 @@ Buffer.alloc = function(size, fill, encoding) {
         createBuffer(size).fill(fill, encoding) :
         createBuffer(size).fill(fill);
   }
+
+  if (size < (Buffer.poolSize >>> 1)) {
+    return safePool.allocate(size);
+  }
+
   flags[kNoZeroFill] = 0;
   return createBuffer(size);
 };
@@ -206,12 +235,8 @@ function allocate(size) {
     return createBuffer(size);
   }
   if (size < (Buffer.poolSize >>> 1)) {
-    if (size > (poolSize - poolOffset))
-      createPool();
-    var b = allocPool.slice(poolOffset, poolOffset + size);
-    poolOffset += size;
-    alignPool();
-    return b;
+    // Allocate from unsafe Buffer pool
+    return unsafePool.allocate(size);
   } else {
     // Even though this is checked above, the conditional is a safety net and
     // sanity check to prevent any subsequent typed array allocation from not
@@ -238,13 +263,7 @@ function fromString(string, encoding) {
   if (length >= (Buffer.poolSize >>> 1))
     return binding.createFromString(string, encoding);
 
-  if (length > (poolSize - poolOffset))
-    createPool();
-  var actual = allocPool.write(string, poolOffset, encoding);
-  var b = allocPool.slice(poolOffset, poolOffset + actual);
-  poolOffset += actual;
-  alignPool();
-  return b;
+  return unsafePool.fromString(string, length, encoding);
 }
 
 function fromArrayLike(obj) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
buffer

##### Description of change

<!-- provide a description of the change below this comment -->

It makes Buffer.alloc() more faster ~2.5x.