### PR TITLE
src: refactor constants, "deprecate" require('constants')

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -856,6 +856,12 @@ thrown.
 
 ## `crypto` module methods and properties
 
+## crypto.constants
+
+Returns an object containing commonly used constants for crypto and security
+related operations. The specific constants currently defined are described in
+[Crypto Constants][].
+
 ### crypto.DEFAULT_ENCODING
 
 The default encoding to use for functions that can take either strings
@@ -1205,11 +1211,11 @@ keys:
 * `key` : {String} - PEM encoded private key
 * `passphrase` : {String} - Optional passphrase for the private key
 * `padding` : An optional padding value, one of the following:
-  * `constants.RSA_NO_PADDING`
-  * `constants.RSA_PKCS1_PADDING`
-  * `constants.RSA_PKCS1_OAEP_PADDING`
+  * `crypto.constants.RSA_NO_PADDING`
+  * `crypto.constants.RSA_PKCS1_PADDING`
+  * `crypto.constants.RSA_PKCS1_OAEP_PADDING`
 
-All paddings are defined in the `constants` module.
+All paddings are defined in `crypto.constants`.
 
 ### crypto.privateEncrypt(private_key, buffer)
 
@@ -1223,11 +1229,11 @@ keys:
 * `key` : {String} - PEM encoded private key
 * `passphrase` : {String} - Optional passphrase for the private key
 * `padding` : An optional padding value, one of the following:
-  * `constants.RSA_NO_PADDING`
-  * `constants.RSA_PKCS1_PADDING`
-  * `constants.RSA_PKCS1_OAEP_PADDING`
+  * `crypto.constants.RSA_NO_PADDING`
+  * `crypto.constants.RSA_PKCS1_PADDING`
+  * `crypto.constants.RSA_PKCS1_OAEP_PADDING`
 
-All paddings are defined in the `constants` module.
+All paddings are defined in `crypto.constants`.
 
 ### crypto.publicDecrypt(public_key, buffer)
 
@@ -1241,14 +1247,14 @@ keys:
 * `key` : {String} - PEM encoded public key
 * `passphrase` : {String} - Optional passphrase for the private key
 * `padding` : An optional padding value, one of the following:
-  * `constants.RSA_NO_PADDING`
-  * `constants.RSA_PKCS1_PADDING`
-  * `constants.RSA_PKCS1_OAEP_PADDING`
+  * `crypto.constants.RSA_NO_PADDING`
+  * `crypto.constants.RSA_PKCS1_PADDING`
+  * `crypto.constants.RSA_PKCS1_OAEP_PADDING`
 
 Because RSA public keys can be derived from private keys, a private key may
 be passed instead of a public key.
 
-All paddings are defined in the `constants` module.
+All paddings are defined in `crypto.constants`.
 
 ### crypto.publicEncrypt(public_key, buffer)
 
@@ -1262,14 +1268,14 @@ keys:
 * `key` : {String} - PEM encoded public key
 * `passphrase` : {String} - Optional passphrase for the private key
 * `padding` : An optional padding value, one of the following:
-  * `constants.RSA_NO_PADDING`
-  * `constants.RSA_PKCS1_PADDING`
-  * `constants.RSA_PKCS1_OAEP_PADDING`
+  * `crypto.constants.RSA_NO_PADDING`
+  * `crypto.constants.RSA_PKCS1_PADDING`
+  * `crypto.constants.RSA_PKCS1_OAEP_PADDING`
 
 Because RSA public keys can be derived from private keys, a private key may
 be passed instead of a public key.
 
-All paddings are defined in the `constants` module.
+All paddings are defined in `crypto.constants`.
 
 ### crypto.randomBytes(size[, callback])
 
@@ -1313,22 +1319,22 @@ Load and set the `engine` for some or all OpenSSL functions (selected by flags).
 `engine` could be either an id or a path to the engine's shared library.
 
 The optional `flags` argument uses `ENGINE_METHOD_ALL` by default. The `flags`
-is a bit field taking one of or a mix of the following flags (defined in the
-`constants` module):
+is a bit field taking one of or a mix of the following flags (defined in
+`crypto.constants`):
 
-* `ENGINE_METHOD_RSA`
-* `ENGINE_METHOD_DSA`
-* `ENGINE_METHOD_DH`
-* `ENGINE_METHOD_RAND`
-* `ENGINE_METHOD_ECDH`
-* `ENGINE_METHOD_ECDSA`
-* `ENGINE_METHOD_CIPHERS`
-* `ENGINE_METHOD_DIGESTS`
-* `ENGINE_METHOD_STORE`
-* `ENGINE_METHOD_PKEY_METHS`
-* `ENGINE_METHOD_PKEY_ASN1_METHS`
-* `ENGINE_METHOD_ALL`
-* `ENGINE_METHOD_NONE`
+* `crypto.constants.ENGINE_METHOD_RSA`
+* `crypto.constants.ENGINE_METHOD_DSA`
+* `crypto.constants.ENGINE_METHOD_DH`
+* `crypto.constants.ENGINE_METHOD_RAND`
+* `crypto.constants.ENGINE_METHOD_ECDH`
+* `crypto.constants.ENGINE_METHOD_ECDSA`
+* `crypto.constants.ENGINE_METHOD_CIPHERS`
+* `crypto.constants.ENGINE_METHOD_DIGESTS`
+* `crypto.constants.ENGINE_METHOD_STORE`
+* `crypto.constants.ENGINE_METHOD_PKEY_METHS`
+* `crypto.constants.ENGINE_METHOD_PKEY_ASN1_METHS`
+* `crypto.constants.ENGINE_METHOD_ALL`
+* `crypto.constants.ENGINE_METHOD_NONE`
 
 ## Notes
 
@@ -1380,6 +1386,316 @@ Based on the recommendations of [NIST SP 800-131A][]:
 
 See the reference for other recommendations and details.
 
