### PR TITLE
benchmark: Fix crash in net benchmarks

### DIFF
--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -62,6 +62,7 @@ Writer.prototype.write = function(chunk, encoding, cb) {
 Writer.prototype.on = function() {};
 Writer.prototype.once = function() {};
 Writer.prototype.emit = function() {};
+Writer.prototype.prependListener = function() {};
 
 function server() {
   var writer = new Writer();

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -62,6 +62,7 @@ Writer.prototype.write = function(chunk, encoding, cb) {
 Writer.prototype.on = function() {};
 Writer.prototype.once = function() {};
 Writer.prototype.emit = function() {};
+Writer.prototype.prependListener = function() {};
 
 
 function Reader() {

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -62,6 +62,7 @@ Writer.prototype.write = function(chunk, encoding, cb) {
 Writer.prototype.on = function() {};
 Writer.prototype.once = function() {};
 Writer.prototype.emit = function() {};
+Writer.prototype.prependListener = function() {};
 
 
 function Reader() {

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -62,6 +62,7 @@ Writer.prototype.write = function(chunk, encoding, cb) {
 Writer.prototype.on = function() {};
 Writer.prototype.once = function() {};
 Writer.prototype.emit = function() {};
+Writer.prototype.prependListener = function() {};
 
 
 function Reader() {


### PR DESCRIPTION
##### Checklist

- [ ] tests and code linting passes
  - test-tick-processor/test-domain-no-error-handler-abort-on-uncaught
    are failing but these should be unrelated.
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

benchmark


##### Description of change

Net benchmarks create partial event emitters that do not have all of the
required event emitter functions. They currently mock out `on`, `once`,
and `emit` functions. This change mocks out `prependListener` as well to
avoid crashing in `_stream_readable`.

Fixes #6405