### PR TITLE
Fix invalid date output with util.inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -304,7 +304,11 @@ function formatValue(ctx, value, recurseTimes) {
       return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
     }
     if (isDate(value)) {
-      return ctx.stylize(Date.prototype.toISOString.call(value), 'date');
+      if (Number.isNaN(value.getTime())) {
+        return ctx.stylize(value.toString(), 'date');
+      } else {
+        return ctx.stylize(Date.prototype.toISOString.call(value), 'date');
+      }
     }
     if (isError(value)) {
       return formatError(value);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -12,8 +12,9 @@ assert.equal(util.inspect(function() {}), '[Function]');
 assert.equal(util.inspect(undefined), 'undefined');
 assert.equal(util.inspect(null), 'null');
 assert.equal(util.inspect(/foo(bar\n)?/gi), '/foo(bar\\n)?/gi');
-assert.equal(util.inspect(new Date('Sun, 14 Feb 2010 11:48:40 GMT')),
+assert.strictEqual(util.inspect(new Date('Sun, 14 Feb 2010 11:48:40 GMT')),
   new Date('2010-02-14T12:48:40+01:00').toISOString());
+assert.strictEqual(util.inspect(new Date('')), (new Date('')).toString());
 
 assert.equal(util.inspect('\n\u0001'), "'\\n\\u0001'");
 


### PR DESCRIPTION
##### Checklist

- [ ] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Description of change

util.inspect produces default string value for invalid date instead of throwing RangeError.