+## Crypto Constants
+
+The following constants exported by `crypto.constants` apply to various uses of 
+the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
+
+### OpenSSL Options
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_ALL</code></td>
+    <td>Applies multiple bug workarounds within OpenSSL. See
+    https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_options.html for
+    detail.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</code></td>
+    <td>Allows legacy insecure renegotiation between OpenSSL and unpatched
+    clients or servers. See 
+    https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_options.html.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_CIPHER_SERVER_PREFERENCE</code></td>
+    <td>Uses the server's preferences instead of the clients when selecting a
+    cipher. See 
+    https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_options.html.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_CISCO_ANYCONNECT</code></td>
+    <td>Instructs OpenSSL to use Cisco's "speshul" version of DTLS_BAD_VER.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_COOKIE_EXCHANGE</code></td>
+    <td>Instructs OpenSSL to turn on cookie exchange.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_CRYPTOPRO_TLSEXT_BUG</code></td>
+    <td>Instructs OpenSSL to add server-hello extension from an early version
+    of the cryptopro draft.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS</code></td>
+    <td>Instructs OpenSSL to disable a SSL 3.0/TLS 1.0 vulnerability
+    workaround added in OpenSSL 0.9.6d.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_EPHEMERAL_RSA</code></td>
+    <td>Instructs OpenSSL to always use the tmp_rsa key when performing RSA
+    operations.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_LEGACY_SERVER_CONNECT</code></td>
+    <td>Allow initial connection to servers that do not support RI.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_MICROSOFT_SESS_ID_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_MSIE_SSLV2_RSA_PADDING</code></td>
+    <td>Instructs OpenSSL to disable the workaround for a man-in-the-middle
+    protocol-version vulnerability in the SSL 2.0 server implementation.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NETSCAPE_CA_DN_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NETSCAPE_CHALLENGE_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_COMPRESSION</code></td>
+    <td>Instructs OpenSSL to disable support for SSL/TLS compression.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_QUERY_MTU</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION</code></td>
+    <td>Instructs OpenSSL to always start a new session when performing
+    renegotiation.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_SSLv2</code></td>
+    <td>Instructs OpenSSL to turn off SSL v2</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_SSLv3</code></td>
+    <td>Instructs OpenSSL to turn off SSL v3</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_TICKET</code></td>
+    <td>Instructs OpenSSL to disable use of RFC4507bis tickets.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_TLSv1</code></td>
+    <td>Instructs OpenSSL to turn off TLS v1</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_TLSv1_1</code></td>
+    <td>Instructs OpenSSL to turn off TLS v1.1</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_TLSv1_2</code></td>
+    <td>Instructs OpenSSL to turn off TLS v1.2</td>
+  </tr>
+    <td><code>SSL_OP_PKCS1_CHECK_1</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_PKCS1_CHECK_2</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_SINGLE_DH_USE</code></td>
+    <td>Instructs OpenSSL to always create a new key when using
+    temporary/ephemeral DH parameters.</td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_SINGLE_ECDH_USE</code></td>
+    <td>Instructs OpenSSL to always create a new key when using
+    temporary/ephemeral ECDH parameters.</td>
+  </tr>
+    <td><code>SSL_OP_SSLEAY_080_CLIENT_DH_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_TLS_BLOCK_PADDING_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_TLS_D5_BUG</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_TLS_ROLLBACK_BUG</code></td>
+    <td>Instructs OpenSSL to disable version rollback attack detection.</td>
+  </tr>
+</table>
+
+### OpenSSL Engine Constants
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_RSA</code></td>
+    <td>Limit engine usage to RSA</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_DSA</code></td>
+    <td>Limit engine usage to DSA</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_DH</code></td>
+    <td>Limit engine usage to DH</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_RAND</code></td>
+    <td>Limit engine usage to RAND</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_ECDH</code></td>
+    <td>Limit engine usage to ECDH</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_ECDSA</code></td>
+    <td>Limit engine usage to ECDSA</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_CIPHERS</code></td>
+    <td>Limit engine usage to CIPHERS</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_DIGESTS</code></td>
+    <td>Limit engine usage to DIGESTS</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_STORE</code></td>
+    <td>Limit engine usage to STORE</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_PKEY_METHS</code></td>
+    <td>Limit engine usage to PKEY_METHDS</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_PKEY_ASN1_METHS</code></td>
+    <td>Limit engine usage to PKEY_ASN1_METHS</td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_ALL</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>ENGINE_METHOD_NONE</code></td>
+    <td></td>
+  </tr>
+</table>
+
+### Other OpenSSL Constants
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>DH_CHECK_P_NOT_SAFE_PRIME</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>DH_CHECK_P_NOT_PRIME</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>DH_UNABLE_TO_CHECK_GENERATOR</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>DH_NOT_SUITABLE_GENERATOR</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>NPN_ENABLED</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>ALPN_ENABLED</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>RSA_PKCS1_PADDING</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>RSA_SSLV23_PADDING</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>RSA_NO_PADDING</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>RSA_PKCS1_OAEP_PADDING</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>RSA_X931_PADDING</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>RSA_PKCS1_PSS_PADDING</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>POINT_CONVERSION_COMPRESSED</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>POINT_CONVERSION_UNCOMPRESSED</code></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><code>POINT_CONVERSION_HYBRID</code></td>
+    <td></td>
+  </tr>
+</table>
+
+### Node.js Crypto Constants
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>defaultCoreCipherList</code></td>
+    <td>Specifies the built-in default cipher list used by Node.js.</td>
+  </tr>
+  <tr>
+    <td><code>defaultCipherList</code></td>
+    <td>Specifies the active default cipher list used by the current Node.js
+    process.</td>
+  </tr>
+</table>
+
+
 [`Buffer`]: buffer.html
 [`cipher.final()`]: #crypto_cipher_final_output_encoding
 [`cipher.update()`]: #crypto_cipher_update_data_input_encoding_output_encoding
