### PR TITLE
doc: fix broken references

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1724,7 +1724,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`hmac.update()`]: #crypto_hmac_update_data_input_encoding
 [`sign.sign()`]: #crypto_sign_sign_private_key_output_format
 [`sign.update()`]: #crypto_sign_update_data_input_encoding
-[`tls.createSecureContext()`]: tls.html#tls_tls_createsecurecontext_details
+[`tls.createSecureContext()`]: tls.html#tls_tls_createsecurecontext_options
 [`verify.update()`]: #crypto_verifier_update_data_input_encoding
 [`verify.verify()`]: #crypto_verifier_verify_object_signature_signature_format
 [Caveats]: #crypto_support_for_weak_or_compromised_algorithms

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -731,7 +731,7 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`connect()`]: #net_socket_connect_options_connectlistener
 [`destroy()`]: #net_socket_destroy
 [`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
-[`dns.lookup()` hints]: #dns_supported_getaddrinfo_flags
+[`dns.lookup()` hints]: dns.html#dns_supported_getaddrinfo_flags
 [`end()`]: #net_socket_end_data_encoding
 [`EventEmitter`]: events.html#events_class_eventemitter
 [`net.Socket`]: #net_class_net_socket

--- a/doc/topics/domain-postmortem.md
+++ b/doc/topics/domain-postmortem.md
@@ -153,7 +153,7 @@ handle. More on this in _Resource Cleanup on Exception_.
 
 ### Resource Cleanup on Exception
 
-The script [`domain-resource-cleanup.js`](domain-resource-cleanup.js)
+The script [`domain-resource-cleanup-example.js`][]
 contains a more complex example of properly cleaning up in a small resource
 dependency tree in the case that an exception occurs in a given connection or
 any of its dependencies. Breaking down the script into its basic operations:
@@ -297,3 +297,5 @@ this writing there is ongoing work building out the `AsyncWrap` API and a
 proposal for Zones being prepared for the TC39. At such time there is suitable
 functionality to replace domains it will undergo the full deprecation cycle and
 eventually be removed from core.
+
+[domain-resource-cleanup-example.js]: ./domain-resource-cleanup-example.js

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -24,7 +24,7 @@ const typeMap = {
   'cluster.Worker': 'cluster.html#cluster_class_worker',
   'dgram.Socket': 'dgram.html#dgram_class_dgram_socket',
   'net.Socket': 'net.html#net_class_net_socket',
-  'EventEmitter': 'events.html#events_class_events_eventemitter',
+  'EventEmitter': 'events.html#events_class_eventemitter',
   'Timer': 'timers.html#timers_timers'
 };
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

Fix minor broken references in crypto.md, net.md and domains.md (which uses `EventEmitter` as a type, of which the anchor in `events.md` has changed).