### PR TITLE
test: avoid test-cluster-master-kill flakiness

### DIFF
--- a/test/parallel/test-cluster-master-error.js
+++ b/test/parallel/test-cluster-master-error.js
@@ -30,7 +30,7 @@ if (cluster.isWorker) {
     }
   });
 
-  // Throw accidently error when all workers are listening
+  // Throw accidental error when all workers are listening
   var listeningNum = 0;
   cluster.on('listening', function listeningEvent() {
 
@@ -39,10 +39,10 @@ if (cluster.isWorker) {
       // Stop listening
       cluster.removeListener('listening', listeningEvent);
 
-      // throw accidently error
+      // Throw accidental error
       process.nextTick(function() {
         console.error('about to throw');
-        throw new Error('accidently error');
+        throw new Error('accidental error');
       });
     }
 
@@ -68,8 +68,8 @@ if (cluster.isWorker) {
     }
   };
 
-  var existMaster = false;
-  var existWorker = false;
+  var masterExited = false;
+  var workersExited = false;
 
   // List all workers
   var workers = [];
@@ -89,36 +89,33 @@ if (cluster.isWorker) {
   // When cluster is dead
   master.on('exit', function(code) {
 
-    // Check that the cluster died accidently
-    existMaster = !!code;
+    // Check that the cluster died accidentally (non-zero exit code)
+    masterExited = !!code;
 
-    // Give the workers time to shut down
-    var timeout = 200;
-    if (common.isAix) {
-      // AIX needs more time due to default exit performance
-      timeout = 1000;
-    }
-    setTimeout(checkWorkers, timeout);
-
-    function checkWorkers() {
-      // When master is dead all workers should be dead to
+    var pollWorkers = function() {
+      // When master is dead all workers should be dead too
       var alive = false;
       workers.forEach(function(pid) {
         if (isAlive(pid)) {
           alive = true;
         }
       });
+      if (alive) {
+        setTimeout(pollWorkers, 500);
+      } else {
+        workersExited = true;
+      }
+    };
 
-      // If a worker was alive this did not act as expected
-      existWorker = !alive;
-    }
+    // Loop indefinitely until worker exit
+    pollWorkers();
   });
 
   process.once('exit', function() {
-    var m = 'The master did not die after an error was throwed';
-    assert.ok(existMaster, m);
+    var m = 'The master did not die after an error was thrown';
+    assert.ok(masterExited, m);
     m = 'The workers did not die after an error in the master';
-    assert.ok(existWorker, m);
+    assert.ok(workersExited, m);
   });
 
 }

--- a/test/parallel/test-cluster-master-error.js
+++ b/test/parallel/test-cluster-master-error.js
@@ -101,7 +101,7 @@ if (cluster.isWorker) {
         }
       });
       if (alive) {
-        setTimeout(pollWorkers, 500);
+        setTimeout(pollWorkers, 50);
       } else {
         workersExited = true;
       }

--- a/test/parallel/test-cluster-master-kill.js
+++ b/test/parallel/test-cluster-master-kill.js
@@ -62,7 +62,7 @@ if (cluster.isWorker) {
     var pollWorker = function() {
       alive = isAlive(pid);
       if (alive) {
-        setTimeout(pollWorker, 500);
+        setTimeout(pollWorker, 50);
       }
     };
     // Loop indefinitely until worker exit.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] a test and/or benchmark is included
- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)

test, cluster

##### Description of change

<!-- provide a description of the change below this comment -->

I've observed that _test-cluster-master-kill_ fails intermittently on an AIX 6.1 machine (oslevel 6100-07-08-1339) due to timeout before worker termination. There was a previous PR (https://github.com/nodejs/node-v0.x-archive/pull/9431) which arbitrarily increased the timeout for AIX to 1 second, however this value is still a guess and appears to be insufficient. It's also worth noting the arbitrary timeouts have also caused problems for other platforms, see https://github.com/nodejs/node/pull/2891#issuecomment-179158473. Arbitrary timeouts cannot compensate for external factors such as system load.

In this PR I propose removing the timeout mechanism entirely, here is how the test currently works:

1. Fork a master process from the test harness.
2. The master uses cluster.fork to create a worker.
3. The worker starts an HTTP server.
4. The master will kill itself with process.exit.
5. The worker will then also call process.exit as part of its [IPC pipe disconnect handler](https://github.com/nodejs/node/blob/8ebec086a50712bce675ae59c10ac30a4f01fa8d/lib/cluster.js#L547-L553). (*)
6. The test harness will wait an arbitrary amount of time after the master's exit to check for the child's liveness, if it is still alive the test fails.

(*) Without this mechanism the worker would become an orphan child of init.

Step 6 is inherently flaky. The test was originally added as part of https://github.com/nodejs/node-v0.x-archive/commit/94d337eb0fbf78bda2af6938b4a65d3c94808caf#diff-0faa53fc02580d5de2ebb484c41d691cR498 where it specifically tested the new disconnect pathway.
 
The test boils down to the following actions:

1. Cause the worker's disconnect handler to be run by calling exit(0) in the cluster master.
2. Insure that the disconnect handler also exits the worker process.

Since step 2 does not actually require step 1, I propose the following alternate flow:

1. Fork a master process from the test harness.
2. The master uses cluster.fork to create a worker.
3. The worker starts an HTTP server.
4. The master kills the IPC pipe (note this not the same as using the graceful cluster shutdown API in https://github.com/nodejs/node-v0.x-archive/pull/2740/commits/6c383c61611fb78d0961a332c1ad55d1d5514ba6) which causes the child to disconnect itself. Ungracefully closing the IPC pipe causes the child to execute the same disconnect handler it executes when the master calls exit(0).
5. The master waits for the child's exit event.
6. The test harness checks for the child's liveness after the master's exit event.

With this setup there is no need for the arbitrary wait time. The obvious problem is if the child never exits the test will hang - however in that case the test will still be killed by the [test harness's global timeout](https://github.com/nodejs/node/blob/8ebec086a50712bce675ae59c10ac30a4f01fa8d/tools/test.py#L587-L591).

I do believe a timeout mechanism is useful for detecting liveness issues, but the presence of arbitrary timeouts in the tests themselves should be minimized, the single timeout in the test harness suffices.

Any comments are appreciated, especially from @AndreasMadsen.