### PR TITLE
doc: fix position of `fs.readSync()`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -945,6 +945,16 @@ object with an `encoding` property specifying the character encoding to use for
 the link path passed to the callback. If the `encoding` is set to `'buffer'`,
 the link path returned will be passed as a `Buffer` object.
 
+## fs.readSync(fd, buffer, offset, length, position)
+
+* `fd` {Integer}
+* `buffer` {String | Buffer}
+* `offset` {Integer}
+* `length` {Integer}
+* `position` {Integer}
+
+Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
+
 ## fs.realpath(path[, options], callback)
 
 * `path` {String | Buffer}
@@ -959,16 +969,6 @@ The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use for
 the path passed to the callback. If the `encoding` is set to `'buffer'`,
 the path returned will be passed as a `Buffer` object.
-
-## fs.readSync(fd, buffer, offset, length, position)
-
-* `fd` {Integer}
-* `buffer` {String | Buffer}
-* `offset` {Integer}
-* `length` {Integer}
-* `position` {Integer}
-
-Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 
 ## fs.realpathSync(path[, options])
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->


- [X] documentation is changed or added
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc

##### Description of change



<!-- provide a description of the change below this comment -->


noticed this was out of alphabetical order while working on something else, I think the new position is correct, alphabetically at least