### PR TITLE
assert: allow circular references

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -143,7 +143,7 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
   }
 };
 
-function _deepEqual(actual, expected, strict) {
+function _deepEqual(actual, expected, strict, actualVisitedObjects) {
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
     return true;
@@ -191,7 +191,14 @@ function _deepEqual(actual, expected, strict) {
   // corresponding key, and an identical 'prototype' property. Note: this
   // accounts for both named and indexed properties on Arrays.
   } else {
-    return objEquiv(actual, expected, strict);
+    actualVisitedObjects = actualVisitedObjects || [];
+
+    if (actualVisitedObjects.includes(actual))
+      return true;
+
+    actualVisitedObjects.push(actual);
+
+    return objEquiv(actual, expected, strict, actualVisitedObjects);
   }
 }
 
@@ -199,7 +206,7 @@ function isArguments(object) {
   return Object.prototype.toString.call(object) == '[object Arguments]';
 }
 
-function objEquiv(a, b, strict) {
+function objEquiv(a, b, strict, actualVisitedObjects) {
   if (a === null || a === undefined || b === null || b === undefined)
     return false;
   // if one is a primitive, the other must be same
@@ -235,7 +242,8 @@ function objEquiv(a, b, strict) {
   //~~~possibly expensive deep test
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
-    if (!_deepEqual(a[key], b[key], strict)) return false;
+    if (!_deepEqual(a[key], b[key], strict, actualVisitedObjects))
+      return false;
   }
   return true;
 }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -381,25 +381,22 @@ try {
 
 assert.ok(threw);
 
-// GH-207. Make sure deepEqual doesn't loop forever on circular refs
+// https://github.com/nodejs/node/issues/6416
+// Make sure circular refs don't throw.
 var b = {};
 b.b = b;
 
 var c = {};
 c.b = c;
 
-var gotError = false;
-try {
-  assert.deepEqual(b, c);
-} catch (e) {
-  gotError = true;
-}
+a.doesNotThrow(makeBlock(a.deepEqual, b, c));
+a.doesNotThrow(makeBlock(a.deepStrictEqual, b, c));
+
 
 // GH-7178. Ensure reflexivity of deepEqual with `arguments` objects.
 var args = (function() { return arguments; })();
 a.throws(makeBlock(a.deepEqual, [], args));
 a.throws(makeBlock(a.deepEqual, args, []));
-assert.ok(gotError);
 
 
 var circular = {y: 1};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test assert
##### Description of change

<!-- provide a description of the change below this comment -->

assert.deepEqual() and assert.deepStrictEqual() will no longer throw a
RangeError if passed objects with circular references.
    
Refs: https://github.com/strager/node/commit/56dbd80eb883641e0fa734bd9f91be5d680feb54
Fixes: https://github.com/nodejs/node/issues/6416