### PR TITLE
timers: warn on overflowed timeout duration

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -296,6 +296,9 @@ exports.enroll = function(item, msecs) {
 
   // Ensure that msecs fits into signed int32
   if (msecs > TIMEOUT_MAX) {
+    process.emitWarning(`${msecs} does not fit into a 32-bit signed integer.` +
+                        `\nTimer duration was truncated to ${TIMEOUT_MAX}.`,
+                        'TimeoutOverflowWarning');
     msecs = TIMEOUT_MAX;
   }
 
@@ -316,6 +319,11 @@ exports.setTimeout = function(callback, after) {
 
   after *= 1; // coalesce to number or NaN
 
+  if (after > TIMEOUT_MAX) {
+    process.emitWarning(`${after} does not fit into a 32-bit signed integer.` +
+                        '\nTimeout duration was set to 1.',
+                        'TimeoutOverflowWarning');
+  }
   if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     after = 1; // schedule on next tick, follows browser behaviour
   }
@@ -376,6 +384,11 @@ exports.setInterval = function(callback, repeat) {
 
   repeat *= 1; // coalesce to number or NaN
 
+  if (repeat > TIMEOUT_MAX) {
+    process.emitWarning(`${repeat} does not fit into a 32-bit signed integer.` +
+                        '\nInterval duration was set to 1.',
+                        'TimeoutOverflowWarning');
+  }
   if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour
   }

--- a/test/parallel/test-timers-max-duration-warning.js
+++ b/test/parallel/test-timers-max-duration-warning.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const timers = require('timers');
+
+const OVERFLOW = Math.pow(2, 31); // TIMEOUT_MAX is 2^31-1
+
+function TimerNotCanceled() {
+  common.fail('Timer should be canceled');
+}
+
+process.on('warning', common.mustCall((warning) => {
+  const lines = warning.message.split('\n');
+
+  assert.strictEqual(warning.name, 'TimeoutOverflowWarning');
+  assert.strictEqual(lines[0], `${OVERFLOW} does not fit into a 32-bit signed` +
+                               ' integer.');
+  assert.strictEqual(lines.length, 2);
+}, 3));
+
+
+{
+  const timeout = setTimeout(TimerNotCanceled, OVERFLOW);
+  clearTimeout(timeout);
+}
+
+{
+  const interval = setInterval(TimerNotCanceled, OVERFLOW);
+  clearInterval(interval);
+}
+
+{
+  const timer = {
+    _onTimeout: TimerNotCanceled
+  };
+  timers.enroll(timer, OVERFLOW);
+  timers.active(timer);
+  timers.unenroll(timer);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

timers
##### Description of change

<!-- provide a description of the change below this comment -->

Documentation is in @jasnell's PR at https://github.com/nodejs/node/pull/6937

I realized there wasn't any clear indicator when you hit the overflow other than possibly unexpected behavior, and I think a warning may be appropriate.
