### PR TITLE
doc: ensures consistent grammar in node.1 file

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -59,7 +59,7 @@ Syntax check the script without executing.
 
 .TP
 .BR \-i ", " \-\-interactive
-Opens the REPL even if stdin does not appear to be a terminal.
+Open the REPL even if stdin does not appear to be a terminal.
 
 .TP
 .BR \-r ", " \-\-require " " \fImodule\fR
@@ -88,7 +88,7 @@ Print stack traces for process warnings (including deprecations).
 
 .TP
 .BR \-\-trace\-sync\-io
-Prints a stack trace whenever synchronous I/O is detected after the first turn
+Print a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
 
 .TP


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc


##### Description of change

Grammar in node.1 file was inconsistent when starting man-page responses (Open vs Opens). I've changed this to ensure these responses are consistent throughout. 

