### PR TITLE
tools: restore change of doc building function signatures to opts hashes

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -60,7 +60,14 @@ testData.forEach(function(item) {
 
   fs.readFile(item.file, 'utf8', common.mustCall(function(err, input) {
     assert.ifError(err);
-    html(input, 'foo', 'doc/template.html',
+    html(
+      {
+        input: input,
+        filename: 'foo',
+        template: 'doc/template.html',
+        nodeVersion: process.version,
+      },
+
       common.mustCall(function(err, output) {
         assert.ifError(err);
 
@@ -68,6 +75,7 @@ testData.forEach(function(item) {
         // Assert that the input stripped of all whitespace contains the
         // expected list
         assert.notEqual(actual.indexOf(expected), -1);
-      }));
+      })
+    );
   }));
 });

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -48,11 +48,19 @@ function next(er, input) {
       break;
 
     case 'html':
-      require('./html.js')(input, inputFile, template, nodeVersion,
+      require('./html.js')(
+        {
+          input: input,
+          filename: inputFile,
+          template: template,
+          nodeVersion: nodeVersion,
+        },
+
         function(er, html) {
           if (er) throw er;
           console.log(html);
-        });
+        }
+      );
       break;
 
     default:

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -30,12 +30,12 @@ var gtocPath = path.resolve(path.join(
 var gtocLoading = null;
 var gtocData = null;
 
-function toHTML(input, filename, template, nodeVersion, cb) {
-  if (typeof nodeVersion === 'function') {
-    cb = nodeVersion;
-    nodeVersion = null;
-  }
-  nodeVersion = nodeVersion || process.version;
+/**
+ * opts: input, filename, template, nodeVersion.
+ */
+function toHTML(opts, cb) {
+  var template = opts.template;
+  var nodeVersion = opts.nodeVersion || process.version;
 
   if (gtocData) {
     return onGtocLoaded();
@@ -57,10 +57,15 @@ function toHTML(input, filename, template, nodeVersion, cb) {
   }
 
   function onGtocLoaded() {
-    var lexed = marked.lexer(input);
+    var lexed = marked.lexer(opts.input);
     fs.readFile(template, 'utf8', function(er, template) {
       if (er) return cb(er);
-      render(lexed, filename, template, nodeVersion, cb);
+      render({
+        lexed: lexed,
+        filename: opts.filename,
+        template: template,
+        nodeVersion: nodeVersion,
+      }, cb);
     });
   }
 }
@@ -87,13 +92,14 @@ function toID(filename) {
     .replace(/-+/g, '-');
 }
 
-function render(lexed, filename, template, nodeVersion, cb) {
-  if (typeof nodeVersion === 'function') {
-    cb = nodeVersion;
-    nodeVersion = null;
-  }
-
-  nodeVersion = nodeVersion || process.version;
+/**
+ * opts: lexed, filename, template, nodeVersion.
+ */
+function render(opts, cb) {
+  var lexed = opts.lexed;
+  var filename = opts.filename;
+  var template = opts.template;
+  var nodeVersion = opts.nodeVersion || process.version;
 
   // get the section
   var section = getSection(lexed);


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description of change

/cc @TheAlphaNerd In #3888 signatures of some functions used to build the docs were converted to take options hashes and then those changes were interpreted as the intrinsic cause of a test failure and reverted in #6680. The test *did* fail because the callsite signatures didn't match the updates, but passes once that's resolved. This PR restores the changes converting those signatures to take options hashes, and updates the callsites in the recently added [`test/doctool/test-doctool-html.js`](https://github.com/nodejs/node/blob/2e845f85016f4d4b971e534f1f50f0c3416952e3/test/doctool/test-doctool-html.js). See discussion in https://github.com/nodejs/node/pull/6680 for more info.

`make test` passes for me locally, and anecdotal testing of `NODE=node make doc-only` (what #3888 enabled) works as expected.

# Node version defaults

I retained the additions from https://github.com/nodejs/node/pull/6680 that set a default node version:

```js
nodeVersion = nodeVersion || process.version;
```

However, I'd note that those additions aren't covered by tests and that of the 3 of them, I'd consider 2 of them to be redundant with the one in [`tools/doc/html.js:toHTML`](https://github.com/jmm/node/blob/76577aa02ea6986d6b9e65e1bf77fee7930268ec/tools/doc/html.js#L38).

# ES6

I noticed that since I started #3888 some ES6 (template literals) were added to `tools/doc/html.js`. Some of the changes I made could be written considerably more elegantly using some ES6 (a little bit with object literal shorthand properties, and most of all with destructuring), but the purpose of #3888 was to make it possible to build the docs (which relies on the files in this PR) using an existing Node install, which may be earlier than the Node version for which the docs are being built. So it'd be worth keeping that in mind and perhaps limiting the features used in the doc build tools to those that'll work a few versions back. (Example: I think template literals and object literal shorthand properties are both available without a flag in v4, but not destructuring.)
