### PR TITLE
doc: added note warning about change to console.endTime()

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -230,6 +230,11 @@ console.timeEnd('100-elements');
 // prints 100-elements: 225.438ms
 ```
 
+*Note: As of Node.js v6.0.0, `console.timeEnd()` deletes the timer to avoid
+leaking it. On older versions, the timer persisted. This allowed
+`console.timeEnd()` to be called multiple times for the same label. This
+functionality was unintended and is no longer supported.*
+
 ### console.trace(message[, ...])
 
 Prints to `stderr` the string `'Trace :'`, followed by the [`util.format()`][]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->
I added a note warning about a change to console.endTime(). Prior to https://github.com/nodejs/node/pull/3562, you could call console.endTime multiple times for the same label. This was unintended functionality, but the change needed to be documented.

Related Issue: https://github.com/nodejs/node/issues/6452