### PR TITLE
doc: revert backported commits

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -83,22 +83,7 @@ path.extname('.index')
 
 ## path.format(pathObject)
 
-Returns a path string from an object. This is the opposite of [`path.parse`][].
-
-If `pathObject` has `dir` and `base` properties, the returned string will
-be a concatenation of the `dir` property, the platform-dependent path separator,
-and the `base` property.
-
-If the `dir` property is not supplied, the `root` property will be used as the
-`dir` property. However, it will be assumed that the `root` property already
-ends with the platform-dependent path separator. In this case, the returned
-string will be the concatenation of the `root` property and the `base` property.
-
-If both the `dir` and the `root` properties are not supplied, then the returned
-string will be the contents of the `base` property.
-
-If the `base` property is not supplied, a concatenation of the `name` property
-and the `ext` property will be used as the `base` property.
+Returns a path string from an object, the opposite of [`path.parse`][].
 
 Examples:
 
@@ -113,41 +98,11 @@ path.format({
 });
 // returns '/home/user/dir/file.txt'
 
-// `root` will be used if `dir` is not specified.
-// `name` + `ext` will be used if `base` is not specified.
-// If only `root` is provided or `dir` is equal to `root` then the
-// platform separator will not be included.
-path.format({
-    root: '/',
-    base: 'file.txt'
-});
-// returns '/file.txt'
-
-path.format({
-    dir: '/',
-    root: '/',
-    name: 'file',
-    ext: '.txt'
-});
-// returns '/file.txt'
-
 // `base` will be returned if `dir` or `root` are not provided.
 path.format({
     base: 'file.txt'
 });
 // returns 'file.txt'
-```
-An example on Windows:
-
-```js
-path.format({
-    root : "C:\\",
-    dir : "C:\\path\\dir",
-    base : "file.txt",
-    ext : ".txt",
-    name : "file"
-})
-// returns 'C:\\path\\dir\\file.txt'
 ```
 
 ## path.isAbsolute(path)


### PR DESCRIPTION
This reverts changes found in daf3ef66ef 0943001563 that incorrectly
updated the docs for `path.format`

closes #6437 