### PR TITLE
tls,https: respect address family when connecting

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -102,6 +102,11 @@ Agent.prototype.getName = function(options) {
   if (options.localAddress)
     name += options.localAddress;
 
+  // Pacify parallel/test-http-agent-getname by only appending
+  // the ':' when options.family is set.
+  if (options.family === 4 || options.family === 6)
+    name += ':' + options.family;
+
   return name;
 };
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1025,6 +1025,7 @@ exports.connect = function(/* [port, host], options, cb */) {
       connect_opt = {
         port: options.port,
         host: options.host,
+        family: options.family,
         localAddress: options.localAddress
       };
     }

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,6 +12,13 @@ test-tick-processor     : PASS,FLAKY
 [$system==linux]
 test-tick-processor           : PASS,FLAKY
 
+# Flaky until https://github.com/nodejs/build/issues/415 is resolved.
+# On some of the buildbots, AAAA queries for localhost don't resolve
+# to an address and neither do any of the alternatives from the
+# localIPv6Hosts list from test/common.js.
+test-https-connect-address-family : PASS,FLAKY
+test-tls-connect-address-family : PASS,FLAKY
+
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -30,3 +30,9 @@ assert.equal(
   }),
   '0.0.0.0:80:192.168.1.1'
 );
+
+for (const family of [0, null, undefined, 'bogus'])
+  assert.strictEqual(agent.getName({ family }), 'localhost::');
+
+for (const family of [4, 6])
+  assert.strictEqual(agent.getName({ family }), 'localhost:::' + family);

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -1,13 +1,13 @@
 'use strict';
 
 require('../common');
-var assert = require('assert');
-var http = require('http');
+const assert = require('assert');
+const http = require('http');
 
-var agent = new http.Agent();
+const agent = new http.Agent();
 
 // default to localhost
-assert.equal(
+assert.strictEqual(
   agent.getName({
     port: 80,
     localAddress: '192.168.1.1'
@@ -16,13 +16,13 @@ assert.equal(
 );
 
 // empty
-assert.equal(
+assert.strictEqual(
   agent.getName({}),
   'localhost::'
 );
 
 // pass all arguments
-assert.equal(
+assert.strictEqual(
   agent.getName({
     host: '0.0.0.0',
     port: 80,

--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const https = require('https');
+
+if (!common.hasIPv6) {
+  common.skip('no IPv6 support');
+  return;
+}
+
+const ciphers = 'AECDH-NULL-SHA';
+https.createServer({ ciphers }, function(req, res) {
+  this.close();
+  res.end();
+}).listen(common.PORT, '::1', function() {
+  const options = {
+    host: 'localhost',
+    port: common.PORT,
+    family: 6,
+    ciphers: ciphers,
+    rejectUnauthorized: false,
+  };
+  // Will fail with ECONNREFUSED if the address family is not honored.
+  https.get(options, common.mustCall(function() {
+    assert.strictEqual('::1', this.socket.remoteAddress);
+    this.destroy();
+  }));
+});

--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const tls = require('tls');
+
+if (!common.hasIPv6) {
+  common.skip('no IPv6 support');
+  return;
+}
+
+const ciphers = 'AECDH-NULL-SHA';
+tls.createServer({ ciphers }, function() {
+  this.close();
+}).listen(common.PORT, '::1', function() {
+  const options = {
+    host: 'localhost',
+    port: common.PORT,
+    family: 6,
+    ciphers: ciphers,
+    rejectUnauthorized: false,
+  };
+  // Will fail with ECONNREFUSED if the address family is not honored.
+  tls.connect(options).once('secureConnect', common.mustCall(function() {
+    assert.strictEqual('::1', this.remoteAddress);
+    this.destroy();
+  }));
+});


### PR DESCRIPTION
Respect the `{ family: 6 }` address family property when connecting to
a remote peer over TLS.

Fixes: #6440 

CI: https://ci.nodejs.org/job/node-test-pull-request/2549/