### PR TITLE
doc: update vm.runInDebugContext() example

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -221,8 +221,10 @@ a separate process.
 context. The primary use case is to get access to the V8 debug object:
 
 ```js
+const vm = require('vm');
 const Debug = vm.runInDebugContext('Debug');
-Debug.scripts().forEach((script) => { console.log(script.name); });
+console.log(Debug.findScript(process.emit).name);  // 'events.js'
+console.log(Debug.findScript(process.exit).name);  // 'internal/process.js'
 ```
 
 Note that the debug context and object are intrinsically tied to V8's debugger


### PR DESCRIPTION
The debugger needs to be active now before one is allowed to query the
list of scripts.  Replace the example with one that works without
installing a debug event listener first.

Fixes: #4862

R=@TheAlphaNerd