### PR TITLE
fs: move SyncWriteStream to internal/fs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -14,6 +14,9 @@ const Stream = require('stream').Stream;
 const EventEmitter = require('events');
 const FSReqWrap = binding.FSReqWrap;
 const FSEvent = process.binding('fs_event_wrap').FSEvent;
+const internalFS = require('internal/fs');
+const assertEncoding = internalFS.assertEncoding;
+const SyncWriteStream = internalFS.SyncWriteStream;
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,
@@ -94,12 +97,6 @@ function makeCallback(cb) {
   return function() {
     return cb.apply(null, arguments);
   };
-}
-
-function assertEncoding(encoding) {
-  if (encoding && !Buffer.isEncoding(encoding)) {
-    throw new Error('Unknown encoding: ' + encoding);
-  }
 }
 
 function nullCheck(path, callback) {
@@ -2144,75 +2141,12 @@ WriteStream.prototype.close = ReadStream.prototype.close;
 // There is no shutdown() for files.
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 
-
 // SyncWriteStream is internal. DO NOT USE.
-// Temporary hack for process.stdout and process.stderr when piped to files.
-function SyncWriteStream(fd, options) {
-  Stream.call(this);
-
-  options = options || {};
-
-  this.fd = fd;
-  this.writable = true;
-  this.readable = false;
-  this.autoClose = options.autoClose === undefined ? true : options.autoClose;
-}
-
-util.inherits(SyncWriteStream, Stream);
-
-
-// Export
+// todo(jasnell): "Docs-only" deprecation for now. This was never documented
+// so there's no documentation to modify. In the future, add a runtime
+// deprecation.
 Object.defineProperty(fs, 'SyncWriteStream', {
   configurable: true,
   writable: true,
   value: SyncWriteStream
 });
-
-SyncWriteStream.prototype.write = function(data, arg1, arg2) {
-  var encoding, cb;
-
-  // parse arguments
-  if (arg1) {
-    if (typeof arg1 === 'string') {
-      encoding = arg1;
-      cb = arg2;
-    } else if (typeof arg1 === 'function') {
-      cb = arg1;
-    } else {
-      throw new Error('Bad arguments');
-    }
-  }
-  assertEncoding(encoding);
-
-  // Change strings to buffers. SLOW
-  if (typeof data === 'string') {
-    data = Buffer.from(data, encoding);
-  }
-
-  fs.writeSync(this.fd, data, 0, data.length);
-
-  if (cb) {
-    process.nextTick(cb);
-  }
-
-  return true;
-};
-
-
-SyncWriteStream.prototype.end = function(data, arg1, arg2) {
-  if (data) {
-    this.write(data, arg1, arg2);
-  }
-  this.destroy();
-};
-
-
-SyncWriteStream.prototype.destroy = function() {
-  if (this.autoClose)
-    fs.closeSync(this.fd);
-  this.fd = null;
-  this.emit('close');
-  return true;
-};
-
-SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const Buffer = require('buffer').Buffer;
+const Stream = require('stream').Stream;
+const fs = require('fs');
+const util = require('util');
+
+function assertEncoding(encoding) {
+  if (encoding && !Buffer.isEncoding(encoding)) {
+    throw new Error(`Unknown encoding: ${encoding}`);
+  }
+}
+exports.assertEncoding = assertEncoding;
+
+// Temporary hack for process.stdout and process.stderr when piped to files.
+function SyncWriteStream(fd, options) {
+  Stream.call(this);
+
+  options = options || {};
+
+  this.fd = fd;
+  this.writable = true;
+  this.readable = false;
+  this.autoClose = options.autoClose === undefined ? true : options.autoClose;
+}
+
+util.inherits(SyncWriteStream, Stream);
+
+SyncWriteStream.prototype.write = function(data, arg1, arg2) {
+  var encoding, cb;
+
+  // parse arguments
+  if (arg1) {
+    if (typeof arg1 === 'string') {
+      encoding = arg1;
+      cb = arg2;
+    } else if (typeof arg1 === 'function') {
+      cb = arg1;
+    } else {
+      throw new Error('Bad arguments');
+    }
+  }
+  assertEncoding(encoding);
+
+  // Change strings to buffers. SLOW
+  if (typeof data === 'string') {
+    data = Buffer.from(data, encoding);
+  }
+
+  fs.writeSync(this.fd, data, 0, data.length);
+
+  if (cb) {
+    process.nextTick(cb);
+  }
+
+  return true;
+};
+
+
+SyncWriteStream.prototype.end = function(data, arg1, arg2) {
+  if (data) {
+    this.write(data, arg1, arg2);
+  }
+  this.destroy();
+};
+
+
+SyncWriteStream.prototype.destroy = function() {
+  if (this.autoClose)
+    fs.closeSync(this.fd);
+  this.fd = null;
+  this.emit('close');
+  return true;
+};
+
+SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
+
+exports.SyncWriteStream = SyncWriteStream;

--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -145,7 +145,7 @@ function createWritableStdioStream(fd) {
       break;
 
     case 'FILE':
-      const fs = require('fs');
+      const fs = require('internal/fs');
       stream = new fs.SyncWriteStream(fd, { autoClose: false });
       stream._type = 'fs';
       break;

--- a/node.gyp
+++ b/node.gyp
@@ -77,6 +77,7 @@
       'lib/internal/child_process.js',
       'lib/internal/cluster.js',
       'lib/internal/freelist.js',
+      'lib/internal/fs.js',
       'lib/internal/linkedlist.js',
       'lib/internal/net.js',
       'lib/internal/module.js',


### PR DESCRIPTION
##### Checklist

- [ ] tests and code linting passes
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

Move the internal SyncWriteStream class to internal/fs. This pulls it off require('fs') without a deprecation. It was always intended to be private, says that it's private in the source and tells people not to use it.

Update the impl a bit while we're at it to use class instead of util.extends