### PR TITLE
test: unmark test-http-regr-gh-2928 as flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -13,7 +13,6 @@ prefix sequential
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS
-test-http-regr-gh-2928      : PASS,FLAKY
 
 [$system==freebsd]
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test

##### Description of change

<!-- provide a description of the change below this comment -->

The flakiness issue for test-http-regr-gh-2928 on SmartOS was resolved
in late February in https://github.com/nodejs/node/pull/5454. This
change removes its flaky designation in sequential.status.