### PR TITLE
buffer: Fix dataview-set benchmark.

### DIFF
--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -40,18 +40,20 @@ function main(conf) {
 }
 
 function benchInt(dv, fn, len, le) {
-  var m = mod[fn];
+  const m = mod[fn];
+  const method = dv[fn];
   bench.start();
   for (var i = 0; i < len; i++) {
-    dv[fn](0, i % m, le);
+    method.call(dv, 0, i % m, le);
   }
   bench.end(len / 1e6);
 }
 
 function benchFloat(dv, fn, len, le) {
+  const method = dv[fn];
   bench.start();
   for (var i = 0; i < len; i++) {
-    dv[fn](0, i * 0.1, le);
+    method.call(dv, 0, i * 0.1, le);
   }
   bench.end(len / 1e6);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
buffer


##### Description of change
<!-- provide a description of the change below this comment -->

Just fixes a benchmark code itself to provide proper measurement.

Improves numbers up to 4x by avoiding repetitive dynamic method lookup.

Before the change:
```
buffers\dataview-set.js type=Uint8 millions=1: 4.52066
buffers\dataview-set.js type=Uint16LE millions=1: 5.03784
buffers\dataview-set.js type=Uint16BE millions=1: 5.36833
buffers\dataview-set.js type=Uint32LE millions=1: 4.49819
buffers\dataview-set.js type=Uint32BE millions=1: 4.46667
buffers\dataview-set.js type=Int8 millions=1: 5.52648
buffers\dataview-set.js type=Int16LE millions=1: 5.54321
buffers\dataview-set.js type=Int16BE millions=1: 5.48971
buffers\dataview-set.js type=Int32LE millions=1: 5.61572
buffers\dataview-set.js type=Int32BE millions=1: 5.48682
buffers\dataview-set.js type=Float32LE millions=1: 5.43213
buffers\dataview-set.js type=Float32BE millions=1: 5.49020
buffers\dataview-set.js type=Float64LE millions=1: 5.41688
buffers\dataview-set.js type=Float64BE millions=1: 5.15072
```

After the change:
```
buffers\dataview-set.js type=Uint8 millions=1: 19.16623
buffers\dataview-set.js type=Uint16LE millions=1: 17.47599
buffers\dataview-set.js type=Uint16BE millions=1: 17.82669
buffers\dataview-set.js type=Uint32LE millions=1: 11.06974
buffers\dataview-set.js type=Uint32BE millions=1: 11.06411
buffers\dataview-set.js type=Int8 millions=1: 19.36784
buffers\dataview-set.js type=Int16LE millions=1: 13.45155
buffers\dataview-set.js type=Int16BE millions=1: 11.97407
buffers\dataview-set.js type=Int32LE millions=1: 18.88772
buffers\dataview-set.js type=Int32BE millions=1: 18.31484
buffers\dataview-set.js type=Float32LE millions=1: 18.33773
buffers\dataview-set.js type=Float32BE millions=1: 15.50081
buffers\dataview-set.js type=Float64LE millions=1: 16.86952
buffers\dataview-set.js type=Float64BE millions=1: 17.21089
```
(Just noticed this when going through #6893 and couldn't pass by.)