### PR TITLE
child_process: check accessing a null stderr

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -494,7 +494,7 @@ function execFileSync(/*command, args, options*/) {
 
   var ret = spawnSync(opts.file, opts.args.slice(1), opts.options);
 
-  if (inheritStderr)
+  if (inheritStderr && ret.stderr)
     process.stderr.write(ret.stderr);
 
   var err = checkExecSyncError(ret);
@@ -514,7 +514,7 @@ function execSync(command /*, options*/) {
   var ret = spawnSync(opts.file, opts.options);
   ret.cmd = command;
 
-  if (inheritStderr)
+  if (inheritStderr && ret.stderr)
     process.stderr.write(ret.stderr);
 
   var err = checkExecSyncError(ret);

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -12,6 +12,18 @@ var start = Date.now();
 var err;
 var caught = false;
 
+// Verify that stderr is not accessed when a bad shell is used
+assert.throws(
+  function() { execSync('exit -1', {shell: 'bad_shell'}); },
+  /spawnSync bad_shell ENOENT/,
+  'execSync did not throw the expected exception!'
+);
+assert.throws(
+  function() { execFileSync('exit -1', {shell: 'bad_shell'}); },
+  /spawnSync bad_shell ENOENT/,
+  'execFileSync did not throw the expected exception!'
+);
+
 try {
   var cmd = `"${process.execPath}" -e "setTimeout(function(){}, ${SLEEP});"`;
   var ret = execSync(cmd, {timeout: TIMER});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
child_process, test

##### Description of change
<!-- provide a description of the change below this comment -->
Fix for child_process when accessing a null stderr and addition test path to exercise this false path.