### PR TITLE
dgram,test: add addMembership/dropMembership tests

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -71,6 +71,9 @@ socket.on('message', (msg, rinfo) => {
 ```
 
 ### socket.addMembership(multicastAddress[, multicastInterface])
+<!-- YAML
+added: v0.6.9
+-->
 
 * `multicastAddress` {String}
 * `multicastInterface` {String}, Optional
@@ -173,6 +176,9 @@ Close the underlying socket and stop listening for data on it. If a callback is
 provided, it is added as a listener for the [`'close'`][] event.
 
 ### socket.dropMembership(multicastAddress[, multicastInterface])
+<!-- YAML
+added: v0.6.9
+-->
 
 * `multicastAddress` {String}
 * `multicastInterface` {String}, Optional

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const multicastAddress = '224.0.0.114';
+
+const setup = () => {
+  return dgram.createSocket({type: 'udp4', reuseAddr: true});
+};
+
+// addMembership() on closed socket should throw
+{
+  const socket = setup();
+  socket.close(common.mustCall(() => {
+    assert.throws(() => { socket.addMembership(multicastAddress); },
+                  /Not running/);
+  }));
+}
+
+// dropMembership() on closed socket should throw
+{
+  const socket = setup();
+  socket.close(common.mustCall(() => {
+    assert.throws(() => { socket.dropMembership(multicastAddress); },
+                  /Not running/);
+  }));
+}
+
+// addMembership() with no argument should throw
+{
+  const socket = setup();
+  assert.throws(() => { socket.addMembership(); },
+                /multicast address must be specified/);
+  socket.close();
+}
+
+// dropMembership() with no argument should throw
+{
+  const socket = setup();
+  assert.throws(() => { socket.dropMembership(); },
+                /multicast address must be specified/);
+  socket.close();
+}
+
+// addMembership() with invalid multicast address should throw
+{
+  const socket = setup();
+  assert.throws(() => { socket.addMembership('256.256.256.256'); }, /EINVAL/);
+  socket.close();
+}
+
+// dropMembership() with invalid multicast address should throw
+{
+  const socket = setup();
+  assert.throws(() => { socket.dropMembership('256.256.256.256'); }, /EINVAL/);
+  socket.close();
+}
+
+// addMembership() with valid socket and multicast address should not throw
+{
+  const socket = setup();
+  assert.doesNotThrow(() => { socket.addMembership(multicastAddress); });
+  socket.close();
+}
+
+// dropMembership() without previous addMembership should throw
+{
+  const socket = setup();
+  assert.throws(
+    () => { socket.dropMembership(multicastAddress); },
+    /EADDRNOTAVAIL/
+  );
+  socket.close();
+}
+
+// dropMembership() after addMembership() should not throw
+{
+  const socket = setup();
+  assert.doesNotThrow(
+    () => {
+      socket.addMembership(multicastAddress);
+      socket.dropMembership(multicastAddress);
+    }
+  );
+  socket.close();
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test dgram
##### Description of change

<!-- provide a description of the change below this comment -->

The only tests for `addMembership()` and `dropMembership()` (from the
`dgram` module) were in `test/internet` which means they almost never
get run. This adds checks in `test/parallel`.

Since I was doing the necessary git archaeology anyway, I took the time
to add YAML information to the docs about when `addMembership()` and
`dropMembership()` first appeared in their current forms.

I also did some minor tidying on the existing `test/internet` test.