### PR TITLE
doc,cluster: fix the lint of an example

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -140,9 +140,9 @@ Similar to the `cluster.on('exit')` event, but specific to this worker.
 ```js
 const worker = cluster.fork();
 worker.on('exit', (code, signal) => {
-  if( signal ) {
+  if (signal) {
     console.log(`worker was killed by signal: ${signal}`);
-  } else if( code !== 0 ) {
+  } else if (code !== 0) {
     console.log(`worker exited with error code: ${code}`);
   } else {
     console.log('worker success!');

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -285,7 +285,7 @@ if (cluster.isMaster) {
   server.listen(8000);
 
   process.on('message', (msg) => {
-    if(msg === 'shutdown') {
+    if (msg === 'shutdown') {
       // initiate graceful close of any connections to server
     }
   });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

- doc
- cluster

##### Description of change

<!-- provide a description of the change below this comment -->

Just fix the example at https://nodejs.org/dist/latest-v6.x/docs/api/cluster.html, which doesn't follow the coding style.

By the way, how about moving example codes outside to separate files so that we can lint them in our build system.