### PR TITLE
doc: buffers are not sent over IPC with a socket

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -856,7 +856,8 @@ Applications should avoid using such messages or listening for
 The optional `sendHandle` argument that may be passed to `child.send()` is for
 passing a TCP server or socket object to the child process. The child will
 receive the object as the second argument passed to the callback function
-registered on the [`process.on('message')`][] event.
+registered on the [`process.on('message')`][] event. Any data that is received
+and buffered in the socket will not be sent to the child.
 
 The `options` argument, if present, is an object used to parameterize the
 sending of certain types of handles. `options` supports the following


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
doc/child_process

##### Description of change
If a socket is sent to a child, any data that is buffered in the
socket will not be sent to the child. The child will only receive
data from the socket that is sent after the child has the socket.