### PR TITLE
doc: crypto decipher.final fix parameter doc

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -277,7 +277,7 @@ console.log(decrypted);
 ### decipher.final([output_encoding])
 
 Returns any remaining deciphered contents. If `output_encoding`
-parameter is one of `'binary'`, `'base64'` or `'hex'`, a string is returned.
+parameter is one of `'binary'`, `'ascii'` or `'utf8'`, a string is returned.
 If an `output_encoding` is not provided, a [`Buffer`][] is returned.
 
 Once the `decipher.final()` method has been called, the `Decipher` object can


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc
##### Description of change

<!-- provide a description of the change below this comment -->

The output_encoding parameter of decipher.final should correctly state
the possible values of `'binary'`, `'ascii'`, or `'utf8'`. This aligns the docs
with the examples of decipher.

This fixes issue #6414 

I think this fix could (_and should_) be backported since the error exists in v5 and probably earlier...
