### PR TITLE
test: ensure test-npm-install uses correct node

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -33,7 +33,10 @@ const pkgPath = path.join(common.tmpDir, 'package.json');
 fs.writeFileSync(pkgPath, pkgContent);
 
 const proc = spawn(process.execPath, args, {
-  cwd: common.tmpDir
+  cwd: common.tmpDir,
+  env: {
+    PATH: path.dirname(process.execPath)
+  }
 });
 
 function handleExit(code, signalCode) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] ~~documentation is changed or added~~
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test

##### Description of change

<!-- provide a description of the change below this comment -->

Currently it is possible that the shelled out instance of npm will use
the system copy of node. This PR changes the test to shim the build
directory into the path. This will ensure that npm will use the correct
version of node.