### PR TITLE
util: improve perf for format

### DIFF
--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -9,7 +9,8 @@ const bench = common.createBenchmark(main, {
          'number',
          'object',
          'unknown',
-         'no-replace']
+         'no-replace',
+         'no-replace-object']
 });
 
 const inputs = {
@@ -17,7 +18,14 @@ const inputs = {
   'number': ['Hi, I was born in %d', 1942],
   'object': ['An error occurred %j', {msg: 'This is an error', code: 'ERR'}],
   'unknown': ['hello %a', 'test'],
-  'no-replace': [1, 2]
+  'no-replace': [1, 2],
+  'no-replace-object': [{
+    msg: 'This is an object',
+    a: 1,
+    b: true,
+    c: null,
+    d: undefined
+  }, {code: true}]
 };
 
 function main(conf) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,11 +20,12 @@ function tryStringify(arg) {
 
 exports.format = function(f) {
   if (typeof f !== 'string') {
-    const objects = new Array(arguments.length);
+    var out = '';
     for (var index = 0; index < arguments.length; index++) {
-      objects[index] = inspect(arguments[index]);
+      out += inspect(arguments[index]);
+      if (index !== arguments.length - 1) out += ' ';
     }
-    return objects.join(' ');
+    return out;
   }
 
   var argLen = arguments.length;


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

util


##### Description of change

In the event the first argument to util.format is not a string, we were
previously using Array#join. If we switch to string concatenation, we
can improve the performance by (5%-100%). The largest improvement can
be seen when the arguments are primitives that are not strings.

```
$ ./node benchmark/compare.js ./node ./node_before  -- util format
running ./node
util/format.js
running ./node_before
util/format.js

util/format.js n=1000000 type=string: ./node: 8109400 ./node_before: 8075700 ........ 0.42%
util/format.js n=1000000 type=number: ./node: 7745800 ./node_before: 8095700 ....... -4.32%
util/format.js n=1000000 type=object: ./node: 1892000 ./node_before: 1903900 ....... -0.62%
util/format.js n=1000000 type=unknown: ./node: 14278000 ./node_before: 13761000 ..... 3.76%
util/format.js n=1000000 type=no-replace: ./node: 3287200 ./node_before: 1639200 .. 100.54%
util/format.js n=1000000 type=no-replace-object: ./node: 75547 ./node_before: 70183 . 7.64%
```