### PR TITLE
tls: Add PSK support

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -111,6 +111,46 @@ exports.createSecureContext = function createSecureContext(options, context) {
     }
   }
 
+  if (options.pskCallback && c.context.enablePskCallback) {
+    c.context.onpskexchange = (identity, maxPskLen, maxIdentLen) => {
+      let ret = options.pskCallback(identity);
+      if (typeof ret !== 'object') {
+        ret = undefined;
+      }
+
+      if (ret) {
+        ret = { psk: ret.psk, identity: ret.identity };
+
+        if (typeof ret.psk === 'string') {
+          ret.psk = Buffer.from(ret.psk);
+        } else if (!Buffer.isBuffer(ret.psk)) {
+          throw new TypeError('Pre-shared key is not a string or buffer');
+        }
+        if (ret.psk.length > maxPskLen) {
+          throw new TypeError(`Pre-shared key exceed ${maxPskLen} bytes`);
+        }
+
+        // Only set for the client callback, which must provide an identity.
+        if (maxIdentLen) {
+          if (typeof ret.identity === 'string') {
+            ret.identity = Buffer.from(ret.identity + '\0');
+          } else {
+            throw new TypeError('PSK identity is not a string');
+          }
+          if (ret.identity.length > maxIdentLen) {
+            throw new TypeError(`PSK identity exceeds ${maxIdentLen} bytes`);
+          }
+        }
+      }
+
+      return ret;
+    };
+    c.context.enablePskCallback();
+
+    if (options.pskIdentity)
+      c.context.setPskIdentity(options.pskIdentity);
+  }
+
   if (options.sessionIdContext) {
     c.context.setSessionIdContext(options.sessionIdContext);
   }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -681,7 +681,7 @@ TLSSocket.prototype.getProtocol = function() {
   return null;
 };
 
-// TODO: support anonymous (nocert) and PSK
+// TODO: support anonymous (nocert)
 
 
 // AUTHENTICATION MODES
