### PR TITLE
repl: preload missing `constants` module

### DIFF
--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -52,9 +52,9 @@ function stripBOM(content) {
 }
 
 exports.builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
-  'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net',
-  'os', 'path', 'punycode', 'querystring', 'readline', 'repl', 'stream',
-  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'];
+  'constants', 'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http',
+  'https', 'net', 'os', 'path', 'punycode', 'querystring', 'readline', 'repl',
+  'stream', 'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'];
 
 function addBuiltinLibsToObject(object) {
   // Make built-in modules available directly (loaded lazily).


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

repl, node cli

##### Description of change

The `constants` module was previously missing from the list of builtin modules which are available without requiring in the repl and using the `--eval` command line option. This patch adds it to that list.