### PR TITLE
doc: fix typos in event loop doc to aid readability

### DIFF
--- a/doc/topics/the-event-loop-timers-and-nexttick.md
+++ b/doc/topics/the-event-loop-timers-and-nexttick.md
@@ -218,15 +218,15 @@ ways depending on when they are called.
 * `setTimeout()` schedules a script to be run
 after a minimum threshold in ms has elapsed.
 
-The order in which they are executed varies depending on the context in
-which they are called.  If both are called in the main module, then you
-are bound by how fast your process goes (which is impacted by other
-programs running on your machine).
+The order in which the timers are executed will vary depending on the
+context in which they are called.  If both are called from within the
+main module, then timing will be bound by the performance of the process
+(which can be impacted by other applications running on the machine).
 
-For example, if we run the following script which is not within a I/O
-cycle (i.e. the main module), the order in which the two functions are
-executed is non-deterministic as it is based upon how fast your process 
-goes (which is impacted by other programs running on your machine):
+For example, if we run the following script which is not within an I/O
+cycle (i.e. the main module), the order in which the two timers are
+executed is non-deterministic, as it is bound by the performance of the
+process:
 
 
 ```js

--- a/doc/topics/the-event-loop-timers-and-nexttick.md
+++ b/doc/topics/the-event-loop-timers-and-nexttick.md
@@ -218,10 +218,10 @@ ways depending on when they are called.
 * `setTimeout()` schedules a script to be run
 after a minimum threshold in ms has elapsed.
 
-The order in which they are execute varies depending on the context in
-which they are called.  If both are called in the main module then you
-are bound to how fast your process go, which is impacted by other
-programs running on your machine.
+The order in which they are executed varies depending on the context in
+which they are called.  If both are called in the main module, then you
+are bound by how fast your process goes (which is impacted by other
+programs running on your machine).
 
 For example, if we run the following script which is not within a I/O
 cycle (i.e. the main module), the order in which the two functions are


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change
<!-- provide a description of the change below this comment -->

Typos in the `setTimeout` vs. `setImmediate` section were hindering
readability. Fixed these typos.