### PR TITLE
tools: lint for object literal spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,6 +57,7 @@ rules:
   comma-spacing: 2
   eol-last: 2
   indent: [2, 2, {SwitchCase: 1}]
+  key-spacing: [2, {mode: "minimum"}]
   keyword-spacing: 2
   max-len: [2, 80, 2]
   new-parens: 2

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -15,68 +15,68 @@ const httpSocketSetup = common.httpSocketSetup;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 
 const STATUS_CODES = exports.STATUS_CODES = {
-  100 : 'Continue',
-  101 : 'Switching Protocols',
-  102 : 'Processing',                 // RFC 2518, obsoleted by RFC 4918
-  200 : 'OK',
-  201 : 'Created',
-  202 : 'Accepted',
-  203 : 'Non-Authoritative Information',
-  204 : 'No Content',
-  205 : 'Reset Content',
-  206 : 'Partial Content',
-  207 : 'Multi-Status',               // RFC 4918
-  208 : 'Already Reported',
-  226 : 'IM Used',
-  300 : 'Multiple Choices',
-  301 : 'Moved Permanently',
-  302 : 'Found',
-  303 : 'See Other',
-  304 : 'Not Modified',
-  305 : 'Use Proxy',
-  307 : 'Temporary Redirect',
-  308 : 'Permanent Redirect',         // RFC 7238
-  400 : 'Bad Request',
-  401 : 'Unauthorized',
-  402 : 'Payment Required',
-  403 : 'Forbidden',
-  404 : 'Not Found',
-  405 : 'Method Not Allowed',
-  406 : 'Not Acceptable',
-  407 : 'Proxy Authentication Required',
-  408 : 'Request Timeout',
-  409 : 'Conflict',
-  410 : 'Gone',
-  411 : 'Length Required',
-  412 : 'Precondition Failed',
-  413 : 'Payload Too Large',
-  414 : 'URI Too Long',
-  415 : 'Unsupported Media Type',
-  416 : 'Range Not Satisfiable',
-  417 : 'Expectation Failed',
-  418 : 'I\'m a teapot',              // RFC 2324
-  421 : 'Misdirected Request',
-  422 : 'Unprocessable Entity',       // RFC 4918
-  423 : 'Locked',                     // RFC 4918
-  424 : 'Failed Dependency',          // RFC 4918
-  425 : 'Unordered Collection',       // RFC 4918
-  426 : 'Upgrade Required',           // RFC 2817
-  428 : 'Precondition Required',      // RFC 6585
-  429 : 'Too Many Requests',          // RFC 6585
-  431 : 'Request Header Fields Too Large', // RFC 6585
-  451 : 'Unavailable For Legal Reasons',
-  500 : 'Internal Server Error',
-  501 : 'Not Implemented',
-  502 : 'Bad Gateway',
-  503 : 'Service Unavailable',
-  504 : 'Gateway Timeout',
-  505 : 'HTTP Version Not Supported',
-  506 : 'Variant Also Negotiates',    // RFC 2295
-  507 : 'Insufficient Storage',       // RFC 4918
-  508 : 'Loop Detected',
-  509 : 'Bandwidth Limit Exceeded',
-  510 : 'Not Extended',               // RFC 2774
-  511 : 'Network Authentication Required' // RFC 6585
+  100: 'Continue',
+  101: 'Switching Protocols',
+  102: 'Processing',                 // RFC 2518, obsoleted by RFC 4918
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  203: 'Non-Authoritative Information',
+  204: 'No Content',
+  205: 'Reset Content',
+  206: 'Partial Content',
+  207: 'Multi-Status',               // RFC 4918
+  208: 'Already Reported',
+  226: 'IM Used',
+  300: 'Multiple Choices',
+  301: 'Moved Permanently',
+  302: 'Found',
+  303: 'See Other',
+  304: 'Not Modified',
+  305: 'Use Proxy',
+  307: 'Temporary Redirect',
+  308: 'Permanent Redirect',         // RFC 7238
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  406: 'Not Acceptable',
+  407: 'Proxy Authentication Required',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  411: 'Length Required',
+  412: 'Precondition Failed',
+  413: 'Payload Too Large',
+  414: 'URI Too Long',
+  415: 'Unsupported Media Type',
+  416: 'Range Not Satisfiable',
+  417: 'Expectation Failed',
+  418: 'I\'m a teapot',              // RFC 2324
+  421: 'Misdirected Request',
+  422: 'Unprocessable Entity',       // RFC 4918
+  423: 'Locked',                     // RFC 4918
+  424: 'Failed Dependency',          // RFC 4918
+  425: 'Unordered Collection',       // RFC 4918
+  426: 'Upgrade Required',           // RFC 2817
+  428: 'Precondition Required',      // RFC 6585
+  429: 'Too Many Requests',          // RFC 6585
+  431: 'Request Header Fields Too Large', // RFC 6585
+  451: 'Unavailable For Legal Reasons',
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  505: 'HTTP Version Not Supported',
+  506: 'Variant Also Negotiates',    // RFC 2295
+  507: 'Insufficient Storage',       // RFC 4918
+  508: 'Loop Detected',
+  509: 'Bandwidth Limit Exceeded',
+  510: 'Not Extended',               // RFC 2774
+  511: 'Network Authentication Required' // RFC 6585
 };
 
 const kOnExecute = HTTPParser.kOnExecute | 0;

