### PR TITLE
build: add REPLACEME tag for version info in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,10 @@ PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacO
 PKGDIR=out/dist-osx
 
 release-only:
+	@if `grep -q REPLACEME doc/api/*.md`; then \
+		echo 'Please update Added: tags in the documentation first.' ; \
+		exit 1 ; \
+	fi
 	@if [ "$(shell git status --porcelain | egrep -v '^\?\? ')" = "" ]; then \
 		exit 0 ; \
 	else \

--- a/tools/doc/README.md
+++ b/tools/doc/README.md
@@ -34,6 +34,15 @@ Each type of heading has a description block.
 
     A description of the function.
 
+    ### module.someNewFunction(x)
+    <!-- YAML
+    added: REPLACEME
+    -->
+
+    * `x` {String} the description of the string
+
+    This feature is not in a release yet.
+
     ### Event: 'blerg'
     <!-- YAML
     added: v0.10.0


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

build

##### Description of change

Add a `REPLACEME` tag that should be used when introducing docs for new features, so that they can be updated when releases are made. Example usage:

```md
## process.cpuUsage([previousValue])
<!-- YAML
added: REPLACEME
-->
```

Ref: https://github.com/nodejs/node/issues/6578

@bnoordhuis This is taken straight from https://github.com/nodejs/node/issues/6578#issuecomment-219162917 so I’ve set the commit author to you. I guess that’s okay with you?