### PR TITLE
unix,stream: fix getting the correct fd for a handle

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -86,7 +86,7 @@ int StreamWrap::GetFD() {
   int fd = -1;
 #if !defined(_WIN32)
   if (stream() != nullptr)
-    fd = stream()->io_watcher.fd;
+    uv_fileno(reinterpret_cast<uv_handle_t*>(stream()), &fd);
 #endif
   return fd;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
stream

##### Description of change
<!-- provide a description of the change below this comment -->

On OSX it's possible that the fd is replaced, so use the proper libuv
API to get the correct fd.