### PR TITLE
build: unbreak -prof, disable PIE on OS X

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -325,7 +325,12 @@
         },
         'target_conditions': [
           ['_type!="static_library"', {
-            'xcode_settings': {'OTHER_LDFLAGS': ['-Wl,-search_paths_first']},
+            'xcode_settings': {
+              'OTHER_LDFLAGS': [
+                '-Wl,-no_pie',
+                '-Wl,-search_paths_first',
+              ],
+            },
           }],
         ],
         'conditions': [


### PR DESCRIPTION
Commit 204f3a8 ("build: Bump MACOSX_DEPLOYMENT_TARGET to 10.7")
unwittingly turned on new ASLR features that make `-prof` unusable for
profiling C++ code, breaking `test/parallel/test-tick-processor.js` in
the process.  Build with `-Wl,-no_pie` for now.

Fixes: #5903

CI: https://ci.nodejs.org/job/node-test-pull-request/2420/