### PR TITLE
repl: add a `noUnderscore` option

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -429,8 +429,6 @@ changes:
     is no longer accessible via `_`.
     * This also means assigning to `_` will not cause warnings.
 
-
-
 The `repl.start()` method creates and starts a `repl.REPLServer` instance.
 
 If `options` is a string, then it specifies the input prompt:
@@ -476,7 +474,8 @@ environment variables:
    history will be persisted if history is available. Must be a positive number.
  - `NODE_REPL_MODE` - May be any of `sloppy`, `strict`, or `magic`. Defaults
    to `sloppy`, which will allow non-strict mode code to be run. `magic` is
-   **deprecated** and treated as an alias of `sloppy`.
+   **deprecated** and treated as an alias of `sloppy`. It is possible to
+   activate `noUnderscore` mode by appending `;noUnderscore` to the mode.
 
 ### Persistent History
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -425,6 +425,11 @@ changes:
   * `breakEvalOnSigint` - Stop evaluating the current piece of code when
     `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
     with a custom `eval` function. Defaults to `false`.
+  * `noUnderscore` - if set to `true`, the result of the repl's last expression
+    is no longer accessible via `_`.
+    * This also means assigning to `_` will not cause warnings.
+
+
 
 The `repl.start()` method creates and starts a `repl.REPLServer` instance.
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -41,14 +41,16 @@ function createRepl(env, opts, cb) {
     opts.useColors = false;
   }
 
-  opts.replMode = {
+  const [mode, noUnderscore] = String(env.NODE_REPL_MODE)
+    .toLowerCase()
+    .trim()
+    .split(';')
+  const validModes = {
     'strict': REPL.REPL_MODE_STRICT,
     'sloppy': REPL.REPL_MODE_SLOPPY
-  }[String(env.NODE_REPL_MODE).toLowerCase().trim()];
-
-  if (opts.replMode === undefined) {
-    opts.replMode = REPL.REPL_MODE_SLOPPY;
-  }
+  };
+  opts.replMode = validModes[(mode in validModes) ? mode : 'sloppy'];
+  opts.noUnderscore = noUnderscore === 'noUnderscore';
 
   const historySize = Number(env.NODE_REPL_HISTORY_SIZE);
   if (!isNaN(historySize) && historySize > 0) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -118,7 +118,12 @@ function REPLServer(prompt,
                           replMode);
   }
 
-  var options, input, output, dom, breakEvalOnSigint;
+  var options,
+    input,
+    output,
+    dom,
+    breakEvalOnSigint,
+    noUnderscore;
   if (prompt !== null && typeof prompt === 'object') {
     // an options object was given
     options = prompt;
@@ -132,6 +137,7 @@ function REPLServer(prompt,
     dom = options.domain;
     replMode = options.replMode;
     breakEvalOnSigint = options.breakEvalOnSigint;
+    noUnderscore = options.noUnderscore;
   } else {
     options = {};
   }
@@ -149,7 +155,7 @@ function REPLServer(prompt,
   self.useGlobal = !!useGlobal;
   self.ignoreUndefined = !!ignoreUndefined;
   self.replMode = replMode || exports.REPL_MODE_SLOPPY;
-  self.underscoreAssigned = false;
+  self.underscoreAssigned = self.noUnderscore = !!noUnderscore;
   self.last = undefined;
   self.breakEvalOnSigint = !!breakEvalOnSigint;
   self.editorMode = false;
@@ -610,7 +616,7 @@ REPLServer.prototype.createContext = function() {
   context.require = require;
 
 
-  this.underscoreAssigned = false;
+  this.underscoreAssigned = this.noUnderscore;
   this.lines = [];
   this.lines.level = [];
 

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -67,7 +67,8 @@ const r2 = repl.start({
   ignoreUndefined: true,
   eval: evaler,
   writer: writer,
-  replMode: repl.REPL_MODE_STRICT
+  replMode: repl.REPL_MODE_STRICT,
+  noUnderscore: true
 });
 assert.strictEqual(r2.input, stream);
 assert.strictEqual(r2.output, stream);
@@ -79,6 +80,7 @@ assert.strictEqual(r2.useGlobal, true);
 assert.strictEqual(r2.ignoreUndefined, true);
 assert.strictEqual(r2.writer, writer);
 assert.strictEqual(r2.replMode, repl.REPL_MODE_STRICT);
+assert.strictEqual(r2.noUnderscore, true);
 
 // test r2 for backwards compact
 assert.strictEqual(r2.rli.input, stream);

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -10,6 +10,7 @@ testStrictMode();
 testResetContext();
 testResetContextGlobal();
 testMagicMode();
+testNoUnderscoreOption();
 
 function testSloppyMode() {
   const r = initRepl(repl.REPL_MODE_SLOPPY);
@@ -110,6 +111,27 @@ function testMagicMode() {
   ]);
 }
 
+function testNoUnderscoreOption() {
+  const r = initRepl(repl.REPL_MODE_MAGIC, true);
+
+  r.write(`_ = 10;     // explicitly set to 10
+          _;           // 10 from user input
+          .clear       // Clearing context...
+          _;           // remains 10
+          x = 20;      // behavior *does not* revert to last eval
+          _;           // expect 10
+          `);
+
+  assertOutput(r.output, [
+    '10',
+    '10',
+    'Clearing context...',
+    '10',
+    '20',
+    '10'
+  ]);
+}
+
 function testResetContext() {
   const r = initRepl(repl.REPL_MODE_SLOPPY);
 
@@ -133,7 +155,7 @@ function testResetContext() {
 }
 
 function testResetContextGlobal() {
-  const r = initRepl(repl.REPL_MODE_STRICT, true);
+  const r = initRepl(repl.REPL_MODE_STRICT, false, true);
 
   r.write(`_ = 10;     // explicitly set to 10
           _;           // 10 from user input
@@ -153,7 +175,7 @@ function testResetContextGlobal() {
   delete global.require;
 }
 
-function initRepl(mode, useGlobal) {
+function initRepl(mode, useGlobal = false, noUnderscore = false) {
   const inputStream = new stream.PassThrough();
   const outputStream = new stream.PassThrough();
   outputStream.accum = '';
@@ -169,7 +191,8 @@ function initRepl(mode, useGlobal) {
     terminal: false,
     prompt: '',
     replMode: mode,
-    useGlobal: useGlobal
+    useGlobal: useGlobal,
+    noUnderscore
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- remove lines that do not apply to you -->
- [X] tests and code linting passes
- [X] a test and/or benchmark is included
- [X] documentation is changed or added
- [X] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

repl
##### Description of change

<!-- provide a description of the change below this comment -->

This option is useful if you never want `_` to contain the previous
operation, but rather be used as a regular variable, thus never emitting warnings.

Refs: https://github.com/nodejs/node/issues/6966

CI: https://ci.nodejs.org/job/node-test-pull-request/2784/

---

The name for the option isn't the best though... any suggestions appreciated!
