### PR TITLE
deps: backport f617ccc644 from uv upstream

### DIFF
--- a/deps/uv/src/unix/fs.c
+++ b/deps/uv/src/unix/fs.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h> /* PATH_MAX */
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -383,7 +384,7 @@ static ssize_t uv__fs_pathmax_size(const char* path) {
 #if defined(PATH_MAX)
     return PATH_MAX;
 #else
-    return 4096;
+#error "PATH_MAX undefined in the current platform"
 #endif
   }
 


### PR DESCRIPTION
protect against realpath(3) exploit

ref: https://github.com/isaacs/node-glob/pull/259#issuecomment-213367860

Original commit message:

    unix: error on realpath if PATH_MAX is undefined

    Currently when PATH_MAX is undefined realpath will default to using 4096.
    There is a potential stack overflow attack that can be mitigated by having
    PATH_MAX defined. This change conservatively errors if a system does not
    have PATH_MAX defined.

    This change also explicitly includes `limits.h` to ensure that all platforms
    have PATH_MAX defined if it is available.

    Ref: http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html

    Refs: nodejs/node#2680 (comment)
    PR-URL: #843
    Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
    Reviewed-By: Fedor Indutny <fedor@indutny.com>
    Reviewed-By: Saúl Ibarra Corretgé <saghul@gmail.com>