### PR TITLE
process: make serialization function configurable

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -859,12 +859,15 @@ receive the object as the second argument passed to the callback function
 registered on the [`process.on('message')`][] event.
 
 The `options` argument, if present, is an object used to parameterize the
-sending of certain types of handles. `options` supports the following
+sending of messages. `options` supports the following
 properties:
 
   * `keepOpen` - A Boolean value that can be used when passing instances of
     `net.Socket`. When `true`, the socket is kept open in the sending process.
     Defaults to `false`.
+  * `serializer(message)` - A function used to serialize messages before
+    sending. The receiving process deserializes the message using `JSON.parse()`
+    so this function should output valid JSON. Defaults to `JSON.stringify()`.
 
 The optional `callback` is a function that is invoked after the message is
 sent but before the child may have received it.  The function is called with a
@@ -957,9 +960,6 @@ Once a socket has been passed to a child, the parent is no longer capable of
 tracking when the socket is destroyed. To indicate this, the `.connections`
 property becomes `null`. It is recommended not to use `.maxConnections` when
 this occurs.
-
-*Note: this function uses [`JSON.stringify()`][] internally to serialize the
-`message`.*
 
 ### child.stderr
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1046,13 +1046,15 @@ relied upon to exist.
 * `callback` {Function}
 * Return: {Boolean}
 
-When Node.js is spawned with an IPC channel attached, it can send messages to its
-parent process using `process.send()`. Each will be received as a
+When Node.js is spawned with an IPC channel attached, it can send messages to
+its parent process using `process.send()`. Each will be received as a
 [`'message'`][] event on the parent's [`ChildProcess`][] object.
 
-*Note: this function uses [`JSON.stringify()`][] internally to serialize the `message`.*
+By default, [`JSON.stringify()`][] is used to serialize the `message`. This can
+be overridden using the `serializer` option.
 
-If Node.js was not spawned with an IPC channel, `process.send()` will be undefined.
+If Node.js was not spawned with an IPC channel, `process.send()` will be
+undefined.
 
 ## process.setegid(id)
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -606,7 +606,9 @@ function setupChannel(target, channel) {
     var req = new WriteWrap();
     req.async = false;
 
-    var string = JSON.stringify(message) + '\n';
+    var serializer = typeof options.serializer === 'function' ?
+                     options.serializer : JSON.stringify;
+    var string = serializer(message) + '\n';
     var err = channel.writeUtf8String(req, string, handle);
 
     if (err === 0) {

--- a/test/parallel/test-child-process-send-serializer.js
+++ b/test/parallel/test-child-process-send-serializer.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  function serializer(data) {
+    return JSON.stringify(data, (key, value) => {
+      if (value === undefined)
+        return '[undefined]';
+
+      return value;
+    });
+  }
+
+  process.send({foo: 42, bar: undefined}, null, {serializer});
+} else {
+  const child = cp.fork(process.argv[1], ['child']);
+
+  child.on('message', common.mustCall(function(msg) {
+    assert.deepStrictEqual(msg, {foo: 42, bar: '[undefined]'});
+  }));
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

process

##### Description of change

By default `process.send()` serializes messages using vanilla JSON.stringify(). This commit makes the serialization function configurable.

Refs: https://github.com/nodejs/node/issues/6300