### PR TITLE
Backport 5786 to v4.x (memory growth with 'vm' module)

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -43,7 +43,7 @@ using v8::TryCatch;
 using v8::UnboundScript;
 using v8::V8;
 using v8::Value;
-using v8::WeakCallbackData;
+using v8::WeakCallbackInfo;
 
 
 class ContextifyContext {
@@ -64,7 +64,7 @@ class ContextifyContext {
     // Allocation failure or maximum call stack size reached
     if (context_.IsEmpty())
       return;
-    context_.SetWeak(this, WeakCallback<Context>);
+    context_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
     context_.MarkIndependent();
   }
 
@@ -302,10 +302,8 @@ class ContextifyContext {
   }
 
 
-  template <class T>
-  static void WeakCallback(const WeakCallbackData<T, ContextifyContext>& data) {
+  static void WeakCallback(const WeakCallbackInfo<ContextifyContext>& data) {
     ContextifyContext* context = data.GetParameter();
-    context->context_.ClearWeak();
     delete context;
   }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -207,7 +207,17 @@ class ContextifyContext {
 
     CHECK(!ctx.IsEmpty());
     ctx->SetSecurityToken(env->context()->GetSecurityToken());
+
+    // We need to tie the lifetime of the sandbox object with the lifetime of
+    // newly created context. We do this by making them hold references to each
+    // other. The context can directly hold a reference to the sandbox as an
+    // embedder data field. However, we cannot hold a reference to a v8::Context
+    // directly in an Object, we instead hold onto the new context's global
+    // object instead (which then has a reference to the context).
     ctx->SetEmbedderData(kSandboxObjectIndex, sandbox_obj);
+    sandbox_obj->SetHiddenValue(
+        FIXED_ONE_BYTE_STRING(env->isolate(), "_contextifyHiddenGlobal"),
+        ctx->Global());
 
     env->AssignToContext(ctx);
 

--- a/test/parallel/test-vm-create-and-run-in-context.js
+++ b/test/parallel/test-vm-create-and-run-in-context.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-gc
 require('../common');
 var assert = require('assert');
 
@@ -18,3 +19,11 @@ console.error('test updating context');
 result = vm.runInContext('var foo = 3;', context);
 assert.equal(3, context.foo);
 assert.equal('lala', context.thing);
+
+// https://github.com/nodejs/node/issues/5768
+console.error('run in contextified sandbox without referencing the context');
+var sandbox = {x: 1};
+vm.createContext(sandbox);
+gc();
+vm.runInContext('x = 2', sandbox);
+// Should not crash.


### PR DESCRIPTION
Original issue: https://github.com/nodejs/node/issues/3113

Backports https://github.com/nodejs/node/pull/5786 & https://github.com/nodejs/node/pull/5786 together to v4.x-staging. This combination was tested by users with a v4.x build @ https://github.com/nodejs/node/issues/3113#issuecomment-198888744, we said we'd backport it properly but were waiting for a solid proving time in v5.x because of some problems we had (the bug that #5786 fixed).

Backported to 5.x in https://github.com/nodejs/node/pull/5800 and was released in v5.9.1 / 2016-03-23 with no additional problems beyond #5786. IMO this is ready to roll into the next v4.x.

/ @nodejs/lts 