### PR TITLE
test: allow out-of-order replies in dgram tests

### DIFF
--- a/test/parallel/test-dgram-udp6-send-default-host.js
+++ b/test/parallel/test-dgram-udp6-send-default-host.js
@@ -11,26 +11,31 @@ if (!common.hasIPv6) {
 
 const client = dgram.createSocket('udp6');
 
-const toSend = [new Buffer(256), new Buffer(256), new Buffer(256), 'hello'];
+const toSend = [Buffer.alloc(256, 'x'),
+                Buffer.alloc(256, 'y'),
+                Buffer.alloc(256, 'z'),
+                'hello'];
 
-toSend[0].fill('x');
-toSend[1].fill('y');
-toSend[2].fill('z');
+const received = [];
 
-client.on('listening', function() {
+client.on('listening', common.mustCall(() => {
   client.send(toSend[0], 0, toSend[0].length, common.PORT);
   client.send(toSend[1], common.PORT);
   client.send([toSend[2]], common.PORT);
   client.send(toSend[3], 0, toSend[3].length, common.PORT);
-});
+}));
 
-client.on('message', function(buf, info) {
-  const expected = toSend.shift().toString();
-  assert.ok(buf.toString() === expected, 'message was received correctly');
+client.on('message', common.mustCall((buf, info) => {
+  received.push(buf.toString());
 
-  if (toSend.length === 0) {
+  if (received.length === toSend.length) {
+    // The replies may arrive out of order -> sort them before checking.
+    received.sort();
+
+    const expected = toSend.map(String).sort();
+    assert.deepStrictEqual(received, expected);
     client.close();
   }
-});
+}, toSend.length));
 
 client.bind(common.PORT);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

test, dgram

##### Description of change

Allow out of order replies in the flaky `test-dgram{-upd6,}-send-default-host.js` files by sorting the incoming replies after receiving them.

Fixes: https://github.com/nodejs/node/issues/6577

/cc @Trott @santigimeno 