### PR TITLE
build: Update build-addons when node-gyp changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ ADDONS_BINDING_GYPS := \
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
 # Depends on node-gyp package.json so that build-addons is (re)executed when
 # node-gyp is updated as part of an npm update.
-test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json $(ADDONS_BINDING_GYPS) \
+test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json \
+  $(ADDONS_BINDING_GYPS) \
 	deps/uv/include/*.h deps/v8/include/*.h \
 	src/node.h src/node_buffer.h src/node_object_wrap.h \
 	test/addons/.docbuildstamp

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ ADDONS_BINDING_GYPS := \
 # Depends on node-gyp package.json so that build-addons is (re)executed when
 # node-gyp is updated as part of an npm update.
 test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json \
-  $(ADDONS_BINDING_GYPS) \
+	$(ADDONS_BINDING_GYPS) \
 	deps/uv/include/*.h deps/v8/include/*.h \
 	src/node.h src/node_buffer.h src/node_object_wrap.h \
 	test/addons/.docbuildstamp

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,9 @@ ADDONS_BINDING_GYPS := \
 		$(wildcard test/addons/*/binding.gyp))
 
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
-test/addons/.buildstamp: $(ADDONS_BINDING_GYPS) \
+# Depends on node-gyp package.json so that build-addons is (re)executed when
+# node-gyp is updated as part of an npm update.
+test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json $(ADDONS_BINDING_GYPS) \
 	deps/uv/include/*.h deps/v8/include/*.h \
 	src/node.h src/node_buffer.h src/node_object_wrap.h \
 	test/addons/.docbuildstamp
@@ -163,7 +165,7 @@ test/addons/.buildstamp: $(ADDONS_BINDING_GYPS) \
 # if the subprocess touched anything so it pessimistically assumes that
 # .buildstamp and .docbuildstamp are out of date and need a rebuild.
 # Just goes to show that recursive make really is harmful...
-# TODO(bnoordhuis) Force rebuild after gyp or node-gyp update.
+# TODO(bnoordhuis) Force rebuild after gyp update.
 build-addons: $(NODE_EXE) test/addons/.buildstamp
 
 test-gc: all test/gc/node_modules/weak/build/Release/weakref.node


### PR DESCRIPTION
Partially addresses https://github.com/nodejs/node/issues/4607 by ensuring that `build-addons` are rebuilt when `node-gyp` is updated.

##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

build


##### Description of change

We can tell when `node-gyp` is changed by creating a prerequisite on
`deps/npm/node_modules/node-gyp/package.json`. The prerequisite is added
to the `test/addons/.buildstamp` since `build-addons` is .PHONY.

Testing for this change was entirely manual.

    $ make clean test-build # Initial build
    $ make test-build # Make sure build-addons doesn't rebuild
    $ touch deps/npm/node_modules/node-gyp/package.json # simulate change
    $ make test-build # Ensure build-addons rebuilds