### PR TITLE
Backport 6039 and 6073: fix flakiness of stringbytes-external

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,9 @@ Tests for when the `--abort-on-uncaught-exception` flag is used.
 
 ### addons
 
-Tests for [addon](https://nodejs.org/api/addons.html) functionality.
+Tests for [addon](https://nodejs.org/api/addons.html) functionality along with
+some tests that require an addon to function properly.
+
 
 | Runs on CI |
 |:----------:|

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <node.h>
+#include <v8.h>
+
+void EnsureAllocation(const v8::FunctionCallbackInfo<v8::Value> &args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  uintptr_t size = args[0]->IntegerValue();
+  v8::Local<v8::Boolean> success;
+
+  void* buffer = malloc(size);
+  if (buffer) {
+    success = v8::Boolean::New(isolate, true);
+    free(buffer);
+  } else {
+    success = v8::Boolean::New(isolate, false);
+  }
+  args.GetReturnValue().Set(success);
+}
+
+void init(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "ensureAllocation", EnsureAllocation);
+}
+
+NODE_MODULE(binding, init);

--- a/test/addons/stringbytes-external-exceed-max/binding.gyp
+++ b/test/addons/stringbytes-external-exceed-max/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength
@@ -14,16 +14,18 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 try {
   var buf = new Buffer(kStringMaxLength);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
   console.log(skipMessage);
   return;
 }

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,9 +17,6 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = new Buffer(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
@@ -28,14 +24,12 @@ try {
   return;
 }
 
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
 assert.throws(function() {
-  buf.toString('binary');
+  buf.toString('ascii');
 }, /toString failed/);
-
-var maxString = buf.toString('binary', 1);
-assert.equal(maxString.length, kStringMaxLength);
-// Free the memory early instead of at the end of the next assignment
-maxString = undefined;
-
-maxString = buf.toString('binary', 0, kStringMaxLength);
-assert.equal(maxString.length, kStringMaxLength);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,12 +17,15 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = new Buffer(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
   console.log(skipMessage);
   return;
 }

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,9 +17,6 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = new Buffer(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
@@ -28,6 +24,12 @@ try {
   return;
 }
 
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
 assert.throws(function() {
-  buf.toString('ascii');
+  buf.toString('hex');
 }, /toString failed/);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,7 +10,6 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
@@ -18,12 +17,15 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
   var buf = new Buffer(kStringMaxLength + 1);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
+  console.log(skipMessage);
+  return;
+}
+
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
   console.log(skipMessage);
   return;
 }

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,17 +10,13 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  var buf = new Buffer(kStringMaxLength * 2 + 2);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
+  var buf = new Buffer(kStringMaxLength + 2);
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
@@ -28,6 +24,11 @@ try {
   return;
 }
 
-assert.throws(function() {
-  buf.toString('utf16le');
-}, /toString failed/);
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
+const maxString = buf.toString('utf16le');
+assert.equal(maxString.length, (kStringMaxLength + 2) / 2);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -1,7 +1,7 @@
 'use strict';
-// Flags: --expose-gc
 
-const common = require('../common');
+const common = require('../../common');
+const binding = require('./build/Release/binding');
 const assert = require('assert');
 
 const skipMessage =
@@ -10,17 +10,13 @@ if (!common.enoughTestMem) {
   console.log(skipMessage);
   return;
 }
-assert(typeof gc === 'function', 'Run this test with --expose-gc');
 
 // v8 fails silently if string length > v8::String::kMaxLength
 // v8::String::kMaxLength defined in v8.h
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 
 try {
-  var buf = new Buffer(kStringMaxLength + 2);
-  // Try to allocate memory first then force gc so future allocations succeed.
-  new Buffer(2 * kStringMaxLength);
-  gc();
+  var buf = new Buffer(kStringMaxLength * 2 + 2);
 } catch (e) {
   // If the exception is not due to memory confinement then rethrow it.
   if (e.message !== 'Invalid array buffer length') throw (e);
@@ -28,5 +24,12 @@ try {
   return;
 }
 
-const maxString = buf.toString('utf16le');
-assert.equal(maxString.length, (kStringMaxLength + 2) / 2);
+// Ensure we have enough memory available for future allocations to succeed.
+if (!binding.ensureAllocation(2 * kStringMaxLength)) {
+  console.log(skipMessage);
+  return;
+}
+
+assert.throws(function() {
+  buf.toString('utf16le');
+}, /toString failed/);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change

<!-- provide a description of the change below this comment -->

As requested, this is a backport of #6039 and #6073 to `v4.x-staging`.

R= @TheAlphaNerd , @Trott 