### PR TITLE
tools: lint for use of space in template strings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,6 +83,7 @@ rules:
   no-new-symbol: 2
   no-this-before-super: 2
   prefer-const: 2
+  template-curly-spacing: 2
 
   # Custom rules in tools/eslint-rules
   align-function-arguments: 2


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools

##### Description of change

<!-- provide a description of the change below this comment -->

There are over 70 files in the project using template strings and all of
them have followed the convention of no spaces in curly braces.

Good: `${foo}`

Not used: `${ foo }`

Since the project has adopted a convention, and ESLint has a rule to
enforce exactly this convention, enable the rule.