### PR TITLE
doc: fix incorrect syntax in examples

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -305,7 +305,7 @@ this value.
 ```js
 cluster.on('exit', (worker, code, signal) => {
   if (worker.exitedAfterDisconnect === true) {
-    console.log('Oh, it was just voluntary\' – no need to worry').
+    console.log('Oh, it was just voluntary – no need to worry');
   }
 });
 
@@ -408,7 +408,7 @@ this value.
 ```js
 cluster.on('exit', (worker, code, signal) => {
   if (worker.suicide === true) {
-    console.log('Oh, it was just voluntary\' – no need to worry').
+    console.log('Oh, it was just voluntary – no need to worry');
   }
 });
 


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc

##### Description of change

The cluster docs had a period instead of a semicolon at the end of two
lines.

