### PR TITLE
debugger: display array contents in repl

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -548,8 +548,8 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
           mirrorValue = '[?]';
         }
 
-        if (Array.isArray(mirror) && typeof prop.name !== 'number') {
-          // Skip the 'length' property.
+        // Skip the 'length' property.
+        if (Array.isArray(mirror) && prop.name === 'length') {
           return;
         }
 

--- a/test/debugger/test-debugger-repl.js
+++ b/test/debugger/test-debugger-repl.js
@@ -75,3 +75,7 @@ addTest('for (var i in process.env) delete process.env[i]', []);
 addTest('process.env', [
   /\{\}/
 ]);
+
+addTest('arr = [{foo: "bar"}]', [
+  /\[ \{ foo: 'bar' \} \]/
+]);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

debugger

##### Description of change

This commit allows all array properties to be printed except for `length`. Previously, this filter was applied by checking the type of each property. However, something changed in V8, and array elements started coming through as numeric strings, which stopped them from being displayed.

Fixes: https://github.com/nodejs/node/issues/6444