### PR TITLE
lib: replace legacy uses of __defineGetter__

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -350,8 +350,12 @@ CryptoStream.prototype.setKeepAlive = function(enable, initialDelay) {
   if (this.socket) this.socket.setKeepAlive(enable, initialDelay);
 };
 
-CryptoStream.prototype.__defineGetter__('bytesWritten', function() {
-  return this.socket ? this.socket.bytesWritten : 0;
+Object.defineProperty(CryptoStream.prototype, 'bytesWritten', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.socket ? this.socket.bytesWritten : 0;
+  }
 });
 
 CryptoStream.prototype.getPeerCertificate = function(detailed) {
@@ -526,27 +530,44 @@ CleartextStream.prototype.address = function() {
   return this.socket && this.socket.address();
 };
 
-
-CleartextStream.prototype.__defineGetter__('remoteAddress', function() {
-  return this.socket && this.socket.remoteAddress;
+Object.defineProperty(CleartextStream.prototype, 'remoteAddress', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.socket && this.socket.remoteAddress;
+  }
 });
 
-CleartextStream.prototype.__defineGetter__('remoteFamily', function() {
-  return this.socket && this.socket.remoteFamily;
+Object.defineProperty(CleartextStream.prototype, 'remoteFamily', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.socket && this.socket.remoteFamily;
+  }
 });
 
-CleartextStream.prototype.__defineGetter__('remotePort', function() {
-  return this.socket && this.socket.remotePort;
+Object.defineProperty(CleartextStream.prototype, 'remotePort', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.socket && this.socket.remotePort;
+  }
 });
 
-
-CleartextStream.prototype.__defineGetter__('localAddress', function() {
-  return this.socket && this.socket.localAddress;
+Object.defineProperty(CleartextStream.prototype, 'localAddress', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.socket && this.socket.localAddress;
+  }
 });
 
-
-CleartextStream.prototype.__defineGetter__('localPort', function() {
-  return this.socket && this.socket.localPort;
+Object.defineProperty(CleartextStream.prototype, 'localPort', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.socket && this.socket.localPort;
+  }
 });
 
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -662,13 +662,20 @@ function filterDuplicates(names) {
 }
 
 // Legacy API
-exports.__defineGetter__('createCredentials',
-  internalUtil.deprecate(function() {
+Object.defineProperty(exports, 'createCredentials', {
+  configurable: true,
+  enumerable: true,
+  get: internalUtil.deprecate(function() {
     return require('tls').createSecureContext;
   }, 'crypto.createCredentials is deprecated. ' +
-     'Use tls.createSecureContext instead.'));
+     'Use tls.createSecureContext instead.')
+});
 
-exports.__defineGetter__('Credentials', internalUtil.deprecate(function() {
-  return require('tls').SecureContext;
-}, 'crypto.Credentials is deprecated. ' +
-   'Use tls.SecureContext instead.'));
+Object.defineProperty(exports, 'Credentials', {
+  configurable: true,
+  enumerable: true,
+  get: internalUtil.deprecate(function() {
+    return require('tls').SecureContext;
+  }, 'crypto.Credentials is deprecated. ' +
+     'Use tls.SecureContext instead.')
+});

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -251,8 +251,12 @@
   }
 
   function setupGlobalConsole() {
-    global.__defineGetter__('console', function() {
-      return NativeModule.require('console');
+    Object.defineProperty(global, 'console', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return NativeModule.require('console');
+      }
     });
   }
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -165,11 +165,15 @@ function Interface(input, output, completer, terminal) {
 
 inherits(Interface, EventEmitter);
 
-Interface.prototype.__defineGetter__('columns', function() {
-  var columns = Infinity;
-  if (this.output && this.output.columns)
-    columns = this.output.columns;
-  return columns;
+Object.defineProperty(Interface.prototype, 'columns', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    var columns = Infinity;
+    if (this.output && this.output.columns)
+      columns = this.output.columns;
+    return columns;
+  }
 });
 
 Interface.prototype.setPrompt = function(prompt) {


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

crypto, readline, internal

##### Description of change

Minor clean up. There are still some places in core that use the legacy `__defineGetter__` syntax. This updates those.