### PR TITLE
test: multiple cas works in any order

### DIFF
--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const common = require('../common');
 const tls = require('tls');
 const fs = require('fs');
@@ -13,23 +14,37 @@ const cert =
 const key =
     fs.readFileSync(`${common.fixturesDir}/keys/agent3-key.pem`, 'utf8');
 
-function test(ca, next) {
-  const server = tls.createServer({ ca, cert, key }, function(conn) {
-    this.close();
-    conn.end();
+
+function test(ca) {
+  return new Promise(function(resolve, reject) {
+    const server = tls.createServer(function(conn) {
+      this.close();
+      conn.end();
+    });
+
+    server.addContext('agent3', { ca, cert, key });
+
+    const host = common.localhostIPv4;
+    const port = common.PORT;
+    server.listen(port, host, function() {
+      var socket = tls.connect({ servername: 'agent3', host, port, ca });
+      var socketError = false;
+      socket.on('error', (e) => { socketError = e; });
+      server.once('close',
+                  (e) => {
+                    return socketError ? reject(socketError) : resolve();
+                  });
+    });
   });
-
-  server.addContext('agent3', { ca, cert, key });
-
-  const host = common.localhostIPv4;
-  const port = common.PORT;
-  server.listen(port, host, function() {
-    tls.connect({ servername: 'agent3', host, port, ca });
-  });
-
-  server.once('close', next);
 }
 
-const array = [ca1, ca2];
-const string = ca1 + '\n' + ca2;
-test(array, () => test(string, () => {}));
+test(ca1 + '\n' + ca2)
+  .then(test.bind(null, ca2 + '\n' + ca1))
+  .then(test.bind(null, ca1 + ca2))
+  .then(test.bind(null, ca2 + ca1))
+  .then(test.bind(null, [ca1, ca2]))
+  .then(test.bind(null, [ca2, ca1]));
+
+process.on('unhandledRejection', function(reason) {
+  assert.fail(null, null, reason);
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change

<!-- provide a description of the change below this comment -->

if the valid `ca` is the first item within the concatenated string
then the bug addressed by #4099 was not getting exposed. This test
makes sure the order of valid `ca` should not effect the expected
behaviour when multiple `ca` certs are concatenated.