### PR TITLE
Fix 6899: console.* not working when running out of stack space

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -357,6 +357,7 @@
     this.id = id;
     this.exports = {};
     this.loaded = false;
+    this.loading = false;
   }
 
   NativeModule._source = process.binding('natives');
@@ -368,7 +369,7 @@
     }
 
     var cached = NativeModule.getCached(id);
-    if (cached) {
+    if (cached && (cached.loaded || cached.loading)) {
       return cached.exports;
     }
 
@@ -432,14 +433,20 @@
     var source = NativeModule.getSource(this.id);
     source = NativeModule.wrap(source);
 
-    var fn = runInThisContext(source, {
-      filename: this.filename,
-      lineOffset: 0,
-      displayErrors: true
-    });
-    fn(this.exports, NativeModule.require, this, this.filename);
+    this.loading = true;
 
-    this.loaded = true;
+    try {
+      var fn = runInThisContext(source, {
+        filename: this.filename,
+        lineOffset: 0,
+        displayErrors: true
+      });
+      fn(this.exports, NativeModule.require, this, this.filename);
+
+      this.loaded = true;
+    } finally {
+      this.loading = false;
+    }
   };
 
   NativeModule.prototype.cache = function() {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1521,8 +1521,8 @@ void AppendExceptionLine(Environment* env,
   // sourceline to 78 characters, and we end up not providing very much
   // useful debugging info to the user if we remove 62 characters.
 
-  int start = message->GetStartColumn(env->context()).FromJust();
-  int end = message->GetEndColumn(env->context()).FromJust();
+  int start = message->GetStartColumn(env->context()).FromMaybe(0);
+  int end = message->GetEndColumn(env->context()).FromMaybe(0);
 
   char arrow[1024];
   int max_off = sizeof(arrow) - 2;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -205,7 +205,11 @@ class ContextifyContext {
 
     Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
 
-    CHECK(!ctx.IsEmpty());
+    if (ctx.IsEmpty()) {
+      env->ThrowError("Could not instantiate context");
+      return Local<Context>();
+    }
+
     ctx->SetSecurityToken(env->context()->GetSecurityToken());
 
     // We need to tie the lifetime of the sandbox object with the lifetime of
@@ -632,9 +636,11 @@ class ContextifyScript : public BaseObject {
             env->arrow_message_private_symbol());
 
     Local<Value> arrow;
-    if (!(maybe_value.ToLocal(&arrow) &&
-          arrow->IsString() &&
-          stack->IsString())) {
+    if (!(maybe_value.ToLocal(&arrow) && arrow->IsString())) {
+      return;
+    }
+
+    if (stack.IsEmpty() || !stack->IsString()) {
       return;
     }
 

--- a/test/message/console_low_stack_space.js
+++ b/test/message/console_low_stack_space.js
@@ -1,0 +1,22 @@
+'use strict';
+// copy console accessor because requiring ../common touches it
+const consoleDescriptor = Object.getOwnPropertyDescriptor(global, 'console');
+delete global.console;
+global.console = {};
+
+require('../common');
+
+function a() {
+  try {
+    return a();
+  } catch (e) {
+    const console = consoleDescriptor.get();
+    if (console.log) {
+      console.log('Hello, World!');
+    } else {
+      throw e;
+    }
+  }
+}
+
+a();

--- a/test/message/console_low_stack_space.out
+++ b/test/message/console_low_stack_space.out
@@ -1,0 +1,1 @@
+Hello, World!

--- a/test/parallel/test-vm-low-stack-space.js
+++ b/test/parallel/test-vm-low-stack-space.js
@@ -1,0 +1,26 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+function a() {
+  try {
+    return a();
+  } catch (e) {
+    // Throw an exception as near to the recursion-based RangeError as possible.
+    return vm.runInThisContext('() => 42')();
+  }
+}
+
+assert.strictEqual(a(), 42);
+
+function b() {
+  try {
+    return b();
+  } catch (e) {
+    // This writes a lot of noise to stderr, but it still works.
+    return vm.runInNewContext('() => 42')();
+  }
+}
+
+assert.strictEqual(b(), 42);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
vm, module(?), console(?)

##### Description of change

Commit 1: vm: don't abort process when stack space runs out

Make less assumptions about what objects will be available when vm context creation or error message printing fail because V8 runs out of JS stack space.

Commit 2: module: don't cache uninitialized builtins

Don't cache the exported values of fully uninitialized builtins. This works by adding an additional `loading` flag that is only active during initial loading of an internal module and checking that either the module is fully loaded or is in that state before using its cached value.

This has the effect that builtins modules which could not be loaded (e.g. because compilation failed due to missing stack space) can be loaded at a later point.

--------

I’m definitely open for the possibility of leaving the `module` commit out, if others think this specific bug is not worth fixing beyond not aborting the process.

Initial CI: https://ci.nodejs.org/job/node-test-commit/3417/