### PR TITLE
doc: extra clarification of historySize option

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -302,7 +302,7 @@ the following values:
 
  - `historySize` - maximum number of history lines retained. To disable the
    history set this value to `0`. Defaults to `30`. This option makes sense
-   only if `terminal` is set `true` by user or by internal `output` check,
+   only if `terminal` is set to `true` by user or by internal `output` check,
    otherwise the history caching mechanism is not initialized at all.
 
 The `completer` function is given the current line entered by the user, and

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -301,7 +301,9 @@ the following values:
    Defaults to checking `isTTY` on the `output` stream upon instantiation.
 
  - `historySize` - maximum number of history lines retained. To disable the
-   history set this value to `0`. Defaults to `30`.
+   history set this value to `0`. Defaults to `30`. This option makes sense
+   only if `terminal` is set `true` by user or by internal `output` check,
+   otherwise the history caching mechanism is not initialized at all.
 
 The `completer` function is given the current line entered by the user, and
 is supposed to return an Array with 2 entries:


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

History caching in the `readline` io is active only for terminal interaction. Appropriate variables are initialized and relevant `_addHistory()` function is called only if exposed `terminal` option of `readline.createInterface()` is set to `true` by user or internal output check.

This clarification is useful to assure users there will be now wasted overhead connected with history caching if `readline` is used not for terminal interaction (e.g. for reading files line by line).

Particularly this fix is helpful after #6352 landing.