### PR TITLE
Fix compilation with gcc 5.3 on illumos

### DIFF
--- a/deps/openssl/openssl/crypto/rand/randfile.c
+++ b/deps/openssl/openssl/crypto/rand/randfile.c
@@ -57,7 +57,7 @@
  */
 
 /* We need to define this to get macros like S_IFBLK and S_IFCHR */
-#if !defined(OPENSSL_SYS_VXWORKS)
+#if !defined(OPENSSL_SYS_VXWORKS) && !defined(__sun__)
 # define _XOPEN_SOURCE 500
 #endif
 


### PR DESCRIPTION
##### Checklist
- [x] the commit message follows commit guidelines

##### Description of change

gcc 5.3 defines __STDC_VERSION__ to 201112L  (c99), together with _XOPEN_SOURCE 500 this leads to compilation error in feature-tests.h ("Compiler or options invalid for pre-UNIX 03 X/Open applications and pre-2001 POSIX applications").

