### PR TITLE
util: pretty-print SIMD types

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,56 @@ const isError = internalUtil.isError;
 const kDefaultMaxLength = 100;
 
 var Debug;
+var simdFormatters;
+
+// SIMD is only available when --harmony_simd is specified on the command line
+// and the set of available types differs between v5 and v6, that's why we use
+// a map to look up and store the formatters.  It also provides a modicum of
+// protection against users monkey-patching the SIMD object.
+if (typeof global.SIMD === 'object' && global.SIMD !== null) {
+  simdFormatters = new Map();
+
+  const make = (extractLane, count) => {
+    return (ctx, value, recurseTimes, visibleKeys, keys) => {
+      const output = new Array(count);
+      for (let i = 0; i < count; i += 1)
+        output[i] = formatPrimitive(ctx, extractLane(value, i));
+      return output;
+    };
+  };
+
+  const SIMD = global.SIMD;  // Pacify eslint.
+
+  if (typeof SIMD.Bool16x8 === 'function')
+    simdFormatters.set(SIMD.Bool16x8, make(SIMD.Bool16x8.extractLane, 8));
+
+  if (typeof SIMD.Bool32x4 === 'function')
+    simdFormatters.set(SIMD.Bool32x4, make(SIMD.Bool32x4.extractLane, 4));
+
+  if (typeof SIMD.Bool8x16 === 'function')
+    simdFormatters.set(SIMD.Bool8x16, make(SIMD.Bool8x16.extractLane, 16));
+
+  if (typeof SIMD.Float32x4 === 'function')
+    simdFormatters.set(SIMD.Float32x4, make(SIMD.Float32x4.extractLane, 4));
+
+  if (typeof SIMD.Int16x8 === 'function')
+    simdFormatters.set(SIMD.Int16x8, make(SIMD.Int16x8.extractLane, 8));
+
+  if (typeof SIMD.Int32x4 === 'function')
+    simdFormatters.set(SIMD.Int32x4, make(SIMD.Int32x4.extractLane, 4));
+
+  if (typeof SIMD.Int8x16 === 'function')
+    simdFormatters.set(SIMD.Int8x16, make(SIMD.Int8x16.extractLane, 16));
+
+  if (typeof SIMD.Uint16x8 === 'function')
+    simdFormatters.set(SIMD.Uint16x8, make(SIMD.Uint16x8.extractLane, 8));
+
+  if (typeof SIMD.Uint32x4 === 'function')
+    simdFormatters.set(SIMD.Uint32x4, make(SIMD.Uint32x4.extractLane, 4));
+
+  if (typeof SIMD.Uint8x16 === 'function')
+    simdFormatters.set(SIMD.Uint8x16, make(SIMD.Uint8x16.extractLane, 16));
+}
 
 function tryStringify(arg) {
   try {
@@ -432,6 +482,10 @@ function formatValue(ctx, value, recurseTimes) {
                    'byteOffset',
                    'buffer');
     }
+  } else if (simdFormatters &&
+             typeof value.constructor === 'function' &&
+             (formatter = simdFormatters.get(value.constructor))) {
+    braces = ['[', ']'];
   } else {
     var promiseInternals = inspectPromise(value);
     if (promiseInternals) {

--- a/test/parallel/test-util-inspect-simd.js
+++ b/test/parallel/test-util-inspect-simd.js
@@ -1,0 +1,61 @@
+// Flags: --harmony_simd
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const inspect = require('util').inspect;
+
+const SIMD = global.SIMD;  // Pacify eslint.
+
+assert.strictEqual(
+    inspect(SIMD.Bool16x8()),
+    'Bool16x8 [ false, false, false, false, false, false, false, false ]');
+
+assert.strictEqual(
+    inspect(SIMD.Bool32x4()),
+    'Bool32x4 [ false, false, false, false ]');
+
+assert.strictEqual(
+    inspect(SIMD.Bool8x16()),
+    'Bool8x16 [\n  false,\n  false,\n  false,\n  false,\n  false,\n' +
+    '  false,\n  false,\n  false,\n  false,\n  false,\n  false,\n' +
+    '  false,\n  false,\n  false,\n  false,\n  false ]');
+
+assert.strictEqual(
+    inspect(SIMD.Bool32x4()),
+    'Bool32x4 [ false, false, false, false ]');
+
+assert.strictEqual(
+    inspect(SIMD.Float32x4()),
+    'Float32x4 [ NaN, NaN, NaN, NaN ]');
+
+assert.strictEqual(
+    inspect(SIMD.Int16x8()),
+    'Int16x8 [ 0, 0, 0, 0, 0, 0, 0, 0 ]');
+
+assert.strictEqual(
+    inspect(SIMD.Int32x4()),
+    'Int32x4 [ 0, 0, 0, 0 ]');
+
+assert.strictEqual(
+    inspect(SIMD.Int8x16()),
+    'Int8x16 [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]');
+
+// The SIMD types below are not available in v5.
+if (typeof SIMD.Uint16x8 === 'function') {
+  assert.strictEqual(
+      inspect(SIMD.Uint16x8()),
+      'Uint16x8 [ 0, 0, 0, 0, 0, 0, 0, 0 ]');
+}
+
+if (typeof SIMD.Uint32x4 === 'function') {
+  assert.strictEqual(
+      inspect(SIMD.Uint32x4()),
+      'Uint32x4 [ 0, 0, 0, 0 ]');
+}
+
+if (typeof SIMD.Uint8x16 === 'function') {
+  assert.strictEqual(
+      inspect(SIMD.Uint8x16()),
+      'Uint8x16 [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]');
+}


### PR DESCRIPTION
Before:

    Bool32x4 {}
    Float32x4 {}
    Int32x4 {}
    // etc.

After:

    Bool32x4 [ false, false, false, false ]
    Float32x4 [ NaN, NaN, NaN, NaN ]
    Int32x4 [ 0, 0, 0, 0 ]
    // etc.

CI: https://ci.nodejs.org/job/node-test-pull-request/2724/