### PR TITLE
process, os: rename process.reallyExit to os._exit; exit gracefully

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -685,10 +685,10 @@ function workerInit() {
   Worker.prototype.destroy = function() {
     this.exitedAfterDisconnect = true;
     if (!this.isConnected()) {
-      process.exit(0);
+      process.exit(0, {graceful: true});
     } else {
       send({ act: 'exitedAfterDisconnect' }, () => process.disconnect());
-      process.once('disconnect', () => process.exit(0));
+      process.once('disconnect', () => process.exit(0, {graceful: true}));
     }
   };
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -132,7 +132,7 @@
           source = Module.wrap(source);
           // compile the script, this will throw if it fails
           new vm.Script(source, {filename: filename, displayErrors: true});
-          process.exit(0);
+          process.exit(0, {graceful: true});
         }
 
         preloadModules();
@@ -175,7 +175,7 @@
               if (repl._flushing) {
                 repl.pause();
                 return repl.once('flushHistory', function() {
-                  process.exit();
+                  process.exit(null, {graceful: true});
                 });
               }
               process.exit();

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -61,6 +61,7 @@
       _process.setupChannel();
 
     _process.setupRawDebug();
+    _process.setupReallyExit();
 
     process.argv[0] = process.execPath;
 

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -16,6 +16,7 @@ exports.setupKillAndExit = setupKillAndExit;
 exports.setupSignalHandlers = setupSignalHandlers;
 exports.setupChannel = setupChannel;
 exports.setupRawDebug = setupRawDebug;
+exports.setupReallyExit = setupReallyExit;
 
 
 const assert = process.assert = function(x, msg) {
@@ -249,5 +250,13 @@ function setupRawDebug() {
   var rawDebug = process._rawDebug;
   process._rawDebug = function() {
     rawDebug(format.apply(null, arguments));
+  };
+}
+
+function setupReallyExit() {
+  var osExit = require('os')._exit;
+
+  process.reallyExit = function(code) {
+    osExit(code);
   };
 }

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -138,7 +138,9 @@ function setupConfig(_source) {
 
 function setupKillAndExit() {
 
-  process.exit = function(code) {
+  process.exit = function(code, options) {
+    var osExit = require('os')._exit;
+    var opts = Object.assign({}, options);
     if (code || code === 0)
       process.exitCode = code;
 
@@ -146,7 +148,12 @@ function setupKillAndExit() {
       process._exiting = true;
       process.emit('exit', process.exitCode || 0);
     }
-    process.reallyExit(process.exitCode || 0);
+    if (opts.graceful === true) {
+      process._exit(process.exitCode || 0);
+    } else {
+      // old behavior; panics via OS and won't flush stdio
+      osExit(process.exitCode || 0);
+    }
   };
 
   process.kill = function(pid, sig) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -148,10 +148,12 @@ function setupKillAndExit() {
       process._exiting = true;
       process.emit('exit', process.exitCode || 0);
     }
+    // opt in for no-op at exit in cpp, else panic. This is intended to
+    // have backwards compatible to process.reallyExit behavior, but scheduled
+    // for deprecation, REVIEW(eljefedelrodeodeljefe)
     if (opts.graceful === true) {
       process._exit(process.exitCode || 0);
     } else {
-      // old behavior; panics via OS and won't flush stdio
       osExit(process.exitCode || 0);
     }
   };

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -57,7 +57,7 @@ try {
   fs.accessSync(logFile);
 } catch(e) {
   console.error('Please provide a valid isolate file as the final argument.');
-  process.exit(1);
+  process.exit(1, {graceful: true});
 }
 const fd = fs.openSync(logFile, 'r');
 const buf = Buffer.allocUnsafe(4096);

--- a/lib/os.js
+++ b/lib/os.js
@@ -17,6 +17,10 @@ exports.homedir = binding.getHomeDirectory;
 exports.userInfo = binding.getUserInfo;
 
 
+exports._exit = function(code) {
+  binding._exit(code);
+};
+
 exports.arch = function() {
   return process.arch;
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -2141,7 +2141,8 @@ static void InitGroups(const FunctionCallbackInfo<Value>& args) {
 
 
 void Exit(const FunctionCallbackInfo<Value>& args) {
-  exit(args[0]->Int32Value());
+  // no-op
+  return;
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3223,7 +3223,7 @@ void SetupProcessObject(Environment* env,
                  StopProfilerIdleNotifier);
   env->SetMethod(process, "_getActiveRequests", GetActiveRequests);
   env->SetMethod(process, "_getActiveHandles", GetActiveHandles);
-  env->SetMethod(process, "reallyExit", Exit);
+  env->SetMethod(process, "_exit", Exit);
   env->SetMethod(process, "abort", Abort);
   env->SetMethod(process, "chdir", Chdir);
   env->SetMethod(process, "cwd", Cwd);

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -4,6 +4,7 @@
 #include "env-inl.h"
 #include "string_bytes.h"
 
+#include <stdlib.h>
 #include <errno.h>
 #include <string.h>
 
@@ -39,6 +40,9 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
+static void Exit(const FunctionCallbackInfo<Value>& args) {
+  exit(args[0]->Int32Value());
+}
 
 static void GetHostname(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -362,6 +366,7 @@ void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
+  env->SetMethod(target, "_exit", Exit);
   env->SetMethod(target, "getHostname", GetHostname);
   env->SetMethod(target, "getLoadAvg", GetLoadAvg);
   env->SetMethod(target, "getUptime", GetUptime);

--- a/test/parallel/test-beforeexit-event-os-exit.js
+++ b/test/parallel/test-beforeexit-event-os-exit.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+var assert = require('assert');
+var os = require('os');
+
+process.on('beforeExit', function() {
+  assert(false, 'exit should not allow this to occur');
+});
+
+os._exit();


### PR DESCRIPTION
_WIP_, no docs, explorative

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

`doc`, `process`, `child_process`, `os`, (`debugger`), `cluster`

##### Description of change

FIxes: https://github.com/nodejs/node/issues/6509
Fixes: https://github.com/nodejs/node/issues/6456

Renames `process.reallyExit()` due to poor naming to more domain specific `os._exit()` - exit(3) is an OS-specific implementation and behavior of deconstruction is underterministic. Users should not call this directly, since this leads to unexpected behaviors. We should deprecate this in the future, but for now it is aliased in `js`-land.

Adds an option object to `process.exit(code, options)`, that can have a property `graceful` that can be set to `true`. If true the user is opting in to exit the cpp function stacks without a call to `exit(3)`.

Specifically it makes it possible to run the following code and expect console.log to print 10000 correctly

```js
process.on('exit', () => {
  // assert.equal(i, 10000, 'Should be called succesfully 10000 times')
  process._rawDebug('caught exit');
})

for (let i = 1; i <= 10000; ++i) {
    console.log(i);
}

process.exit(111, {graceful: true});
```

Potentially this doesn't break API, but underlying exiting behavior is different.

cc/ @bnoordhuis: this approach at least compiles and works in the context of the problem. You probably have the better insight of what happens below.