### PR TITLE
Release zlib callbacks and buffer after processing chunks

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -574,11 +574,14 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
   req.callback = callback;
 
   function callback(availInAfter, availOutAfter) {
+    // When the callback is used in an async write, the callback's
+    // context is the `req` object that was created. The req object
+    // is === this._handle, and that's why it's important to null
+    // out the values after they are done being used. `this._handle`
+    // can stay in memory longer than the callback and buffer are needed.
     if (this) {
-      // Don't hold onto the buffer and the callback
-      // after they have been used.
-      delete this.buffer;
-      delete this.callback;
+      this.buffer = null;
+      this.callback = null;
     }
 
     if (self._hadError)

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -574,6 +574,13 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
   req.callback = callback;
 
   function callback(availInAfter, availOutAfter) {
+    if (this) {
+      // Don't hold onto the buffer and the callback
+      // after they have been used.
+      delete this.buffer;
+      delete this.callback;
+    }
+
     if (self._hadError)
       return;
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
zlib

##### Description of change
When a long lived zlib compressor is created, using zlib.createDeflateRaw() for example, the compressor will hold onto some functions and buffers longer than it needs to.  If there are lots of zlib compressors created, the total allocated space can add up to consume a non-trivial amount of memory.

One example of a real project that can experience this issue is the WS library with per-message deflating: https://github.com/websockets/ws/blob/master/lib/PerMessageDeflate.js .  A common user of that is socket.io, which will create possibly create many web sockets.  If a socket.io server has lots of web sockets connected with zlib compression, the leaked objects can take memory that could be freed.  When New Relic is being used, the amount of memory is even more obvious, because the held closures also keep some New Relic transaction data alive as well.

I know that test cases are desired for changes, but I wasn’t sure about the best way to automate the test for this bug.  There are some simple tests that could be added, like checking for certain attributes being null after certain code execution, but I wasn’t sure if that was useful enough.  I’m open to suggestions.  In place of a unit test, I created a standalone example that can demonstrate the problem here:  https://gist.github.com/mdlavin/334338eb801bd3243679db89c219c7ac

Before the fix, the output looks like this:

    Closure changes [ { what: 'Closure',
        size_bytes: 648,
        size: '648 bytes',
        '+': 11,
        '-': 2 } ]
    Uint8Array changes [ { what: 'Uint8Array',
        size_bytes: 240,
        size: '240 bytes',
        '+': 3,
        '-': 0 } ]

After the fix, the number of Closures and Uint8Arrays are reduced by 1 each because the memory can be reclaimed by the GC.

    Closure changes [ { what: 'Closure',
        size_bytes: 576,
        size: '576 bytes',
        '+': 10,
        '-': 2 } ]
    Uint8Array changes [ { what: 'Uint8Array',
        size_bytes: 160,
        size: '160 bytes',
        '+': 2,
        '-': 0 } ]

