### PR TITLE
build: turn on -fno-delete-null-pointer-checks (v0.10)

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -179,7 +179,11 @@
       }],
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-pthread', ],
-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
+        'cflags_cc': [
+          '-fno-delete-null-pointer-checks',
+          '-fno-exceptions',
+          '-fno-rtti',
+        ],
         'ldflags': [ '-pthread', '-rdynamic' ],
         'target_conditions': [
           ['_type=="static_library"', {


### PR DESCRIPTION
Work around spec violations in V8 where it checks that `this == NULL`.
GCC 6 started exploiting this particular kind of UB, resulting in
runtime crashes.

Fixes: #6724

CI: https://ci.nodejs.org/job/node-test-pull-request/2634/