### PR TITLE
dgram,test: add tests for setBroadcast()

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -283,6 +283,9 @@ not work because the packet will get silently dropped without informing the
 source that the data did not reach its intended recipient.
 
 ### socket.setBroadcast(flag)
+<!-- YAML
+added: v0.6.9
+-->
 
 * `flag` {Boolean}
 

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -20,7 +20,9 @@ if (common.inFreeBSDJail) {
   return;
 }
 
-// take the first non-internal interface as the address for binding
+// Take the first non-internal interface as the address for binding.
+// Ideally, this should check for whether or not an interface is set up for
+// BROADCAST and favor internal/private interfaces.
 get_bindAddress: for (var name in networkInterfaces) {
   var interfaces = networkInterfaces[name];
   for (var i = 0; i < interfaces.length; i++) {
@@ -209,7 +211,7 @@ if (process.argv[2] === 'child') {
 
     receivedMessages.push(buf);
 
-    process.send({ message: buf.toString() });
+    process.send({message: buf.toString()});
 
     if (receivedMessages.length == messages.length) {
       process.nextTick(function() {
@@ -228,7 +230,7 @@ if (process.argv[2] === 'child') {
   });
 
   listenSocket.on('listening', function() {
-    process.send({ listening: true });
+    process.send({listening: true});
   });
 
   listenSocket.bind(common.PORT);

--- a/test/parallel/test-dgram-setBroadcast.js
+++ b/test/parallel/test-dgram-setBroadcast.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const setup = () => {
+  return dgram.createSocket({type: 'udp4', reuseAddr: true});
+};
+
+const teardown = (socket) => {
+  if (socket.close)
+    socket.close();
+};
+
+const runTest = (testCode, expectError) => {
+  const socket = setup();
+  const assertion = expectError ? assert.throws : assert.doesNotThrow;
+  const wrapped = () => { testCode(socket); };
+  assertion(wrapped, expectError);
+  teardown(socket);
+};
+
+// Should throw EBADF if socket is never bound.
+runTest((socket) => { socket.setBroadcast(true); }, /EBADF/);
+
+// Should not throw if broadcast set to false after binding.
+runTest((socket) => {
+  socket.bind(common.PORT, common.localhostIPv4, () => {
+    socket.setBroadcast(false);
+  });
+});
+
+// Should not throw if broadcast set to true after binding.
+runTest((socket) => {
+  socket.bind(common.PORT, common.localhostIPv4, () => {
+    socket.setBroadcast(true);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

dgram test

##### Description of change

<!-- provide a description of the change below this comment -->

The only tests for `setBroadcast()` (from the `dgram` module) were in
`test/internet` which means they almost never get run. This adds a
minimal test that can check JS-land functionality in `test/parallel`.

Since I was doing the necessary git spelunking anyway, I took the time
to add the YAML information into the docs about when `setBroadcast()`
first appeared in its current form.

I also expanded a comment and did some minor formatting on the existing
`test/internet` test. If there were an easy and reliable way to check
for the BROADCAST flag on an interface, it's possible that a version of
the test could be moved to `test/sequential` or `test/parallel` once it
was modified to only use internal networks.