### PR TITLE
process: remove deprecated process.EventEmitter

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -21,18 +21,6 @@
 
     EventEmitter.call(process);
 
-    let eeWarned = false;
-    Object.defineProperty(process, 'EventEmitter', {
-      get() {
-        const internalUtil = NativeModule.require('internal/util');
-        eeWarned = internalUtil.printDeprecationMessage(
-          "process.EventEmitter is deprecated. Use require('events') instead.",
-          eeWarned
-        );
-        return EventEmitter;
-      }
-    });
-
     setupProcessObject();
 
     // do this good and early, since it handles errors.


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
process

##### Description of change
`process.EventEmitter` was deprecated for v6. This commit removes it for v7.

Refs: https://github.com/nodejs/node/pull/5049