### PR TITLE
Backport #6511 to v4.x: Buffer.indexOf UCS2 fixes

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -827,9 +827,9 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   Local<String> needle = args[1].As<String>();
   const char* haystack = ts_obj_data;
   const size_t haystack_length = ts_obj_length;
-  // Extended latin-1 characters are 2 bytes in Utf8.
+
   const size_t needle_length =
-      enc == BINARY ? needle->Length() : needle->Utf8Length();
+      StringBytes::Size(args.GetIsolate(), needle, enc);
 
 
   if (needle_length == 0 || haystack_length == 0) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -826,7 +826,9 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
 
   Local<String> needle = args[1].As<String>();
   const char* haystack = ts_obj_data;
-  const size_t haystack_length = ts_obj_length;
+  // Round down to the nearest multiple of 2 in case of UCS2.
+  const size_t haystack_length = (enc == UCS2) ?
+      ts_obj_length &~ 1 : ts_obj_length;  // NOLINT(whitespace/operators)
 
   const size_t needle_length =
       StringBytes::Size(args.GetIsolate(), needle, enc);

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -276,7 +276,8 @@ inline uint8_t GetHighestValueByte(uint8_t character) { return character; }
 
 template <typename PatternChar, typename SubjectChar>
 inline size_t FindFirstCharacter(Vector<const PatternChar> pattern,
-                              Vector<const SubjectChar> subject, size_t index) {
+                                 Vector<const SubjectChar> subject,
+                                 size_t index) {
   const PatternChar pattern_first_char = pattern[0];
   const size_t max_n = (subject.length() - pattern.length() + 1);
 

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -233,6 +233,12 @@ var allCharsBufferUcs2 = new Buffer(allCharsString, 'ucs2');
 assert.equal(-1, allCharsBufferUtf8.indexOf('notfound'));
 assert.equal(-1, allCharsBufferUcs2.indexOf('notfound'));
 
+// Needle is longer than haystack, but only because it's encoded as UTF-16
+assert.strictEqual(new Buffer('aaaa').indexOf('a'.repeat(4), 'ucs2'), -1);
+
+assert.strictEqual(new Buffer('aaaa').indexOf('a'.repeat(4), 'utf8'), 0);
+assert.strictEqual(new Buffer('aaaa').indexOf('你好', 'ucs2'), -1);
+
 {
   // Find substrings in Utf8.
   const lengths = [1, 3, 15];  // Single char, simple and complex.

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -239,6 +239,9 @@ assert.strictEqual(new Buffer('aaaa').indexOf('a'.repeat(4), 'ucs2'), -1);
 assert.strictEqual(new Buffer('aaaa').indexOf('a'.repeat(4), 'utf8'), 0);
 assert.strictEqual(new Buffer('aaaa').indexOf('你好', 'ucs2'), -1);
 
+// Haystack has odd length, but the needle is UCS2.
+assert.strictEqual(new Buffer('aaaaa').indexOf('b', 'ucs2'), -1);
+
 {
   // Find substrings in Utf8.
   const lengths = [1, 3, 15];  // Single char, simple and complex.


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Original PR: https://github.com/nodejs/node/pull/6511
See commit descriptions for details, the original PR fixed more than was originally planned.
This is the same content up to `s/Buffer.from/new Buffer/` in the tests and a slightly different whitespace fixup in the last commit (that can safely be left out anyway).