### PR TITLE
doc: make param names consistent & fix doc link

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -931,7 +931,7 @@ fs.mkdtemp(tmpDir + path.sep, (err, folder) => {
 });
 ```
 
-## fs.mkdtempSync(template)
+## fs.mkdtempSync(prefix)
 <!-- YAML
 added: v5.10.0
 -->
@@ -1929,6 +1929,7 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`fs.FSWatcher`]: #fs_class_fs_fswatcher
 [`fs.futimes()`]: #fs_fs_futimes_fd_atime_mtime_callback
 [`fs.lstat()`]: #fs_fs_lstat_path_callback
+[`fs.mkdtemp()`]: #fs_fs_mkdtemp_prefix_callback
 [`fs.open()`]: #fs_fs_open_path_flags_mode_callback
 [`fs.read()`]: #fs_fs_read_fd_buffer_offset_length_position_callback
 [`fs.readFile`]: #fs_fs_readfile_file_options_callback


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

The parameter to `fs.mkdtemp` is actually `prefix`, not `template`,
because the string passed is appended with the randomly generated
string.

The doc link for `fs.mkdtemp()` was missing and it is included in this
patch.

@nodejs/documentation 