### PR TITLE
test: fix test-debugger-repl-break-in-module

### DIFF
--- a/test/debugger/test-debugger-repl-break-in-module.js
+++ b/test/debugger/test-debugger-repl-break-in-module.js
@@ -7,7 +7,7 @@ repl.startDebugger('break-in-module/main.js');
 // -- SET BREAKPOINT --
 
 // Set breakpoint by file name + line number where the file is not loaded yet
-repl.addTest('sb("mod.js", 23)', [
+repl.addTest('sb("mod.js", 2)', [
   /Warning: script 'mod\.js' was not loaded yet\./,
   /1/, /2/, /3/, /4/, /5/, /6/
 ]);
@@ -20,8 +20,8 @@ repl.addTest('sb(")^$*+?}{|][(.js\\\\", 1)', [
 
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
-  /break in .*[\\\/]mod\.js:23/,
-  /21/, /22/, /23/, /24/, /25/
+  /break in .*[\\\/]mod\.js:2/,
+  /1/, /2/, /3/, /4/
 ]);
 
 // -- RESTORE BREAKPOINT ON RESTART --
@@ -33,7 +33,7 @@ repl.addTest('restart', [].concat(
   ],
   repl.handshakeLines,
   [
-    /Restoring breakpoint mod.js:23/,
+    /Restoring breakpoint mod.js:2/,
     /Warning: script 'mod\.js' was not loaded yet\./,
     /Restoring breakpoint \).*:\d+/,
     /Warning: script '\)[^']*' was not loaded yet\./
@@ -42,14 +42,14 @@ repl.addTest('restart', [].concat(
 
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
-  /break in .*[\\\/]mod\.js:23/,
-  /21/, /22/, /23/, /24/, /25/
+  /break in .*[\\\/]mod\.js:2/,
+  /1/, /2/, /3/, /4/
 ]);
 
 // -- CLEAR BREAKPOINT SET IN MODULE TO BE LOADED --
 
-repl.addTest('cb("mod.js", 23)', [
-  /18/, /./, /./, /./, /./, /./, /./, /./, /26/
+repl.addTest('cb("mod.js", 2)', [
+  /1/, /2/, /3/, /4/, /5/
 ]);
 
 repl.addTest('c', [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test debugger

##### Description of change

<!-- provide a description of the change below this comment -->

The line number checks in test-debugger-repl-break-in-module were
checking for line numbers that exceed the total number of lines in the
files that were being inspected. Change the checks to match the actual
files.