### PR TITLE
doc: add info on what's used for fswatch on AIX

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1467,6 +1467,7 @@ to be notified of filesystem changes.
 * On OS X, this uses `kqueue` for files and 'FSEvents' for directories.
 * On SunOS systems (including Solaris and SmartOS), this uses `event ports`.
 * On Windows systems, this feature depends on `ReadDirectoryChangesW`.
+* On Aix systems, this feature depends on `AHAFS`, which must be enabled.
 
 If the underlying functionality is not available for some reason, then
 `fs.watch` will not be able to function.  For example, watching files or


### PR DESCRIPTION
##### Checklist
- [X] tests and code linting passes
- [X] documentation is changed or added
- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)
fs

##### Description of change
Noticed we don't mention how fswatch is implemented for AIX like
we do on other platforms, adding

