### PR TITLE
tools: remove minifying logic

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -32,34 +32,13 @@
 # library.
 
 import os
-from os.path import dirname
 import re
 import sys
 import string
 
-sys.path.append(dirname(__file__) + "/../deps/v8/tools");
-import jsmin
-
 
 def ToCArray(filename, lines):
   return ','.join(str(ord(c)) for c in lines)
-
-
-def CompressScript(lines, do_jsmin):
-  # If we're not expecting this code to be user visible, we can run it through
-  # a more aggressive minifier.
-  if do_jsmin:
-    minifier = JavaScriptMinifier()
-    return minifier.JSMinify(lines)
-
-  # Remove stuff from the source that we don't want to appear when
-  # people print the source code using Function.prototype.toString().
-  # Note that we could easily compress the scripts mode but don't
-  # since we want it to remain readable.
-  #lines = re.sub('//.*\n', '\n', lines) # end-of-line comments
-  #lines = re.sub(re.compile(r'/\*.*?\*/', re.DOTALL), '', lines) # comments.
-  #lines = re.sub('\s+\n+', '\n', lines) # trailing whitespace
-  return lines
 
 
 def ReadFile(filename):
@@ -264,11 +243,9 @@ def JS2C(source, target):
   for s in modules:
     delay = str(s).endswith('-delay.js')
     lines = ReadFile(str(s))
-    do_jsmin = lines.find('// jsminify this file, js2c: jsmin') != -1
 
     lines = ExpandConstants(lines, consts)
     lines = ExpandMacros(lines, macros)
-    lines = CompressScript(lines, do_jsmin)
     data = ToCArray(s, lines)
 
     # On Windows, "./foo.bar" in the .gyp file is passed as "foo.bar"


### PR DESCRIPTION
##### Checklist

- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description of change

~~`jsmin` module is imported to use `JavaScriptMinifier` class, but the
class should be referenced with the module name. Otherwise, it will
throw a `NameError` at runtime.~~

As we don't use minifier at all, this patch removes the entire minifying logic.

cc @bnoordhuis 

CI Run: https://ci.nodejs.org/job/node-test-pull-request/2538/