### PR TITLE
child_process: use /system/bin/sh on android

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -332,7 +332,12 @@ function normalizeSpawnArguments(file /*, args, options*/) {
       args = ['/s', '/c', '"' + command + '"'];
       options.windowsVerbatimArguments = true;
     } else {
-      file = typeof options.shell === 'string' ? options.shell : '/bin/sh';
+      if (typeof options.shell === 'string')
+        file = options.shell;
+      else if (process.platform === 'android')
+        file = '/system/bin/sh';
+      else
+        file = '/bin/sh';
       args = ['-c', command];
     }
   }


### PR DESCRIPTION
`/bin/sh` does not exist on Android but `/system/bin/sh` does.

Refs: #6733

CI: https://ci.nodejs.org/job/node-test-pull-request/2640/