### PR TITLE
doc: make doc-only -> fallback to user binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,11 +278,15 @@ out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets/
 out/doc/%: doc/%
 	cp -r $< $@
 
+# check if ./node is actually set, else use user pre-installed binary
+gen-json = tools/doc/generate.js --format=json $< > $@
 out/doc/api/%.json: doc/api/%.md
-	$(NODE) tools/doc/generate.js --format=json $< > $@
+	[ -x $(NODE) ] && $(NODE) $(gen-json) || node $(gen-json)
 
+# check if ./node is actually set, else use user pre-installed binary
+gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html --template=doc/template.html $< > $@
 out/doc/api/%.html: doc/api/%.md
-	$(NODE) tools/doc/generate.js --node-version=$(FULLVERSION) --format=html --template=doc/template.html $< > $@
+	[ -x $(NODE) ] && $(NODE) $(gen-html) || node $(gen-html)
 
 docopen: out/doc/api/all.html
 	-google-chrome out/doc/api/all.html


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
`build`, `doc`

##### Description of change

Fixes:
When checking out a fresh clone or `rm -rf out/` or `rm ./node` make doc-only was not working (Mac OS), failing to find `./node`. I think this has slipped, because likely contributors have at least some binary, from e.g. a build of another branch still in `out/`.

This then would check if `$(NODE)` was set correctly take it or fallback to a user pre-installed `node` binary.

Bash syntax and implementation is a little too clever unfortunately, but I guess that won't hurt anyone there.
