### PR TITLE
src,lib: minor --debug-brk cleanup

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -136,7 +136,7 @@
 
         preloadModules();
 
-        if (global.v8debug &&
+        if (process._debugWaitConnect &&
             process.execArgv.some(function(arg) {
               return arg.match(/^--debug-brk(=[0-9]*)?$/);
             })) {
@@ -149,7 +149,7 @@
           // breakpoint message on line 1.
           //
           // A better fix would be to somehow get a message from the
-          // global.v8debug object about a connection, and runMain when
+          // V8 debug object about a connection, and runMain when
           // that occurs.  --isaacs
 
           var debugTimeout = +process.env.NODE_DEBUG_TIMEOUT || 50;

--- a/lib/module.js
+++ b/lib/module.js
@@ -4,7 +4,7 @@ const NativeModule = require('native_module');
 const util = require('util');
 const internalModule = require('internal/module');
 const internalUtil = require('internal/util');
-const runInThisContext = require('vm').runInThisContext;
+const vm = require('vm');
 const assert = require('assert').ok;
 const fs = require('fs');
 const path = require('path');
@@ -508,13 +508,13 @@ Module.prototype._compile = function(content, filename) {
   // create wrapper function
   var wrapper = Module.wrap(content);
 
-  var compiledWrapper = runInThisContext(wrapper, {
+  var compiledWrapper = vm.runInThisContext(wrapper, {
     filename: filename,
     lineOffset: 0,
     displayErrors: true
   });
 
-  if (global.v8debug) {
+  if (process._debugWaitConnect) {
     if (!resolvedArgv) {
       // we enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
@@ -526,11 +526,9 @@ Module.prototype._compile = function(content, filename) {
 
     // Set breakpoint on module start
     if (filename === resolvedArgv) {
-      // Installing this dummy debug event listener tells V8 to start
-      // the debugger.  Without it, the setBreakPoint() fails with an
-      // 'illegal access' error.
-      global.v8debug.Debug.setListener(function() {});
-      global.v8debug.Debug.setBreakPoint(compiledWrapper, 0, 0);
+      delete process._debugWaitConnect;
+      const Debug = vm.runInDebugContext('Debug');
+      Debug.setBreakPoint(compiledWrapper, 0, 0);
     }
   }
   var dirname = path.dirname(filename);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3179,6 +3179,11 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
   }
 
+  // --debug-brk
+  if (debug_wait_connect) {
+    READONLY_PROPERTY(process, "_debugWaitConnect", True(env->isolate()));
+  }
+
   // --security-revert flags
 #define V(code, _, __)                                                        \
   do {                                                                        \
@@ -4085,11 +4090,6 @@ void Init(int* argc,
 
   if (v8_argc > 1) {
     exit(9);
-  }
-
-  if (debug_wait_connect) {
-    const char expose_debug_as[] = "--expose_debug_as=v8debug";
-    V8::SetFlagsFromString(expose_debug_as, sizeof(expose_debug_as) - 1);
   }
 
   // Unconditionally force typed arrays to allocate outside the v8 heap. This


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
src,lib

##### Description of change

<!-- provide a description of the change below this comment -->

Minor cleanup of how --debug-brk works:
* We no longer need to use command line flags to expose the debug
  object.
* Do not depend on the existence of global.v8debug as a mechanism to
  determine if --debug-brk was specified.  ~~We may overwrite the debug
  listener with the dummy listener when --expose-debug-as=v8debug
  was otherwise present on the command line.~~
* We no longer need to set a dummy listener with --debug-brk.

This in anticipation of an upcoming PR with v8-inspector support.

R=@bnoordhuis
/cc @eugeneo