--- a/lib/util.js
+++ b/lib/util.js
@@ -151,19 +151,19 @@ exports.inspect = inspect;
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
 inspect.colors = {
-  'bold' : [1, 22],
-  'italic' : [3, 23],
-  'underline' : [4, 24],
-  'inverse' : [7, 27],
-  'white' : [37, 39],
-  'grey' : [90, 39],
-  'black' : [30, 39],
-  'blue' : [34, 39],
-  'cyan' : [36, 39],
-  'green' : [32, 39],
-  'magenta' : [35, 39],
-  'red' : [31, 39],
-  'yellow' : [33, 39]
+  'bold': [1, 22],
+  'italic': [3, 23],
+  'underline': [4, 24],
+  'inverse': [7, 27],
+  'white': [37, 39],
+  'grey': [90, 39],
+  'black': [30, 39],
+  'blue': [34, 39],
+  'cyan': [36, 39],
+  'green': [32, 39],
+  'magenta': [35, 39],
+  'red': [31, 39],
+  'yellow': [33, 39]
 };
 
 // Don't use 'blue' not visible on cmd.exe

--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -17,7 +17,7 @@ var testData = [
       'source': 'foo',
       'modules': [ { 'textRaw': 'Sample Markdown',
         'name': 'sample_markdown',
-        'modules': [ { 'textRaw':'Seussian Rhymes',
+        'modules': [ { 'textRaw': 'Seussian Rhymes',
           'name': 'seussian_rhymes',
           'desc': '<ol>\n<li>fish</li>\n<li><p>fish</p>\n</li>\n<li>' +
                   '<p>Red fish</p>\n</li>\n<li>Blue fish</li>\n</ol>\n',
@@ -32,7 +32,7 @@ var testData = [
   {
     'file': common.fixturesDir + '/order_of_end_tags_5873.md',
     'json': {
-      'source':'foo',
+      'source': 'foo',
       'modules': [ {
         'textRaw': 'Title',
         'name': 'title',
@@ -41,8 +41,8 @@ var testData = [
           'name': 'subsection',
           'classMethods': [ {
             'textRaw': 'Class Method: Buffer.from(array)',
-            'type':'classMethod',
-            'name':'from',
+            'type': 'classMethod',
+            'name': 'from',
             'signatures': [ {
               'params': [ {
                 'textRaw': '`array` {Array} ',
@@ -51,7 +51,7 @@ var testData = [
               } ]
             },
               {
-                'params' : [ {
+                'params': [ {
                   'name': 'array'
                 } ]
               }

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -66,8 +66,8 @@ console.warn(custom_inspect);
 // test console.dir()
 console.dir(custom_inspect);
 console.dir(custom_inspect, { showHidden: false });
-console.dir({ foo : { bar : { baz : true } } }, { depth: 0 });
-console.dir({ foo : { bar : { baz : true } } }, { depth: 1 });
+console.dir({ foo: { bar: { baz: true } } }, { depth: 0 });
+console.dir({ foo: { bar: { baz: true } } }, { depth: 1 });
 
 // test console.trace()
 console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -30,19 +30,19 @@ var rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
 
 // PFX tests
 assert.doesNotThrow(function() {
-  tls.createSecureContext({pfx:certPfx, passphrase:'sample'});
+  tls.createSecureContext({pfx: certPfx, passphrase: 'sample'});
 });
 
 assert.throws(function() {
-  tls.createSecureContext({pfx:certPfx});
+  tls.createSecureContext({pfx: certPfx});
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx:certPfx, passphrase:'test'});
+  tls.createSecureContext({pfx: certPfx, passphrase: 'test'});
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx:'sample', passphrase:'test'});
+  tls.createSecureContext({pfx: 'sample', passphrase: 'test'});
 }, 'not enough data');
 
 // Test HMAC

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -32,19 +32,19 @@ assert.throws(function() {
 
 // PFX tests
 assert.doesNotThrow(function() {
-  tls.createSecureContext({pfx:certPfx, passphrase:'sample'});
+  tls.createSecureContext({pfx: certPfx, passphrase: 'sample'});
 });
 
 assert.throws(function() {
-  tls.createSecureContext({pfx:certPfx});
+  tls.createSecureContext({pfx: certPfx});
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx:certPfx, passphrase:'test'});
+  tls.createSecureContext({pfx: certPfx, passphrase: 'test'});
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx:'sample', passphrase:'test'});
+  tls.createSecureContext({pfx: 'sample', passphrase: 'test'});
 }, 'not enough data');
 
 

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -20,7 +20,7 @@ var server = http.createServer(function(req, res) {
     serverCaught++;
     console.log('horray! got a server error', er);
     // try to send a 500.  If that fails, oh well.
-    res.writeHead(500, {'content-type':'text/plain'});
+    res.writeHead(500, {'content-type': 'text/plain'});
     res.end(er.stack || er.message || 'Unknown error');
   });
 

--- a/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -29,7 +29,7 @@ if (process.argv[2] === 'child') {
   var fork = require('child_process').fork;
   var assert = require('assert');
 
-  var child = fork(process.argv[1], ['child'], {silent:true});
+  var child = fork(process.argv[1], ['child'], {silent: true});
   var stderrOutput = '';
   if (child) {
     child.stderr.on('data', function onStderrData(data) {

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -11,7 +11,7 @@ if (process.argv[2] === 'request') {
   const http = require('http');
   const options = {
     port: common.PORT,
-    path : '/'
+    path: '/'
   };
 
   http.get(options, (res) => {

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -18,7 +18,7 @@ common.refreshTmpDir();
 server.listen(common.PIPE, function() {
   var req = http.request({
     socketPath: common.PIPE,
-    headers: {'Content-Length':'1'},
+    headers: {'Content-Length': '1'},
     method: 'POST',
     path: '/'
   });

--- a/test/parallel/test-http-client-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-client-reject-chunked-with-content-length.js
@@ -17,7 +17,7 @@ server.listen(common.PORT, () => {
   // The callback should not be called because the server is sending
   // both a Content-Length header and a Transfer-Encoding: chunked
   // header, which is a violation of the HTTP spec.
-  const req = http.get({port:common.PORT}, (res) => {
+  const req = http.get({port: common.PORT}, (res) => {
     assert.fail(null, null, 'callback should not be called');
   });
   req.on('error', common.mustCall((err) => {

--- a/test/parallel/test-http-client-reject-cr-no-lf.js
+++ b/test/parallel/test-http-client-reject-cr-no-lf.js
@@ -16,7 +16,7 @@ const server = net.createServer((socket) => {
 server.listen(common.PORT, () => {
   // The callback should not be called because the server is sending a
   // header field that ends only in \r with no following \n
-  const req = http.get({port:common.PORT}, (res) => {
+  const req = http.get({port: common.PORT}, (res) => {
     assert.fail(null, null, 'callback should not be called');
   });
   req.on('error', common.mustCall((err) => {

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -34,7 +34,7 @@ function test() {
 
   var req = http.get({
     socketPath: common.PIPE,
-    headers: {'Content-Length':'1'},
+    headers: {'Content-Length': '1'},
     method: 'POST',
     path: '/'
   });

--- a/test/parallel/test-http-client-timeout-with-data.js
+++ b/test/parallel/test-http-client-timeout-with-data.js
@@ -19,7 +19,7 @@ const options = {
 };
 
 const server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Length':'2'});
+  res.writeHead(200, {'Content-Length': '2'});
   res.write('*');
   setTimeout(function() { res.end('*'); }, common.platformTimeout(100));
 });

--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -13,8 +13,8 @@ function handler(req, res) {
   assert.equal(sent_continue, true, 'Full response sent before 100 Continue');
   console.error('Server sending full response...');
   res.writeHead(200, {
-    'Content-Type' : 'text/plain',
-    'ABCD' : '1'
+    'Content-Type': 'text/plain',
+    'ABCD': '1'
   });
   res.end(test_res_body);
 }

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -30,7 +30,7 @@ process.on('exit', function() {
 server.listen(common.PORT, function() {
   http.get({ port: common.PORT }, function(res) {
     assert.equal(200, res.statusCode);
-    assert.deepStrictEqual(res.headers, { date : 'coffee o clock' });
+    assert.deepStrictEqual(res.headers, { date: 'coffee o clock' });
 
     res.setEncoding('ascii');
     res.on('data', function(chunk) {

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -33,7 +33,7 @@ server.listen(common.PORT, common.mustCall(() => {
     // case, the error handler must be called because the client
     // is not allowed to accept multiple content-length headers.
     http.get(
-      {port:common.PORT, headers:{'x-num': n}},
+      {port: common.PORT, headers: {'x-num': n}},
       (res) => {
         assert(false, 'client allowed multiple content-length headers.');
       }

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -56,7 +56,7 @@ server.listen(common.PORT, common.mustCall(function() {
     // value should be reported for the header fields listed
     // in the norepeat array.
     http.get(
-      {port:common.PORT, headers:{'x-num': n}},
+      {port: common.PORT, headers: {'x-num': n}},
       common.mustCall(function(res) {
         if (++count === 2) server.close();
         for (const name of norepeat) {

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -29,12 +29,12 @@ const server = http.createServer((req, res) => {
       break;
     case 1:
       assert.throws(common.mustCall(() => {
-        res.writeHead(200, {'foo' : x});
+        res.writeHead(200, {'foo': x});
       }));
       break;
     case 2:
       assert.throws(common.mustCall(() => {
-        res.writeHead(200, {'foo' : y});
+        res.writeHead(200, {'foo': y});
       }));
       break;
     default:

--- a/test/parallel/test-http-server-multiheaders.js
+++ b/test/parallel/test-http-server-multiheaders.js
@@ -18,7 +18,7 @@ var srv = http.createServer(function(req, res) {
   assert.equal(req.headers['sec-websocket-extensions'], 'foo; 1, bar; 2, baz');
   assert.equal(req.headers['constructor'], 'foo, bar, baz');
 
-  res.writeHead(200, {'Content-Type' : 'text/plain'});
+  res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end('EOF');
 
   srv.close();

--- a/test/parallel/test-http-server-multiheaders2.js
+++ b/test/parallel/test-http-server-multiheaders2.js
@@ -58,7 +58,7 @@ var srv = http.createServer(function(req, res) {
                  'foo, bar', 'header parsed incorrectly: ' + header);
   });
 
-  res.writeHead(200, {'Content-Type' : 'text/plain'});
+  res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end('EOF');
 
   srv.close();

--- a/test/parallel/test-http-server-reject-cr-no-lf.js
+++ b/test/parallel/test-http-server-reject-cr-no-lf.js
@@ -20,7 +20,7 @@ server.on('clientError', common.mustCall((err) => {
   server.close();
 }));
 server.listen(common.PORT, () => {
-  const client = net.connect({port:common.PORT}, () => {
+  const client = net.connect({port: common.PORT}, () => {
     client.on('data', (chunk) => {
       assert.fail(null, null, 'this should not be called');
     });

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -9,8 +9,8 @@ process.on('exit', function() {
   assert.equal(gotError, 2);
 });
 
-net.createServer(common.fail).listen({fd:2}).on('error', onError);
-net.createServer(common.fail).listen({fd:42}).on('error', onError);
+net.createServer(common.fail).listen({fd: 2}).on('error', onError);
+net.createServer(common.fail).listen({fd: 42}).on('error', onError);
 
 function onError(ex) {
   assert.equal(ex.code, 'EINVAL');

--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -10,7 +10,7 @@ process.on('exit', function() {
 });
 
 // this should fail with an async EINVAL error, not throw an exception
-net.createServer(common.fail).listen({fd:0}).on('error', function(e) {
+net.createServer(common.fail).listen({fd: 0}).on('error', function(e) {
   switch (e.code) {
     case 'EINVAL':
     case 'ENOTSOCK':

--- a/test/parallel/test-stream-transform-split-objectmode.js
+++ b/test/parallel/test-stream-transform-split-objectmode.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 var Transform = require('stream').Transform;
 
-var parser = new Transform({ readableObjectMode : true });
+var parser = new Transform({ readableObjectMode: true });
 
 assert(parser._readableState.objectMode);
 assert(!parser._writableState.objectMode);
@@ -12,7 +12,7 @@ assert(parser._readableState.highWaterMark === 16);
 assert(parser._writableState.highWaterMark === (16 * 1024));
 
 parser._transform = function(chunk, enc, callback) {
-  callback(null, { val : chunk[0] });
+  callback(null, { val: chunk[0] });
 };
 
 var parsed;
@@ -28,7 +28,7 @@ process.on('exit', function() {
 });
 
 
-var serializer = new Transform({ writableObjectMode : true });
+var serializer = new Transform({ writableObjectMode: true });
 
 assert(!serializer._readableState.objectMode);
 assert(serializer._writableState.objectMode);
@@ -45,7 +45,7 @@ serializer.on('data', function(chunk) {
   serialized = chunk;
 });
 
-serializer.write({ val : 42 });
+serializer.write({ val: 42 });
 
 process.on('exit', function() {
   assert(serialized[0] === 42);

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -267,7 +267,7 @@ test('assymetric transform (compress)', function(t) {
 test('complex transform', function(t) {
   var count = 0;
   var saved = null;
-  var pt = new Transform({highWaterMark:3});
+  var pt = new Transform({highWaterMark: 3});
   pt._transform = function(c, e, cb) {
     if (count++ === 1)
       saved = c;

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -29,7 +29,7 @@ function loadPEM(n) {
 var server = tls.Server({
   secureProtocol: 'TLSv1_2_server_method',
   key: loadPEM('agent2-key'),
-  cert:loadPEM('agent2-cert')
+  cert: loadPEM('agent2-cert')
 }, null).listen(common.PORT, function() {
   var args = ['s_client', '-quiet', '-tls1_1',
               '-connect', '127.0.0.1:' + common.PORT];

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -284,7 +284,7 @@ function Test7() {
                               client: {ALPN: false, NPN: false}});
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN:  'first-priority-unsupported'},
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
                   client: {ALPN: false, NPN: false}});
     // execute next test
     Test8();
@@ -308,7 +308,7 @@ function Test8() {
                               client: {ALPN: false, NPN: false}});
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN:  'http/1.1'},
+                 {server: {ALPN: false, NPN: 'http/1.1'},
                   client: {ALPN: false, NPN: false}});
     // execute next test
     Test9();

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -822,7 +822,7 @@ var parseTests = {
     query: '@c'
   },
 
-  'http://a\r" \t\n<\'b:b@c\r\nd/e?f':{
+  'http://a\r" \t\n<\'b:b@c\r\nd/e?f': {
     protocol: 'http:',
     slashes: true,
     auth: 'a\r" \t\n<\'b:b',
@@ -1129,7 +1129,7 @@ var formatTests = {
 
   // `#`,`?` in path
   '/path/to/%%23%3F+=&.txt?foo=theA1#bar': {
-    href : '/path/to/%%23%3F+=&.txt?foo=theA1#bar',
+    href: '/path/to/%%23%3F+=&.txt?foo=theA1#bar',
     pathname: '/path/to/%#?+=&.txt',
     query: {
       foo: 'theA1'
@@ -1139,7 +1139,7 @@ var formatTests = {
 
   // `#`,`?` in path + `#` in query
   '/path/to/%%23%3F+=&.txt?foo=the%231#bar': {
-    href : '/path/to/%%23%3F+=&.txt?foo=the%231#bar',
+    href: '/path/to/%%23%3F+=&.txt?foo=the%231#bar',
     pathname: '/path/to/%#?+=&.txt',
     query: {
       foo: 'the#1'

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -76,10 +76,10 @@ assert.equal(false, util.isBuffer('foo'));
 assert.equal(true, util.isBuffer(Buffer.from('foo')));
 
 // _extend
-assert.deepStrictEqual(util._extend({a:1}),             {a:1});
-assert.deepStrictEqual(util._extend({a:1}, []),         {a:1});
-assert.deepStrictEqual(util._extend({a:1}, null),       {a:1});
-assert.deepStrictEqual(util._extend({a:1}, true),       {a:1});
-assert.deepStrictEqual(util._extend({a:1}, false),      {a:1});
-assert.deepStrictEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
-assert.deepStrictEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});
+assert.deepStrictEqual(util._extend({a: 1}), {a: 1});
+assert.deepStrictEqual(util._extend({a: 1}, []), {a: 1});
+assert.deepStrictEqual(util._extend({a: 1}, null), {a: 1});
+assert.deepStrictEqual(util._extend({a: 1}, true), {a: 1});
+assert.deepStrictEqual(util._extend({a: 1}, false), {a: 1});
+assert.deepStrictEqual(util._extend({a: 1}, {b: 2}), {a: 1, b: 2});
+assert.deepStrictEqual(util._extend({a: 1, b: 2}, {b: 3}), {a: 1, b: 3});

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -52,7 +52,7 @@ console.error('test RegExp as argument to assert.throws');
 script = vm.createScript('var assert = require(\'assert\'); assert.throws(' +
                          'function() { throw "hello world"; }, /hello/);',
                          'some.js');
-script.runInNewContext({ require : require });
+script.runInNewContext({ require: require });
 
 // Issue GH-7529
 script = vm.createScript('delete b');

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -19,14 +19,14 @@ assert.throws(function() {
 });
 
 var hashes = {
-  modp1 : '630e9acd2cc63f7e80d8507624ba60ac0757201a',
-  modp2 : '18f7aa964484137f57bca64b21917a385b6a0b60',
-  modp5 : 'c0a8eec0c2c8a5ec2f9c26f9661eb339a010ec61',
-  modp14 : 'af5455606fe74cec49782bb374e4c63c9b1d132c',
-  modp15 : '7bdd39e5cdbb9748113933e5c2623b559c534e74',
-  modp16 : 'daea5277a7ad0116e734a8e0d2f297ef759d1161',
-  modp17 : '3b62aaf0142c2720f0bf26a9589b0432c00eadc1',
-  modp18 : 'a870b491bbbec9b131ae9878d07449d32e54f160'
+  modp1: '630e9acd2cc63f7e80d8507624ba60ac0757201a',
+  modp2: '18f7aa964484137f57bca64b21917a385b6a0b60',
+  modp5: 'c0a8eec0c2c8a5ec2f9c26f9661eb339a010ec61',
+  modp14: 'af5455606fe74cec49782bb374e4c63c9b1d132c',
+  modp15: '7bdd39e5cdbb9748113933e5c2623b559c534e74',
+  modp16: 'daea5277a7ad0116e734a8e0d2f297ef759d1161',
+  modp17: '3b62aaf0142c2720f0bf26a9589b0432c00eadc1',
+  modp18: 'a870b491bbbec9b131ae9878d07449d32e54f160'
 };
 
 for (const name in hashes) {

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -16,7 +16,7 @@ catch (e) {
   // swallow
 }
 
-fs.watchFile(FILENAME, {interval:TIMEOUT - 250}, function(curr, prev) {
+fs.watchFile(FILENAME, {interval: TIMEOUT - 250}, function(curr, prev) {
   console.log([curr, prev]);
   switch (++nevents) {
     case 1:

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -119,7 +119,7 @@ assert.throws(function() {
 oldhandle.close(); // clean up
 
 assert.throws(function() {
-  var w = fs.watchFile(__filename, {persistent:false}, function() {});
+  var w = fs.watchFile(__filename, {persistent: false}, function() {});
   oldhandle = w._handle;
   w._handle = { stop: w._handle.stop };
   w.stop();

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -152,7 +152,7 @@ function parseLists(input) {
       if (tok.type === 'list_start') {
         state = 'LIST';
         if (depth === 0) {
-          output.push({ type:'html', text: '<div class="signature">' });
+          output.push({ type: 'html', text: '<div class="signature">' });
         }
         depth++;
         output.push(tok);
@@ -176,7 +176,7 @@ function parseLists(input) {
         output.push(tok);
         if (depth === 0) {
           state = null;
-          output.push({ type:'html', text: '</div>' });
+          output.push({ type: 'html', text: '</div>' });
         }
         return;
       }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools lib test

##### Description of change

<!-- provide a description of the change below this comment -->

There have been occasional nits for spacing in object literals in PRs but
the project does not lint for it and it is not always handled
consistently in the existing code, even on adjacent lines of a file.

This change enables a linting rule requiring no space between the key
and the colon, and requiring at least one space (but allowing for more
so property values can be lined up if desired) between the colon and the
value. This appears to be the most common style used in the current code
base.

Example code the complies with lint rule:

    myObj = { foo: 'bar' };

Examples that do not comply with the lint rule:

    myObj = { foo : 'bar' };
    myObj = { foo:'bar' };