### PR TITLE
src: print backtrace on fatal error

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -466,6 +466,7 @@
 
         [ 'OS=="win"', {
           'sources': [
+            'src/backtrace_win32.cc',
             'src/res/node.rc',
           ],
           'defines!': [
@@ -480,6 +481,7 @@
           'libraries': [ '-lpsapi.lib' ]
         }, { # POSIX
           'defines': [ '__POSIX__' ],
+          'sources': [ 'src/backtrace_posix.cc' ],
         }],
         [ 'OS=="mac"', {
           # linking Corefoundation is needed since certain OSX debugging tools

--- a/src/backtrace_posix.cc
+++ b/src/backtrace_posix.cc
@@ -1,0 +1,50 @@
+#include "node.h"
+
+#if defined(__linux__)
+#include <features.h>
+#endif
+
+#if defined(__linux__) && !defined(__GLIBC__)
+#define HAVE_EXECINFO_H 0
+#else
+#define HAVE_EXECINFO_H 1
+#endif
+
+#if HAVE_EXECINFO_H
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <stdio.h>
+#endif
+
+namespace node {
+
+void DumpBacktrace(FILE* fp) {
+#if HAVE_EXECINFO_H
+  void* frames[256];
+  const int size = backtrace(frames, arraysize(frames));
+  if (size <= 0) {
+    return;
+  }
+  for (int i = 1; i < size; i += 1) {
+    void* frame = frames[i];
+    fprintf(fp, "%2d: ", i);
+    Dl_info info;
+    const bool have_info = dladdr(frame, &info);
+    if (!have_info || info.dli_sname == nullptr) {
+      fprintf(fp, "%p", frame);
+    } else if (char* demangled = abi::__cxa_demangle(info.dli_sname, 0, 0, 0)) {
+      fprintf(fp, "%s", demangled);
+      free(demangled);
+    } else {
+      fprintf(fp, "%s", info.dli_sname);
+    }
+    if (have_info && info.dli_fname != nullptr) {
+      fprintf(fp, " [%s]", info.dli_fname);
+    }
+    fprintf(fp, "\n");
+  }
+#endif  // HAVE_EXECINFO_H
+}
+
+}  // namespace node

--- a/src/backtrace_win32.cc
+++ b/src/backtrace_win32.cc
@@ -1,0 +1,8 @@
+#include "node.h"
+
+namespace node {
+
+void DumpBacktrace(FILE* fp) {
+}
+
+}  // namespace node

--- a/src/node.cc
+++ b/src/node.cc
@@ -2398,6 +2398,7 @@ static void OnFatalError(const char* location, const char* message) {
   } else {
     PrintErrorString("FATAL ERROR: %s\n", message);
   }
+  DumpBacktrace(stderr);
   fflush(stderr);
   ABORT();
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1734,8 +1734,15 @@ void GetActiveHandles(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+NO_RETURN void Abort() {
+  DumpBacktrace(stderr);
+  fflush(stderr);
+  ABORT_NO_BACKTRACE();
+}
+
+
 static void Abort(const FunctionCallbackInfo<Value>& args) {
-  ABORT();
+  Abort();
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1741,6 +1741,31 @@ NO_RETURN void Abort() {
 }
 
 
+NO_RETURN void Assert(const char* const (*args)[4]) {
+  auto filename = (*args)[0];
+  auto linenum = (*args)[1];
+  auto message = (*args)[2];
+  auto function = (*args)[3];
+
+  char exepath[256];
+  size_t exepath_size = sizeof(exepath);
+  if (uv_exepath(exepath, &exepath_size))
+    snprintf(exepath, sizeof(exepath), "node");
+
+  char pid[12] = {0};
+#ifndef _WIN32
+  snprintf(pid, sizeof(pid), "[%u]", getpid());
+#endif
+
+  fprintf(stderr, "%s%s: %s:%s:%s%s Assertion `%s' failed.\n",
+          exepath, pid, filename, linenum,
+          function, *function ? ":" : "", message);
+  fflush(stderr);
+
+  Abort();
+}
+
+
 static void Abort(const FunctionCallbackInfo<Value>& args) {
   Abort();
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -2398,7 +2398,6 @@ static void OnFatalError(const char* location, const char* message) {
   } else {
     PrintErrorString("FATAL ERROR: %s\n", message);
   }
-  DumpBacktrace(stderr);
   fflush(stderr);
   ABORT();
 }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -127,12 +127,10 @@ constexpr size_t arraysize(const T(&)[N]) { return N; }
 # define ROUND_UP(a, b) ((a) % (b) ? ((a) + (b)) - ((a) % (b)) : (a))
 #endif
 
-#if defined(__GNUC__) && __GNUC__ >= 4
+#ifdef __GNUC__
 # define MUST_USE_RESULT __attribute__((warn_unused_result))
-# define NO_RETURN __attribute__((noreturn))
 #else
 # define MUST_USE_RESULT
-# define NO_RETURN
 #endif
 
 bool IsExceptionDecorated(Environment* env, v8::Local<v8::Value> er);

--- a/src/util.h
+++ b/src/util.h
@@ -38,10 +38,17 @@ template <typename T> using remove_reference = std::remove_reference<T>;
 
 // Windows 8+ does not like abort() in Release mode
 #ifdef _WIN32
-#define ABORT() raise(SIGABRT)
+#define ABORT_NO_BACKTRACE() raise(SIGABRT)
 #else
-#define ABORT() abort()
+#define ABORT_NO_BACKTRACE() abort()
 #endif
+
+#define ABORT()                                                               \
+  do {                                                                        \
+    node::DumpBacktrace(stderr);                                              \
+    fflush(stderr);                                                           \
+    ABORT_NO_BACKTRACE();                                                     \
+  } while (0)
 
 #if defined(NDEBUG)
 # define ASSERT(expression)

--- a/src/util.h
+++ b/src/util.h
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #ifdef __APPLE__
@@ -17,6 +18,8 @@
 #endif
 
 namespace node {
+
+void DumpBacktrace(FILE* fp);
 
 #ifdef __APPLE__
 template <typename T> using remove_reference = std::tr1::remove_reference<T>;

--- a/src/util.h
+++ b/src/util.h
@@ -19,6 +19,13 @@
 
 namespace node {
 
+#ifdef __GNUC__
+#define NO_RETURN __attribute__((noreturn))
+#else
+#define NO_RETURN
+#endif
+
+NO_RETURN void Abort();
 void DumpBacktrace(FILE* fp);
 
 #ifdef __APPLE__
@@ -43,12 +50,7 @@ template <typename T> using remove_reference = std::remove_reference<T>;
 #define ABORT_NO_BACKTRACE() abort()
 #endif
 
-#define ABORT()                                                               \
-  do {                                                                        \
-    node::DumpBacktrace(stderr);                                              \
-    fflush(stderr);                                                           \
-    ABORT_NO_BACKTRACE();                                                     \
-  } while (0)
+#define ABORT() node::Abort()
 
 #if defined(NDEBUG)
 # define ASSERT(expression)

--- a/test/abort/test-abort-backtrace.js
+++ b/test/abort/test-abort-backtrace.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (common.isWindows) {
+  common.skip('Backtraces unimplemented on Windows.');
+  return;
+}
+
+if (process.argv[2] === 'child') {
+  process.abort();
+} else {
+  const child = cp.spawnSync(`${process.execPath}`, [`${__filename}`, 'child']);
+  const frames =
+      child.stderr.toString().trimRight().split('\n').map((s) => s.trim());
+
+  assert.strictEqual(child.stdout.toString(), '');
+  assert.ok(frames.length > 0);
+  // All frames should start with a frame number.
+  assert.ok(frames.every((frame, index) => frame.startsWith(`${index + 1}:`)));
+  // At least some of the frames should include the binary name.
+  assert.ok(frames.some((frame) => frame.includes(`[${process.execPath}]`)));
+}

--- a/test/abort/test-abort-uncaught-exception.js
+++ b/test/abort/test-abort-uncaught-exception.js
@@ -9,23 +9,26 @@ if (process.argv[2] === 'child') {
   throw new Error('child error');
 } else {
   run('', null);
-  run('--abort-on-uncaught-exception', 'SIGABRT');
+  run('--abort-on-uncaught-exception', ['SIGABRT', 'SIGILL']);
 }
 
-function run(flags, signal) {
+function run(flags, signals) {
   const args = [__filename, 'child'];
   if (flags)
     args.unshift(flags);
 
   const child = spawn(node, args);
   child.on('exit', common.mustCall(function(code, sig) {
-    if (!common.isWindows) {
-      assert.strictEqual(sig, signal);
-    } else {
-      if (signal)
+    if (common.isWindows) {
+      if (signals)
         assert.strictEqual(code, 3);
       else
         assert.strictEqual(code, 1);
+    } else {
+      if (signals)
+        assert.strictEqual(signals.includes(sig), true);
+      else
+        assert.strictEqual(sig, null);
     }
   }));
 }

--- a/test/abort/testcfg.py
+++ b/test/abort/testcfg.py
@@ -1,0 +1,6 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import testpy
+
+def GetConfiguration(context, root):
+  return testpy.SimpleTestConfiguration(context, root, 'abort')

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -1,7 +1,8 @@
 #include <node.h>
 #include <node_buffer.h>
-#include <util.h>
 #include <v8.h>
+
+#include <assert.h>
 
 static int alive;
 static char buf[1024];
@@ -32,7 +33,7 @@ void Check(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   isolate->RequestGarbageCollectionForTesting(
       v8::Isolate::kFullGarbageCollection);
-  CHECK_GT(alive, 0);
+  assert(alive > 0);
 }
 
 void init(v8::Local<v8::Object> target) {

--- a/test/addons/buffer-free-callback/binding.gyp
+++ b/test/addons/buffer-free-callback/binding.gyp
@@ -2,10 +2,7 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [
-        'NODE_WANT_INTERNALS=1',
-        'V8_DEPRECATION_WARNINGS=1',
-      ],
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ]
     }
   ]

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -1,7 +1,7 @@
 #include "node.h"
 #include "v8.h"
 
-#include "../../../src/util.h"
+#include <assert.h>
 
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -13,8 +13,8 @@ using v8::Value;
 namespace {
 
 void MakeCallback(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsObject());
-  CHECK(args[1]->IsFunction());
+  assert(args[0]->IsObject());
+  assert(args[1]->IsFunction());
   Isolate* isolate = args.GetIsolate();
   Local<Object> recv = args[0].As<Object>();
   Local<Function> method = args[1].As<Function>();

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -2,10 +2,7 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [
-        'NODE_WANT_INTERNALS=1',
-        'V8_DEPRECATION_WARNINGS=1',
-      ],
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ]
     }
   ]

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -1,15 +1,14 @@
 #include "node.h"
 #include "v8.h"
 
-#include "../../../src/util.h"
-
+#include <assert.h>
 #include <vector>
 
 namespace {
 
 void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args[0]->IsObject());
-  CHECK(args[1]->IsFunction() || args[1]->IsString());
+  assert(args[0]->IsObject());
+  assert(args[1]->IsFunction() || args[1]->IsString());
   auto isolate = args.GetIsolate();
   auto recv = args[0].As<v8::Object>();
   std::vector<v8::Local<v8::Value>> argv;
@@ -26,7 +25,7 @@ void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
     result =
         node::MakeCallback(isolate, recv, method, argv.size(), argv.data());
   } else {
-    UNREACHABLE();
+    assert(0 && "unreachable");
   }
   args.GetReturnValue().Set(result);
 }

--- a/test/addons/make-callback/binding.gyp
+++ b/test/addons/make-callback/binding.gyp
@@ -2,10 +2,7 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [
-        'NODE_WANT_INTERNALS=1',
-        'V8_DEPRECATION_WARNINGS=1',
-      ],
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ]
     }
   ]

