### PR TITLE
doc: make scrollbar wider in large screens

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -475,3 +475,15 @@ th > *:last-child, td > *:last-child {
     font-size: 3.5em;
   }
 }
+
+@media only screen and (min-width: 1280px) and (max-width: 2047px) {
+  ::-webkit-scrollbar {
+    width: 12px;
+  }
+}
+
+@media only screen and (min-width: 2048px) {
+  ::-webkit-scrollbar {
+    width: 0.5vw;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

Adds media queries to doc css to make TOC and content scrollbars
wider in larger screens.

Fixes: https://github.com/nodejs/node/issues/6443