### PR TITLE
child_process: emit IPC messages on next tick

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -719,7 +719,11 @@ function workerInit() {
       const handle = handles[key];
       delete handles[key];
       waitingCount++;
-      handle.owner.close(checkWaitingCount);
+
+      if (handle.owner)
+        handle.owner.close(checkWaitingCount);
+      else
+        handle.close(checkWaitingCount);
     }
 
     checkWaitingCount();

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -715,7 +715,9 @@ function handleMessage(target, message, handle) {
       message.cmd.slice(0, INTERNAL_PREFIX.length) === INTERNAL_PREFIX) {
     eventName = 'internalMessage';
   }
-  target.emit(eventName, message, handle);
+  process.nextTick(() => {
+    target.emit(eventName, message, handle);
+  });
 }
 
 function nop() { }

--- a/test/parallel/test-cluster-ipc-throw.js
+++ b/test/parallel/test-cluster-ipc-throw.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const cluster = require('cluster');
+
+cluster.schedulingPolicy = cluster.SCHED_RR;
+
+const server = http.createServer();
+
+if (cluster.isMaster) {
+  server.listen(common.PORT);
+  const worker = cluster.fork();
+  worker.on('exit', common.mustCall(() => {
+    server.close();
+  }));
+} else {
+  process.on('uncaughtException', common.mustCall((e) => {}));
+  server.listen(common.PORT);
+  server.on('error', common.mustCall((e) => {
+    cluster.worker.disconnect();
+    throw e;
+  }));
+}

--- a/test/parallel/test-cluster-worker-disconnect-on-error.js
+++ b/test/parallel/test-cluster-worker-disconnect-on-error.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const cluster = require('cluster');
+
+cluster.schedulingPolicy = cluster.SCHED_NONE;
+
+const server = http.createServer();
+if (cluster.isMaster) {
+  server.listen(common.PORT);
+  const worker = cluster.fork();
+  worker.on('exit', common.mustCall(() => {
+    server.close();
+  }));
+} else {
+  server.listen(common.PORT);
+  server.on('error', common.mustCall((e) => {
+    cluster.worker.disconnect();
+  }));
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
child_process

##### Description of change
Currently, if an IPC event handler throws an error, it can cause the message to not be consumed, leading to messages piling up. This commit causes IPC events to be emitted on the next tick, allowing the channel's processing logic to move forward as normal.

Refs: #6561 
Refs: #6902 

R= @santigimeno @bnoordhuis 