### PR TITLE
build: fix cross-compile issue for Android

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -50,6 +50,10 @@ export AR=$TOOLCHAIN/bin/$SUFFIX-ar
 export CC=$TOOLCHAIN/bin/$SUFFIX-gcc
 export CXX=$TOOLCHAIN/bin/$SUFFIX-g++
 export LINK=$TOOLCHAIN/bin/$SUFFIX-g++
+export AR_host=ar
+export CC_host=gcc
+export CXX_host=g++
+export LINK_host=g++
 
 GYP_DEFINES="target_arch=$ARCH"
 GYP_DEFINES+=" v8_target_arch=$ARCH"

--- a/common.gypi
+++ b/common.gypi
@@ -242,59 +242,110 @@
           ['_type=="static_library"', {
             'standalone_static_library': 1, # disable thin archive which needs binutils >= 2.19
           }],
-        ],
-        'conditions': [
-          [ 'target_arch=="ia32"', {
-            'cflags': [ '-m32' ],
-            'ldflags': [ '-m32' ],
-          }],
-          [ 'target_arch=="x32"', {
-            'cflags': [ '-mx32' ],
-            'ldflags': [ '-mx32' ],
-          }],
-          [ 'target_arch=="x64"', {
-            'cflags': [ '-m64' ],
-            'ldflags': [ '-m64' ],
-          }],
-          [ 'target_arch=="ppc" and OS!="aix"', {
-            'cflags': [ '-m32' ],
-            'ldflags': [ '-m32' ],
-          }],
-          [ 'target_arch=="ppc64" and OS!="aix"', {
-	    'cflags': [ '-m64', '-mminimal-toc' ],
-	    'ldflags': [ '-m64' ],
-	   }],
-          [ 'target_arch=="s390"', {
-            'cflags': [ '-m31' ],
-            'ldflags': [ '-m31' ],
-          }],
-          [ 'target_arch=="s390x"', {
-            'cflags': [ '-m64' ],
-            'ldflags': [ '-m64' ],
-          }],
-          [ 'OS=="solaris"', {
-            'cflags': [ '-pthreads' ],
-            'ldflags': [ '-pthreads' ],
-            'cflags!': [ '-pthread' ],
-            'ldflags!': [ '-pthread' ],
-          }],
-          [ 'OS=="aix"', {
+          ['_toolset=="host"', {
             'conditions': [
-              [ 'target_arch=="ppc"', {
-                'ldflags': [ '-Wl,-bmaxdata:0x60000000/dsa' ],
+              ['host_arch=="ia32"', {
+                'cflags': [ '-m32' ],
+                'ldflags': [ '-m32' ],
               }],
-              [ 'target_arch=="ppc64"', {
-                'cflags': [ '-maix64' ],
-                'ldflags': [ '-maix64' ],
+              ['host_arch=="x32"', {
+                'cflags': [ '-mx32' ],
+                'ldflags': [ '-mx32' ],
+              }],
+              [ 'host_arch=="x64"', {
+                'cflags': [ '-m64' ],
+                'ldflags': [ '-m64' ],
+              }],
+              [ 'host_arch=="ppc" and OS!="aix"', {
+                'cflags': [ '-m32' ],
+                'ldflags': [ '-m32' ],
+              }],
+              [ 'host_arch=="ppc64" and OS!="aix"', {
+                'cflags': [ '-m64', '-mminimal-toc' ],
+                'ldflags': [ '-m64' ],
+              }],
+              [ 'host_arch=="s390"', {
+                'cflags': [ '-m31' ],
+                'ldflags': [ '-m31' ],
+              }],
+              [ 'host_arch=="s390x"', {
+                'cflags': [ '-m64' ],
+                'ldflags': [ '-m64' ],
+              }],
+              [ 'OS=="solaris"', {
+                'cflags': [ '-pthreads' ],
+                'ldflags': [ '-pthreads' ],
+                'cflags!': [ '-pthread' ],
+                'ldflags!': [ '-pthread' ],
+              }],
+              [ 'OS=="aix"', {
+                'conditions': [
+                  [ 'host_arch=="ppc"', {
+                    'ldflags': [ '-Wl,-bmaxdata:0x60000000/dsa' ],
+                  }],
+                  [ 'host_arch=="ppc64"', {
+                    'cflags': [ '-maix64' ],
+                    'ldflags': [ '-maix64' ],
+                  }],
+                ],
+                'ldflags!': [ '-rdynamic' ],
               }],
             ],
-            'ldflags!': [ '-rdynamic' ],
+          }],
+          ['_toolset=="target"', {
+            'conditions': [
+              ['target_arch=="ia32"', {
+                'cflags': [ '-m32' ],
+                'ldflags': [ '-m32' ],
+              }],
+              ['target_arch=="x32"', {
+                'cflags': [ '-mx32' ],
+                'ldflags': [ '-mx32' ],
+              }],
+              [ 'target_arch=="x64"', {
+                'cflags': [ '-m64' ],
+                'ldflags': [ '-m64' ],
+              }],
+              [ 'target_arch=="ppc" and OS!="aix"', {
+                'cflags': [ '-m32' ],
+                'ldflags': [ '-m32' ],
+              }],
+              [ 'target_arch=="ppc64" and OS!="aix"', {
+                'cflags': [ '-m64', '-mminimal-toc' ],
+                'ldflags': [ '-m64' ],
+              }],
+              [ 'target_arch=="s390"', {
+                'cflags': [ '-m31' ],
+                'ldflags': [ '-m31' ],
+              }],
+              [ 'target_arch=="s390x"', {
+                'cflags': [ '-m64' ],
+                'ldflags': [ '-m64' ],
+              }],
+              [ 'OS=="solaris"', {
+                'cflags': [ '-pthreads' ],
+                'ldflags': [ '-pthreads' ],
+                'cflags!': [ '-pthread' ],
+                'ldflags!': [ '-pthread' ],
+              }],
+              [ 'OS=="aix"', {
+                'conditions': [
+                  [ 'target_arch=="ppc"', {
+                    'ldflags': [ '-Wl,-bmaxdata:0x60000000/dsa' ],
+                  }],
+                  [ 'target_arch=="ppc64"', {
+                    'cflags': [ '-maix64' ],
+                    'ldflags': [ '-maix64' ],
+                  }],
+                ],
+                'ldflags!': [ '-rdynamic' ],
+              }],
+            ],
+          }],
+          ['OS=="android" and _toolset=="target"', {
+            'libraries': [ '-llog' ],
           }],
         ],
-      }],
-      [ 'OS=="android"', {
-        'defines': ['_GLIBCXX_USE_C99_MATH'],
-        'libraries': [ '-llog' ],
       }],
       ['OS=="mac"', {
         'defines': ['_DARWIN_USE_64_BIT_INODE=1'],

--- a/tools/create_android_makefiles
+++ b/tools/create_android_makefiles
@@ -21,6 +21,10 @@ fi
 
 cd $(dirname $0)/..
 
+# Export CC_host to gcc, so that the configure script will detect the correct
+# host arch
+export CC_host=gcc
+
 ./configure \
     --without-snapshot \
     --openssl-no-asm \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

build
##### Description of change

<!-- provide a description of the change below this comment -->

Some tools from icu are building host binaries, which are failing
because the current logic is using the target_arch.
So, I added _host exports to local build tools in order to use them,
when building host binaries.
Also, in the commin.gypi file, we need to take care of the current
toolset used when generating makefiles. This needs to be done, so that
we will use the host_arch when generating makefiles for host and
target_arch when generating makefiles for target.
Also, removed the unnecessary define '_GLIBCXX_USE_C99_MATH'.

Signed-off-by: Robert Chiras robert.chiras@intel.com
