### PR TITLE
benchmark: use apache bench instead of wrk

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -5,14 +5,11 @@ Node.js APIs.
 
 ## Prerequisites
 
-Most of the http benchmarks require [`wrk`][wrk] and [`ab`][ab] (ApacheBench) being installed.
-These may be available through your preferred package manager.
+Most of the http benchmarks require [`ab`][ab] (ApacheBench) being installed.
+It may be available through your preferred package manager.
 
-If they are not available:
-- `wrk` may easily be built [from source][wrk] via `make`.
-- `ab` is sometimes bundled in a package called `apache2-utils`.
+If it is not available, `ab` is sometimes bundled in a package called `apache2-utils`.
 
-[wrk]: https://github.com/wg/wrk
 [ab]: http://httpd.apache.org/docs/2.2/programs/ab.html
 
 ## How to run tests

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -44,10 +44,10 @@ if (module === require.main) {
   runBenchmarks();
 }
 
-function hasWrk() {
-  var result = child_process.spawnSync('wrk', ['-h']);
+function hasApacheBench() {
+  var result = child_process.spawnSync('ab', ['-h']);
   if (result.error && result.error.code === 'ENOENT') {
-    console.error('Couldn\'t locate `wrk` which is needed for running ' +
+    console.error('Couldn\'t locate `ab` which is needed for running ' +
       'benchmarks. Check benchmark/README.md for further instructions.');
     process.exit(-1);
   }
@@ -99,15 +99,15 @@ function Benchmark(fn, options) {
 
 // benchmark an http server.
 Benchmark.prototype.http = function(p, args, cb) {
-  hasWrk();
+  hasApacheBench();
   var self = this;
-  var regexp = /Requests\/sec:[ \t]+([0-9\.]+)/;
+  var regexp = /Requests per second:[ \t]+([0-9\.]+) \[#\/sec\] \(mean\)/;
   var url = 'http://127.0.0.1:' + exports.PORT + p;
 
   args = args.concat(url);
 
   var out = '';
-  var child = child_process.spawn('wrk', args);
+  var child = child_process.spawn('ab', args);
 
   child.stdout.setEncoding('utf8');
 
@@ -120,14 +120,14 @@ Benchmark.prototype.http = function(p, args, cb) {
       cb(code);
 
     if (code) {
-      console.error('wrk failed with ' + code);
+      console.error('ab failed with ' + code);
       process.exit(code);
     }
     var match = out.match(regexp);
     var qps = match && +match[1];
     if (!qps) {
       console.error('%j', out);
-      console.error('wrk produced strange output');
+      console.error('ab produced strange output');
       process.exit(1);
     }
     self.report(+qps);

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -20,7 +20,7 @@ function main(conf) {
   const http = require('http');
   var chunk = Buffer.alloc(conf.size, '8');
 
-  var args = ['-d', '10s', '-t', 8, '-c', conf.c];
+  var args = ['-t', '10s', '-c', conf.c, '-k'];
 
   var server = http.createServer(function(req, res) {
     function send(left) {

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -27,7 +27,7 @@ function main(conf) {
 
     setTimeout(function() {
       var path = '/' + conf.type + '/' + conf.length;
-      var args = ['-d', '10s', '-t', 8, '-c', conf.c];
+      var args = ['-t', '10s', '-c', conf.c, '-k'];
 
       bench.http(path, args, function() {
         w1.destroy();

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -43,7 +43,7 @@ function main(conf) {
   }
 
   var method = conf.method === 'write' ? write : end;
-  var args = ['-d', '10s', '-t', 8, '-c', conf.c];
+  var args = ['-t', '10s', '-c', conf.c, '-k'];
 
   var server = http.createServer(function(req, res) {
     method(res);

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -15,7 +15,7 @@ function main(conf) {
   var server = require('../http_simple.js');
   setTimeout(function() {
     var path = '/' + conf.type + '/' + conf.length + '/' + conf.chunks;
-    var args = ['-d', '10s', '-t', 8, '-c', conf.c];
+    var args = ['-t', '10s', '-c', conf.c, '-k'];
 
     bench.http(path, args, function() {
       server.close();


### PR DESCRIPTION
##### Checklist
- [X] documentation is changed or added
- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)

benchmarks

##### Description of change

Switches all HTTP benchmarks to Apache Benchmark instead of `wrk`. This allows for running benchmarks under Windows.

Apache Bench gives different results than wrk, but they are still consistent. For different parameters for the same benchmark parameters both tools provide similar relative performance.