### PR TITLE
build: Bump MACOSX_DEPLOYMENT_TARGET to 10.7

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -308,7 +308,7 @@
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.5',       # -mmacosx-version-min=10.5
+          'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',


### PR DESCRIPTION
Ref: #5731.

We currently target 10.5.
Libuv is going to drop 10.6 in v2: libuv/libuv#758.

Note that OS X versions 10.5-10.8 are not supported by Apple anymore and do not receive security patches.

Note that we don't state supported OS X versions anywhere, and the only version tested at CI is 10.10. Ref: https://github.com/nodejs/build/issues/367.

/cc @bnoordhuis, @ofrobots, @jbergstroem, @nodejs/ctc