### PR TITLE
doc: correct anchors for buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1883,9 +1883,11 @@ console.log(buf);
 
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
 [`Array#indexOf()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
+[`Buffer#indexOf()`]: #buffer_buf_indexof_value_byteoffset_encoding
 [`Array#includes()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
 [`buf.entries()`]: #buffer_buf_entries
 [`buf.fill(0)`]: #buffer_buf_fill_value_offset_end_encoding
+[`buf.fill()`]: #buffer_buf_fill_value_offset_end_encoding
 [`buf.keys()`]: #buffer_buf_keys
 [`buf.slice()`]: #buffer_buf_slice_start_end
 [`buf.values()`]: #buffer_buf_values


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

the `buf.fill()` and `Buffer#indexOf` don't have correctly anchors