### PR TITLE
child_process: measure buffer length in bytes

### DIFF
--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -5,7 +5,7 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-const spawn = require('child_process').spawn;
+const exec = require('child_process').exec;
 function main(conf) {
   bench.start();
 
@@ -13,17 +13,17 @@ function main(conf) {
   const len = +conf.len;
 
   const msg = '"' + Array(len).join('.') + '"';
-  const options = {'stdio': ['ignore', 'ipc', 'ignore']};
-  const child = spawn('yes', [msg], options);
+  const options = {'stdio': ['ignore', 'pipe', 'ignore']};
+  // NOTE: Command below assumes bash shell.
+  const child = exec(`while\n  echo ${msg}\ndo :; done\n`, options);
 
   var bytes = 0;
-  child.on('message', function(msg) {
+  child.stdout.on('data', function(msg) {
     bytes += msg.length;
   });
 
   setTimeout(function() {
     child.kill();
-    const gbits = (bytes * 8) / (1024 * 1024 * 1024);
-    bench.end(gbits);
+    bench.end(bytes);
   }, dur * 1000);
 }

--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -12,7 +12,8 @@ function main(conf) {
   const dur = +conf.dur;
   const len = +conf.len;
 
-  const msg = '"' + Array(len).join('.') + '"';
+  const msg = `"${'.'.repeat(len)}"`;
+  msg.match(/./);
   const options = {'stdio': ['ignore', 'pipe', 'ignore']};
   // NOTE: Command below assumes bash shell.
   const child = exec(`while\n  echo ${msg}\ndo :; done\n`, options);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -245,11 +245,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (child.stdout) {
-    if (encoding)
-      child.stdout.setEncoding(encoding);
-
     child.stdout.addListener('data', function(chunk) {
-      stdoutLen += chunk.length;
+      stdoutLen += chunk.byteLength;
 
       if (stdoutLen > options.maxBuffer) {
         ex = new Error('stdout maxBuffer exceeded');
@@ -258,17 +255,14 @@ exports.execFile = function(file /*, args, options, callback*/) {
         if (!encoding)
           _stdout.push(chunk);
         else
-          _stdout += chunk;
+          _stdout += chunk.toString(encoding);
       }
     });
   }
 
   if (child.stderr) {
-    if (encoding)
-      child.stderr.setEncoding(encoding);
-
     child.stderr.addListener('data', function(chunk) {
-      stderrLen += chunk.length;
+      stderrLen += chunk.byteLength;
 
       if (stderrLen > options.maxBuffer) {
         ex = new Error('stderr maxBuffer exceeded');
@@ -277,7 +271,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
         if (!encoding)
           _stderr.push(chunk);
         else
-          _stderr += chunk;
+          _stderr += chunk.toString(encoding);
       }
     });
   }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -242,6 +242,13 @@ exports.execFile = function(file /*, args, options, callback*/) {
     }, options.timeout);
   }
 
+  // Use chunk.byteLength to get accurate count of bytes, but fall back to
+  // chunk.length in case someone does something like
+  // `child.stdout.setEncoding('utf8')` in userland. That means the bytes may
+  // be under-counted in that situation (if there are characters represented by
+  // more than one byte), but there doesn't seem to be a good fix that wouldn't
+  // be a semver-major (breaking) change.
+
   if (child.stdout) {
     child.stdout.addListener('data', function(chunk) {
       stdoutLen += (chunk.byteLength || chunk.length);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -253,8 +253,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
     stdoutState = child.stdout._readableState;
 
     child.stdout.addListener('data', function(chunk) {
-      // If `child.stdout.setEncoding('utf8') happened in userland, convert
-      // string to Buffer`.
+      // If `child.stdout.setEncoding('utf8')` happened in userland, convert
+      // string to Buffer.
       if (stdoutState.decoder) {
         chunk = Buffer.from(chunk, stdoutState.decoder.encoding);
       }
@@ -275,8 +275,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
     stderrState = child.stderr._readableState;
 
     child.stderr.addListener('data', function(chunk) {
-      // If `child.stderr.setEncoding('utf8') happened in userland, convert
-      // string to Buffer and save encoding for later.
+      // If `child.stderr.setEncoding('utf8')` happened in userland, convert
+      // string to Buffer.
       if (stderrState.decoder) {
         chunk = Buffer.from(chunk, stderrState.decoder.encoding);
       }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -180,10 +180,10 @@ exports.execFile = function(file /*, args, options, callback*/) {
     var stdoutEncoding = encoding;
     var stderrEncoding = encoding;
 
-    if (stdoutState.decoder)
+    if (stdoutState && stdoutState.decoder)
       stdoutEncoding = stdoutState.decoder.encoding;
 
-    if (stderrState.decoder)
+    if (stderrState && stderrState.decoder)
       stderrEncoding = stderrState.decoder.encoding;
 
     if (stdoutEncoding)
@@ -254,7 +254,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
     child.stdout.addListener('data', function(chunk) {
       // If `child.stdout.setEncoding('utf8') happened in userland, convert
-      // string to Buffer.
+      // string to Buffer`.
       if (stdoutState.decoder) {
         chunk = Buffer.from(chunk, stdoutState.decoder.encoding);
       }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -145,7 +145,9 @@ exports.execFile = function(file /*, args, options, callback*/) {
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 
-  var encoding, stdoutEncoding, stderrEncoding;
+  var encoding;
+  var stdoutState;
+  var stderrState;
   var _stdout = [];
   var _stderr = [];
   if (options.encoding !== 'buffer' && Buffer.isEncoding(options.encoding)) {
@@ -172,19 +174,23 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
     if (!callback) return;
 
-    // Merge chunks. _stdout/_stderr may contain strings if the calling code
-    // does something like `child.stdout.setEncoding('utf8')`
-    var stdout = (typeof _stdout[0] === 'string') ?
-      _stdout.join('') : Buffer.concat(_stdout, stdoutLen);
+    var stdout = Buffer.concat(_stdout, stdoutLen);
+    var stderr = Buffer.concat(_stderr, stderrLen);
 
-    var stderr = (typeof _stderr[0] === 'string') ?
-      _stderr.join('') : Buffer.concat(_stderr, stderrLen);
+    var stdoutEncoding = encoding;
+    var stderrEncoding = encoding;
 
-    stdoutEncoding = stdoutEncoding || encoding;
+    if (stdoutState && stdoutState.decoder && stdoutState.decoder.encoding) {
+      stdoutEncoding = stdoutState.decoder.encoding;
+    }
+
+    if (stderrState && stderrState.decoder && stderrState.decoder.encoding) {
+      stderrEncoding = stderrState.decoder.encoding;
+    }
+
     if (stdoutEncoding)
       stdout = stdout.toString(stdoutEncoding);
 
-    stderrEncoding = stderrEncoding || encoding;
     if (stderrEncoding)
       stderr = stderr.toString(stderrEncoding);
 
@@ -246,14 +252,13 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (child.stdout) {
-    const stdoutState = child.stdout._readableState;
+    stdoutState = child.stdout._readableState;
 
     child.stdout.addListener('data', function(chunk) {
       // If `child.stdout.setEncoding('utf8') happened in userland, convert
       // string to Buffer and save encoding for later.
       if (stdoutState.decoder) {
-        stdoutEncoding = stdoutState.decoder.encoding;
-        chunk = Buffer.from(chunk, stdoutEncoding);
+        chunk = Buffer.from(chunk, stdoutState.decoder.encoding);
       }
 
       stdoutLen += chunk.byteLength;
@@ -269,14 +274,13 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (child.stderr) {
-    const stderrState = child.stderr._readableState;
+    stderrState = child.stderr._readableState;
 
     child.stderr.addListener('data', function(chunk) {
       // If `child.stderr.setEncoding('utf8') happened in userland, convert
       // string to Buffer and save encoding for later.
       if (stderrState.decoder) {
-        stderrEncoding = stderrState.decoder.encoding;
-        chunk = Buffer.from(chunk, stderrEncoding);
+        chunk = Buffer.from(chunk, stderrState.decoder.encoding);
       }
 
       stderrLen += chunk.byteLength;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -180,11 +180,11 @@ exports.execFile = function(file /*, args, options, callback*/) {
     var stdoutEncoding = encoding;
     var stderrEncoding = encoding;
 
-    if (stdoutState && stdoutState.decoder && stdoutState.decoder.encoding) {
+    if (stdoutState.decoder) {
       stdoutEncoding = stdoutState.decoder.encoding;
     }
 
-    if (stderrState && stderrState.decoder && stderrState.decoder.encoding) {
+    if (stderrState.decoder) {
       stderrEncoding = stderrState.decoder.encoding;
     }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -253,8 +253,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
     stdoutState = child.stdout._readableState;
 
     child.stdout.addListener('data', function(chunk) {
-      // If `child.stdout.setEncoding('utf8')` happened in userland, convert
-      // string to Buffer.
+      // If `child.stdout.setEncoding()` happened in userland, convert string to
+      // Buffer.
       if (stdoutState.decoder) {
         chunk = Buffer.from(chunk, stdoutState.decoder.encoding);
       }
@@ -275,8 +275,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
     stderrState = child.stderr._readableState;
 
     child.stderr.addListener('data', function(chunk) {
-      // If `child.stderr.setEncoding('utf8')` happened in userland, convert
-      // string to Buffer.
+      // If `child.stderr.setEncoding()` happened in userland, convert string to
+      // Buffer.
       if (stderrState.decoder) {
         chunk = Buffer.from(chunk, stderrState.decoder.encoding);
       }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -145,7 +145,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 
-  var encoding;
+  var encoding, stdoutEncoding, stderrEncoding;
   var _stdout = [];
   var _stderr = [];
   if (options.encoding !== 'buffer' && Buffer.isEncoding(options.encoding)) {
@@ -180,10 +180,13 @@ exports.execFile = function(file /*, args, options, callback*/) {
     var stderr = (typeof _stderr[0] === 'string') ?
       _stderr.join('') : Buffer.concat(_stderr, stderrLen);
 
-    if (encoding) {
-      stdout = stdout.toString(encoding);
-      stderr = stderr.toString(encoding);
-    }
+    stdoutEncoding = stdoutEncoding || encoding;
+    if (stdoutEncoding)
+      stdout = stdout.toString(stdoutEncoding);
+
+    stderrEncoding = stderrEncoding || encoding;
+    if (stderrEncoding)
+      stderr = stderr.toString(stderrEncoding);
 
     if (ex) {
       // Will be handled later
@@ -242,20 +245,22 @@ exports.execFile = function(file /*, args, options, callback*/) {
     }, options.timeout);
   }
 
-  // Use chunk.byteLength to get accurate count of bytes, but fall back to
-  // chunk.length in case someone does something like
-  // `child.stdout.setEncoding('utf8')` in userland. That means the bytes may
-  // be under-counted in that situation (if there are characters represented by
-  // more than one byte), but there doesn't seem to be a good fix that wouldn't
-  // be a semver-major (breaking) change.
-
   if (child.stdout) {
+    const stdoutState = child.stdout._readableState;
+
     child.stdout.addListener('data', function(chunk) {
-      stdoutLen += (chunk.byteLength || chunk.length);
+      // If `child.stdout.setEncoding('utf8') happened in userland, convert
+      // string to Buffer and save encoding for later.
+      if (stdoutState.decoder) {
+        stdoutEncoding = stdoutState.decoder.encoding;
+        chunk = Buffer.from(chunk, stdoutEncoding);
+      }
+
+      stdoutLen += chunk.byteLength;
 
       if (stdoutLen > options.maxBuffer) {
         ex = new Error('stdout maxBuffer exceeded');
-        stdoutLen -= (chunk.byteLength || chunk.length);
+        stdoutLen -= chunk.byteLength;
         kill();
       } else {
         _stdout.push(chunk);
@@ -264,12 +269,21 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (child.stderr) {
+    const stderrState = child.stderr._readableState;
+
     child.stderr.addListener('data', function(chunk) {
-      stderrLen += (chunk.byteLength || chunk.length);
+      // If `child.stderr.setEncoding('utf8') happened in userland, convert
+      // string to Buffer and save encoding for later.
+      if (stderrState.decoder) {
+        stderrEncoding = stderrState.decoder.encoding;
+        chunk = Buffer.from(chunk, stderrEncoding);
+      }
+
+      stderrLen += chunk.byteLength;
 
       if (stderrLen > options.maxBuffer) {
         ex = new Error('stderr maxBuffer exceeded');
-        stderrLen -= (chunk.byteLength || chunk.length);
+        stderrLen -= chunk.byteLength;
         kill();
       } else {
         _stderr.push(chunk);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -180,13 +180,11 @@ exports.execFile = function(file /*, args, options, callback*/) {
     var stdoutEncoding = encoding;
     var stderrEncoding = encoding;
 
-    if (stdoutState.decoder) {
+    if (stdoutState.decoder)
       stdoutEncoding = stdoutState.decoder.encoding;
-    }
 
-    if (stderrState.decoder) {
+    if (stderrState.decoder)
       stderrEncoding = stderrState.decoder.encoding;
-    }
 
     if (stdoutEncoding)
       stdout = stdout.toString(stdoutEncoding);
@@ -256,7 +254,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
     child.stdout.addListener('data', function(chunk) {
       // If `child.stdout.setEncoding('utf8') happened in userland, convert
-      // string to Buffer and save encoding for later.
+      // string to Buffer.
       if (stdoutState.decoder) {
         chunk = Buffer.from(chunk, stdoutState.decoder.encoding);
       }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -146,15 +146,11 @@ exports.execFile = function(file /*, args, options, callback*/) {
   });
 
   var encoding;
-  var _stdout;
-  var _stderr;
+  var _stdout = [];
+  var _stderr = [];
   if (options.encoding !== 'buffer' && Buffer.isEncoding(options.encoding)) {
     encoding = options.encoding;
-    _stdout = '';
-    _stderr = '';
   } else {
-    _stdout = [];
-    _stderr = [];
     encoding = null;
   }
   var stdoutLen = 0;
@@ -183,8 +179,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
       stdout = Buffer.concat(_stdout);
       stderr = Buffer.concat(_stderr);
     } else {
-      stdout = _stdout;
-      stderr = _stderr;
+      stdout = Buffer.concat(_stdout).toString(encoding);
+      stderr = Buffer.concat(_stderr).toString(encoding);
     }
 
     if (ex) {
@@ -252,10 +248,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
         ex = new Error('stdout maxBuffer exceeded');
         kill();
       } else {
-        if (!encoding)
-          _stdout.push(chunk);
-        else
-          _stdout += chunk.toString(encoding);
+        _stdout.push(chunk);
       }
     });
   }
@@ -268,10 +261,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
         ex = new Error('stderr maxBuffer exceeded');
         kill();
       } else {
-        if (!encoding)
-          _stderr.push(chunk);
-        else
-          _stderr += chunk.toString(encoding);
+        _stderr.push(chunk);
       }
     });
   }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -172,15 +172,17 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
     if (!callback) return;
 
-    // merge chunks
-    var stdout;
-    var stderr;
-    if (!encoding) {
-      stdout = Buffer.concat(_stdout);
-      stderr = Buffer.concat(_stderr);
-    } else {
-      stdout = Buffer.concat(_stdout).toString(encoding);
-      stderr = Buffer.concat(_stderr).toString(encoding);
+    // Merge chunks. _stdout/_stderr may contain strings if the calling code
+    // does something like `child.stdout.setEncoding('utf8')`
+    var stdout = (typeof _stdout[0] === 'string') ?
+      _stdout.join('') : Buffer.concat(_stdout, stdoutLen);
+
+    var stderr = (typeof _stderr[0] === 'string') ?
+      _stderr.join('') : Buffer.concat(_stderr, stderrLen);
+
+    if (encoding) {
+      stdout = stdout.toString(encoding);
+      stderr = stderr.toString(encoding);
     }
 
     if (ex) {
@@ -242,10 +244,11 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
   if (child.stdout) {
     child.stdout.addListener('data', function(chunk) {
-      stdoutLen += chunk.byteLength;
+      stdoutLen += (chunk.byteLength || chunk.length);
 
       if (stdoutLen > options.maxBuffer) {
         ex = new Error('stdout maxBuffer exceeded');
+        stdoutLen -= (chunk.byteLength || chunk.length);
         kill();
       } else {
         _stdout.push(chunk);
@@ -255,10 +258,11 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
   if (child.stderr) {
     child.stderr.addListener('data', function(chunk) {
-      stderrLen += chunk.byteLength;
+      stderrLen += (chunk.byteLength || chunk.length);
 
       if (stderrLen > options.maxBuffer) {
         ex = new Error('stderr maxBuffer exceeded');
+        stderrLen -= (chunk.byteLength || chunk.length);
         kill();
       } else {
         _stderr.push(chunk);

--- a/test/parallel/test-child-process-maxBuffer-stderr.js
+++ b/test/parallel/test-child-process-maxBuffer-stderr.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const unicode = '中文测试'; // Length = 4, Byte length = 13
+
+if (process.argv[2] === 'child') {
+  console.error(unicode);
+} else {
+  const cmd = `${process.execPath} ${__filename} child`;
+
+  cp.exec(cmd, {maxBuffer: 10}, common.mustCall((err, stdout, stderr) => {
+    assert.strictEqual(err.message, 'stderr maxBuffer exceeded');
+  }));
+}

--- a/test/parallel/test-child-process-maxBuffer-stdout.js
+++ b/test/parallel/test-child-process-maxBuffer-stdout.js
@@ -1,5 +1,4 @@
 'use strict';
-// Refs: https://github.com/nodejs/node/issues/1901
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
@@ -10,7 +9,7 @@ if (process.argv[2] === 'child') {
 } else {
   const cmd = `${process.execPath} ${__filename} child`;
 
-  cp.exec(cmd, { maxBuffer: 10 }, common.mustCall((err, stdout, stderr) => {
+  cp.exec(cmd, {maxBuffer: 10}, common.mustCall((err, stdout, stderr) => {
     assert.strictEqual(err.message, 'stdout maxBuffer exceeded');
   }));
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

child_process test

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

child_process test

##### Description of change

<!-- provide a description of the change below this comment -->

This change fixes a known issue where `maxBuffer` limits by characters
rather than bytes.

Fixes: https://github.com/nodejs/node/issues/1901

Probably need to benchmark it against the current implementation. It's entirely possible no one has done it this way because of performance?