### PR TITLE
tools: enforce arrow function brace usage linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,6 +73,7 @@ rules:
 
   # ECMAScript 6
   # http://eslint.org/docs/rules/#ecmascript-6
+  arrow-body-style: 2
   arrow-parens: [2, "always"]
   arrow-spacing: [2, {"before": true, "after": true}]
   constructor-super: 2

--- a/lib/net.js
+++ b/lib/net.js
@@ -1122,9 +1122,8 @@ function Server(options, connectionListener) {
       return this._connections;
     }, 'Server.connections property is deprecated. ' +
        'Use Server.getConnections method instead.'),
-    set: internalUtil.deprecate((val) => {
-      return (this._connections = val);
-    }, 'Server.connections property is deprecated.'),
+    set: internalUtil.deprecate((val) => (this._connections = val),
+                                'Server.connections property is deprecated.'),
     configurable: true, enumerable: false
   });
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -566,9 +566,7 @@ REPLServer.prototype.createContext = function() {
 
   Object.defineProperty(context, '_', {
     configurable: true,
-    get: () => {
-      return this.last;
-    },
+    get: () => this.last,
     set: (value) => {
       this.last = value;
       if (!this.underscoreAssigned) {

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -31,9 +31,7 @@ assert.throws(() => {
 const dir = Buffer.from(common.fixturesDir);
 fs.readdir(dir, 'hex', common.mustCall((err, list) => {
   if (err) throw err;
-  list = list.map((i) => {
-    return Buffer.from(i, 'hex').toString();
-  });
+  list = list.map((i) => Buffer.from(i, 'hex').toString());
   fs.readdir(dir, common.mustCall((err, list2) => {
     if (err) throw err;
     assert.deepStrictEqual(list, list2);

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -20,9 +20,10 @@ if (!dlerror_msg) {
 try {
   require('../fixtures/module-loading-error.node');
 } catch (e) {
-  assert.strictEqual(dlerror_msg.some((errMsgCase) => {
-    return e.toString().indexOf(errMsgCase) !== -1;
-  }), true);
+  assert.strictEqual(
+    dlerror_msg.some((errMsgCase) => e.toString().includes(errMsgCase)),
+    true
+  );
 }
 
 try {

--- a/tools/eslint-rules/align-function-arguments.js
+++ b/tools/eslint-rules/align-function-arguments.js
@@ -41,7 +41,7 @@ function checkArgumentAlignment(context, node) {
   // For now, don't bother trying to validate potentially complicating things
   // like closures. Different people will have very different ideas and it's
   // probably best to implement configuration options.
-  if (args.some((node) => { return ignoreTypes.indexOf(node.type) !== -1; })) {
+  if (args.some((node) => ignoreTypes.indexOf(node.type) !== -1)) {
     return;
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools test lib

##### Description of change

<!-- provide a description of the change below this comment -->

Enable linting such that if braces are not required for an arrow function body, omit them.

Refs: https://github.com/nodejs/node/pull/6390#discussion-diff-61484591 (where there was a nit about this and I'd rather tools tell me code style nits rather than people...)

/cc @bnoordhuis 