### PR TITLE
process: add process.exitSoon()

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -46,7 +46,7 @@ process.on('exit', (code) => {
 ```
 ## Event: 'exitingSoon'
 
-Emitted when `process.exit()` is called using the optional `timeout` argument.
+Emitted when `process.exitSoon()` is called.
 
 Calling `process.exitSoon()` will trigger all `exitingSoon` listeners and
 pass each a callback to be invoked when the listener is ready for the process
@@ -752,7 +752,7 @@ a code.
 Specifying a code to [`process.exit(code)`][`process.exit()`] will override any previous
 setting of `process.exitCode`.
 
-## process.exitSoon([code][, forceExitTimeout])
+## process.exitSoon([code[, forceExitTimeout]])
 
 * `code` {Number} The exit code. Defaults to `0` or `process.exitCode`
 * `forceExitTimeOut` {Number} A number of milliseconds to wait until forcing

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -70,47 +70,66 @@ function setupConfig(_source) {
 
 function setupKillAndExit() {
 
-  const kExitTimer = Symbol('kExitTimer');
+  var exiting = false;
+  var exitTimer;
 
-  function exitWithTimeout(code, timeout) {
-    // The way this works is simple. When exitWithTimeout is called, the
+  process.exitSoon = function exitSoon(code, timeout) {
+    // The way this works is simple. When exitSoon is called, the
     // number of listeners registered for the `exitingSoon` event on
     // process is grabbed. A callback is created and passed to each of
     // the listeners on emit. When each is done doing it's thing, it
     // invokes the callback, which counts down. Once the counter hits
-    // zero, the real process.exit is called. In the meantime, an unref'd
-    // timer is created to run proecss.exit() at a given timeout just in
-    // case the cleanup code takes too long. Returns true if the method
-    // schedules the exit, returns false if an exit has already been
-    // scheduled.
-    if (process[kExitTimer] !== undefined)
-      return false;   // Already called!
+    // zero, the real process.exit is called. In the meantime, if timeout
+    // is a number greater than zero, an unref'd timer is created to run
+    // proecss.exit() at a given timeout just in case the cleanup code takes
+    // too long. Returns true if the method schedules the exit, returns false
+    // if an exit has already been scheduled.
+
+    // Already been called, return false.
+    if (exiting) return false;
+
+    // How many listeners do we have currently?
     var count = process.listenerCount('exitingSoon');
+
+    // There's nobody listening, go ahead and exit normally.
+    if (count === 0)
+      process.exit(code);
+
+    // Set the exiting flag so this is not run again
+    exiting = true;
+    var timed = false;
+
+    // Was a timeout specified? Just check truthy value.
+    if (timeout) {
+      timeout |= 0;
+      // Create the exit timer only if a non-zero timeout is specified.
+      if (timeout > 0) {
+        timed = true;
+        exitTimer = setTimeout(() => process.exit(code), timeout);
+        exitTimer.unref();
+      }
+    }
+
+    // Set up the ready callback.
     function ready() {
       count--;
       if (count <= 0) {
-        // If we're here, we beat the exit timeout, clear it and exit.
-        clearTimeout(process[kExitTimer]);
+        // Clear the exit timer.
+        clearTimeout(exitTimer);
         process.exit(code);
       }
     }
-    process[kExitTimer] = setTimeout(() => {
-      process.exit(code);
-    }, timeout);
-    process[kExitTimer].unref();
-    process.emit('exitingSoon', ready);
-    return true;
-  }
 
-  process.exit = function(code, timeout) {
     if (code || code === 0)
       process.exitCode = code;
 
-    if (timeout) {
-      timeout |= 0;
-      if (timeout > 0)
-        return exitWithTimeout(code, timeout);
-    }
+    process.nextTick(() => process.emit('exitingSoon', ready, timed));
+    return true;
+  };
+
+  process.exit = function(code) {
+    if (code || code === 0)
+      process.exitCode = code;
 
     if (!process._exiting) {
       process._exiting = true;

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -70,9 +70,47 @@ function setupConfig(_source) {
 
 function setupKillAndExit() {
 
-  process.exit = function(code) {
+  const kExitTimer = Symbol('kExitTimer');
+
+  function exitWithTimeout(code, timeout) {
+    // The way this works is simple. When exitWithTimeout is called, the
+    // number of listeners registered for the `exitingSoon` event on
+    // process is grabbed. A callback is created and passed to each of
+    // the listeners on emit. When each is done doing it's thing, it
+    // invokes the callback, which counts down. Once the counter hits
+    // zero, the real process.exit is called. In the meantime, an unref'd
+    // timer is created to run proecss.exit() at a given timeout just in
+    // case the cleanup code takes too long. Returns true if the method
+    // schedules the exit, returns false if an exit has already been
+    // scheduled.
+    if (process[kExitTimer] !== undefined)
+      return false;   // Already called!
+    var count = process.listenerCount('exitingSoon');
+    function ready() {
+      count--;
+      if (count <= 0) {
+        // If we're here, we beat the exit timeout, clear it and exit.
+        clearTimeout(process[kExitTimer]);
+        process.exit(code);
+      }
+    }
+    process[kExitTimer] = setTimeout(() => {
+      process.exit(code);
+    }, timeout);
+    process[kExitTimer].unref();
+    process.emit('exitingSoon', ready);
+    return true;
+  }
+
+  process.exit = function(code, timeout) {
     if (code || code === 0)
       process.exitCode = code;
+
+    if (timeout) {
+      timeout |= 0;
+      if (timeout > 0)
+        return exitWithTimeout(code, timeout);
+    }
 
     if (!process._exiting) {
       process._exiting = true;

--- a/test/parallel/test-process-exit-soon.js
+++ b/test/parallel/test-process-exit-soon.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// Schedule something that'll keep the loop active normally
+const timer1 = setInterval(() => {}, 1000);
+const timer2 = setInterval(() => {}, 1000);
+
+// Register an exitingSoon handler to clean up before exit
+process.on('exitingSoon', common.mustCall((ready, timed) => {
+  // timed is false because there is no timer
+  assert.strictEqual(timed, false);
+  // Simulate some async task
+  assert.strictEqual(process.exitCode, 0);
+  // Shouldn't be callable twice
+  assert.strictEqual(process.exitSoon(0), false);
+  setImmediate(() => {
+    // Clean up resources
+    clearInterval(timer1);
+    // Notify that we're done
+    ready();
+  });
+}));
+
+process.once('exitingSoon', common.mustCall((ready) => {
+  clearInterval(timer2);
+  ready();
+}));
+
+assert.strictEqual(process.exitSoon(0), true);

--- a/test/parallel/test-process-exit-timeout.js
+++ b/test/parallel/test-process-exit-timeout.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// Schedule something that'll keep the loop active normally
+const timer1 = setInterval(() => {}, 1000);
+const timer2 = setInterval(() => {}, 1000);
+
+// Register an exitingSoon handler to clean up before exit
+process.on('exitingSoon', common.mustCall((ready) => {
+  // Simulate some async task
+  assert.strictEqual(process.exitCode, 0);
+  // Shouldn't be callable twice
+  assert.strictEqual(process.exit(0, 10000), false);
+  setImmediate(() => {
+    // Clean up resources
+    clearInterval(timer1);
+    // Notify that we're done
+    ready();
+  });
+}));
+
+process.on('exitingSoon', common.mustCall((ready) => {
+  clearInterval(timer2);
+  ready();
+}));
+
+assert.strictEqual(process.exit(0, 10000), true);


### PR DESCRIPTION
##### Checklist

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines

##### Affected core subsystem(s)

process

##### Description of change

Updated: adds process.exitSoon([code[, timeout]]) and `'exitingSoon'` event to process. Allows exitingSoon handlers to defer exit until they are ready. Timer is optional.

~~When set, an internal timer will be set that will exit the process at the given timeout. In the meantime, the registered listeners for process.on('exitingSoon') will be invoked and passed a callback to be called when the handler is ready for the process to exit. The process will exit either when the internal timer fires or all the callbacks are called, whichever comes first.~~

This is an attempt to deal more intelligently with resource cleanup and async op completion on exit

Docs / test case included

Refs: https://github.com/nodejs/node/issues/6456