### PR TITLE
tools,test: make argument linting more stringent

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -376,7 +376,7 @@ try {
 } catch (e) {
   threw = true;
   assert(e instanceof AnotherErrorType,
-    `expected AnotherErrorType, received ${e}`);
+         `expected AnotherErrorType, received ${e}`);
 }
 
 assert.ok(threw);

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -45,7 +45,7 @@ var notSocketClient = net.createConnection(emptyTxt, function() {
 
 notSocketClient.on('error', function(err) {
   assert(err.code === 'ENOTSOCK' || err.code === 'ECONNREFUSED',
-    `received ${err.code} instead of ENOTSOCK or ECONNREFUSED`);
+         `received ${err.code} instead of ENOTSOCK or ECONNREFUSED`);
   notSocketErrorFired = true;
 });
 

--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -19,14 +19,14 @@ process.chdir(common.tmpDir);
 // Unknown checked for to prevent flakiness, if pattern is not found,
 // then a large number of unknown ticks should be present
 runTest(/LazyCompile.*\[eval\]:1|.*%  UNKNOWN/,
-  `function f() {
-     for (var i = 0; i < 1000000; i++) {
-       i++;
-     }
-     setImmediate(function() { f(); });
-   };
-   setTimeout(function() { process.exit(0); }, 2000);
-   f();`);
+        `function f() {
+           for (var i = 0; i < 1000000; i++) {
+             i++;
+           }
+           setImmediate(function() { f(); });
+         };
+         setTimeout(function() { process.exit(0); }, 2000);
+         f();`);
 if (common.isWindows ||
     common.isSunOS ||
     common.isAix ||
@@ -36,12 +36,12 @@ if (common.isWindows ||
   return;
 }
 runTest(/RunInDebugContext/,
-  `function f() {
-     require(\'vm\').runInDebugContext(\'Debug\');
-     setImmediate(function() { f(); });
-   };
-   setTimeout(function() { process.exit(0); }, 2000);
-   f();`);
+        `function f() {
+           require(\'vm\').runInDebugContext(\'Debug\');
+           setImmediate(function() { f(); });
+         };
+         setTimeout(function() { process.exit(0); }, 2000);
+         f();`);
 
 function runTest(pattern, code) {
   cp.execFileSync(process.execPath, ['-prof', '-pe', code]);

--- a/tools/eslint-rules/align-function-arguments.js
+++ b/tools/eslint-rules/align-function-arguments.js
@@ -33,7 +33,6 @@ function checkArgumentAlignment(context, node) {
     'CallExpression',
     'FunctionExpression',
     'ObjectExpression',
-    'TemplateLiteral'
   ];
 
   const args = node.arguments;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test tools

##### Description of change

<!-- provide a description of the change below this comment -->

The custom linting rule for argument alignment in multi-line function
calls previously ignored template strings in an effort to avoid false
positives. This isn't really necessary. Enforce for template strings and
adjust whitespace in three tests to abide. (Insert "The test abides"
joke of your choosing here.)