### PR TITLE
win, build: add node.lib file into headers package

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -140,8 +140,12 @@ def headers(action):
   ], 'include/node/')
 
   # Add the expfile that is created on AIX
-  if sys.platform.startswith('aix'):
+  if os.isfile('out/Release/node.exp'):
     action(['out/Release/node.exp'], 'include/node/')
+
+  # Add the x64 windows libfile
+  if os.isfile('Release/node.lib'):
+    action(['Release/node.lib'], 'include/node/')
 
   subdir_files('deps/v8/include', 'include/node/', action)
 

--- a/tools/install.py
+++ b/tools/install.py
@@ -140,11 +140,11 @@ def headers(action):
   ], 'include/node/')
 
   # Add the expfile that is created on AIX
-  if os.isfile('out/Release/node.exp'):
+  if os.path.isfile('out/Release/node.exp'):
     action(['out/Release/node.exp'], 'include/node/')
 
   # Add the x64 windows libfile
-  if os.isfile('Release/node.lib'):
+  if os.path.isfile('Release/node.lib'):
     action(['Release/node.lib'], 'include/node/')
 
   subdir_files('deps/v8/include', 'include/node/', action)

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -23,6 +23,7 @@ set nosnapshot=
 set test_args=
 set msi=
 set upload=
+set tar_headers=
 set licensertf=
 set jslint=
 set buildnodeweak=
@@ -55,6 +56,7 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
+if /i "%1"=="tar-headers"   set tar_headers=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% addons doctool known_issues message parallel sequential -J&set jslint=1&set build_addons=1&goto arg-ok
 if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap addons doctool known_issues message sequential parallel&set build_addons=1&goto arg-ok
 if /i "%1"=="test-addons"   set test_args=%test_args% addons&set build_addons=1&goto arg-ok
@@ -246,6 +248,17 @@ ssh -F %SSHCONFIG% %STAGINGSERVER% "touch nodejs/%DISTTYPEDIR%/v%FULLVERSION%/no
 :run
 @rem Run tests if requested.
 
+:tar-headers
+@rem build headers package
+if "%tar_headers%"=="" goto build-node-weak
+set HEADERS_ONLY=1
+set TARNAME=node-%FULLVERSION%
+python tools\install.py install %TARNAME% ""
+7z a %TARNAME%-headers.tar %TARNAME%
+rmdir /s /q %TARNAME%
+7z a %TARNAME%-headers.tar.gz %TARNAME%-headers.tar
+del %TARNAME%-headers.tar
+
 :build-node-weak
 @rem Build node-weak if required
 if "%buildnodeweak%"=="" goto build-addons
@@ -316,6 +329,7 @@ echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build
 echo   vcbuild.bat release msi    : builds release build and MSI installer package
+echo   vcbuild.bat tar-headers    : builds header package with node.lib
 echo   vcbuild.bat test           : builds debug build and runs tests
 echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
 echo   vcbuild.bat enable-vtune   : builds nodejs with Intel VTune profiling support to profile JavaScript


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

build (win)
##### Description of change

This PR makes two changes. 
- It changes the headers function in `tools/install.py` so that it includes AIX's `out/Release/node.exp` and Windows `Release/node.lib` if those files exist.
- It adds a `vcbuild.bat tar-headers` option to vcbuild.bat that does the same as `make tar-headers`.
##### Issues/Comments
- AFAIK, the primary purpose of the headers package is to facilitate building native modules, which for windows requires a node.lib, and for AIX requires a node.exp.
- It would be possible to include the node.lib and node.exp files when building on Linux (or OSX) by copying the node.lib file into `Release/node.lib` before running `make tar-headers`.
- As I understand - e.g. from https://github.com/nodejs/node/issues/4932#issuecomment-205483725 - building native modules on windows can also require things from Release\lib (e.g. openssl.lib). I suspect it would be impractical to include these in the headers package due to their size:

```
6.1M    cares.lib
13M     gtest.lib
116K    http_parser.lib
1.8M    icudata.lib
29M     icui18n.lib
8.0K    icustubdata.lib
54M     icutools.lib
16M     icuucx.lib
5.4M    libuv.lib
71M     openssl.lib
740K    zlib.lib
```
- At the moment everything is put into the `node-7.0.0/include/node` directory, it might make sense to put the .exp and .lib files in a different directory, e.g. `node-7.0.0/lib`.
- A limitation of this approach is that only one node.lib would be included (x64 or x86, depending which version of node had been built).
- I'm not sure whether the tar-headers process is documented anywhere, if it is I should probably update the documentation.

Related: https://github.com/nodejs/node/pull/6274#issuecomment-213707169
