### PR TITLE
doc: fix EventEmitter#eventNames() example

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -310,8 +310,8 @@ myEE.on('bar', () => {});
 const sym = Symbol('symbol');
 myEE.on(sym, () => {});
 
-console.log(myErr.eventNames());
-  // Prints ['foo', 'bar', Symbol('symbol')]
+console.log(myEE.eventNames());
+  // Prints [ 'foo', 'bar', Symbol(symbol) ]
 ```
 
 ### emitter.getMaxListeners()


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc


##### Description of change

Replace `myErr` with `myEE` in one place (that was obviously a mistype).
Fix the expected output to have the actual formatting.

This was overlooked in #5617 (I also didn't notice that).

/cc @jasnell 