### PR TITLE
tools: do not build addons during compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,9 @@ v8:
 	tools/make-v8.sh v8
 	$(MAKE) -C deps/v8 $(V8_ARCH) $(V8_BUILD_OPTIONS)
 
-test: | build-addons cctest  # Both targets depend on 'all'.
+test: all
+	$(MAKE) build-addons
+	$(MAKE) cctest
 	$(PYTHON) tools/test.py --mode=release -J \
 		addon doctool known_issues message parallel sequential
 	$(MAKE) lint


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
Tools

##### Description of change

<!-- provide a description of the change below this comment -->

The current makefile runs both `cctest` and `build-addons` in parallel
under the assumption that both rely on `all`. Unfortunately
`build-addons` does not rely on all, and there is an edge case where
by it is possible to call `build-addons` while compilation is still
happening.

This patch takes the simplest route by forcing `build-addons` and
`cctest` to run in sequence like the other test targets. This ensures
that `build-addons` will never be run during compilation.

It would be possible to modify `build-addons` to rely on `all` but it
would be a much more aggressive change to the MAKEFILE for a fairly
minor perf bump, as cctest is so fast.