### PR TITLE
src: fix without-intl build

### DIFF
--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -29,8 +29,8 @@ using v8::Value;
 void InitConfig(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
-#ifdef NODE_HAVE_I18N_SUPPORT
   Environment* env = Environment::GetCurrent(context);
+#ifdef NODE_HAVE_I18N_SUPPORT
 
   READONLY_BOOLEAN_PROPERTY("hasIntl");
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

src

##### Description of change

In 5d38d543cd, an additional property in node_config.cc was added whose definition depends on having the local `env` variable declared, which in turn depended on `NODE_HAVE_I18N_SUPPORT` being defined.

Moving `env = ...` out of the `#ifdef` block allows building via `./configure --without-intl` again.

/cc @jasnell 