### PR TITLE
doc: fix formatting issues for child_process docs

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -125,7 +125,7 @@ exec('my.bat', (err, stdout, stderr) => {
      command line parsing should be compatible with `cmd.exe`.)
   * `timeout` {Number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
-    stdout or stderr - if exceeded child process is killed (Default: `200\*1024`)
+    stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
   * `killSignal` {String} (Default: `'SIGTERM'`)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
@@ -195,7 +195,7 @@ replace the existing process and uses a shell to execute the command.*
   * `encoding` {String} (Default: `'utf8'`)
   * `timeout` {Number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
-    stdout or stderr - if exceeded child process is killed (Default: `200\*1024`)
+    stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
   * `killSignal` {String} (Default: `'SIGTERM'`)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)


### PR DESCRIPTION
doc: Fix formatting for child_process docs

Ref: https://github.com/nodejs/node/issues/6911

##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
doc, child_process

##### Description of change
A couple of backspaces had been placed within backticks inside the `exec()` and `execFile()` sections. These were not needed due to backtick formatting and have been removed.

The `maxBuffer` links are affecting readability as they look different than the other bulleted items around them. This styling issue is a WIP.
