### PR TITLE
Add {shell: 'auto'} to child_process.spawn

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -289,8 +289,11 @@ not clone the current process.*
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
   * `shell` {Boolean|String} If `true`, runs `command` inside of a shell. Uses
-    `'/bin/sh'` on UNIX, and `'cmd.exe'` on Windows. A different shell can be
-    specified as a string. The shell should understand the `-c` switch on UNIX,
+    `'/bin/sh'` on UNIX, and `'cmd.exe'` on Windows. If `'auto'`, tries to
+    detect if a shell is required. On Windows, this means that the `command`
+    has an extension other than `.exe` or `.com`; on UNIX, it is equivalent to
+    `false` (no shell). A different shell can also be specified as a string
+    other than `'auto'`. The shell should understand the `-c` switch on UNIX,
     or `/s /c` on Windows. Defaults to `false` (no shell).
 * return: {ChildProcess}
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const path = require('path');
 const internalUtil = require('internal/util');
 const debug = util.debuglog('child_process');
 const constants = require('constants');
@@ -322,6 +323,11 @@ function normalizeSpawnArguments(file /*, args, options*/) {
 
   // Make a shallow copy so we don't clobber the user's options object.
   options = Object.assign({}, options);
+
+  if (options.shell === 'auto') {
+    options.shell = (process.platform === 'win32' &&
+      ['.exe', '.com'].indexOf(path.extname(file).toLowerCase()) < 0);
+  }
 
   if (options.shell) {
     const command = [file].concat(args).join(' ');

--- a/test/fixtures/child-process-shell-auto
+++ b/test/fixtures/child-process-shell-auto
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo Success.

--- a/test/fixtures/child-process-shell-auto.cmd
+++ b/test/fixtures/child-process-shell-auto.cmd
@@ -1,0 +1,2 @@
+@echo off
+echo Success.

--- a/test/parallel/test-child-process-spawn-shell-auto.js
+++ b/test/parallel/test-child-process-spawn-shell-auto.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const cp = require('child_process');
+
+let output = '';
+const cmd = path.resolve(common.fixturesDir, 'child-process-shell-auto');
+const proc = cp.spawn(cmd, {shell: 'auto'});
+proc.stdout.on('data', (data) => {
+  output += data;
+});
+proc.on('error', common.fail);
+proc.on('close', common.mustCall((code) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(output.trim(), 'Success.');
+}));


### PR DESCRIPTION
##### Checklist

- [ ] tests and code linting passes **(see below)**
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

child_process

##### Description of change

Discussed in #6671.

Synopsis: On Windows, Node/uv doesn't take PATHEXT into account, making spawning fail unexpectedly if you don't pass {shell: true}. However, that option makes spawning roughly twice as slow. Hence, I'm adding {shell: 'auto'} to guess the need to spawn a shell from the extension on Windows.

This implies that you can no longer pass 'auto' as the name of a shell, which breaks backward compatibility. Alternatives include:

- Allowing {shell: 1} and checking if the type is 'number'.
- Introducing a new option such as autoShell.
- Defaulting to 'auto' if shell is undefined.

Sidenote: I'm adding a test but:

- vcbuild test makes my Windows machine freeze. Running the test directly worked though.
- I didn't test on *NIX yet.