### PR TITLE
doc: clarified use of sexual language in the CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,7 +12,7 @@
   all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that some individuals and cultures consider the casual use of
-  profanity offensive and off-putting.
+  profanity and sexualized language offensive and off-putting.
 * Respect that people have differences of opinion and that every
   design or implementation choice carries a trade-off and numerous
   costs. There is seldom a right answer.


### PR DESCRIPTION
Clarifies the code of conduct by adding some wording discouraging the
use of sexualized language.

This PR was prompted by some moderation discussion, and we realized
that there was some ambiguity around this topic in the current CoC