### PR TITLE
doc: fix mkdtemp example by removing hyphen

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -914,7 +914,7 @@ const tmpDir = '/tmp';
 fs.mkdtemp(tmpDir, (err, folder) => {
   if (err) throw err;
   console.log(folder);
-    // Will print something similar to `/tmp-abc123`.
+    // Will print something similar to `/tmpabc123`.
     // Note that a new temporary directory is created
     // at the file system root rather than *within*
     // the /tmp directory.


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

The example uses only `/tmp`, not `/tmp-`. So, the result cannot be
`/tmp-abc123`, but just `/tmpabc123`.

cc @jasnell 