### PR TITLE
build: Enable building with Ninja

### DIFF
--- a/configure
+++ b/configure
@@ -394,6 +394,11 @@ parser.add_option('--xcode',
     dest='use_xcode',
     help='generate build files for use with xcode')
 
+parser.add_option('--ninja',
+    action='store_true',
+    dest='use_ninja',
+    help='generate build files for use with Ninja')
+
 parser.add_option('--enable-asan',
     action='store_true',
     dest='enable_asan',
@@ -805,6 +810,9 @@ def configure_node(o):
     o['variables']['library_files'] = options.linked_module
 
   o['variables']['asan'] = int(options.enable_asan or 0)
+
+  if options.use_xcode and options.use_ninja:
+    raise Exception('--xcode and --ninja cannot be used together.')
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
@@ -1241,6 +1249,8 @@ gyp_args = [sys.executable, 'tools/gyp_node.py', '--no-parallel']
 
 if options.use_xcode:
   gyp_args += ['-f', 'xcode']
+elif options.use_ninja:
+  gyp_args += ['-f', 'ninja']
 elif flavor == 'win' and sys.platform != 'msys':
   gyp_args += ['-f', 'msvs', '-G', 'msvs_version=auto']
 else:

--- a/doc/guides/building-node-with-ninja.md
+++ b/doc/guides/building-node-with-ninja.md
@@ -2,12 +2,11 @@
 
 The purpose of this guide is to show how to build Node.js using [Ninja][], as doing so can be significantly quicker than using `make`. Please see [Ninja's site][Ninja] for installation instructions (unix only).
 
-To build Node with ninja, there are 4 steps that must be taken:
+To build Node with ninja, there are 3 steps that must be taken:
 
-1. Configure the project's OS-based build rules via `./configure` as usual.
-2. Use `tools/gyp_node.py -f ninja` to produce Ninja-buildable `gyp` output.
-3. Run `ninja -C out/Release` to produce a compiled release binary.
-4. Lastly, make symlink to `./node` using `ln -fs out/Release/node node`.
+1. Configure the project's OS-based build rules via `./configure --ninja`.
+2. Run `ninja -C out/Release` to produce a compiled release binary.
+3. Lastly, make symlink to `./node` using `ln -fs out/Release/node node`.
 
 When running `ninja -C out/Release` you will see output similar to the following if the build has succeeded:
 ```
@@ -28,12 +27,12 @@ As such, if you wish to run the tests, it can be helpful to invoke the test runn
 
 ## Alias
 
-`alias nnode='./configure && tools/gyp_node.py -f ninja && ninja -C out/Release && ln -fs out/Release/node node'`
+`alias nnode='./configure --ninja && ninja -C out/Release && ln -fs out/Release/node node'`
 
 ## Producing a debug build
 
 The above alias can be modified slightly to produce a debug build, rather than a release build as shown below:
-`alias nnodedebug='./configure && tools/gyp_node.py -f ninja && ninja -C out/Debug && ln -fs out/Debug/node node_g'`
+`alias nnodedebug='./configure --ninja && ninja -C out/Debug && ln -fs out/Debug/node node_g'`
 
 
 [Ninja]: https://martine.github.io/ninja/


### PR DESCRIPTION
#<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
build

##### Description of change

<!-- provide a description of the change below this comment -->

Ninja is a build backend supported by gyp which is much faster than make
and is able to parallelize builds across all of the available cores very
well.  On my machine, this reduces the average build time from 5:14
minutes to 4:33 minutes.