### PR TITLE
Adding Google Analytics to doc pages.

### DIFF
--- a/doc/template.html
+++ b/doc/template.html
@@ -7,6 +7,14 @@
   <link rel="stylesheet" href="assets/style.css">
   <link rel="stylesheet" href="assets/sh.css">
   <link rel="canonical" href="https://nodejs.org/api/__FILENAME__.html">
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-67020396-1', 'auto');
+    ga('send', 'pageview');
+  </script>
 </head>
 <body class="alt apidoc" id="api-section-__FILENAME__">
   <div id="content" class="clearfix">


### PR DESCRIPTION
This adds the same analytics line to our documentation as we have on the rest of the website.
