### PR TITLE
stream: Correct bufferedRequestCount in writes

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -403,6 +403,7 @@ function clearBuffer(stream, state) {
     } else {
       state.corkedRequestsFree = new CorkedRequest(state);
     }
+    state.bufferedRequestCount = 0;
   } else {
     // Slow case, write chunks one-by-one
     while (entry) {
@@ -413,6 +414,7 @@ function clearBuffer(stream, state) {
 
       doWrite(stream, state, false, len, chunk, encoding, cb);
       entry = entry.next;
+      state.bufferedRequestCount--;
       // if we didn't call the onwrite immediately, then
       // it means that we need to wait until it does.
       // also, that means that the chunk and cb are currently
@@ -426,7 +428,6 @@ function clearBuffer(stream, state) {
       state.lastBufferedRequest = null;
   }
 
-  state.bufferedRequestCount = 0;
   state.bufferedRequest = entry;
   state.bufferProcessing = false;
 }


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

stream
##### Description of change

`_writableState.bufferedRequestCount` now gives the correct value if the _write is asynchronous. Fixes #6758.
