### PR TITLE
Fix windows segfault

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -11,7 +11,7 @@ int wmain(int argc, wchar_t *wargv[]) {
   }
 
   // Convert argv to to UTF8
-  char** argv = new char*[argc];
+  char** argv = new char*[argc + 1];
   for (int i = 0; i < argc; i++) {
     // Compute the size of the required buffer
     DWORD size = WideCharToMultiByte(CP_UTF8,
@@ -43,6 +43,7 @@ int wmain(int argc, wchar_t *wargv[]) {
       exit(1);
     }
   }
+  argv[argc] = nullptr;
   // Now that conversion is done, we can finally start.
   return node::Start(argc, argv);
 }

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -11,7 +11,6 @@ const child = require('child_process');
 const path = require('path');
 const nodejs = '"' + process.execPath + '"';
 
-
 // replace \ by / because windows uses backslashes in paths, but they're still
 // interpreted as the escape character when put between quotes.
 var filename = __filename.replace(/\\/g, '/');
@@ -66,8 +65,14 @@ child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
       assert.equal(status.code, 42);
     });
 
+// Missing argument should not crash
+child.exec(nodejs + ' -e', function (status, stdout, stderr) {
+  assert.notStrictEqual(status, null);
+  assert.equal(status.code, 9);
+});
+
 // empty program should do nothing
-child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
+child.exec(nodejs + ' -e ""', function (status, stdout, stderr) {
   assert.equal(stdout, '');
   assert.equal(stderr, '');
 });

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -69,7 +69,7 @@ child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
 // Missing argument should not crash
 child.exec(nodejs + ' -e', function(status, stdout, stderr) {
   assert.notStrictEqual(status, null);
-  assert.equal(status.code, 9);
+  assert.strictEqual(status.code, 9);
 });
 
 // empty program should do nothing

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -66,13 +66,13 @@ child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
     });
 
 // Missing argument should not crash
-child.exec(nodejs + ' -e', function (status, stdout, stderr) {
+child.exec(nodejs + ' -e', function(status, stdout, stderr) {
   assert.notStrictEqual(status, null);
   assert.equal(status.code, 9);
 });
 
 // empty program should do nothing
-child.exec(nodejs + ' -e ""', function (status, stdout, stderr) {
+child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
   assert.equal(stdout, '');
   assert.equal(stderr, '');
 });

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -40,11 +40,11 @@ child.exec(nodejs + ' --eval "console.error(42)"',
         assert.equal(stderr, '');
       });
 
-  child.exec(cmd + "'[]'",
+  child.exec(cmd + "'[]'", common.mustCall(
       function(err, stdout, stderr) {
         assert.equal(stdout, '[]\n');
         assert.equal(stderr, '');
-      });
+      }));
 });
 
 // assert that module loading works

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -11,6 +11,7 @@ const child = require('child_process');
 const path = require('path');
 const nodejs = '"' + process.execPath + '"';
 
+
 // replace \ by / because windows uses backslashes in paths, but they're still
 // interpreted as the escape character when put between quotes.
 var filename = __filename.replace(/\\/g, '/');


### PR DESCRIPTION
Fix for Windows Segfault with missing arguments.

Platform: Windows
Arch: x64
Compiler: VC2015

When specifying a parameter that requires an additional argument on the
command line, node would segfault.  This appears to be specific to
Windows, adjusted command line argument parsing to hold a nullptr
terminal.

Take two of the fix, based on feedback from @addaleax 