### PR TITLE
doc: Fix formatting for child_process docs.

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -195,7 +195,7 @@ replace the existing process and uses a shell to execute the command.*
   * `encoding` {String} (Default: `'utf8'`)
   * `timeout` {Number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
-    stdout or stderr - if exceeded child process is killed (Default: `200\*1024`)
+    stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
   * `killSignal` {String} (Default: `'SIGTERM'`)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -125,7 +125,7 @@ exec('my.bat', (err, stdout, stderr) => {
      command line parsing should be compatible with `cmd.exe`.)
   * `timeout` {Number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
-    stdout or stderr - if exceeded child process is killed (Default: `200\*1024`)
+    stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
   * `killSignal` {String} (Default: `'SIGTERM'`)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -348,8 +348,12 @@ p tt, p code, li code {
 
 a code {
   color: inherit;
-  background: inherit;
-  padding: 0;
+  background:#f2f2f2;
+  padding: .1em .3em;
+}
+
+a:hover code {
+  background: #43853d;
 }
 
 .type {


### PR DESCRIPTION
##### Checklist

- [X] documentation is changed or added
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)
doc


##### Description of change

Ref: https://github.com/nodejs/node/issues/6911

Remove unnecessary backslash in `exec()` option `maxBuffer`.
Adjust CSS so that links formatted as `code` display a grey background.

Note that the CSS changes do affect DOM elements outside of those explicitly listed, API documents outside of child_process.html. For example, in this screen capture, you can see that TOC items with `code` formatting also get the grey background treatment.

<img width="337" alt="screen shot 2016-05-24 at 10 54 24 am" src="https://cloud.githubusercontent.com/assets/15952/15508753/b7e0af24-219e-11e6-997e-80267af393b6.png">
