### PR TITLE
test: fix test-process-exec-argv flakiness

### DIFF
--- a/test/parallel/test-process-exec-argv.js
+++ b/test/parallel/test-process-exec-argv.js
@@ -15,7 +15,7 @@ if (process.argv[2] === 'child') {
     out += chunk;
   });
 
-  child.on('exit', function() {
+  child.on('close', function() {
     assert.deepStrictEqual(JSON.parse(out), execArgv);
   });
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test

##### Description of change

<!-- provide a description of the change below this comment -->

Wait for the `close` event before parsing the child stdout output.

Fixes: https://github.com/nodejs/node/issues/6480

I was able to reproduce the error reported in https://github.com/nodejs/node/issues/6480 in my `OS X` box. This change fixed the issue.