### PR TITLE
doc: note that PR-URL should be first metadata

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -93,14 +93,16 @@ information regarding the change process:
 
 - A `PR-URL:` line that references the *full* GitHub URL of the original
   pull request being merged so it's easy to trace a commit back to the
-  conversation that led up to that change. Please be sure that the `PR-URL`
-  line appears first, above the `Reviewed-By` lines and any `Fixes` lines.
+  conversation that led up to that change.
 - A `Fixes: X` line, where _X_ either includes the *full* GitHub URL
   for an issue, and/or the hash and commit message if the commit fixes
   a bug in a previous commit. Multiple `Fixes:` lines may be added if
   appropriate.
 - A `Reviewed-By: Name <email>` line for yourself and any
   other Collaborators who have reviewed the change.
+
+Make sure that the order of metadata follows the outline above; meaning
+`PR-URL`, followed by `Fixes` and so on.
 
 Review the commit message to ensure that it adheres to the guidelines
 outlined in the [contributing](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit) guide.
@@ -213,8 +215,8 @@ fixup 7d6f433 test for feature B
 
 Save the file and close the editor. You'll be asked to enter a new
 commit message for that commit. This is a good moment to fix incorrect
-commit logs, ensure that they are properly formatted, and add
-`Reviewed-By` lines.
+commit logs, ensure that they are properly formatted, and add metadata as
+appropriate.
 
 Time to push it:
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -95,12 +95,12 @@ information regarding the change process:
   pull request being merged so it's easy to trace a commit back to the
   conversation that led up to that change. Please be sure that the `PR-URL`
   line appears first, above the `Reviewed-By` lines and any `Fixes` lines.
-- A `Reviewed-By: Name <email>` line for yourself and any
-  other Collaborators who have reviewed the change.
 - A `Fixes: X` line, where _X_ either includes the *full* GitHub URL
   for an issue, and/or the hash and commit message if the commit fixes
   a bug in a previous commit. Multiple `Fixes:` lines may be added if
   appropriate.
+- A `Reviewed-By: Name <email>` line for yourself and any
+  other Collaborators who have reviewed the change.
 
 Review the commit message to ensure that it adheres to the guidelines
 outlined in the [contributing](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit) guide.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -91,11 +91,12 @@ The CTC should serve as the final arbiter where required.
 Always modify the original commit message to include additional meta
 information regarding the change process:
 
-- A `Reviewed-By: Name <email>` line for yourself and any
-  other Collaborators who have reviewed the change.
 - A `PR-URL:` line that references the *full* GitHub URL of the original
   pull request being merged so it's easy to trace a commit back to the
-  conversation that led up to that change.
+  conversation that led up to that change. Please be sure that the `PR-URL`
+  line appears first, above the `Reviewed-By` lines and any `Fixes` lines.
+- A `Reviewed-By: Name <email>` line for yourself and any
+  other Collaborators who have reviewed the change.
 - A `Fixes: X` line, where _X_ either includes the *full* GitHub URL
   for an issue, and/or the hash and commit message if the commit fixes
   a bug in a previous commit. Multiple `Fixes:` lines may be added if

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -164,11 +164,11 @@ Landing a PR
   * commits should follow `subsystem[,subsystem]: small description\n\nbig description\n\n<metadata>`
   * first line 50 columns, all others 72
   * add metadata:
+    * `PR-URL: <full-pr-url>` (this line should always be the first metadata line!)
     * `Fixes: <full-issue-url>`
     * `Reviewed-By: human <email>`
       * Easiest to use `git log` then do a search
       * (`/Name` + `enter` (+ `n` as much as you need to) in vim)
-    * `PR-URL: <full-pr-url>`
 * `git push upstream master`
     * close the original PR with "Landed in `<commit hash>`".
 
@@ -180,7 +180,7 @@ Landing a PR
   * Collaborators in alphabetical order by username
   * Label your pull request with the `doc` subsystem label
   * If you would like to run CI on your PR, feel free to
-  * Make sure to added the `PR-URL: <full-pr-url>`!
+  * Make sure to add the `PR-URL: <full-pr-url>`!
 
 
 ### final notes:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc

##### Description of change

<!-- provide a description of the change below this comment -->

Convention has coalesced around putting the PR-URL as the first metadata
item in pull requests, so much so that collaborators are now flagging
other collaborators' commit messages when they don't do that. So let's
make it official and document that the PR-URL should be first.

Refs: https://github.com/nodejs/build/issues/325
Refs: https://github.com/nodejs/node/pull/6385