### PR TITLE
doc: add `added:` information for os

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -7,16 +7,25 @@ Provides a few basic operating-system related utility functions.
 Use `require('os')` to access this module.
 
 ## os.EOL
+<!-- YAML
+added: v0.7.8
+-->
 
 A constant defining the appropriate End-of-line marker for the operating
 system.
 
 ## os.arch()
+<!-- YAML
+added: v0.5.0
+-->
 
 Returns the operating system CPU architecture. Possible values are `'x64'`,
 `'arm'` and `'ia32'`. Returns the value of [`process.arch`][].
 
 ## os.cpus()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns an array of objects containing information about each CPU/core
 installed: model, speed (in MHz), and times (an object containing the number of
@@ -95,23 +104,38 @@ Note that since `nice` values are UNIX centric in Windows the `nice` values of
 all processors are always 0.
 
 ## os.endianness()
+<!-- YAML
+added: v0.9.4
+-->
 
 Returns the endianness of the CPU. Possible values are `'BE'` for big endian
 or `'LE'` for little endian.
 
 ## os.freemem()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns the amount of free system memory in bytes.
 
 ## os.homedir()
+<!-- YAML
+added: v2.3.0
+-->
 
 Returns the home directory of the current user.
 
 ## os.hostname()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns the hostname of the operating system.
 
 ## os.loadavg()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns an array containing the 1, 5, and 15 minute load averages.
 
@@ -124,6 +148,9 @@ Windows platforms.  That is why this function always returns `[0, 0, 0]` on
 Windows.
 
 ## os.networkInterfaces()
+<!-- YAML
+added: v0.6.0
+-->
 
 Get a list of network interfaces:
 
@@ -156,33 +183,54 @@ Note that due to the underlying implementation this will only return network
 interfaces that have been assigned an address.
 
 ## os.platform()
+<!-- YAML
+added: v0.5.0
+-->
 
 Returns the operating system platform. Possible values are `'darwin'`,
 `'freebsd'`, `'linux'`, `'sunos'` or `'win32'`. Returns the value of
 [`process.platform`][].
 
 ## os.release()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns the operating system release.
 
 ## os.tmpdir()
+<!-- YAML
+added: v0.9.9
+-->
 
 Returns the operating system's default directory for temporary files.
 
 ## os.totalmem()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns the total amount of system memory in bytes.
 
 ## os.type()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns the operating system name. For example `'Linux'` on Linux, `'Darwin'`
 on OS X and `'Windows_NT'` on Windows.
 
 ## os.uptime()
+<!-- YAML
+added: v0.3.3
+-->
 
 Returns the system uptime in seconds.
 
 ## os.userInfo([options])
+<!-- YAML
+added: v6.0.0
+-->
 
 * `options` {Object}
   * `encoding` {String} Character encoding used to interpret resulting strings.


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc


##### Description of change

Add `added:` information for os.

Via git spelunking, mostly.
Some functions have been renamed. Used the version in which they were
renamed.

Ref: https://github.com/nodejs/node/issues/6578