### PR TITLE
tools: disallow multiple spaces except for indentation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@ rules:
   # Best Practices
   # http://eslint.org/docs/rules/#best-practices
   no-fallthrough: 2
+  no-multi-spaces: 2
   no-octal: 2
   no-redeclare: 2
   no-self-assign: 2

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -12,10 +12,10 @@ var bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-const INT8   = 0x7f;
-const INT16  = 0x7fff;
-const INT32  = 0x7fffffff;
-const UINT8  = (INT8 * 2) + 1;
+const INT8 = 0x7f;
+const INT16 = 0x7fff;
+const INT32 = 0x7fffffff;
+const UINT8 = (INT8 * 2) + 1;
 const UINT16 = (INT16 * 2) + 1;
 const UINT32 = INT32;
 

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -10,10 +10,10 @@ var bench = common.createBenchmark(main, {
   millions: [1]
 });
 
-const INT8   = 0x7f;
-const INT16  = 0x7fff;
-const INT32  = 0x7fffffff;
-const UINT8  = INT8 * 2;
+const INT8 = 0x7f;
+const INT16 = 0x7fff;
+const INT32 = 0x7fffffff;
+const UINT8 = INT8 * 2;
 const UINT16 = INT16 * 2;
 const UINT32 = INT32 * 2;
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -136,7 +136,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
           `the new one i.e., ${historyPath} and is empty.\nUsing it as is.\n`);
       repl._refreshLine();
 
-    }  else if (oldHistoryPath) {
+    } else if (oldHistoryPath) {
       // Grab data from the older pre-v3.0 JSON NODE_REPL_HISTORY_FILE format.
       repl._writeToOutput(
           '\nConverting old JSON repl history to line-separated history.\n' +

--- a/lib/path.js
+++ b/lib/path.js
@@ -779,7 +779,7 @@ const win32 = {
           end = i;
           break;
         }
-      } else  {
+      } else {
         // We saw the first non-path separator
         matchedSlash = false;
       }
@@ -1335,7 +1335,7 @@ const posix = {
           end = i;
           break;
         }
-      } else  {
+      } else {
         // We saw the first non-path separator
         matchedSlash = false;
       }

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -58,7 +58,7 @@ QueryString.unescapeBuffer = function(s, decodeSpaces) {
       case 2: // Second hex digit
         state = 0;
         if (c >= 48/*0*/ && c <= 57/*9*/) {
-          m = c -  48/*0*/;
+          m = c - 48/*0*/;
         } else if (c >= 65/*A*/ && c <= 70/*F*/) {
           m = c - 65/*A*/ + 10;
         } else if (c >= 97/*a*/ && c <= 102/*f*/) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -156,7 +156,7 @@ class LineParser {
 
     this.shouldFail = this.shouldFail ||
                       ((!this._literal && lastChar === '\\') ||
-                      (this._literal   && lastChar !== '\\'));
+                      (this._literal && lastChar !== '\\'));
 
     return line;
   }

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -50,7 +50,7 @@ function convertProtocols(protocols) {
   return buff;
 }
 
