### PR TITLE
os: deprecate `tmpDir()` in favour of `tmpdir()`

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -51,7 +51,8 @@ exports.tmpdir = function() {
   return path;
 };
 
-exports.tmpDir = exports.tmpdir;
+exports.tmpDir = internalUtil.deprecate(exports.tmpdir,
+    'os.tmpDir() is deprecated. Use os.tmpdir() instead.');
 
 exports.getNetworkInterfaces = internalUtil.deprecate(function() {
   return exports.networkInterfaces();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
os

##### Description of change

<!-- provide a description of the change below this comment -->

`tmpdir()` was introduced as replacement 3 years ago in
3fe6aba558efe3f1cac17dd6c0c41fb11443788b

cc @bnoordhuis?

CI: https://ci.nodejs.org/job/node-test-pull-request/2636/