### PR TITLE
child_process: allow buffer encoding in spawnSync

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -438,7 +438,7 @@ function spawnSync(/*file, args, options*/) {
 
   var result = spawn_sync.spawn(options);
 
-  if (result.output && options.encoding) {
+  if (result.output && options.encoding && options.encoding !== 'buffer') {
     for (i = 0; i < result.output.length; i++) {
       if (!result.output[i])
         continue;

--- a/test/common.js
+++ b/test/common.js
@@ -241,6 +241,17 @@ exports.spawnPwd = function(options) {
   }
 };
 
+
+exports.spawnSyncPwd = function(options) {
+  const spawnSync = require('child_process').spawnSync;
+
+  if (exports.isWindows) {
+    return spawnSync('cmd.exe', ['/c', 'cd'], options);
+  } else {
+    return spawnSync('pwd', [], options);
+  }
+};
+
 exports.platformTimeout = function(ms) {
   if (process.config.target_defaults.default_configuration === 'Debug')
     ms = 2 * ms;

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -33,3 +33,17 @@ assert.deepStrictEqual(ret_err.spawnargs, ['bar']);
 
   assert.strictEqual(response.stdout.toString().trim(), cwd);
 })();
+
+{
+  // Test the encoding option
+  const noEncoding = common.spawnSyncPwd();
+  const bufferEncoding = common.spawnSyncPwd({encoding: 'buffer'});
+  const utf8Encoding = common.spawnSyncPwd({encoding: 'utf8'});
+
+  assert.deepStrictEqual(noEncoding.output, bufferEncoding.output);
+  assert.deepStrictEqual([
+    null,
+    noEncoding.stdout.toString(),
+    noEncoding.stderr.toString()
+  ], utf8Encoding.output);
+}

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -18,21 +18,13 @@ assert.strictEqual(ret_err.syscall, 'spawnSync command_does_not_exist');
 assert.strictEqual(ret_err.path, 'command_does_not_exist');
 assert.deepStrictEqual(ret_err.spawnargs, ['bar']);
 
-// Verify that the cwd option works - GH #7824
-(function() {
-  var response;
-  var cwd;
-
-  if (common.isWindows) {
-    cwd = 'c:\\';
-    response = spawnSync('cmd.exe', ['/c', 'cd'], {cwd: cwd});
-  } else {
-    cwd = '/';
-    response = spawnSync('pwd', [], {cwd: cwd});
-  }
+{
+  // Test the cwd option
+  const cwd = common.isWindows ? 'c:\\' : '/';
+  const response = common.spawnSyncPwd({cwd});
 
   assert.strictEqual(response.stdout.toString().trim(), cwd);
-})();
+}
 
 {
   // Test the encoding option


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
child_process

##### Description of change

When the `'buffer'` encoding is passed to `spawnSync()`, an exception is thrown in `Buffer`'s `toString()` method because `'buffer'` is not a valid encoding there. This commit special cases the `'buffer'` encoding.

Fixes: #6930