### PR TITLE
deps: limit regress/regress-crbug-514081 v8 test

### DIFF
--- a/deps/v8/test/mjsunit/mjsunit.status
+++ b/deps/v8/test/mjsunit/mjsunit.status
@@ -930,4 +930,13 @@
   'wasm/asm-wasm' : [SKIP],
 }],  # 'arch == ppc64''
 
+##############################################################################
+# This test allocates a 2G block of memory and if there are multiple
+# varients this leads kills by the OOM killer, crashes or messages
+# indicating the OS cannot allocate memory, exclude for Node.js runs
+# re-evalute when we move up to v8 5.1
+[ALWAYS, {
+'regress/regress-crbug-514081': [PASS, NO_VARIANTS],
+}],  # ALWAYS
+
 ]


### PR DESCRIPTION
##### Checklist
- [X] tests and code linting passes
- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)

deps/v8

##### Description of change

regress/regress-crbug-514081 allocates a 2G block of memory
and if there  are multiple variants running at the
same time this can lead to crashes, OOM kills or
the OS failing to allocate memory.  This patch
limits us to running a single variant of the test


Addresses: https://github.com/nodejs/node/issues/6340