### PR TITLE
cluster: guard against undefined message handlers

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -749,7 +749,7 @@ function internal(worker, cb) {
   return function(message, handle) {
     if (message.cmd !== 'NODE_CLUSTER') return;
     var fn = cb;
-    if (message.ack !== undefined) {
+    if (message.ack !== undefined && callbacks[message.ack] !== undefined) {
       fn = callbacks[message.ack];
       delete callbacks[message.ack];
     }

--- a/test/parallel/test-cluster-invalid-message.js
+++ b/test/parallel/test-cluster-invalid-message.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+
+  worker.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+
+  worker.on('online', () => {
+    worker.send({
+      cmd: 'NODE_CLUSTER',
+      ack: -1
+    }, () => {
+      worker.disconnect();
+    });
+  });
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
cluster

##### Description of change
`cluster`'s internal message handling includes a cache of callback functions. Once the message for that callback is received, it is removed from the cache. If, for any reason, the same message ID is processed twice, the callback will be missing from the cache and `cluster` will try to call `undefined` as a function. This commit guards against this scenario.

Fixes #6561