### PR TITLE
util: adhere to `noDeprecation` set at runtime

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -67,9 +67,9 @@ exports.puts = util.deprecate(() => {
 
 It returns a modified function which warns once by default.
 
-If `--no-deprecation` is set then this function is a NO-OP.  Configurable
-at run-time through the `process.noDeprecation` boolean (only effective
-when set before a module is loaded.)
+This function does nothing if either the `--no-deprecation` command
+line flag is used, or the `process.noDeprecation` property is set to
+`true` *prior* to the first deprecation warning.
 
 If `--trace-deprecation` is set, a warning and a stack trace are logged
 to the console the first time the deprecated API is used.  Configurable

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -2,7 +2,6 @@
 
 const binding = process.binding('util');
 const prefix = `(${process.release.name}:${process.pid}) `;
-const noDeprecation = process.noDeprecation;
 
 exports.getHiddenValue = binding.getHiddenValue;
 exports.setHiddenValue = binding.setHiddenValue;
@@ -16,7 +15,7 @@ exports.deprecate = function(fn, msg) {
 // All the internal deprecations have to use this function only, as this will
 // prepend the prefix to the actual message.
 exports.printDeprecationMessage = function(msg, warned, ctor) {
-  if (warned || noDeprecation)
+  if (warned || process.noDeprecation)
     return true;
   process.emitWarning(msg, 'DeprecationWarning',
                       ctor || exports.printDeprecationMessage);

--- a/test/parallel/test-process-no-deprecation.js
+++ b/test/parallel/test-process-no-deprecation.js
@@ -1,0 +1,33 @@
+'use strict';
+// Flags: --expose_internals --no-warnings
+
+// The --no-warnings flag only supresses writing the warning to stderr, not the
+// emission of the corresponding event. This test file can be run without it.
+
+process.noDeprecation = true;
+
+const common = require('../common');
+const assert = require('assert');
+
+function listener() {
+  common.fail('received unexpected warning');
+}
+
+process.addListener('warning', listener);
+
+const internalUtil = require('internal/util');
+internalUtil.printDeprecationMessage('Something is deprecated.');
+
+// The warning would be emitted in the next tick, so continue after that.
+process.nextTick(common.mustCall(() => {
+  // Check that deprecations can be re-enabled.
+  process.noDeprecation = false;
+  process.removeListener('warning', listener);
+
+  process.addListener('warning', common.mustCall((warning) => {
+    assert.strictEqual(warning.name, 'DeprecationWarning');
+    assert.strictEqual(warning.message, 'Something else is deprecated.');
+  }));
+
+  internalUtil.printDeprecationMessage('Something else is deprecated.');
+}));


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

process (util?)

##### Description of change

Until now, the docs stated that `process.noDeprecation` could be set at runtime, but before any modules were loaded. That was not true, because `lib/internal/util.js` was loaded during the process startup process, so setting the flag at runtime was always pointless.

Minimal test case:
```js
process.noDeprecation = true;
process.EventEmitter;
```

This patch moves checking `process.noDeprecation` to the place where it was actually used.

/cc @jasnell 

CI: https://ci.nodejs.org/job/node-test-commit/3263/