### PR TITLE
tools: make sure doctool anchors respect @include

### DIFF
--- a/test/fixtures/doc_inc_1.md
+++ b/test/fixtures/doc_inc_1.md
@@ -1,0 +1,3 @@
+Look [here][]!
+
+[here]: doc_inc_2.html#doc_inc_2_foobar

--- a/test/fixtures/doc_inc_2.md
+++ b/test/fixtures/doc_inc_2.md
@@ -1,0 +1,3 @@
+# foobar
+
+I exist and am being linked to.

--- a/test/fixtures/doc_with_includes.md
+++ b/test/fixtures/doc_with_includes.md
@@ -1,0 +1,2 @@
+@include doc_inc_1
+@include doc_inc_2.md

--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -48,7 +48,11 @@ function processIncludes(inputFile, input, cb) {
         if (errState) return;
         if (er) return cb(errState = er);
         incCount--;
-        includeData[fname] = inc;
+
+        // Add comments to let the HTML generator know how the anchors for
+        // headings should look like.
+        includeData[fname] = `<!-- [start-include:${fname}] -->\n` +
+                             inc + `\n<!-- [end-include:${fname}] -->\n`;
         input = input.split(include + '\n').join(includeData[fname] + '\n');
         if (incCount === 0) {
           return cb(null, input);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doctool

##### Description of change

Previously, output files which were created using `@include` (notably, the single-page all.html) had basically broken internal links all over the place because references like `errors.html#errors_class_error` are being used, yet `id` attributes were generated that looked like
`all_class_error`.

This PR adds generation of comments from the `@include` preprocessor that indicate from which file the current markdown bits come and lets the HTML output generation take advantage of that so that more appropriate `id` attributes can be generated.