### PR TITLE
crypto: Read OpenSSL config before init

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5696,10 +5696,10 @@ void ExportChallenge(const FunctionCallbackInfo<Value>& args) {
 
 
 void InitCryptoOnce() {
+  OPENSSL_config(NULL);
   SSL_library_init();
   OpenSSL_add_all_algorithms();
   SSL_load_error_strings();
-  OPENSSL_config(NULL);
 
   crypto_lock_init();
   CRYPTO_set_locking_callback(crypto_lock_cb);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)

crypto

##### Description of change

<!-- provide a description of the change below this comment -->

The OpenSSL configuration file allows a directive for a custom crypto engine to be used, but such a directive will not be respected if the config file is loaded after initializing all crypto subsystems. 

This PR reads the configuration file first, and is meant to directly address the issues raised by @burmisov and @fast0490f in https://github.com/nodejs/node/issues/5101.

The previous PR (https://github.com/nodejs/node/pull/5739) proposed to address the same problem introduces new runtime argument which is not strictly necessary and thus has a higher impact.

In this PR I've opted, after discussion, to propose the minimal possible change to resolve the issue reported with the GOST engine support. For more information, please see https://github.com/nodejs/node/pull/5739#issuecomment-213162214.