### PR TITLE
tools: use py2.6 equivalent of check_output

### DIFF
--- a/configure
+++ b/configure
@@ -444,7 +444,7 @@ def pkg_config(pkg):
       stdout = subprocess.Popen(shlex.split(pkg_config) + [args, flag, pkg],
                                 stdout=subprocess.PIPE).communicate()[0].strip()
     except OSError as e:
-      if e.errno == errno.ENONET:
+      if e.errno == errno.ENOENT:
         # no pkg-config/pkgconf installed
         return (None, None, None)
       raise e

--- a/configure
+++ b/configure
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+import errno
 import optparse
 import os
 import pprint
@@ -439,16 +441,14 @@ def pkg_config(pkg):
   retval = ()
   for flag in ['--libs-only-l', '--cflags-only-I', '--libs-only-L']:
     try:
-      val = subprocess.check_output([pkg_config, args, flag, pkg])
-      # check_output returns bytes
-      val = val.encode().strip().rstrip('\n')
-    except subprocess.CalledProcessError:
-      # most likely missing a .pc-file
-      val = None
-    except OSError:
-      # no pkg-config/pkgconf installed
-      return (None, None, None)
-    retval += (val,)
+      stdout = subprocess.Popen(shlex.split(pkg_config) + [args, flag, pkg],
+                                stdout=subprocess.PIPE).communicate()[0].strip()
+    except OSError as e:
+      if e.errno == errno.ENONET:
+        # no pkg-config/pkgconf installed
+        return (None, None, None)
+      raise e
+    retval += (stdout,)
   return retval
 
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description of change

Python 2.6 does not have `subprocess.check_output`, as it was
introduced only in Python 2.7. This patch uses `subprocess.Popen` to
get the data written to stdout by the `pkg-config` program.

Fixes: https://github.com/nodejs/node/issues/6711

cc @bnoordhuis 