### PR TITLE
util: fix inspecting of proxy objects

### DIFF
--- a/benchmark/util/inspect-proxy.js
+++ b/benchmark/util/inspect-proxy.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const util = require('util');
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  v: [1, 2],
+  n: [1e6]
+});
+
+function twoDifferentProxies(n) {
+  // This one should be slower between we're looking up multiple proxies.
+  const proxyA = new Proxy({}, {get: () => {}});
+  const proxyB = new Proxy({}, {get: () => {}});
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    util.inspect({a: proxyA, b: proxyB}, {showProxy: true});
+  bench.end(n);
+}
+
+function oneProxy(n) {
+  // This one should be a bit faster because of the internal caching.
+  const proxy = new Proxy({}, {get: () => {}});
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    util.inspect({a: proxy, b: proxy}, {showProxy: true});
+  bench.end(n);
+}
+
+function main(conf) {
+  const n = conf.n | 0;
+  const v = conf.v | 0;
+
+  switch (v) {
+    case 1:
+      oneProxy(n);
+      break;
+    case 2:
+      twoDifferentProxies(n);
+      break;
+    default:
+      throw new Error('Should not get to here');
+  }
+}

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -179,8 +179,9 @@ formatted string:
  - `customInspect` - if `false`, then custom `inspect(depth, opts)` functions
    defined on the objects being inspected won't be called. Defaults to `true`.
 
- - `showProxy` - if `true`, then objects that are Proxy objects will be
-   introspected to show their `target` and `hander` objects.
+ - `showProxy` - if `true`, then objects and functions that are Proxy objects
+   will be introspected to show their `target` and `hander` objects. Defaults to
+   `false`.
 
 Example of inspecting all properties of the `util` object:
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -179,6 +179,9 @@ formatted string:
  - `customInspect` - if `false`, then custom `inspect(depth, opts)` functions
    defined on the objects being inspected won't be called. Defaults to `true`.
 
+ - `showProxy` - if `true`, then objects that are Proxy objects will be
+   introspected to show their `target` and `hander` objects.
+
 Example of inspecting all properties of the `util` object:
 
 ```js

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -478,6 +478,22 @@ util.isPrimitive(new Date())
   // false
 ```
 
