### PR TITLE
fs: mkdtemp should not fail if no callback passed

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2000,7 +2000,8 @@ SyncWriteStream.prototype.destroy = function() {
 
 SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
 
-fs.mkdtemp = function(prefix, options, callback) {
+fs.mkdtemp = function(prefix, options, callback_) {
+  var callback = maybeCallback(callback_);
   if (!prefix || typeof prefix !== 'string')
     throw new TypeError('filename prefix is required');
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1596,6 +1596,47 @@ fs.realpath = function realpath(path, options, callback) {
 };
 
 
+fs.mkdtemp = function(prefix, options, callback_) {
+  var callback = maybeCallback(callback_);
+  if (!prefix || typeof prefix !== 'string')
+    throw new TypeError('filename prefix is required');
+
+  options = options || {};
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  } else if (typeof options === 'string') {
+    options = {encoding: options};
+  }
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
+
+  if (!nullCheck(prefix, callback)) {
+    return;
+  }
+
+  var req = new FSReqWrap();
+  req.oncomplete = callback;
+
+  binding.mkdtemp(prefix + 'XXXXXX', options.encoding, req);
+};
+
+
+fs.mkdtempSync = function(prefix, options) {
+  if (!prefix || typeof prefix !== 'string')
+    throw new TypeError('filename prefix is required');
+
+  options = options || {};
+  if (typeof options === 'string')
+    options = {encoding: options};
+  if (typeof options !== 'object')
+    throw new TypeError('"options" must be a string or an object');
+  nullCheck(prefix);
+
+  return binding.mkdtemp(prefix + 'XXXXXX', options.encoding);
+};
+
+
 var pool;
 
 function allocNewPool(poolSize) {
@@ -1999,42 +2040,3 @@ SyncWriteStream.prototype.destroy = function() {
 };
 
 SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;
-
-fs.mkdtemp = function(prefix, options, callback_) {
-  var callback = maybeCallback(callback_);
-  if (!prefix || typeof prefix !== 'string')
-    throw new TypeError('filename prefix is required');
-
-  options = options || {};
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  } else if (typeof options === 'string') {
-    options = {encoding: options};
-  }
-  if (typeof options !== 'object')
-    throw new TypeError('"options" must be a string or an object');
-
-  if (!nullCheck(prefix, callback)) {
-    return;
-  }
-
-  var req = new FSReqWrap();
-  req.oncomplete = callback;
-
-  binding.mkdtemp(prefix + 'XXXXXX', options.encoding, req);
-};
-
-fs.mkdtempSync = function(prefix, options) {
-  if (!prefix || typeof prefix !== 'string')
-    throw new TypeError('filename prefix is required');
-
-  options = options || {};
-  if (typeof options === 'string')
-    options = {encoding: options};
-  if (typeof options !== 'object')
-    throw new TypeError('"options" must be a string or an object');
-  nullCheck(prefix);
-
-  return binding.mkdtemp(prefix + 'XXXXXX', options.encoding);
-};

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -25,3 +25,5 @@ fs.mkdtemp(
       assert(common.fileExists(folder));
     })
 );
+
+assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-')));


### PR DESCRIPTION

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

As it is, `fs.mkdtemp` crashes with a C++ assertion if the callback
function is not passed. This patch uses `maybeCallback` to create one,
if no callback function is passed.