### PR TITLE
test: fix component printing on windows

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -273,10 +273,11 @@ class TapProgressIndicator(SimpleProgressIndicator):
     # Print test name as (for example) "parallel/test-assert".  Tests that are
     # scraped from the addons documentation are all named test.js, making it
     # hard to decipher what test is running when only the filename is printed.
-    prefix = abspath(join(dirname(__file__), '../test')) + '/'
+    prefix = abspath(join(dirname(__file__), '../test')) + os.sep
     command = output.command[-1]
     if command.endswith('.js'): command = command[:-3]
     if command.startswith(prefix): command = command[len(prefix):]
+    command = command.replace('\\', '/')
 
     if output.UnexpectedOutput():
       status_line = 'not ok %i %s' % (self._done, command)


### PR DESCRIPTION
Commit 084b2ec ("test: include component in tap output") introduced
an in hindsight glaringly obvious but fortunately not very critical
Windows-specific bug by failing to take the path separator into account.
This commit rectifies that, the prefix is now correctly stripped.

Refs: #6653 

CI: https://ci.nodejs.org/job/node-test-pull-request/2723/