### PR TITLE
Buffer bug fix

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -227,7 +227,7 @@ function fromString(string, encoding) {
 
   var length = byteLength(string, encoding);
 
-  if (length === 0)
+  if (length === 0 && string.length === 0)
     return Buffer.alloc(0);
 
   if (length >= (Buffer.poolSize >>> 1))

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -225,10 +225,10 @@ function fromString(string, encoding) {
   if (!Buffer.isEncoding(encoding))
     throw new TypeError('"encoding" must be a valid string encoding');
 
-  var length = byteLength(string, encoding);
-
-  if (length === 0 && string.length === 0)
+  if (string.length === 0)
     return Buffer.alloc(0);
+
+  var length = byteLength(string, encoding);
 
   if (length >= (Buffer.poolSize >>> 1))
     return binding.createFromString(string, encoding);

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -749,10 +749,14 @@ for (let i = 0; i < 256; i++) {
   assert.equal(hexb2[i], hexb[i]);
 }
 
-//#6770 Test single hex character throws TypeError
+// Test single hex character throws TypeError
+// - https://github.com/nodejs/node/issues/6770
 assert.throws(function() {
   Buffer.from('A', 'hex');
 }, TypeError);
+
+// Test single base64 char encodes as 0
+assert.equal(Buffer.from('A', 'base64'), 0);
 
 {
   // test an invalid slice end.

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -751,8 +751,8 @@ for (let i = 0; i < 256; i++) {
 
 //#6770 Test single hex character throws TypeError
 assert.throws(function() {
-  var b = Buffer.from('A', 'hex');
-}, TypeError)
+  Buffer.from('A', 'hex');
+}, TypeError);
 
 {
   // test an invalid slice end.

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -756,7 +756,7 @@ assert.throws(function() {
 }, TypeError);
 
 // Test single base64 char encodes as 0
-assert.equal(Buffer.from('A', 'base64'), 0);
+assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 
 {
   // test an invalid slice end.

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -749,6 +749,11 @@ for (let i = 0; i < 256; i++) {
   assert.equal(hexb2[i], hexb[i]);
 }
 
+//#6770 Test single hex character throws TypeError
+assert.throws(function() {
+  var b = Buffer.from('A', 'hex');
+}, TypeError)
+
 {
   // test an invalid slice end.
   console.log('Try to slice off the end of the buffer');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes - Linting passes, tests had failures but none additional to `master`
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

Buffer

##### Description of change

 Fixes #6770, Single digit hex strings not raising TypeError on Buffer creation


