### PR TITLE
doc: remove obsolete comment in isError() example

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -341,7 +341,6 @@ possible to obtain an incorrect result when the `object` argument manipulates
 `@@toStringTag`.
 
 ```js
-// This example requires the `--harmony-tostring` flag
 const util = require('util');
 const obj = { name: 'Error', message: 'an error occurred' };
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

One of the `util.isError()` examples states that a harmony flag is required. As of v6.0.0, this is no longer true. This commit removes the out of date reference.

Refs: https://github.com/nodejs/node/pull/5414

This should not be backported.