### PR TITLE
build: turn on -fno-delete-null-pointer-checks (v0.12)

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -181,7 +181,11 @@
       }],
       [ 'OS in "linux freebsd openbsd solaris android"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
+        'cflags_cc': [
+          '-fno-delete-null-pointer-checks',
+          '-fno-exceptions',
+          '-fno-rtti',
+        ],
         'ldflags': [ '-rdynamic' ],
         'target_conditions': [
           ['_type=="static_library"', {


### PR DESCRIPTION
Work around spec violations in V8 where it checks that `this == NULL`.
GCC 6 started exploiting this particular kind of UB, resulting in
runtime crashes.

Fixes: #6724 

CI: https://ci.nodejs.org/job/node-test-pull-request/2633/