### PR TITLE
test: robust handling of env for npm-test-install

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -32,11 +32,12 @@ const pkgPath = path.join(common.tmpDir, 'package.json');
 
 fs.writeFileSync(pkgPath, pkgContent);
 
+const env = Object.create(process.env);
+env['PATH'] = path.dirname(process.execPath);
+
 const proc = spawn(process.execPath, args, {
   cwd: common.tmpDir,
-  env: {
-    PATH: path.dirname(process.execPath)
-  }
+  env: env
 });
 
 function handleExit(code, signalCode) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Node.js. Before you submit, please
review below requirements and walk through the checklist. You can 'tick'
a box by using the letter "x": [x].

Run the test suite by invoking: `make -j4 lint test` on linux or
`vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. Finally – if possible – a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test

##### Description of change

<!-- provide a description of the change below this comment -->

Currently we are overwriting the entire env object of the child-process
spawned in `npm-test-install`. This commit alternatively clones the
`process.env` object and modifies it with the neccessary changes before
passing it the the spawned process.

Fixes: https://github.com/nodejs/node/issues/6736