### PR TITLE
events: pass the original listener added by EventEmitter#once to the removeListener handler

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -308,7 +308,7 @@ EventEmitter.prototype.prependOnceListener =
 // emits a 'removeListener' event iff the listener was removed
 EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
-      var list, events, position, i;
+      var list, events, position, i, originalListener;
 
       if (typeof listener !== 'function')
         throw new TypeError('"listener" argument must be a function');
@@ -327,7 +327,7 @@ EventEmitter.prototype.removeListener =
         else {
           delete events[type];
           if (events.removeListener)
-            this.emit('removeListener', type, listener);
+            this.emit('removeListener', type, list.listener || listener);
         }
       } else if (typeof list !== 'function') {
         position = -1;
@@ -335,6 +335,7 @@ EventEmitter.prototype.removeListener =
         for (i = list.length; i-- > 0;) {
           if (list[i] === listener ||
               (list[i].listener && list[i].listener === listener)) {
+            originalListener = list[i].listener;
             position = i;
             break;
           }
@@ -356,7 +357,7 @@ EventEmitter.prototype.removeListener =
         }
 
         if (events.removeListener)
-          this.emit('removeListener', type, listener);
+          this.emit('removeListener', type, originalListener || listener);
       }
 
       return this;

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -102,3 +102,14 @@ e6.emit('hello');
 
 // Interal listener array [listener3]
 e6.emit('hello');
+
+const e7 = new events.EventEmitter();
+
+const listener5 = () => {};
+
+e7.once('hello', listener5);
+e7.on('removeListener', common.mustCall((eventName, listener) => {
+  assert.strictEqual(eventName, 'hello');
+  assert.strictEqual(listener, listener5);
+}));
+e7.emit('hello');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines
- [x] a test and/or benchmark is included

##### Description of change

We use the [`_onceWrap`](https://github.com/nodejs/node/blob/master/lib/events.js#L280) function to wrap the listener added by `EventEmitter#once`, and use the flag `fired` inside to make sure the listener will only be called once, including the calling in the `removeListener ` event: 

```js
'use strict'
const EventEmitter = require('events')

let ee = new EventEmitter()

ee.once('test', () => console.log('test'))

ee.on('removeListener', (eventName, listener) => {
  console.log(`eventName: ${eventName}`)
  listener.call(ee)
  listener.call(ee)
  listener.call(ee)
})

ee.emit('test')
// eventName: test
// test

```

But by explicitly invoking the listener in the removeListener handler the user expresses a pretty strong intent that the listener should be called. By now we can use a `listener.listener` trick to archive this:

```js
'use strict'
const EventEmitter = require('events')

let ee = new EventEmitter()

ee.once('test', () => console.log('test'))

ee.on('removeListener', (eventName, listener) => {
  console.log(`eventName: ${eventName}`)
  listener.listener.call(ee)
  listener.listener.call(ee)
  listener.listener.call(ee)
})

ee.emit('test')
// eventName: test
// test
// test
// test
// test

```

But those who have not read the the code of `lib/events.js` should not know this trick at all, and using tricks is alway not a good way. so this PR is to pass the original listener added by `EventEmitter#once` to the `removeListener` handler:

```js
'use strict'
const EventEmitter = require('events')

let ee = new EventEmitter()

ee.once('test', () => console.log('test'))

ee.on('removeListener', (eventName, listener) => {
  console.log(`eventName: ${eventName}`)
  listener()
  listener()
  listener()
})

ee.emit('test')
// eventName: test
// test
// test
// test
// test

```