### PR TITLE
doc: increase webkit scrollbar width and fix colors

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -72,7 +72,8 @@ em code {
   background: #d2d2d2;
   background-clip: padding-box;
   border: 3px solid #fff;
-  border-radius: 5px;
+  border-left-width: 9px;
+  border-radius: 0px;
 }
 
 ::-webkit-scrollbar-thumb:active {
@@ -81,7 +82,12 @@ em code {
 }
 
 ::-webkit-scrollbar {
-  width: 10px;
+  width: 16px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  border-width: 3px;
+  border-radius: 5px;
 }
 
 #column2::-webkit-scrollbar-track {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -84,6 +84,14 @@ em code {
   width: 10px;
 }
 
+#column2::-webkit-scrollbar-track {
+  background: #333;
+}
+
+#column2::-webkit-scrollbar-thumb {
+  border-color: #333;
+}
+
 #changelog #gtoc {
   display: none;
 }


### PR DESCRIPTION
##### Checklist

- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

Only `-webkit-scrollbar-*` properties are affected.

There are two changes here:
 1. The background color of the left (navigation) scrollbar is fixed to match the background color of the navigation.
 2. The width of the scrollbars has been increased to 16px, but their visible width is 10px until the users hovers them. This way, they don't bother people who don't want to see gigantic scrollbars, but they are actually big enough for people who want to use them.

Unfortunately, the second change forced me to remove border-radius on unhovered scrollbars, but it still looks nice to me this way.

This is alternate to #6445 and should fix #6443.