### PR TITLE
doc: linkify remaining references to fs.Stats object

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -563,8 +563,8 @@ Synchronous fdatasync(2). Returns `undefined`.
 * `callback` {Function}
 
 Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a [`fs.Stats`][] object. `fstat()` is identical to [`stat()`][], except that
-the file to be stat-ed is specified by the file descriptor `fd`.
+`stats` is a [`fs.Stats`][] object. `fstat()` is identical to [`stat()`][],
+except that the file to be stat-ed is specified by the file descriptor `fd`.
 
 ## fs.fstatSync(fd)
 
@@ -678,9 +678,9 @@ Synchronous link(2). Returns `undefined`.
 * `callback` {Function}
 
 Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a [`fs.Stats`][] object. `lstat()` is identical to `stat()`, except that if
-`path` is a symbolic link, then the link itself is stat-ed, not the file that it
-refers to.
+`stats` is a [`fs.Stats`][] object. `lstat()` is identical to `stat()`,
+except that if `path` is a symbolic link, then the link itself is stat-ed,
+not the file that it refers to.
 
 ## fs.lstatSync(path)
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -563,7 +563,7 @@ Synchronous fdatasync(2). Returns `undefined`.
 * `callback` {Function}
 
 Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a `fs.Stats` object. `fstat()` is identical to [`stat()`][], except that
+`stats` is a [`fs.Stats`][] object. `fstat()` is identical to [`stat()`][], except that
 the file to be stat-ed is specified by the file descriptor `fd`.
 
 ## fs.fstatSync(fd)
@@ -678,7 +678,7 @@ Synchronous link(2). Returns `undefined`.
 * `callback` {Function}
 
 Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a `fs.Stats` object. `lstat()` is identical to `stat()`, except that if
+`stats` is a [`fs.Stats`][] object. `lstat()` is identical to `stat()`, except that if
 `path` is a symbolic link, then the link itself is stat-ed, not the file that it
 refers to.
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

In the `fs` doc, one reference to the `fs.Stats object` is linkified, while two other very similarly made references to the object are not linkified.