### PR TITLE
doc: server.listen truncates socket path on unix

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -153,9 +153,12 @@ This function is asynchronous.  When the server has been bound,
 will be added as a listener for the [`'listening'`][] event.
 
 On UNIX, the local domain is usually known as the UNIX domain. The path is a
-filesystem path name. It is subject to the same naming conventions and
-permissions checks as would be done on file creation, will be visible in the
-filesystem, and will *persist until unlinked*.
+filesystem path name. It gets truncated to `sizeof(sockaddr_un.sun_path)` 
+bytes, decreased by 1. It varies on different operating system between 91 and
+107 bytes. The typical values are 107 on Linux and 103 on OS X. The path is
+subject to the same naming conventions and permissions checks as would be done
+on file creation, will be visible in the filesystem, and will *persist until
+unlinked*.
 
 On Windows, the local domain is implemented using a named pipe. The path *must*
 refer to an entry in `\\?\pipe\` or `\\.\pipe\`. Any characters are permitted,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change

<!-- provide a description of the change below this comment -->

I found out that calling the following code would create a UNIX socket with a truncated path:
```js
const net = require('net');
var server = net.createServer();
server.listen('/tmp/0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz');
// On the FS it ends up creating '/tmp/0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnop' 
// i.e. 103 chars on OSX instead of the initial 113 chars
```

Internally it ends up calling `uv_pipe_bind` with the given path which itself is documented to truncate the path. See http://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe_bind

This is NOT a bug, but a restriction of the unix socket api, as it stores the path in `sockaddr_un.sun_path` (104 chars on OSX, 108 chars on Linux), see `man unix`.