--- a/test/addons/null-buffer-neuter/binding.cc
+++ b/test/addons/null-buffer-neuter/binding.cc
@@ -1,12 +1,13 @@
 #include <node.h>
 #include <node_buffer.h>
-#include <util.h>
 #include <v8.h>
+
+#include <assert.h>
 
 static int alive;
 
 static void FreeCallback(char* data, void* hint) {
-  CHECK_EQ(data, nullptr);
+  assert(data == nullptr);
   alive--;
 }
 
@@ -24,13 +25,13 @@ void Run(const v8::FunctionCallbackInfo<v8::Value>& args) {
           nullptr).ToLocalChecked();
 
     char* data = node::Buffer::Data(buf);
-    CHECK_EQ(data, nullptr);
+    assert(data == nullptr);
   }
 
   isolate->RequestGarbageCollectionForTesting(
       v8::Isolate::kFullGarbageCollection);
 
-  CHECK_EQ(alive, 0);
+  assert(alive == 0);
 }
 
 void init(v8::Local<v8::Object> target) {

--- a/test/addons/null-buffer-neuter/binding.gyp
+++ b/test/addons/null-buffer-neuter/binding.gyp
@@ -2,10 +2,7 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [
-        'NODE_WANT_INTERNALS=1',
-        'V8_DEPRECATION_WARNINGS=1',
-      ],
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
       'sources': [ 'binding.cc' ]
     }
   ]


### PR DESCRIPTION
Print a C backtrace on fatal errors to make it easier to debug issues
like #6727.

CI: https://ci.nodejs.org/job/node-test-pull-request/2629/