### PR TITLE
test: fix flaky test-stdout-close-catch

### DIFF
--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -9,7 +9,7 @@ var testScript = path.join(common.fixturesDir, 'catch-stdout-error.js');
 var cmd = JSON.stringify(process.execPath) + ' ' +
           JSON.stringify(testScript) + ' | ' +
           JSON.stringify(process.execPath) + ' ' +
-          '-pe "process.exit(1);"';
+          '-pe "process.stdin.on(\'data\' , () => process.exit(1))"';
 
 var child = child_process.exec(cmd);
 var output = '';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test

##### Description of change
<!-- provide a description of the change below this comment -->

Make sure that `catch-stdout-error` has written data before the
destination process exits.

Fixes: https://github.com/nodejs/node/issues/6791

Stress test on `FreeBSD` without this change fails: https://ci.nodejs.org/job/node-stress-single-test/727/

Stress test with this change succeeds: https://ci.nodejs.org/job/node-stress-single-test/731/