### PR TITLE
test: make sure O_NOATIME is present only in Linux

### DIFF
--- a/test/parallel/test-process-constants-noatime.js
+++ b/test/parallel/test-process-constants-noatime.js
@@ -5,8 +5,8 @@ const assert = require('assert');
 const constants = process.binding('constants');
 
 if (process.platform === 'linux') {
-  assert(constants.hasOwnProperty('O_NOATIME'));
+  assert('O_NOATIME' in constants);
   assert.strictEqual(constants.O_NOATIME, 0x40000);
 } else {
-  assert(false === constants.hasOwnProperty('O_NOATIME'));
+  assert(!('O_NOATIME' in constants));
 }

--- a/test/parallel/test-process-constants-noatime.js
+++ b/test/parallel/test-process-constants-noatime.js
@@ -2,10 +2,11 @@
 
 require('../common');
 const assert = require('assert');
+const constants = process.binding('constants');
 
-const isLinux = process.platform === 'linux';
-
-const O_NOATIME = process.binding('constants').O_NOATIME;
-const expected = isLinux ? 0x40000 : undefined;
-
-assert.strictEqual(O_NOATIME, expected);
+if (process.platform === 'linux') {
+  assert(constants.hasOwnProperty('O_NOATIME'));
+  assert.strictEqual(constants.O_NOATIME, 0x40000);
+} else {
+  assert(false === constants.hasOwnProperty('O_NOATIME'));
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

As it is, the test checks if the return value is `undefined` in other
platforms. But it should also make sure that the `O_NOATIME` should be
found only in Linux.

Ref: https://github.com/nodejs/node/pull/6492

cc @Trott @bnoordhuis @jasnell 

CI Run: https://ci.nodejs.org/job/node-test-pull-request/2522/