### PR TITLE
test: make stdout buffer test more robust

### DIFF
--- a/test/known_issues/test-stdout-buffer-flush-on-exit.js
+++ b/test/known_issues/test-stdout-buffer-flush-on-exit.js
@@ -15,7 +15,7 @@ if (process.argv[2] === 'child') {
   process.exit();
 }
 
-[16, 18, 20].forEach((exponent) => {
+[16, 18, 20, 21, 22].forEach((exponent) => {
   const bigNum = Math.pow(2, exponent);
   const longLine = lineSeed.repeat(bigNum);
   const cmd = `${process.execPath} ${__filename} child ${exponent} ${bigNum}`;

--- a/test/known_issues/test-stdout-buffer-flush-on-exit.js
+++ b/test/known_issues/test-stdout-buffer-flush-on-exit.js
@@ -15,7 +15,7 @@ if (process.argv[2] === 'child') {
   process.exit();
 }
 
-[16, 18, 20, 21, 22].forEach((exponent) => {
+[22, 21, 20, 19, 18, 17, 16, 16, 17, 18, 19, 20, 21, 22].forEach((exponent) => {
   const bigNum = Math.pow(2, exponent);
   const longLine = lineSeed.repeat(bigNum);
   const cmd = `${process.execPath} ${__filename} child ${exponent} ${bigNum}`;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test

##### Description of change

<!-- provide a description of the change below this comment -->

test-stdout-buffer-flush-on-exit is unfortunately non-deterministic. It
will, every so often, pass when it is supposed to fail. This is
currently guarded against by running the test with three different long
strings. This change increases it to five to reduce the false negatives.