### PR TITLE
benchmark: fix child-process-read on Windows

### DIFF
--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -1,0 +1,37 @@
+'use strict';
+if (process.argv[2] === 'child')
+{
+  var len = +process.argv[3];
+  var msg = '"' + Array(len).join('.') + '"';
+  while(true) {
+    process.send(msg);
+  }
+} else {
+  var common = require('../common.js');
+  var bench = common.createBenchmark(main, {
+    len: [64, 256, 1024, 4096, 32768],
+    dur: [5]
+  });
+  var spawn = require('child_process').spawn;
+  function main(conf) {
+    bench.start();
+
+    var dur = +conf.dur;
+    var len = +conf.len;
+
+    var options = { 'stdio': ['ignore', 'ignore', 'ignore', 'ipc'] };
+    var child = spawn(process.argv[0],
+      [process.argv[1], 'child', len], options);
+
+    var bytes = 0;
+    child.on('message', function(msg) {
+      bytes += msg.length;
+    });
+
+    setTimeout(function() {
+      child.kill();
+      var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+      bench.end(gbits);
+    }, dur * 1000);
+  }
+}

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -1,26 +1,26 @@
 'use strict';
 if (process.argv[2] === 'child')
 {
-  var len = +process.argv[3];
-  var msg = '"' + Array(len).join('.') + '"';
-  while(true) {
+  const len = +process.argv[3];
+  const msg = '"' + Array(len).join('.') + '"';
+  while (true) {
     process.send(msg);
   }
 } else {
-  var common = require('../common.js');
-  var bench = common.createBenchmark(main, {
+  const common = require('../common.js');
+  const bench = common.createBenchmark(main, {
     len: [64, 256, 1024, 4096, 32768],
     dur: [5]
   });
-  var spawn = require('child_process').spawn;
+  const spawn = require('child_process').spawn;
   function main(conf) {
     bench.start();
 
-    var dur = +conf.dur;
-    var len = +conf.len;
+    const dur = +conf.dur;
+    const len = +conf.len;
 
-    var options = { 'stdio': ['ignore', 'ignore', 'ignore', 'ipc'] };
-    var child = spawn(process.argv[0],
+    const options = { 'stdio': ['ignore', 'ignore', 'ignore', 'ipc'] };
+    const child = spawn(process.argv[0],
       [process.argv[1], 'child', len], options);
 
     var bytes = 0;
@@ -30,7 +30,7 @@ if (process.argv[2] === 'child')
 
     setTimeout(function() {
       child.kill();
-      var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+      const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
     }, dur * 1000);
   }

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -2,7 +2,7 @@
 if (process.argv[2] === 'child')
 {
   const len = +process.argv[3];
-  const msg = '"' + Array(len).join('.') + '"';
+  const msg = `"${'.'.repeat(len)}"`;
   while (true) {
     process.send(msg);
   }

--- a/benchmark/child_process/child-process-read.js
+++ b/benchmark/child_process/child-process-read.js
@@ -2,13 +2,13 @@
 const common = require('../common.js');
 const os = require('os');
 
-var messagesLenght = [64, 256, 1024, 4096];
+var messagesLength = [64, 256, 1024, 4096];
 // Windows does not support that long arguments
 if (os.platform() !== 'win32')
-  messagesLenght.push(32768);
+  messagesLength.push(32768);
 
 const bench = common.createBenchmark(main, {
-  len: messagesLenght,
+  len: messagesLength,
   dur: [5]
 });
 

--- a/benchmark/child_process/child-process-read.js
+++ b/benchmark/child_process/child-process-read.js
@@ -1,7 +1,14 @@
 'use strict';
 const common = require('../common.js');
+const os = require('os');
+
+var messagesLenght = [64, 256, 1024, 4096];
+// Windows does not support that long arguments
+if (os.platform() !== 'win32')
+  messagesLenght.push(32768);
+
 const bench = common.createBenchmark(main, {
-  len: [64, 256, 1024, 4096, 32768],
+  len: messagesLenght,
   dur: [5]
 });
 
@@ -13,11 +20,11 @@ function main(conf) {
   const len = +conf.len;
 
   const msg = '"' + Array(len).join('.') + '"';
-  const options = {'stdio': ['ignore', 'ipc', 'ignore']};
+  const options = { 'stdio': ['ignore', 'pipe', 'ignore'] };
   const child = spawn('yes', [msg], options);
 
   var bytes = 0;
-  child.on('message', function(msg) {
+  child.stdout.on('data', function(msg) {
     bytes += msg.length;
   });
 


### PR DESCRIPTION
##### Checklist

- [X] the commit message follows commit guidelines

##### Affected core subsystem(s)

benchmark

##### Description of change

Under Windows `ipc` communication requires the other process to format its messages with 'IPC framing protocol'. Otherwise, an assert is triggered in libuv. This commit changes `child-process-read.js` benchmark to use stdout to communicate with parent process. It also adds `child-process-read-ipc.js` to benchmark IPC communication using child node process.