### PR TITLE
lib: http server multi same-named headers support

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -350,7 +350,10 @@ OutgoingMessage.prototype.setHeader = function(name, value) {
   if (this._headers === null)
     this._headers = {};
 
-  var key = name.toLowerCase();
+  var key = name.toLowerCase(), serial = 0, origKey = key;
+  while (this._headers[key] !== undefined) {
+    key = (origKey + serial++);
+  }
   this._headers[key] = value;
   this._headerNames[key] = name;
 
@@ -408,7 +411,18 @@ OutgoingMessage.prototype._renderHeaders = function() {
 
   for (var i = 0, l = keys.length; i < l; i++) {
     var key = keys[i];
-    headers[headerNames[key]] = headersMap[key];
+    if (headers[headerNames[key]] !== undefined) {
+      var isArray = Array.isArray(headers[headerNames[key]]);
+      if (isArray) {
+        headers[headerNames[key]].push(headersMap[key]);
+      } else {
+        var orig = headers[headerNames[key]];
+        headers[headerNames[key]] = [];
+        headers[headerNames[key]].push(orig);
+      }
+    } else {
+      headers[headerNames[key]] = headersMap[key];
+    }
   }
   return headers;
 };

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -103,7 +103,7 @@ function nextTest() {
         break;
 
       case 'writeHead':
-        assert.equal(response.headers['x-foo'], 'bar');
+        assert.equal(response.headers['x-foo'], 'keyboard cat');
         assert.equal(response.headers['x-bar'], 'baz');
         assert.equal(200, response.statusCode);
         test = 'end';

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -39,7 +39,7 @@ s.listen(common.PORT, runTest);
 function runTest() {
   http.get({ port: common.PORT }, function(response) {
     response.on('end', function() {
-      assert.equal(response.headers['test'], '2');
+      assert.equal(response.headers['test'], '1, 2');
       assert(response.rawHeaders.indexOf('Test') !== -1);
       s.close();
     });


### PR DESCRIPTION
This is my first PR to nodejs, hope didn't do anything stupid or funny ... Thanks.

##### Checklist

- [ ] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
lib/_http_outgoing.js

##### Description of change

Let http server support response multiple same-named header as RFC2612
defined, this feature is also used in http/2.0 "server push" feature.

Fix #3591