### PR TITLE
timers: use HandleWrap::Unrefed

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -133,8 +133,6 @@ function insert(item, unrefed) {
     list = new TimersList(msecs, unrefed);
     L.init(list);
     list._timer._list = list;
-
-    if (unrefed === true) list._timer.unref();
     list._timer.start(msecs, 0);
 
     lists[msecs] = list;
@@ -149,7 +147,7 @@ function TimersList(msecs, unrefed) {
   this._idleNext = null; // Create the list with the linkedlist properties to
   this._idlePrev = null; // prevent any unnecessary hidden class changes.
   this._timer = new TimerWrap();
-  this._unrefed = unrefed;
+  if (unrefed === true) this._timer.unref();
   this.msecs = msecs;
 }
 
@@ -206,12 +204,12 @@ function listOnTimeout() {
   // As such, we can remove the list and clean up the TimerWrap C++ handle.
   debug('%d list empty', msecs);
   assert(L.isEmpty(list));
-  this.close();
-  if (list._unrefed === true) {
-    delete unrefedLists[msecs];
-  } else {
+  if (this.hasRef() === true) {
     delete refedLists[msecs];
+  } else {
+    delete unrefedLists[msecs];
   }
+  this.close();
 }
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [X] tests and code linting passes
- [X] a test and/or benchmark is included
- [X] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

timers
##### Description of change

<!-- provide a description of the change below this comment -->

So, there a couple things going on here:
- I originally wanted to do this, I don't like relying on a JS property much.
- This breaks down if someone {un}refs the handle from C++, is that actually an issue?

CI: https://ci.nodejs.org/job/node-test-pull-request/2594/
