### PR TITLE
doc: readline.emitKeypressEvents and raw mode

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -362,6 +362,15 @@ Move cursor to the specified position in a given TTY stream.
 Causes `stream` to begin emitting `'keypress'` events corresponding to its
 input.
 
+Note that the stream, if it is a TTY, needs to be in raw mode:
+```js
+readline.emitKeypressEvents(process.stdin);
+if (process.stdin.isTTY) {
+  // might not be a TTY if spawned from another node process
+  process.stdin.setRawMode(true);
+}
+```
+
 ## readline.moveCursor(stream, dx, dy)
 
 Move cursor relative to it's current position in a given TTY stream.


### PR DESCRIPTION
##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc

##### Description of change

`readline.emitKeypressEvents` needs `stream` to be in raw mode, fixes #6626