### PR TITLE
src: only disable PIE on OS X when -prof is passed

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -327,7 +327,6 @@
           ['_type!="static_library"', {
             'xcode_settings': {
               'OTHER_LDFLAGS': [
-                '-Wl,-no_pie',
                 '-Wl,-search_paths_first',
               ],
             },

--- a/src/node.cc
+++ b/src/node.cc
@@ -85,6 +85,7 @@ typedef int mode_t;
 
 #ifdef __APPLE__
 #include <crt_externs.h>
+#include <mach-o/dyld.h>
 #include <spawn.h>
 #define environ (*_NSGetEnviron())
 #elif !defined(_MSC_VER)
@@ -3914,7 +3915,7 @@ inline void PlatformInit(int argc, char** argv) {
   // ignored for setuid/setgid binaries; in that particular case the only
   // option is to recompile with `make LINK="c++ -Wl,-no_pie"` to disable
   // PIE (and therefore ASLR) altogether.
-  if (v8_is_profiling) {
+  if (v8_is_profiling && _dyld_get_image_vmaddr_slide(0) != 0) {
     // Use a key that is unlikely to have been set by the user.
     static const char kRespawnEnvKey[] = "\x01NODE_MAC_RESPAWN_FOR_PROFILING";
     if (getenv(kRespawnEnvKey)) {


### PR DESCRIPTION
This is a follow-up to commit a5012a0 ("build: unbreak -prof, disable
PIE on OS X") that disabled PIE (and therefore ASLR) completely on OS X.

We now scan the command line options and re-exec the process with the
_POSIX_SPAWN_DISABLE_ASLR flag set when `-prof` is specified.

The options parser is smart enough to understand any combination of
`-prof` and `-noprof`, including alternative spellings like `--no_prof`.

Fixes: #6466

CI: https://ci.nodejs.org/job/node-test-pull-request/2429/