### PR TITLE
doc: add note for fs.watch on virtualized env

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1179,9 +1179,10 @@ to be notified of filesystem changes.
 * On Windows systems, this feature depends on `ReadDirectoryChangesW`.
 
 If the underlying functionality is not available for some reason, then
-`fs.watch` will not be able to function.  For example, watching files or
-directories on network file systems (NFS, SMB, etc.) often doesn't work
-reliably or at all.
+`fs.watch` will not be able to function. For example, watching files or
+directories can be unreliable, and in some cases impossible, on network file
+systems (NFS, SMB, etc), or host file systems when using virtualization software
+such as Vagrant, Docker, etc.
 
 You can still use `fs.watchFile`, which uses stat polling, but it is slower and
 less reliable.


### PR DESCRIPTION

##### Checklist
<!-- remove lines that do not apply to you -->

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
`doc`

##### Description of change

On virtualization systems `fs.watch` doesn't work reliably, which is implicitly already in the respective docs. To make it more explicit this PR adds a subsentence. The following statement defers to use of fs.watchFile, which is the potential workaround.

Fixes: https://github.com/nodejs/node/issues/6765




