### PR TITLE
build: don't compile with -B, redux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -25,9 +25,6 @@
     # Don't bake anything extra into the snapshot.
     'v8_use_external_startup_data%': 0,
 
-    # Don't compile with -B, we don't bundle ld.gold.
-    'linux_use_bundled_gold%': 0,
-
     'conditions': [
       ['OS == "win"', {
         'os_posix': 0,

--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -56,5 +56,12 @@ if __name__ == '__main__':
 
   args.append('-Dcomponent=static_library')
   args.append('-Dlibrary=static_library')
+
+  # Don't compile with -B and -fuse-ld=, we don't bundle ld.gold.  Can't be
+  # set in common.gypi due to how deps/v8/build/toolchain.gypi uses them.
+  args.append('-Dlinux_use_bundled_binutils=0')
+  args.append('-Dlinux_use_bundled_gold=0')
+  args.append('-Dlinux_use_gold_flags=0')
+
   gyp_args = list(args)
   run_gyp(gyp_args)


### PR DESCRIPTION
It looks like suppressing `-B` and `-fuse-ld=gold` from common.gypi is
not very reliable.  I'm positive it worked when commit 3cdb506 ("build:
don't compile with -B") was merged but subsequent updates appear to have
broken it again.

Take the nuclear option and disable them from `tools/node_gyp.py`.

Fixes: #6603
Refs: #6393

CI: https://ci.nodejs.org/job/node-test-pull-request/2545/