### PR TITLE
http: server code refactor

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -198,7 +198,6 @@ function freeParser(parser, req, socket) {
     parser[kOnExecute] = null;
     if (parsers.free(parser) === false)
       parser.close();
-    parser = null;
   }
   if (req) {
     req.parser = null;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -246,44 +246,44 @@ exports.httpSocketSetup = httpSocketSetup;
  * so take care when making changes to the implementation so that the source
  * code size does not exceed v8's default max_inlined_source_size setting.
  **/
-function isValidTokenChar(ch) {
-  if (ch >= 94 && ch <= 122)
-    return true;
-  if (ch >= 65 && ch <= 90)
-    return true;
-  if (ch === 45)
-    return true;
-  if (ch >= 48 && ch <= 57)
-    return true;
-  if (ch === 34 || ch === 40 || ch === 41 || ch === 44)
-    return false;
-  if (ch >= 33 && ch <= 46)
-    return true;
-  if (ch === 124 || ch === 126)
-    return true;
-  return false;
-}
+var validTokens = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0 - 15
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 - 31
+  0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0, // 32 - 47
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, // 48 - 63
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 64 - 79
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, // 80 - 95
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 96 - 111
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, // 112 - 127
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 128 ...
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  // ... 255
+];
 function checkIsHttpToken(val) {
   if (typeof val !== 'string' || val.length === 0)
     return false;
-  if (!isValidTokenChar(val.charCodeAt(0)))
+  if (!validTokens[val.charCodeAt(0)])
     return false;
-  const len = val.length;
-  if (len > 1) {
-    if (!isValidTokenChar(val.charCodeAt(1)))
+  if (val.length < 2)
+    return true;
+  if (!validTokens[val.charCodeAt(1)])
+    return false;
+  if (val.length < 3)
+    return true;
+  if (!validTokens[val.charCodeAt(2)])
+    return false;
+  if (val.length < 4)
+    return true;
+  if (!validTokens[val.charCodeAt(3)])
+    return false;
+  for (var i = 4; i < val.length; ++i) {
+    if (!validTokens[val.charCodeAt(i)])
       return false;
-    if (len > 2) {
-      if (!isValidTokenChar(val.charCodeAt(2)))
-        return false;
-      if (len > 3) {
-        if (!isValidTokenChar(val.charCodeAt(3)))
-          return false;
-        for (var i = 4; i < len; i++) {
-          if (!isValidTokenChar(val.charCodeAt(i)))
-            return false;
-        }
-      }
-    }
   }
   return true;
 }
@@ -299,26 +299,44 @@ exports._checkIsHttpToken = checkIsHttpToken;
  * so take care when making changes to the implementation so that the source
  * code size does not exceed v8's default max_inlined_source_size setting.
  **/
+var validHdrChars = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, // 0 - 15
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 - 31
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 32 - 47
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 48 - 63
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 64 - 79
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 80 - 95
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 96 - 111
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, // 112 - 127
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 128 ...
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1  // ... 255
+];
 function checkInvalidHeaderChar(val) {
   val += '';
   if (val.length < 1)
     return false;
-  var c = val.charCodeAt(0);
-  if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+  if (!validHdrChars[val.charCodeAt(0)])
     return true;
   if (val.length < 2)
     return false;
-  c = val.charCodeAt(1);
-  if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+  if (!validHdrChars[val.charCodeAt(1)])
     return true;
   if (val.length < 3)
     return false;
-  c = val.charCodeAt(2);
-  if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+  if (!validHdrChars[val.charCodeAt(2)])
     return true;
-  for (var i = 3; i < val.length; ++i) {
-    c = val.charCodeAt(i);
-    if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+  if (val.length < 4)
+    return false;
+  if (!validHdrChars[val.charCodeAt(3)])
+    return true;
+  for (var i = 4; i < val.length; ++i) {
+    if (!validHdrChars[val.charCodeAt(i)])
       return true;
   }
   return false;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -103,21 +103,17 @@ IncomingMessage.prototype.destroy = function destroy(error) {
 IncomingMessage.prototype._addHeaderLines = _addHeaderLines;
 function _addHeaderLines(headers, n) {
   if (headers && headers.length) {
-    var raw, dest;
+    var dest;
     if (this.complete) {
-      raw = this.rawTrailers;
+      this.rawTrailers = headers;
       dest = this.trailers;
     } else {
-      raw = this.rawHeaders;
+      this.rawHeaders = headers;
       dest = this.headers;
     }
 
     for (var i = 0; i < n; i += 2) {
-      var k = headers[i];
-      var v = headers[i + 1];
-      raw.push(k);
-      raw.push(v);
-      this._addHeaderLine(k, v, dest);
+      this._addHeaderLine(headers[i], headers[i + 1], dest);
     }
   }
 }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -380,8 +380,7 @@ OutgoingMessage.prototype.getHeader = function getHeader(name) {
 
   if (!this._headers) return;
 
-  var key = name.toLowerCase();
-  return this._headers[key];
+  return this._headers[name.toLowerCase()];
 };
 
 
@@ -585,7 +584,6 @@ OutgoingMessage.prototype.end = function end(data, encoding, callback) {
   if (this.connection && data)
     this.connection.cork();
 
-  var ret;
   if (data) {
     // Normal body write.
     this.write(data, encoding);
@@ -598,6 +596,7 @@ OutgoingMessage.prototype.end = function end(data, encoding, callback) {
     this.emit('finish');
   };
 
+  var ret;
   if (this._hasBody && this.chunkedEncoding) {
     ret = this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
   } else {
@@ -677,8 +676,7 @@ OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
   var outputCallbacks = this.outputCallbacks;
   socket.cork();
   for (var i = 0; i < outputLength; i++) {
-    ret = socket.write(output[i], outputEncodings[i],
-                       outputCallbacks[i]);
+    ret = socket.write(output[i], outputEncodings[i], outputCallbacks[i]);
   }
   socket.uncork();
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -545,6 +545,9 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
 
 const crlf_buf = Buffer.from('\r\n');
 
+function onFinish(outmsg) {
+  outmsg.emit('finish');
+}
 
 OutgoingMessage.prototype.end = function end(data, encoding, callback) {
   if (typeof data === 'function') {
@@ -592,9 +595,7 @@ OutgoingMessage.prototype.end = function end(data, encoding, callback) {
   if (typeof callback === 'function')
     this.once('finish', callback);
 
-  const finish = () => {
-    this.emit('finish');
-  };
+  var finish = onFinish.bind(undefined, this);
 
   var ret;
   if (this._hasBody && this.chunkedEncoding) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -239,7 +239,7 @@ function _storeHeader(firstLine, headers) {
     this.upgrading = true;
 
   // Date header
-  if (this.sendDate === true && state.sentDateHeader === false) {
+  if (this.sendDate && !state.sentDateHeader) {
     state.messageHeader += 'Date: ' + utcDate() + CRLF;
   }
 
@@ -255,8 +255,7 @@ function _storeHeader(firstLine, headers) {
   // of creating security liabilities, so suppress the zero chunk and force
   // the connection to close.
   var statusCode = this.statusCode;
-  if ((statusCode === 204 || statusCode === 304) &&
-      this.chunkedEncoding === true) {
+  if ((statusCode === 204 || statusCode === 304) && this.chunkedEncoding) {
     debug(statusCode + ' response should not use chunked encoding,' +
           ' closing connection.');
     this.chunkedEncoding = false;
@@ -267,7 +266,7 @@ function _storeHeader(firstLine, headers) {
   if (this._removedHeader.connection) {
     this._last = true;
     this.shouldKeepAlive = false;
-  } else if (state.sentConnectionHeader === false) {
+  } else if (!state.sentConnectionHeader) {
     var shouldSendKeepAlive = this.shouldKeepAlive &&
         (state.sentContentLengthHeader ||
          this.useChunkedEncodingByDefault ||
@@ -280,8 +279,7 @@ function _storeHeader(firstLine, headers) {
     }
   }
 
-  if (state.sentContentLengthHeader === false &&
-      state.sentTransferEncodingHeader === false) {
+  if (!state.sentContentLengthHeader && !state.sentTransferEncodingHeader) {
     if (!this._hasBody) {
       // Make sure we don't end the 0\r\n\r\n at the end of the message.
       this.chunkedEncoding = false;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -209,23 +209,31 @@ function _storeHeader(firstLine, headers) {
     messageHeader: firstLine
   };
 
-  if (headers) {
-    var keys = Object.keys(headers);
-    var isArray = Array.isArray(headers);
-    var field, value;
+  var i;
+  var j;
+  var field;
+  var value;
+  if (headers instanceof Array) {
+    for (i = 0; i < headers.length; ++i) {
+      field = headers[i][0];
+      value = headers[i][1];
 
-    for (var i = 0, l = keys.length; i < l; i++) {
-      var key = keys[i];
-      if (isArray) {
-        field = headers[key][0];
-        value = headers[key][1];
+      if (value instanceof Array) {
+        for (j = 0; j < value.length; j++) {
+          storeHeader(this, state, field, value[j]);
+        }
       } else {
-        field = key;
-        value = headers[key];
+        storeHeader(this, state, field, value);
       }
+    }
+  } else if (headers) {
+    var keys = Object.keys(headers);
+    for (i = 0; i < keys.length; ++i) {
+      field = keys[i];
+      value = headers[field];
 
-      if (Array.isArray(value)) {
-        for (var j = 0; j < value.length; j++) {
+      if (value instanceof Array) {
+        for (j = 0; j < value.length; j++) {
           storeHeader(this, state, field, value[j]);
         }
       } else {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -7,6 +7,8 @@ const util = require('util');
 const internalUtil = require('internal/util');
 const Buffer = require('buffer').Buffer;
 const common = require('_http_common');
+const checkIsHttpToken = common._checkIsHttpToken;
+const checkInvalidHeaderChar = common._checkInvalidHeaderChar;
 
 const CRLF = common.CRLF;
 const trfrEncChunkExpression = common.chunkExpression;
@@ -312,11 +314,11 @@ function _storeHeader(firstLine, headers) {
 }
 
 function storeHeader(self, state, field, value) {
-  if (!common._checkIsHttpToken(field)) {
+  if (!checkIsHttpToken(field)) {
     throw new TypeError(
       'Header name must be a valid HTTP Token ["' + field + '"]');
   }
-  if (common._checkInvalidHeaderChar(value) === true) {
+  if (checkInvalidHeaderChar(value)) {
     debug('Header "%s" contains invalid characters', field);
     throw new TypeError('The header content contains invalid characters');
   }
@@ -350,14 +352,14 @@ function storeHeader(self, state, field, value) {
 
 
 OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
-  if (!common._checkIsHttpToken(name))
+  if (!checkIsHttpToken(name))
     throw new TypeError(
       'Header name must be a valid HTTP Token ["' + name + '"]');
   if (value === undefined)
     throw new Error('"value" required in setHeader("' + name + '", value)');
   if (this._header)
     throw new Error('Can\'t set headers after they are sent.');
-  if (common._checkInvalidHeaderChar(value) === true) {
+  if (checkInvalidHeaderChar(value)) {
     debug('Header "%s" contains invalid characters', name);
     throw new TypeError('The header content contains invalid characters');
   }
@@ -530,11 +532,11 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
       field = key;
       value = headers[key];
     }
-    if (!common._checkIsHttpToken(field)) {
+    if (!checkIsHttpToken(field)) {
       throw new TypeError(
         'Trailer name must be a valid HTTP Token ["' + field + '"]');
     }
-    if (common._checkInvalidHeaderChar(value) === true) {
+    if (checkInvalidHeaderChar(value)) {
       debug('Trailer "%s" contains invalid characters', field);
       throw new TypeError('The trailer content contains invalid characters');
     }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -264,40 +264,6 @@ exports.Server = Server;
 
 
 function connectionListener(socket) {
-  var self = this;
-  var outgoing = [];
-  var incoming = [];
-  var outgoingData = 0;
-
-  function updateOutgoingData(delta) {
-    // `outgoingData` is an approximate amount of bytes queued through all
-    // inactive responses. If more data than the high watermark is queued - we
-    // need to pause TCP socket/HTTP parser, and wait until the data will be
-    // sent to the client.
-    outgoingData += delta;
-    if (socket._paused && outgoingData < socket._writableState.highWaterMark)
-      return socketOnDrain();
-  }
-
-  function abortIncoming() {
-    while (incoming.length) {
-      var req = incoming.shift();
-      req.emit('aborted');
-      req.emit('close');
-    }
-    // abort socket._httpMessage ?
-  }
-
-  function serverSocketCloseListener() {
-    debug('server socket close');
-    // mark this parser as reusable
-    if (this.parser) {
-      freeParser(this.parser, null, this);
-    }
-
-    abortIncoming();
-  }
-
   debug('SERVER new http connection');
 
   httpSocketSetup(socket);
@@ -305,18 +271,9 @@ function connectionListener(socket) {
   // If the user has added a listener to the server,
   // request, or response, then it's their responsibility.
   // otherwise, destroy on timeout by default
-  if (self.timeout)
-    socket.setTimeout(self.timeout);
-  socket.on('timeout', function() {
-    var req = socket.parser && socket.parser.incoming;
-    var reqTimeout = req && !req.complete && req.emit('timeout', socket);
-    var res = socket._httpMessage;
-    var resTimeout = res && res.emit('timeout', socket);
-    var serverTimeout = self.emit('timeout', socket);
-
-    if (!reqTimeout && !resTimeout && !serverTimeout)
-      socket.destroy();
-  });
+  if (this.timeout)
+    socket.setTimeout(this.timeout);
+  socket.on('timeout', socketOnTimeout.bind(undefined, this, socket));
 
   var parser = parsers.alloc();
   parser.reinitialize(HTTPParser.REQUEST);
@@ -332,17 +289,34 @@ function connectionListener(socket) {
     parser.maxHeaderPairs = 2000;
   }
 
-  socket.addListener('error', socketOnError);
-  socket.addListener('close', serverSocketCloseListener);
-  parser.onIncoming = parserOnIncoming;
-  socket.on('end', socketOnEnd);
-  socket.on('data', socketOnData);
+  var state = {
+    onData: null,
+    onError: null,
+    onEnd: null,
+    onClose: null,
+    outgoing: [],
+    incoming: [],
+    // `outgoingData` is an approximate amount of bytes queued through all
+    // inactive responses. If more data than the high watermark is queued - we
+    // need to pause TCP socket/HTTP parser, and wait until the data will be
+    // sent to the client.
+    outgoingData: 0
+  };
+  state.onData = socketOnData.bind(undefined, this, socket, parser, state);
+  state.onError = socketOnError.bind(undefined, this, socket, state);
+  state.onEnd = socketOnEnd.bind(undefined, this, socket, parser, state);
+  state.onClose = socketOnClose.bind(undefined, socket, state);
+  socket.on('data', state.onData);
+  socket.on('error', state.onError);
+  socket.on('end', state.onEnd);
+  socket.on('close', state.onClose);
+  parser.onIncoming = parserOnIncoming.bind(undefined, this, socket, state);
 
   // We are consuming socket, so it won't get any actual data
   socket.on('resume', onSocketResume);
   socket.on('pause', onSocketPause);
 
-  socket.on('drain', socketOnDrain);
+  socket.on('drain', socketOnDrain.bind(undefined, socket, state));
 
   // Override on to unconsume on `data`, `readable` listeners
   socket.on = socketOnWrap;
@@ -352,205 +326,243 @@ function connectionListener(socket) {
     parser._consumed = true;
     parser.consume(external);
   }
-  external = null;
-  parser[kOnExecute] = onParserExecute;
-
-  // TODO(isaacs): Move all these functions out of here
-  function socketOnError(e) {
-    // Ignore further errors
-    this.removeListener('error', socketOnError);
-    this.on('error', () => {});
-
-    if (!self.emit('clientError', e, this))
-      this.destroy(e);
-  }
-
-  function socketOnData(d) {
-    assert(!socket._paused);
-    debug('SERVER socketOnData %d', d.length);
-    var ret = parser.execute(d);
-
-    onParserExecuteCommon(ret, d);
-  }
-
-  function onParserExecute(ret, d) {
-    socket._unrefTimer();
-    debug('SERVER socketOnParserExecute %d', ret);
-    onParserExecuteCommon(ret, undefined);
-  }
-
-  function onParserExecuteCommon(ret, d) {
-    if (ret instanceof Error) {
-      debug('parse error');
-      socketOnError.call(socket, ret);
-    } else if (parser.incoming && parser.incoming.upgrade) {
-      // Upgrade or CONNECT
-      var bytesParsed = ret;
-      var req = parser.incoming;
-      debug('SERVER upgrade or connect', req.method);
-
-      if (!d)
-        d = parser.getCurrentBuffer();
-
-      socket.removeListener('data', socketOnData);
-      socket.removeListener('end', socketOnEnd);
-      socket.removeListener('close', serverSocketCloseListener);
-      unconsume(parser, socket);
-      parser.finish();
-      freeParser(parser, req, null);
-      parser = null;
-
-      var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
-      if (self.listenerCount(eventName) > 0) {
-        debug('SERVER have listener for %s', eventName);
-        var bodyHead = d.slice(bytesParsed, d.length);
-
-        // TODO(isaacs): Need a way to reset a stream to fresh state
-        // IE, not flowing, and not explicitly paused.
-        socket._readableState.flowing = null;
-        self.emit(eventName, req, socket, bodyHead);
-      } else {
-        // Got upgrade header or CONNECT method, but have no handler.
-        socket.destroy();
-      }
-    }
-
-    if (socket._paused && socket.parser) {
-      // onIncoming paused the socket, we should pause the parser as well
-      debug('pause parser');
-      socket.parser.pause();
-    }
-  }
-
-  function socketOnEnd() {
-    var socket = this;
-    var ret = parser.finish();
-
-    if (ret instanceof Error) {
-      debug('parse error');
-      socketOnError.call(socket, ret);
-      return;
-    }
-
-    if (!self.httpAllowHalfOpen) {
-      abortIncoming();
-      if (socket.writable) socket.end();
-    } else if (outgoing.length) {
-      outgoing[outgoing.length - 1]._last = true;
-    } else if (socket._httpMessage) {
-      socket._httpMessage._last = true;
-    } else {
-      if (socket.writable) socket.end();
-    }
-  }
-
-
-  // The following callback is issued after the headers have been read on a
-  // new message. In this callback we setup the response object and pass it
-  // to the user.
+  parser[kOnExecute] =
+    onParserExecute.bind(undefined, this, socket, parser, state);
 
   socket._paused = false;
-  function socketOnDrain() {
-    var needPause = outgoingData > socket._writableState.highWaterMark;
-
-    // If we previously paused, then start reading again.
-    if (socket._paused && !needPause) {
-      socket._paused = false;
-      if (socket.parser)
-        socket.parser.resume();
-      socket.resume();
-    }
-  }
-
-  function parserOnIncoming(req, shouldKeepAlive) {
-    incoming.push(req);
-
-    // If the writable end isn't consuming, then stop reading
-    // so that we don't become overwhelmed by a flood of
-    // pipelined requests that may never be resolved.
-    if (!socket._paused) {
-      var needPause = socket._writableState.needDrain ||
-          outgoingData >= socket._writableState.highWaterMark;
-      if (needPause) {
-        socket._paused = true;
-        // We also need to pause the parser, but don't do that until after
-        // the call to execute, because we may still be processing the last
-        // chunk.
-        socket.pause();
-      }
-    }
-
-    var res = new ServerResponse(req);
-    res._onPendingData = updateOutgoingData;
-
-    res.shouldKeepAlive = shouldKeepAlive;
-    DTRACE_HTTP_SERVER_REQUEST(req, socket);
-    LTTNG_HTTP_SERVER_REQUEST(req, socket);
-    COUNTER_HTTP_SERVER_REQUEST();
-
-    if (socket._httpMessage) {
-      // There are already pending outgoing res, append.
-      outgoing.push(res);
-    } else {
-      res.assignSocket(socket);
-    }
-
-    // When we're finished writing the response, check if this is the last
-    // response, if so destroy the socket.
-    res.on('finish', resOnFinish);
-    function resOnFinish() {
-      // Usually the first incoming element should be our request.  it may
-      // be that in the case abortIncoming() was called that the incoming
-      // array will be empty.
-      assert(incoming.length === 0 || incoming[0] === req);
-
-      incoming.shift();
-
-      // if the user never called req.read(), and didn't pipe() or
-      // .resume() or .on('data'), then we call req._dump() so that the
-      // bytes will be pulled off the wire.
-      if (!req._consuming && !req._readableState.resumeScheduled)
-        req._dump();
-
-      res.detachSocket(socket);
-
-      if (res._last) {
-        socket.destroySoon();
-      } else {
-        // start sending the next message
-        var m = outgoing.shift();
-        if (m) {
-          m.assignSocket(socket);
-        }
-      }
-    }
-
-    if (req.headers.expect !== undefined &&
-        (req.httpVersionMajor === 1 && req.httpVersionMinor === 1)) {
-      if (continueExpression.test(req.headers.expect)) {
-        res._expect_continue = true;
-
-        if (self.listenerCount('checkContinue') > 0) {
-          self.emit('checkContinue', req, res);
-        } else {
-          res.writeContinue();
-          self.emit('request', req, res);
-        }
-      } else {
-        if (self.listenerCount('checkExpectation') > 0) {
-          self.emit('checkExpectation', req, res);
-        } else {
-          res.writeHead(417);
-          res.end();
-        }
-      }
-    } else {
-      self.emit('request', req, res);
-    }
-    return false; // Not a HEAD response. (Not even a response!)
-  }
 }
 exports._connectionListener = connectionListener;
+
+function updateOutgoingData(socket, state, delta) {
+  state.outgoingData += delta;
+  if (socket._paused &&
+      state.outgoingData < socket._writableState.highWaterMark) {
+    return socketOnDrain(socket, state);
+  }
+}
+
+function socketOnDrain(socket, state) {
+  var needPause = state.outgoingData > socket._writableState.highWaterMark;
+
+  // If we previously paused, then start reading again.
+  if (socket._paused && !needPause) {
+    socket._paused = false;
+    if (socket.parser)
+      socket.parser.resume();
+    socket.resume();
+  }
+}
+
+function socketOnTimeout(server, socket) {
+  var req = socket.parser && socket.parser.incoming;
+  var reqTimeout = req && !req.complete && req.emit('timeout', socket);
+  var res = socket._httpMessage;
+  var resTimeout = res && res.emit('timeout', socket);
+  var serverTimeout = server.emit('timeout', socket);
+
+  if (!reqTimeout && !resTimeout && !serverTimeout)
+    socket.destroy();
+}
+
+function socketOnClose(socket, state) {
+  debug('server socket close');
+  // mark this parser as reusable
+  if (socket.parser) {
+    freeParser(socket.parser, null, socket);
+  }
+
+  abortIncoming(state.incoming);
+}
+
+function abortIncoming(incoming) {
+  while (incoming.length) {
+    var req = incoming.shift();
+    req.emit('aborted');
+    req.emit('close');
+  }
+  // abort socket._httpMessage ?
+}
+
+function socketOnEnd(server, socket, parser, state) {
+  var ret = parser.finish();
+
+  if (ret instanceof Error) {
+    debug('parse error');
+    state.onError(ret);
+    return;
+  }
+
+  if (!server.httpAllowHalfOpen) {
+    abortIncoming(state.incoming);
+    if (socket.writable) socket.end();
+  } else if (state.outgoing.length) {
+    state.outgoing[state.outgoing.length - 1]._last = true;
+  } else if (socket._httpMessage) {
+    socket._httpMessage._last = true;
+  } else {
+    if (socket.writable) socket.end();
+  }
+}
+
+function socketOnData(server, socket, parser, state, d) {
+  assert(!socket._paused);
+  debug('SERVER socketOnData %d', d.length);
+  var ret = parser.execute(d);
+
+  onParserExecuteCommon(server, socket, parser, state, ret, d);
+}
+
+function onParserExecute(server, socket, parser, state, ret, d) {
+  socket._unrefTimer();
+  debug('SERVER socketOnParserExecute %d', ret);
+  onParserExecuteCommon(server, socket, parser, state, ret, undefined);
+}
+
+function socketOnError(server, socket, state, e) {
+  // Ignore further errors
+  socket.removeListener('error', state.onError);
+  socket.on('error', () => {});
+
+  if (!server.emit('clientError', e, socket))
+    socket.destroy(e);
+}
+
+function onParserExecuteCommon(server, socket, parser, state, ret, d) {
+  if (ret instanceof Error) {
+    debug('parse error');
+    state.onError(ret);
+  } else if (parser.incoming && parser.incoming.upgrade) {
+    // Upgrade or CONNECT
+    var bytesParsed = ret;
+    var req = parser.incoming;
+    debug('SERVER upgrade or connect', req.method);
+
+    if (!d)
+      d = parser.getCurrentBuffer();
+
+    socket.removeListener('data', state.onData);
+    socket.removeListener('end', state.onEnd);
+    socket.removeListener('close', state.onClose);
+    unconsume(parser, socket);
+    parser.finish();
+    freeParser(parser, req, null);
+    parser = null;
+
+    var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+    if (server.listenerCount(eventName) > 0) {
+      debug('SERVER have listener for %s', eventName);
+      var bodyHead = d.slice(bytesParsed, d.length);
+
+      // TODO(isaacs): Need a way to reset a stream to fresh state
+      // IE, not flowing, and not explicitly paused.
+      socket._readableState.flowing = null;
+      server.emit(eventName, req, socket, bodyHead);
+    } else {
+      // Got upgrade header or CONNECT method, but have no handler.
+      socket.destroy();
+    }
+  }
+
+  if (socket._paused && socket.parser) {
+    // onIncoming paused the socket, we should pause the parser as well
+    debug('pause parser');
+    socket.parser.pause();
+  }
+}
+
+function resOnFinish(req, res, socket, state) {
+  // Usually the first incoming element should be our request.  it may
+  // be that in the case abortIncoming() was called that the incoming
+  // array will be empty.
+  assert(state.incoming.length === 0 || state.incoming[0] === req);
+
+  state.incoming.shift();
+
+  // if the user never called req.read(), and didn't pipe() or
+  // .resume() or .on('data'), then we call req._dump() so that the
+  // bytes will be pulled off the wire.
+  if (!req._consuming && !req._readableState.resumeScheduled)
+    req._dump();
+
+  res.detachSocket(socket);
+
+  if (res._last) {
+    socket.destroySoon();
+  } else {
+    // start sending the next message
+    var m = state.outgoing.shift();
+    if (m) {
+      m.assignSocket(socket);
+    }
+  }
+}
+
+// The following callback is issued after the headers have been read on a
+// new message. In this callback we setup the response object and pass it
+// to the user.
+function parserOnIncoming(server, socket, state, req, keepAlive) {
+  state.incoming.push(req);
+
+  // If the writable end isn't consuming, then stop reading
+  // so that we don't become overwhelmed by a flood of
+  // pipelined requests that may never be resolved.
+  if (!socket._paused) {
+    var needPause = socket._writableState.needDrain ||
+        state.outgoingData >= socket._writableState.highWaterMark;
+    if (needPause) {
+      socket._paused = true;
+      // We also need to pause the parser, but don't do that until after
+      // the call to execute, because we may still be processing the last
+      // chunk.
+      socket.pause();
+    }
+  }
+
+  var res = new ServerResponse(req);
+  res._onPendingData = updateOutgoingData.bind(undefined, socket, state);
+
+  res.shouldKeepAlive = keepAlive;
+  DTRACE_HTTP_SERVER_REQUEST(req, socket);
+  LTTNG_HTTP_SERVER_REQUEST(req, socket);
+  COUNTER_HTTP_SERVER_REQUEST();
+
+  if (socket._httpMessage) {
+    // There are already pending outgoing res, append.
+    state.outgoing.push(res);
+  } else {
+    res.assignSocket(socket);
+  }
+
+  // When we're finished writing the response, check if this is the last
+  // response, if so destroy the socket.
+  var finish =
+    resOnFinish.bind(undefined, req, res, socket, state);
+  res.on('finish', finish);
+
+  if (req.headers.expect !== undefined &&
+      (req.httpVersionMajor === 1 && req.httpVersionMinor === 1)) {
+    if (continueExpression.test(req.headers.expect)) {
+      res._expect_continue = true;
+
+      if (server.listenerCount('checkContinue') > 0) {
+        server.emit('checkContinue', req, res);
+      } else {
+        res.writeContinue();
+        server.emit('request', req, res);
+      }
+    } else {
+      if (server.listenerCount('checkExpectation') > 0) {
+        server.emit('checkExpectation', req, res);
+      } else {
+        res.writeHead(417);
+        res.end();
+      }
+    }
+  } else {
+    server.emit('request', req, res);
+  }
+  return false; // Not a HEAD response. (Not even a response!)
+}
 
 function onSocketResume() {
   // It may seem that the socket is resumed, but this is an enemy's trick to

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -88,6 +88,8 @@ function ServerResponse(req) {
   if (req.method === 'HEAD') this._hasBody = false;
 
   this.sendDate = true;
+  this._sent100 = false;
+  this._expect_continue = false;
 
   if (req.httpVersionMajor < 1 || req.httpVersionMinor < 1) {
     this.useChunkedEncodingByDefault = chunkExpression.test(req.headers.te);
@@ -195,8 +197,7 @@ function writeHead(statusCode, reason, obj) {
   if (common._checkInvalidHeaderChar(this.statusMessage))
     throw new Error('Invalid character in statusMessage.');
 
-  var statusLine = 'HTTP/1.1 ' + statusCode.toString() + ' ' +
-                   this.statusMessage + CRLF;
+  var statusLine = 'HTTP/1.1 ' + statusCode + ' ' + this.statusMessage + CRLF;
 
   if (statusCode === 204 || statusCode === 304 ||
       (100 <= statusCode && statusCode <= 199)) {
@@ -232,7 +233,7 @@ function Server(requestListener) {
   net.Server.call(this, { allowHalfOpen: true });
 
   if (requestListener) {
-    this.addListener('request', requestListener);
+    this.on('request', requestListener);
   }
 
   /* eslint-disable max-len */
@@ -242,7 +243,7 @@ function Server(requestListener) {
   /* eslint-enable max-len */
   this.httpAllowHalfOpen = false;
 
-  this.addListener('connection', connectionListener);
+  this.on('connection', connectionListener);
 
   this.timeout = 2 * 60 * 1000;
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -86,9 +86,7 @@ function WritableState(options, stream) {
   this.bufferProcessing = false;
 
   // the callback that's passed to _write(chunk,cb)
-  this.onwrite = function(er) {
-    onwrite(stream, er);
-  };
+  this.onwrite = onwrite.bind(undefined, stream);
 
   // the callback that the user supplies to write(chunk,encoding,cb)
   this.writecb = null;
@@ -538,20 +536,21 @@ function endWritable(stream, state, cb) {
 function CorkedRequest(state) {
   this.next = null;
   this.entry = null;
+  this.finish = onCorkedFinish.bind(undefined, this, state);
+}
 
-  this.finish = (err) => {
-    var entry = this.entry;
-    this.entry = null;
-    while (entry) {
-      var cb = entry.callback;
-      state.pendingcb--;
-      cb(err);
-      entry = entry.next;
-    }
-    if (state.corkedRequestsFree) {
-      state.corkedRequestsFree.next = this;
-    } else {
-      state.corkedRequestsFree = this;
-    }
-  };
+function onCorkedFinish(corkReq, state, err) {
+  var entry = corkReq.entry;
+  corkReq.entry = null;
+  while (entry) {
+    var cb = entry.callback;
+    state.pendingcb--;
+    cb(err);
+    entry = entry.next;
+  }
+  if (state.corkedRequestsFree) {
+    state.corkedRequestsFree.next = corkReq;
+  } else {
+    state.corkedRequestsFree = corkReq;
+  }
 }


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)
- http
- streams
##### Description of change

This PR consists of a refactor of http server-related code as well as various cleanups and minor optimizations in the http and writable stream modules.

Here are some benchmark results with these changes:

```
http/simple.js type=bytes length=4 chunks=0 c=50: ./node: 25895 ./node-http-before: 21780 ........ 18.90%
http/simple.js type=bytes length=4 chunks=0 c=500: ./node: 24965 ./node-http-before: 21956 ....... 13.70%
http/simple.js type=bytes length=4 chunks=1 c=50: ./node: 21823 ./node-http-before: 20029 ......... 8.96%
http/simple.js type=bytes length=4 chunks=1 c=500: ./node: 21403 ./node-http-before: 17624 ....... 21.44%
http/simple.js type=bytes length=4 chunks=4 c=50: ./node: 1197.3 ./node-http-before: 1197.1 ....... 0.01%
http/simple.js type=bytes length=4 chunks=4 c=500: ./node: 11844 ./node-http-before: 11817 ........ 0.22%
http/simple.js type=bytes length=1024 chunks=0 c=50: ./node: 22803 ./node-http-before: 21585 ...... 5.65%
http/simple.js type=bytes length=1024 chunks=0 c=500: ./node: 21938 ./node-http-before: 20275 ..... 8.20%
http/simple.js type=bytes length=1024 chunks=1 c=50: ./node: 18782 ./node-http-before: 17787 ...... 5.59%
http/simple.js type=bytes length=1024 chunks=1 c=500: ./node: 17992 ./node-http-before: 16139 .... 11.48%
http/simple.js type=bytes length=1024 chunks=4 c=50: ./node: 1197.8 ./node-http-before: 1195.8 .... 0.17%
http/simple.js type=bytes length=1024 chunks=4 c=500: ./node: 11656 ./node-http-before: 11675 .... -0.17%
http/simple.js type=bytes length=102400 chunks=0 c=50: ./node: 1487.3 ./node-http-before: 1466.3 .. 1.44%
http/simple.js type=bytes length=102400 chunks=0 c=500: ./node: 1494.2 ./node-http-before: 1470.5 . 1.61%
http/simple.js type=bytes length=102400 chunks=1 c=50: ./node: 1125.4 ./node-http-before: 1132.1 . -0.60%
http/simple.js type=bytes length=102400 chunks=1 c=500: ./node: 1084.6 ./node-http-before: 1079.8 . 0.44%
http/simple.js type=bytes length=102400 chunks=4 c=50: ./node: 4260.3 ./node-http-before: 4279.6 . -0.45%
http/simple.js type=bytes length=102400 chunks=4 c=500: ./node: 4241.2 ./node-http-before: 4148.5 . 2.23%
http/simple.js type=buffer length=4 chunks=0 c=50: ./node: 21961 ./node-http-before: 20022 ........ 9.68%
http/simple.js type=buffer length=4 chunks=0 c=500: ./node: 20901 ./node-http-before: 19318 ....... 8.20%
http/simple.js type=buffer length=4 chunks=1 c=50: ./node: 20613 ./node-http-before: 19061 ........ 8.15%
http/simple.js type=buffer length=4 chunks=1 c=500: ./node: 19639 ./node-http-before: 18314 ....... 7.23%
http/simple.js type=buffer length=4 chunks=4 c=50: ./node: 17262 ./node-http-before: 15158 ....... 13.89%
http/simple.js type=buffer length=4 chunks=4 c=500: ./node: 16812 ./node-http-before: 15758 ....... 6.69%
http/simple.js type=buffer length=1024 chunks=0 c=50: ./node: 21184 ./node-http-before: 20191 ..... 4.92%
http/simple.js type=buffer length=1024 chunks=0 c=500: ./node: 18821 ./node-http-before: 18476 .... 1.87%
http/simple.js type=buffer length=1024 chunks=1 c=50: ./node: 19632 ./node-http-before: 16735 .... 17.31%
http/simple.js type=buffer length=1024 chunks=1 c=500: ./node: 18979 ./node-http-before: 17733 .... 7.02%
http/simple.js type=buffer length=1024 chunks=4 c=50: ./node: 14943 ./node-http-before: 14621 ..... 2.20%
http/simple.js type=buffer length=1024 chunks=4 c=500: ./node: 16062 ./node-http-before: 15061 .... 6.65%
http/simple.js type=buffer length=102400 chunks=0 c=50: ./node: 17115 ./node-http-before: 15099 .. 13.35%
http/simple.js type=buffer length=102400 chunks=0 c=500: ./node: 16807 ./node-http-before: 15763 .. 6.62%
http/simple.js type=buffer length=102400 chunks=1 c=50: ./node: 14429 ./node-http-before: 13821 ... 4.39%
http/simple.js type=buffer length=102400 chunks=1 c=500: ./node: 15486 ./node-http-before: 13636 . 13.57%
http/simple.js type=buffer length=102400 chunks=4 c=50: ./node: 14031 ./node-http-before: 12521 .. 12.06%
http/simple.js type=buffer length=102400 chunks=4 c=500: ./node: 14034 ./node-http-before: 13554 .. 3.54%
```

Probably the more controversial changes here would be the ones in the writable stream module because of:
- var -> const changes
  - Thinking about the `readable-stream` module in particular here, which would see problems with older versions of node (e.g. v0.10), unless these changes were specifically not pulled in there (is this even feasible, despite older node versions going unmaintained at the end of this year?).
- passing of the stream to `write()` callbacks as a second argument
  - This may be considered a semver-major change, as it may or may not affect modules that use (directly or indirectly) `arguments` inside callbacks passed to `write()`
  - The reason for this particular change is that (AFAICT) it is the only way to keep v8 from having to constantly recompile/reoptimize the `write()` callback used in `OutgoingMessage.prototype.end()`, since writable streams do not call their `write()` callbacks within the context of the stream (e.g. they use `cb()` instead of `cb.call(stream)`.

/cc @nodejs/http
