### PR TITLE
module: fix wrong condition in early return logic for node_module path

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -229,7 +229,7 @@ if (process.platform === 'win32') {
           paths.push(from.slice(0, last) + '\\node_modules');
         last = i;
         p = 0;
-      } else if (p !== -1 && p < nmLen) {
+      } else if (p !== -1) {
         if (nmChars[p] === code) {
           ++p;
         } else {
@@ -263,7 +263,7 @@ if (process.platform === 'win32') {
           paths.push(from.slice(0, last) + '/node_modules');
         last = i;
         p = 0;
-      } else if (p !== -1 && p < nmLen) {
+      } else if (p !== -1) {
         if (nmChars[p] === code) {
           ++p;
         } else {

--- a/lib/module.js
+++ b/lib/module.js
@@ -231,8 +231,11 @@ if (process.platform === 'win32') {
     var last = from.length;
     for (var i = from.length - 1; i >= 0; --i) {
       const code = from.charCodeAt(i);
-      // use colon as a split to add driver root node_modules
-      // it's a little more tricky than posix version to avoid parse drive name.
+      // The path segment separator check ('\' and '/') was used to get
+      // node_modules path for every path segment.
+      // Use colon as an extra condition since we can get node_modules
+      // path for dirver root like 'C:\node_modules' and don't need to
+      // parse driver name.
       if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/) {
         if (p !== nmLen)
           paths.push(from.slice(0, last) + '\\node_modules');
@@ -280,7 +283,8 @@ if (process.platform === 'win32') {
         }
       }
     }
-    // append /node_modules since this approach didn't handle root path
+
+    // Append /node_modules to handle root paths.
     paths.push('/node_modules');
 
     return paths;

--- a/lib/module.js
+++ b/lib/module.js
@@ -219,12 +219,21 @@ if (process.platform === 'win32') {
     // note: this approach *only* works when the path is guaranteed
     // to be absolute.  Doing a fully-edge-case-correct path.split
     // that works on both Windows and Posix is non-trivial.
+
+    // return root node_modules when path is 'D:\\'.
+    // path.resolve will make sure from.length >=3 in Windows.
+    if (from.charCodeAt(from.length - 1) === 92/*\*/ &&
+        from.charCodeAt(from.length - 2) === 58/*:*/)
+      return [from + 'node_modules'];
+
     const paths = [];
     var p = 0;
     var last = from.length;
     for (var i = from.length - 1; i >= 0; --i) {
       const code = from.charCodeAt(i);
-      if (code === 92/*\*/ || code === 47/*/*/) {
+      // use colon as a split to add driver root node_modules
+      // it's a little more tricky than posix version to avoid parse drive name.
+      if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/) {
         if (p !== nmLen)
           paths.push(from.slice(0, last) + '\\node_modules');
         last = i;
@@ -271,6 +280,8 @@ if (process.platform === 'win32') {
         }
       }
     }
+    // append /node_modules since this approach didn't handle root path
+    paths.push('/node_modules');
 
     return paths;
   };

--- a/test/parallel/test-module-nodemodulepaths.js
+++ b/test/parallel/test-module-nodemodulepaths.js
@@ -12,7 +12,7 @@ const cases = {
       'C:\\Users\\Rocko Artischocko\\node_stuff\\node_modules',
       'C:\\Users\\Rocko Artischocko\\node_modules',
       'C:\\Users\\node_modules',
-      'C:\\node_modules',
+      'C:\\node_modules'
     ]
   }, {
     file: 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo_node_modules',
@@ -22,10 +22,20 @@ Artischocko\\node_stuff\\foo_node_modules\\node_modules',
       'C:\\Users\\Rocko Artischocko\\node_stuff\\node_modules',
       'C:\\Users\\Rocko Artischocko\\node_modules',
       'C:\\Users\\node_modules',
-      'C:\\node_modules',
+      'C:\\node_modules'
+    ]
+  }, {
+    file: 'C:\\node_modules',
+    expect: [
+      'C:\\node_modules'
+    ]
+  }, {
+    file: 'C:\\',
+    expect: [
+      'C:\\node_modules'
     ]
   }],
-  'UNIX': [{
+  'POSIX': [{
     file: '/usr/test/lib/node_modules/npm/foo',
     expect: [
       '/usr/test/lib/node_modules/npm/foo/node_modules',
@@ -33,6 +43,7 @@ Artischocko\\node_stuff\\foo_node_modules\\node_modules',
       '/usr/test/lib/node_modules',
       '/usr/test/node_modules',
       '/usr/node_modules',
+      '/node_modules'
     ]
   }, {
     file: '/usr/test/lib/node_modules/npm/foo_node_modules',
@@ -42,12 +53,24 @@ Artischocko\\node_stuff\\foo_node_modules\\node_modules',
       '/usr/test/lib/node_modules',
       '/usr/test/node_modules',
       '/usr/node_modules',
+      '/node_modules'
+    ]
+  }, {
+    file: '/node_modules',
+    expect: [
+      '/node_modules'
+    ]
+  }, {
+    file: '/',
+    expect: [
+      '/node_modules'
     ]
   }]
 };
 
-const platformCases = common.isWindows ? cases.WIN : cases.UNIX;
+const platformCases = common.isWindows ? cases.WIN : cases.POSIX;
 platformCases.forEach((c) => {
   const paths = _module._nodeModulePaths(c.file);
-  assert.deepStrictEqual(c.expect, paths);
+  assert.deepStrictEqual(c.expect, paths, 'case ' + c.file +
+    ' failed, actual paths is ' + JSON.stringify(paths));
 });

--- a/test/parallel/test-module-nodemodulepaths.js
+++ b/test/parallel/test-module-nodemodulepaths.js
@@ -6,6 +6,21 @@ const _module = require('module');
 
 const cases = {
   'WIN': [{
+    file: 'C:\\Users\\hefangshi\\AppData\\Roaming\
+\\npm\\node_modules\\npm\\node_modules\\minimatch',
+    expect: [
+      'C:\\Users\\hefangshi\\AppData\\Roaming\
+\\npm\\node_modules\\npm\\node_modules\\minimatch\\node_modules',
+      'C:\\Users\\hefangshi\\AppData\\Roaming\
+\\npm\\node_modules\\npm\\node_modules',
+      'C:\\Users\\hefangshi\\AppData\\Roaming\\npm\\node_modules',
+      'C:\\Users\\hefangshi\\AppData\\Roaming\\node_modules',
+      'C:\\Users\\hefangshi\\AppData\\node_modules',
+      'C:\\Users\\hefangshi\\node_modules',
+      'C:\\Users\\node_modules',
+      'C:\\node_modules'
+    ]
+  }, {
     file: 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo',
     expect: [
       'C:\\Users\\Rocko Artischocko\\node_stuff\\foo\\node_modules',
@@ -36,6 +51,20 @@ Artischocko\\node_stuff\\foo_node_modules\\node_modules',
     ]
   }],
   'POSIX': [{
+    file: '/usr/lib/node_modules/npm/node_modules/\
+node-gyp/node_modules/glob/node_modules/minimatch',
+    expect: [
+      '/usr/lib/node_modules/npm/node_modules/\
+node-gyp/node_modules/glob/node_modules/minimatch/node_modules',
+      '/usr/lib/node_modules/npm/node_modules/\
+node-gyp/node_modules/glob/node_modules',
+      '/usr/lib/node_modules/npm/node_modules/node-gyp/node_modules',
+      '/usr/lib/node_modules/npm/node_modules',
+      '/usr/lib/node_modules',
+      '/usr/node_modules',
+      '/node_modules'
+    ]
+  }, {
     file: '/usr/test/lib/node_modules/npm/foo',
     expect: [
       '/usr/test/lib/node_modules/npm/foo/node_modules',

--- a/test/parallel/test-module-nodemodulepaths.js
+++ b/test/parallel/test-module-nodemodulepaths.js
@@ -1,20 +1,53 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
 
-var module = require('module');
+const common = require('../common');
+const assert = require('assert');
+const _module = require('module');
 
-var file, delimiter, paths;
+const cases = {
+  'WIN': [{
+    file: 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo',
+    expect: [
+      'C:\\Users\\Rocko Artischocko\\node_stuff\\foo\\node_modules',
+      'C:\\Users\\Rocko Artischocko\\node_stuff\\node_modules',
+      'C:\\Users\\Rocko Artischocko\\node_modules',
+      'C:\\Users\\node_modules',
+      'C:\\node_modules',
+    ]
+  }, {
+    file: 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo_node_modules',
+    expect: [
+      'C:\\Users\\Rocko \
+Artischocko\\node_stuff\\foo_node_modules\\node_modules',
+      'C:\\Users\\Rocko Artischocko\\node_stuff\\node_modules',
+      'C:\\Users\\Rocko Artischocko\\node_modules',
+      'C:\\Users\\node_modules',
+      'C:\\node_modules',
+    ]
+  }],
+  'UNIX': [{
+    file: '/usr/test/lib/node_modules/npm/foo',
+    expect: [
+      '/usr/test/lib/node_modules/npm/foo/node_modules',
+      '/usr/test/lib/node_modules/npm/node_modules',
+      '/usr/test/lib/node_modules',
+      '/usr/test/node_modules',
+      '/usr/node_modules',
+    ]
+  }, {
+    file: '/usr/test/lib/node_modules/npm/foo_node_modules',
+    expect: [
+      '/usr/test/lib/node_modules/npm/foo_node_modules/node_modules',
+      '/usr/test/lib/node_modules/npm/node_modules',
+      '/usr/test/lib/node_modules',
+      '/usr/test/node_modules',
+      '/usr/node_modules',
+    ]
+  }]
+};
 
-if (common.isWindows) {
-  file = 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo';
-  delimiter = '\\';
-} else {
-  file = '/usr/test/lib/node_modules/npm/foo';
-  delimiter = '/';
-}
-
-paths = module._nodeModulePaths(file);
-
-assert.ok(paths.indexOf(file + delimiter + 'node_modules') !== -1);
-assert.ok(Array.isArray(paths));
+const platformCases = common.isWindows ? cases.WIN : cases.UNIX;
+platformCases.forEach((c) => {
+  const paths = _module._nodeModulePaths(c.file);
+  assert.deepStrictEqual(c.expect, paths);
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

module

##### Description of change

<!-- provide a description of the change below this comment -->

the `p < nmLen` condition will fail when a module's name is end with
`node_modules` like `foo_node_modules`. The old logic will miss the
`foo_node_modules/node_modules` in node_modules paths.

TL;TR, a module named like `foo_node_modules` can't require any module
 in his node_modules folder.

Here is a demo which compared the new nodeModulePaths with the old one.

```javascript
const path = require('path');
var nmChars = [115, 101, 108, 117, 100, 111, 109, 95, 101, 100, 111, 110];
var nmLen = nmChars.length;

function nodeModulePaths(from) {
    // guarantee that 'from' is absolute.
    from = path.resolve(from);
    // Return early not only to avoid unnecessary work, but to *avoid* returning
    // an array of two items for a root: [ '//node_modules', '/node_modules' ]
    if (from === '/')
        return ['/node_modules'];

    // note: this approach *only* works when the path is guaranteed
    // to be absolute.  Doing a fully-edge-case-correct path.split
    // that works on both Windows and Posix is non-trivial.
    const paths = [];
    var p = 0;
    var last = from.length;
    for (var i = from.length - 1; i >= 0; --i) {
        const code = from.charCodeAt(i);
        if (code === 47 /*/*/ ) {
            if (p !== nmLen)
                paths.push(from.slice(0, last) + '/node_modules');
            last = i;
            p = 0;
        }
        else if (p !== -1 && p < nmLen) {
            if (nmChars[p] === code) {
                ++p;
            }
            else {
                p = -1;
            }
        }
    }

    return paths;
};

const splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
nodeModulePathsOld = function (from) {
    // guarantee that 'from' is absolute.
    from = path.resolve(from);
    // note: this approach *only* works when the path is guaranteed
    // to be absolute.  Doing a fully-edge-case-correct path.split
    // that works on both Windows and Posix is non-trivial.
    var paths = [];
    var parts = from.split(splitRe);
    for (var tip = parts.length - 1; tip >= 0; tip--) {
        // don't search in .../node_modules/node_modules
        if (parts[tip] === 'node_modules') continue;
        var dir = parts.slice(0, tip + 1).concat('node_modules').join(path.sep);
        paths.push(dir);
    }
    return paths;
}

console.log('new:', nodeModulePaths('/Users/hefangshi/test/foo_node_modules'));
console.log('old:', nodeModulePathsOld('/Users/hefangshi/test/foo_node_modules'));
```

Output: 

```
new: [ '/Users/hefangshi/test/node_modules',
  '/Users/hefangshi/node_modules',
  '/Users/node_modules' ]
old: [ '/Users/hefangshi/test/foo_node_modules/node_modules',
  '/Users/hefangshi/test/node_modules',
  '/Users/hefangshi/node_modules',
  '/Users/node_modules',
  '/node_modules' ]
```

The main reason is the `p < nmLen` condition will ignore `foo_node_modules` and simply 
think it should be `/node_modules`, and won't search `/Users/hefangshi/test/foo_node_modules/node_modules` for dependency.

**I already tested in mac and windows, but the testcases were not very full edge tested.**

@mscdex please have a look on it.