### PR TITLE
src: add include guards to internal headers

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -706,6 +706,7 @@
         'GTEST_DONT_DEFINE_ASSERT_LE=1',
         'GTEST_DONT_DEFINE_ASSERT_LT=1',
         'GTEST_DONT_DEFINE_ASSERT_NE=1',
+        'NODE_WANT_INTERNALS=1',
       ],
       'sources': [
         'test/cctest/util.cc',

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_ASYNC_WRAP_INL_H_
 #define SRC_ASYNC_WRAP_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "base-object.h"
 #include "base-object-inl.h"
@@ -119,5 +121,7 @@ inline v8::Local<v8::Value> AsyncWrap::MakeCallback(
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_ASYNC_WRAP_INL_H_

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_ASYNC_WRAP_H_
 #define SRC_ASYNC_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "base-object.h"
 #include "v8.h"
 
@@ -86,5 +88,6 @@ void LoadAsyncWrapperInfo(Environment* env);
 
 }  // namespace node
 
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_ASYNC_WRAP_H_

--- a/src/base-object-inl.h
+++ b/src/base-object-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_BASE_OBJECT_INL_H_
 #define SRC_BASE_OBJECT_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "base-object.h"
 #include "env.h"
 #include "env-inl.h"
@@ -67,5 +69,7 @@ inline void BaseObject::ClearWeak() {
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_BASE_OBJECT_INL_H_

--- a/src/base-object.h
+++ b/src/base-object.h
@@ -1,6 +1,8 @@
 #ifndef SRC_BASE_OBJECT_H_
 #define SRC_BASE_OBJECT_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "v8.h"
 
 namespace node {
@@ -47,5 +49,7 @@ class BaseObject {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_BASE_OBJECT_H_

--- a/src/debug-agent.h
+++ b/src/debug-agent.h
@@ -22,6 +22,8 @@
 #ifndef SRC_DEBUG_AGENT_H_
 #define SRC_DEBUG_AGENT_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "util.h"
 #include "util-inl.h"
 #include "uv.h"
@@ -131,5 +133,7 @@ class Agent {
 
 }  // namespace debugger
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_DEBUG_AGENT_H_

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_ENV_INL_H_
 #define SRC_ENV_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "env.h"
 #include "node.h"
 #include "util.h"
@@ -575,5 +577,7 @@ inline v8::Local<v8::Object> Environment::NewInternalFieldObject() {
 #undef PER_ISOLATE_STRING_PROPERTIES
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_ENV_INL_H_

--- a/src/env.h
+++ b/src/env.h
@@ -1,6 +1,8 @@
 #ifndef SRC_ENV_H_
 #define SRC_ENV_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "ares.h"
 #include "debug-agent.h"
 #include "handle_wrap.h"
@@ -646,5 +648,7 @@ class Environment {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_ENV_H_

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_HANDLE_WRAP_H_
 #define SRC_HANDLE_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "util.h"
 #include "uv.h"
@@ -69,5 +71,6 @@ class HandleWrap : public AsyncWrap {
 
 }  // namespace node
 
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_HANDLE_WRAP_H_

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -1,6 +1,8 @@
 #ifndef SRC_JS_STREAM_H_
 #define SRC_JS_STREAM_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "env.h"
 #include "stream_base.h"
@@ -47,5 +49,7 @@ class JSStream : public AsyncWrap, public StreamBase {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_JS_STREAM_H_

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CONSTANTS_H_
 #define SRC_NODE_CONSTANTS_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "v8.h"
 
@@ -36,5 +38,7 @@ extern const char* default_cipher_list;
 
 void DefineConstants(v8::Isolate* isolate, v8::Local<v8::Object> target);
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CONSTANTS_H_

--- a/src/node_counters.h
+++ b/src/node_counters.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_COUNTERS_H_
 #define SRC_NODE_COUNTERS_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 
 #ifdef HAVE_PERFCTR
@@ -30,5 +32,7 @@ void InitPerfCounters(Environment* env, v8::Local<v8::Object> target);
 void TermPerfCounters(v8::Local<v8::Object> target);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_COUNTERS_H_

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CRYPTO_H_
 #define SRC_NODE_CRYPTO_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "node_crypto_clienthello.h"  // ClientHelloParser
 #include "node_crypto_clienthello-inl.h"
@@ -741,5 +743,7 @@ void InitCrypto(v8::Local<v8::Object> target);
 
 }  // namespace crypto
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CRYPTO_H_

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CRYPTO_BIO_H_
 #define SRC_NODE_CRYPTO_BIO_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "openssl/bio.h"
 #include "env.h"
 #include "env-inl.h"
@@ -133,5 +135,7 @@ class NodeBIO {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CRYPTO_BIO_H_

--- a/src/node_crypto_clienthello-inl.h
+++ b/src/node_crypto_clienthello-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CRYPTO_CLIENTHELLO_INL_H_
 #define SRC_NODE_CRYPTO_CLIENTHELLO_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "util.h"
 #include "util-inl.h"
 
@@ -52,5 +54,7 @@ inline bool ClientHelloParser::IsPaused() const {
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CRYPTO_CLIENTHELLO_INL_H_

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CRYPTO_CLIENTHELLO_H_
 #define SRC_NODE_CRYPTO_CLIENTHELLO_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 
 #include <stddef.h>  // size_t
@@ -111,5 +113,7 @@ class ClientHelloParser {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CRYPTO_CLIENTHELLO_H_

--- a/src/node_crypto_groups.h
+++ b/src/node_crypto_groups.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_CRYPTO_GROUPS_H_
 #define SRC_NODE_CRYPTO_GROUPS_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 /*
     These modular groups were literally taken from:
        * RFC 2412 (groups 1 and 2)
@@ -387,5 +389,7 @@ static const modp_group modp_groups[] = {
   { "modp18", V(group_modp18), sizeof(group_modp18), V(two_generator), 1 }
 #undef V
 };
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CRYPTO_GROUPS_H_

--- a/src/node_dtrace.h
+++ b/src/node_dtrace.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_DTRACE_H_
 #define SRC_NODE_DTRACE_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "v8.h"
 #include "env.h"
@@ -57,5 +59,7 @@ namespace node {
 void InitDTrace(Environment* env, v8::Local<v8::Object> target);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_DTRACE_H_

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_FILE_H_
 #define SRC_NODE_FILE_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "v8.h"
 
@@ -9,5 +11,7 @@ namespace node {
 void InitFs(v8::Local<v8::Object> target);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_FILE_H_

--- a/src/node_http_parser.h
+++ b/src/node_http_parser.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_HTTP_PARSER_H_
 #define SRC_NODE_HTTP_PARSER_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "v8.h"
 
 #include "http_parser.h"
@@ -10,5 +12,7 @@ namespace node {
 void InitHttpParser(v8::Local<v8::Object> target);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_HTTP_PARSER_H_

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_I18N_H_
 #define SRC_NODE_I18N_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
@@ -17,5 +19,7 @@ bool InitializeICUDirectory(const char* icu_data_path);
 }  // namespace node
 
 #endif  // NODE_HAVE_I18N_SUPPORT
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_I18N_H_

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_INTERNALS_H_
 #define SRC_NODE_INTERNALS_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "util.h"
 #include "util-inl.h"
@@ -312,5 +314,7 @@ v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
 }  // namespace Buffer
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_INTERNALS_H_

--- a/src/node_javascript.h
+++ b/src/node_javascript.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_JAVASCRIPT_H_
 #define SRC_NODE_JAVASCRIPT_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "v8.h"
 #include "env.h"
 
@@ -10,5 +12,7 @@ void DefineJavaScript(Environment* env, v8::Local<v8::Object> target);
 v8::Local<v8::String> MainSource(Environment* env);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_JAVASCRIPT_H_

--- a/src/node_lttng.h
+++ b/src/node_lttng.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_LTTNG_H_
 #define SRC_NODE_LTTNG_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "v8.h"
 #include "env.h"
@@ -36,5 +38,7 @@ namespace node {
 void InitLTTNG(Environment* env, v8::Local<v8::Object> target);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_LTTNG_H_

--- a/src/node_lttng_provider.h
+++ b/src/node_lttng_provider.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_LTTNG_PROVIDER_H_
 #define SRC_NODE_LTTNG_PROVIDER_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #define TRACEPOINT_CREATE_PROBES
 #define TRACEPOINT_DEFINE
 #include "node_lttng_tp.h"
@@ -98,5 +100,7 @@ bool NODE_NET_SERVER_CONNECTION_ENABLED() { return true; }
 bool NODE_NET_STREAM_END_ENABLED() { return true; }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_LTTNG_PROVIDER_H_

--- a/src/node_lttng_tp.h
+++ b/src/node_lttng_tp.h
@@ -1,3 +1,5 @@
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #undef TRACEPOINT_PROVIDER
 #define TRACEPOINT_PROVIDER node
 
@@ -128,3 +130,5 @@ TRACEPOINT_EVENT(
 #endif /* __NODE_LTTNG_TP_H */
 
 #include <lttng/tracepoint-event.h>
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_revert.h
+++ b/src/node_revert.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_REVERT_H_
 #define SRC_NODE_REVERT_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 
 /**
@@ -40,5 +42,7 @@ bool IsReverted(const unsigned int cve);
 bool IsReverted(const char * cve);
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_REVERT_H_

--- a/src/node_root_certs.h
+++ b/src/node_root_certs.h
@@ -1,3 +1,4 @@
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 /* GlobalSign Root CA */
 "-----BEGIN CERTIFICATE-----\n"
@@ -3881,3 +3882,5 @@
 "1T2wdKyUpOgOPQB0TKGXa/kNUTyh2Tv0Daupn75OcsqF1NnstTJFGG+rrQIwfcf3aWMvoeGY\n"
 "7xMQ0Xk/0f7qO3/eVvSQsRUR2LIiFdAvwyYua/GRspBl9JrmkO5K\n"
 "-----END CERTIFICATE-----\n",
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_STAT_WATCHER_H_
 #define SRC_NODE_STAT_WATCHER_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "async-wrap.h"
 #include "env.h"
@@ -35,4 +37,7 @@ class StatWatcher : public AsyncWrap {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #endif  // SRC_NODE_STAT_WATCHER_H_

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_WATCHDOG_H_
 #define SRC_NODE_WATCHDOG_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "v8.h"
 #include "uv.h"
 
@@ -31,5 +33,7 @@ class Watchdog {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_WATCHDOG_H_

--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_WIN32_ETW_PROVIDER_INL_H_
 #define SRC_NODE_WIN32_ETW_PROVIDER_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node_win32_etw_provider.h"
 #include "node_etw_provider.h"
 
@@ -264,5 +266,7 @@ bool NODE_NET_STREAM_END_ENABLED() { return events_enabled > 0; }
 bool NODE_V8SYMBOL_ENABLED() { return events_enabled > 0; }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_WIN32_ETW_PROVIDER_INL_H_

--- a/src/node_win32_etw_provider.h
+++ b/src/node_win32_etw_provider.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_WIN32_ETW_PROVIDER_H_
 #define SRC_NODE_WIN32_ETW_PROVIDER_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node_dtrace.h"
 #include <evntprov.h>
 
@@ -70,5 +72,7 @@ INLINE bool NODE_NET_STREAM_END_ENABLED();
 INLINE bool NODE_V8SYMBOL_ENABLED();
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_WIN32_ETW_PROVIDER_H_

--- a/src/node_win32_perfctr_provider.h
+++ b/src/node_win32_perfctr_provider.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_WIN32_PERFCTR_PROVIDER_H_
 #define SRC_NODE_WIN32_PERFCTR_PROVIDER_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #if defined(_MSC_VER)
 # define INLINE __forceinline
 #else
@@ -29,5 +31,7 @@ void InitPerfCountersWin32();
 void TermPerfCountersWin32();
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_WIN32_PERFCTR_PROVIDER_H_

--- a/src/node_wrap.h
+++ b/src/node_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_WRAP_H_
 #define SRC_NODE_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "env.h"
 #include "env-inl.h"
 #include "js_stream.h"
@@ -48,5 +50,7 @@ inline uv_stream_t* HandleToStream(Environment* env,
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_WRAP_H_

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_PIPE_WRAP_H_
 #define SRC_PIPE_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "env.h"
 #include "stream_wrap.h"
@@ -44,5 +46,6 @@ class PipeWrap : public StreamWrap {
 
 }  // namespace node
 
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_PIPE_WRAP_H_

--- a/src/req-wrap-inl.h
+++ b/src/req-wrap-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_REQ_WRAP_INL_H_
 #define SRC_REQ_WRAP_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "req-wrap.h"
 #include "async-wrap.h"
 #include "async-wrap-inl.h"
@@ -38,5 +40,7 @@ void ReqWrap<T>::Dispatched() {
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_REQ_WRAP_INL_H_

--- a/src/req-wrap.h
+++ b/src/req-wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_REQ_WRAP_H_
 #define SRC_REQ_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "env.h"
 #include "util.h"
@@ -26,5 +28,7 @@ class ReqWrap : public AsyncWrap {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_REQ_WRAP_H_

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -1,6 +1,8 @@
 #ifndef SRC_SPAWN_SYNC_H_
 #define SRC_SPAWN_SYNC_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "node_buffer.h"
 
@@ -221,5 +223,7 @@ class SyncProcessRunner {
   Environment* env_;
 };
 }
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_SPAWN_SYNC_H_

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_STREAM_BASE_INL_H_
 #define SRC_STREAM_BASE_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "stream_base.h"
 
 #include "node.h"
@@ -161,5 +163,7 @@ char* WriteWrap::Extra(size_t offset) {
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_STREAM_BASE_INL_H_

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -1,6 +1,8 @@
 #ifndef SRC_STREAM_BASE_H_
 #define SRC_STREAM_BASE_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "env.h"
 #include "async-wrap.h"
 #include "req-wrap.h"
@@ -269,5 +271,7 @@ class StreamBase : public StreamResource {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_STREAM_BASE_H_

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_STREAM_WRAP_H_
 #define SRC_STREAM_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "stream_base.h"
 
 #include "env.h"
@@ -103,5 +105,6 @@ class StreamWrap : public HandleWrap, public StreamBase {
 
 }  // namespace node
 
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_STREAM_WRAP_H_

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -1,6 +1,8 @@
 #ifndef SRC_STRING_BYTES_H_
 #define SRC_STRING_BYTES_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 // Decodes a v8::Local<v8::String> or Buffer to a raw char*
 
 #include "v8.h"
@@ -107,5 +109,7 @@ class StringBytes {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_STRING_BYTES_H_

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -5,6 +5,8 @@
 #ifndef SRC_STRING_SEARCH_H_
 #define SRC_STRING_SEARCH_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include <string.h>
 
@@ -673,5 +675,7 @@ size_t SearchString(const Char* haystack,
   return is_forward ? pos : (haystack_length - needle_length - pos);
 }
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_STRING_SEARCH_H_

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_TCP_WRAP_H_
 #define SRC_TCP_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "env.h"
 #include "stream_wrap.h"
@@ -52,5 +54,6 @@ class TCPWrap : public StreamWrap {
 
 }  // namespace node
 
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_TCP_WRAP_H_

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_TLS_WRAP_H_
 #define SRC_TLS_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "node.h"
 #include "node_crypto.h"  // SSLWrap
 
@@ -164,5 +166,7 @@ class TLSWrap : public AsyncWrap,
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_TLS_WRAP_H_

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_TTY_WRAP_H_
 #define SRC_TTY_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "env.h"
 #include "handle_wrap.h"
 #include "stream_wrap.h"
@@ -33,5 +35,7 @@ class TTYWrap : public StreamWrap {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_TTY_WRAP_H_

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -1,6 +1,8 @@
 #ifndef SRC_UDP_WRAP_H_
 #define SRC_UDP_WRAP_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "async-wrap.h"
 #include "env.h"
 #include "handle_wrap.h"
@@ -69,5 +71,7 @@ class UDPWrap: public HandleWrap {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_UDP_WRAP_H_

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_UTIL_INL_H_
 #define SRC_UTIL_INL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "util.h"
 
 namespace node {
@@ -218,5 +220,7 @@ bool StringEqualNoCase(const char* a, const char* b) {
 }
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_UTIL_INL_H_

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,8 @@
 #ifndef SRC_UTIL_H_
 #define SRC_UTIL_H_
 
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
 #include "v8.h"
 
 #include <assert.h>
@@ -303,5 +305,7 @@ class BufferValue : public MaybeStackBuffer<char> {
 };
 
 }  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_UTIL_H_

--- a/test/addons/buffer-free-callback/binding.gyp
+++ b/test/addons/buffer-free-callback/binding.gyp
@@ -2,7 +2,10 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'defines': [
+        'NODE_WANT_INTERNALS=1',
+        'V8_DEPRECATION_WARNINGS=1',
+      ],
       'sources': [ 'binding.cc' ]
     }
   ]

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -2,7 +2,10 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'defines': [
+        'NODE_WANT_INTERNALS=1',
+        'V8_DEPRECATION_WARNINGS=1',
+      ],
       'sources': [ 'binding.cc' ]
     }
   ]

--- a/test/addons/make-callback/binding.gyp
+++ b/test/addons/make-callback/binding.gyp
@@ -2,7 +2,10 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'defines': [
+        'NODE_WANT_INTERNALS=1',
+        'V8_DEPRECATION_WARNINGS=1',
+      ],
       'sources': [ 'binding.cc' ]
     }
   ]

--- a/test/addons/null-buffer-neuter/binding.gyp
+++ b/test/addons/null-buffer-neuter/binding.gyp
@@ -2,7 +2,10 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'defines': [
+        'NODE_WANT_INTERNALS=1',
+        'V8_DEPRECATION_WARNINGS=1',
+      ],
       'sources': [ 'binding.cc' ]
     }
   ]


### PR DESCRIPTION
For consistency with the newly added src/base64.h header, check that
NODE_WANT_INTERNALS is defined and set in internal headers.

Refs: #6910
CI: https://ci.nodejs.org/job/node-test-pull-request/2758/

R=@indutny @trevnorris