@@ -1423,3 +1739,4 @@ See the reference for other recommendations and details.
 [RFC 3526]: https://www.rfc-editor.org/rfc/rfc3526.txt
 [stream]: stream.html
 [stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback
+[Crypto Constants]: #crypto_crypto_constants

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -266,13 +266,13 @@ optional integer that specifies the accessibility checks to be performed. The
 following constants define the possible values of `mode`. It is possible to
 create a mask consisting of the bitwise OR of two or more values.
 
-- `fs.F_OK` - File is visible to the calling process. This is useful for
-determining if a file exists, but says nothing about `rwx` permissions.
+- `fs.constants.F_OK` - File is visible to the calling process. This is useful 
+for determining if a file exists, but says nothing about `rwx` permissions.
 Default if no `mode` is specified.
-- `fs.R_OK` - File can be read by the calling process.
-- `fs.W_OK` - File can be written by the calling process.
-- `fs.X_OK` - File can be executed by the calling process. This has no effect
-on Windows (will behave like `fs.F_OK`).
+- `fs.constants.R_OK` - File can be read by the calling process.
+- `fs.constants.W_OK` - File can be written by the calling process.
+- `fs.constants.X_OK` - File can be executed by the calling process. This has no
+effect on Windows (will behave like `fs.constants.F_OK`).
 
 The final argument, `callback`, is a callback function that is invoked with
 a possible error argument. If any of the accessibility checks fail, the error
@@ -280,7 +280,7 @@ argument will be populated. The following example checks if the file
 `/etc/passwd` can be read and written by the current process.
 
 ```js
-fs.access('/etc/passwd', fs.R_OK | fs.W_OK, (err) => {
+fs.access('/etc/passwd', fs.constants.R_OK | fs.constants.W_OK, (err) => {
   console.log(err ? 'no access!' : 'can read/write');
 });
 ```
@@ -290,8 +290,8 @@ fs.access('/etc/passwd', fs.R_OK | fs.W_OK, (err) => {
 * `path` {String | Buffer}
 * `mode` {Integer}
 
-Synchronous version of [`fs.access()`][]. This throws if any accessibility checks
-fail, and does nothing otherwise.
+Synchronous version of [`fs.access()`][]. This throws if any accessibility 
+checks fail, and does nothing otherwise.
 
 ## fs.appendFile(file, data[, options], callback)
 
@@ -384,6 +384,12 @@ to the completion callback.
 
 Synchronous close(2). Returns `undefined`.
 
+## fs.constants
+
+Returns an object containing commonly used constants for file system
+operations. The specific constants currently defined are described in
+[FS Constants][].
+
 ## fs.createReadStream(path[, options])
 
 * `path` {String | Buffer}
@@ -419,9 +425,9 @@ the file instead of the entire file.  Both `start` and `end` are inclusive and
 start at 0. The `encoding` can be any one of those accepted by [`Buffer`][].
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
-the specified file descriptor. This means that no `'open'` event will be emitted.
-Note that `fd` should be blocking; non-blocking `fd`s should be passed to
-[`net.Socket`][].
+the specified file descriptor. This means that no `'open'` event will be 
+emitted. Note that `fd` should be blocking; non-blocking `fd`s should be passed 
+to [`net.Socket`][].
 
 If `autoClose` is false, then the file descriptor won't be closed, even if
 there's an error.  It is your responsibility to close it and make sure
@@ -468,7 +474,8 @@ Returns a new [`WriteStream`][] object. (See [Writable Stream][]).
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
-default mode `w`. The `defaultEncoding` can be any one of those accepted by [`Buffer`][].
+default mode `w`. The `defaultEncoding` can be any one of those accepted by
+[`Buffer`][].
 
 If `autoClose` is set to true (default behavior) on `error` or `end`
 the file descriptor will be closed automatically. If `autoClose` is false,
@@ -507,7 +514,8 @@ non-existent.
 
 ## fs.existsSync(path)
 
-    Stability: 0 - Deprecated: Use [`fs.statSync()`][] or [`fs.accessSync()`][] instead.
+    Stability: 0 - Deprecated: Use [`fs.statSync()`][] or [`fs.accessSync()`][]
+    instead.
 
 * `path` {String | Buffer}
 
@@ -789,7 +797,7 @@ to a non-existent file. The exclusive flag may or may not work with network file
 systems.
 
 `flags` can also be a number as documented by open(2); commonly used constants
-are available from `require('constants')`.  On Windows, flags are translated to
+are available from `fs.constants`.  On Windows, flags are translated to
 their equivalent ones where applicable, e.g. `O_WRONLY` to `FILE_GENERIC_WRITE`,
 or `O_EXCL|O_CREAT` to `CREATE_NEW`, as accepted by CreateFileW.
 
@@ -1038,11 +1046,11 @@ Synchronous stat(2). Returns an instance of [`fs.Stats`][].
 * `callback` {Function}
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
-to the completion callback.
-The `type` argument can be set to `'dir'`, `'file'`, or `'junction'` (default
-is `'file'`) and is only available on Windows (ignored on other platforms).
-Note that Windows junction points require the destination path to be absolute.  When using
-`'junction'`, the `target` argument will automatically be normalized to absolute path.
+to the completion callback. The `type` argument can be set to `'dir'`,
+`'file'`, or `'junction'` (default is `'file'`) and is only available on
+Windows (ignored on other platforms). Note that Windows junction points require
+the destination path to be absolute. When using `'junction'`, the `target`
+argument will automatically be normalized to absolute path.
 
 Here is an example below:
 
@@ -1255,9 +1263,9 @@ _Note: when an `fs.watchFile` operation results in an `ENOENT` error, it will
  of zero. If the file is created later on, the listener will be called again,
  with the latest stat objects. This is a change in functionality since v0.10._
 
-_Note: [`fs.watch()`][] is more efficient than `fs.watchFile` and `fs.unwatchFile`.
-`fs.watch` should be used instead of `fs.watchFile` and `fs.unwatchFile`
-when possible._
+_Note: [`fs.watch()`][] is more efficient than `fs.watchFile` and
+`fs.unwatchFile`. `fs.watch` should be used instead of `fs.watchFile` and
+`fs.unwatchFile` when possible._
 
 ## fs.write(fd, buffer, offset, length[, position], callback)
 
@@ -1387,6 +1395,226 @@ The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 
 Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 
+## FS Constants
+
+The following constants are exported by `fs.constants`. **Note:** Not every
+constant will be available on every operating system.
+
+### File Access Constants
+
+The following constants are meant for use with [`fs.access()`][].
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>F_OK</code></td>
+    <td>Flag indicating that the file is visible to the calling process.</td>
+  </tr>
+  <tr>
+    <td><code>R_OK</code></td>
+    <td>Flag indicating that the file can be read by the calling process.</td>
+  </tr>
+  <tr>
+    <td><code>W_OK</code></td>
+    <td>Flag indicating that the file can be written by the calling
+    process.</td>
+  </tr>
+  <tr>
+    <td><code>X_OK</code></td>
+    <td>Flag indicating that the file can be executed by the calling
+    process.</td>
+  </tr>
+</table>
+
+### File Open Constants
+
+The following constants are meant for use with `fs.open()`.
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>O_RDONLY</code></td>
+    <td>Flag indicating to open a file for read-only access.</td>
+  </tr>
+  <tr>
+    <td><code>O_WRONLY</code></td>
+    <td>Flag indicating to open a file for write-only access.</td>
+  </tr>
+  <tr>
+    <td><code>O_RDWR</code></td>
+    <td>Flag indicating to open a file for read-write access.</td>
+  </tr>
+  <tr>
+    <td><code>O_CREAT</code></td>
+    <td>Flag indicating to create the file if it does not already exist.</td>
+  </tr>
+  <tr>
+    <td><code>O_EXCL</code></td>
+    <td>Flag indicating that opening a file should fail if the
+    <code>O_CREAT</code> flag is set and the file already exists.</td>
+  </tr>
+  <tr>
+    <td><code>O_NOCTTY</code></td>
+    <td>Flag indicating that if path identifies a terminal device, opening the
+    path shall not cause that terminal to become the controlling terminal for
+    the process (if the process does not already have one).</td>
+  </tr>
+  <tr>
+    <td><code>O_TRUNC</code></td>
+    <td>Flag indicating that if the file exists and is a regular file, and the
+    file is opened successfully for write access, its length shall be truncated
+    to zero.</td>
+  </tr>
+  <tr>
+    <td><code>O_APPEND</code></td>
+    <td>Flag indicating that data will be appended to the end of the file.</td>
+  </tr>
+  <tr>
+    <td><code>O_DIRECTORY</code></td>
+    <td>Flag indicating that the open should fail if the path is not a
+    directory.</td>
+  </tr>
+  <tr>
+  <td><code>O_NOATIME</code></td>
+    <td>Flag indicating reading accesses to the file system will no longer
+    result in an update to the `atime` information associated with the file.
+    This flag is available on Linux operating systems only.</td>
+  </tr>
+  <tr>
+    <td><code>O_NOFOLLOW</code></td>
+    <td>Flag indicating that the open should fail if the path is a symbolic
+    link.</td>
+  </tr>
+  <tr>
+    <td><code>O_SYNC</code></td>
+    <td>Flag indicating that the file is opened for synchronous I/O.</td>
+  </tr>
+  <tr>
+    <td><code>O_SYMLINK</code></td>
+    <td>Flag indicating to open the symbolic link itself rather than the 
+    resource it is pointing to.</td>
+  </tr>
+  <tr>
+    <td><code>O_DIRECT</code></td>
+    <td>When set, an attempt will be made to minimize caching effects of file
+    I/O.</td>
+  </tr>
+  <tr>
+    <td><code>O_NONBLOCK</code></td>
+    <td>Flag indicating to open the file in nonblocking mode when possible.</td>
+  </tr>
+</table>
+
+### File Type Constants
+
+The following constants are meant for use with the [`fs.Stats`][] object's
+`mode` property for determining a file's type.
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>S_IFMT</code></td>
+    <td>Bit mask used to extract the file type code.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFREG</code></td>
+    <td>File type constant for a regular file.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFDIR</code></td>
+    <td>File type constant for a directory.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFCHR</code></td>
+    <td>File type constant for a character-oriented device file.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFBLK</code></td>
+    <td>File type constant for a block-oriented device file.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFIFO</code></td>
+    <td>File type constant for a FIFO/pipe.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFLNK</code></td>
+    <td>File type constant for a symbolic link.</td>
+  </tr>
+  <tr>
+    <td><code>S_IFSOCK</code></td>
+    <td>File type constant for a socket.</td>
+  </tr>
+</table>
+
+### File Mode Constants
+
+The following constants are meant for use with the [`fs.Stats`][] object's
+`mode` property for determining the access permissions for a file.
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>S_IRWXU</code></td>
+    <td>File mode indicating readable, writable and executable by owner.</td>
+  </tr>
+  <tr>
+    <td><code>S_IRUSR</code></td>
+    <td>File mode indicating readable by owner.</td>
+  </tr>
+  <tr>
+    <td><code>S_IWUSR</code></td>
+    <td>File mode indicating writable by owner.</td>
+  </tr>
+  <tr>
+    <td><code>S_IXUSR</code></td>
+    <td>File mode indicating executable by owner.</td>
+  </tr>
+  <tr>
+    <td><code>S_IRWXG</code></td>
+    <td>File mode indicating readable, writable and executable by group.</td>
+  </tr>
+  <tr>
+    <td><code>S_IRGRP</code></td>
+    <td>File mode indicating readable by group.</td>
+  </tr>
+  <tr>
+    <td><code>S_IWGRP</code></td>
+    <td>File mode indicating writable by group.</td>
+  </tr>
+  <tr>
+    <td><code>S_IXGRP</code></td>
+    <td>File mode indicating executable by group.</td>
+  </tr>
+  <tr>
+    <td><code>S_IRWXO</code></td>
+    <td>File mode indicating readable, writable and executable by others.</td>
+  </tr>
+  <tr>
+    <td><code>S_IROTH</code></td>
+    <td>File mode indicating readable by others.</td>
+  </tr>
+  <tr>
+    <td><code>S_IWOTH</code></td>
+    <td>File mode indicating writable by others.</td>
+  </tr>
+  <tr>
+    <td><code>S_IXOTH</code></td>
+    <td>File mode indicating executable by others.</td>
+  </tr>
+</table>
+
 [`Buffer.byteLength`]: buffer.html#buffer_class_method_buffer_bytelength_string_encoding
 [`Buffer`]: buffer.html#buffer_buffer
 [Caveats]: #fs_caveats
@@ -1418,3 +1646,4 @@ Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
 [inode]: http://www.linux.org/threads/intro-to-inodes.4130
+[FS Constants]: #fs_fs_constants

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -22,6 +22,12 @@ added: v0.5.0
 Returns the operating system CPU architecture. Possible values are `'x64'`,
 `'arm'` and `'ia32'`. Returns the value of [`process.arch`][].
 
+## os.constants
+
+Returns an object containing commonly used operating system specific constants
+for error codes, process signals, and so on. The specific constants currently
+defined are described in [OS Constants][].
+
 ## os.cpus()
 <!-- YAML
 added: v0.3.3
@@ -246,5 +252,769 @@ operating system. This differs from the result of `os.homedir()`, which queries
 several environment variables for the home directory before falling back to the
 operating system response.
 
+## OS Constants
+
+The following constants are exported by `os.constants`. **Note:** Not all
+constants will be available on every operating system.
+
+### Signal Constants
+
+The following signal constants are exported by `os.constants.signals`:
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>SIGHUP</code></td>
+    <td>Sent to indicate when a controlling terminal is closed or a parent
+    process exits.</td>
+  </tr>
+  <tr>
+    <td><code>SIGINT</code></td>
+    <td>Sent to indicate when a user wishes to interrupt a process 
+    (`(Ctrl+C)`).</td>
+  </tr>
+  <tr>
+    <td><code>SIGQUIT</code></td>
+    <td>Sent to indicate when a user wishes to terminate a process and perform a
+    core dump.</td>
+  </tr>
+  <tr>
+    <td><code>SIGILL</code></td>
+    <td>Sent to a process to notify that it has attempted to perform an illegal,
+    malformed, unknown or privileged instruction.</td>
+  </tr>
+  <tr>
+    <td><code>SIGTRAP</code></td>
+    <td>Sent to a proces when an exception has occurred.</td>
+  </tr>
+  <tr>
+    <td><code>SIGABRT</code></td>
+    <td>Sent to a process to request that it abort.</td>
+  </tr>
+  <tr>
+    <td><code>SIGIOT</code></td>
+    <td>Synonym for <code>SIGABRT</code></td>
+  </tr>
+  <tr>
+    <td><code>SIGBUS</code></td>
+    <td>Sent to a process to notify that it has caused a bus error.</td>
+  </tr>
+  <tr>
+    <td><code>SIGFPE</code></td>
+    <td>Sent to a process to notify that it has performed an illegal arithmetic 
+    operation.</td>
+  </tr>
+  <tr>
+    <td><code>SIGKILL</code></td>
+    <td>Sent to a process to terminate it immediately.</td>
+  </tr>
+  <tr>
+    <td><code>SIGUSR1</code> <code>SIGUSR2</code></td>
+    <td>Sent to a process to identify user-defined conditions.</td>
+  </tr>
+  <tr>
+    <td><code>SIGSEGV</code></td>
+    <td>Sent to a process to notify of a segmentation fault.</td>
+  </tr>
+  <tr>
+    <td><code>SIGPIPE</code></td>
+    <td>Sent to a process when it has attempted to write to a disconnected
+    pipe.</td>
+  </tr>
+  <tr>
+    <td><code>SIGALRM</code></td>
+    <td>Sent to a process when a system timer elapses.</td>
+  </tr>
+  <tr>
+    <td><code>SIGTERM</code></td>
+    <td>Sent to a process to request termination.</td>
+  </tr>
+  <tr>
+    <td><code>SIGCHLD</code></td>
+    <td>Sent to a process when a child process terminates.</td>
+  </tr>
+  <tr>
+    <td><code>SIGSTKFLT</code></td>
+    <td>Sent to a process to indicate a stack fault on a coprocessor.</td>
+  </tr>
+  <tr>
+    <td><code>SIGCONT</code></td>
+    <td>Sent to instruct the operating system to continue a paused process.</td>
+  </tr>
+  <tr>
+    <td><code>SIGSTOP</code></td>
+    <td>Sent to instruct the operating system to halt a process.</td>
+  </tr>
+  <tr>
+    <td><code>SIGTSTP</code></td>
+    <td>Sent to a process to request it to stop.</td>
+  </tr>
+  <tr>
+    <td><code>SIGBREAK</code></td>
+    <td>Sent to indicate when a user wishes to interrupt a process.</td>
+  </tr>
+  <tr>
+    <td><code>SIGTTIN</code></td>
+    <td>Sent to a process when it reads from the TTY while in the
+    background.</td>
+  </tr>
+  <tr>
+    <td><code>SIGTTOU</code></td>
+    <td>Sent to a process when it writes to the TTY while in the
+    background.</td>
+  </tr>
+  <tr>
+    <td><code>SIGURG</code></td>
+    <td>Sent to a process when a socket has urgent data to read.</td>
+  </tr>
+  <tr>
+    <td><code>SIGXCPU</code></td>
+    <td>Sent to a process when it has exceeded its limit on CPU usage.</td>
+  </tr>
+  <tr>
+    <td><code>SIGXFSZ</code></td>
+    <td>Sent to a process when it grows a file larger than the maximum
+    allowed.</td>
+  </tr>
+  <tr>
+    <td><code>SIGVTALRM</code></td>
+    <td>Sent to a process when a virtual timer has elapsed.</td>
+  </tr>
+  <tr>
+    <td><code>SIGPROF</code></td>
+    <td>Sent to a process when a system timer has elapsed.</td>
+  </tr>
+  <tr>
+    <td><code>SIGWINCH</code></td>
+    <td>Sent to a process when the controlling terminal has changed its
+    size.</td>
+  </tr>
+  <tr>
+    <td><code>SIGIO</code></td>
+    <td>Sent to a process when I/O is available.</td>
+  </tr>
+  <tr>
+    <td><code>SIGPOLL</code></td>
+    <td>Synonym for <code>SIGIO</code></td>
+  </tr>
+  <tr>
+    <td><code>SIGLOST</code></td>
+    <td>Sent to a process when a file lock has been lost.</td>
+  </tr>
+  <tr>
+    <td><code>SIGPWR</code></td>
+    <td>Sent to a process to notify of a power failure.</td>
+  </tr>
+  <tr>
+    <td><code>SIGINFO</code></td>
+    <td>Synonym for <code>SIGPWR</code></td>
+  </tr>
+  <tr>
+    <td><code>SIGSYS</code></td>
+    <td>Sent to a process to notify of a bad argument.</td>
+  </tr>
+  <tr>
+    <td><code>SIGUNUSED</code></td>
+    <td>Synonym for <code>SIGSYS</code></td>
+  </tr>
+</table>
+
+### Error Constants
+
+The following error constants are exported by `os.constants.errno`:
+
+#### POSIX Error Constants
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>E2BIG</code></td>
+    <td>Indicates that the list of arguments is longer than expected.</td>
+  </tr>
+  <tr>
+    <td><code>EACCES</code></td>
+    <td>Indicates that the operation did not have sufficient permissions.</td>
+  </tr>
+  <tr>
+    <td><code>EADDRINUSE</code></td>
+    <td>Indicates that the network address is already in use.</td>
+  </tr>
+  <tr>
+    <td><code>EADDRNOTAVAIL</code></td>
+    <td>Indicates that the network address is currently unavailable for
+    use.</td>
+  </tr>
+  <tr>
+    <td><code>EAFNOSUPPORT</code></td>
+    <td>Indicates that the network address family is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>EAGAIN</code></td>
+    <td>Indicates that there is currently no data available and to try the
+    operation again later.</td>
+  </tr>
+  <tr>
+    <td><code>EALREADY</code></td>
+    <td>Indicates that the socket already has a pending connection in
+    progress.</td>
+  </tr>
+  <tr>
+    <td><code>EBADF</code></td>
+    <td>Indicates that a file descriptor is not valid.</td>
+  </tr>
+  <tr>
+    <td><code>EBADMSG</code></td>
+    <td>Indicates an invalid data message.</td>
+  </tr>
+  <tr>
+    <td><code>EBUSY</code></td>
+    <td>Indicates that a device or resource is busy.</td>
+  </tr>
+  <tr>
+    <td><code>ECANCELED</code></td>
+    <td>Indicates that an operation was canceled.</td>
+  </tr>
+  <tr>
+    <td><code>ECHILD</code></td>
+    <td>Indicates that there are no child processes.</td>
+  </tr>
+  <tr>
+    <td><code>ECONNABORTED</code></td>
+    <td>Indicates that the network connection has been aborted.</td>
+  </tr>
+  <tr>
+    <td><code>ECONNREFUSED</code></td>
+    <td>Indicates that the network connection has been refused.</td>
+  </tr>
+  <tr>
+    <td><code>ECONNRESET</code></td>
+    <td>Indicates that the network connection has been reset.</td>
+  </tr>
+  <tr>
+    <td><code>EDEADLK</code></td>
+    <td>Indicates that a resource deadlock has been avoided.</td>
+  </tr>
+  <tr>
+    <td><code>EDESTADDRREQ</code></td>
+    <td>Indicates that a destination address is required.</td>
+  </tr>
+  <tr>
+    <td><code>EDOM</code></td>
+    <td>Indicates that an argument is out of the domain of the function.</td>
+  </tr>
+  <tr>
+    <td><code>EDQUOT</code></td>
+    <td>Indicates that the disk quota has been exceeded.</td>
+  </tr>
+  <tr>
+    <td><code>EEXIST</code></td>
+    <td>Indicates that the file already exists.</td>
+  </tr>
+  <tr>
+    <td><code>EFAULT</code></td>
+    <td>Indicates an invalid pointer address.</td>
+  </tr>
+  <tr>
+    <td><code>EFBIG</code></td>
+    <td>Indicates that the file is too large.</td>
+  </tr>
+  <tr>
+    <td><code>EHOSTUNREACH</code></td>
+    <td>Indicates that the host is unreachable.</td>
+  </tr>
+  <tr>
+    <td><code>EIDRM</code></td>
+    <td>Indicates that the identifier has been removed.</td>
+  </tr>
+  <tr>
+    <td><code>EILSEQ</code></td>
+    <td>Indicates an illegal byte sequence.</td>
+  </tr>
+  <tr>
+    <td><code>EINPROGRESS</code></td>
+    <td>Indicates that an operation is already in progress.</td>
+  </tr>
+  <tr>
+    <td><code>EINTR</code></td>
+    <td>Indicates that a function call was interrupted.</td>
+  </tr>
+  <tr>
+    <td><code>EINVAL</code></td>
+    <td>Indicates that an invalid argument was provided.</td>
+  </tr>
+  <tr>
+    <td><code>EIO</code></td>
+    <td>Indicates an otherwise unspecified I/O error.</td>
+  </tr>
+  <tr>
+    <td><code>EISCONN</code></td>
+    <td>Indicates that the socket is connected.</td>
+  </tr>
+  <tr>
+    <td><code>EISDIR</code></td>
+    <td>Indicates that the path is a directory.</td>
+  </tr>
+  <tr>
+    <td><code>ELOOP</code></td>
+    <td>Indicates too many levels of symbolic links in a path.</td>
+  </tr>
+  <tr>
+    <td><code>EMFILE</code></td>
+    <td>Indicates that there are too many open files.</td>
+  </tr>
+  <tr>
+    <td><code>EMLINK</code></td>
+    <td>Indicates that there are too many hard links to a file.</td>
+  </tr>
+  <tr>
+    <td><code>EMSGSIZE</code></td>
+    <td>Indicates that the provided message is too long.</td>
+  </tr>
+  <tr>
+    <td><code>EMULTIHOP</code></td>
+    <td>Indicates that a multihop was attempted.</td>
+  </tr>
+  <tr>
+    <td><code>ENAMETOOLONG</code></td>
+    <td>Indicates that the filename is too long.</td>
+  </tr>
+  <tr>
+    <td><code>ENETDOWN</code></td>
+    <td>Indicates that the network is down.</td>
+  </tr>
+  <tr>
+    <td><code>ENETRESET</code></td>
+    <td>Indicates that the connection has been aborted by the network.</td>
+  </tr>
+  <tr>
+    <td><code>ENETUNREACH</code></td>
+    <td>Indicates that the network is unreachable.</td>
+  </tr>
+  <tr>
+    <td><code>ENFILE</code></td>
+    <td>Indicates too many open files in the system.</td>
+  </tr>
+  <tr>
+    <td><code>ENOBUFS</code></td>
+    <td>Indicates that no buffer space is available.</td>
+  </tr>
+  <tr>
+    <td><code>ENODATA</code></td>
+    <td>Indicates that no message is available on the stream head read
+    queue.</td>
+  </tr>
+  <tr>
+    <td><code>ENODEV</code></td>
+    <td>Indicates that there is no such device.</td>
+  </tr>
+  <tr>
+    <td><code>ENOENT</code></td>
+    <td>Indicates that there is no such file or directory.</td>
+  </tr>
+  <tr>
+    <td><code>ENOEXEC</code></td>
+    <td>Indicates an exec format error.</td>
+  </tr>
+  <tr>
+    <td><code>ENOLCK</code></td>
+    <td>Indicates that there are no locks available.</td>
+  </tr>
+  <tr>
+    <td><code>ENOLINK</code></td>
+    <td>Indications that a link has been severed.</td>
+  </tr>
+  <tr>
+    <td><code>ENOMEM</code></td>
+    <td>Indicates that there is not enough space.</td>
+  </tr>
+  <tr>
+    <td><code>ENOMSG</code></td>
+    <td>Indicates that there is no message of the desired type.</td>
+  </tr>
+  <tr>
+    <td><code>ENOPROTOOPT</code></td>
+    <td>Indicates that a given protocol is not available.</td>
+  </tr>
+  <tr>
+    <td><code>ENOSPC</code></td>
+    <td>Indicates that there is no space available on the device.</td>
+  </tr>
+  <tr>
+    <td><code>ENOSR</code></td>
+    <td>Indicates that there are no stream resources available.</td>
+  </tr>
+  <tr>
+    <td><code>ENOSTR</code></td>
+    <td>Indicates that a given resource is not a stream.</td>
+  </tr>
+  <tr>
+    <td><code>ENOSYS</code></td>
+    <td>Indicates that a function has not been implemented.</td>
+  </tr>
+  <tr>
+    <td><code>ENOTCONN</code></td>
+    <td>Indicates that the socket is not connected.</td>
+  </tr>
+  <tr>
+    <td><code>ENOTDIR</code></td>
+    <td>Indicates that the path is not a directory.</td>
+  </tr>
+  <tr>
+    <td><code>ENOTEMPTY</code></td>
+    <td>Indicates that the directory is not empty.</td>
+  </tr>
+  <tr>
+    <td><code>ENOTSOCK</code></td>
+    <td>Indicates that the given item is not a socket.</td>
+  </tr>
+  <tr>
+    <td><code>ENOTSUP</code></td>
+    <td>Indicates that a given operation is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>ENOTTY</code></td>
+    <td>Indicates an inappropriate I/O control operation.</td>
+  </tr>
+  <tr>
+    <td><code>ENXIO</code></td>
+    <td>Indicates no such device or address.</td>
+  </tr>
+  <tr>
+    <td><code>EOPNOTSUPP</code></td>
+    <td>Indicates that an operation is not supported on the socket.
+    Note that while `ENOTSUP` and `EOPNOTSUPP` have the same value on Linux,
+    according to POSIX.1 these error values should be distinct.)</td>
+  </tr>
+  <tr>
+    <td><code>EOVERFLOW</code></td>
+    <td>Indicates that a value is too large to be stored in a given data
+    type.</td>
+  </tr>
+  <tr>
+    <td><code>EPERM</code></td>
+    <td>Indicates that the operation is not permitted.</td>
+  </tr>
+  <tr>
+    <td><code>EPIPE</code></td>
+    <td>Indicates a broken pipe.</td>
+  </tr>
+  <tr>
+    <td><code>EPROTO</code></td>
+    <td>Indicates a protocol error.</td>
+  </tr>
+  <tr>
+    <td><code>EPROTONOSUPPORT</code></td>
+    <td>Indicates that a protocol is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>EPROTOTYPE</code></td>
+    <td>Indicates the wrong type of protocol for a socket.</td>
+  </tr>
+  <tr>
+    <td><code>ERANGE</code></td>
+    <td>Indicates that the results are too large.</td>
+  </tr>
+  <tr>
+    <td><code>EROFS</code></td>
+    <td>Indicates that the file system is read only.</td>
+  </tr>
+  <tr>
+    <td><code>ESPIPE</code></td>
+    <td>Indicates an invalid seek operation.</td>
+  </tr>
+  <tr>
+    <td><code>ESRCH</code></td>
+    <td>Indicates that there is no such process.</td>
+  </tr>
+  <tr>
+    <td><code>ESTALE</code></td>
+    <td>Indicates that the file handle is stale.</td>
+  </tr>
+  <tr>
+    <td><code>ETIME</code></td>
+    <td>Indicates an expired timer.</td>
+  </tr>
+  <tr>
+    <td><code>ETIMEDOUT</code></td>
+    <td>Indicates that the connection timed out.</td>
+  </tr>
+  <tr>
+    <td><code>ETXTBSY</code></td>
+    <td>Indicates that a text file is busy.</td>
+  </tr>
+  <tr>
+    <td><code>EWOULDBLOCK</code></td>
+    <td>Indicates that the operation would block.</td>
+  </tr>
+  <tr>
+    <td><code>EXDEV</code></td>
+    <td>Indicates an improper link.
+  </tr>
+</table>
+
+#### Windows Specific Error Constants
+
+The following error codes are specific to the Windows operating system:
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>WSAEINTR</code></td>
+    <td>Indicates an interrupted function call.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEBADF</code></td>
+    <td>Indicates an invalid file handle.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEACCES</code></td>
+    <td>Indicates insufficient permissions to complete the operation.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEFAULT</code></td>
+    <td>Indicates an invalid pointer address.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEINVAL</code></td>
+    <td>Indicates that an invalid argument was passed.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEMFILE</code></td>
+    <td>Indicates that there are too many open files.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEWOULDBLOCK</code></td>
+    <td>Indicates that a resource is temporarily unavailable.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEINPROGRESS</code></td>
+    <td>Indicates that an operation is currently in progress.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEALREADY</code></td>
+    <td>Indicates that an operation is already in progress.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENOTSOCK</code></td>
+    <td>Indicates that the resource is not a socket.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEDESTADDRREQ</code></td>
+    <td>Indicates that a destination address is required.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEMSGSIZE</code></td>
+    <td>Indicates that the message size is too long.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEPROTOTYPE</code></td>
+    <td>Indicates the wrong protocol type for the socket.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENOPROTOOPT</code></td>
+    <td>Indicates a bad protocol option.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEPROTONOSUPPORT</code></td>
+    <td>Indicates that the protocol is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>WSAESOCKTNOSUPPORT</code></td>
+    <td>Indicates that the socket type is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEOPNOTSUPP</code></td>
+    <td>Indicates that the operation is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEPFNOSUPPORT</code></td>
+    <td>Indicates that the protocol family is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEAFNOSUPPORT</code></td>
+    <td>Indicates that the address family is not supported.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEADDRINUSE</code></td>
+    <td>Indicates that the network address is already in use.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEADDRNOTAVAIL</code></td>
+    <td>Indicates that the network address is not available.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENETDOWN</code></td>
+    <td>Indicates that the network is down.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENETUNREACH</code></td>
+    <td>Indicates that the network is unreachable.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENETRESET</code></td>
+    <td>Indicates that the network connection has been reset.</td>
+  </tr>
+  <tr>
+    <td><code>WSAECONNABORTED</code></td>
+    <td>Indicates that the connection has been aborted.</td>
+  </tr>
+  <tr>
+    <td><code>WSAECONNRESET</code></td>
+    <td>Indicates that the connection has been reset by the peer.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENOBUFS</code></td>
+    <td>Indicates that there is no buffer space available.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEISCONN</code></td>
+    <td>Indicates that the socket is already connected.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENOTCONN</code></td>
+    <td>Indicates that the socket is not connected.</td>
+  </tr>
+  <tr>
+    <td><code>WSAESHUTDOWN</code></td>
+    <td>Indicates that data cannot be sent after the socket has been
+    shutdown.</td>
+  </tr>
+  <tr>
+    <td><code>WSAETOOMANYREFS</code></td>
+    <td>Indicates that there are too many references.</td>
+  </tr>
+  <tr>
+    <td><code>WSAETIMEDOUT</code></td>
+    <td>Indicates that the connection has timed out.</td>
+  </tr>
+  <tr>
+    <td><code>WSAECONNREFUSED</code></td>
+    <td>Indicates that the connection has been refused.</td>
+  </tr>
+  <tr>
+    <td><code>WSAELOOP</code></td>
+    <td>Indicates that a name cannot be translated.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENAMETOOLONG</code></td>
+    <td>Indicates that a name was too long.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEHOSTDOWN</code></td>
+    <td>Indicates that a network host is down.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEHOSTUNREACH</code></td>
+    <td>Indicates that there is no route to a network host.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENOTEMPTY</code></td>
+    <td>Indicates that the directory is not empty.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEPROCLIM</code></td>
+    <td>Indicates that there are too many processes.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEUSERS</code></td>
+    <td>Indicates that the user quota has been exceeded.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEDQUOT</code></td>
+    <td>Indicates that the disk quota has been exceeded.</td>
+  </tr>
+  <tr>
+    <td><code>WSAESTALE</code></td>
+    <td>Indicates a stale file handle reference.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEREMOTE</code></td>
+    <td>Indicates that the item is remote.</td>
+  </tr>
+  <tr>
+    <td><code>WSASYSNOTREADY</code></td>
+    <td>Indicates that the network subsystem is not ready.</td>
+  </tr>
+  <tr>
+    <td><code>WSAVERNOTSUPPORTED</code></td>
+    <td>Indicates that the winsock.dll version is out of range.</td>
+  </tr>
+  <tr>
+    <td><code>WSANOTINITIALISED</code></td>
+    <td>Indicates that successful WSAStartup has not yet been performed.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEDISCON</code></td>
+    <td>Indicates that a graceful shutdown is in progress.</td>
+  </tr>
+  <tr>
+    <td><code>WSAENOMORE</code></td>
+    <td>Indicates that there are no more results.</td>
+  </tr>
+  <tr>
+    <td><code>WSAECANCELLED</code></td>
+    <td>Indicates that an operation has been canceled.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEINVALIDPROCTABLE</code></td>
+    <td>Indicates that the procedure call table is invalid.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEINVALIDPROVIDER</code></td>
+    <td>Indicates an invalid service provider.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEPROVIDERFAILEDINIT</code></td>
+    <td>Indicates that the service provider failed to initialized.</td>
+  </tr>
+  <tr>
+    <td><code>WSASYSCALLFAILURE</code></td>
+    <td>Indicates a system call failure.</td>
+  </tr>
+  <tr>
+    <td><code>WSASERVICE_NOT_FOUND</code></td>
+    <td>Indicates that a service was not found.</td>
+  </tr>
+  <tr>
+    <td><code>WSATYPE_NOT_FOUND</code></td>
+    <td>Indicates that a class type was not found.</td>
+  </tr>
+  <tr>
+    <td><code>WSA_E_NO_MORE</code></td>
+    <td>Indicates that there are no more results.</td>
+  </tr>
+  <tr>
+    <td><code>WSA_E_CANCELLED</code></td>
+    <td>Indicates that the call was canceled.</td>
+  </tr>
+  <tr>
+    <td><code>WSAEREFUSED</code></td>
+    <td>Indicates that a database query was refused.</td>
+  </tr>
+</table>
+
+### libuv Constants
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>UV_UDP_REUSEADDR</code></td>
+    <td></td>
+  </tr>
+</table>
+
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
+[OS Constants]: #os_os_constants

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const internalUtil = require('internal/util');
-const constants = require('constants');
 const tls = require('tls');
+
+const SSL_OP_CIPHER_SERVER_PREFERENCE =
+    process.binding('constants').crypto.SSL_OP_CIPHER_SERVER_PREFERENCE;
 
 // Lazily loaded
 var crypto = null;
@@ -38,7 +40,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   var secureOptions = options.secureOptions;
   if (options.honorCipherOrder)
-    secureOptions |= constants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+    secureOptions |= SSL_OP_CIPHER_SERVER_PREFERENCE;
 
   var c = new SecureContext(options.secureProtocol, secureOptions, context);
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -3,7 +3,7 @@
 const util = require('util');
 const internalUtil = require('internal/util');
 const debug = util.debuglog('child_process');
-const constants = require('constants');
+const constants = process.binding('constants').os.signals;
 
 const uv = process.binding('uv');
 const spawn_sync = process.binding('spawn_sync');

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,11 @@
 'use strict';
 
-module.exports = process.binding('constants');
+// This module is soft-deprecated. Users should be directed towards using
+// the specific constants exposed by the individual modules on which they
+// are most relevant.
+const constants = process.binding('constants');
+Object.assign(exports,
+              constants.os.errors,
+              constants.os.signals,
+              constants.fs,
+              constants.crypto);

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -8,6 +8,7 @@ internalUtil.assertCrypto(exports);
 
 exports.DEFAULT_ENCODING = 'buffer';
 
+const constants = process.binding('constants').crypto;
 const binding = process.binding('crypto');
 const randomBytes = binding.randomBytes;
 const getCiphers = binding.getCiphers;
@@ -17,12 +18,17 @@ const getFipsCrypto = binding.getFipsCrypto;
 const setFipsCrypto = binding.setFipsCrypto;
 
 const Buffer = require('buffer').Buffer;
-const constants = require('constants');
 const stream = require('stream');
 const util = require('util');
 const LazyTransform = require('internal/streams/lazy_transform');
 
 const DH_GENERATOR = 2;
+
+Object.defineProperty(exports, 'constants', {
+  configurable: false,
+  enumerable: true,
+  value: constants
+});
 
 // This is here because many functions accepted binary strings without
 // any explicit encoding in older versions of node, and we don't want

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const Buffer = require('buffer').Buffer;
 const util = require('util');
 const EventEmitter = require('events');
-const constants = require('constants');
+const UV_UDP_REUSEADDR = process.binding('constants').os.UV_UDP_REUSEADDR;
 
 const UDP = process.binding('udp_wrap').UDP;
 const SendWrap = process.binding('udp_wrap').SendWrap;
@@ -186,7 +186,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
 
     var flags = 0;
     if (self._reuseAddr)
-      flags |= constants.UV_UDP_REUSEADDR;
+      flags |= UV_UDP_REUSEADDR;
 
     if (cluster.isWorker && !exclusive) {
       function onHandle(err, handle) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3,17 +3,23 @@
 
 'use strict';
 
+const constants = process.binding('constants').fs;
 const util = require('util');
 const pathModule = require('path');
 
 const binding = process.binding('fs');
-const constants = require('constants');
 const fs = exports;
 const Buffer = require('buffer').Buffer;
 const Stream = require('stream').Stream;
 const EventEmitter = require('events');
 const FSReqWrap = binding.FSReqWrap;
 const FSEvent = process.binding('fs_event_wrap').FSEvent;
+
+Object.defineProperty(exports, 'constants', {
+  configurable: false,
+  enumerable: true,
+  value: constants
+});
 
 const Readable = Stream.Readable;
 const Writable = Stream.Writable;

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -6,7 +6,7 @@ const EventEmitter = require('events');
 const net = require('net');
 const dgram = require('dgram');
 const util = require('util');
-const constants = require('constants');
+const constants = process.binding('constants').os.signals;
 const assert = require('assert');
 
 const Process = process.binding('process_wrap').Process;

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -4,7 +4,7 @@ var _lazyConstants = null;
 
 function lazyConstants() {
   if (!_lazyConstants) {
-    _lazyConstants = process.binding('constants');
+    _lazyConstants = process.binding('constants').os.signals;
   }
   return _lazyConstants;
 }
@@ -160,8 +160,7 @@ function setupKillAndExit() {
       err = process._kill(pid, 0);
     } else {
       sig = sig || 'SIGTERM';
-      if (lazyConstants()[sig] &&
-          sig.slice(0, 3) === 'SIG') {
+      if (lazyConstants()[sig]) {
         err = process._kill(pid, lazyConstants()[sig]);
       } else {
         throw new Error(`Unknown signal: ${sig}`);
@@ -185,7 +184,6 @@ function setupSignalHandlers() {
 
   function isSignal(event) {
     return typeof event === 'string' &&
-           event.slice(0, 3) === 'SIG' &&
            lazyConstants().hasOwnProperty(event);
   }
 

--- a/lib/os.js
+++ b/lib/os.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const binding = process.binding('os');
+const constants = process.binding('constants').os;
 const internalUtil = require('internal/util');
 const isWindows = process.platform === 'win32';
 
@@ -16,6 +17,11 @@ exports.networkInterfaces = binding.getInterfaceAddresses;
 exports.homedir = binding.getHomeDirectory;
 exports.userInfo = binding.getUserInfo;
 
+Object.defineProperty(exports, 'constants', {
+  configurable: false,
+  enumerable: true,
+  value: constants
+});
 
 exports.arch = function() {
   return process.arch;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -6,7 +6,6 @@ const net = require('net');
 const url = require('url');
 const binding = process.binding('crypto');
 const Buffer = require('buffer').Buffer;
-const constants = require('constants');
 
 // Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
 // every {CLIENT_RENEG_WINDOW} seconds. An error event is emitted if more
@@ -17,7 +16,8 @@ exports.CLIENT_RENEG_WINDOW = 600;
 
 exports.SLAB_BUFFER_SIZE = 10 * 1024 * 1024;
 
-exports.DEFAULT_CIPHERS = constants.defaultCipherList;
+exports.DEFAULT_CIPHERS =
+    process.binding('constants').crypto.defaultCipherList;
 
 exports.DEFAULT_ECDH_CURVE = 'prime256v1';
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2509,7 +2509,7 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
     cache->Set(module, exports);
   } else if (!strcmp(*module_v, "constants")) {
     exports = Object::New(env->isolate());
-    DefineConstants(exports);
+    DefineConstants(env->isolate(), exports);
     cache->Set(module, exports);
   } else if (!strcmp(*module_v, "natives")) {
     exports = Object::New(env->isolate());

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1,4 +1,6 @@
 #include "node_constants.h"
+#include "env.h"
+#include "env-inl.h"
 
 #include "uv.h"
 
@@ -1140,14 +1142,26 @@ void DefineCryptoConstants(Local<Object> target) {
 #endif
 }
 
-void DefineConstants(Local<Object> target) {
-  DefineErrnoConstants(target);
-  DefineWindowsErrorConstants(target);
-  DefineSignalConstants(target);
-  DefineOpenSSLConstants(target);
-  DefineSystemConstants(target);
-  DefineUVConstants(target);
-  DefineCryptoConstants(target);
+void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
+  Local<Object> os_constants = Object::New(isolate);
+  Local<Object> err_constants = Object::New(isolate);
+  Local<Object> sig_constants = Object::New(isolate);
+  Local<Object> fs_constants = Object::New(isolate);
+  Local<Object> crypto_constants = Object::New(isolate);
+
+  DefineErrnoConstants(err_constants);
+  DefineWindowsErrorConstants(err_constants);
+  DefineSignalConstants(sig_constants);
+  DefineUVConstants(os_constants);
+  DefineSystemConstants(fs_constants);
+  DefineOpenSSLConstants(crypto_constants);
+  DefineCryptoConstants(crypto_constants);
+
+  os_constants->Set(OneByteString(isolate, "errno"), err_constants);
+  os_constants->Set(OneByteString(isolate, "signals"), sig_constants);
+  target->Set(OneByteString(isolate, "os"), os_constants);
+  target->Set(OneByteString(isolate, "fs"), fs_constants);
+  target->Set(OneByteString(isolate, "crypto"), crypto_constants);
 }
 
 }  // namespace node

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -34,7 +34,7 @@ namespace node {
 extern const char* default_cipher_list;
 #endif
 
-void DefineConstants(v8::Local<v8::Object> target);
+void DefineConstants(v8::Isolate* isolate, v8::Local<v8::Object> target);
 }  // namespace node
 
 #endif  // SRC_NODE_CONSTANTS_H_

--- a/test/parallel/test-constants.js
+++ b/test/parallel/test-constants.js
@@ -1,0 +1,12 @@
+'use strict';
+
+require('../common');
+const constants = process.binding('constants');
+const assert = require('assert');
+
+assert.ok(constants);
+assert.ok(constants.os);
+assert.ok(constants.os.signals);
+assert.ok(constants.os.errno);
+assert.ok(constants.fs);
+assert.ok(constants.crypto);

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -5,7 +5,6 @@
 
 var common = require('../common');
 var assert = require('assert');
-var constants = require('constants');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -13,6 +12,7 @@ if (!common.hasCrypto) {
 }
 var crypto = require('crypto');
 var tls = require('tls');
+const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
 
 crypto.DEFAULT_ENCODING = 'binary';
 
@@ -556,7 +556,7 @@ var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
         '4FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED' +
         'EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFF';
 var d = crypto.createDiffieHellman(p, 'hex');
-assert.equal(d.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(d.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 // Test RSA key signing/verification
 var rsaSign = crypto.createSign('RSA-SHA1');

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -1,13 +1,13 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const constants = require('constants');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
 const crypto = require('crypto');
+const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
 
 // Test Diffie-Hellman with two parties sharing a secret,
 // using various encodings as we go along
@@ -79,8 +79,8 @@ bob.generateKeys();
 var aSecret = alice.computeSecret(bob.getPublicKey()).toString('hex');
 var bSecret = bob.computeSecret(alice.getPublicKey()).toString('hex');
 assert.equal(aSecret, bSecret);
-assert.equal(alice.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
-assert.equal(bob.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(alice.verifyError, DH_NOT_SUITABLE_GENERATOR);
+assert.equal(bob.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 /* Ensure specific generator (buffer) works as expected.
  * The values below (modp2/modp2buf) are for a 1024 bits long prime from
@@ -107,8 +107,8 @@ exmodp2.generateKeys();
 var modp2Secret = modp2.computeSecret(exmodp2.getPublicKey()).toString('hex');
 var exmodp2Secret = exmodp2.computeSecret(modp2.getPublicKey()).toString('hex');
 assert.equal(modp2Secret, exmodp2Secret);
-assert.equal(modp2.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
-assert.equal(exmodp2.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(modp2.verifyError, DH_NOT_SUITABLE_GENERATOR);
+assert.equal(exmodp2.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 
 // Ensure specific generator (string with encoding) works as expected.
@@ -118,7 +118,7 @@ modp2Secret = modp2.computeSecret(exmodp2_2.getPublicKey()).toString('hex');
 var exmodp2_2Secret = exmodp2_2.computeSecret(modp2.getPublicKey())
                                .toString('hex');
 assert.equal(modp2Secret, exmodp2_2Secret);
-assert.equal(exmodp2_2.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(exmodp2_2.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 
 // Ensure specific generator (string without encoding) works as expected.
@@ -128,7 +128,7 @@ modp2Secret = modp2.computeSecret(exmodp2_3.getPublicKey()).toString('hex');
 var exmodp2_3Secret = exmodp2_3.computeSecret(modp2.getPublicKey())
                                .toString('hex');
 assert.equal(modp2Secret, exmodp2_3Secret);
-assert.equal(exmodp2_3.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(exmodp2_3.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 
 // Ensure specific generator (numeric) works as expected.
@@ -138,7 +138,7 @@ modp2Secret = modp2.computeSecret(exmodp2_4.getPublicKey()).toString('hex');
 var exmodp2_4Secret = exmodp2_4.computeSecret(modp2.getPublicKey())
                                .toString('hex');
 assert.equal(modp2Secret, exmodp2_4Secret);
-assert.equal(exmodp2_4.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(exmodp2_4.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 
 var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
@@ -146,7 +146,7 @@ var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
         '4FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED' +
         'EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFF';
 var bad_dh = crypto.createDiffieHellman(p, 'hex');
-assert.equal(bad_dh.verifyError, constants.DH_NOT_SUITABLE_GENERATOR);
+assert.equal(bad_dh.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 
 // Test ECDH

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
-var constants = require('constants');
+var constants = require('crypto').constants;
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -2,16 +2,15 @@
 require('../common');
 var assert = require('assert');
 
-var constants = require('constants');
 var fs = require('fs');
 
-var O_APPEND = constants.O_APPEND || 0;
-var O_CREAT = constants.O_CREAT || 0;
-var O_EXCL = constants.O_EXCL || 0;
-var O_RDONLY = constants.O_RDONLY || 0;
-var O_RDWR = constants.O_RDWR || 0;
-var O_TRUNC = constants.O_TRUNC || 0;
-var O_WRONLY = constants.O_WRONLY || 0;
+var O_APPEND = fs.constants.O_APPEND || 0;
+var O_CREAT = fs.constants.O_CREAT || 0;
+var O_EXCL = fs.constants.O_EXCL || 0;
+var O_RDONLY = fs.constants.O_RDONLY || 0;
+var O_RDWR = fs.constants.O_RDWR || 0;
+var O_TRUNC = fs.constants.O_TRUNC || 0;
+var O_WRONLY = fs.constants.O_WRONLY || 0;
 
 assert.equal(fs._stringToFlags('r'), O_RDONLY);
 assert.equal(fs._stringToFlags('r+'), O_RDWR);

--- a/test/parallel/test-fs-open-numeric-flags.js
+++ b/test/parallel/test-fs-open-numeric-flags.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 
-const constants = require('constants');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
@@ -11,6 +10,6 @@ common.refreshTmpDir();
 // O_WRONLY without O_CREAT shall fail with ENOENT
 const pathNE = path.join(common.tmpDir, 'file-should-not-exist');
 assert.throws(
-  () => fs.openSync(pathNE, constants.O_WRONLY),
+  () => fs.openSync(pathNE, fs.constants.O_WRONLY),
   (e) => e.code === 'ENOENT'
 );

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var fn = path.join(common.tmpDir, 'write.txt');
 var fn2 = path.join(common.tmpDir, 'write2.txt');
 var expected = 'ümlaut.';
-var constants = require('constants');
+var constants = fs.constants;
 var found, found2;
 
 common.refreshTmpDir();
@@ -55,4 +55,3 @@ process.on('exit', function() {
   assert.equal(expected, found);
   assert.equal(expected, found2);
 });
-

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -10,12 +10,12 @@ if (!common.hasCrypto) {
 const assert = require('assert');
 const https = require('https');
 const fs = require('fs');
-const constants = require('constants');
+const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
 const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
-  secureOptions: constants.SSL_OP_NO_TICKET
+  secureOptions: SSL_OP_NO_TICKET
 };
 
 // Create TLS1.2 server

--- a/test/parallel/test-process-constants-noatime.js
+++ b/test/parallel/test-process-constants-noatime.js
@@ -5,8 +5,8 @@ const assert = require('assert');
 const constants = process.binding('constants');
 
 if (process.platform === 'linux') {
-  assert('O_NOATIME' in constants);
-  assert.strictEqual(constants.O_NOATIME, 0x40000);
+  assert('O_NOATIME' in constants.fs);
+  assert.strictEqual(constants.fs.O_NOATIME, 0x40000);
 } else {
-  assert(!('O_NOATIME' in constants));
+  assert(!('O_NOATIME' in constants.fs));
 }

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -4,7 +4,7 @@ var common = require('../common');
 
 var path = require('path');
 var fs = require('fs');
-var constants = require('constants');
+const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -14,7 +14,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var options = {
-  secureOptions: constants.SSL_OP_NO_TICKET,
+  secureOptions: SSL_OP_NO_TICKET,
   key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem')),
   cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
 };

--- a/test/parallel/test-tls-cipher-list.js
+++ b/test/parallel/test-tls-cipher-list.js
@@ -8,13 +8,13 @@ if (!common.hasCrypto) {
 
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const defaultCoreList = require('constants').defaultCoreCipherList;
+const defaultCoreList = require('crypto').constants.defaultCoreCipherList;
 
 function doCheck(arg, check) {
   var out = '';
   arg = arg.concat([
     '-pe',
-    'require("constants").defaultCipherList'
+    'require("crypto").constants.defaultCipherList'
   ]);
   spawn(process.execPath, arg, {}).
     on('error', common.fail).

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -18,9 +18,10 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var assert = require('assert');
-var constants = require('constants');
 var fs = require('fs');
 var join = require('path').join;
+
+const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
 var pfx = fs.readFileSync(join(common.fixturesDir, 'keys', 'agent1-pfx.pem'));
 
@@ -76,7 +77,7 @@ function test(testOptions, cb) {
       port: common.PORT,
       requestOCSP: testOptions.ocsp !== false,
       secureOptions: testOptions.ocsp === false ?
-          constants.SSL_OP_NO_TICKET : 0,
+          SSL_OP_NO_TICKET : 0,
       rejectUnauthorized: false
     }, function() {
       clientSecure++;

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -104,7 +104,9 @@ if (!common.hasCrypto) {
 }
 var tls = require('tls');
 
-var constants = require('constants');
+const SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION =
+  require('crypto').constants.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+
 var assert = require('assert');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
@@ -262,7 +264,7 @@ function runTest(port, testIndex) {
    */
   if (tcase.renegotiate) {
     serverOptions.secureOptions =
-        constants.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+        SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
   }
 
   var renegotiated = false;


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

constants, os, fs, crypto

##### Description of change

The require('constants') module is currently undocumented and mashes together unrelated constants. This soft deprecates the require('constants') in favor of distinct os.constants, fs.constants, and crypto.constants that are specific to the modules for which they are relevant. The next step is to document those within the specific modules.

The justification for this is straightforward:

1. The `constants` module was never actually documented. It's referenced a number of times in documentation but never adequately supported.

2. The single constants object mashes up a number of unrelated constants, which can cause issues with sloppy code. For instance, a bug in spawnSync (https://github.com/nodejs/node/blob/master/lib/child_process.js#L383-L391) essentially allows any defined constant to be used as a signal. In another instance, the code is implementing hacks (https://github.com/nodejs/node/blob/master/lib/internal/process.js#L171-L174) to limit look ups to just signals.

3. Constants should be exported by the modules in which they are actually relevant, and they should be logically grouped so that they make sense. 

On the downside, there's a slight bit more overhead in creating the process.binding('constants').

/cc @addaleax @nodejs/documentation @nodejs/ctc @nodejs/crypto