### PR TITLE
build: don't compile with -B

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -25,6 +25,9 @@
     # Don't bake anything extra into the snapshot.
     'v8_use_external_startup_data%': 0,
 
+    # Don't compile with -B, we don't bundle ld.gold.
+    'linux_use_bundled_gold%': 0,
+
     'conditions': [
       ['OS == "win"', {
         'os_posix': 0,


### PR DESCRIPTION
Turn off the custom toolchain, we don't bundle ld.gold.  It's not that
useful anyway because it uses a fixed path.  For people that do use a
custom toolchain, there is the GCC_EXEC_PREFIX environment variable.

CI: https://ci.nodejs.org/job/node-test-pull-request/2397/