### PR TITLE
doc: fix exec example in child_process

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -140,13 +140,13 @@ generated output.
 
 ```js
 const exec = require('child_process').exec;
-const child = exec('cat *.js bad_file | wc -l',
-  (error, stdout, stderr) => {
-    console.log(`stdout: ${stdout}`);
-    console.log(`stderr: ${stderr}`);
-    if (error !== null) {
-      console.log(`exec error: ${error}`);
-    }
+exec('cat *.js bad_file | wc -l', (error, stdout, stderr) => {
+  if (error) {
+    console.error(`exec error: ${error}`);
+    return;
+  }
+  console.log(`stdout: ${stdout}`);
+  console.log(`stderr: ${stderr}`);
 });
 ```
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc


##### Description of change

Previously, the example was checking for error by strict equality to
null. The error could be undefined though which would fail that check.