### PR TITLE
doc: Remove extra space in REPL example

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -13,7 +13,7 @@ dropped into the REPL. It has simplistic emacs line-editing.
 ```
 $ node
 Type '.help' for options.
-> a = [ 1, 2, 3];
+> a = [1, 2, 3];
 [ 1, 2, 3 ]
 > a.forEach((v) => {
 ...   console.log(v);


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Description of change

There was an extra space after an opening square bracket in the REPL example and it was bothering me.