### PR TITLE
tls: catch `certCbDone` exceptions

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -171,7 +171,11 @@ function oncertcb(info) {
       if (!self._handle)
         return self.destroy(new Error('Socket is closed'));
 
-      self._handle.certCbDone();
+      try {
+        self._handle.certCbDone();
+      } catch (e) {
+        self.destroy(e);
+      }
     });
   });
 }

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -23,7 +23,7 @@ const options = {
 };
 
 const server = tls.createServer(options, (c) => {
-  assert(false, 'Should not be called');
+  assert.fail(null, null, 'Should not be called');
 }).on('tlsClientError', common.mustCall((err, c) => {
   assert(/SSL_use_certificate:passed a null parameter/i.test(err.message));
   server.close();
@@ -33,10 +33,10 @@ const server = tls.createServer(options, (c) => {
     rejectUnauthorized: false,
     servername: 'any.name'
   }, () => {
-    assert(false, 'Should not be called');
+    assert.fail(null, null, 'Should not be called');
   });
 
   c.on('error', common.mustCall((err) => {
-    assert(err);
+    assert(/socket hang up/.test(err.message));
   }));
 }));

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -23,7 +23,7 @@ const options = {
 };
 
 const server = tls.createServer(options, (c) => {
-  assert.fail(null, null, 'Should not be called');
+  common.fail('Should not be called');
 }).on('tlsClientError', common.mustCall((err, c) => {
   assert(/SSL_use_certificate:passed a null parameter/i.test(err.message));
   server.close();
@@ -33,7 +33,7 @@ const server = tls.createServer(options, (c) => {
     rejectUnauthorized: false,
     servername: 'any.name'
   }, () => {
-    assert.fail(null, null, 'Should not be called');
+    common.fail('Should not be called');
   });
 
   c.on('error', common.mustCall((err) => {

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -1,0 +1,42 @@
+'use strict';
+
+if (!process.features.tls_sni) {
+  console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
+              'with old OpenSSL version.');
+  return;
+}
+
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+
+const tls = require('tls');
+
+const options = {
+  SNICallback: (name, callback) => {
+    callback(null, tls.createSecureContext());
+  }
+};
+
+const server = tls.createServer(options, (c) => {
+  assert(false, 'Should not be called');
+}).on('tlsClientError', common.mustCall((err, c) => {
+  assert(/SSL_use_certificate:passed a null parameter/i.test(err.message));
+  server.close();
+})).listen(common.PORT, common.mustCall(() => {
+  const c = tls.connect({
+    port: common.PORT,
+    rejectUnauthorized: false,
+    servername: 'any.name'
+  }, () => {
+    assert(false, 'Should not be called');
+  });
+
+  c.on('error', common.mustCall((err) => {
+    assert(err);
+  }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change
<!-- provide a description of the change below this comment -->

Catch and emit `certCbDone` exceptions instead of throwing them as
`uncaughtException` and crashing the whole process.

Fix: https://github.com/nodejs/node/issues/6822

cc @nodejs/crypto 