@@ -780,6 +780,8 @@ function Server(options, listener) {
     dhparam: self.dhparam,
     secureProtocol: self.secureProtocol,
     secureOptions: self.secureOptions,
+    pskCallback: self.pskCallback,
+    pskIdentity: self.pskIdentity,
     honorCipherOrder: self.honorCipherOrder,
     crl: self.crl,
     sessionIdContext: self.sessionIdContext
@@ -920,6 +922,8 @@ Server.prototype.setOptions = function(options) {
   else
     this.honorCipherOrder = true;
   if (secureOptions) this.secureOptions = secureOptions;
+  if (options.pskIdentity) this.pskIdentity = options.pskIdentity;
+  if (options.pskCallback) this.pskCallback = options.pskCallback;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
   if (options.ALPNProtocols)
     tls.convertALPNProtocols(options.ALPNProtocols, this);

--- a/src/env.h
+++ b/src/env.h
@@ -91,6 +91,7 @@ namespace node {
   V(emitting_top_level_domain_error_string, "_emittingTopLevelDomainError")   \
   V(exchange_string, "exchange")                                              \
   V(enumerable_string, "enumerable")                                          \
+  V(identity_string, "identity")                                              \
   V(idle_string, "idle")                                                      \
   V(irq_string, "irq")                                                        \
   V(encoding_string, "encoding")                                              \
@@ -155,6 +156,7 @@ namespace node {
   V(onnewsession_string, "onnewsession")                                      \
   V(onnewsessiondone_string, "onnewsessiondone")                              \
   V(onocspresponse_string, "onocspresponse")                                  \
+  V(onpskexchange_string, "onpskexchange")                                    \
   V(onread_string, "onread")                                                  \
   V(onreadstart_string, "onreadstart")                                        \
   V(onreadstop_string, "onreadstop")                                          \
@@ -175,6 +177,7 @@ namespace node {
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
   V(produce_cached_data_string, "produceCachedData")                          \
+  V(psk_string, "psk")                                                        \
   V(raw_string, "raw")                                                        \
   V(readable_string, "readable")                                              \
   V(received_shutdown_string, "receivedShutdown")                             \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -305,6 +305,13 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   env->SetProtoMethod(t, "getCertificate", SecureContext::GetCertificate<true>);
   env->SetProtoMethod(t, "getIssuer", SecureContext::GetCertificate<false>);
 
+#ifdef OPENSSL_PSK_SUPPORT
+  env->SetProtoMethod(t, "setPskIdentity", SecureContext::SetPskIdentity);
+  env->SetProtoMethod(t,
+                      "enablePskCallback",
+                      SecureContext::EnablePskCallback);
+#endif
+
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kTicketKeyReturnIndex"),
          Integer::NewFromUnsigned(env->isolate(), kTicketKeyReturnIndex));
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kTicketKeyHMACIndex"),
@@ -1285,6 +1292,120 @@ void SecureContext::GetCertificate(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(buff);
 }
+
+
+#ifdef OPENSSL_PSK_SUPPORT
+
+void SecureContext::SetPskIdentity(const FunctionCallbackInfo<Value>& args) {
+  SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
+
+  if (args.Length() != 1 || !args[0]->IsString()) {
+    return wrap->env()->ThrowTypeError("Argument must be a string");
+  }
+
+  String::Utf8Value identity(args[0]);
+  if (!SSL_CTX_use_psk_identity_hint(wrap->ctx_, *identity)) {
+    return wrap->env()->ThrowError("Failed to set PSK identity hint");
+  }
+}
+
+void SecureContext::EnablePskCallback(
+    const FunctionCallbackInfo<Value>& args) {
+  SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
+
+  SSL_CTX_set_psk_server_callback(wrap->ctx_,
+                                  SecureContext::PskServerCallback);
+  SSL_CTX_set_psk_client_callback(wrap->ctx_,
+                                  SecureContext::PskClientCallback);
+}
+
+unsigned int SecureContext::PskServerCallback(SSL *ssl,
+                                              const char *identity,
+                                              unsigned char *psk,
+                                              unsigned int max_psk_len) {
+  SecureContext* sc = static_cast<SecureContext*>(
+      SSL_CTX_get_app_data(ssl->ctx));
+
+  Environment* env = sc->env();
+  Isolate* isolate = env->isolate();
+
+  Local<Value> argv[] = {
+    String::NewFromUtf8(isolate, identity),
+    Integer::NewFromUnsigned(isolate, max_psk_len),
+    Integer::NewFromUnsigned(isolate, 0)
+  };
+  Local<Value> ret = node::MakeCallback(env,
+                                        sc->object(),
+                                        env->onpskexchange_string(),
+                                        arraysize(argv),
+                                        argv);
+
+  // The result is expected to be an object. If it isn't, then return 0,
+  // indicating the identity wasn't found.
+  if (!ret->IsObject()) {
+    return 0;
+  }
+  Local<Object> obj = ret.As<Object>();
+
+  Local<Value> psk_buf = obj->Get(env->psk_string());
+  assert(Buffer::HasInstance(psk_buf));
+  size_t psk_len = Buffer::Length(psk_buf);
+  assert(psk_len <= max_psk_len);
+  memcpy(psk, Buffer::Data(psk_buf), max_psk_len);
+
+  return psk_len;
+}
+
+unsigned int SecureContext::PskClientCallback(SSL *ssl,
+                                              const char *hint,
+                                              char *identity,
+                                              unsigned int max_identity_len,
+                                              unsigned char *psk,
+                                              unsigned int max_psk_len) {
+  SecureContext* sc = static_cast<SecureContext*>(
+      SSL_CTX_get_app_data(ssl->ctx));
+
+  Environment* env = sc->env();
+  Isolate* isolate = env->isolate();
+
+  Local<Value> argv[] = {
+    Null(isolate),
+    Integer::NewFromUnsigned(isolate, max_psk_len),
+    Integer::NewFromUnsigned(isolate, max_identity_len)
+  };
+  if (hint != nullptr) {
+    argv[0] = String::NewFromUtf8(isolate, hint);
+  }
+  Local<Value> ret = node::MakeCallback(env,
+                                        sc->object(),
+                                        env->onpskexchange_string(),
+                                        arraysize(argv),
+                                        argv);
+
+  // The result is expected to be an object. If it isn't, then return 0,
+  // indicating the identity wasn't found.
+  if (!ret->IsObject()) {
+    return 0;
+  }
+  Local<Object> obj = ret.As<Object>();
+
+  Local<Value> psk_buf = obj->Get(env->psk_string());
+  assert(Buffer::HasInstance(psk_buf));
+  size_t psk_len = Buffer::Length(psk_buf);
+  assert(psk_len <= max_psk_len);
+  memcpy(psk, Buffer::Data(psk_buf), psk_len);
+
+  Local<Value> identity_buf = obj->Get(env->identity_string());
+  assert(Buffer::HasInstance(identity_buf));
+  size_t identity_len = Buffer::Length(identity_buf);
+  assert(identity_len <= max_identity_len);
+  memcpy(identity, Buffer::Data(identity_buf), identity_len);
+  assert(identity[identity_len - 1] == '\0');
+
+  return psk_len;
+}
+
+#endif
 
 
 template <class Base>

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -38,6 +38,13 @@
 # define NODE__HAVE_TLSEXT_STATUS_CB
 #endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
 
+// TLS-PSK support requires OpenSSL v1.0.0 or later built with PSK enabled
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#ifndef OPENSSL_NO_PSK
+#define OPENSSL_PSK_SUPPORT
+#endif
+#endif
+
 namespace node {
 namespace crypto {
 
@@ -122,6 +129,23 @@ class SecureContext : public BaseObject {
 
   template <bool primary>
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+#ifdef OPENSSL_PSK_SUPPORT
+  static void SetPskIdentity(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void EnablePskCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static unsigned int PskServerCallback(SSL *ssl,
+                                        const char *identity,
+                                        unsigned char *psk,
+                                        unsigned int max_psk_len);
+  static unsigned int PskClientCallback(SSL *ssl,
+                                        const char *hint,
+                                        char *identity,
+                                        unsigned int max_identity_len,
+                                        unsigned char *psk,
+                                        unsigned int max_psk_len);
+#endif
 
   static int TicketKeyCallback(SSL* ssl,
                                unsigned char* name,

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -1,0 +1,94 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+
+const CIPHERS = 'PSK+HIGH';
+const USERS = {
+  UserA: Buffer.from('d731ef57be09e5204f0b205b60627028', 'hex'),
+  UserB: Buffer.from('82072606b502b0f4025e90eb75fe137d', 'hex')
+};
+const CLIENT_IDENTITIES = [
+  { psk: USERS.UserA, identity: 'UserA' },
+  { psk: USERS.UserB, identity: 'UserB' },
+  // unrecognized user should fail handshake
+  { psk: USERS.UserB, identity: 'UserC' },
+  // recognized user but incorrect secret should fail handshake
+  { psk: USERS.UserA, identity: 'UserB' },
+  { psk: USERS.UserB, identity: 'UserB' }
+];
+const TEST_DATA = 'Hello from test!';
+
+let serverConnections = 0;
+const clientResults = [];
+const connectingIds = [];
+
+const serverOptions = {
+  ciphers: CIPHERS,
+  pskCallback(id) {
+    connectingIds.push(id);
+    if (id in USERS) {
+      return { psk: USERS[id] };
+    }
+  }
+};
+
+const server = tls.createServer(serverOptions, (c) => {
+  serverConnections++;
+  c.once('data', (data) => {
+    assert.strictEqual(data.toString(), TEST_DATA);
+    c.end(data);
+  });
+});
+server.listen(common.PORT, startTest);
+
+function startTest() {
+  function connectClient(options, next) {
+    const client = tls.connect(common.PORT, 'localhost', options, () => {
+      clientResults.push('connect');
+
+      client.end(TEST_DATA);
+
+      client.on('data', (data) => {
+        assert.strictEqual(data.toString(), TEST_DATA);
+      });
+
+      client.on('close', next);
+    });
+    client.on('error', (err) => {
+      clientResults.push(err.message);
+      next();
+    });
+  }
+
+  function doTestCase(tcnum) {
+    if (tcnum >= CLIENT_IDENTITIES.length) {
+      server.close();
+    } else {
+      connectClient({
+        ciphers: CIPHERS,
+        rejectUnauthorized: false,
+        pskCallback: () => CLIENT_IDENTITIES[tcnum]
+      }, () => {
+        doTestCase(tcnum + 1);
+      });
+    }
+  }
+  doTestCase(0);
+}
+
+process.on('exit', () => {
+  assert.strictEqual(serverConnections, 3);
+  assert.deepStrictEqual(clientResults, [
+    'connect', 'connect', 'socket hang up', 'socket hang up', 'connect'
+  ]);
+  assert.deepStrictEqual(connectingIds, [
+    'UserA', 'UserB', 'UserC', 'UserB', 'UserB'
+  ]);
+});

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -1,0 +1,99 @@
+'use strict';
+const common = require('../common');
+
+if (!common.opensslCli) {
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+const spawn = require('child_process').spawn;
+
+const CIPHERS = 'PSK+HIGH';
+const KEY = 'd731ef57be09e5204f0b205b60627028';
+const IDENTITY = 'Client_identity';  // Hardcoded by openssl
+
+const server = spawn(common.opensslCli, [
+  's_server',
+  '-accept', common.PORT,
+  '-cipher', CIPHERS,
+  '-psk', KEY,
+  '-psk_hint', IDENTITY,
+  '-nocert'
+]);
+
+
+let state = 'WAIT-ACCEPT';
+
+let serverStdoutBuffer = '';
+server.stdout.setEncoding('utf8');
+server.stdout.on('data', (s) => {
+  serverStdoutBuffer += s;
+  switch (state) {
+    case 'WAIT-ACCEPT':
+      if (/ACCEPT/g.test(serverStdoutBuffer)) {
+        // Give s_server half a second to start up.
+        setTimeout(startClient, 500);
+        state = 'WAIT-HELLO';
+      }
+      break;
+
+    case 'WAIT-HELLO':
+      if (/hello/g.test(serverStdoutBuffer)) {
+
+        // End the current SSL connection and exit.
+        // See s_server(1ssl).
+        server.stdin.write('Q');
+
+        state = 'WAIT-SERVER-CLOSE';
+      }
+      break;
+
+    default:
+      break;
+  }
+});
+
+
+const timeout = setTimeout(() => {
+  server.kill();
+  process.exit(1);
+}, 5000);
+
+let gotWriteCallback = false;
+let serverExitCode = -1;
+
+server.on('exit', (code) => {
+  serverExitCode = code;
+  clearTimeout(timeout);
+});
+
+
+function startClient() {
+  const s = tls.connect(common.PORT, {
+    ciphers: CIPHERS,
+    rejectUnauthorized: false,
+    pskCallback: (hint) => {
+      if (hint === IDENTITY) {
+        return {
+          identity: IDENTITY,
+          psk: Buffer.from(KEY, 'hex')
+        };
+      }
+    }
+  });
+
+  s.on('secureConnect', () => {
+    s.write('hello\r\n', () => {
+      gotWriteCallback = true;
+    });
+  });
+}
+
+
+process.on('exit', () => {
+  assert.strictEqual(0, serverExitCode);
+  assert.strictEqual('WAIT-SERVER-CLOSE', state);
+  assert.ok(gotWriteCallback);
+});

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -1,0 +1,88 @@
+'use strict';
+const common = require('../common');
+
+if (!common.opensslCli) {
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
+  return;
+}
+
+const assert = require('assert');
+
+const tls = require('tls');
+const spawn = require('child_process').spawn;
+
+const CIPHERS = 'PSK+HIGH';
+const KEY = 'd731ef57be09e5204f0b205b60627028';
+const IDENTITY = 'TestUser';
+
+let connections = 0;
+
+const server = tls.createServer({
+  ciphers: CIPHERS,
+  pskIdentity: IDENTITY,
+  pskCallback: (identity) => {
+    if (identity === IDENTITY) {
+      return {
+        psk: Buffer.from(KEY, 'hex')
+      };
+    }
+  }
+});
+
+server.on('connection', (socket) => {
+  connections++;
+});
+
+server.on('secureConnection', (socket) => {
+  socket.write('hello\r\n');
+
+  socket.on('data', (data) => {
+    socket.write(data);
+  });
+});
+
+let gotHello = false;
+let sentWorld = false;
+let gotWorld = false;
+let opensslExitCode = -1;
+
+server.listen(common.PORT, () => {
+  const client = spawn(common.opensslCli, [
+    's_client',
+    '-connect', '127.0.0.1:' + common.PORT,
+    '-cipher', CIPHERS,
+    '-psk', KEY,
+    '-psk_identity', IDENTITY
+  ]);
+
+  let out = '';
+
+  client.stdout.setEncoding('utf8');
+  client.stdout.on('data', (d) => {
+    out += d;
+
+    if (!gotHello && /hello/.test(out)) {
+      gotHello = true;
+      client.stdin.write('world\r\n');
+      sentWorld = true;
+    }
+
+    if (!gotWorld && /world/.test(out)) {
+      gotWorld = true;
+      client.stdin.end();
+    }
+  });
+
+  client.on('exit', (code) => {
+    opensslExitCode = code;
+    server.close();
+  });
+});
+
+process.on('exit', () => {
+  assert.strictEqual(1, connections);
+  assert.ok(gotHello);
+  assert.ok(sentWorld);
+  assert.ok(gotWorld);
+  assert.strictEqual(0, opensslExitCode);
+});


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

tls, crypto
##### Description of change

This is another attempt at adding support for TLS-PSK, building on earlier work done in https://github.com/nodejs/node-v0.x-archive/pull/1162

The interface is different though, because the node tls interface has also changed some, and then there's also my opinion.
- The default cipher suite is not changed, and still includes `!PSK`.
- Unlike the previous PR, this one does not magically enable TLS-PSK if PSK options are specified. So even when `pskCallback` is specified, you'd still have to specify `ciphers` explicitly for anything to happen.
- The previous PR contained discussion about `rejectUnauthorized` and `socket.authorized`, but these have gotten much more explicit in recent node version it seems. They always pertain to PKI. In scenario's where PSK is used without PKI (most?), `rejectUnauthorized: false` must be explicitly set on the client.
- The `pskCallback` on client and server have compatible signatures, even though they have slightly different purposes. Applications dealing with both sides should have an easier time this way.
- Both JS and C++ check the openssl version and omit the functionality if not supported (like in the previous PR). Builds linked with an older openssl may ignore the new options silently.
- Tests are adapted from the original PR. They used to use `tls.createSecurePair`, but have been rewritten to use `tls.connect` and `tls.createServer`.
- Would personally love to see this in v6.x as well!

Ref: #3553, https://github.com/nodejs/node-v0.x-archive/pull/1162
