### PR TITLE
appendFileSync accepts fd. Was not specified in its doc

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -332,7 +332,7 @@ _Note: Specified file descriptors will not be closed automatically._
 
 ## fs.appendFileSync(file, data[, options])
 
-* `file` {String | Buffer}
+* `file` {String | Buffer | Number} filename or file descriptor
 * `data` {String | Buffer}
 * `options` {Object | String}
   * `encoding` {String | Null} default = `'utf8'`


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

doc


##### Description of change

In reference to the issues  #6508. appendFileSync doc does not state anything about it accepting file descriptors too. Fixed that

