### PR TITLE
test,tools: enable object-curly-spacing linting

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,9 @@
 ## Test-specific linter rules
 
 rules:
+  # Stylistic Issues
+  # http://eslint.org/docs/rules/#stylistic-issues
+  object-curly-spacing: [2, "always"]
+
   ## common module is mandatory in tests
   required-modules: [2, "common"]

--- a/test/common.js
+++ b/test/common.js
@@ -141,7 +141,7 @@ Object.defineProperty(exports, 'localhostIPv4', {
 });
 
 // opensslCli defined lazily to reduce overhead of spawnSync
-Object.defineProperty(exports, 'opensslCli', {get: function() {
+Object.defineProperty(exports, 'opensslCli', { get: function() {
   if (opensslCli !== null) return opensslCli;
 
   if (process.config.variables.node_shared_openssl) {
@@ -428,7 +428,7 @@ exports.getServiceName = function getServiceName(port, protocol) {
 
   try {
     var servicesContent = fs.readFileSync(etcServicesFileName,
-      { encoding: 'utf8'});
+      { encoding: 'utf8' });
     var regexp = `^(\\w+)\\s+\\s${port}/${protocol}\\s`;
     var re = new RegExp(regexp, 'm');
 

--- a/test/debugger/helper-debugger-repl.js
+++ b/test/debugger/helper-debugger-repl.js
@@ -104,7 +104,7 @@ function addTest(input, output) {
       quit();
     }
   }
-  expected.push({input: input, lines: output, callback: next});
+  expected.push({ input: input, lines: output, callback: next });
 }
 
 var handshakeLines = [

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -4,7 +4,7 @@
 
 function serverHandler(req, res) {
   req.resume();
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('Hello World\n');
 }
 

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -2,7 +2,7 @@
 // just a simple http server and client.
 
 function serverHandler(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('Hello World\n');
 }
 

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -150,7 +150,7 @@ TEST(function test_lookup_localhost_ipv4(done) {
 TEST(function test_lookup_all_ipv4(done) {
   var req = dns.lookup(
     'www.google.com',
-    {all: true, family: 4},
+    { all: true, family: 4 },
     function(err, ips) {
       if (err) throw err;
       assert.ok(Array.isArray(ips));

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -158,7 +158,7 @@ TEST(function test_lookup_ip_ipv6(done) {
 TEST(function test_lookup_all_ipv6(done) {
   var req = dns.lookup(
     'www.google.com',
-    {all: true, family: 6},
+    { all: true, family: 6 },
     function(err, ips) {
       if (err) throw err;
       assert.ok(Array.isArray(ips));

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -369,7 +369,7 @@ TEST(function test_lookup_null(done) {
 
 
 TEST(function test_lookup_ip_all(done) {
-  var req = dns.lookup('127.0.0.1', {all: true}, function(err, ips, family) {
+  var req = dns.lookup('127.0.0.1', { all: true }, function(err, ips, family) {
     if (err) throw err;
     assert.ok(Array.isArray(ips));
     assert.ok(ips.length > 0);
@@ -384,7 +384,7 @@ TEST(function test_lookup_ip_all(done) {
 
 
 TEST(function test_lookup_null_all(done) {
-  var req = dns.lookup(null, {all: true}, function(err, ips, family) {
+  var req = dns.lookup(null, { all: true }, function(err, ips, family) {
     if (err) throw err;
     assert.ok(Array.isArray(ips));
     assert.strictEqual(ips.length, 0);
@@ -397,7 +397,7 @@ TEST(function test_lookup_null_all(done) {
 
 
 TEST(function test_lookup_all_mixed(done) {
-  var req = dns.lookup('www.google.com', {all: true}, function(err, ips) {
+  var req = dns.lookup('www.google.com', { all: true }, function(err, ips) {
     if (err) throw err;
     assert.ok(Array.isArray(ips));
     assert.ok(ips.length > 0);

--- a/test/known_issues/test-process-external-stdio-close.js
+++ b/test/known_issues/test-process-external-stdio-close.js
@@ -11,7 +11,7 @@ if (process.argv[2] === 'child') {
     process.disconnect();
   }));
 } else {
-  const child = cp.fork(__filename, ['child'], {silent: true});
+  const child = cp.fork(__filename, ['child'], { silent: true });
 
   child.on('close', common.mustCall((exitCode, signal) => {
     assert.strictEqual(exitCode, 0);

--- a/test/known_issues/test-stdin-is-always-net.socket.js
+++ b/test/known_issues/test-stdin-is-always-net.socket.js
@@ -11,7 +11,8 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const proc = spawn(process.execPath, [__filename, 'child'], {stdio: 'ignore'});
+const proc = spawn(process.execPath, [__filename, 'child'],
+                   { stdio: 'ignore' });
 // To double-check this test, set stdio to 'pipe' and uncomment the line below.
 // proc.stderr.pipe(process.stderr);
 proc.on('exit', common.mustCall(function(exitCode) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -97,14 +97,14 @@ assert.throws(makeBlock(a.deepEqual, 4, '5'),
 
 // 7.5
 // having the same number of owned properties && the same set of keys
-assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4}, {a: 4}));
-assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '2'}, {a: 4, b: '2'}));
+assert.doesNotThrow(makeBlock(a.deepEqual, { a: 4 }, { a: 4 }));
+assert.doesNotThrow(makeBlock(a.deepEqual, { a: 4, b: '2' }, { a: 4, b: '2' }));
 assert.doesNotThrow(makeBlock(a.deepEqual, [4], ['4']));
-assert.throws(makeBlock(a.deepEqual, {a: 4}, {a: 4, b: true}),
+assert.throws(makeBlock(a.deepEqual, { a: 4 }, { a: 4, b: true }),
               a.AssertionError);
-assert.doesNotThrow(makeBlock(a.deepEqual, ['a'], {0: 'a'}));
+assert.doesNotThrow(makeBlock(a.deepEqual, ['a'], { 0: 'a' }));
 //(although not necessarily the same order),
-assert.doesNotThrow(makeBlock(a.deepEqual, {a: 4, b: '1'}, {b: '1', a: 4}));
+assert.doesNotThrow(makeBlock(a.deepEqual, { a: 4, b: '1' }, { b: '1', a: 4 }));
 var a1 = [1, 2, 3];
 var a2 = [1, 2, 3];
 a1.a = 'test';
@@ -147,7 +147,7 @@ assert.doesNotThrow(makeBlock(a.deepEqual, nb1, nb2));
 assert.throws(makeBlock(a.deepEqual, null, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, undefined, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, 'a', ['a']), a.AssertionError);
-assert.throws(makeBlock(a.deepEqual, 'a', {0: 'a'}), a.AssertionError);
+assert.throws(makeBlock(a.deepEqual, 'a', { 0: 'a' }), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, 1, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, true, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepEqual, Symbol(), {}), a.AssertionError);
@@ -155,7 +155,7 @@ assert.throws(makeBlock(a.deepEqual, Symbol(), {}), a.AssertionError);
 // primitive wrappers and object
 assert.doesNotThrow(makeBlock(a.deepEqual, new String('a'), ['a']),
                     a.AssertionError);
-assert.doesNotThrow(makeBlock(a.deepEqual, new String('a'), {0: 'a'}),
+assert.doesNotThrow(makeBlock(a.deepEqual, new String('a'), { 0: 'a' }),
                     a.AssertionError);
 assert.doesNotThrow(makeBlock(a.deepEqual, new Number(1), {}),
                     a.AssertionError);
@@ -205,18 +205,18 @@ assert.throws(makeBlock(a.deepStrictEqual, 4, '5'),
 
 // 7.5 - strict
 // having the same number of owned properties && the same set of keys
-assert.doesNotThrow(makeBlock(a.deepStrictEqual, {a: 4}, {a: 4}));
+assert.doesNotThrow(makeBlock(a.deepStrictEqual, { a: 4 }, { a: 4 }));
 assert.doesNotThrow(makeBlock(a.deepStrictEqual,
-                              {a: 4, b: '2'},
-                              {a: 4, b: '2'}));
+                              { a: 4, b: '2' },
+                              { a: 4, b: '2' }));
 assert.throws(makeBlock(a.deepStrictEqual, [4], ['4']));
-assert.throws(makeBlock(a.deepStrictEqual, {a: 4}, {a: 4, b: true}),
+assert.throws(makeBlock(a.deepStrictEqual, { a: 4 }, { a: 4, b: true }),
               a.AssertionError);
-assert.throws(makeBlock(a.deepStrictEqual, ['a'], {0: 'a'}));
+assert.throws(makeBlock(a.deepStrictEqual, ['a'], { 0: 'a' }));
 //(although not necessarily the same order),
 assert.doesNotThrow(makeBlock(a.deepStrictEqual,
-                              {a: 4, b: '1'},
-                              {b: '1', a: 4}));
+                              { a: 4, b: '1' },
+                              { b: '1', a: 4 }));
 
 assert.throws(makeBlock(a.deepStrictEqual,
                         [0, 1, 2, 'a', 'b'],
@@ -262,7 +262,7 @@ assert.doesNotThrow(makeBlock(assert.deepStrictEqual, s, s));
 assert.throws(makeBlock(a.deepStrictEqual, null, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepStrictEqual, undefined, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepStrictEqual, 'a', ['a']), a.AssertionError);
-assert.throws(makeBlock(a.deepStrictEqual, 'a', {0: 'a'}), a.AssertionError);
+assert.throws(makeBlock(a.deepStrictEqual, 'a', { 0: 'a' }), a.AssertionError);
 assert.throws(makeBlock(a.deepStrictEqual, 1, {}), a.AssertionError);
 assert.throws(makeBlock(a.deepStrictEqual, true, {}), a.AssertionError);
 assert.throws(makeBlock(assert.deepStrictEqual, Symbol(), {}),
@@ -272,7 +272,7 @@ assert.throws(makeBlock(assert.deepStrictEqual, Symbol(), {}),
 // primitive wrappers and object
 assert.throws(makeBlock(a.deepStrictEqual, new String('a'), ['a']),
               a.AssertionError);
-assert.throws(makeBlock(a.deepStrictEqual, new String('a'), {0: 'a'}),
+assert.throws(makeBlock(a.deepStrictEqual, new String('a'), { 0: 'a' }),
               a.AssertionError);
 assert.throws(makeBlock(a.deepStrictEqual, new Number(1), {}),
               a.AssertionError);
@@ -410,7 +410,7 @@ a.throws(makeBlock(a.deepEqual, [], args));
 a.throws(makeBlock(a.deepEqual, args, []));
 
 
-var circular = {y: 1};
+var circular = { y: 1 };
 circular.x = circular;
 
 function testAssertionMessage(actual, expected) {
@@ -442,8 +442,8 @@ testAssertionMessage(function f() {}, '[Function: f]');
 testAssertionMessage(function() {}, '[Function]');
 testAssertionMessage({}, '{}');
 testAssertionMessage(circular, '{ y: 1, x: [Circular] }');
-testAssertionMessage({a: undefined, b: null}, '{ a: undefined, b: null }');
-testAssertionMessage({a: NaN, b: Infinity, c: -Infinity},
+testAssertionMessage({ a: undefined, b: null }, '{ a: undefined, b: null }');
+testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
     '{ a: NaN, b: Infinity, c: -Infinity }');
 
 // #2893

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -345,9 +345,9 @@ assert.equal(rangeBuffer.toString('ascii', 0, 1.99), 'a');
 assert.equal(rangeBuffer.toString('ascii', 0, true), 'a');
 
 // try toString() with a object as a encoding
-assert.equal(rangeBuffer.toString({toString: function() {
+assert.equal(rangeBuffer.toString({ toString: function() {
   return 'ascii';
-}}), 'abc');
+} }), 'abc');
 
 // testing for smart defaults and ability to pass string values as offset
 var writeTest = Buffer.from('abcdes');
@@ -512,10 +512,10 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 }
 
 
-var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
+var arrayIsh = { 0: 0, 1: 1, 2: 2, 3: 3, length: 4 };
 var g = Buffer.from(arrayIsh);
 assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
-var strArrayIsh = {0: '0', 1: '1', 2: '2', 3: '3', length: 4};
+var strArrayIsh = { 0: '0', 1: '1', 2: '2', 3: '3', length: 4 };
 g = Buffer.from(strArrayIsh);
 assert.deepStrictEqual(g, Buffer.from([0, 1, 2, 3]));
 
@@ -984,8 +984,8 @@ Buffer.alloc(3.3).fill().toString();
 assert.equal(Buffer.allocUnsafe(-1).length, 0);
 assert.equal(Buffer.allocUnsafe(NaN).length, 0);
 assert.equal(Buffer.allocUnsafe(3.3).length, 3);
-assert.equal(Buffer.from({length: 3.3}).length, 3);
-assert.equal(Buffer.from({length: 'BAM'}).length, 0);
+assert.equal(Buffer.from({ length: 3.3 }).length, 3);
+assert.equal(Buffer.from({ length: 'BAM' }).length, 0);
 
 // Make sure that strings are not coerced to numbers.
 assert.equal(Buffer.from('99').length, 2);

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -44,7 +44,7 @@ assert.equal(-1, a.compare(b, 0, 7, 4, 6));
 assert.equal(1, a.compare(b, 0, null));
 
 // coerces to targetEnd == 5
-assert.equal(-1, a.compare(b, 0, {valueOf: () => 5}));
+assert.equal(-1, a.compare(b, 0, { valueOf: () => 5 }));
 
 // zero length target
 assert.equal(1, a.compare(b, Infinity, -Infinity));

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -346,9 +346,9 @@ assert.equal(rangeBuffer.toString('ascii', 0, 1.99), 'a');
 assert.equal(rangeBuffer.toString('ascii', 0, true), 'a');
 
 // try toString() with a object as a encoding
-assert.equal(rangeBuffer.toString({toString: function() {
+assert.equal(rangeBuffer.toString({ toString: function() {
   return 'ascii';
-}}), 'abc');
+} }), 'abc');
 
 // testing for smart defaults and ability to pass string values as offset
 var writeTest = new Buffer('abcdes');
@@ -513,10 +513,10 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 }
 
 
-var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
+var arrayIsh = { 0: 0, 1: 1, 2: 2, 3: 3, length: 4 };
 var g = new Buffer(arrayIsh);
 assert.deepStrictEqual(g, new Buffer([0, 1, 2, 3]));
-var strArrayIsh = {0: '0', 1: '1', 2: '2', 3: '3', length: 4};
+var strArrayIsh = { 0: '0', 1: '1', 2: '2', 3: '3', length: 4 };
 g = new Buffer(strArrayIsh);
 assert.deepStrictEqual(g, new Buffer([0, 1, 2, 3]));
 
@@ -977,8 +977,8 @@ Buffer(3.3).fill().toString(); // throws bad argument error in commit 43cb4ec
 assert.equal(Buffer(-1).length, 0);
 assert.equal(Buffer(NaN).length, 0);
 assert.equal(Buffer(3.3).length, 3);
-assert.equal(Buffer({length: 3.3}).length, 3);
-assert.equal(Buffer({length: 'BAM'}).length, 0);
+assert.equal(Buffer({ length: 3.3 }).length, 3);
+assert.equal(Buffer({ length: 'BAM' }).length, 0);
 
 // Make sure that strings are not coerced to numbers.
 assert.equal(Buffer('99').length, 2);

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -37,18 +37,18 @@ function testCwd(options, forCode, forData) {
 
 // Assume these exist, and 'pwd' gives us the right directory back
 if (common.isWindows) {
-  testCwd({cwd: process.env.windir}, 0, process.env.windir);
-  testCwd({cwd: 'c:\\'}, 0, 'c:\\');
+  testCwd({ cwd: process.env.windir }, 0, process.env.windir);
+  testCwd({ cwd: 'c:\\' }, 0, 'c:\\');
 } else {
-  testCwd({cwd: '/dev'}, 0, '/dev');
-  testCwd({cwd: '/'}, 0, '/');
+  testCwd({ cwd: '/dev' }, 0, '/dev');
+  testCwd({ cwd: '/' }, 0, '/');
 }
 
 // Assume does-not-exist doesn't exist, expect exitCode=-1 and errno=ENOENT
 (function() {
   var errors = 0;
 
-  testCwd({cwd: 'does-not-exist'}, -1).on('error', function(e) {
+  testCwd({ cwd: 'does-not-exist' }, -1).on('error', function(e) {
     assert.equal(e.code, 'ENOENT');
     errors++;
   });
@@ -61,9 +61,9 @@ if (common.isWindows) {
 // Spawn() shouldn't try to chdir() so this should just work
 testCwd(undefined, 0);
 testCwd({}, 0);
-testCwd({cwd: ''}, 0);
-testCwd({cwd: undefined}, 0);
-testCwd({cwd: null}, 0);
+testCwd({ cwd: '' }, 0);
+testCwd({ cwd: undefined }, 0);
+testCwd({ cwd: null }, 0);
 
 // Check whether all tests actually returned
 assert.notEqual(0, returns);

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -13,9 +13,9 @@ Object.setPrototypeOf(env, {
 
 var child;
 if (common.isWindows) {
-  child = spawn('cmd.exe', ['/c', 'set'], {env: env});
+  child = spawn('cmd.exe', ['/c', 'set'], { env: env });
 } else {
-  child = spawn('/usr/bin/env', [], {env: env});
+  child = spawn('/usr/bin/env', [], { env: env });
 }
 
 

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -16,7 +16,7 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
+exec(pwdcommand, { cwd: dir }, function(err, stdout, stderr) {
   if (err) {
     error_count++;
     console.log('error!: ' + err.code);

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 var common = require('../common');
-var msg = {test: 'this'};
+var msg = { test: 'this' };
 var nodePath = process.execPath;
 var copyPath = path.join(common.tmpDir, 'node-copy.exe');
 

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -29,13 +29,13 @@ if (process.argv[2] === 'child') {
 
     server.on('connection', function(socket) {
       console.log('CHILD: got connection');
-      process.send({what: 'connection'});
+      process.send({ what: 'connection' });
       socket.destroy();
     });
 
     // start making connection from parent
     console.log('CHILD: server listening');
-    process.send({what: 'listening'});
+    process.send({ what: 'listening' });
   });
 
   process.on('message', function onClose(msg) {
@@ -43,7 +43,7 @@ if (process.argv[2] === 'child') {
     process.removeListener('message', onClose);
 
     serverScope.on('close', function() {
-      process.send({what: 'close'});
+      process.send({ what: 'close' });
     });
     serverScope.close();
   });
@@ -55,7 +55,7 @@ if (process.argv[2] === 'child') {
     console.log('CHILD: got socket');
   });
 
-  process.send({what: 'ready'});
+  process.send({ what: 'ready' });
 } else {
 
   var child = fork(process.argv[1], ['child']);
@@ -71,7 +71,7 @@ if (process.argv[2] === 'child') {
     var progress = new ProgressTracker(2, function() {
       server.on('close', function() {
         console.log('PARENT: server closed');
-        child.send({what: 'close'});
+        child.send({ what: 'close' });
       });
       server.close();
     });
@@ -89,7 +89,7 @@ if (process.argv[2] === 'child') {
     });
     server.on('listening', function() {
       console.log('PARENT: server listening');
-      child.send({what: 'server'}, server);
+      child.send({ what: 'server' }, server);
     });
     server.listen(common.PORT);
 
@@ -131,7 +131,7 @@ if (process.argv[2] === 'child') {
       socket.on('close', function() {
         console.log('CLIENT: socket closed');
       });
-      child.send({what: 'socket'}, socket);
+      child.send({ what: 'socket' }, socket);
     });
     server.on('close', function() {
       console.log('PARENT: server closed');

--- a/test/parallel/test-child-process-fork-ref.js
+++ b/test/parallel/test-child-process-fork-ref.js
@@ -16,7 +16,7 @@ if (process.argv[2] === 'child') {
   });
 
 } else {
-  var child = fork(__filename, ['child'], {silent: true});
+  var child = fork(__filename, ['child'], { silent: true });
 
   var ipc = [], stdout = '';
 

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -4,8 +4,8 @@ var assert = require('assert');
 
 //messages
 var PREFIX = 'NODE_';
-var normal = {cmd: 'foo' + PREFIX};
-var internal = {cmd: PREFIX + 'bar'};
+var normal = { cmd: 'foo' + PREFIX };
+var internal = { cmd: PREFIX + 'bar' };
 
 if (process.argv[2] === 'child') {
   //send non-internal message containing PREFIX at a non prefix position

--- a/test/parallel/test-child-process-send-keep-open.js
+++ b/test/parallel/test-child-process-send-keep-open.js
@@ -32,7 +32,7 @@ if (process.argv[2] !== 'child') {
       });
     }));
 
-    child.send('socket', socket, {keepOpen: true}, common.mustCall((err) => {
+    child.send('socket', socket, { keepOpen: true }, common.mustCall((err) => {
       assert.ifError(err);
     }));
   });

--- a/test/parallel/test-child-process-silent.js
+++ b/test/parallel/test-child-process-silent.js
@@ -18,7 +18,7 @@ if (process.argv[2] === 'pipe') {
 } else if (process.argv[2] === 'parent') {
   // Parent | start child pipe test
 
-  const child = childProcess.fork(process.argv[1], ['pipe'], {silent: true});
+  const child = childProcess.fork(process.argv[1], ['pipe'], { silent: true });
 
   // Allow child process to self terminate
   child._channel.close();
@@ -46,11 +46,11 @@ if (process.argv[2] === 'pipe') {
   });
 
   // testing: do message system work when using silent
-  const child = childProcess.fork(process.argv[1], ['ipc'], {silent: true});
+  const child = childProcess.fork(process.argv[1], ['ipc'], { silent: true });
 
   // Manual pipe so we will get errors
-  child.stderr.pipe(process.stderr, {end: false});
-  child.stdout.pipe(process.stdout, {end: false});
+  child.stderr.pipe(process.stderr, { end: false });
+  child.stdout.pipe(process.stdout, { end: false });
 
   var childSending = false;
   var childReciveing = false;

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cp = require('child_process');
 
 // Verify that a shell is, in fact, executed
-const doesNotExist = cp.spawn('does-not-exist', {shell: true});
+const doesNotExist = cp.spawn('does-not-exist', { shell: true });
 
 assert.notEqual(doesNotExist.spawnfile, 'does-not-exist');
 doesNotExist.on('error', common.fail);
@@ -50,7 +50,7 @@ command.on('close', common.mustCall((code, signal) => {
 
 // Verify that the environment is properly inherited
 const env = cp.spawn(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: Object.assign({}, process.env, {BAZ: 'buzz'}),
+  env: Object.assign({}, process.env, { BAZ: 'buzz' }),
   encoding: 'utf8',
   shell: true
 });

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cp = require('child_process');
 
 // Verify that a shell is, in fact, executed
-const doesNotExist = cp.spawnSync('does-not-exist', {shell: true});
+const doesNotExist = cp.spawnSync('does-not-exist', { shell: true });
 
 assert.notEqual(doesNotExist.file, 'does-not-exist');
 assert.strictEqual(doesNotExist.error, undefined);
@@ -16,7 +16,7 @@ else
   assert.strictEqual(doesNotExist.status, 127);  // Exit code of /bin/sh
 
 // Verify that passing arguments works
-const echo = cp.spawnSync('echo', ['foo'], {shell: true});
+const echo = cp.spawnSync('echo', ['foo'], { shell: true });
 
 assert.strictEqual(echo.args[echo.args.length - 1].replace(/"/g, ''),
                    'echo foo');
@@ -24,13 +24,13 @@ assert.strictEqual(echo.stdout.toString().trim(), 'foo');
 
 // Verify that shell features can be used
 const cmd = common.isWindows ? 'echo bar | more' : 'echo bar | cat';
-const command = cp.spawnSync(cmd, {shell: true});
+const command = cp.spawnSync(cmd, { shell: true });
 
 assert.strictEqual(command.stdout.toString().trim(), 'bar');
 
 // Verify that the environment is properly inherited
 const env = cp.spawnSync(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: Object.assign({}, process.env, {BAZ: 'buzz'}),
+  env: Object.assign({}, process.env, { BAZ: 'buzz' }),
   shell: true
 });
 

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -17,7 +17,7 @@ switch (process.argv[2]) {
   default:
     var start = Date.now();
     var ret = spawnSync(process.execPath, [__filename, 'child'],
-                        {timeout: TIMER});
+                        { timeout: TIMER });
     assert.strictEqual(ret.error.errno, 'ETIMEDOUT');
     console.log(ret);
     var end = Date.now() - start;

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -25,10 +25,10 @@ assert.deepStrictEqual(ret_err.spawnargs, ['bar']);
 
   if (common.isWindows) {
     cwd = 'c:\\';
-    response = spawnSync('cmd.exe', ['/c', 'cd'], {cwd: cwd});
+    response = spawnSync('cmd.exe', ['/c', 'cd'], { cwd: cwd });
   } else {
     cwd = '/';
-    response = spawnSync('pwd', [], {cwd: cwd});
+    response = spawnSync('pwd', [], { cwd: cwd });
   }
 
   assert.strictEqual(response.stdout.toString().trim(), cwd);

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -2,18 +2,18 @@
 var common = require('../common');
 var assert = require('assert');
 
-var options = {stdio: ['pipe']};
+var options = { stdio: ['pipe'] };
 var child = common.spawnPwd(options);
 
 assert.notEqual(child.stdout, null);
 assert.notEqual(child.stderr, null);
 
-options = {stdio: 'ignore'};
+options = { stdio: 'ignore' };
 child = common.spawnPwd(options);
 
 assert.equal(child.stdout, null);
 assert.equal(child.stderr, null);
 
-options = {stdio: 'ignore'};
+options = { stdio: 'ignore' };
 child = common.spawnSyncCat(options);
-assert.deepStrictEqual(options, {stdio: 'ignore'});
+assert.deepStrictEqual(options, { stdio: 'ignore' });

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -27,7 +27,7 @@ var syntaxArgs = [
   // loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
     var _args = args.concat(file);
-    var c = spawnSync(node, _args, {encoding: 'utf8'});
+    var c = spawnSync(node, _args, { encoding: 'utf8' });
 
     // no output should be produced
     assert.equal(c.stdout, '', 'stdout produced');
@@ -48,7 +48,7 @@ var syntaxArgs = [
   // loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
     var _args = args.concat(file);
-    var c = spawnSync(node, _args, {encoding: 'utf8'});
+    var c = spawnSync(node, _args, { encoding: 'utf8' });
 
     // no stdout should be produced
     assert.equal(c.stdout, '', 'stdout produced');
@@ -71,7 +71,7 @@ var syntaxArgs = [
   // loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
     var _args = args.concat(file);
-    var c = spawnSync(node, _args, {encoding: 'utf8'});
+    var c = spawnSync(node, _args, { encoding: 'utf8' });
 
     // no stdout should be produced
     assert.equal(c.stdout, '', 'stdout produced');

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -87,7 +87,7 @@ function worker() {
 
     // Every 10 messages, notify the master.
     if (received == PACKETS_PER_WORKER) {
-      process.send({received: received});
+      process.send({ received: received });
       process.disconnect();
     }
   });

--- a/test/parallel/test-cluster-disconnect-unshared-tcp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-tcp.js
@@ -9,7 +9,7 @@ if (cluster.isMaster) {
   var unbound = cluster.fork().on('online', bind);
 
   function bind() {
-    cluster.fork({BOUND: 'y'}).on('listening', disconnect);
+    cluster.fork({ BOUND: 'y' }).on('listening', disconnect);
   }
 
   function disconnect() {

--- a/test/parallel/test-cluster-disconnect-unshared-udp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-udp.js
@@ -14,7 +14,7 @@ if (cluster.isMaster) {
   var unbound = cluster.fork().on('online', bind);
 
   function bind() {
-    cluster.fork({BOUND: 'y'}).on('listening', disconnect);
+    cluster.fork({ BOUND: 'y' }).on('listening', disconnect);
   }
 
   function disconnect() {

--- a/test/parallel/test-cluster-master-error.js
+++ b/test/parallel/test-cluster-master-error.js
@@ -75,7 +75,7 @@ if (cluster.isWorker) {
   var workers = [];
 
   // Spawn a cluster process
-  var master = fork(process.argv[1], ['cluster'], {silent: true});
+  var master = fork(process.argv[1], ['cluster'], { silent: true });
 
   // Handle messages from the cluster
   master.on('message', function(data) {

--- a/test/parallel/test-cluster-worker-constructor.js
+++ b/test/parallel/test-cluster-worker-constructor.js
@@ -23,6 +23,6 @@ assert.equal(worker.state, 'online');
 assert.equal(worker.id, 3);
 assert.equal(worker.process, process);
 
-worker = cluster.Worker.call({}, {id: 5});
+worker = cluster.Worker.call({}, { id: 5 });
 assert(worker instanceof cluster.Worker);
 assert.equal(worker.id, 5);

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -39,7 +39,7 @@ if (cluster.isMaster) {
 
     worker = cluster.fork()
       .on('online', function() {
-        this.send({port: port});
+        this.send({ port: port });
       });
   });
   process.on('exit', function() {

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -39,28 +39,28 @@ global.process.stderr.write = function(string) {
 console.log('foo');
 console.log('foo', 'bar');
 console.log('%s %s', 'foo', 'bar', 'hop');
-console.log({slashes: '\\\\'});
+console.log({ slashes: '\\\\' });
 console.log(custom_inspect);
 
 // test console.info()
 console.info('foo');
 console.info('foo', 'bar');
 console.info('%s %s', 'foo', 'bar', 'hop');
-console.info({slashes: '\\\\'});
+console.info({ slashes: '\\\\' });
 console.info(custom_inspect);
 
 // test console.error()
 console.error('foo');
 console.error('foo', 'bar');
 console.error('%s %s', 'foo', 'bar', 'hop');
-console.error({slashes: '\\\\'});
+console.error({ slashes: '\\\\' });
 console.error(custom_inspect);
 
 // test console.warn()
 console.warn('foo');
 console.warn('foo', 'bar');
 console.warn('%s %s', 'foo', 'bar', 'hop');
-console.warn({slashes: '\\\\'});
+console.warn({ slashes: '\\\\' });
 console.warn(custom_inspect);
 
 // test console.dir()

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -30,19 +30,19 @@ var rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
 
 // PFX tests
 assert.doesNotThrow(function() {
-  tls.createSecureContext({pfx: certPfx, passphrase: 'sample'});
+  tls.createSecureContext({ pfx: certPfx, passphrase: 'sample' });
 });
 
 assert.throws(function() {
-  tls.createSecureContext({pfx: certPfx});
+  tls.createSecureContext({ pfx: certPfx });
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx: certPfx, passphrase: 'test'});
+  tls.createSecureContext({ pfx: certPfx, passphrase: 'test' });
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx: 'sample', passphrase: 'test'});
+  tls.createSecureContext({ pfx: 'sample', passphrase: 'test' });
 }, 'not enough data');
 
 // Test HMAC
@@ -518,7 +518,7 @@ testCipher4(Buffer.from('0123456789abcd0123456789'), Buffer.from('12345678'));
 
 // update() should only take buffers / strings
 assert.throws(function() {
-  crypto.createHash('sha1').update({foo: 'bar'});
+  crypto.createHash('sha1').update({ foo: 'bar' });
 }, /buffer/);
 
 

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -23,7 +23,7 @@ var tls = require('tls');
 // 'this' safety
 // https://github.com/joyent/node/issues/6690
 assert.throws(function() {
-  var options = {key: keyPem, cert: certPem, ca: caPem};
+  var options = { key: keyPem, cert: certPem, ca: caPem };
   var credentials = crypto.createCredentials(options);
   var context = credentials.context;
   var notcontext = { setOptions: context.setOptions, setKey: context.setKey };
@@ -32,25 +32,25 @@ assert.throws(function() {
 
 // PFX tests
 assert.doesNotThrow(function() {
-  tls.createSecureContext({pfx: certPfx, passphrase: 'sample'});
+  tls.createSecureContext({ pfx: certPfx, passphrase: 'sample' });
 });
 
 assert.throws(function() {
-  tls.createSecureContext({pfx: certPfx});
+  tls.createSecureContext({ pfx: certPfx });
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx: certPfx, passphrase: 'test'});
+  tls.createSecureContext({ pfx: certPfx, passphrase: 'test' });
 }, 'mac verify failure');
 
 assert.throws(function() {
-  tls.createSecureContext({pfx: 'sample', passphrase: 'test'});
+  tls.createSecureContext({ pfx: 'sample', passphrase: 'test' });
 }, 'not enough data');
 
 
 // update() should only take buffers / strings
 assert.throws(function() {
-  crypto.createHash('sha1').update({foo: 'bar'});
+  crypto.createHash('sha1').update({ foo: 'bar' });
 }, /buffer/);
 
 

--- a/test/parallel/test-debug-brk.js
+++ b/test/parallel/test-debug-brk.js
@@ -5,5 +5,5 @@ const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
 
 const args = [`--debug-brk=${common.PORT}`, '-e', '0'];
-const proc = spawnSync(process.execPath, args, {encoding: 'utf8'});
+const proc = spawnSync(process.execPath, args, { encoding: 'utf8' });
 assert(/Debugger listening on/.test(proc.stderr));

--- a/test/parallel/test-dgram-bind-shared-ports.js
+++ b/test/parallel/test-dgram-bind-shared-ports.js
@@ -48,7 +48,7 @@ if (cluster.isMaster) {
     port: common.PORT,
     exclusive: false
   }, function() {
-    socket2.bind({port: common.PORT + 1, exclusive: true}, function() {
+    socket2.bind({ port: common.PORT + 1, exclusive: true }, function() {
       // the first worker should succeed
       process.send('success');
     });

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -75,12 +75,12 @@ if (cluster.isMaster) {
     cluster.fork();
     cluster.fork();
     if (!common.isWindows) {
-      cluster.fork({BOUND: 'y'});
-      cluster.fork({BOUND: 'y'});
+      cluster.fork({ BOUND: 'y' });
+      cluster.fork({ BOUND: 'y' });
     }
   });
 
-  target.bind({port: common.PORT, exclusive: true});
+  target.bind({ port: common.PORT, exclusive: true });
 
   return;
 }

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -20,7 +20,7 @@ var server = http.createServer(function(req, res) {
     serverCaught++;
     console.log('horray! got a server error', er);
     // try to send a 500.  If that fails, oh well.
-    res.writeHead(500, {'content-type': 'text/plain'});
+    res.writeHead(500, { 'content-type': 'text/plain' });
     res.end(er.stack || er.message || 'Unknown error');
   });
 

--- a/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -29,7 +29,7 @@ if (process.argv[2] === 'child') {
   var fork = require('child_process').fork;
   var assert = require('assert');
 
-  var child = fork(process.argv[1], ['child'], {silent: true});
+  var child = fork(process.argv[1], ['child'], { silent: true });
   var stderrOutput = '';
   if (child) {
     child.stderr.on('data', function onStderrData(data) {

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -52,7 +52,7 @@ file.on('close', function() {
   //assert.equal(fs.readFileSync(fn), fileContent);
 });
 
-var file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
+var file3 = fs.createReadStream(fn, Object.create({ encoding: 'utf8' }));
 file3.length = 0;
 file3.on('data', function(data) {
   assert.equal('string', typeof data);
@@ -77,8 +77,8 @@ process.on('exit', function() {
   console.error('ok');
 });
 
-var file4 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
-                                start: 1, end: 2}));
+var file4 = fs.createReadStream(rangeFile, Object.create({ bufferSize: 1,
+                                start: 1, end: 2 }));
 assert.equal(file4.start, 1);
 assert.equal(file4.end, 2);
 var contentRead = '';
@@ -89,8 +89,8 @@ file4.on('end', function(data) {
   assert.equal(contentRead, 'yz');
 });
 
-var file5 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
-                                start: 1}));
+var file5 = fs.createReadStream(rangeFile, Object.create({ bufferSize: 1,
+                                start: 1 }));
 assert.equal(file5.start, 1);
 file5.data = '';
 file5.on('data', function(data) {
@@ -101,8 +101,8 @@ file5.on('end', function() {
 });
 
 // https://github.com/joyent/node/issues/2320
-var file6 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1.23,
-                                start: 1}));
+var file6 = fs.createReadStream(rangeFile, Object.create({ bufferSize: 1.23,
+                                start: 1 }));
 assert.equal(file6.start, 1);
 file6.data = '';
 file6.on('data', function(data) {
@@ -113,7 +113,7 @@ file6.on('end', function() {
 });
 
 assert.throws(function() {
-  fs.createReadStream(rangeFile, Object.create({start: 10, end: 2}));
+  fs.createReadStream(rangeFile, Object.create({ start: 10, end: 2 }));
 }, /"start" option must be <= "end" option/);
 
 var stream = fs.createReadStream(rangeFile, Object.create({ start: 0,
@@ -135,7 +135,7 @@ var pauseRes = fs.createReadStream(rangeFile);
 pauseRes.pause();
 pauseRes.resume();
 
-var file7 = fs.createReadStream(rangeFile, Object.create({autoClose: false }));
+var file7 = fs.createReadStream(rangeFile, Object.create({ autoClose: false }));
 assert.equal(file7.autoClose, false);
 file7.on('data', function() {});
 file7.on('end', function() {
@@ -148,7 +148,7 @@ file7.on('end', function() {
 
 function file7Next() {
   // This will tell us if the fd is usable again or not.
-  file7 = fs.createReadStream(null, Object.create({fd: file7.fd, start: 0 }));
+  file7 = fs.createReadStream(null, Object.create({ fd: file7.fd, start: 0 }));
   file7.data = '';
   file7.on('data', function(data) {
     file7.data += data;
@@ -159,7 +159,7 @@ function file7Next() {
 }
 
 // Just to make sure autoClose won't close the stream because of error.
-var file8 = fs.createReadStream(null, Object.create({fd: 13337,
+var file8 = fs.createReadStream(null, Object.create({ fd: 13337,
                                 autoClose: false }));
 file8.on('data', function() {});
 file8.on('error', common.mustCall(function() {}));

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -13,7 +13,7 @@ assert.doesNotThrow(function() {
   fs.createReadStream(example, 'utf8');
 });
 assert.doesNotThrow(function() {
-  fs.createReadStream(example, {encoding: 'utf8'});
+  fs.createReadStream(example, { encoding: 'utf8' });
 });
 
 assert.throws(function() {

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -52,7 +52,7 @@ file.on('close', function() {
   //assert.equal(fs.readFileSync(fn), fileContent);
 });
 
-var file3 = fs.createReadStream(fn, {encoding: 'utf8'});
+var file3 = fs.createReadStream(fn, { encoding: 'utf8' });
 file3.length = 0;
 file3.on('data', function(data) {
   assert.equal('string', typeof data);
@@ -77,7 +77,7 @@ process.on('exit', function() {
   console.error('ok');
 });
 
-var file4 = fs.createReadStream(rangeFile, {bufferSize: 1, start: 1, end: 2});
+var file4 = fs.createReadStream(rangeFile, { bufferSize: 1, start: 1, end: 2 });
 var contentRead = '';
 file4.on('data', function(data) {
   contentRead += data.toString('utf-8');
@@ -86,7 +86,7 @@ file4.on('end', function(data) {
   assert.equal(contentRead, 'yz');
 });
 
-var file5 = fs.createReadStream(rangeFile, {bufferSize: 1, start: 1});
+var file5 = fs.createReadStream(rangeFile, { bufferSize: 1, start: 1 });
 file5.data = '';
 file5.on('data', function(data) {
   file5.data += data.toString('utf-8');
@@ -96,7 +96,7 @@ file5.on('end', function() {
 });
 
 // https://github.com/joyent/node/issues/2320
-var file6 = fs.createReadStream(rangeFile, {bufferSize: 1.23, start: 1});
+var file6 = fs.createReadStream(rangeFile, { bufferSize: 1.23, start: 1 });
 file6.data = '';
 file6.on('data', function(data) {
   file6.data += data.toString('utf-8');
@@ -106,7 +106,7 @@ file6.on('end', function() {
 });
 
 assert.throws(function() {
-  fs.createReadStream(rangeFile, {start: 10, end: 2});
+  fs.createReadStream(rangeFile, { start: 10, end: 2 });
 }, /"start" option must be <= "end" option/);
 
 var stream = fs.createReadStream(rangeFile, { start: 0, end: 0 });
@@ -125,7 +125,7 @@ var pauseRes = fs.createReadStream(rangeFile);
 pauseRes.pause();
 pauseRes.resume();
 
-var file7 = fs.createReadStream(rangeFile, {autoClose: false });
+var file7 = fs.createReadStream(rangeFile, { autoClose: false });
 file7.on('data', function() {});
 file7.on('end', function() {
   process.nextTick(function() {
@@ -137,7 +137,7 @@ file7.on('end', function() {
 
 function file7Next() {
   // This will tell us if the fd is usable again or not.
-  file7 = fs.createReadStream(null, {fd: file7.fd, start: 0 });
+  file7 = fs.createReadStream(null, { fd: file7.fd, start: 0 });
   file7.data = '';
   file7.on('data', function(data) {
     file7.data += data;
@@ -148,7 +148,7 @@ function file7Next() {
 }
 
 // Just to make sure autoClose won't close the stream because of error.
-var file8 = fs.createReadStream(null, {fd: 13337, autoClose: false });
+var file8 = fs.createReadStream(null, { fd: 13337, autoClose: false });
 file8.on('data', function() {});
 file8.on('error', common.mustCall(function() {}));
 

--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -15,7 +15,7 @@ const a = path.join(common.tmpDir, fn);
 
 const watcher1 = fs.watch(
   common.tmpDir,
-  {encoding: 'hex'},
+  { encoding: 'hex' },
   (event, filename) => {
     if (filename)
       assert.equal(filename, 'e696b0e5bbbae69687e5a4b9e4bbb62e747874');
@@ -34,7 +34,7 @@ const watcher2 = fs.watch(
 
 const watcher3 = fs.watch(
   common.tmpDir,
-  {encoding: 'buffer'},
+  { encoding: 'buffer' },
   (event, filename) => {
     if (filename) {
       assert(filename instanceof Buffer);

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -22,7 +22,7 @@ common.refreshTmpDir();
 
 fs.mkdirSync(testsubdir, 0o700);
 
-const watcher = fs.watch(testDir, {recursive: true});
+const watcher = fs.watch(testDir, { recursive: true });
 
 var watcherClosed = false;
 watcher.on('change', function(event, filename) {

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -42,7 +42,7 @@ common.refreshTmpDir();
 // time, the callback should be invoked again with proper values in stat object
 var fileExists = false;
 
-fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
+fs.watchFile(enoentFile, { interval: 0 }, common.mustCall(function(curr, prev) {
   if (!fileExists) {
     // If the file does not exist, all the fields should be zero and the date
     // fields should be UNIX EPOCH time

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -30,9 +30,9 @@ common.refreshTmpDir();
 // Test writeFileSync
 var file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
 
-fs.writeFileSync(file1, '123', {mode: mode});
+fs.writeFileSync(file1, '123', { mode: mode });
 
-content = fs.readFileSync(file1, {encoding: 'utf8'});
+content = fs.readFileSync(file1, { encoding: 'utf8' });
 assert.equal('123', content);
 
 assert.equal(mode, fs.statSync(file1).mode & 0o777);
@@ -40,9 +40,9 @@ assert.equal(mode, fs.statSync(file1).mode & 0o777);
 // Test appendFileSync
 var file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
 
-fs.appendFileSync(file2, 'abc', {mode: mode});
+fs.appendFileSync(file2, 'abc', { mode: mode });
 
-content = fs.readFileSync(file2, {encoding: 'utf8'});
+content = fs.readFileSync(file2, { encoding: 'utf8' });
 assert.equal('abc', content);
 
 assert.equal(mode, fs.statSync(file2).mode & mode);
@@ -54,7 +54,7 @@ var fd = fs.openSync(file3, 'w+', mode);
 fs.writeFileSync(fd, '123');
 fs.closeSync(fd);
 
-content = fs.readFileSync(file3, {encoding: 'utf8'});
+content = fs.readFileSync(file3, { encoding: 'utf8' });
 assert.equal('123', content);
 
 assert.equal(mode, fs.statSync(file3).mode & 0o777);

--- a/test/parallel/test-fs-write-stream-autoclose-option.js
+++ b/test/parallel/test-fs-write-stream-autoclose-option.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 
 const file = path.join(common.tmpDir, 'write-autoclose-opt1.txt');
 common.refreshTmpDir();
-let stream = fs.createWriteStream(file, {flags: 'w+', autoClose: false});
+let stream = fs.createWriteStream(file, { flags: 'w+', autoClose: false });
 stream.write('Test1');
 stream.end();
 stream.on('finish', common.mustCall(function() {
@@ -19,7 +19,7 @@ stream.on('finish', common.mustCall(function() {
 
 function next() {
   // This will tell us if the fd is usable again or not
-  stream = fs.createWriteStream(null, {fd: stream.fd, start: 0});
+  stream = fs.createWriteStream(null, { fd: stream.fd, start: 0 });
   stream.write('Test2');
   stream.end();
   stream.on('finish', common.mustCall(function() {
@@ -40,7 +40,7 @@ function next2() {
 
 function next3() {
   // This is to test success scenario where autoClose is true
-  const stream = fs.createWriteStream(file, {autoClose: true});
+  const stream = fs.createWriteStream(file, { autoClose: true });
   stream.write('Test3');
   stream.end();
   stream.on('finish', common.mustCall(function() {

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -15,7 +15,7 @@ assert.doesNotThrow(function() {
   fs.createWriteStream(example, 'utf8');
 });
 assert.doesNotThrow(function() {
-  fs.createWriteStream(example, {encoding: 'utf8'});
+  fs.createWriteStream(example, { encoding: 'utf8' });
 });
 
 assert.throws(function() {

--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -18,7 +18,7 @@ check([{
           '\r\n'
   }],
   responses: [{
-    headers: {'Connection': 'keep-alive'},
+    headers: { 'Connection': 'keep-alive' },
     chunks: ['OK']
   }, {
     chunks: []
@@ -37,7 +37,7 @@ check([{
           '\r\n'
   }],
   responses: [{
-    headers: {'Connection': 'keep-alive'},
+    headers: { 'Connection': 'keep-alive' },
     chunks: ['OK']
   }, {
     chunks: []
@@ -55,8 +55,8 @@ check([{
           '\r\n'
   }],
   responses: [{
-    headers: {'Connection': 'keep-alive',
-              'Transfer-Encoding': 'chunked'},
+    headers: { 'Connection': 'keep-alive',
+              'Transfer-Encoding': 'chunked' },
     chunks: ['OK']
   }, {
     chunks: []
@@ -74,8 +74,8 @@ check([{
           '\r\n'
   }],
   responses: [{
-    headers: {'Connection': 'keep-alive',
-              'Content-Length': '2'},
+    headers: { 'Connection': 'keep-alive',
+              'Content-Length': '2' },
     chunks: ['OK']
   }, {
     chunks: []

--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -43,7 +43,7 @@ function test(handler, request_generator, response_validator) {
     assert.equal('1.0', req.httpVersion);
     assert.equal(1, req.httpVersionMajor);
     assert.equal(0, req.httpVersionMinor);
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end(body);
   }
 
@@ -72,7 +72,7 @@ function test(handler, request_generator, response_validator) {
     assert.equal(1, req.httpVersionMajor);
     assert.equal(0, req.httpVersionMinor);
     res.sendDate = false;
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('Hello, '); res._send('');
     res.write('world!'); res._send('');
     res.end();
@@ -108,7 +108,7 @@ function test(handler, request_generator, response_validator) {
     assert.equal(1, req.httpVersionMajor);
     assert.equal(1, req.httpVersionMinor);
     res.sendDate = false;
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('Hello, '); res._send('');
     res.write('world!'); res._send('');
     res.end();

--- a/test/parallel/test-http-abort-before-end.js
+++ b/test/parallel/test-http-abort-before-end.js
@@ -8,7 +8,8 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req = http.request({method: 'GET', host: '127.0.0.1', port: common.PORT});
+  var req = http.request({ method: 'GET', host: '127.0.0.1',
+                           port: common.PORT });
 
   req.on('error', function(ex) {
     // https://github.com/joyent/node/issues/1399#issuecomment-2597359

--- a/test/parallel/test-http-abort-queued.js
+++ b/test/parallel/test-http-abort-queued.js
@@ -22,7 +22,7 @@ var server = http.createServer(function(req, res) {
 server.listen(common.PORT, function() {
   console.log('listen', server.address().port);
 
-  var agent = new http.Agent({maxSockets: 1});
+  var agent = new http.Agent({ maxSockets: 1 });
   assert.equal(Object.keys(agent.sockets).length, 0);
 
   var options = {

--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -4,11 +4,11 @@ var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('Hello World\n');
 }).listen(common.PORT);
 
-var agent = new http.Agent({maxSockets: 1});
+var agent = new http.Agent({ maxSockets: 1 });
 
 agent.on('free', function(socket, host, port) {
   console.log('freeing socket. destroyed? ', socket.destroyed);

--- a/test/parallel/test-http-chunked.js
+++ b/test/parallel/test-http-chunked.js
@@ -14,7 +14,7 @@ var UTF8_STRING = '南越国是前203年至前111年存在于岭南地区的一�
                   '有效的改善了岭南地区落后的政治、经济现状。';
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain; charset=utf8'});
+  res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf8' });
   res.end(UTF8_STRING, 'utf8');
 });
 server.listen(common.PORT, function() {

--- a/test/parallel/test-http-client-abort2.js
+++ b/test/parallel/test-http-client-abort2.js
@@ -7,7 +7,7 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  var req = http.get({ port: common.PORT }, function(res) {
     res.on('data', function(data) {
       req.abort();
       server.close();

--- a/test/parallel/test-http-client-get-url.js
+++ b/test/parallel/test-http-client-get-url.js
@@ -8,7 +8,7 @@ var seen_req = false;
 var server = http.createServer(function(req, res) {
   assert.equal('GET', req.method);
   assert.equal('/foo?bar', req.url);
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('hello\n');
   res.end();
   server.close();

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -18,7 +18,7 @@ common.refreshTmpDir();
 server.listen(common.PIPE, function() {
   var req = http.request({
     socketPath: common.PIPE,
-    headers: {'Content-Length': '1'},
+    headers: { 'Content-Length': '1' },
     method: 'POST',
     path: '/'
   });

--- a/test/parallel/test-http-client-race-2.js
+++ b/test/parallel/test-http-client-race-2.js
@@ -23,8 +23,8 @@ var server = http.createServer(function(req, res) {
     default: body = body3_s;
   }
 
-  res.writeHead(200,
-                {'Content-Type': 'text/plain', 'Content-Length': body.length});
+  res.writeHead(200, { 'Content-Type': 'text/plain',
+                       'Content-Length': body.length });
   res.end(body);
 });
 server.listen(common.PORT);

--- a/test/parallel/test-http-client-race.js
+++ b/test/parallel/test-http-client-race.js
@@ -9,8 +9,8 @@ var body2_s = '22222';
 
 var server = http.createServer(function(req, res) {
   var body = url.parse(req.url).pathname === '/1' ? body1_s : body2_s;
-  res.writeHead(200,
-                {'Content-Type': 'text/plain', 'Content-Length': body.length});
+  res.writeHead(200, { 'Content-Type': 'text/plain',
+                       'Content-Length': body.length });
   res.end(body);
 });
 server.listen(common.PORT);

--- a/test/parallel/test-http-client-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-client-reject-chunked-with-content-length.js
@@ -17,7 +17,7 @@ server.listen(common.PORT, () => {
   // The callback should not be called because the server is sending
   // both a Content-Length header and a Transfer-Encoding: chunked
   // header, which is a violation of the HTTP spec.
-  const req = http.get({port: common.PORT}, (res) => {
+  const req = http.get({ port: common.PORT }, (res) => {
     assert.fail(null, null, 'callback should not be called');
   });
   req.on('error', common.mustCall((err) => {

--- a/test/parallel/test-http-client-reject-cr-no-lf.js
+++ b/test/parallel/test-http-client-reject-cr-no-lf.js
@@ -16,7 +16,7 @@ const server = net.createServer((socket) => {
 server.listen(common.PORT, () => {
   // The callback should not be called because the server is sending a
   // header field that ends only in \r with no following \n
-  const req = http.get({port: common.PORT}, (res) => {
+  const req = http.get({ port: common.PORT }, (res) => {
     assert.fail(null, null, 'callback should not be called');
   });
   req.on('error', common.mustCall((err) => {

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -34,7 +34,7 @@ function test() {
 
   var req = http.get({
     socketPath: common.PIPE,
-    headers: {'Content-Length': '1'},
+    headers: { 'Content-Length': '1' },
     method: 'POST',
     path: '/'
   });

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -20,7 +20,7 @@ var server = http.createServer(function(req, res) {
   if (reqid % 2) {
     // do not reply the request
   } else {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write(reqid.toString());
     res.end();
   }

--- a/test/parallel/test-http-client-timeout-with-data.js
+++ b/test/parallel/test-http-client-timeout-with-data.js
@@ -19,7 +19,7 @@ const options = {
 };
 
 const server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Length': '2'});
+  res.writeHead(200, { 'Content-Length': '2' });
   res.write('*');
   setTimeout(function() { res.end('*'); }, common.platformTimeout(100));
 });

--- a/test/parallel/test-http-client-upload-buf.js
+++ b/test/parallel/test-http-client-upload-buf.js
@@ -18,7 +18,7 @@ var server = http.createServer(function(req, res) {
   req.on('end', function() {
     server_req_complete = true;
     console.log('request complete from server');
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('hello\n');
     res.end();
   });

--- a/test/parallel/test-http-client-upload.js
+++ b/test/parallel/test-http-client-upload.js
@@ -19,7 +19,7 @@ var server = http.createServer(function(req, res) {
   req.on('end', function() {
     server_req_complete = true;
     console.log('request complete from server');
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('hello\n');
     res.end();
   });

--- a/test/parallel/test-http-contentLength0.js
+++ b/test/parallel/test-http-contentLength0.js
@@ -8,7 +8,7 @@ var http = require('http');
 
 
 var s = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Length': '0 '});
+  res.writeHead(200, { 'Content-Length': '0 ' });
   res.end();
 });
 s.listen(common.PORT, function() {

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -20,13 +20,13 @@ function test(mod) {
 
   // Bad host name should not throw an uncatchable exception.
   // Ensure that there is time to attach an error listener.
-  var req1 = mod.get({host: host, port: 42}, do_not_call);
+  var req1 = mod.get({ host: host, port: 42 }, do_not_call);
   req1.on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'ENOTFOUND');
   }));
   // http.get() called req1.end() for us
 
-  var req2 = mod.request({method: 'GET', host: host, port: 42}, do_not_call);
+  var req2 = mod.request({ method: 'GET', host: host, port: 42 }, do_not_call);
   req2.on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'ENOTFOUND');
   }));

--- a/test/parallel/test-http-double-content-length.js
+++ b/test/parallel/test-http-double-content-length.js
@@ -21,7 +21,7 @@ server.listen(common.PORT, () => {
   const req = http.get({
     port: common.PORT,
     // Send two content-length header values.
-    headers: {'Content-Length': [1, 2]}},
+    headers: { 'Content-Length': [1, 2] } },
     (res) => {
       assert.fail(null, null, 'an error should have occurred');
       server.close();

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -4,7 +4,7 @@ var http = require('http');
 
 var server = http.createServer(function(req, res) {
   intentionally_not_defined(); // eslint-disable-line no-undef
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('Thank you, come again.');
   res.end();
 });

--- a/test/parallel/test-http-flush-response-headers.js
+++ b/test/parallel/test-http-flush-response-headers.js
@@ -6,7 +6,7 @@ const http = require('http');
 const server = http.createServer();
 
 server.on('request', function(req, res) {
-  res.writeHead(200, {'foo': 'bar'});
+  res.writeHead(200, { 'foo': 'bar' });
   res.flushHeaders();
   res.flushHeaders(); // Should be idempotent.
 });

--- a/test/parallel/test-http-header-obstext.js
+++ b/test/parallel/test-http-header-obstext.js
@@ -10,7 +10,7 @@ const server = http.createServer(common.mustCall((req, res) => {
 server.listen(common.PORT, () => {
   http.get({
     port: common.PORT,
-    headers: {'Test': 'Düsseldorf'}
+    headers: { 'Test': 'Düsseldorf' }
   }, common.mustCall((res) => {
     assert.equal(res.statusCode, 200);
     server.close();

--- a/test/parallel/test-http-invalidheaderfield.js
+++ b/test/parallel/test-http-invalidheaderfield.js
@@ -18,7 +18,7 @@ const server = http.createServer(function(req, res) {
 });
 server.listen(common.PORT, function() {
 
-  http.get({port: common.PORT}, function() {
+  http.get({ port: common.PORT }, function() {
     ee.emit('done');
   });
 
@@ -26,7 +26,7 @@ server.listen(common.PORT, function() {
     function() {
       var options = {
         port: common.PORT,
-        headers: {'testing 123': 123}
+        headers: { 'testing 123': 123 }
       };
       http.get(options, function() {});
     },
@@ -40,7 +40,7 @@ server.listen(common.PORT, function() {
     function() {
       var options = {
         port: common.PORT,
-        headers: {'testing_123': 123}
+        headers: { 'testing_123': 123 }
       };
       http.get(options, function() {
         ee.emit('done');

--- a/test/parallel/test-http-keep-alive-close-on-header.js
+++ b/test/parallel/test-http-keep-alive-close-on-header.js
@@ -4,10 +4,10 @@ var assert = require('assert');
 var http = require('http');
 
 var body = 'hello world\n';
-var headers = {'connection': 'keep-alive'};
+var headers = { 'connection': 'keep-alive' };
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Length': body.length, 'Connection': 'close'});
+  res.writeHead(200, { 'Content-Length': body.length, 'Connection': 'close' });
   res.write(body);
   res.end();
 });

--- a/test/parallel/test-http-keep-alive.js
+++ b/test/parallel/test-http-keep-alive.js
@@ -6,13 +6,13 @@ var http = require('http');
 var body = 'hello world\n';
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Length': body.length});
+  res.writeHead(200, { 'Content-Length': body.length });
   res.write(body);
   res.end();
 });
 
-var agent = new http.Agent({maxSockets: 1});
-var headers = {'connection': 'keep-alive'};
+var agent = new http.Agent({ maxSockets: 1 });
+var headers = { 'connection': 'keep-alive' };
 var name = agent.getName({ port: common.PORT });
 
 server.listen(common.PORT, function() {

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -29,7 +29,7 @@ var server = http.createServer(function(req, res) {
   }
 
   req.on('end', function() {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('The path was ' + url.parse(req.url).pathname);
     res.end();
     responses_sent += 1;
@@ -39,7 +39,7 @@ var server = http.createServer(function(req, res) {
 
 server.listen(common.PORT, function() {
   var client = http.createClient(common.PORT);
-  var req = client.request('/hello', {'Accept': '*/*', 'Foo': 'bar'});
+  var req = client.request('/hello', { 'Accept': '*/*', 'Foo': 'bar' });
   setTimeout(function() {
     req.end();
   }, 100);

--- a/test/parallel/test-http-malformed-request.js
+++ b/test/parallel/test-http-malformed-request.js
@@ -14,7 +14,7 @@ var nrequests_expected = 1;
 var server = http.createServer(function(req, res) {
   console.log('req: ' + JSON.stringify(url.parse(req.url)));
 
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('Hello World');
   res.end();
 

--- a/test/parallel/test-http-multi-line-headers.js
+++ b/test/parallel/test-http-multi-line-headers.js
@@ -25,7 +25,7 @@ var server = net.createServer(function(conn) {
 });
 
 server.listen(common.PORT, function() {
-  http.get({host: '127.0.0.1', port: common.PORT}, function(res) {
+  http.get({ host: '127.0.0.1', port: common.PORT }, function(res) {
     assert.equal(res.headers['content-type'],
                  'text/plain; x-unix-mode=0600; name="hello.txt"');
     gotResponse = true;

--- a/test/parallel/test-http-no-content-length.js
+++ b/test/parallel/test-http-no-content-length.js
@@ -10,7 +10,7 @@ var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
 }).listen(common.PORT, function() {
-  http.get({port: common.PORT}, function(res) {
+  http.get({ port: common.PORT }, function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       body += chunk;

--- a/test/parallel/test-http-parser-free.js
+++ b/test/parallel/test-http-parser-free.js
@@ -14,7 +14,7 @@ server.listen(common.PORT, function() {
   var parser;
   for (var i = 0; i < N; ++i) {
     (function makeRequest(i) {
-      var req = http.get({port: common.PORT}, function(res) {
+      var req = http.get({ port: common.PORT }, function(res) {
         if (!parser) {
           parser = req.parser;
         } else {

--- a/test/parallel/test-http-pause-resume-one-end.js
+++ b/test/parallel/test-http-pause-resume-one-end.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var http = require('http');
 
 var server = http.Server(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('Hello World\n');
   server.close();
 });

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -12,7 +12,7 @@ var cookies = [
   'prefers_open_id=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT'
 ];
 
-var headers = {'content-type': 'text/plain',
+var headers = { 'content-type': 'text/plain',
                 'set-cookie': cookies,
                 'hello': 'world' };
 

--- a/test/parallel/test-http-request-end-twice.js
+++ b/test/parallel/test-http-request-end-twice.js
@@ -4,11 +4,11 @@ var assert = require('assert');
 var http = require('http');
 
 var server = http.Server(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('hello world\n');
 });
 server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+  var req = http.get({ port: common.PORT }, function(res) {
     res.on('end', function() {
       assert.ok(!req.end());
       server.close();

--- a/test/parallel/test-http-request-methods.js
+++ b/test/parallel/test-http-request-methods.js
@@ -14,7 +14,7 @@ var http = require('http');
 
   var server = http.createServer(function(req, res) {
     received_method = req.method;
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('hello ');
     res.write('world\n');
     res.end();

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -18,7 +18,7 @@ var server = http.Server(function(req, res) {
 });
 
 server.listen(common.PORT, function() {
-  http.get({port: common.PORT}, function(res) {
+  http.get({ port: common.PORT }, function(res) {
     server.close();
   });
 });

--- a/test/parallel/test-http-res-write-end-dont-take-array.js
+++ b/test/parallel/test-http-res-write-end-dont-take-array.js
@@ -6,7 +6,7 @@ var http = require('http');
 var test = 1;
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   if (test === 1) {
     // write should accept string
     res.write('string');
@@ -33,12 +33,12 @@ var server = http.createServer(function(req, res) {
 
 server.listen(common.PORT, function() {
   // just make a request, other tests handle responses
-  http.get({port: common.PORT}, function(res) {
+  http.get({ port: common.PORT }, function(res) {
     res.resume();
     // lazy serial test, because we can only call end once per request
     test += 1;
     // do it again to test .end(Buffer);
-    http.get({port: common.PORT}, function(res) {
+    http.get({ port: common.PORT }, function(res) {
       res.resume();
       server.close();
     });

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -16,7 +16,7 @@ const server = http.createServer((req, res) => {
       res.setHeader('content-length', [2, 1]);
       break;
     case '2':
-      res.writeHead(200, {'content-length': [1, 2]});
+      res.writeHead(200, { 'content-length': [1, 2] });
       break;
     default:
       assert.fail(null, null, 'should never get here');
@@ -33,7 +33,7 @@ server.listen(common.PORT, common.mustCall(() => {
     // case, the error handler must be called because the client
     // is not allowed to accept multiple content-length headers.
     http.get(
-      {port: common.PORT, headers: {'x-num': n}},
+      { port: common.PORT, headers: { 'x-num': n } },
       (res) => {
         assert(false, 'client allowed multiple content-length headers.');
       }

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -56,7 +56,7 @@ server.listen(common.PORT, common.mustCall(function() {
     // value should be reported for the header fields listed
     // in the norepeat array.
     http.get(
-      {port: common.PORT, headers: {'x-num': n}},
+      { port: common.PORT, headers: { 'x-num': n } },
       common.mustCall(function(res) {
         if (++count === 2) server.close();
         for (const name of norepeat) {

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -24,17 +24,17 @@ const server = http.createServer((req, res) => {
     case 0:
       const loc = url.parse(req.url, true).query.lang;
       assert.throws(common.mustCall(() => {
-        res.writeHead(302, {Location: `/foo?lang=${loc}`});
+        res.writeHead(302, { Location: `/foo?lang=${loc}` });
       }));
       break;
     case 1:
       assert.throws(common.mustCall(() => {
-        res.writeHead(200, {'foo': x});
+        res.writeHead(200, { 'foo': x });
       }));
       break;
     case 2:
       assert.throws(common.mustCall(() => {
-        res.writeHead(200, {'foo': y});
+        res.writeHead(200, { 'foo': y });
       }));
       break;
     default:
@@ -46,7 +46,7 @@ const server = http.createServer((req, res) => {
 });
 server.listen(common.PORT, () => {
   const end = 'HTTP/1.1\r\n\r\n';
-  const client = net.connect({port: common.PORT}, () => {
+  const client = net.connect({ port: common.PORT }, () => {
     client.write(`GET ${str} ${end}`);
     client.write(`GET / ${end}`);
     client.write(`GET / ${end}`);

--- a/test/parallel/test-http-server-multiheaders.js
+++ b/test/parallel/test-http-server-multiheaders.js
@@ -18,7 +18,7 @@ var srv = http.createServer(function(req, res) {
   assert.equal(req.headers['sec-websocket-extensions'], 'foo; 1, bar; 2, baz');
   assert.equal(req.headers['constructor'], 'foo, bar, baz');
 
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('EOF');
 
   srv.close();

--- a/test/parallel/test-http-server-multiheaders2.js
+++ b/test/parallel/test-http-server-multiheaders2.js
@@ -58,7 +58,7 @@ var srv = http.createServer(function(req, res) {
                  'foo, bar', 'header parsed incorrectly: ' + header);
   });
 
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('EOF');
 
   srv.close();

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -18,7 +18,7 @@ server.on('clientError', common.mustCall((err) => {
   server.close();
 }));
 server.listen(common.PORT, () => {
-  const client = net.connect({port: common.PORT}, () => {
+  const client = net.connect({ port: common.PORT }, () => {
     client.write(reqstr);
     client.end();
   });

--- a/test/parallel/test-http-server-reject-cr-no-lf.js
+++ b/test/parallel/test-http-server-reject-cr-no-lf.js
@@ -20,7 +20,7 @@ server.on('clientError', common.mustCall((err) => {
   server.close();
 }));
 server.listen(common.PORT, () => {
-  const client = net.connect({port: common.PORT}, () => {
+  const client = net.connect({ port: common.PORT }, () => {
     client.on('data', (chunk) => {
       assert.fail(null, null, 'this should not be called');
     });

--- a/test/parallel/test-http-server-stale-close.js
+++ b/test/parallel/test-http-server-stale-close.js
@@ -6,7 +6,7 @@ var fork = require('child_process').fork;
 
 if (process.env.NODE_TEST_FORK) {
   var req = http.request({
-    headers: {'Content-Length': '42'},
+    headers: { 'Content-Length': '42' },
     method: 'POST',
     host: '127.0.0.1',
     port: common.PORT,
@@ -16,7 +16,7 @@ if (process.env.NODE_TEST_FORK) {
 }
 else {
   var server = http.createServer(function(req, res) {
-    res.writeHead(200, {'Content-Length': '42'});
+    res.writeHead(200, { 'Content-Length': '42' });
     req.pipe(res);
     req.on('close', function() {
       server.close();
@@ -25,7 +25,7 @@ else {
   });
   server.listen(common.PORT, function() {
     fork(__filename, {
-      env: util._extend(process.env, {NODE_TEST_FORK: '1'})
+      env: util._extend(process.env, { NODE_TEST_FORK: '1' })
     });
   });
 }

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -37,7 +37,7 @@ var server = http.createServer(function(req, res) {
   }
 
   setTimeout(function() {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write(url.parse(req.url).pathname);
     res.end();
   }, 1);

--- a/test/parallel/test-http-set-timeout.js
+++ b/test/parallel/test-http-set-timeout.js
@@ -22,7 +22,7 @@ server.listen(common.PORT, function() {
     throw new Error('Timeout was not successful');
   }, common.platformTimeout(2000));
 
-  var x = http.get({port: common.PORT, path: '/'});
+  var x = http.get({ port: common.PORT, path: '/' });
   x.on('error', function() {
     clearTimeout(errorTimer);
     console.log('HTTP REQUEST COMPLETE (this is good)');

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -8,7 +8,7 @@ var outstanding_reqs = 0;
 
 var server = http.createServer(function(req, res) {
   res.writeHead(200, [['content-type', 'text/plain']]);
-  res.addTrailers({'x-foo': 'bar'});
+  res.addTrailers({ 'x-foo': 'bar' });
   res.end('stuff' + '\n');
 });
 server.listen(common.PORT);

--- a/test/parallel/test-http-should-keep-alive.js
+++ b/test/parallel/test-http-should-keep-alive.js
@@ -29,7 +29,7 @@ var server = net.createServer(function(socket) {
   ++requests;
 }).listen(common.PORT, function() {
   function makeRequest() {
-    var req = http.get({port: common.PORT}, function(res) {
+    var req = http.get({ port: common.PORT }, function(res) {
       assert.equal(req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],
                    SERVER_RESPONSES[responses] + ' should ' +
                    (SHOULD_KEEP_ALIVE[responses] ? '' : 'not ') +

--- a/test/parallel/test-http-status-code.js
+++ b/test/parallel/test-http-status-code.js
@@ -12,7 +12,7 @@ var testIdx = 0;
 
 var s = http.createServer(function(req, res) {
   var t = tests[testIdx];
-  res.writeHead(t, {'Content-Type': 'text/plain'});
+  res.writeHead(t, { 'Content-Type': 'text/plain' });
   console.log('--\nserver: statusCode after writeHead: ' + res.statusCode);
   assert.equal(res.statusCode, t);
   res.end('hello world\n');

--- a/test/parallel/test-http-timeout-overflow.js
+++ b/test/parallel/test-http-timeout-overflow.js
@@ -10,7 +10,7 @@ var clientRequests = 0;
 
 var server = http.createServer(function(req, res) {
   serverRequests++;
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('OK');
 });
 

--- a/test/parallel/test-http-timeout.js
+++ b/test/parallel/test-http-timeout.js
@@ -6,11 +6,11 @@ var http = require('http');
 var port = common.PORT;
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('OK');
 });
 
-var agent = new http.Agent({maxSockets: 1});
+var agent = new http.Agent({ maxSockets: 1 });
 
 server.listen(port, function() {
 
@@ -24,7 +24,7 @@ server.listen(port, function() {
 
   function createRequest() {
     const req = http.request(
-      {port: port, path: '/', agent: agent},
+      { port: port, path: '/', agent: agent },
       function(res) {
         req.clearTimeout(callback);
 

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -50,7 +50,7 @@ srv.listen(common.PORT, '127.0.0.1', function() {
     }));
 
     console.log(res.headers);
-    var expectedHeaders = {'hello': 'world',
+    var expectedHeaders = { 'hello': 'world',
                             'connection': 'upgrade',
                             'upgrade': 'websocket' };
     assert.deepStrictEqual(expectedHeaders, res.headers);

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -24,7 +24,7 @@ function testServer() {
   });
 
   server.on('request', function(req, res) {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('okay');
     res.end();
   });

--- a/test/parallel/test-http-wget.js
+++ b/test/parallel/test-http-wget.js
@@ -24,7 +24,7 @@ var client_got_eof = false;
 var connection_was_closed = false;
 
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('hello ');
   res.write('world\n');
   res.end();

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -7,7 +7,7 @@ var http = require('http');
 var server = http.createServer(function(request, response) {
   console.log('responding to ' + request.url);
 
-  response.writeHead(200, {'Content-Type': 'text/plain'});
+  response.writeHead(200, { 'Content-Type': 'text/plain' });
   response.write('1\n');
   response.write('');
   response.write('2\n');

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -29,7 +29,7 @@ var server = http.Server(function(req, res) {
   }
 
   req.on('end', function() {
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.write('The path was ' + url.parse(req.url).pathname);
     res.end();
     responses_sent += 1;
@@ -45,7 +45,7 @@ server.on('listening', function() {
   http.get({
     port: common.PORT,
     path: '/hello',
-    headers: {'Accept': '*/*', 'Foo': 'bar'},
+    headers: { 'Accept': '*/*', 'Foo': 'bar' },
     agent: agent
   }, function(res) {
     assert.equal(200, res.statusCode);

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -23,7 +23,7 @@ var options = {
 var server = https.createServer(options, function(req, res) {
   assert.equal('GET', req.method);
   assert.equal('/foo?bar', req.url);
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('hello\n');
   res.end();
   server.close();

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -40,9 +40,8 @@ if (!haveIntl) {
   var GMT = 'Etc/GMT';
 
   // Construct an English formatter. Should format to "Jan 70"
-  var dtf =
-      new Intl.DateTimeFormat(['en'],
-                              {timeZone: GMT, month: 'short', year: '2-digit'});
+  var dtf = new Intl.DateTimeFormat(['en'], { timeZone: GMT, month: 'short',
+                                              year: '2-digit' });
 
   // If list is specified and doesn't contain 'en' then return.
   if (process.config.variables.icu_locales && !haveLocale('en')) {
@@ -58,7 +57,7 @@ if (!haveIntl) {
   assert.equal(localeString, 'Jan 70');
 
   // Options to request GMT
-  var optsGMT = {timeZone: GMT};
+  var optsGMT = { timeZone: GMT };
 
   // Test format
   localeString = date0.toLocaleString(['en'], optsGMT);

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -9,8 +9,8 @@ process.on('exit', function() {
   assert.equal(gotError, 2);
 });
 
-net.createServer(common.fail).listen({fd: 2}).on('error', onError);
-net.createServer(common.fail).listen({fd: 42}).on('error', onError);
+net.createServer(common.fail).listen({ fd: 2 }).on('error', onError);
+net.createServer(common.fail).listen({ fd: 42 }).on('error', onError);
 
 function onError(ex) {
   assert.equal(ex.code, 'EINVAL');

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const client = net.connect({host: '...', port: common.PORT});
+const client = net.connect({ host: '...', port: common.PORT });
 
 client.once('error', common.mustCall(function(err) {
   assert(err);

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -13,7 +13,7 @@ var hostIdx = 0;
 var host = hosts[hostIdx];
 var localhostTries = 10;
 
-const server = net.createServer({allowHalfOpen: true}, function(socket) {
+const server = net.createServer({ allowHalfOpen: true }, function(socket) {
   socket.resume();
   socket.on('end', common.mustCall(function() {}));
   socket.end();

--- a/test/parallel/test-net-connect-options.js
+++ b/test/parallel/test-net-connect-options.js
@@ -6,7 +6,7 @@ var net = require('net');
 var serverGotEnd = false;
 var clientGotEnd = false;
 
-var server = net.createServer({allowHalfOpen: true}, function(socket) {
+var server = net.createServer({ allowHalfOpen: true }, function(socket) {
   socket.resume();
   socket.on('end', function() {
     serverGotEnd = true;

--- a/test/parallel/test-net-create-connection.js
+++ b/test/parallel/test-net-create-connection.js
@@ -34,8 +34,8 @@ server.listen(tcpPort, 'localhost', function() {
   net.createConnection(tcpPort, cb);
   net.createConnection(tcpPort, 'localhost', cb);
   net.createConnection(tcpPort + '', 'localhost', cb);
-  net.createConnection({port: tcpPort + ''}).on('connect', cb);
-  net.createConnection({port: '0x' + tcpPort.toString(16)}, cb);
+  net.createConnection({ port: tcpPort + '' }).on('connect', cb);
+  net.createConnection({ port: '0x' + tcpPort.toString(16) }, cb);
 
   fail({
     port: true
@@ -98,8 +98,8 @@ server.listen(tcpPort, 'localhost', function() {
 server.on('close', function() {
   function nop() {}
 
-  net.createConnection({port: 0}).on('error', nop);
-  net.createConnection({port: undefined}).on('error', nop);
+  net.createConnection({ port: 0 }).on('error', nop);
+  net.createConnection({ port: undefined }).on('error', nop);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -10,7 +10,7 @@ process.on('exit', function() {
 });
 
 // this should fail with an async EINVAL error, not throw an exception
-net.createServer(common.fail).listen({fd: 0}).on('error', function(e) {
+net.createServer(common.fail).listen({ fd: 0 }).on('error', function(e) {
   switch (e.code) {
     case 'EINVAL':
     case 'ENOTSOCK':

--- a/test/parallel/test-net-listen-shared-ports.js
+++ b/test/parallel/test-net-listen-shared-ports.js
@@ -38,7 +38,7 @@ if (cluster.isMaster) {
     port: common.PORT,
     exclusive: false
   }, function() {
-    server2.listen({port: common.PORT + 1, exclusive: true}, function() {
+    server2.listen({ port: common.PORT + 1, exclusive: true }, function() {
       // the first worker should succeed
       process.send('success');
     });

--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -21,7 +21,7 @@ const server1ConnHandler = function(socket) {
   server1Sock = socket;
 };
 
-const server1 = net.createServer({pauseOnConnect: true}, server1ConnHandler);
+const server1 = net.createServer({ pauseOnConnect: true }, server1ConnHandler);
 
 const server2ConnHandler = function(socket) {
   socket.on('data', function(data) {
@@ -35,15 +35,15 @@ const server2ConnHandler = function(socket) {
   });
 };
 
-const server2 = net.createServer({pauseOnConnect: false}, server2ConnHandler);
+const server2 = net.createServer({ pauseOnConnect: false }, server2ConnHandler);
 
 server1.listen(common.PORT, function() {
   const clientHandler = common.mustCall(function() {
     server2.listen(common.PORT + 1, function() {
-      net.createConnection({port: common.PORT + 1}).write(msg);
+      net.createConnection({ port: common.PORT + 1 }).write(msg);
     });
   });
-  net.createConnection({port: common.PORT}).write(msg, clientHandler);
+  net.createConnection({ port: common.PORT }).write(msg, clientHandler);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-net-socket-timeout-unref.js
+++ b/test/parallel/test-net-socket-timeout-unref.js
@@ -31,5 +31,5 @@ delays.forEach(function(T) {
     }
   }));
 
-  sockets.push({socket: socket, timeout: T * 1000});
+  sockets.push({ socket: socket, timeout: T * 1000 });
 });

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -21,16 +21,16 @@ const winPaths = [
 ];
 
 const winSpecialCaseParseTests = [
-  ['/foo/bar', {root: '/'}]
+  ['/foo/bar', { root: '/' }]
 ];
 
 const winSpecialCaseFormatTests = [
-  [{dir: 'some\\dir'}, 'some\\dir\\'],
-  [{base: 'index.html'}, 'index.html'],
-  [{root: 'C:\\'}, 'C:\\'],
-  [{name: 'index', ext: '.html'}, 'index.html'],
-  [{dir: 'some\\dir', name: 'index', ext: '.html'}, 'some\\dir\\index.html'],
-  [{root: 'C:\\', name: 'index', ext: '.html'}, 'C:\\index.html'],
+  [{ dir: 'some\\dir' }, 'some\\dir\\'],
+  [{ base: 'index.html' }, 'index.html'],
+  [{ root: 'C:\\' }, 'C:\\'],
+  [{ name: 'index', ext: '.html' }, 'index.html'],
+  [{ dir: 'some\\dir', name: 'index', ext: '.html' }, 'some\\dir\\index.html'],
+  [{ root: 'C:\\', name: 'index', ext: '.html' }, 'C:\\index.html'],
   [{}, '']
 ];
 
@@ -58,34 +58,34 @@ const unixPaths = [
 ];
 
 const unixSpecialCaseFormatTests = [
-  [{dir: 'some/dir'}, 'some/dir/'],
-  [{base: 'index.html'}, 'index.html'],
-  [{root: '/'}, '/'],
-  [{name: 'index', ext: '.html'}, 'index.html'],
-  [{dir: 'some/dir', name: 'index', ext: '.html'}, 'some/dir/index.html'],
-  [{root: '/', name: 'index', ext: '.html'}, '/index.html'],
+  [{ dir: 'some/dir' }, 'some/dir/'],
+  [{ base: 'index.html' }, 'index.html'],
+  [{ root: '/' }, '/'],
+  [{ name: 'index', ext: '.html' }, 'index.html'],
+  [{ dir: 'some/dir', name: 'index', ext: '.html' }, 'some/dir/index.html'],
+  [{ root: '/', name: 'index', ext: '.html' }, '/index.html'],
   [{}, '']
 ];
 
 const errors = [
-  {method: 'parse', input: [null],
-   message: /Path must be a string. Received null/},
-  {method: 'parse', input: [{}],
-   message: /Path must be a string. Received {}/},
-  {method: 'parse', input: [true],
-   message: /Path must be a string. Received true/},
-  {method: 'parse', input: [1],
-   message: /Path must be a string. Received 1/},
-  {method: 'parse', input: [],
-   message: /Path must be a string. Received undefined/},
-  {method: 'format', input: [null],
-   message: /Parameter "pathObject" must be an object, not/},
-  {method: 'format', input: [''],
-   message: /Parameter "pathObject" must be an object, not string/},
-  {method: 'format', input: [true],
-   message: /Parameter "pathObject" must be an object, not boolean/},
-  {method: 'format', input: [1],
-   message: /Parameter "pathObject" must be an object, not number/},
+  { method: 'parse', input: [null],
+   message: /Path must be a string. Received null/ },
+  { method: 'parse', input: [{}],
+   message: /Path must be a string. Received {}/ },
+  { method: 'parse', input: [true],
+   message: /Path must be a string. Received true/ },
+  { method: 'parse', input: [1],
+   message: /Path must be a string. Received 1/ },
+  { method: 'parse', input: [],
+   message: /Path must be a string. Received undefined/ },
+  { method: 'format', input: [null],
+   message: /Parameter "pathObject" must be an object, not/ },
+  { method: 'format', input: [''],
+   message: /Parameter "pathObject" must be an object, not string/ },
+  { method: 'format', input: [true],
+   message: /Parameter "pathObject" must be an object, not boolean/ },
+  { method: 'format', input: [1],
+   message: /Parameter "pathObject" must be an object, not number/ },
 ];
 
 checkParseFormat(path.win32, winPaths);

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -29,7 +29,7 @@ var server = http.createServer(function(req, res) {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
-    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end();
   });
 });

--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -11,14 +11,14 @@ assert.deepStrictEqual(qs.escape([5, 10]), '5%2C10');
 
 // using toString for objects
 assert.strictEqual(
-  qs.escape({test: 5, toString: () => 'test', valueOf: () => 10 }),
+  qs.escape({ test: 5, toString: () => 'test', valueOf: () => 10 }),
   'test'
 );
 
 // toString is not callable, must throw an error
-assert.throws(() => qs.escape({toString: 5}));
+assert.throws(() => qs.escape({ toString: 5 }));
 
 // should use valueOf instead of non-callable toString
-assert.strictEqual(qs.escape({toString: 5, valueOf: () => 'test'}), 'test');
+assert.strictEqual(qs.escape({ toString: 5, valueOf: () => 'test' }), 'test');
 
 assert.throws(() => qs.escape(Symbol('test')));

--- a/test/parallel/test-querystring-maxKeys-non-finite.js
+++ b/test/parallel/test-querystring-maxKeys-non-finite.js
@@ -39,12 +39,13 @@ const params = createManyParams(count);
 // In this instance split will always return an empty array
 // this test confirms that the output of parse is the expected length
 // when passed Infinity as the argument for maxKeys
-const resultInfinity = parse(params, undefined, undefined, {maxKeys: Infinity});
-const resultNaN = parse(params, undefined, undefined, {maxKeys: NaN});
+const resultInfinity = parse(params, undefined, undefined,
+                             { maxKeys: Infinity });
+const resultNaN = parse(params, undefined, undefined, { maxKeys: NaN });
 const resultInfinityString = parse(params, undefined, undefined, {
   maxKeys: 'Infinity'
 });
-const resultNaNString = parse(params, undefined, undefined, {maxKeys: 'NaN'});
+const resultNaNString = parse(params, undefined, undefined, { maxKeys: 'NaN' });
 
 // Non Finite maxKeys should return the length of input
 assert.equal(Object.keys(resultInfinity).length, count);

--- a/test/parallel/test-querystring-multichar-separator.js
+++ b/test/parallel/test-querystring-multichar-separator.js
@@ -12,11 +12,13 @@ function check(actual, expected) {
   });
 }
 
-check(qs.parse('foo=>bar&&bar=>baz', '&&', '=>'), {foo: 'bar', bar: 'baz'});
+check(qs.parse('foo=>bar&&bar=>baz', '&&', '=>'), { foo: 'bar', bar: 'baz' });
 
-check(qs.stringify({foo: 'bar', bar: 'baz'}, '&&', '=>'), 'foo=>bar&&bar=>baz');
+check(qs.stringify({ foo: 'bar', bar: 'baz' }, '&&', '=>'),
+      'foo=>bar&&bar=>baz');
 
-check(qs.parse('foo==>bar, bar==>baz', ', ', '==>'), {foo: 'bar', bar: 'baz'});
+check(qs.parse('foo==>bar, bar==>baz', ', ', '==>'),
+      { foo: 'bar', bar: 'baz' });
 
-check(qs.stringify({foo: 'bar', bar: 'baz'}, ', ', '==>'),
+check(qs.stringify({ foo: 'bar', bar: 'baz' }, ', ', '==>'),
       'foo==>bar, bar==>baz');

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -18,30 +18,30 @@ function createWithNoPrototype(properties) {
 var qsTestCases = [
   ['__proto__=1',
    '__proto__=1',
-   createWithNoPrototype([{key: '__proto__', value: '1'}])],
+   createWithNoPrototype([{ key: '__proto__', value: '1' }])],
   ['__defineGetter__=asdf',
    '__defineGetter__=asdf',
    JSON.parse('{"__defineGetter__":"asdf"}')],
   ['foo=918854443121279438895193',
    'foo=918854443121279438895193',
-   {'foo': '918854443121279438895193'}],
-  ['foo=bar', 'foo=bar', {'foo': 'bar'}],
-  ['foo=bar&foo=quux', 'foo=bar&foo=quux', {'foo': ['bar', 'quux']}],
-  ['foo=1&bar=2', 'foo=1&bar=2', {'foo': '1', 'bar': '2'}],
+   { 'foo': '918854443121279438895193' }],
+  ['foo=bar', 'foo=bar', { 'foo': 'bar' }],
+  ['foo=bar&foo=quux', 'foo=bar&foo=quux', { 'foo': ['bar', 'quux'] }],
+  ['foo=1&bar=2', 'foo=1&bar=2', { 'foo': '1', 'bar': '2' }],
   ['my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F',
    'my%20weird%20field=q1!2%22\'w%245%267%2Fz8)%3F',
-   {'my weird field': 'q1!2"\'w$5&7/z8)?' }],
-  ['foo%3Dbaz=bar', 'foo%3Dbaz=bar', {'foo=baz': 'bar'}],
-  ['foo=baz=bar', 'foo=baz%3Dbar', {'foo': 'baz=bar'}],
+   { 'my weird field': 'q1!2"\'w$5&7/z8)?' }],
+  ['foo%3Dbaz=bar', 'foo%3Dbaz=bar', { 'foo=baz': 'bar' }],
+  ['foo=baz=bar', 'foo=baz%3Dbar', { 'foo': 'baz=bar' }],
   ['str=foo&arr=1&arr=2&arr=3&somenull=&undef=',
    'str=foo&arr=1&arr=2&arr=3&somenull=&undef=',
    { 'str': 'foo',
      'arr': ['1', '2', '3'],
      'somenull': '',
-     'undef': ''}],
-  [' foo = bar ', '%20foo%20=%20bar%20', {' foo ': ' bar '}],
-  ['foo=%zx', 'foo=%25zx', {'foo': '%zx'}],
-  ['foo=%EF%BF%BD', 'foo=%EF%BF%BD', {'foo': '\ufffd' }],
+     'undef': '' }],
+  [' foo = bar ', '%20foo%20=%20bar%20', { ' foo ': ' bar ' }],
+  ['foo=%zx', 'foo=%25zx', { 'foo': '%zx' }],
+  ['foo=%EF%BF%BD', 'foo=%EF%BF%BD', { 'foo': '\ufffd' }],
   // See: https://github.com/joyent/node/issues/1707
   ['hasOwnProperty=x&toString=foo&valueOf=bar&__defineGetter__=baz',
     'hasOwnProperty=x&toString=foo&valueOf=bar&__defineGetter__=baz',
@@ -57,33 +57,35 @@ var qsTestCases = [
 
 // [ wonkyQS, canonicalQS, obj ]
 var qsColonTestCases = [
-  ['foo:bar', 'foo:bar', {'foo': 'bar'}],
-  ['foo:bar;foo:quux', 'foo:bar;foo:quux', {'foo': ['bar', 'quux']}],
+  ['foo:bar', 'foo:bar', { 'foo': 'bar' }],
+  ['foo:bar;foo:quux', 'foo:bar;foo:quux', { 'foo': ['bar', 'quux'] }],
   ['foo:1&bar:2;baz:quux',
    'foo:1%26bar%3A2;baz:quux',
-   {'foo': '1&bar:2', 'baz': 'quux'}],
-  ['foo%3Abaz:bar', 'foo%3Abaz:bar', {'foo:baz': 'bar'}],
-  ['foo:baz:bar', 'foo:baz%3Abar', {'foo': 'baz:bar'}]
+   { 'foo': '1&bar:2', 'baz': 'quux' }],
+  ['foo%3Abaz:bar', 'foo%3Abaz:bar', { 'foo:baz': 'bar' }],
+  ['foo:baz:bar', 'foo:baz%3Abar', { 'foo': 'baz:bar' }]
 ];
 
 // [wonkyObj, qs, canonicalObj]
 var extendedFunction = function() {};
-extendedFunction.prototype = {a: 'b'};
+extendedFunction.prototype = { a: 'b' };
 var qsWeirdObjects = [
-  [{regexp: /./g}, 'regexp=', {'regexp': ''}],
-  [{regexp: new RegExp('.', 'g')}, 'regexp=', {'regexp': ''}],
-  [{fn: function() {}}, 'fn=', {'fn': ''}],
-  [{fn: new Function('')}, 'fn=', {'fn': ''}],
-  [{math: Math}, 'math=', {'math': ''}],
-  [{e: extendedFunction}, 'e=', {'e': ''}],
-  [{d: new Date()}, 'd=', {'d': ''}],
-  [{d: Date}, 'd=', {'d': ''}],
-  [{f: new Boolean(false), t: new Boolean(true)}, 'f=&t=', {'f': '', 't': ''}],
-  [{f: false, t: true}, 'f=false&t=true', {'f': 'false', 't': 'true'}],
-  [{n: null}, 'n=', {'n': ''}],
-  [{nan: NaN}, 'nan=', {'nan': ''}],
-  [{inf: Infinity}, 'inf=', {'inf': ''}],
-  [{a: [], b: []}, '', {}]
+  [{ regexp: /./g }, 'regexp=', { 'regexp': '' }],
+  [{ regexp: new RegExp('.', 'g') }, 'regexp=', { 'regexp': '' }],
+  [{ fn: function() {} }, 'fn=', { 'fn': '' }],
+  [{ fn: new Function('') }, 'fn=', { 'fn': '' }],
+  [{ math: Math }, 'math=', { 'math': '' }],
+  [{ e: extendedFunction }, 'e=', { 'e': '' }],
+  [{ d: new Date() }, 'd=', { 'd': '' }],
+  [{ d: Date }, 'd=', { 'd': '' }],
+  [{ f: new Boolean(false), t: new Boolean(true) },
+   'f=&t=',
+   { 'f': '', 't': '' }],
+  [{ f: false, t: true }, 'f=false&t=true', { 'f': 'false', 't': 'true' }],
+  [{ n: null }, 'n=', { 'n': '' }],
+  [{ nan: NaN }, 'nan=', { 'nan': '' }],
+  [{ inf: Infinity }, 'inf=', { 'inf': '' }],
+  [{ a: [], b: [] }, '', {}]
 ];
 // }}}
 
@@ -92,13 +94,13 @@ var foreignObject = vm.runInNewContext('({"foo": ["bar", "baz"]})');
 
 var qsNoMungeTestCases = [
   ['', {}],
-  ['foo=bar&foo=baz', {'foo': ['bar', 'baz']}],
+  ['foo=bar&foo=baz', { 'foo': ['bar', 'baz'] }],
   ['foo=bar&foo=baz', foreignObject],
-  ['blah=burp', {'blah': 'burp'}],
-  ['gragh=1&gragh=3&goo=2', {'gragh': ['1', '3'], 'goo': '2'}],
+  ['blah=burp', { 'blah': 'burp' }],
+  ['gragh=1&gragh=3&goo=2', { 'gragh': ['1', '3'], 'goo': '2' }],
   ['frappucino=muffin&goat%5B%5D=scone&pond=moose',
-   {'frappucino': 'muffin', 'goat[]': 'scone', 'pond': 'moose'}],
-  ['trololol=yes&lololo=no', {'trololol': 'yes', 'lololo': 'no'}]
+   { 'frappucino': 'muffin', 'goat[]': 'scone', 'pond': 'moose' }],
+  ['trololol=yes&lololo=no', { 'trololol': 'yes', 'lololo': 'no' }]
 ];
 
 assert.strictEqual('918854443121279438895193',
@@ -137,14 +139,14 @@ qsNoMungeTestCases.forEach(function(testCase) {
 (function() {
   const f = qs.parse('a=b&q=x%3Dy%26y%3Dz');
   check(f, createWithNoPrototype([
-    { key: 'a', value: 'b'},
-    {key: 'q', value: 'x=y&y=z'}
+    { key: 'a', value: 'b' },
+    { key: 'q', value: 'x=y&y=z' }
   ]));
 
   f.q = qs.parse(f.q);
   const expectedInternal = createWithNoPrototype([
-    { key: 'x', value: 'y'},
-    {key: 'y', value: 'z' }
+    { key: 'x', value: 'y' },
+    { key: 'y', value: 'z' }
   ]);
   check(f.q, expectedInternal);
 })();
@@ -153,13 +155,13 @@ qsNoMungeTestCases.forEach(function(testCase) {
 (function() {
   const f = qs.parse('a:b;q:x%3Ay%3By%3Az', ';', ':');
   check(f, createWithNoPrototype([
-    {key: 'a', value: 'b'},
-    {key: 'q', value: 'x:y;y:z'}
+    { key: 'a', value: 'b' },
+    { key: 'q', value: 'x:y;y:z' }
   ]));
   f.q = qs.parse(f.q, ';', ':');
   const expectedInternal = createWithNoPrototype([
-    { key: 'x', value: 'y'},
-    {key: 'y', value: 'z' }
+    { key: 'x', value: 'y' },
+    { key: 'y', value: 'z' }
   ]);
   check(f.q, expectedInternal);
 })();
@@ -290,7 +292,8 @@ var prevUnescape = qs.unescape;
 qs.unescape = function(str) {
   return str.replace(/o/g, '_');
 };
-check(qs.parse('foo=bor'), createWithNoPrototype([{key: 'f__', value: 'b_r'}]));
+check(qs.parse('foo=bor'),
+      createWithNoPrototype([{ key: 'f__', value: 'b_r' }]));
 qs.unescape = prevUnescape;
 
 // test separator and "equals" parsing order

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -41,7 +41,7 @@ function isWarned(emitter) {
 
   // default history size 30
   fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
+  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
   assert.strictEqual(rli.historySize, 30);
 
   fi.emit('data', 'asdf\n');
@@ -365,7 +365,7 @@ function isWarned(emitter) {
 
   //can create a new readline Interface with a null output arugument
   fi = new FakeInput();
-  rli = new readline.Interface({input: fi, output: null, terminal: terminal });
+  rli = new readline.Interface({ input: fi, output: null, terminal: terminal });
 
   called = false;
   rli.on('line', function(line) {

--- a/test/parallel/test-regress-GH-2245.js
+++ b/test/parallel/test-regress-GH-2245.js
@@ -25,4 +25,4 @@ function test() {
 
 }
 
-assert.deepStrictEqual(test(), {m: 1});
+assert.deepStrictEqual(test(), { m: 1 });

--- a/test/parallel/test-regress-GH-4948.js
+++ b/test/parallel/test-regress-GH-4948.js
@@ -16,8 +16,8 @@ var server = http.createServer(function(serverReq, serverRes) {
 
   // normally the use case would be to call an external site
   // does not require connecting locally or to itself to fail
-  var r = http.request({hostname: 'localhost',
-                        port: common.PORT}, function(res) {
+  var r = http.request({ hostname: 'localhost',
+                        port: common.PORT }, function(res) {
     // required, just needs to be in the client response somewhere
     serverRes.end();
 

--- a/test/parallel/test-repl-eval-scope.js
+++ b/test/parallel/test-repl-eval-scope.js
@@ -8,7 +8,7 @@ const repl = require('repl');
   const options = {
     eval: common.mustCall((cmd, context) => {
       assert.strictEqual(cmd, '.scope\n');
-      assert.deepStrictEqual(context, {animal: 'Sterrance'});
+      assert.deepStrictEqual(context, { animal: 'Sterrance' });
     }),
     input: stream,
     output: stream,
@@ -16,7 +16,7 @@ const repl = require('repl');
   };
 
   const r = repl.start(options);
-  r.context = {animal: 'Sterrance'};
+  r.context = { animal: 'Sterrance' };
 
   stream.emit('data', '\t');
   stream.emit('.exit\n');

--- a/test/parallel/test-repl-eval.js
+++ b/test/parallel/test-repl-eval.js
@@ -15,7 +15,7 @@ const repl = require('repl');
   };
 
   const r = repl.start(options);
-  r.context = {foo: 'bar'};
+  r.context = { foo: 'bar' };
 
   try {
     r.write('foo\n');

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -43,7 +43,7 @@ const checkResults = common.mustCall(function(err, r) {
 });
 
 repl.createInternalRepl(
-  {NODE_REPL_HISTORY: replHistoryPath},
+  { NODE_REPL_HISTORY: replHistoryPath },
   {
     terminal: true,
     input: stream,

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -145,7 +145,7 @@ function error_test() {
       expect: '0.2' },
     // Can parse valid JSON
     { client: client_unix, send: 'JSON.parse(\'{"valid": "json"}\');',
-      expect: '{ valid: \'json\' }'},
+      expect: '{ valid: \'json\' }' },
     // invalid input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{invalid: \\\'json\\\'}\');',

--- a/test/parallel/test-require-cache.js
+++ b/test/parallel/test-require-cache.js
@@ -7,7 +7,7 @@ var assert = require('assert');
   var absolutePath = require.resolve(relativePath);
   var fakeModule = {};
 
-  require.cache[absolutePath] = {exports: fakeModule};
+  require.cache[absolutePath] = { exports: fakeModule };
 
   assert.strictEqual(require(relativePath), fakeModule);
 })();
@@ -17,7 +17,7 @@ var assert = require('assert');
   var relativePath = 'fs';
   var fakeModule = {};
 
-  require.cache[relativePath] = {exports: fakeModule};
+  require.cache[relativePath] = { exports: fakeModule };
 
   assert.strictEqual(require(relativePath), fakeModule);
 })();

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -32,7 +32,7 @@ var s2 = new PassThrough();
 var s3 = new TestStream();
 s1.pipe(s3);
 // Don't let s2 auto close which may close s3
-s2.pipe(s3, {end: false});
+s2.pipe(s3, { end: false });
 
 // We must write a buffer larger than highWaterMark
 var big = Buffer.alloc(s1._writableState.highWaterMark + 1, 'x');

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -17,11 +17,11 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
 };
 
 assert.throws(() => {
-  var m = new MyWritable({objectMode: true});
+  var m = new MyWritable({ objectMode: true });
   m.write(null, (err) => assert.ok(err));
 }, TypeError, 'May not write null values to stream');
 assert.doesNotThrow(() => {
-  var m = new MyWritable({objectMode: true}).on('error', (e) => {
+  var m = new MyWritable({ objectMode: true }).on('error', (e) => {
     assert.ok(e);
   });
   m.write(null, (err) => {
@@ -43,11 +43,11 @@ assert.doesNotThrow(() => {
 });
 
 assert.doesNotThrow(() => {
-  var m = new MyWritable({objectMode: true});
+  var m = new MyWritable({ objectMode: true });
   m.write(false, (err) => assert.ifError(err));
 });
 assert.doesNotThrow(() => {
-  var m = new MyWritable({objectMode: true}).on('error', (e) => {
+  var m = new MyWritable({ objectMode: true }).on('error', (e) => {
     assert.ifError(e || new Error('should not get here'));
   });
   m.write(false, (err) => {

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -53,7 +53,7 @@ function test(decode, uncork, multi, next) {
     { encoding: 'buffer',
       chunk: [10, 97, 110, 100, 32, 116, 104, 101, 110, 46, 46, 46] },
     { encoding: 'buffer',
-      chunk: [250, 206, 190, 167, 222, 173, 190, 239, 222, 202, 251, 173]}
+      chunk: [250, 206, 190, 167, 222, 173, 190, 239, 222, 202, 251, 173] }
   ] : [
     { encoding: 'ascii', chunk: 'hello, ' },
     { encoding: 'utf8', chunk: 'world' },

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -4,7 +4,7 @@ var R = require('_stream_readable');
 var W = require('_stream_writable');
 var assert = require('assert');
 
-var src = new R({encoding: 'base64'});
+var src = new R({ encoding: 'base64' });
 var dst = new W();
 var hasRead = false;
 var accum = [];

--- a/test/parallel/test-stream2-httpclient-response-end.js
+++ b/test/parallel/test-stream2-httpclient-response-end.js
@@ -6,10 +6,10 @@ var msg = 'Hello';
 var readable_event = false;
 var end_event = false;
 var server = http.createServer(function(req, res) {
-  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end(msg);
 }).listen(common.PORT, function() {
-  http.get({port: common.PORT}, function(res) {
+  http.get({ port: common.PORT }, function(res) {
     var data = '';
     res.on('readable', function() {
       console.log('readable event');

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -66,7 +66,7 @@ function fromArray(list) {
 function noop() {}
 
 test('can read objects from stream', function(t) {
-  var r = fromArray([{ one: '1'}, { two: '2' }]);
+  var r = fromArray([{ one: '1' }, { two: '2' }]);
 
   var v1 = r.read();
   var v2 = r.read();
@@ -80,7 +80,7 @@ test('can read objects from stream', function(t) {
 });
 
 test('can pipe objects into stream', function(t) {
-  var r = fromArray([{ one: '1'}, { two: '2' }]);
+  var r = fromArray([{ one: '1' }, { two: '2' }]);
 
   r.pipe(toArray(function(list) {
     assert.deepStrictEqual(list, [
@@ -93,7 +93,7 @@ test('can pipe objects into stream', function(t) {
 });
 
 test('read(n) is ignored', function(t) {
-  var r = fromArray([{ one: '1'}, { two: '2' }]);
+  var r = fromArray([{ one: '1' }, { two: '2' }]);
 
   var value = r.read(2);
 
@@ -104,7 +104,7 @@ test('read(n) is ignored', function(t) {
 
 test('can read objects from _read (sync)', function(t) {
   var r = new Readable({ objectMode: true });
-  var list = [{ one: '1'}, { two: '2' }];
+  var list = [{ one: '1' }, { two: '2' }];
   r._read = function(n) {
     var item = list.shift();
     r.push(item || null);
@@ -122,7 +122,7 @@ test('can read objects from _read (sync)', function(t) {
 
 test('can read objects from _read (async)', function(t) {
   var r = new Readable({ objectMode: true });
-  var list = [{ one: '1'}, { two: '2' }];
+  var list = [{ one: '1' }, { two: '2' }];
   r._read = function(n) {
     var item = list.shift();
     process.nextTick(function() {

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -93,7 +93,7 @@ test('object passthrough', function(t) {
   pt.write(0);
   pt.write('foo');
   pt.write('');
-  pt.write({ a: 'b'});
+  pt.write({ a: 'b' });
   pt.end();
 
   t.equal(pt.read(), 1);
@@ -102,7 +102,7 @@ test('object passthrough', function(t) {
   t.equal(pt.read(), 0);
   t.equal(pt.read(), 'foo');
   t.equal(pt.read(), '');
-  t.same(pt.read(), { a: 'b'});
+  t.same(pt.read(), { a: 'b' });
   t.end();
 });
 
@@ -140,7 +140,7 @@ test('simple object transform', function(t) {
   pt.write(0);
   pt.write('foo');
   pt.write('');
-  pt.write({ a: 'b'});
+  pt.write({ a: 'b' });
   pt.end();
 
   t.equal(pt.read(), '1');
@@ -267,7 +267,7 @@ test('assymetric transform (compress)', function(t) {
 test('complex transform', function(t) {
   var count = 0;
   var saved = null;
-  var pt = new Transform({highWaterMark: 3});
+  var pt = new Transform({ highWaterMark: 3 });
   pt._transform = function(c, e, cb) {
     if (count++ === 1)
       saved = c;

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -54,7 +54,7 @@ function runTest(pattern, code) {
   var log = matches[0];
   var out = cp.execSync(process.execPath +
                         ' --prof-process --call-graph-size=10 ' + log,
-                        {encoding: 'utf8'});
+                        { encoding: 'utf8' });
   assert(pattern.test(out));
   fs.unlinkSync(log);
 }

--- a/test/parallel/test-timers-active.js
+++ b/test/parallel/test-timers-active.js
@@ -30,5 +30,5 @@ bogusTimers.forEach(function(bogus) {
   const savedTimeout = bogus._idleTimeout;
   active(bogus);
   // active() should not mutate these objects
-  assert.deepStrictEqual(bogus, {_idleTimeout: savedTimeout});
+  assert.deepStrictEqual(bogus, { _idleTimeout: savedTimeout });
 });

--- a/test/parallel/test-timers-throw-when-cb-not-function.js
+++ b/test/parallel/test-timers-throw-when-cb-not-function.js
@@ -10,7 +10,7 @@ function doSetTimeout(callback, after) {
 
 assert.throws(doSetTimeout('foo'),
   /"callback" argument must be a function/);
-assert.throws(doSetTimeout({foo: 'bar'}),
+assert.throws(doSetTimeout({ foo: 'bar' }),
   /"callback" argument must be a function/);
 assert.throws(doSetTimeout(),
   /"callback" argument must be a function/);
@@ -30,7 +30,7 @@ function doSetInterval(callback, after) {
 
 assert.throws(doSetInterval('foo'),
   /"callback" argument must be a function/);
-assert.throws(doSetInterval({foo: 'bar'}),
+assert.throws(doSetInterval({ foo: 'bar' }),
   /"callback" argument must be a function/);
 assert.throws(doSetInterval(),
   /"callback" argument must be a function/);
@@ -50,7 +50,7 @@ function doSetImmediate(callback, after) {
 
 assert.throws(doSetImmediate('foo'),
   /"callback" argument must be a function/);
-assert.throws(doSetImmediate({foo: 'bar'}),
+assert.throws(doSetImmediate({ foo: 'bar' }),
   /"callback" argument must be a function/);
 assert.throws(doSetImmediate(),
   /"callback" argument must be a function/);

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -40,7 +40,7 @@ function runTest(clientsOptions, serverOptions, cb) {
   var results = [];
   var index = 0;
   var server = tls.createServer(serverOptions, function(c) {
-    results[index].server = {ALPN: c.alpnProtocol, NPN: c.npnProtocol};
+    results[index].server = { ALPN: c.alpnProtocol, NPN: c.npnProtocol };
   });
 
   server.listen(serverPort, serverIP, function() {
@@ -55,8 +55,8 @@ function runTest(clientsOptions, serverOptions, cb) {
 
     results[index] = {};
     var client = tls.connect(opt, function() {
-      results[index].client = {ALPN: client.alpnProtocol,
-                               NPN: client.npnProtocol};
+      results[index].client = { ALPN: client.alpnProtocol,
+                               NPN: client.npnProtocol };
       client.destroy();
       if (options.length) {
         index++;
@@ -91,16 +91,16 @@ function Test1() {
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by ALPN
     checkResults(results[0],
-                 {server: {ALPN: 'a', NPN: false},
-                  client: {ALPN: 'a', NPN: undefined}});
+                 { server: { ALPN: 'a', NPN: false },
+                  client: { ALPN: 'a', NPN: undefined } });
     // 'b' is selected by ALPN
     checkResults(results[1],
-                 {server: {ALPN: 'b', NPN: false},
-                  client: {ALPN: 'b', NPN: undefined}});
+                 { server: { ALPN: 'b', NPN: false },
+                  client: { ALPN: 'b', NPN: undefined } });
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'first-priority-unsupported' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test2();
   });
@@ -124,16 +124,16 @@ function Test2() {
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by ALPN
     checkResults(results[0],
-                 {server: {ALPN: 'a', NPN: false},
-                  client: {ALPN: 'a', NPN: undefined}});
+                 { server: { ALPN: 'a', NPN: false },
+                  client: { ALPN: 'a', NPN: undefined } });
     // 'b' is selected by ALPN
     checkResults(results[1],
-                 {server: {ALPN: 'b', NPN: false},
-                  client: {ALPN: 'b', NPN: undefined}});
+                 { server: { ALPN: 'b', NPN: false },
+                  client: { ALPN: 'b', NPN: undefined } });
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test3();
   });
@@ -157,16 +157,16 @@ function Test3() {
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by NPN
     checkResults(results[0],
-                 {server: {ALPN: false, NPN: 'a'},
-                  client: {ALPN: false, NPN: 'a'}});
+                 { server: { ALPN: false, NPN: 'a' },
+                  client: { ALPN: false, NPN: 'a' } });
     // nothing is selected by ALPN
     checkResults(results[1],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test4();
   });
@@ -184,16 +184,16 @@ function Test4() {
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected by ALPN
     checkResults(results[0],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
     checkResults(results[1],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test5();
   });
@@ -218,15 +218,15 @@ function Test5() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by ALPN
-    checkResults(results[0], {server: {ALPN: 'a', NPN: false},
-                              client: {ALPN: 'a', NPN: undefined}});
+    checkResults(results[0], { server: { ALPN: 'a', NPN: false },
+                              client: { ALPN: 'a', NPN: undefined } });
     // 'b' is selected by ALPN
-    checkResults(results[1], {server: {ALPN: 'b', NPN: false},
-                              client: {ALPN: 'b', NPN: undefined}});
+    checkResults(results[1], { server: { ALPN: 'b', NPN: false },
+                              client: { ALPN: 'b', NPN: undefined } });
     // nothing is selected by ALPN
-    checkResults(results[2], {server: {ALPN: false,
-                                       NPN: 'first-priority-unsupported'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[2], { server: { ALPN: false,
+                                       NPN: 'first-priority-unsupported' },
+                              client: { ALPN: false, NPN: false } });
     // execute next test
     Test6();
   });
@@ -248,14 +248,14 @@ function Test6() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by ALPN
-    checkResults(results[0], {server: {ALPN: 'a', NPN: false},
-                              client: {ALPN: 'a', NPN: undefined}});
+    checkResults(results[0], { server: { ALPN: 'a', NPN: false },
+                              client: { ALPN: 'a', NPN: undefined } });
     // 'b' is selected by ALPN
-    checkResults(results[1], {server: {ALPN: 'b', NPN: false},
-                              client: {ALPN: 'b', NPN: undefined}});
+    checkResults(results[1], { server: { ALPN: 'b', NPN: false },
+                              client: { ALPN: 'b', NPN: undefined } });
     // nothing is selected by ALPN
-    checkResults(results[2], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[2], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // execute next test
     Test7();
   });
@@ -277,15 +277,15 @@ function Test7() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected by ALPN
-    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'a' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
-    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'c' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'first-priority-unsupported' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test8();
   });
@@ -301,15 +301,15 @@ function Test8() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected by ALPN
-    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
-    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test9();
   });
@@ -334,15 +334,15 @@ function Test9() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by NPN
-    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
-                              client: {ALPN: false, NPN: 'a'}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'a' },
+                              client: { ALPN: false, NPN: 'a' } });
     // 'b' is selected by NPN
-    checkResults(results[1], {server: {ALPN: false, NPN: 'b'},
-                              client: {ALPN: false, NPN: 'b'}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'b' },
+                              client: { ALPN: false, NPN: 'b' } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'first-priority-unsupported' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test10();
   });
@@ -364,14 +364,14 @@ function Test10() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected
-    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[2], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[2], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // execute next test
     Test11();
   });
@@ -393,15 +393,15 @@ function Test11() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // 'a' is selected by NPN
-    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
-                              client: {ALPN: false, NPN: 'a'}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'a' },
+                              client: { ALPN: false, NPN: 'a' } });
     // 'b' is selected by NPN
-    checkResults(results[1], {server: {ALPN: false, NPN: 'b'},
-                              client: {ALPN: false, NPN: 'b'}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'b' },
+                              client: { ALPN: false, NPN: 'b' } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'first-priority-unsupported' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test12();
   });
@@ -417,15 +417,15 @@ function Test12() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected
-    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test13();
   });
@@ -448,15 +448,15 @@ function Test13() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected
-    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'a' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'c' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'first-priority-unsupported' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test14();
   });
@@ -476,15 +476,15 @@ function Test14() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected
-    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test15();
   });
@@ -504,15 +504,15 @@ function Test15() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected
-    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'a' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'c' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'first-priority-unsupported' },
+                  client: { ALPN: false, NPN: false } });
     // execute next test
     Test16();
   });
@@ -526,15 +526,15 @@ function Test16() {
 
   runTest(clientsOptions, serverOptions, function(results) {
     // nothing is selected
-    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[0], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
-    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
-                              client: {ALPN: false, NPN: false}});
+    checkResults(results[1], { server: { ALPN: false, NPN: 'http/1.1' },
+                              client: { ALPN: false, NPN: false } });
     // nothing is selected
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: 'http/1.1'},
-                  client: {ALPN: false, NPN: false}});
+                 { server: { ALPN: false, NPN: 'http/1.1' },
+                  client: { ALPN: false, NPN: false } });
   });
 }
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -4,31 +4,31 @@ require('../common');
 const assert = require('assert');
 const tls = require('tls');
 
-assert.throws(() => tls.createSecureContext({ciphers: 1}),
+assert.throws(() => tls.createSecureContext({ ciphers: 1 }),
               /TypeError: Ciphers must be a string/);
 
-assert.throws(() => tls.createServer({ciphers: 1}),
+assert.throws(() => tls.createServer({ ciphers: 1 }),
               /TypeError: Ciphers must be a string/);
 
-assert.throws(() => tls.createSecureContext({key: 'dummykey', passphrase: 1}),
+assert.throws(() => tls.createSecureContext({ key: 'dummykey', passphrase: 1 }),
               /TypeError: Pass phrase must be a string/);
 
-assert.throws(() => tls.createServer({key: 'dummykey', passphrase: 1}),
+assert.throws(() => tls.createServer({ key: 'dummykey', passphrase: 1 }),
               /TypeError: Pass phrase must be a string/);
 
-assert.throws(() => tls.createServer({ecdhCurve: 1}),
+assert.throws(() => tls.createServer({ ecdhCurve: 1 }),
               /TypeError: ECDH curve name must be a string/);
 
-assert.throws(() => tls.createServer({handshakeTimeout: 'abcd'}),
+assert.throws(() => tls.createServer({ handshakeTimeout: 'abcd' }),
               /TypeError: handshakeTimeout must be a number/);
 
-assert.throws(() => tls.createServer({sessionTimeout: 'abcd'}),
+assert.throws(() => tls.createServer({ sessionTimeout: 'abcd' }),
               /TypeError: Session timeout must be a 32-bit integer/);
 
-assert.throws(() => tls.createServer({ticketKeys: 'abcd'}),
+assert.throws(() => tls.createServer({ ticketKeys: 'abcd' }),
               /TypeError: Ticket keys must be a buffer/);
 
-assert.throws(() => tls.createServer({ticketKeys: new Buffer(0)}),
+assert.throws(() => tls.createServer({ ticketKeys: new Buffer(0) }),
               /TypeError: Ticket keys length must be 48 bytes/);
 
 assert.throws(() => tls.createSecurePair({}),

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -14,7 +14,7 @@ var path = require('path');
 var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-var conn = tls.connect({cert: cert, key: key, port: common.PORT}, function() {
+var conn = tls.connect({ cert: cert, key: key, port: common.PORT }, function() {
   assert.ok(false); // callback should never be executed
 });
 conn.on('error', function() {

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -23,8 +23,8 @@ var path = require('path');
     assert.ok(errorEmitted);
   });
 
-  var conn = tls.connect({cert: cert, key: key, port: common.PORT}, function() {
-    assert.ok(false); // callback should never be executed
+  var conn = tls.connect({ cert: cert, key: key, port: common.PORT }, () => {
+    common.fail('callback should never be executed');
   });
 
   conn.on('error', function() {

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -35,7 +35,7 @@ var server = net.createServer(function(c) {
     });
   }, 200);
 }).listen(common.PORT, function() {
-  var c = net.connect({port: common.PORT}, function() {
+  var c = net.connect({ port: common.PORT }, function() {
     c.write(bonkers);
   });
 });

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -24,7 +24,7 @@ function log(a) {
 var server = net.createServer(function(socket) {
   connections++;
   log('connection fd=' + socket.fd);
-  var sslcontext = tls.createSecureContext({key: key, cert: cert});
+  var sslcontext = tls.createSecureContext({ key: key, cert: cert });
   sslcontext.context.setCiphers('RC4-SHA:AES128-SHA:AES256-SHA');
 
   var pair = tls.createSecurePair(sslcontext, true);

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -913,7 +913,7 @@ var parseTestsWithQueryString = {
     href: '/foo/bar?baz=quux#frag',
     hash: '#frag',
     search: '?baz=quux',
-    query: createWithNoPrototype([{key: 'baz', value: 'quux'}]),
+    query: createWithNoPrototype([{ key: 'baz', value: 'quux' }]),
     pathname: '/foo/bar',
     path: '/foo/bar?baz=quux'
   },

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -4,7 +4,7 @@ require('../common');
 const assert = require('assert');
 const util = require('util');
 const processUtil = process.binding('util');
-const opts = {showProxy: true};
+const opts = { showProxy: true };
 
 const target = {};
 const handler = {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -23,22 +23,22 @@ assert.equal(util.inspect([1, 2]), '[ 1, 2 ]');
 assert.equal(util.inspect([1, [2, 3]]), '[ 1, [ 2, 3 ] ]');
 
 assert.equal(util.inspect({}), '{}');
-assert.equal(util.inspect({a: 1}), '{ a: 1 }');
-assert.equal(util.inspect({a: function() {}}), '{ a: [Function] }');
-assert.equal(util.inspect({a: 1, b: 2}), '{ a: 1, b: 2 }');
-assert.equal(util.inspect({'a': {}}), '{ a: {} }');
-assert.equal(util.inspect({'a': {'b': 2}}), '{ a: { b: 2 } }');
-assert.equal(util.inspect({'a': {'b': { 'c': { 'd': 2 }}}}),
+assert.equal(util.inspect({ a: 1 }), '{ a: 1 }');
+assert.equal(util.inspect({ a: function() {} }), '{ a: [Function] }');
+assert.equal(util.inspect({ a: 1, b: 2 }), '{ a: 1, b: 2 }');
+assert.equal(util.inspect({ 'a': {} }), '{ a: {} }');
+assert.equal(util.inspect({ 'a': { 'b': 2 } }), '{ a: { b: 2 } }');
+assert.equal(util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }),
   '{ a: { b: { c: [Object] } } }');
-assert.equal(util.inspect({'a': {'b': { 'c': { 'd': 2 }}}}, false, null),
+assert.equal(util.inspect({ 'a': { 'b': { 'c': { 'd': 2 } } } }, false, null),
   '{ a: { b: { c: { d: 2 } } } }');
 assert.equal(util.inspect([1, 2, 3], true), '[ 1, 2, 3, [length]: 3 ]');
-assert.equal(util.inspect({'a': {'b': { 'c': 2}}}, false, 0),
+assert.equal(util.inspect({ 'a': { 'b': { 'c': 2 } } }, false, 0),
   '{ a: [Object] }');
-assert.equal(util.inspect({'a': {'b': { 'c': 2}}}, false, 1),
+assert.equal(util.inspect({ 'a': { 'b': { 'c': 2 } } }, false, 1),
   '{ a: { b: [Object] } }');
 assert.equal(util.inspect(Object.create({},
-  {visible: {value: 1, enumerable: true}, hidden: {value: 2}})),
+  { visible: { value: 1, enumerable: true }, hidden: { value: 2 } })),
   '{ visible: 1 }'
 );
 
@@ -162,7 +162,7 @@ for (const showHidden of [true, false]) {
 
 {
   const out = util.inspect(Object.create({},
-      {visible: {value: 1, enumerable: true}, hidden: {value: 2}}), true);
+      { visible: { value: 1, enumerable: true }, hidden: { value: 2 } }), true);
   if (out !== '{ [hidden]: 2, visible: 1 }' &&
       out !== '{ visible: 1, [hidden]: 2 }') {
     assert.ok(false);
@@ -172,8 +172,8 @@ for (const showHidden of [true, false]) {
 // Objects without prototype
 {
   const out = util.inspect(Object.create(null,
-      { name: {value: 'Tim', enumerable: true},
-        hidden: {value: 'secret'}}), true);
+      { name: { value: 'Tim', enumerable: true },
+        hidden: { value: 'secret' } }), true);
   if (out !== "{ [hidden]: 'secret', name: 'Tim' }" &&
       out !== "{ name: 'Tim', [hidden]: 'secret' }") {
     assert(false);
@@ -182,20 +182,20 @@ for (const showHidden of [true, false]) {
 
 assert.equal(
   util.inspect(Object.create(null,
-    {name: {value: 'Tim', enumerable: true},
-      hidden: {value: 'secret'}})),
+    { name: { value: 'Tim', enumerable: true },
+      hidden: { value: 'secret' } })),
   '{ name: \'Tim\' }'
 );
 
 
 // Dynamic properties
-assert.equal(util.inspect({get readonly() {}}),
+assert.equal(util.inspect({ get readonly() {} }),
   '{ readonly: [Getter] }');
 
-assert.equal(util.inspect({get readwrite() {}, set readwrite(val) {}}),
+assert.equal(util.inspect({ get readwrite() {}, set readwrite(val) {} }),
   '{ readwrite: [Getter/Setter] }');
 
-assert.equal(util.inspect({set writeonly(val) {}}),
+assert.equal(util.inspect({ set writeonly(val) {} }),
   '{ writeonly: [Setter] }');
 
 var value = {};
@@ -445,7 +445,7 @@ function test_lines(input) {
   };
 
   var without_color = util.inspect(input);
-  var with_color = util.inspect(input, {colors: true});
+  var with_color = util.inspect(input, { colors: true });
   assert.equal(count_lines(without_color), count_lines(with_color));
 }
 
@@ -457,11 +457,11 @@ test_lines(function() {
   }
   return big_array;
 }());
-test_lines({foo: 'bar', baz: 35, b: {a: 35}});
+test_lines({ foo: 'bar', baz: 35, b: { a: 35 } });
 test_lines({
   foo: 'bar',
   baz: 35,
-  b: {a: 35},
+  b: { a: 35 },
   very_long_key: 'very_long_value',
   even_longer_key: ['with even longer value in array']
 });
@@ -659,13 +659,13 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
 
 {
   const x = Array(101);
-  assert(!/1 more item/.test(util.inspect(x, {maxArrayLength: 101})));
+  assert(!/1 more item/.test(util.inspect(x, { maxArrayLength: 101 })));
 }
 
 {
   const x = Array(101);
   assert(/^\[ ... 101 more items \]$/.test(
-      util.inspect(x, {maxArrayLength: 0})));
+      util.inspect(x, { maxArrayLength: 0 })));
 }
 
 {
@@ -675,31 +675,31 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
 
 {
   const x = new Uint8Array(101);
-  assert(!/1 more item/.test(util.inspect(x, {maxArrayLength: 101})));
+  assert(!/1 more item/.test(util.inspect(x, { maxArrayLength: 101 })));
 }
 
 {
   const x = new Uint8Array(101);
   assert(/\[ ... 101 more items \]$/.test(
-      util.inspect(x, {maxArrayLength: 0})));
+      util.inspect(x, { maxArrayLength: 0 })));
 }
 
 {
   const x = Array(101);
-  assert(!/1 more item/.test(util.inspect(x, {maxArrayLength: null})));
+  assert(!/1 more item/.test(util.inspect(x, { maxArrayLength: null })));
 }
 
 {
   const x = Array(101);
-  assert(!/1 more item/.test(util.inspect(x, {maxArrayLength: Infinity})));
+  assert(!/1 more item/.test(util.inspect(x, { maxArrayLength: Infinity })));
 }
 
 {
   const x = new Uint8Array(101);
-  assert(!/1 more item/.test(util.inspect(x, {maxArrayLength: null})));
+  assert(!/1 more item/.test(util.inspect(x, { maxArrayLength: null })));
 }
 
 {
   const x = new Uint8Array(101);
-  assert(!/1 more item/.test(util.inspect(x, {maxArrayLength: Infinity})));
+  assert(!/1 more item/.test(util.inspect(x, { maxArrayLength: Infinity })));
 }

--- a/test/parallel/test-util-log.js
+++ b/test/parallel/test-util-log.js
@@ -14,15 +14,15 @@ global.process.stdout.write = function(string) {
 console._stderr = process.stdout;
 
 var tests = [
-  {input: 'foo', output: 'foo'},
-  {input: undefined, output: 'undefined'},
-  {input: null, output: 'null'},
-  {input: false, output: 'false'},
-  {input: 42, output: '42'},
-  {input: function() {}, output: '[Function]'},
-  {input: parseInt('not a number', 10), output: 'NaN'},
-  {input: {answer: 42}, output: '{ answer: 42 }'},
-  {input: [1, 2, 3], output: '[ 1, 2, 3 ]'}
+  { input: 'foo', output: 'foo' },
+  { input: undefined, output: 'undefined' },
+  { input: null, output: 'null' },
+  { input: false, output: 'false' },
+  { input: 42, output: '42' },
+  { input: function() {}, output: '[Function]' },
+  { input: parseInt('not a number', 10), output: 'NaN' },
+  { input: { answer: 42 }, output: '{ answer: 42 }' },
+  { input: [1, 2, 3], output: '[ 1, 2, 3 ]' }
 ];
 
 // test util.log()

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -76,10 +76,10 @@ assert.equal(false, util.isBuffer('foo'));
 assert.equal(true, util.isBuffer(Buffer.from('foo')));
 
 // _extend
-assert.deepStrictEqual(util._extend({a: 1}), {a: 1});
-assert.deepStrictEqual(util._extend({a: 1}, []), {a: 1});
-assert.deepStrictEqual(util._extend({a: 1}, null), {a: 1});
-assert.deepStrictEqual(util._extend({a: 1}, true), {a: 1});
-assert.deepStrictEqual(util._extend({a: 1}, false), {a: 1});
-assert.deepStrictEqual(util._extend({a: 1}, {b: 2}), {a: 1, b: 2});
-assert.deepStrictEqual(util._extend({a: 1, b: 2}, {b: 3}), {a: 1, b: 3});
+assert.deepStrictEqual(util._extend({ a: 1 }), { a: 1 });
+assert.deepStrictEqual(util._extend({ a: 1 }, []), { a: 1 });
+assert.deepStrictEqual(util._extend({ a: 1 }, null), { a: 1 });
+assert.deepStrictEqual(util._extend({ a: 1 }, true), { a: 1 });
+assert.deepStrictEqual(util._extend({ a: 1 }, false), { a: 1 });
+assert.deepStrictEqual(util._extend({ a: 1 }, { b: 2 }), { a: 1, b: 2 });
+assert.deepStrictEqual(util._extend({ a: 1, b: 2 }, { b: 3 }), { a: 1, b: 3 });

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -12,7 +12,7 @@ var result = script.runInContext(context);
 assert.equal('passed', result);
 
 console.error('create a new pre-populated context');
-context = vm.createContext({'foo': 'bar', 'thing': 'lala'});
+context = vm.createContext({ 'foo': 'bar', 'thing': 'lala' });
 assert.equal('bar', context.foo);
 assert.equal('lala', context.thing);
 

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -11,7 +11,7 @@ var result = vm.runInContext('"passed";', context);
 assert.equal('passed', result);
 
 console.error('create a new pre-populated context');
-context = vm.createContext({'foo': 'bar', 'thing': 'lala'});
+context = vm.createContext({ 'foo': 'bar', 'thing': 'lala' });
 assert.equal('bar', context.foo);
 assert.equal('lala', context.thing);
 
@@ -22,7 +22,7 @@ assert.equal('lala', context.thing);
 
 // https://github.com/nodejs/node/issues/5768
 console.error('run in contextified sandbox without referencing the context');
-var sandbox = {x: 1};
+var sandbox = { x: 1 };
 vm.createContext(sandbox);
 global.gc();
 vm.runInContext('x = 2', sandbox);

--- a/test/parallel/test-zerolengthbufferbug.js
+++ b/test/parallel/test-zerolengthbufferbug.js
@@ -8,8 +8,8 @@ var http = require('http');
 var server = http.createServer(function(req, res) {
   var buffer = Buffer.alloc(0);
   // FIXME: WTF gjslint want this?
-  res.writeHead(200, {'Content-Type': 'text/html',
-                 'Content-Length': buffer.length});
+  res.writeHead(200, { 'Content-Type': 'text/html',
+                 'Content-Length': buffer.length });
   res.end(buffer);
 });
 

--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -11,7 +11,7 @@ assert.equal(zlib.Z_OK, 0, 'Z_OK should be 0');
 assert.equal(zlib.codes.Z_OK, 0, 'Z_OK should be 0');
 zlib.codes.Z_OK = 1;
 assert.equal(zlib.codes.Z_OK, 0, 'zlib.codes.Z_OK should be 0');
-zlib.codes = {Z_OK: 1};
+zlib.codes = { Z_OK: 1 };
 assert.equal(zlib.codes.Z_OK, 0, 'zlib.codes.Z_OK should be 0');
 
 assert.ok(Object.isFrozen(zlib.codes), 'zlib.codes should be frozen');

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -5,7 +5,7 @@ require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-var nonStringInputs = [1, true, {a: 1}, ['a']];
+var nonStringInputs = [1, true, { a: 1 }, ['a']];
 
 console.error('Doing the non-strings');
 nonStringInputs.forEach(function(input) {

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -65,7 +65,7 @@ exec(SLEEP3_COMMAND, { timeout: 50 }, function(err, stdout, stderr) {
 
 
 var startSleep3 = new Date();
-var killMeTwice = exec(SLEEP3_COMMAND, {timeout: 1000}, killMeTwiceCallback);
+var killMeTwice = exec(SLEEP3_COMMAND, { timeout: 1000 }, killMeTwiceCallback);
 
 process.nextTick(function() {
   console.log('kill pid %d', killMeTwice.pid);
@@ -90,7 +90,7 @@ function killMeTwiceCallback(err, stdout, stderr) {
 }
 
 
-exec('python -c "print 200000*\'C\'"', {maxBuffer: 1000},
+exec('python -c "print 200000*\'C\'"', { maxBuffer: 1000 },
      function(err, stdout, stderr) {
        assert.ok(err);
        assert.ok(/maxBuffer/.test(err.message));

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -16,7 +16,7 @@ catch (e) {
   // swallow
 }
 
-fs.watchFile(FILENAME, {interval: TIMEOUT - 250}, function(curr, prev) {
+fs.watchFile(FILENAME, { interval: TIMEOUT - 250 }, function(curr, prev) {
   console.log([curr, prev]);
   switch (++nevents) {
     case 1:

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -27,7 +27,7 @@ server.on('listening', function() {
     eofCount++;
   });
 
-  var request = client.request('GET', '/', {'host': 'localhost'});
+  var request = client.request('GET', '/', { 'host': 'localhost' });
   request.end();
   request.on('response', function(response) {
     console.log('STATUS: ' + response.statusCode);

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -39,7 +39,7 @@ function runAb(opts, callback) {
   }
 
   args.push(url.format({ hostname: '127.0.0.1',
-                         port: common.PORT, protocol: 'http'}));
+                         port: common.PORT, protocol: 'http' }));
 
   //console.log(comm, args.join(' '));
 

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -78,7 +78,7 @@ var server = https.Server(serverOptions, function(req, res) {
 
   req.on('end', function() {
     assert.equal(bytesExpected, uploadCount);
-    res.writeHead(200, {'content-type': 'text/plain'});
+    res.writeHead(200, { 'content-type': 'text/plain' });
     res.end('successful upload\n');
   });
 });

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -110,7 +110,7 @@ function test(keyfn, certfn, check, next) {
   function startClient() {
     var s = new net.Stream();
 
-    var sslcontext = tls.createSecureContext({key: key, cert: cert});
+    var sslcontext = tls.createSecureContext({ key: key, cert: cert });
     sslcontext.context.setCiphers('RC4-SHA:AES128-SHA:AES256-SHA');
 
     var pair = tls.createSecurePair(sslcontext, false);

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -14,7 +14,7 @@ var caught = false;
 
 try {
   var cmd = `"${process.execPath}" -e "setTimeout(function(){}, ${SLEEP});"`;
-  var ret = execSync(cmd, {timeout: TIMER});
+  var ret = execSync(cmd, { timeout: TIMER });
 } catch (e) {
   caught = true;
   assert.strictEqual(e.errno, 'ETIMEDOUT');
@@ -67,10 +67,10 @@ assert.strictEqual(ret, msg + '\n',
 
   if (common.isWindows) {
     cwd = 'c:\\';
-    response = execSync('echo %cd%', {cwd: cwd});
+    response = execSync('echo %cd%', { cwd: cwd });
   } else {
     cwd = '/';
-    response = execSync('pwd', {cwd: cwd});
+    response = execSync('pwd', { cwd: cwd });
   }
 
   assert.strictEqual(response.toString().trim(), cwd);
@@ -79,6 +79,6 @@ assert.strictEqual(ret, msg + '\n',
 // Verify that stderr is not accessed when stdio = 'ignore' - GH #7966
 (function() {
   assert.throws(function() {
-    execSync('exit -1', {stdio: 'ignore'});
+    execSync('exit -1', { stdio: 'ignore' });
   }, /Command failed: exit -1/);
 })();

--- a/test/sequential/test-child-process-fork-getconnections.js
+++ b/test/sequential/test-child-process-fork-getconnections.js
@@ -10,7 +10,7 @@ if (process.argv[2] === 'child') {
 
   process.on('message', function(m, socket) {
     function sendClosed(id) {
-      process.send({ id: id, status: 'closed'});
+      process.send({ id: id, status: 'closed' });
     }
 
     if (m.cmd === 'new') {

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -103,7 +103,7 @@ setImmediate(function() {
 
 // https://github.com/joyent/node/issues/2293 - non-persistent watcher should
 // not block the event loop
-fs.watch(__filename, {persistent: false}, function() {
+fs.watch(__filename, { persistent: false }, function() {
   assert(0);
 });
 
@@ -119,7 +119,7 @@ assert.throws(function() {
 oldhandle.close(); // clean up
 
 assert.throws(function() {
-  var w = fs.watchFile(__filename, {persistent: false}, function() {});
+  var w = fs.watchFile(__filename, { persistent: false }, function() {});
   oldhandle = w._handle;
   w._handle = { stop: w._handle.stop };
   w.stop();

--- a/test/sequential/test-init.js
+++ b/test/sequential/test-init.js
@@ -15,12 +15,12 @@
     var envCopy = JSON.parse(JSON.stringify(process.env));
     envCopy.TEST_INIT = 1;
 
-    child.exec('"' + process.execPath + '" test-init', {env: envCopy},
+    child.exec('"' + process.execPath + '" test-init', { env: envCopy },
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init` failed!');
         });
-    child.exec('"' + process.execPath + '" test-init.js', {env: envCopy},
+    child.exec('"' + process.execPath + '" test-init.js', { env: envCopy },
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init.js` failed!');
@@ -29,7 +29,7 @@
     // test-init-index is in fixtures dir as requested by ry, so go there
     process.chdir(common.fixturesDir);
 
-    child.exec('"' + process.execPath + '" test-init-index', {env: envCopy},
+    child.exec('"' + process.execPath + '" test-init-index', { env: envCopy },
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init-index failed!');
@@ -40,7 +40,7 @@
     // expected in node
     process.chdir(common.fixturesDir + '/test-init-native/');
 
-    child.exec('"' + process.execPath + '" fs', {env: envCopy},
+    child.exec('"' + process.execPath + '" fs', { env: envCopy },
         function(err, stdout, stderr) {
           assert.equal(stdout, 'fs loaded successfully',
                        '`node fs` failed!');

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -46,7 +46,7 @@ function child2() {
   var socket = new net.Socket({
     fd: 2,
     readable: false,
-    writable: true});
+    writable: true });
   socket.write('child 2\n');
   socket.write('foo\n');
   socket.write('bar\n');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

tools test

##### Description of change

<!-- provide a description of the change below this comment -->

For `test` directory only, enforce consistent use of a space between
object curly brackets and the object contents.

Good: `{ foo: bar }`

Bad: `{foo: bar}`

The former (labeled "Good") style is more common, though far from
universal, in both the tests and the other JS files in the project.

I explored eight different rule configuration possibilities, and this is the one that results in the least churn. I suspect this may be a bit much churn for a lot of collaborators. I guess we'll see. Insert usual arguments about benefits of a single consistent style here. Hashtag: ChurnBabyChurn.