+## util.isProxy(object)
+
+Returns `true` if the given "object" is a `Proxy` object. Otherwise, returns
+`false`.
+
+```js
+const util = require('util');
+const proxyObj = new Proxy({}, {get: () => { return 5; }});
+
+util.isProxy(proxyObj);
+  // true
+
+util.isProxy({});
+  // false
+```
+
 ## util.isRegExp(object)
 
     Stability: 0 - Deprecated

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -478,22 +478,6 @@ util.isPrimitive(new Date())
   // false
 ```
 
-## util.isProxy(object)
-
-Returns `true` if the given "object" is a `Proxy` object. Otherwise, returns
-`false`.
-
-```js
-const util = require('util');
-const proxyObj = new Proxy({}, {get: () => { return 5; }});
-
-util.isProxy(proxyObj);
-  // true
-
-util.isProxy({});
-  // false
-```
-
 ## util.isRegExp(object)
 
     Stability: 0 - Deprecated

--- a/lib/util.js
+++ b/lib/util.js
@@ -241,6 +241,13 @@ function inspectPromise(p) {
 
 
 function formatValue(ctx, value, recurseTimes) {
+
+  if (isProxy(value)) {
+    return 'Proxy ' + formatValue(ctx,
+                                  binding.getProxyDetails(value),
+                                  recurseTimes);
+  }
+
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it
   if (ctx.customInspect &&
@@ -785,6 +792,10 @@ exports.isPrimitive = isPrimitive;
 
 exports.isBuffer = Buffer.isBuffer;
 
+function isProxy(p) {
+  return binding.isProxy(p);
+}
+exports.isProxy = isProxy;
 
 function pad(n) {
   return n < 10 ? '0' + n.toString(10) : n.toString(10);

--- a/lib/util.js
+++ b/lib/util.js
@@ -122,7 +122,6 @@ function inspect(obj, opts) {
   // default options
   var ctx = {
     seen: [],
-    proxyCache: new WeakMap(),
     stylize: stylizeNoColor
   };
   // legacy...
@@ -244,19 +243,37 @@ function inspectPromise(p) {
 
 function formatValue(ctx, value, recurseTimes) {
 
-  if (ctx.showProxy && typeof value === 'object') {
-    const inProxyCache = ctx.proxyCache.has(value);
-    var proxy = inProxyCache ? ctx.proxyCache.get(value) : undefined;
-    if (inProxyCache && proxy) {
-      return 'Proxy ' + formatValue(ctx, proxy, recurseTimes);
-    } else if (!inProxyCache) {
-      if (binding.isProxy(value)) {
-        proxy = binding.getProxyDetails(value);
-        ctx.proxyCache.set(value, proxy);
-        return 'Proxy ' + formatValue(ctx, proxy, recurseTimes);
-      } else {
-        ctx.proxyCache.set(value, undefined);
+  if (ctx.showProxy &&
+      (typeof value === 'object' || typeof value === 'function')) {
+    var proxy = undefined;
+    var proxyCache = ctx.proxyCache;
+    if (!proxyCache)
+      proxyCache = ctx.proxyCache = new WeakMap();
+    // Determine if we've already seen this object and have
+    // determined that it either is or is not a proxy.
+    if (proxyCache.has(value)) {
+      // We've seen it, if the value is not undefined, it's a Proxy.
+      proxy = proxyCache.get(value);
+    } else {
+      // Haven't seen it. Need to check.
+      // If it's not a Proxy, this will return undefined.
+      // Otherwise, it'll return an array. The first item
+      // is the target, the second item is the handler.
+      // We ignore (and do not return) the Proxy isRevoked property.
+      proxy = binding.getProxyDetails(value);
+      if (proxy) {
+        // We know for a fact that this isn't a Proxy.
+        // Mark it as having already been evaluated.
+        proxyCache.set(proxy, undefined);
       }
+      // If the object is not a Proxy, then this stores undefined.
+      // This tells the code above that we've already checked and
+      // ruled it out. If the object is a proxy, this caches the
+      // results of the getProxyDetails call.
+      proxyCache.set(value, proxy);
+    }
+    if (proxy) {
+      return 'Proxy ' + formatValue(ctx, proxy, recurseTimes);
     }
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -242,7 +242,7 @@ function inspectPromise(p) {
 
 function formatValue(ctx, value, recurseTimes) {
 
-  if (isProxy(value)) {
+  if (binding.isProxy(value)) {
     return 'Proxy ' + formatValue(ctx,
                                   binding.getProxyDetails(value),
                                   recurseTimes);
@@ -791,11 +791,6 @@ function isPrimitive(arg) {
 exports.isPrimitive = isPrimitive;
 
 exports.isBuffer = Buffer.isBuffer;
-
-function isProxy(p) {
-  return binding.isProxy(p);
-}
-exports.isProxy = isProxy;
 
 function pad(n) {
   return n < 10 ? '0' + n.toString(10) : n.toString(10);

--- a/lib/util.js
+++ b/lib/util.js
@@ -122,6 +122,7 @@ function inspect(obj, opts) {
   // default options
   var ctx = {
     seen: [],
+    proxyCache: new WeakMap(),
     stylize: stylizeNoColor
   };
   // legacy...
@@ -139,6 +140,7 @@ function inspect(obj, opts) {
   if (ctx.depth === undefined) ctx.depth = 2;
   if (ctx.colors === undefined) ctx.colors = false;
   if (ctx.customInspect === undefined) ctx.customInspect = true;
+  if (ctx.showProxy === undefined) ctx.showProxy = false;
   if (ctx.colors) ctx.stylize = stylizeWithColor;
   return formatValue(ctx, obj, ctx.depth);
 }
@@ -242,10 +244,20 @@ function inspectPromise(p) {
 
 function formatValue(ctx, value, recurseTimes) {
 
-  if (binding.isProxy(value)) {
-    return 'Proxy ' + formatValue(ctx,
-                                  binding.getProxyDetails(value),
-                                  recurseTimes);
+  if (ctx.showProxy && typeof value === 'object') {
+    const inProxyCache = ctx.proxyCache.has(value);
+    var proxy = inProxyCache ? ctx.proxyCache.get(value) : undefined;
+    if (inProxyCache && proxy) {
+      return 'Proxy ' + formatValue(ctx, proxy, recurseTimes);
+    } else if (!inProxyCache) {
+      if (binding.isProxy(value)) {
+        proxy = binding.getProxyDetails(value);
+        ctx.proxyCache.set(value, proxy);
+        return 'Proxy ' + formatValue(ctx, proxy, recurseTimes);
+      } else {
+        ctx.proxyCache.set(value, undefined);
+      }
+    }
   }
 
   // Provide a hook for user-specified inspect functions.

--- a/lib/util.js
+++ b/lib/util.js
@@ -242,13 +242,13 @@ function inspectPromise(p) {
 
 
 function formatValue(ctx, value, recurseTimes) {
-
   if (ctx.showProxy &&
-      (typeof value === 'object' || typeof value === 'function')) {
+      ((typeof value === 'object' && value !== null) ||
+       typeof value === 'function')) {
     var proxy = undefined;
     var proxyCache = ctx.proxyCache;
     if (!proxyCache)
-      proxyCache = ctx.proxyCache = new WeakMap();
+      proxyCache = ctx.proxyCache = new Map();
     // Determine if we've already seen this object and have
     // determined that it either is or is not a proxy.
     if (proxyCache.has(value)) {
@@ -264,6 +264,11 @@ function formatValue(ctx, value, recurseTimes) {
       if (proxy) {
         // We know for a fact that this isn't a Proxy.
         // Mark it as having already been evaluated.
+        // We do this because this object is passed
+        // recursively to formatValue below in order
+        // for it to get proper formatting, and because
+        // the target and handle objects also might be
+        // proxies... it's unfortunate but necessary.
         proxyCache.set(proxy, undefined);
       }
       // If the object is not a Proxy, then this stores undefined.

--- a/src/env.h
+++ b/src/env.h
@@ -121,7 +121,6 @@ namespace node {
   V(fsevent_string, "FSEvent")                                                \
   V(gid_string, "gid")                                                        \
   V(handle_string, "handle")                                                  \
-  V(handler_string, "handler")                                                \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
   V(homedir_string, "homedir")                                                \
@@ -223,7 +222,6 @@ namespace node {
   V(subjectaltname_string, "subjectaltname")                                  \
   V(sys_string, "sys")                                                        \
   V(syscall_string, "syscall")                                                \
-  V(target_string, "target")                                                  \
   V(tick_callback_string, "_tickCallback")                                    \
   V(tick_domain_cb_string, "_tickDomainCallback")                             \
   V(ticketkeycallback_string, "onticketkeycallback")                          \

--- a/src/env.h
+++ b/src/env.h
@@ -121,6 +121,7 @@ namespace node {
   V(fsevent_string, "FSEvent")                                                \
   V(gid_string, "gid")                                                        \
   V(handle_string, "handle")                                                  \
+  V(handler_string, "handler")                                                \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
   V(homedir_string, "homedir")                                                \
@@ -222,6 +223,7 @@ namespace node {
   V(subjectaltname_string, "subjectaltname")                                  \
   V(sys_string, "sys")                                                        \
   V(syscall_string, "syscall")                                                \
+  V(target_string, "target")                                                  \
   V(tick_callback_string, "_tickCallback")                                    \
   V(tick_domain_cb_string, "_tickDomainCallback")                             \
   V(ticketkeycallback_string, "onticketkeycallback")                          \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -6,6 +6,7 @@
 namespace node {
 namespace util {
 
+using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Local;
@@ -23,7 +24,6 @@ using v8::Value;
   V(isMap, IsMap)                                                             \
   V(isMapIterator, IsMapIterator)                                             \
   V(isPromise, IsPromise)                                                     \
-  V(isProxy, IsProxy)                                                         \
   V(isRegExp, IsRegExp)                                                       \
   V(isSet, IsSet)                                                             \
   V(isSetIterator, IsSetIterator)                                             \
@@ -42,15 +42,15 @@ using v8::Value;
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  // Return nothing if it's not a proxy.
+  // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
     return;
 
   Local<Proxy> proxy = args[0].As<Proxy>();
 
-  Local<Object> ret = Object::New(env->isolate());
-  ret->Set(env->handler_string(), proxy->GetHandler());
-  ret->Set(env->target_string(), proxy->GetTarget());
+  Local<Array> ret = Array::New(env->isolate(), 2);
+  ret->Set(0, proxy->GetTarget());
+  ret->Set(1, proxy->GetHandler());
 
   args.GetReturnValue().Set(ret);
 }

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -11,6 +11,7 @@ using v8::FunctionCallbackInfo;
 using v8::Local;
 using v8::Object;
 using v8::Private;
+using v8::Proxy;
 using v8::String;
 using v8::Value;
 
@@ -22,6 +23,7 @@ using v8::Value;
   V(isMap, IsMap)                                                             \
   V(isMapIterator, IsMapIterator)                                             \
   V(isPromise, IsPromise)                                                     \
+  V(isProxy, IsProxy)                                                         \
   V(isRegExp, IsRegExp)                                                       \
   V(isSet, IsSet)                                                             \
   V(isSetIterator, IsSetIterator)                                             \
@@ -37,6 +39,21 @@ using v8::Value;
   VALUE_METHOD_MAP(V)
 #undef V
 
+static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  // Return nothing if it's not a proxy.
+  if (!args[0]->IsProxy())
+    return;
+
+  Local<Proxy> proxy = args[0].As<Proxy>();
+
+  Local<Object> ret = Object::New(env->isolate());
+  ret->Set(env->handler_string(), proxy->GetHandler());
+  ret->Set(env->target_string(), proxy->GetTarget());
+
+  args.GetReturnValue().Set(ret);
+}
 
 static void GetHiddenValue(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -84,6 +101,7 @@ void Initialize(Local<Object> target,
 
   env->SetMethod(target, "getHiddenValue", GetHiddenValue);
   env->SetMethod(target, "setHiddenValue", SetHiddenValue);
+  env->SetMethod(target, "getProxyDetails", GetProxyDetails);
 }
 
 }  // namespace util

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -40,15 +40,13 @@ using v8::Value;
 #undef V
 
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
     return;
 
   Local<Proxy> proxy = args[0].As<Proxy>();
 
-  Local<Array> ret = Array::New(env->isolate(), 2);
+  Local<Array> ret = Array::New(args.GetIsolate(), 2);
   ret->Set(0, proxy->GetTarget());
   ret->Set(1, proxy->GetHandler());
 

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+const processUtil = process.binding('util');
+
+const target = {};
+const handler = {
+  get: function() { throw new Error('Getter should not be called'); }
+};
+const proxyObj = new Proxy(target, handler);
+
+assert.strictEqual(util.isProxy(proxyObj), true);
+
+// Inspecting the proxy should not actually walk it's properties
+assert.doesNotThrow(() => util.inspect(proxyObj));
+
+const details = processUtil.getProxyDetails(proxyObj);
+assert.deepStrictEqual(target, details.target);
+assert.deepStrictEqual(handler, details.handler);
+
+assert.strictEqual(util.inspect(proxyObj),
+    'Proxy { handler: { get: [Function] }, target: {} }');
+
+// Using getProxyDetails with non-proxy returns undefined
+assert.strictEqual(processUtil.getProxyDetails({}), undefined);
+// isProxy with non-Proxy returns false
+assert.strictEqual(util.isProxy({}), false);

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -11,11 +11,11 @@ const handler = {
 };
 const proxyObj = new Proxy(target, handler);
 
-assert.strictEqual(util.isProxy(proxyObj), true);
-
 // Inspecting the proxy should not actually walk it's properties
 assert.doesNotThrow(() => util.inspect(proxyObj));
 
+// getProxyDetails is an internal method, not intended for public use.
+// This is here to test that the internals are working correctly.
 const details = processUtil.getProxyDetails(proxyObj);
 assert.deepStrictEqual(target, details.target);
 assert.deepStrictEqual(handler, details.handler);
@@ -25,5 +25,3 @@ assert.strictEqual(util.inspect(proxyObj),
 
 // Using getProxyDetails with non-proxy returns undefined
 assert.strictEqual(processUtil.getProxyDetails({}), undefined);
-// isProxy with non-Proxy returns false
-assert.strictEqual(util.isProxy({}), false);

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -4,6 +4,7 @@ require('../common');
 const assert = require('assert');
 const util = require('util');
 const processUtil = process.binding('util');
+const opts = {showProxy: true};
 
 const target = {};
 const handler = {
@@ -12,16 +13,16 @@ const handler = {
 const proxyObj = new Proxy(target, handler);
 
 // Inspecting the proxy should not actually walk it's properties
-assert.doesNotThrow(() => util.inspect(proxyObj, {showProxy: true}));
+assert.doesNotThrow(() => util.inspect(proxyObj, opts));
 
 // getProxyDetails is an internal method, not intended for public use.
 // This is here to test that the internals are working correctly.
 const details = processUtil.getProxyDetails(proxyObj);
-assert.deepStrictEqual(target, details.target);
-assert.deepStrictEqual(handler, details.handler);
+assert.deepStrictEqual(target, details[0]);
+assert.deepStrictEqual(handler, details[1]);
 
-assert.strictEqual(util.inspect(proxyObj, {showProxy: true}),
-    'Proxy { handler: { get: [Function] }, target: {} }');
+assert.strictEqual(util.inspect(proxyObj, opts),
+                   'Proxy [ {}, { get: [Function] } ]');
 
 // Using getProxyDetails with non-proxy returns undefined
 assert.strictEqual(processUtil.getProxyDetails({}), undefined);
@@ -32,3 +33,52 @@ assert.strictEqual(processUtil.getProxyDetails({}), undefined);
 assert.throws(
   () => util.inspect(proxyObj)
 );
+
+// Yo dawg, I heard you liked Proxy so I put a Proxy
+// inside your Proxy that proxies your Proxy's Proxy.
+const proxy1 = new Proxy({}, {});
+const proxy2 = new Proxy(proxy1, {});
+const proxy3 = new Proxy(proxy2, proxy1);
+const proxy4 = new Proxy(proxy1, proxy2);
+const proxy5 = new Proxy(proxy3, proxy4);
+const proxy6 = new Proxy(proxy5, proxy5);
+const expected0 = '{}';
+const expected1 = 'Proxy [ {}, {} ]';
+const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
+const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
+const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
+const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Object], {} ],' +
+                  ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
+                  ', Proxy [ Proxy [Object], {} ] ] ]';
+const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Object], Proxy [Object]' +
+                  ' ],\n    Proxy [ Proxy [Object], Proxy [Object] ] ],\n' +
+                  '  Proxy [ Proxy [ Proxy [Object], Proxy [Object] ],\n' +
+                  '    Proxy [ Proxy [Object], Proxy [Object] ] ] ]';
+assert.strictEqual(util.inspect(proxy1, opts), expected1);
+assert.strictEqual(util.inspect(proxy2, opts), expected2);
+assert.strictEqual(util.inspect(proxy3, opts), expected3);
+assert.strictEqual(util.inspect(proxy4, opts), expected4);
+assert.strictEqual(util.inspect(proxy5, opts), expected5);
+assert.strictEqual(util.inspect(proxy6, opts), expected6);
+assert.strictEqual(util.inspect(proxy1), expected0);
+assert.strictEqual(util.inspect(proxy2), expected0);
+assert.strictEqual(util.inspect(proxy3), expected0);
+assert.strictEqual(util.inspect(proxy4), expected0);
+assert.strictEqual(util.inspect(proxy5), expected0);
+assert.strictEqual(util.inspect(proxy6), expected0);
+
+// Just for fun, let's create a Proxy using Arrays.
+const proxy7 = new Proxy([], []);
+const expected7 = 'Proxy [ [], [] ]';
+assert.strictEqual(util.inspect(proxy7, opts), expected7);
+assert.strictEqual(util.inspect(proxy7), '[]');
+
+// Now we're just getting silly, right?
+const proxy8 = new Proxy(Date, []);
+const proxy9 = new Proxy(Date, String);
+const expected8 = 'Proxy [ [Function: Date], [] ]';
+const expected9 = 'Proxy [ [Function: Date], [Function: String] ]';
+assert.strictEqual(util.inspect(proxy8, opts), expected8);
+assert.strictEqual(util.inspect(proxy9, opts), expected9);
+assert.strictEqual(util.inspect(proxy8), '[Function: Date]');
+assert.strictEqual(util.inspect(proxy9), '[Function: Date]');

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -12,7 +12,7 @@ const handler = {
 const proxyObj = new Proxy(target, handler);
 
 // Inspecting the proxy should not actually walk it's properties
-assert.doesNotThrow(() => util.inspect(proxyObj));
+assert.doesNotThrow(() => util.inspect(proxyObj, {showProxy: true}));
 
 // getProxyDetails is an internal method, not intended for public use.
 // This is here to test that the internals are working correctly.
@@ -20,8 +20,15 @@ const details = processUtil.getProxyDetails(proxyObj);
 assert.deepStrictEqual(target, details.target);
 assert.deepStrictEqual(handler, details.handler);
 
-assert.strictEqual(util.inspect(proxyObj),
+assert.strictEqual(util.inspect(proxyObj, {showProxy: true}),
     'Proxy { handler: { get: [Function] }, target: {} }');
 
 // Using getProxyDetails with non-proxy returns undefined
 assert.strictEqual(processUtil.getProxyDetails({}), undefined);
+
+// This will throw because the showProxy option is not used
+// and the get function on the handler object defined above
+// is actually invoked.
+assert.throws(
+  () => util.inspect(proxyObj)
+);

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -18,8 +18,8 @@ assert.doesNotThrow(() => util.inspect(proxyObj, opts));
 // getProxyDetails is an internal method, not intended for public use.
 // This is here to test that the internals are working correctly.
 const details = processUtil.getProxyDetails(proxyObj);
-assert.deepStrictEqual(target, details[0]);
-assert.deepStrictEqual(handler, details[1]);
+assert.strictEqual(target, details[0]);
+assert.strictEqual(handler, details[1]);
 
 assert.strictEqual(util.inspect(proxyObj, opts),
                    'Proxy [ {}, { get: [Function] } ]');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

util

##### Description of change

In certain conditions (see https://github.com/nodejs/node/issues/6464), inspecting a Proxy object can lead to a max call stack error. Avoid that by detecting the Proxy object and outputting information about the Proxy object itself.

Also adds util.isProxy()

Fixes: https://github.com/nodejs/node/issues/6464

/cc @bnoordhuis 