### PR TITLE
test: replace util.inherits with es6 extends

### DIFF
--- a/benchmark/misc/console.js
+++ b/benchmark/misc/console.js
@@ -122,12 +122,10 @@ function main(conf) {
 
 function createNullStream() {
   // Used to approximate /dev/null
-  function NullStream() {
-    Writable.call(this, {});
+  class NullStream extends Writable {
+    _write(cb) {
+      assert.strictEqual(cb.toString(), 'this is a of 1\n');
+    }
   }
-  util.inherits(NullStream, Writable);
-  NullStream.prototype._write = function(cb) {
-    assert.strictEqual(cb.toString(), 'this is a of 1\n');
-  };
-  return new NullStream();
+  return new NullStream({});
 }

--- a/test/common.js
+++ b/test/common.js
@@ -6,7 +6,6 @@ var assert = require('assert');
 var os = require('os');
 var child_process = require('child_process');
 const stream = require('stream');
-const util = require('util');
 
 const testRoot = path.resolve(process.env.NODE_TEST_DIR ||
                               path.dirname(__filename));
@@ -467,21 +466,21 @@ exports.fail = function(msg) {
 
 
 // A stream to push an array into a REPL
-function ArrayStream() {
-  this.run = function(data) {
-    data.forEach((line) => {
-      this.emit('data', line + '\n');
-    });
-  };
+class ArrayStream extends stream.Stream {
+  run(data) {
+    data.forEach((line) => this.emit('data', line + '\n'));
+  }
+  pause() {
+  }
+  resume() {
+  }
+  write() {
+  }
 }
 
-util.inherits(ArrayStream, stream.Stream);
-exports.ArrayStream = ArrayStream;
 ArrayStream.prototype.readable = true;
 ArrayStream.prototype.writable = true;
-ArrayStream.prototype.pause = function() {};
-ArrayStream.prototype.resume = function() {};
-ArrayStream.prototype.write = function() {};
+exports.ArrayStream = ArrayStream;
 
 // Returns true if the exit code "exitCode" and/or signal name "signal"
 // represent the exit code and/or signal name of a node process that aborted,

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
-var util = require('util');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
@@ -11,20 +10,20 @@ if (!common.hasCrypto) {
 var crypto = require('crypto');
 
 // Small stream to buffer converter
-function Stream2buffer(callback) {
-  stream.Writable.call(this);
+class Stream2buffer extends stream.Writable {
+  constructor(callback) {
+    super();
+    this._buffers = [];
+    this.once('finish', function() {
+      callback(null, Buffer.concat(this._buffers));
+    });
+  }
 
-  this._buffers = [];
-  this.once('finish', function() {
-    callback(null, Buffer.concat(this._buffers));
-  });
+  _write(data, encoding, done) {
+    this._buffers.push(data);
+    return done(null);
+  }
 }
-util.inherits(Stream2buffer, stream.Writable);
-
-Stream2buffer.prototype._write = function(data, encodeing, done) {
-  this._buffers.push(data);
-  return done(null);
-};
 
 if (!common.hasFipsCrypto) {
   // Create an md5 hash of "Hallo world"

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -20,21 +20,22 @@ myEE.emit('foo');
 
 // Test fallback if prependListener is undefined.
 const stream = require('stream');
-const util = require('util');
 
 delete EventEmitter.prototype.prependListener;
 
-function Writable() {
-  this.writable = true;
-  stream.Stream.call(this);
+class Writable extends stream.Stream {
+  constructor() {
+    super();
+    this.writable = true;
+  }
 }
-util.inherits(Writable, stream.Stream);
 
-function Readable() {
-  this.readable = true;
-  stream.Stream.call(this);
+class Readable extends stream.Stream {
+  constructor() {
+    super();
+    this.readable = true;
+  }
 }
-util.inherits(Readable, stream.Stream);
 
 const w = new Writable();
 const r = new Readable();

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -2,15 +2,14 @@
 require('../common');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
-var util = require('util');
 
-util.inherits(MyEE, EventEmitter);
-
-function MyEE(cb) {
-  this.once(1, cb);
-  this.emit(1);
-  this.removeAllListeners();
-  EventEmitter.call(this);
+class MyEE extends EventEmitter {
+  constructor(cb) {
+    super();
+    this.once(1, cb);
+    this.emit(1);
+    this.removeAllListeners();
+  }
 }
 
 var called = false;
@@ -19,9 +18,11 @@ var myee = new MyEE(function() {
 });
 
 
-util.inherits(ErrorEE, EventEmitter);
-function ErrorEE() {
-  this.emit('error', new Error('blerg'));
+class ErrorEE extends EventEmitter {
+  constructor() {
+    super();
+    this.emit('error', new Error('blerg'));
+  }
 }
 
 assert.throws(function() {

--- a/test/parallel/test-http-client-read-in-error.js
+++ b/test/parallel/test-http-client-read-in-error.js
@@ -2,38 +2,34 @@
 require('../common');
 var net = require('net');
 var http = require('http');
-var util = require('util');
 
-function Agent() {
-  http.Agent.call(this);
-}
-util.inherits(Agent, http.Agent);
+class Agent extends http.Agent {
+  createConnection() {
+    var self = this;
+    var socket = new net.Socket();
 
-Agent.prototype.createConnection = function() {
-  var self = this;
-  var socket = new net.Socket();
-
-  socket.on('error', function() {
-    socket.push('HTTP/1.1 200\r\n\r\n');
-  });
-
-  socket.on('newListener', function onNewListener(name) {
-    if (name !== 'error')
-      return;
-    socket.removeListener('newListener', onNewListener);
-
-    // Let other listeners to be set up too
-    process.nextTick(function() {
-      self.breakSocket(socket);
+    socket.on('error', function() {
+      socket.push('HTTP/1.1 200\r\n\r\n');
     });
-  });
 
-  return socket;
-};
+    socket.on('newListener', function onNewListener(name) {
+      if (name !== 'error')
+        return;
+      socket.removeListener('newListener', onNewListener);
 
-Agent.prototype.breakSocket = function breakSocket(socket) {
-  socket.emit('error', new Error('Intentional error'));
-};
+      // Let other listeners to be set up too
+      process.nextTick(function() {
+        self.breakSocket(socket);
+      });
+    });
+
+    return socket;
+  }
+
+  breakSocket(socket) {
+    socket.emit('error', new Error('Intentional error'));
+  }
+}
 
 var agent = new Agent();
 

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -2,41 +2,37 @@
 require('../common');
 var assert = require('assert');
 var http = require('http');
-var util = require('util');
 
 var Duplex = require('stream').Duplex;
 
-function FakeAgent() {
-  http.Agent.call(this);
+class FakeAgent extends http.Agent {
+  createConnection() {
+    var s = new Duplex();
+    var once = false;
+
+    s._read = function read() {
+      if (once)
+        return this.push(null);
+      once = true;
+
+      this.push('HTTP/1.1 200 Ok\r\nTransfer-Encoding: chunked\r\n\r\n');
+      this.push('b\r\nhello world\r\n');
+      this.readable = false;
+      this.push('0\r\n\r\n');
+    };
+
+    // Blackhole
+    s._write = function write(data, enc, cb) {
+      cb();
+    };
+
+    s.destroy = s.destroySoon = function destroy() {
+      this.writable = false;
+    };
+
+    return s;
+  }
 }
-util.inherits(FakeAgent, http.Agent);
-
-FakeAgent.prototype.createConnection = function createConnection() {
-  var s = new Duplex();
-  var once = false;
-
-  s._read = function read() {
-    if (once)
-      return this.push(null);
-    once = true;
-
-    this.push('HTTP/1.1 200 Ok\r\nTransfer-Encoding: chunked\r\n\r\n');
-    this.push('b\r\nhello world\r\n');
-    this.readable = false;
-    this.push('0\r\n\r\n');
-  };
-
-  // Blackhole
-  s._write = function write(data, enc, cb) {
-    cb();
-  };
-
-  s.destroy = s.destroySoon = function destroy() {
-    this.writable = false;
-  };
-
-  return s;
-};
 
 var received = '';
 var ended = 0;

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -4,7 +4,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const util = require('util');
 
 process.on('warning', common.mustCall((warning) => {
   assert(warning);
@@ -15,13 +14,14 @@ process.on('warning', common.mustCall((warning) => {
 process.emitWarning('A Warning');
 process.emitWarning('A Warning', 'CustomWarning');
 
-function CustomWarning() {
-  Error.call(this);
-  this.name = 'CustomWarning';
-  this.message = 'A Warning';
-  Error.captureStackTrace(this, CustomWarning);
+class CustomWarning extends Error {
+  constructor() {
+    super();
+    this.name = 'CustomWarning';
+    this.message = 'A Warning';
+    Error.captureStackTrace(this, CustomWarning);
+  }
 }
-util.inherits(CustomWarning, Error);
 process.emitWarning(new CustomWarning());
 
 // TypeError is thrown on invalid output

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -5,16 +5,17 @@ const assert = require('assert');
 const readline = require('readline');
 const internalReadline = require('internal/readline');
 const EventEmitter = require('events').EventEmitter;
-const inherits = require('util').inherits;
 
-function FakeInput() {
-  EventEmitter.call(this);
+class FakeInput extends EventEmitter {
+  resume() {
+  }
+  pause() {
+  }
+  write() {
+  }
+  end() {
+  }
 }
-inherits(FakeInput, EventEmitter);
-FakeInput.prototype.resume = function() {};
-FakeInput.prototype.pause = function() {};
-FakeInput.prototype.write = function() {};
-FakeInput.prototype.end = function() {};
 
 function isWarned(emitter) {
   for (var name in emitter) {

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -2,16 +2,11 @@
 require('../common');
 var PassThrough = require('stream').PassThrough;
 var assert = require('assert');
-var inherits = require('util').inherits;
 var extend = require('util')._extend;
 var Interface = require('readline').Interface;
 
-
-function FakeInput() {
-  PassThrough.call(this);
+class FakeInput extends PassThrough {
 }
-inherits(FakeInput, PassThrough);
-
 
 var fi = new FakeInput();
 var fo = new FakeInput();

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -1,31 +1,26 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-var util = require('util');
 var stream = require('stream');
 
 var passed = false;
 
-function PassThrough() {
-  stream.Transform.call(this);
-}
-util.inherits(PassThrough, stream.Transform);
-PassThrough.prototype._transform = function(chunk, encoding, done) {
-  this.push(chunk);
-  done();
-};
-
-function TestStream() {
-  stream.Transform.call(this);
-}
-util.inherits(TestStream, stream.Transform);
-TestStream.prototype._transform = function(chunk, encoding, done) {
-  if (!passed) {
-    // Char 'a' only exists in the last write
-    passed = chunk.toString().indexOf('a') >= 0;
+class PassThrough extends stream.Transform {
+  _transform(chunk, encoding, done) {
+    this.push(chunk);
+    done();
   }
-  done();
-};
+}
+
+class TestStream extends stream.Transform {
+  _transform(chunk, encoding, done) {
+    if (!passed) {
+      // Char 'a' only exists in the last write
+      passed = chunk.toString().indexOf('a') >= 0;
+    }
+    done();
+  }
+}
 
 var s1 = new PassThrough();
 var s2 = new PassThrough();

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -4,35 +4,32 @@ var assert = require('assert');
 
 var Readable = require('_stream_readable');
 var Writable = require('_stream_writable');
-var util = require('util');
 
-util.inherits(TestReadable, Readable);
-function TestReadable(opt) {
-  if (!(this instanceof TestReadable))
-    return new TestReadable(opt);
-  Readable.call(this, opt);
-  this._ended = false;
+class TestReadable extends Readable {
+  constructor(opt) {
+    super(opt);
+    this._ended = false;
+  }
+
+  _read(n) {
+    if (this._ended)
+      this.emit('error', new Error('_read called twice'));
+    this._ended = true;
+    this.push(null);
+  }
 }
 
-TestReadable.prototype._read = function(n) {
-  if (this._ended)
-    this.emit('error', new Error('_read called twice'));
-  this._ended = true;
-  this.push(null);
-};
+class TestWritable extends Writable {
+  constructor(opt) {
+    super(opt);
+    this._written = [];
+  }
 
-util.inherits(TestWritable, Writable);
-function TestWritable(opt) {
-  if (!(this instanceof TestWritable))
-    return new TestWritable(opt);
-  Writable.call(this, opt);
-  this._written = [];
+  _write(chunk, encoding, cb) {
+    this._written.push(chunk);
+    cb();
+  }
 }
-
-TestWritable.prototype._write = function(chunk, encoding, cb) {
-  this._written.push(chunk);
-  cb();
-};
 
 // this one should not emit 'end' until we read() from it later.
 var ender = new TestReadable();

--- a/test/parallel/test-stream-pipe-cleanup.js
+++ b/test/parallel/test-stream-pipe-cleanup.js
@@ -5,33 +5,36 @@
 require('../common');
 var stream = require('stream');
 var assert = require('assert');
-var util = require('util');
 
-function Writable() {
-  this.writable = true;
-  this.endCalls = 0;
-  stream.Stream.call(this);
+class Writable extends stream.Stream {
+  constructor() {
+    super();
+    this.writable = true;
+    this.endCalls = 0;
+  }
+
+  end() {
+    this.endCalls++;
+  }
+
+  destroy() {
+    this.endCalls++;
+  }
 }
-util.inherits(Writable, stream.Stream);
-Writable.prototype.end = function() {
-  this.endCalls++;
-};
 
-Writable.prototype.destroy = function() {
-  this.endCalls++;
-};
-
-function Readable() {
-  this.readable = true;
-  stream.Stream.call(this);
+class Readable extends stream.Stream {
+  constructor() {
+    super();
+    this.readable = true;
+  }
 }
-util.inherits(Readable, stream.Stream);
 
-function Duplex() {
-  this.readable = true;
-  Writable.call(this);
+class Duplex extends Writable {
+  constructor() {
+    super();
+    this.readable = true;
+  }
 }
-util.inherits(Duplex, Writable);
 
 var i = 0;
 var limit = 100;

--- a/test/parallel/test-stream-pipe-event.js
+++ b/test/parallel/test-stream-pipe-event.js
@@ -2,20 +2,20 @@
 require('../common');
 var stream = require('stream');
 var assert = require('assert');
-var util = require('util');
 
-function Writable() {
-  this.writable = true;
-  stream.Stream.call(this);
+class Writable extends stream.Stream {
+  constructor() {
+    super();
+    this.writable = true;
+  }
 }
-util.inherits(Writable, stream.Stream);
 
-function Readable() {
-  this.readable = true;
-  stream.Stream.call(this);
+class Readable extends stream.Stream {
+  constructor() {
+    super();
+    this.readable = true;
+  }
 }
-util.inherits(Readable, stream.Stream);
-
 var passed = false;
 
 var w = new Writable();

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -1,34 +1,33 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-
 var Readable = require('stream').Readable;
-var util = require('util');
 
-util.inherits(MyStream, Readable);
-function MyStream(options) {
-  Readable.call(this, options);
-  this._chunks = 3;
-}
-
-MyStream.prototype._read = function(n) {
-  switch (this._chunks--) {
-    case 0:
-      return this.push(null);
-    case 1:
-      return setTimeout(function() {
-        this.push('last chunk');
-      }.bind(this), 100);
-    case 2:
-      return this.push('second to last chunk');
-    case 3:
-      return process.nextTick(function() {
-        this.push('first chunk');
-      }.bind(this));
-    default:
-      throw new Error('?');
+class MyStream extends Readable {
+  constructor(options) {
+    super(options);
+    this._chunks = 3;
   }
-};
+
+  _read(n) {
+    switch (this._chunks--) {
+      case 0:
+        return this.push(null);
+      case 1:
+        return setTimeout(function() {
+          this.push('last chunk');
+        }.bind(this), 100);
+      case 2:
+        return this.push('second to last chunk');
+      case 3:
+        return process.nextTick(function() {
+          this.push('first chunk');
+        }.bind(this));
+      default:
+        throw new Error('?');
+    }
+  }
+}
 
 var ms = new MyStream();
 var results = [];

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -1,21 +1,19 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-
 var stream = require('stream');
-var util = require('util');
 
-function MyWritable(fn, options) {
-  stream.Writable.call(this, options);
-  this.fn = fn;
+class MyWritable extends stream.Writable {
+  constructor(fn, options) {
+    super(options);
+    this.fn = fn;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+    callback();
+  }
 }
-
-util.inherits(MyWritable, stream.Writable);
-
-MyWritable.prototype._write = function(chunk, encoding, callback) {
-  this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
-  callback();
-};
 
 (function defaultCondingIsUtf8() {
   var m = new MyWritable(function(isBuffer, type, enc) {

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -1,21 +1,19 @@
 'use strict';
 require('../common');
 var assert = require('assert');
-
 var stream = require('stream');
-var util = require('util');
 
-function MyWritable(fn, options) {
-  stream.Writable.call(this, options);
-  this.fn = fn;
+class MyWritable extends stream.Writable {
+  constructor(fn, options) {
+    super(options);
+    this.fn = fn;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+    callback();
+  }
 }
-
-util.inherits(MyWritable, stream.Writable);
-
-MyWritable.prototype._write = function(chunk, encoding, callback) {
-  this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
-  callback();
-};
 
 (function decodeStringsTrue() {
   var m = new MyWritable(function(isBuffer, type, enc) {

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -1,20 +1,14 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-
 const stream = require('stream');
-const util = require('util');
 
-function MyWritable(options) {
-  stream.Writable.call(this, options);
+class MyWritable extends stream.Writable {
+  _write(chunk, encoding, callback) {
+    assert.notStrictEqual(chunk, null);
+    callback();
+  }
 }
-
-util.inherits(MyWritable, stream.Writable);
-
-MyWritable.prototype._write = function(chunk, encoding, callback) {
-  assert.notStrictEqual(chunk, null);
-  callback();
-};
 
 assert.throws(() => {
   var m = new MyWritable({objectMode: true});

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -4,25 +4,23 @@ var R = require('_stream_readable');
 var W = require('_stream_writable');
 var assert = require('assert');
 
-var util = require('util');
-
 var ondataCalled = 0;
 
-function TestReader() {
-  R.apply(this);
-  this._buffer = Buffer.alloc(100, 'x');
+class TestReader extends R {
+  constructor() {
+    super();
+    this._buffer = Buffer.alloc(100, 'x');
 
-  this.on('data', function() {
-    ondataCalled++;
-  });
+    this.on('data', function() {
+      ondataCalled++;
+    });
+  }
+
+  _read(n) {
+    this.push(this._buffer);
+    this._buffer = Buffer.alloc(0);
+  }
 }
-
-util.inherits(TestReader, R);
-
-TestReader.prototype._read = function(n) {
-  this.push(this._buffer);
-  this._buffer = Buffer.alloc(0);
-};
 
 var reader = new TestReader();
 setImmediate(function() {
@@ -31,17 +29,17 @@ setImmediate(function() {
   reader.push(null);
 });
 
-function TestWriter() {
-  W.apply(this);
-  this.write('foo');
-  this.end();
+class TestWriter extends W {
+  constructor() {
+    super();
+    this.write('foo');
+    this.end();
+  }
+
+  _write(chunk, enc, cb) {
+    cb();
+  }
 }
-
-util.inherits(TestWriter, W);
-
-TestWriter.prototype._write = function(chunk, enc, cb) {
-  cb();
-};
 
 var writer = new TestWriter();
 

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,30 +1,20 @@
 'use strict';
 require('../common');
-
-var util = require('util');
 var stream = require('stream');
 
+class Read extends stream.Readable {
+  _read(size) {
+    this.push('x');
+    this.push(null);
+  }
+}
 
-var Read = function() {
-  stream.Readable.call(this);
-};
-util.inherits(Read, stream.Readable);
-
-Read.prototype._read = function(size) {
-  this.push('x');
-  this.push(null);
-};
-
-
-var Write = function() {
-  stream.Writable.call(this);
-};
-util.inherits(Write, stream.Writable);
-
-Write.prototype._write = function(buffer, encoding, cb) {
-  this.emit('error', new Error('boom'));
-  this.emit('alldone');
-};
+class Write extends stream.Writable {
+  _write(buffer, encoding, cb) {
+    this.emit('error', new Error('boom'));
+    this.emit('alldone');
+  }
+}
 
 var read = new Read();
 var write = new Write();

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -9,30 +9,26 @@ if (!common.hasCrypto) {
 }
 var crypto = require('crypto');
 
-var util = require('util');
-
-function TestWriter() {
-  stream.Writable.call(this);
+class TestWriter extends stream.Writable {
+  _write(buffer, encoding, callback) {
+    console.log('write called');
+    // super slow write stream (callback never called)
+  }
 }
-util.inherits(TestWriter, stream.Writable);
-
-TestWriter.prototype._write = function(buffer, encoding, callback) {
-  console.log('write called');
-  // super slow write stream (callback never called)
-};
 
 var dest = new TestWriter();
 
-function TestReader(id) {
-  stream.Readable.call(this);
-  this.reads = 0;
-}
-util.inherits(TestReader, stream.Readable);
+class TestReader extends stream.Readable {
+  constructor() {
+    super();
+    this.reads = 0;
+  }
 
-TestReader.prototype._read = function(size) {
-  this.reads += 1;
-  this.push(crypto.randomBytes(size));
-};
+  _read(size) {
+    this.reads += 1;
+    this.push(crypto.randomBytes(size));
+  }
+}
 
 var src1 = new TestReader();
 var src2 = new TestReader();

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -5,29 +5,25 @@ var stream = require('stream');
 
 var chunk = Buffer.from('hallo');
 
-var util = require('util');
-
-function TestWriter() {
-  stream.Writable.call(this);
+class TestWriter extends stream.Writable {
+  _write(buffer, encoding, callback) {
+    callback(null);
+  }
 }
-util.inherits(TestWriter, stream.Writable);
-
-TestWriter.prototype._write = function(buffer, encoding, callback) {
-  callback(null);
-};
 
 var dest = new TestWriter();
 
 // Set this high so that we'd trigger a nextTick warning
 // and/or RangeError if we do maybeReadMore wrong.
-function TestReader() {
-  stream.Readable.call(this, { highWaterMark: 0x10000 });
-}
-util.inherits(TestReader, stream.Readable);
+class TestReader extends stream.Readable {
+  constructor() {
+    super({ highWaterMark: 0x10000 });
+  }
 
-TestReader.prototype._read = function(size) {
-  this.push(chunk);
-};
+  _read(size) {
+    this.push(chunk);
+  }
+}
 
 var src = new TestReader();
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -4,23 +4,22 @@ var W = require('_stream_writable');
 var D = require('_stream_duplex');
 var assert = require('assert');
 
-var util = require('util');
-util.inherits(TestWriter, W);
+class TestWriter extends W {
+  constructor(options) {
+    super(options);
+    this.buffer = [];
+    this.written = 0;
+  }
 
-function TestWriter() {
-  W.apply(this, arguments);
-  this.buffer = [];
-  this.written = 0;
+  _write(chunk, encoding, cb) {
+    // simulate a small unpredictable latency
+    setTimeout(() => {
+      this.buffer.push(chunk.toString());
+      this.written += chunk.length;
+      cb();
+    }, Math.floor(Math.random() * 10));
+  }
 }
-
-TestWriter.prototype._write = function(chunk, encoding, cb) {
-  // simulate a small unpredictable latency
-  setTimeout(function() {
-    this.buffer.push(chunk.toString());
-    this.written += chunk.length;
-    cb();
-  }.bind(this), Math.floor(Math.random() * 10));
-};
 
 var chunks = new Array(50);
 for (var i = 0; i < chunks.length; i++) {

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -57,15 +57,16 @@ assert.equal(util.format('%%%s%%%%', 'hi'), '%hi%%');
 // Errors
 const err = new Error('foo');
 assert.equal(util.format(err), err.stack);
-function CustomError(msg) {
-  Error.call(this);
-  Object.defineProperty(this, 'message',
-                        { value: msg, enumerable: false });
-  Object.defineProperty(this, 'name',
-                        { value: 'CustomError', enumerable: false });
-  Error.captureStackTrace(this, CustomError);
+class CustomError extends Error {
+  constructor(msg) {
+    super();
+    Object.defineProperty(this, 'message',
+                          { value: msg, enumerable: false });
+    Object.defineProperty(this, 'name',
+                          { value: 'CustomError', enumerable: false });
+    Error.captureStackTrace(this, CustomError);
+  }
 }
-util.inherits(CustomError, Error);
 const customError = new CustomError('bar');
 assert.equal(util.format(customError), customError.stack);
 // Doesn't capture stack trace
@@ -76,5 +77,6 @@ function BadCustomError(msg) {
   Object.defineProperty(this, 'name',
                         { value: 'BadCustomError', enumerable: false });
 }
-util.inherits(BadCustomError, Error);
+BadCustomError.prototype =
+    Object.create(Error.prototype, { constructor: { value: BadCustomError } });
 assert.equal(util.format(new BadCustomError('foo')), '[BadCustomError: foo]');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -317,7 +317,8 @@ function BadCustomError(msg) {
   Object.defineProperty(this, 'name',
                         { value: 'BadCustomError', enumerable: false });
 }
-util.inherits(BadCustomError, Error);
+BadCustomError.prototype =
+    Object.create(Error.prototype, { constructor: { value: BadCustomError } });
 assert.equal(util.inspect(new BadCustomError('foo')), '[BadCustomError: foo]');
 
 // GH-1941

--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -10,123 +10,121 @@ var crypto = require('crypto');
 
 var stream = require('stream');
 var Stream = stream.Stream;
-var util = require('util');
 var zlib = require('zlib');
 
 
 // emit random bytes, and keep a shasum
-function RandomReadStream(opt) {
-  Stream.call(this);
+class RandomReadStream extends Stream {
+  constructor(opt) {
+    super();
 
-  this.readable = true;
-  this._paused = false;
-  this._processing = false;
-
-  this._hasher = crypto.createHash('sha1');
-  opt = opt || {};
-
-  // base block size.
-  opt.block = opt.block || 256 * 1024;
-
-  // total number of bytes to emit
-  opt.total = opt.total || 256 * 1024 * 1024;
-  this._remaining = opt.total;
-
-  // how variable to make the block sizes
-  opt.jitter = opt.jitter || 1024;
-
-  this._opt = opt;
-
-  this._process = this._process.bind(this);
-
-  process.nextTick(this._process);
-}
-
-util.inherits(RandomReadStream, Stream);
-
-RandomReadStream.prototype.pause = function() {
-  this._paused = true;
-  this.emit('pause');
-};
-
-RandomReadStream.prototype.resume = function() {
-  // console.error("rrs resume");
-  this._paused = false;
-  this.emit('resume');
-  this._process();
-};
-
-RandomReadStream.prototype._process = function() {
-  if (this._processing) return;
-  if (this._paused) return;
-
-  this._processing = true;
-
-  if (!this._remaining) {
-    this._hash = this._hasher.digest('hex').toLowerCase().trim();
+    this.readable = true;
+    this._paused = false;
     this._processing = false;
 
-    this.emit('end');
-    return;
+    this._hasher = crypto.createHash('sha1');
+    opt = opt || {};
+
+    // base block size.
+    opt.block = opt.block || 256 * 1024;
+
+    // total number of bytes to emit
+    opt.total = opt.total || 256 * 1024 * 1024;
+    this._remaining = opt.total;
+
+    // how variable to make the block sizes
+    opt.jitter = opt.jitter || 1024;
+
+    this._opt = opt;
+
+    this._process = this._process.bind(this);
+
+    process.nextTick(this._process);
   }
 
-  // figure out how many bytes to output
-  // if finished, then just emit end.
-  var block = this._opt.block;
-  var jitter = this._opt.jitter;
-  if (jitter) {
-    block += Math.ceil(Math.random() * jitter - (jitter / 2));
-  }
-  block = Math.min(block, this._remaining);
-  var buf = Buffer.allocUnsafe(block);
-  for (var i = 0; i < block; i++) {
-    buf[i] = Math.random() * 256;
+  pause() {
+    this._paused = true;
+    this.emit('pause');
   }
 
-  this._hasher.update(buf);
+  resume() {
+    // console.error("rrs resume");
+    this._paused = false;
+    this.emit('resume');
+    this._process();
+  }
 
-  this._remaining -= block;
+  _process() {
+    if (this._processing) return;
+    if (this._paused) return;
 
-  console.error('block=%d\nremain=%d\n', block, this._remaining);
-  this._processing = false;
+    this._processing = true;
 
-  this.emit('data', buf);
-  process.nextTick(this._process);
-};
+    if (!this._remaining) {
+      this._hash = this._hasher.digest('hex').toLowerCase().trim();
+      this._processing = false;
+
+      this.emit('end');
+      return;
+    }
+
+    // figure out how many bytes to output
+    // if finished, then just emit end.
+    var block = this._opt.block;
+    var jitter = this._opt.jitter;
+    if (jitter) {
+      block += Math.ceil(Math.random() * jitter - (jitter / 2));
+    }
+    block = Math.min(block, this._remaining);
+    var buf = Buffer.allocUnsafe(block);
+    for (var i = 0; i < block; i++) {
+      buf[i] = Math.random() * 256;
+    }
+
+    this._hasher.update(buf);
+
+    this._remaining -= block;
+
+    console.error('block=%d\nremain=%d\n', block, this._remaining);
+    this._processing = false;
+
+    this.emit('data', buf);
+    process.nextTick(this._process);
+  }
+}
 
 
 // a filter that just verifies a shasum
-function HashStream() {
-  Stream.call(this);
-
-  this.readable = this.writable = true;
-  this._hasher = crypto.createHash('sha1');
-}
-
-util.inherits(HashStream, Stream);
-
-HashStream.prototype.write = function(c) {
-  // Simulate the way that an fs.ReadStream returns false
-  // on *every* write like a jerk, only to resume a
-  // moment later.
-  this._hasher.update(c);
-  process.nextTick(this.resume.bind(this));
-  return false;
-};
-
-HashStream.prototype.resume = function() {
-  this.emit('resume');
-  process.nextTick(this.emit.bind(this, 'drain'));
-};
-
-HashStream.prototype.end = function(c) {
-  if (c) {
-    this.write(c);
+class HashStream extends Stream {
+  constructor() {
+    super();
+    this.readable = this.writable = true;
+    this._hasher = crypto.createHash('sha1');
   }
-  this._hash = this._hasher.digest('hex').toLowerCase().trim();
-  this.emit('data', this._hash);
-  this.emit('end');
-};
+
+  write(c) {
+    // Simulate the way that an fs.ReadStream returns false
+    // on *every* write like a jerk, only to resume a
+    // moment later.
+    this._hasher.update(c);
+    process.nextTick(this.resume.bind(this));
+    return false;
+  }
+
+  resume() {
+    this.emit('resume');
+    process.nextTick(this.emit.bind(this, 'drain'));
+  }
+
+  end(c) {
+    if (c) {
+      this.write(c);
+    }
+    this._hash = this._hasher.digest('hex').toLowerCase().trim();
+    this.emit('data', this._hash);
+    this.emit('end');
+  }
+}
 
 
 var inp = new RandomReadStream({ total: 1024, block: 256, jitter: 16 });

--- a/test/pummel/test-stream2-basic.js
+++ b/test/pummel/test-stream2-basic.js
@@ -3,67 +3,66 @@ require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 
-var util = require('util');
 var EE = require('events').EventEmitter;
 
-function TestReader(n) {
-  R.apply(this);
-  this._buffer = Buffer.alloc(n || 100, 'x');
-  this._pos = 0;
-  this._bufs = 10;
-}
-
-util.inherits(TestReader, R);
-
-TestReader.prototype._read = function(n) {
-  var max = this._buffer.length - this._pos;
-  n = Math.max(n, 0);
-  var toRead = Math.min(n, max);
-  if (toRead === 0) {
-    // simulate the read buffer filling up with some more bytes some time
-    // in the future.
-    setTimeout(function() {
-      this._pos = 0;
-      this._bufs -= 1;
-      if (this._bufs <= 0) {
-        // read them all!
-        if (!this.ended)
-          this.push(null);
-      } else {
-        // now we have more.
-        // kinda cheating by calling _read, but whatever,
-        // it's just fake anyway.
-        this._read(n);
-      }
-    }.bind(this), 10);
-    return;
+class TestReader extends R {
+  constructor(n) {
+    super();
+    this._buffer = Buffer.alloc(n || 100, 'x');
+    this._pos = 0;
+    this._bufs = 10;
   }
 
-  var ret = this._buffer.slice(this._pos, this._pos + toRead);
-  this._pos += toRead;
-  this.push(ret);
-};
+  _read(n) {
+    var max = this._buffer.length - this._pos;
+    n = Math.max(n, 0);
+    var toRead = Math.min(n, max);
+    if (toRead === 0) {
+      // simulate the read buffer filling up with some more bytes some time
+      // in the future.
+      setTimeout(function() {
+        this._pos = 0;
+        this._bufs -= 1;
+        if (this._bufs <= 0) {
+          // read them all!
+          if (!this.ended)
+            this.push(null);
+        } else {
+          // now we have more.
+          // kinda cheating by calling _read, but whatever,
+          // it's just fake anyway.
+          this._read(n);
+        }
+      }.bind(this), 10);
+      return;
+    }
+
+    var ret = this._buffer.slice(this._pos, this._pos + toRead);
+    this._pos += toRead;
+    this.push(ret);
+  }
+}
 
 /////
 
-function TestWriter() {
-  EE.apply(this);
-  this.received = [];
-  this.flush = false;
+class TestWriter extends EE {
+  constructor() {
+    super();
+    this.received = [];
+    this.flush = false;
+  }
+
+  write(c) {
+    this.received.push(c.toString());
+    this.emit('write', c);
+    return true;
+  }
+
+  end(c) {
+    if (c) this.write(c);
+    this.emit('end', this.received);
+  }
 }
-
-util.inherits(TestWriter, EE);
-
-TestWriter.prototype.write = function(c) {
-  this.received.push(c.toString());
-  this.emit('write', c);
-  return true;
-};
-
-TestWriter.prototype.end = function(c) {
-  if (c) this.write(c);
-  this.emit('end', this.received);
-};
 
 ////////
 

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -10,7 +10,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 var stream = require('stream');
-var util = require('util');
 
 var clientConnected = 0;
 var serverConnected = 0;
@@ -21,21 +20,22 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-function Mediator() {
-  stream.Writable.call(this);
-  this.buf = '';
-}
-util.inherits(Mediator, stream.Writable);
-
-Mediator.prototype._write = function write(data, enc, cb) {
-  this.buf += data;
-  setTimeout(cb, 0);
-
-  if (this.buf.length >= request.length) {
-    assert.equal(this.buf, request.toString());
-    server.close();
+class Mediator extends stream.Writable {
+  constructor() {
+    super();
+    this.buf = '';
   }
-};
+
+  _write(data, enc, cb) {
+    this.buf += data;
+    setTimeout(cb, 0);
+
+    if (this.buf.length >= request.length) {
+      assert.equal(this.buf, request.toString());
+      server.close();
+    }
+  }
+}
 
 var mediator = new Mediator();
 

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -12,27 +12,26 @@ var size = fs.statSync(file).size;
 
 var expectLengths = [1024];
 
-var util = require('util');
 var Stream = require('stream');
 
-util.inherits(TestWriter, Stream);
+class TestWriter extends Stream {
+  constructor() {
+    super();
+    this.buffer = [];
+    this.length = 0;
+  }
 
-function TestWriter() {
-  Stream.apply(this);
-  this.buffer = [];
-  this.length = 0;
+  write(c) {
+    this.buffer.push(c.toString());
+    this.length += c.length;
+    return true;
+  }
+
+  end(c) {
+    if (c) this.buffer.push(c.toString());
+    this.emit('results', this.buffer);
+  }
 }
-
-TestWriter.prototype.write = function(c) {
-  this.buffer.push(c.toString());
-  this.length += c.length;
-  return true;
-};
-
-TestWriter.prototype.end = function(c) {
-  if (c) this.buffer.push(c.toString());
-  this.emit('results', this.buffer);
-};
 
 var r = new FSReadable(file);
 var w = new TestWriter();


### PR DESCRIPTION
I wanted to see how hard it would be to eradicate `util.inherits()` from an existing code base and I figured, having done the work, I might as well PR it.

I did a quick and partial attempt at updating lib/ as well but it makes for _huge_ diffs, plus it breaks code that calls constructors as functions (e.g. `server = http.Server(cb)`.)
```
$ git stash show 
 lib/_debug_agent.js                             | 237 ++++++++++++++++++------------------
 lib/_debugger.js                                | 808 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------------------------------------
 lib/_http_agent.js                              | 460 +++++++++++++++++++++++++++++++++++----------------------------------
 lib/_http_client.js                             | 590 ++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------
 lib/_http_incoming.js                           | 275 +++++++++++++++++++++---------------------
 lib/http.js                                     |  85 ++++++-------
 lib/https.js                                    | 253 +++++++++++++++++++-------------------
 test/parallel/test-http-keepalive-client.js     |   4 +-
 test/parallel/test-http-keepalive-maxsockets.js |   4 +-
 test/parallel/test-http-keepalive-request.js    |   4 +-
 test/parallel/test-https-agent-servername.js    |   2 +-
 test/parallel/test-https-agent-sni.js           |   2 +-
 test/parallel/test-https-agent.js               |   2 +-
 13 files changed, 1347 insertions(+), 1379 deletions(-)
```
CI: https://ci.nodejs.org/job/node-test-pull-request/2477/