-exports.convertNPNProtocols  = function(protocols, out) {
+exports.convertNPNProtocols = function(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
     protocols = convertProtocols(protocols);

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -22,13 +22,13 @@ check(64, 1, 0);
 check(97, 1, 0);
 
 // Buffers can be unaligned
-check(64,  8, 0);
+check(64, 8, 0);
 check(64, 16, 0);
-check(64,  8, 1);
+check(64, 8, 1);
 check(64, 16, 1);
-check(97,  8, 1);
+check(97, 8, 1);
 check(97, 16, 1);
-check(97,  8, 3);
+check(97, 8, 3);
 check(97, 16, 3);
 
 // Empty ArrayBuffer does not allocate data, worth checking

--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -6,7 +6,7 @@ function serverHandler(req, res) {
   res.connection.destroy();
 }
 
-const http  = require('http');
+const http = require('http');
 const weak = require('weak');
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1023,7 +1023,7 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 [ 'utf9',
   'utf-7',
   'Unicode-FTW',
-  'new gnu gun'  ].forEach(function(enc) {
+  'new gnu gun' ].forEach(function(enc) {
     assert.equal(Buffer.isEncoding(enc), false);
   });
 

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -3,7 +3,7 @@ require('../common');
 var assert = require('assert');
 
 var zero = [];
-var one  = [ Buffer.from('asdf') ];
+var one = [ Buffer.from('asdf') ];
 var long = [];
 for (var i = 0; i < 10; i++) long.push(Buffer.from('asdf'));
 

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -164,7 +164,7 @@ assert(!mixedByteStringUtf8.includes('\u0396'));
 // Long string that isn't a simple repeat of a shorter string.
 var longString = 'A';
 for (let i = 66; i < 76; i++) {  // from 'B' to 'K'
-  longString =  longString + String.fromCharCode(i) + longString;
+  longString = longString + String.fromCharCode(i) + longString;
 }
 
 const longBufferString = Buffer.from(longString);

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -183,7 +183,7 @@ assert.equal(-1, mixedByteStringUtf8.indexOf('\u0396'));
 // Long string that isn't a simple repeat of a shorter string.
 var longString = 'A';
 for (let i = 66; i < 76; i++) {  // from 'B' to 'K'
-  longString =  longString + String.fromCharCode(i) + longString;
+  longString = longString + String.fromCharCode(i) + longString;
 }
 
 var longBufferString = Buffer.from(longString);

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1016,7 +1016,7 @@ Buffer(Buffer(0), 0, 0);
 [ 'utf9',
   'utf-7',
   'Unicode-FTW',
-  'new gnu gun'  ].forEach(function(enc) {
+  'new gnu gun' ].forEach(function(enc) {
     assert.equal(Buffer.isEncoding(enc), false);
   });
 

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -41,7 +41,7 @@ function testHelper(stream, args, expectedOutput, cmd, env) {
       cmd + ' and args \'' + args + '\'');
 
   function childOk(child) {
-    console.error('Child #' +  ++num_children_ok +
+    console.error('Child #' + ++num_children_ok +
         ' [pid:' + child.pid + '] OK.');
   }
 

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -11,7 +11,7 @@ var crypto = require('crypto');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 function aes256(decipherFinal) {
-  var iv  = Buffer.from('00000000000000000000000000000000', 'hex');
+  var iv = Buffer.from('00000000000000000000000000000000', 'hex');
   var key = Buffer.from('0123456789abcdef0123456789abcdef' +
                        '0123456789abcdef0123456789abcdef', 'hex');
 

--- a/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/parallel/test-dgram-send-bad-arguments.js
@@ -12,12 +12,12 @@ assert.throws(function() {
 }, TypeError);  // First argument should be a buffer.
 
 // send(buf, offset, length, port, host)
-assert.throws(function() { sock.send(buf, 1, 1, -1, host);    }, RangeError);
-assert.throws(function() { sock.send(buf, 1, 1, 0, host);     }, RangeError);
+assert.throws(function() { sock.send(buf, 1, 1, -1, host); }, RangeError);
+assert.throws(function() { sock.send(buf, 1, 1, 0, host); }, RangeError);
 assert.throws(function() { sock.send(buf, 1, 1, 65536, host); }, RangeError);
 
 // send(buf, port, host)
-assert.throws(function() { sock.send(23, 12345, host);        }, TypeError);
+assert.throws(function() { sock.send(23, 12345, host); }, TypeError);
 
 // send([buf1, ..], port, host)
 assert.throws(function() { sock.send([buf, 23], 12345, host); }, TypeError);

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -239,7 +239,7 @@ if (process.argv[2] === 'child') {
       testCmd += 'ulimit -c 0 && ';
     }
 
-    testCmd +=  process.argv[0];
+    testCmd += process.argv[0];
     testCmd += ' ' + '--abort-on-uncaught-exception';
     testCmd += ' ' + process.argv[1];
     testCmd += ' ' + 'child';

--- a/test/parallel/test-domain-no-error-handler-abort-on-uncaught.js
+++ b/test/parallel/test-domain-no-error-handler-abort-on-uncaught.js
@@ -150,7 +150,7 @@ if (process.argv[2] === 'child') {
       testCmd += 'ulimit -c 0 && ';
     }
 
-    testCmd +=  process.argv[0];
+    testCmd += process.argv[0];
     testCmd += ' ' + '--abort-on-uncaught-exception';
     testCmd += ' ' + process.argv[1];
     testCmd += ' ' + 'child';

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -103,7 +103,7 @@ if (process.argv[2] === 'child') {
     if (options.useTryCatch)
       useTryCatchOpt = 'useTryCatch';
 
-    cmdToExec +=  process.argv[0] + ' ';
+    cmdToExec += process.argv[0] + ' ';
     cmdToExec += (cmdLineOption ? cmdLineOption : '') + ' ';
     cmdToExec += process.argv[1] + ' ';
     cmdToExec += [

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -21,33 +21,33 @@ function check(async, sync) {
     async.apply(null, argsAsync);
 }
 
-check(fs.access,      fs.accessSync,      'foo\u0000bar');
-check(fs.access,      fs.accessSync,      'foo\u0000bar', fs.F_OK);
-check(fs.appendFile,  fs.appendFileSync,  'foo\u0000bar');
-check(fs.chmod,       fs.chmodSync,       'foo\u0000bar', '0644');
-check(fs.chown,       fs.chownSync,       'foo\u0000bar', 12, 34);
-check(fs.link,        fs.linkSync,        'foo\u0000bar', 'foobar');
-check(fs.link,        fs.linkSync,        'foobar', 'foo\u0000bar');
-check(fs.lstat,       fs.lstatSync,       'foo\u0000bar');
-check(fs.mkdir,       fs.mkdirSync,       'foo\u0000bar', '0755');
-check(fs.open,        fs.openSync,        'foo\u0000bar', 'r');
-check(fs.readFile,    fs.readFileSync,    'foo\u0000bar');
-check(fs.readdir,     fs.readdirSync,     'foo\u0000bar');
-check(fs.readlink,    fs.readlinkSync,    'foo\u0000bar');
-check(fs.realpath,    fs.realpathSync,    'foo\u0000bar');
-check(fs.rename,      fs.renameSync,      'foo\u0000bar', 'foobar');
-check(fs.rename,      fs.renameSync,      'foobar', 'foo\u0000bar');
-check(fs.rmdir,       fs.rmdirSync,       'foo\u0000bar');
-check(fs.stat,        fs.statSync,        'foo\u0000bar');
-check(fs.symlink,     fs.symlinkSync,     'foo\u0000bar', 'foobar');
-check(fs.symlink,     fs.symlinkSync,     'foobar', 'foo\u0000bar');
-check(fs.truncate,    fs.truncateSync,    'foo\u0000bar');
-check(fs.unlink,      fs.unlinkSync,      'foo\u0000bar');
-check(null,           fs.unwatchFile,     'foo\u0000bar', common.fail);
-check(fs.utimes,      fs.utimesSync,      'foo\u0000bar', 0, 0);
-check(null,           fs.watch,           'foo\u0000bar', common.fail);
-check(null,           fs.watchFile,       'foo\u0000bar', common.fail);
-check(fs.writeFile,   fs.writeFileSync,   'foo\u0000bar');
+check(fs.access, fs.accessSync, 'foo\u0000bar');
+check(fs.access, fs.accessSync, 'foo\u0000bar', fs.F_OK);
+check(fs.appendFile, fs.appendFileSync, 'foo\u0000bar');
+check(fs.chmod, fs.chmodSync, 'foo\u0000bar', '0644');
+check(fs.chown, fs.chownSync, 'foo\u0000bar', 12, 34);
+check(fs.link, fs.linkSync, 'foo\u0000bar', 'foobar');
+check(fs.link, fs.linkSync, 'foobar', 'foo\u0000bar');
+check(fs.lstat, fs.lstatSync, 'foo\u0000bar');
+check(fs.mkdir, fs.mkdirSync, 'foo\u0000bar', '0755');
+check(fs.open, fs.openSync, 'foo\u0000bar', 'r');
+check(fs.readFile, fs.readFileSync, 'foo\u0000bar');
+check(fs.readdir, fs.readdirSync, 'foo\u0000bar');
+check(fs.readlink, fs.readlinkSync, 'foo\u0000bar');
+check(fs.realpath, fs.realpathSync, 'foo\u0000bar');
+check(fs.rename, fs.renameSync, 'foo\u0000bar', 'foobar');
+check(fs.rename, fs.renameSync, 'foobar', 'foo\u0000bar');
+check(fs.rmdir, fs.rmdirSync, 'foo\u0000bar');
+check(fs.stat, fs.statSync, 'foo\u0000bar');
+check(fs.symlink, fs.symlinkSync, 'foo\u0000bar', 'foobar');
+check(fs.symlink, fs.symlinkSync, 'foobar', 'foo\u0000bar');
+check(fs.truncate, fs.truncateSync, 'foo\u0000bar');
+check(fs.unlink, fs.unlinkSync, 'foo\u0000bar');
+check(null, fs.unwatchFile, 'foo\u0000bar', common.fail);
+check(fs.utimes, fs.utimesSync, 'foo\u0000bar', 0, 0);
+check(null, fs.watch, 'foo\u0000bar', common.fail);
+check(null, fs.watchFile, 'foo\u0000bar', common.fail);
+check(fs.writeFile, fs.writeFileSync, 'foo\u0000bar');
 
 // an 'error' for exists means that it doesn't exist.
 // one of many reasons why this file is the absolute worst.

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -26,7 +26,7 @@ https.createServer(options, function(req, res) {
 });
 
 // Do request and let agent cache the session
-function first(server)  {
+function first(server) {
   const req = https.request({
     port: common.PORT,
     rejectUnauthorized: false

--- a/test/parallel/test-regress-GH-7511.js
+++ b/test/parallel/test-regress-GH-7511.js
@@ -5,6 +5,6 @@ const vm = require('vm');
 
 assert.doesNotThrow(function() {
   var context = vm.createContext({ process: process });
-  var result  = vm.runInContext('process.env["PATH"]', context);
+  var result = vm.runInContext('process.env["PATH"]', context);
   assert.notEqual(undefined, result);
 });

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -1,7 +1,7 @@
 'use strict';
 var common = require('../common');
 
-var repl   = require('repl');
+var repl = require('repl');
 
 const putIn = new common.ArrayStream();
 repl.start('', putIn);

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -258,7 +258,7 @@ test('end callback after .write() call', function(t) {
 test('end callback called after write callback', function(t) {
   var tw = new TestWriter();
   var writeCalledback = false;
-  tw.write(Buffer.from('hello world'),  function() {
+  tw.write(Buffer.from('hello world'), function() {
     writeCalledback = true;
   });
   tw.end(function() {

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -27,7 +27,7 @@ test(
 test('ucs2', Buffer.from('ababc', 'ucs2'), 'ababc');
 
 // UTF-16LE
-test('ucs2', Buffer.from('3DD84DDC', 'hex'),  '\ud83d\udc4d'); // thumbs up
+test('ucs2', Buffer.from('3DD84DDC', 'hex'), '\ud83d\udc4d'); // thumbs up
 
 console.log(' crayon!');
 

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -9,7 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var key =  fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
+var key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
 
 var ntests = 0;

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -9,7 +9,7 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 
 var fs = require('fs');
-var key =  fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
+var key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
 
 var nsuccess = 0;

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -10,7 +10,7 @@ var tls = require('tls');
 
 var spawn = require('child_process').spawn;
 var fs = require('fs');
-var key =  fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
+var key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
 var nsuccess = 0;
 var ntests = 0;

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -3,10 +3,10 @@
 
 require('../common');
 
-var Timer  = process.binding('timer_wrap').Timer;
+var Timer = process.binding('timer_wrap').Timer;
 var assert = require('assert');
 
-var timerFired    = false;
+var timerFired = false;
 var intervalFired = false;
 
 /*


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools test benchmark lib

##### Description of change

<!-- provide a description of the change below this comment -->

Except for indentation, disallow multiple whitespace around logical
expressions, conditional expressions, declarations, array elements,
object properties, sequences and function parameters.

This stems from comments in https://github.com/nodejs/node/pull/6592 
where five collaborators expressed frustration with the use of spaces to 
align things that do not appear first on a line. I would not be surprised if there
are others who feel differently, but rather than make an assumption, I'm
putting this out there and we'll see....

Anyway, @cjihrig probably stated the argument for this rule the clearest:

> I'm in favor of not lining these up. It looks nice, but almost always ends with something being added that requires everything to be realigned, leading to more churn.

/cc @jasnell @targos @mscdex @jbergstroem @cjihrig 