### PR TITLE
build: use shorthand lint target from test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,9 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH) $(V8_BUILD_OPTIONS)
 
 test: | cctest  # Depends on 'all'.
-	$(PYTHON) tools/test.py --mode=release doctool message parallel sequential -J
-	$(MAKE) jslint
-	$(MAKE) cpplint
+	$(PYTHON) tools/test.py --mode=release -J \
+		doctool message parallel sequential
+	$(MAKE) lint
 
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

build

##### Description of change

<!-- provide a description of the change below this comment -->

Instead of invoking jslint/cpplint from the test target, call on the generic lint instead, since it checks if eslint exists. Since our tarballs lacks eslint we get a more graceful exit from `make test` instead of a traceback from jslint.

/cc: @nodejs/build