### PR TITLE
test: favor strictEqual() in addon test

### DIFF
--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -24,51 +24,50 @@ assert.throws(function() {
 // TODO(trevnorris): Is there a way to verify this is being run during
 // bootstrap?
 (function verifyExecutionOrder(arg) {
-  const results_arr = [];
+  const results = [];
 
   // Processing of the MicrotaskQueue is manually handled by node. They are not
   // processed until after the nextTickQueue has been processed.
   Promise.resolve(1).then(common.mustCall(function() {
-    results_arr.push(7);
+    results.push(7);
   }));
 
   // The nextTick should run after all immediately invoked calls.
   process.nextTick(common.mustCall(function() {
-    results_arr.push(3);
+    results.push(3);
 
     // Run same test again but while processing the nextTickQueue to make sure
     // the following MakeCallback call breaks in the middle of processing the
     // queue and allows the script to run normally.
     process.nextTick(common.mustCall(function() {
-      results_arr.push(6);
+      results.push(6);
     }));
 
     makeCallback({}, common.mustCall(function() {
-      results_arr.push(4);
+      results.push(4);
     }));
 
-    results_arr.push(5);
+    results.push(5);
   }));
 
-  results_arr.push(0);
+  results.push(0);
 
   // MakeCallback is calling the function immediately, but should then detect
   // that a script is already in the middle of execution and return before
   // either the nextTickQueue or MicrotaskQueue are processed.
   makeCallback({}, common.mustCall(function() {
-    results_arr.push(1);
+    results.push(1);
   }));
 
   // This should run before either the nextTickQueue or MicrotaskQueue are
   // processed. Previously MakeCallback would not detect this circumstance
   // and process them immediately.
-  results_arr.push(2);
+  results.push(2);
 
   setImmediate(common.mustCall(function() {
-    for (var i = 0; i < results_arr.length; i++) {
-      assert.equal(results_arr[i],
-                   i,
-                   `verifyExecutionOrder(${arg}) results: ${results_arr}`);
+    for (var i = 0; i < results.length; i++) {
+      assert.strictEqual(results[i], i,
+                         `verifyExecutionOrder(${arg}) results: ${results}`);
     }
     if (arg === 1) {
       // The tests are first run on bootstrap during LoadEnvironment() in
@@ -102,16 +101,16 @@ function checkDomains() {
     const d2 = domain.create();
     const d3 = domain.create();
 
-    makeCallback({ domain: d1 }, common.mustCall(function() {
-      assert.equal(d1, process.domain);
-      makeCallback({ domain: d2 }, common.mustCall(function() {
-        assert.equal(d2, process.domain);
-        makeCallback({ domain: d3 }, common.mustCall(function() {
-          assert.equal(d3, process.domain);
+    makeCallback({domain: d1}, common.mustCall(function() {
+      assert.strictEqual(d1, process.domain);
+      makeCallback({domain: d2}, common.mustCall(function() {
+        assert.strictEqual(d2, process.domain);
+        makeCallback({domain: d3}, common.mustCall(function() {
+          assert.strictEqual(d3, process.domain);
         }));
-        assert.equal(d2, process.domain);
+        assert.strictEqual(d2, process.domain);
       }));
-      assert.equal(d1, process.domain);
+      assert.strictEqual(d1, process.domain);
     }));
   }));
 
@@ -120,16 +119,16 @@ function checkDomains() {
     const d2 = domain.create();
     const d3 = domain.create();
 
-    makeCallback({ domain: d1 }, common.mustCall(function() {
-      assert.equal(d1, process.domain);
-      makeCallback({ domain: d2 }, common.mustCall(function() {
-        assert.equal(d2, process.domain);
-        makeCallback({ domain: d3 }, common.mustCall(function() {
-          assert.equal(d3, process.domain);
+    makeCallback({domain: d1}, common.mustCall(function() {
+      assert.strictEqual(d1, process.domain);
+      makeCallback({domain: d2}, common.mustCall(function() {
+        assert.strictEqual(d2, process.domain);
+        makeCallback({domain: d3}, common.mustCall(function() {
+          assert.strictEqual(d3, process.domain);
         }));
-        assert.equal(d2, process.domain);
+        assert.strictEqual(d2, process.domain);
       }));
-      assert.equal(d1, process.domain);
+      assert.strictEqual(d1, process.domain);
     }));
   }), 1);
 
@@ -138,9 +137,9 @@ function checkDomains() {
   process.nextTick(common.mustCall(function() {
     const d = domain.create();
     d.on('error', common.mustCall(function(e) {
-      assert.equal(e.message, 'throw from domain 3');
+      assert.strictEqual(e.message, 'throw from domain 3');
     }));
-    makeCallback({ domain: d }, function() {
+    makeCallback({domain: d}, function() {
       throw new Error('throw from domain 3');
     });
     throw new Error('UNREACHABLE');
@@ -149,9 +148,9 @@ function checkDomains() {
   setImmediate(common.mustCall(function() {
     const d = domain.create();
     d.on('error', common.mustCall(function(e) {
-      assert.equal(e.message, 'throw from domain 2');
+      assert.strictEqual(e.message, 'throw from domain 2');
     }));
-    makeCallback({ domain: d }, function() {
+    makeCallback({domain: d}, function() {
       throw new Error('throw from domain 2');
     });
     throw new Error('UNREACHABLE');
@@ -160,9 +159,9 @@ function checkDomains() {
   setTimeout(common.mustCall(function() {
     const d = domain.create();
     d.on('error', common.mustCall(function(e) {
-      assert.equal(e.message, 'throw from domain 1');
+      assert.strictEqual(e.message, 'throw from domain 1');
     }));
-    makeCallback({ domain: d }, function() {
+    makeCallback({domain: d}, function() {
       throw new Error('throw from domain 1');
     });
     throw new Error('UNREACHABLE');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test

##### Description of change

<!-- provide a description of the change below this comment -->

Replace `assert.equal()` with `assert.strictEqual()` throughout
`addon/make-callback-recurse/test.js`.