### PR TITLE
doc, tools: refactor html generation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ out/doc/api/%.json: doc/api/%.md
 	[ -x $(NODE) ] && $(NODE) $(gen-json) || node $(gen-json)
 
 # check if ./node is actually set, else use user pre-installed binary
-gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html --template=doc/template.html $< > $@
+gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html --template=doc/template.html $<
 out/doc/api/%.html: doc/api/%.md
 	[ -x $(NODE) ] && $(NODE) $(gen-html) || node $(gen-html)
 

--- a/doc/guides/_toc.md
+++ b/doc/guides/_toc.md
@@ -1,0 +1,11 @@
+* [About these Docs](documentation.html)
+* [Usage & Example](synopsis.html)
+
+<div class="line"></div>
+
+* [Building Node With Ninja](building-node-with-ninja.html)
+
+<div class="line"></div>
+
+* [GitHub Repo & Issue Tracker](https://github.com/nodejs/node)
+* [Mailing List](http://groups.google.com/group/nodejs)

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -5,6 +5,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+common.globalCheck = false;
+
 const html = require('../../tools/doc/html.js').toHTML;
 
 // Test data is a list of objects with two properties.

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const html = require('../../tools/doc/html.js');
+const html = require('../../tools/doc/html.js').toHTML;
 
 // Test data is a list of objects with two properties.
 // The file property is the file path.

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 common.globalCheck = false;
 
+const processIncludes = require('../../tools/doc/preprocess.js');
 const html = require('../../tools/doc/html.js').toHTML;
 
 // Test data is a list of objects with two properties.
@@ -55,22 +56,43 @@ const testData = [
       '<p>Describe <code>Something</code> in more detail here. ' +
       '</p>'
   },
+  {
+    file: path.join(common.fixturesDir, 'doc_with_includes.md'),
+    html: '<!-- [start-include:doc_inc_1.md] -->' +
+    '<p>Look <a href="doc_inc_2.html#doc_inc_2_foobar">here</a>!</p>' +
+    '<!-- [end-include:doc_inc_1.md] -->' +
+    '<!-- [start-include:doc_inc_2.md] -->' +
+    '<h1>foobar<span><a class="mark" href="#doc_inc_2_foobar" ' +
+    'id="doc_inc_2_foobar">#</a></span></h1>' +
+    '<p>I exist and am being linked to.</p>' +
+    '<!-- [end-include:doc_inc_2.md] -->'
+  },
 ];
 
 testData.forEach(function(item) {
   // Normalize expected data by stripping whitespace
   const expected = item.html.replace(/\s/g, '');
 
-  fs.readFile(item.file, 'utf8', common.mustCall(function(err, input) {
+  fs.readFile(item.file, 'utf8', common.mustCall((err, input) => {
     assert.ifError(err);
-    html(input, 'foo', 'doc/template.html',
-      common.mustCall(function(err, output) {
-        assert.ifError(err);
+    processIncludes(item.file, input, common.mustCall((err, preprocessed) => {
+      assert.ifError(err);
 
-        const actual = output.replace(/\s/g, '');
-        // Assert that the input stripped of all whitespace contains the
-        // expected list
-        assert.notEqual(actual.indexOf(expected), -1);
-      }));
+      html(
+        {
+          input: preprocessed,
+          filename: 'foo',
+          template: 'doc/template.html',
+          nodeVersion: process.version,
+        },
+        common.mustCall((err, output) => {
+          assert.ifError(err);
+
+          const actual = output.replace(/\s/g, '');
+          // Assert that the input stripped of all whitespace contains the
+          // expected list
+          assert.notEqual(actual.indexOf(expected), -1);
+        }));
+    }));
   }));
 });

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -48,7 +48,7 @@ function next(er, input) {
       break;
 
     case 'html':
-      require('./html.js')(input, inputFile, template, nodeVersion,
+      require('./html.js').toHTML(input, inputFile, template, nodeVersion,
         function(er, html) {
           if (er) throw er;
           console.log(html);

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -2,6 +2,8 @@
 
 const processIncludes = require('./preprocess.js');
 const fs = require('fs');
+const path = require('path');
+const toHTML = require('./html.js').toHTML;
 
 // parse the args.
 // Don't use nopt or whatever for this.  It's simple enough.
@@ -48,11 +50,15 @@ function next(er, input) {
       break;
 
     case 'html':
-      require('./html.js').toHTML(input, inputFile, template, nodeVersion,
-        function(er, html) {
-          if (er) throw er;
-          console.log(html);
+      toHTML(input, inputFile, template, nodeVersion, (er, html) => {
+        if (er) throw er;
+        const filename = `./out/doc/api/${path.basename(inputFile, 'md')}html`;
+        fs.writeFile(filename, html, (err) => {
+          if (err)
+            console.log(err);
+          console.log('generated:', filename);
         });
+      });
       break;
 
     default:

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -12,6 +12,7 @@ const parseText = require('./lib/parseText')
 const toHTML = require('./lib/toHTML')
 const loadGtoc = require('./lib/loadGtoc')
 const toID = require('./lib/toID')
+const render = require('./lib/render')
 
 module.exports = toHTML;
 
@@ -23,50 +24,6 @@ renderer.heading = function(text, level) {
 marked.setOptions({
   renderer: renderer
 });
-
-
-
-function render(lexed, filename, template, nodeVersion, cb) {
-  if (typeof nodeVersion === 'function') {
-    cb = nodeVersion;
-    nodeVersion = null;
-  }
-
-  nodeVersion = nodeVersion || process.version;
-
-  // get the section
-  var section = getSection(lexed);
-
-  filename = path.basename(filename, '.md');
-
-  parseText(lexed);
-  lexed = parseLists(lexed);
-
-  // generate the table of contents.
-  // this mutates the lexed contents in-place.
-  buildToc(lexed, filename, function(er, toc) {
-    if (er) return cb(er);
-
-    var id = toID(path.basename(filename));
-
-    template = template.replace(/__ID__/g, id);
-    template = template.replace(/__FILENAME__/g, filename);
-    template = template.replace(/__SECTION__/g, section);
-    template = template.replace(/__VERSION__/g, nodeVersion);
-    template = template.replace(/__TOC__/g, toc);
-    template = template.replace(
-      /__GTOC__/g,
-      gtocData.replace('class="nav-' + id, 'class="nav-' + id + ' active')
-    );
-
-    // content has to be the last thing we do with
-    // the lexed tokens, because it's destructive.
-    const content = marked.parser(lexed);
-    template = template.replace(/__CONTENT__/g, content);
-
-    cb(null, template);
-  });
-}
 
 
 // just update the list item text in-place.

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -8,6 +8,7 @@ const preprocess = require('./preprocess.js');
 const typeParser = require('./type-parser.js');
 
 const linkManPages = require('./lib/linkManPages')
+const parseText = require('./lib/parseText')
 
 module.exports = toHTML;
 
@@ -131,16 +132,6 @@ function render(lexed, filename, template, nodeVersion, cb) {
   });
 }
 
-// handle general body-text replacements
-// for example, link man page references to the actual page
-function parseText(lexed) {
-  lexed.forEach(function(tok) {
-    if (tok.text && tok.type !== 'code') {
-      tok.text = linkManPages(tok.text);
-      tok.text = linkJsTypeDocs(tok.text);
-    }
-  });
-}
 
 // just update the list item text in-place.
 // lists that come right after a heading are what we're after.

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -17,6 +17,7 @@ const parseLists = require('./lib/parseLists')
 const parseYAML = require('./lib/parseYAML')
 const linkJsTypeDocs = require('./lib/linkJsTypeDocs')
 const parseAPIHeader = require('./lib/parseAPIHeader')
+const getSection = require('./lib/getSection')
 
 module.exports = toHTML;
 
@@ -30,14 +31,6 @@ marked.setOptions({
 });
 
 
-// section is just the first heading
-function getSection(lexed) {
-  for (var i = 0, l = lexed.length; i < l; i++) {
-    var tok = lexed[i];
-    if (tok.type === 'heading') return tok.text;
-  }
-  return '';
-}
 
 
 function buildToc(lexed, filename, cb) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -15,6 +15,7 @@ const toID = require('./lib/toID')
 const render = require('./lib/render')
 const parseLists = require('./lib/parseLists')
 const parseYAML = require('./lib/parseYAML')
+const linkJsTypeDocs = require('./lib/linkJsTypeDocs')
 
 module.exports = toHTML;
 
@@ -28,27 +29,6 @@ marked.setOptions({
 });
 
 
-
-
-function linkJsTypeDocs(text) {
-  var parts = text.split('`');
-  var i;
-  var typeMatches;
-
-  // Handle types, for example the source Markdown might say
-  // "This argument should be a {Number} or {String}"
-  for (i = 0; i < parts.length; i += 2) {
-    typeMatches = parts[i].match(/\{([^\}]+)\}/g);
-    if (typeMatches) {
-      typeMatches.forEach(function(typeMatch) {
-        parts[i] = parts[i].replace(typeMatch, typeParser.toLink(typeMatch));
-      });
-    }
-  }
-
-  //XXX maybe put more stuff here?
-  return parts.join('`');
-}
 
 function parseAPIHeader(text) {
   text = text.replace(

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -11,6 +11,7 @@ const linkManPages = require('./lib/linkManPages')
 const parseText = require('./lib/parseText')
 const toHTML = require('./lib/toHTML')
 const loadGtoc = require('./lib/loadGtoc')
+const toID = require('./lib/toID')
 
 module.exports = toHTML;
 
@@ -24,12 +25,6 @@ marked.setOptions({
 });
 
 
-function toID(filename) {
-  return filename
-    .replace('.html', '')
-    .replace(/[^\w\-]/g, '-')
-    .replace(/-+/g, '-');
-}
 
 function render(lexed, filename, template, nodeVersion, cb) {
   if (typeof nodeVersion === 'function') {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -14,6 +14,7 @@ const loadGtoc = require('./lib/loadGtoc')
 const toID = require('./lib/toID')
 const render = require('./lib/render')
 const parseLists = require('./lib/parseLists')
+const parseYAML = require('./lib/parseYAML')
 
 module.exports = toHTML;
 
@@ -27,21 +28,6 @@ marked.setOptions({
 });
 
 
-function parseYAML(text) {
-  const meta = common.extractAndParseYAML(text);
-  const html = ['<div class="api_metadata">'];
-
-  if (meta.added) {
-    html.push(`<span>Added in: ${meta.added.join(', ')}</span>`);
-  }
-
-  if (meta.deprecated) {
-    html.push(`<span>Deprecated since: ${meta.deprecated.join(', ')} </span>`);
-  }
-
-  html.push('</div>');
-  return html.join('\n');
-}
 
 
 function linkJsTypeDocs(text) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -10,6 +10,7 @@ const typeParser = require('./type-parser.js');
 const linkManPages = require('./lib/linkManPages')
 const parseText = require('./lib/parseText')
 const toHTML = require('./lib/toHTML')
+const loadGtoc = require('./lib/loadGtoc')
 
 module.exports = toHTML;
 
@@ -22,33 +23,6 @@ marked.setOptions({
   renderer: renderer
 });
 
-// TODO(chrisdickinson): never stop vomitting / fix this.
-var gtocPath = path.resolve(path.join(
-  __dirname,
-  '..',
-  '..',
-  'doc',
-  'api',
-  '_toc.md'
-));
-var gtocLoading = null;
-var gtocData = null;
-
-
-function loadGtoc(cb) {
-  fs.readFile(gtocPath, 'utf8', function(err, data) {
-    if (err) return cb(err);
-
-    preprocess(gtocPath, data, function(err, data) {
-      if (err) return cb(err);
-
-      data = marked(data).replace(/<a href="(.*?)"/gm, function(a, m) {
-        return '<a class="nav-' + toID(m) + '" href="' + m + '"';
-      });
-      return cb(null, data);
-    });
-  });
-}
 
 function toID(filename) {
   return filename

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -18,6 +18,7 @@ const parseYAML = require('./lib/parseYAML')
 const linkJsTypeDocs = require('./lib/linkJsTypeDocs')
 const parseAPIHeader = require('./lib/parseAPIHeader')
 const getSection = require('./lib/getSection')
+const buildToc = require('./lib/buildToc')
 
 module.exports = toHTML;
 
@@ -30,31 +31,6 @@ marked.setOptions({
   renderer: renderer
 });
 
-
-
-
-function buildToc(lexed, filename, cb) {
-  var toc = [];
-  var depth = 0;
-  lexed.forEach(function(tok) {
-    if (tok.type !== 'heading') return;
-    if (tok.depth - depth > 1) {
-      return cb(new Error('Inappropriate heading level\n' +
-                          JSON.stringify(tok)));
-    }
-
-    depth = tok.depth;
-    var id = getId(filename + '_' + tok.text.trim());
-    toc.push(new Array((depth - 1) * 2 + 1).join(' ') +
-             '* <a href="#' + id + '">' +
-             tok.text + '</a>');
-    tok.text += '<span><a class="mark" href="#' + id + '" ' +
-                'id="' + id + '">#</a></span>';
-  });
-
-  toc = marked.parse(toc.join('\n'));
-  cb(null, toc);
-}
 
 var idCounters = {};
 function getId(text) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -7,6 +7,8 @@ const path = require('path');
 const preprocess = require('./preprocess.js');
 const typeParser = require('./type-parser.js');
 
+const linkManPages = require('./lib/linkManPages')
+
 module.exports = toHTML;
 
 // customized heading without id attribute
@@ -216,25 +218,6 @@ function parseYAML(text) {
   return html.join('\n');
 }
 
-// Syscalls which appear in the docs, but which only exist in BSD / OSX
-var BSD_ONLY_SYSCALLS = new Set(['lchmod']);
-
-// Handle references to man pages, eg "open(2)" or "lchmod(2)"
-// Returns modified text, with such refs replace with HTML links, for example
-// '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
-function linkManPages(text) {
-  return text.replace(/ ([a-z]+)\((\d)\)/gm, function(match, name, number) {
-    // name consists of lowercase letters, number is a single digit
-    var displayAs = name + '(' + number + ')';
-    if (BSD_ONLY_SYSCALLS.has(name)) {
-      return ' <a href="https://www.freebsd.org/cgi/man.cgi?query=' + name +
-             '&sektion=' + number + '">' + displayAs + '</a>';
-    } else {
-      return ' <a href="http://man7.org/linux/man-pages/man' + number +
-             '/' + name + '.' + number + '.html">' + displayAs + '</a>';
-    }
-  });
-}
 
 function linkJsTypeDocs(text) {
   var parts = text.split('`');

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -16,6 +16,7 @@ const render = require('./lib/render')
 const parseLists = require('./lib/parseLists')
 const parseYAML = require('./lib/parseYAML')
 const linkJsTypeDocs = require('./lib/linkJsTypeDocs')
+const parseAPIHeader = require('./lib/parseAPIHeader')
 
 module.exports = toHTML;
 
@@ -28,15 +29,6 @@ marked.setOptions({
   renderer: renderer
 });
 
-
-
-function parseAPIHeader(text) {
-  text = text.replace(
-    /(.*:)\s(\d)([\s\S]*)/,
-    '<pre class="api_stability api_stability_$2">$1 $2$3</pre>'
-  );
-  return text;
-}
 
 // section is just the first heading
 function getSection(lexed) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -9,6 +9,7 @@ const typeParser = require('./type-parser.js');
 
 const linkManPages = require('./lib/linkManPages')
 const parseText = require('./lib/parseText')
+const toHTML = require('./lib/toHTML')
 
 module.exports = toHTML;
 
@@ -33,40 +34,6 @@ var gtocPath = path.resolve(path.join(
 var gtocLoading = null;
 var gtocData = null;
 
-function toHTML(input, filename, template, nodeVersion, cb) {
-  if (typeof nodeVersion === 'function') {
-    cb = nodeVersion;
-    nodeVersion = null;
-  }
-  nodeVersion = nodeVersion || process.version;
-
-  if (gtocData) {
-    return onGtocLoaded();
-  }
-
-  if (gtocLoading === null) {
-    gtocLoading = [onGtocLoaded];
-    return loadGtoc(function(err, data) {
-      if (err) throw err;
-      gtocData = data;
-      gtocLoading.forEach(function(xs) {
-        xs();
-      });
-    });
-  }
-
-  if (gtocLoading) {
-    return gtocLoading.push(onGtocLoaded);
-  }
-
-  function onGtocLoaded() {
-    var lexed = marked.lexer(input);
-    fs.readFile(template, 'utf8', function(er, template) {
-      if (er) return cb(er);
-      render(lexed, filename, template, nodeVersion, cb);
-    });
-  }
-}
 
 function loadGtoc(cb) {
   fs.readFile(gtocPath, 'utf8', function(err, data) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -19,6 +19,7 @@ const linkJsTypeDocs = require('./lib/linkJsTypeDocs')
 const parseAPIHeader = require('./lib/parseAPIHeader')
 const getSection = require('./lib/getSection')
 const buildToc = require('./lib/buildToc')
+const getId = require('./lib/getId')
 
 module.exports = toHTML;
 
@@ -30,18 +31,3 @@ renderer.heading = function(text, level) {
 marked.setOptions({
   renderer: renderer
 });
-
-
-var idCounters = {};
-function getId(text) {
-  text = text.toLowerCase();
-  text = text.replace(/[^a-z0-9]+/g, '_');
-  text = text.replace(/^_+|_+$/, '');
-  text = text.replace(/^([^a-z])/, '_$1');
-  if (idCounters.hasOwnProperty(text)) {
-    text += '_' + (++idCounters[text]);
-  } else {
-    idCounters[text] = 0;
-  }
-  return text;
-}

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -1,33 +1,5 @@
 'use strict';
-
-const common = require('./common.js');
-const fs = require('fs');
 const marked = require('marked');
-const path = require('path');
-const preprocess = require('./preprocess.js');
-const typeParser = require('./type-parser.js');
-
-const linkManPages = require('./lib/linkManPages')
-const parseText = require('./lib/parseText')
 const toHTML = require('./lib/toHTML')
-const loadGtoc = require('./lib/loadGtoc')
-const toID = require('./lib/toID')
-const render = require('./lib/render')
-const parseLists = require('./lib/parseLists')
-const parseYAML = require('./lib/parseYAML')
-const linkJsTypeDocs = require('./lib/linkJsTypeDocs')
-const parseAPIHeader = require('./lib/parseAPIHeader')
-const getSection = require('./lib/getSection')
-const buildToc = require('./lib/buildToc')
-const getId = require('./lib/getId')
 
-module.exports = toHTML;
-
-// customized heading without id attribute
-var renderer = new marked.Renderer();
-renderer.heading = function(text, level) {
-  return '<h' + level + '>' + text + '</h' + level + '>\n';
-};
-marked.setOptions({
-  renderer: renderer
-});
+module.exports.toHTML = toHTML;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -1,5 +1,2 @@
 'use strict';
-const marked = require('marked');
-const toHTML = require('./lib/toHTML')
-
-module.exports.toHTML = toHTML;
+module.exports.toHTML = require('./lib/toHTML');

--- a/tools/doc/lib/buildToc.js
+++ b/tools/doc/lib/buildToc.js
@@ -5,7 +5,21 @@ const getId = require('./getId.js');
 module.exports = function buildToc(lexed, filename, cb) {
   var toc = [];
   var depth = 0;
+
+  const startIncludeRefRE = /^\s*<!-- \[start-include:(.+)\] -->\s*$/;
+  const endIncludeRefRE = /^\s*<!-- \[end-include:(.+)\] -->\s*$/;
+  const realFilenames = [filename];
+
   lexed.forEach(function(tok) {
+    // Keep track of the current filename along @include directives.
+    if (tok.type === 'html') {
+      let match;
+      if ((match = tok.text.match(startIncludeRefRE)) !== null)
+        realFilenames.unshift(match[1]);
+      else if (tok.text.match(endIncludeRefRE))
+        realFilenames.shift();
+    }
+
     if (tok.type !== 'heading') return;
     if (tok.depth - depth > 1) {
       return cb(new Error('Inappropriate heading level\n' +
@@ -13,7 +27,8 @@ module.exports = function buildToc(lexed, filename, cb) {
     }
 
     depth = tok.depth;
-    var id = getId(filename + '_' + tok.text.trim());
+    const realFilename = path.basename(realFilenames[0], '.md');
+    const id = getId(realFilename + '_' + tok.text.trim());
     toc.push(new Array((depth - 1) * 2 + 1).join(' ') +
              '* <a href="#' + id + '">' +
              tok.text + '</a>');

--- a/tools/doc/lib/buildToc.js
+++ b/tools/doc/lib/buildToc.js
@@ -1,5 +1,5 @@
-const marked = require('marked')
-const toID = require('./toID.js');
+'use strict';
+const marked = require('marked');
 const getId = require('./getId.js');
 
 module.exports = function buildToc(lexed, filename, cb) {
@@ -23,4 +23,4 @@ module.exports = function buildToc(lexed, filename, cb) {
 
   toc = marked.parse(toc.join('\n'));
   cb(null, toc);
-}
+};

--- a/tools/doc/lib/buildToc.js
+++ b/tools/doc/lib/buildToc.js
@@ -1,3 +1,6 @@
+const marked = require('marked')
+const toID = require('./toID.js');
+const getId = require('./getId.js');
 
 module.exports = function buildToc(lexed, filename, cb) {
   var toc = [];

--- a/tools/doc/lib/buildToc.js
+++ b/tools/doc/lib/buildToc.js
@@ -1,0 +1,23 @@
+
+module.exports = function buildToc(lexed, filename, cb) {
+  var toc = [];
+  var depth = 0;
+  lexed.forEach(function(tok) {
+    if (tok.type !== 'heading') return;
+    if (tok.depth - depth > 1) {
+      return cb(new Error('Inappropriate heading level\n' +
+                          JSON.stringify(tok)));
+    }
+
+    depth = tok.depth;
+    var id = getId(filename + '_' + tok.text.trim());
+    toc.push(new Array((depth - 1) * 2 + 1).join(' ') +
+             '* <a href="#' + id + '">' +
+             tok.text + '</a>');
+    tok.text += '<span><a class="mark" href="#' + id + '" ' +
+                'id="' + id + '">#</a></span>';
+  });
+
+  toc = marked.parse(toc.join('\n'));
+  cb(null, toc);
+}

--- a/tools/doc/lib/getId.js
+++ b/tools/doc/lib/getId.js
@@ -1,0 +1,13 @@
+var idCounters = {};
+module.exports = function getId(text) {
+  text = text.toLowerCase();
+  text = text.replace(/[^a-z0-9]+/g, '_');
+  text = text.replace(/^_+|_+$/, '');
+  text = text.replace(/^([^a-z])/, '_$1');
+  if (idCounters.hasOwnProperty(text)) {
+    text += '_' + (++idCounters[text]);
+  } else {
+    idCounters[text] = 0;
+  }
+  return text;
+}

--- a/tools/doc/lib/getId.js
+++ b/tools/doc/lib/getId.js
@@ -1,3 +1,4 @@
+'use strict';
 var idCounters = {};
 module.exports = function getId(text) {
   text = text.toLowerCase();
@@ -10,4 +11,4 @@ module.exports = function getId(text) {
     idCounters[text] = 0;
   }
   return text;
-}
+};

--- a/tools/doc/lib/getSection.js
+++ b/tools/doc/lib/getSection.js
@@ -1,0 +1,9 @@
+
+// section is just the first heading
+module.exports = function getSection(lexed) {
+  for (var i = 0, l = lexed.length; i < l; i++) {
+    var tok = lexed[i];
+    if (tok.type === 'heading') return tok.text;
+  }
+  return '';
+}

--- a/tools/doc/lib/getSection.js
+++ b/tools/doc/lib/getSection.js
@@ -1,4 +1,4 @@
-
+'use strict';
 // section is just the first heading
 module.exports = function getSection(lexed) {
   for (var i = 0, l = lexed.length; i < l; i++) {
@@ -6,4 +6,4 @@ module.exports = function getSection(lexed) {
     if (tok.type === 'heading') return tok.text;
   }
   return '';
-}
+};

--- a/tools/doc/lib/linkJsTypeDocs.js
+++ b/tools/doc/lib/linkJsTypeDocs.js
@@ -1,3 +1,4 @@
+'use strict';
 const typeParser = require('../type-parser.js');
 
 module.exports = function linkJsTypeDocs(text) {
@@ -18,4 +19,4 @@ module.exports = function linkJsTypeDocs(text) {
 
   //XXX maybe put more stuff here?
   return parts.join('`');
-}
+};

--- a/tools/doc/lib/linkJsTypeDocs.js
+++ b/tools/doc/lib/linkJsTypeDocs.js
@@ -1,0 +1,19 @@
+module.exports = function linkJsTypeDocs(text) {
+  var parts = text.split('`');
+  var i;
+  var typeMatches;
+
+  // Handle types, for example the source Markdown might say
+  // "This argument should be a {Number} or {String}"
+  for (i = 0; i < parts.length; i += 2) {
+    typeMatches = parts[i].match(/\{([^\}]+)\}/g);
+    if (typeMatches) {
+      typeMatches.forEach(function(typeMatch) {
+        parts[i] = parts[i].replace(typeMatch, typeParser.toLink(typeMatch));
+      });
+    }
+  }
+
+  //XXX maybe put more stuff here?
+  return parts.join('`');
+}

--- a/tools/doc/lib/linkJsTypeDocs.js
+++ b/tools/doc/lib/linkJsTypeDocs.js
@@ -1,3 +1,5 @@
+const typeParser = require('../type-parser.js');
+
 module.exports = function linkJsTypeDocs(text) {
   var parts = text.split('`');
   var i;

--- a/tools/doc/lib/linkManPages.js
+++ b/tools/doc/lib/linkManPages.js
@@ -1,3 +1,4 @@
+'use strict';
 // Syscalls which appear in the docs, but which only exist in BSD / OSX
 var BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 
@@ -16,4 +17,4 @@ module.exports = function linkManPages(text) {
              '/' + name + '.' + number + '.html">' + displayAs + '</a>';
     }
   });
-}
+};

--- a/tools/doc/lib/linkManPages.js
+++ b/tools/doc/lib/linkManPages.js
@@ -1,0 +1,19 @@
+// Syscalls which appear in the docs, but which only exist in BSD / OSX
+var BSD_ONLY_SYSCALLS = new Set(['lchmod']);
+
+// Handle references to man pages, eg "open(2)" or "lchmod(2)"
+// Returns modified text, with such refs replace with HTML links, for example
+// '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
+module.exports = function linkManPages(text) {
+  return text.replace(/ ([a-z]+)\((\d)\)/gm, function(match, name, number) {
+    // name consists of lowercase letters, number is a single digit
+    var displayAs = name + '(' + number + ')';
+    if (BSD_ONLY_SYSCALLS.has(name)) {
+      return ' <a href="https://www.freebsd.org/cgi/man.cgi?query=' + name +
+             '&sektion=' + number + '">' + displayAs + '</a>';
+    } else {
+      return ' <a href="http://man7.org/linux/man-pages/man' + number +
+             '/' + name + '.' + number + '.html">' + displayAs + '</a>';
+    }
+  });
+}

--- a/tools/doc/lib/loadGtoc.js
+++ b/tools/doc/lib/loadGtoc.js
@@ -1,0 +1,27 @@
+// TODO(chrisdickinson): never stop vomitting / fix this.
+var gtocPath = path.resolve(path.join(
+  __dirname,
+  '..',
+  '..',
+  'doc',
+  'api',
+  '_toc.md'
+));
+var gtocLoading = null;
+var gtocData = null;
+
+
+module.epxorts = function loadGtoc(cb) {
+  fs.readFile(gtocPath, 'utf8', function(err, data) {
+    if (err) return cb(err);
+
+    preprocess(gtocPath, data, function(err, data) {
+      if (err) return cb(err);
+
+      data = marked(data).replace(/<a href="(.*?)"/gm, function(a, m) {
+        return '<a class="nav-' + toID(m) + '" href="' + m + '"';
+      });
+      return cb(null, data);
+    });
+  });
+}

--- a/tools/doc/lib/loadGtoc.js
+++ b/tools/doc/lib/loadGtoc.js
@@ -1,6 +1,7 @@
-const path = require('path')
-const fs = require('fs')
-const marked = require('marked')
+'use strict';
+const path = require('path');
+const fs = require('fs');
+const marked = require('marked');
 const preprocess = require('../preprocess.js');
 const toID = require('./toID.js');
 // TODO(chrisdickinson): never stop vomitting / fix this.
@@ -30,4 +31,4 @@ exports.loadGtoc = (cb) => {
       return cb(null, data);
     });
   });
-}
+};

--- a/tools/doc/lib/loadGtoc.js
+++ b/tools/doc/lib/loadGtoc.js
@@ -1,17 +1,23 @@
+const path = require('path')
+const fs = require('fs')
+const marked = require('marked')
+const preprocess = require('../preprocess.js');
+const toID = require('./toID.js');
 // TODO(chrisdickinson): never stop vomitting / fix this.
 var gtocPath = path.resolve(path.join(
   __dirname,
+  '..',
   '..',
   '..',
   'doc',
   'api',
   '_toc.md'
 ));
-var gtocLoading = null;
-var gtocData = null;
+global.global.gtocLoading = null;
+global.gtocData = null;
 
 
-module.epxorts = function loadGtoc(cb) {
+exports.loadGtoc = (cb) => {
   fs.readFile(gtocPath, 'utf8', function(err, data) {
     if (err) return cb(err);
 

--- a/tools/doc/lib/parseAPIHeader.js
+++ b/tools/doc/lib/parseAPIHeader.js
@@ -1,7 +1,8 @@
+'use strict';
 module.exports = function parseAPIHeader(text) {
   text = text.replace(
     /(.*:)\s(\d)([\s\S]*)/,
     '<pre class="api_stability api_stability_$2">$1 $2$3</pre>'
   );
   return text;
-}
+};

--- a/tools/doc/lib/parseAPIHeader.js
+++ b/tools/doc/lib/parseAPIHeader.js
@@ -1,0 +1,7 @@
+module.exports = function parseAPIHeader(text) {
+  text = text.replace(
+    /(.*:)\s(\d)([\s\S]*)/,
+    '<pre class="api_stability api_stability_$2">$1 $2$3</pre>'
+  );
+  return text;
+}

--- a/tools/doc/lib/parseLists.js
+++ b/tools/doc/lib/parseLists.js
@@ -1,4 +1,6 @@
-
+const common = require('../common.js');
+const parseAPIHeader = require('./parseAPIHeader.js');
+const parseYAML = require('./parseYAML.js');
 // just update the list item text in-place.
 // lists that come right after a heading are what we're after.
 module.exports = function parseLists(input) {

--- a/tools/doc/lib/parseLists.js
+++ b/tools/doc/lib/parseLists.js
@@ -1,0 +1,60 @@
+
+// just update the list item text in-place.
+// lists that come right after a heading are what we're after.
+module.exports = function parseLists(input) {
+  var state = null;
+  var depth = 0;
+  var output = [];
+  output.links = input.links;
+  input.forEach(function(tok) {
+    if (tok.type === 'code' && tok.text.match(/Stability:.*/g)) {
+      tok.text = parseAPIHeader(tok.text);
+      output.push({ type: 'html', text: tok.text });
+      return;
+    }
+    if (state === null ||
+      (state === 'AFTERHEADING' && tok.type === 'heading')) {
+      if (tok.type === 'heading') {
+        state = 'AFTERHEADING';
+      }
+      output.push(tok);
+      return;
+    }
+    if (state === 'AFTERHEADING') {
+      if (tok.type === 'list_start') {
+        state = 'LIST';
+        if (depth === 0) {
+          output.push({ type: 'html', text: '<div class="signature">' });
+        }
+        depth++;
+        output.push(tok);
+        return;
+      }
+      if (tok.type === 'html' && common.isYAMLBlock(tok.text)) {
+        tok.text = parseYAML(tok.text);
+      }
+      state = null;
+      output.push(tok);
+      return;
+    }
+    if (state === 'LIST') {
+      if (tok.type === 'list_start') {
+        depth++;
+        output.push(tok);
+        return;
+      }
+      if (tok.type === 'list_end') {
+        depth--;
+        output.push(tok);
+        if (depth === 0) {
+          state = null;
+          output.push({ type: 'html', text: '</div>' });
+        }
+        return;
+      }
+    }
+    output.push(tok);
+  });
+
+  return output;
+}

--- a/tools/doc/lib/parseLists.js
+++ b/tools/doc/lib/parseLists.js
@@ -1,3 +1,4 @@
+'use strict';
 const common = require('../common.js');
 const parseAPIHeader = require('./parseAPIHeader.js');
 const parseYAML = require('./parseYAML.js');
@@ -59,4 +60,4 @@ module.exports = function parseLists(input) {
   });
 
   return output;
-}
+};

--- a/tools/doc/lib/parseText.js
+++ b/tools/doc/lib/parseText.js
@@ -1,5 +1,6 @@
-const linkManPages = require('./linkManPages')
-const linkJsTypeDocs = require('./linkJsTypeDocs')
+'use strict';
+const linkManPages = require('./linkManPages');
+const linkJsTypeDocs = require('./linkJsTypeDocs');
 // handle general body-text replacements
 // for example, link man page references to the actual page
 module.exports = function parseText(lexed) {
@@ -9,4 +10,4 @@ module.exports = function parseText(lexed) {
       tok.text = linkJsTypeDocs(tok.text);
     }
   });
-}
+};

--- a/tools/doc/lib/parseText.js
+++ b/tools/doc/lib/parseText.js
@@ -1,3 +1,5 @@
+const linkManPages = require('./linkManPages')
+const linkJsTypeDocs = require('./linkJsTypeDocs')
 // handle general body-text replacements
 // for example, link man page references to the actual page
 module.exports = function parseText(lexed) {

--- a/tools/doc/lib/parseText.js
+++ b/tools/doc/lib/parseText.js
@@ -1,0 +1,10 @@
+// handle general body-text replacements
+// for example, link man page references to the actual page
+module.exports = function parseText(lexed) {
+  lexed.forEach(function(tok) {
+    if (tok.text && tok.type !== 'code') {
+      tok.text = linkManPages(tok.text);
+      tok.text = linkJsTypeDocs(tok.text);
+    }
+  });
+}

--- a/tools/doc/lib/parseYAML.js
+++ b/tools/doc/lib/parseYAML.js
@@ -1,3 +1,5 @@
+const common = require('../common.js');
+
 module.exports = function parseYAML(text) {
   const meta = common.extractAndParseYAML(text);
   const html = ['<div class="api_metadata">'];

--- a/tools/doc/lib/parseYAML.js
+++ b/tools/doc/lib/parseYAML.js
@@ -1,3 +1,4 @@
+'use strict';
 const common = require('../common.js');
 
 module.exports = function parseYAML(text) {
@@ -14,4 +15,4 @@ module.exports = function parseYAML(text) {
 
   html.push('</div>');
   return html.join('\n');
-}
+};

--- a/tools/doc/lib/parseYAML.js
+++ b/tools/doc/lib/parseYAML.js
@@ -1,0 +1,15 @@
+module.exports = function parseYAML(text) {
+  const meta = common.extractAndParseYAML(text);
+  const html = ['<div class="api_metadata">'];
+
+  if (meta.added) {
+    html.push(`<span>Added in: ${meta.added.join(', ')}</span>`);
+  }
+
+  if (meta.deprecated) {
+    html.push(`<span>Deprecated since: ${meta.deprecated.join(', ')} </span>`);
+  }
+
+  html.push('</div>');
+  return html.join('\n');
+}

--- a/tools/doc/lib/render.js
+++ b/tools/doc/lib/render.js
@@ -1,0 +1,41 @@
+module.exports = function render(lexed, filename, template, nodeVersion, cb) {
+  if (typeof nodeVersion === 'function') {
+    cb = nodeVersion;
+    nodeVersion = null;
+  }
+
+  nodeVersion = nodeVersion || process.version;
+
+  // get the section
+  var section = getSection(lexed);
+
+  filename = path.basename(filename, '.md');
+
+  parseText(lexed);
+  lexed = parseLists(lexed);
+
+  // generate the table of contents.
+  // this mutates the lexed contents in-place.
+  buildToc(lexed, filename, function(er, toc) {
+    if (er) return cb(er);
+
+    var id = toID(path.basename(filename));
+
+    template = template.replace(/__ID__/g, id);
+    template = template.replace(/__FILENAME__/g, filename);
+    template = template.replace(/__SECTION__/g, section);
+    template = template.replace(/__VERSION__/g, nodeVersion);
+    template = template.replace(/__TOC__/g, toc);
+    template = template.replace(
+      /__GTOC__/g,
+      gtocData.replace('class="nav-' + id, 'class="nav-' + id + ' active')
+    );
+
+    // content has to be the last thing we do with
+    // the lexed tokens, because it's destructive.
+    const content = marked.parser(lexed);
+    template = template.replace(/__CONTENT__/g, content);
+
+    cb(null, template);
+  });
+}

--- a/tools/doc/lib/render.js
+++ b/tools/doc/lib/render.js
@@ -1,9 +1,10 @@
-const path = require('path')
-const marked = require('marked')
-const getSection = require('./getSection')
-const parseText = require('./parseText')
-const parseLists = require('./parseLists')
-const buildToc = require('./buildToc')
+'use strict';
+const path = require('path');
+const marked = require('marked');
+const getSection = require('./getSection');
+const parseText = require('./parseText');
+const parseLists = require('./parseLists');
+const buildToc = require('./buildToc');
 const toID = require('./toID.js');
 
 module.exports = function render(lexed, filename, template, nodeVersion, cb) {
@@ -36,7 +37,7 @@ module.exports = function render(lexed, filename, template, nodeVersion, cb) {
     template = template.replace(/__TOC__/g, toc);
     template = template.replace(
       /__GTOC__/g,
-      global.gtocData.replace('class="nav-' + id, 'class="nav-' + id + ' active')
+      global.gtocData.replace(`class="nav-${id}`, `class="nav-${id} active`)
     );
 
     // content has to be the last thing we do with
@@ -46,4 +47,4 @@ module.exports = function render(lexed, filename, template, nodeVersion, cb) {
 
     cb(null, template);
   });
-}
+};

--- a/tools/doc/lib/render.js
+++ b/tools/doc/lib/render.js
@@ -1,3 +1,11 @@
+const path = require('path')
+const marked = require('marked')
+const getSection = require('./getSection')
+const parseText = require('./parseText')
+const parseLists = require('./parseLists')
+const buildToc = require('./buildToc')
+const toID = require('./toID.js');
+
 module.exports = function render(lexed, filename, template, nodeVersion, cb) {
   if (typeof nodeVersion === 'function') {
     cb = nodeVersion;
@@ -28,7 +36,7 @@ module.exports = function render(lexed, filename, template, nodeVersion, cb) {
     template = template.replace(/__TOC__/g, toc);
     template = template.replace(
       /__GTOC__/g,
-      gtocData.replace('class="nav-' + id, 'class="nav-' + id + ' active')
+      global.gtocData.replace('class="nav-' + id, 'class="nav-' + id + ' active')
     );
 
     // content has to be the last thing we do with

--- a/tools/doc/lib/toHTML.js
+++ b/tools/doc/lib/toHTML.js
@@ -1,7 +1,8 @@
-const fs = require('fs')
-const loadGtoc = require('./loadGtoc').loadGtoc
-const render = require('./render')
-const marked = require('marked')
+'use strict';
+const fs = require('fs');
+const loadGtoc = require('./loadGtoc').loadGtoc;
+const render = require('./render');
+const marked = require('marked');
 
 // customized heading without id attribute
 var renderer = new marked.Renderer();
@@ -46,4 +47,4 @@ module.exports = function toHTML(input, filename, template, nodeVersion, cb) {
       render(lexed, filename, template, nodeVersion, cb);
     });
   }
-}
+};

--- a/tools/doc/lib/toHTML.js
+++ b/tools/doc/lib/toHTML.js
@@ -1,0 +1,34 @@
+module.exports = function toHTML(input, filename, template, nodeVersion, cb) {
+  if (typeof nodeVersion === 'function') {
+    cb = nodeVersion;
+    nodeVersion = null;
+  }
+  nodeVersion = nodeVersion || process.version;
+
+  if (gtocData) {
+    return onGtocLoaded();
+  }
+
+  if (gtocLoading === null) {
+    gtocLoading = [onGtocLoaded];
+    return loadGtoc(function(err, data) {
+      if (err) throw err;
+      gtocData = data;
+      gtocLoading.forEach(function(xs) {
+        xs();
+      });
+    });
+  }
+
+  if (gtocLoading) {
+    return gtocLoading.push(onGtocLoaded);
+  }
+
+  function onGtocLoaded() {
+    var lexed = marked.lexer(input);
+    fs.readFile(template, 'utf8', function(er, template) {
+      if (er) return cb(er);
+      render(lexed, filename, template, nodeVersion, cb);
+    });
+  }
+}

--- a/tools/doc/lib/toHTML.js
+++ b/tools/doc/lib/toHTML.js
@@ -1,3 +1,18 @@
+const fs = require('fs')
+const loadGtoc = require('./loadGtoc').loadGtoc
+const render = require('./render')
+const marked = require('marked')
+
+// customized heading without id attribute
+var renderer = new marked.Renderer();
+renderer.heading = function(text, level) {
+  return '<h' + level + '>' + text + '</h' + level + '>\n';
+};
+marked.setOptions({
+  renderer: renderer
+});
+
+
 module.exports = function toHTML(input, filename, template, nodeVersion, cb) {
   if (typeof nodeVersion === 'function') {
     cb = nodeVersion;
@@ -5,23 +20,23 @@ module.exports = function toHTML(input, filename, template, nodeVersion, cb) {
   }
   nodeVersion = nodeVersion || process.version;
 
-  if (gtocData) {
+  if (global.gtocData) {
     return onGtocLoaded();
   }
 
-  if (gtocLoading === null) {
-    gtocLoading = [onGtocLoaded];
+  if (global.gtocLoading === null) {
+    global.gtocLoading = [onGtocLoaded];
     return loadGtoc(function(err, data) {
       if (err) throw err;
-      gtocData = data;
-      gtocLoading.forEach(function(xs) {
+      global.gtocData = data;
+      global.gtocLoading.forEach(function(xs) {
         xs();
       });
     });
   }
 
-  if (gtocLoading) {
-    return gtocLoading.push(onGtocLoaded);
+  if (global.gtocLoading) {
+    return global.gtocLoading.push(onGtocLoaded);
   }
 
   function onGtocLoaded() {

--- a/tools/doc/lib/toID.js
+++ b/tools/doc/lib/toID.js
@@ -1,6 +1,7 @@
+'use strict';
 module.exports = function toID(filename) {
   return filename
     .replace('.html', '')
     .replace(/[^\w\-]/g, '-')
     .replace(/-+/g, '-');
-}
+};

--- a/tools/doc/lib/toID.js
+++ b/tools/doc/lib/toID.js
@@ -1,0 +1,6 @@
+module.exports = function toID(filename) {
+  return filename
+    .replace('.html', '')
+    .replace(/[^\w\-]/g, '-')
+    .replace(/-+/g, '-');
+}

--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -48,7 +48,10 @@ function processIncludes(inputFile, input, cb) {
         if (errState) return;
         if (er) return cb(errState = er);
         incCount--;
-        includeData[fname] = inc;
+        // Add comments to let the HTML generator know how the anchors for
+        // headings should look like.
+        includeData[fname] = `<!-- [start-include:${fname}] -->\n` +
+                             inc + `\n<!-- [end-include:${fname}] -->\n`;
         input = input.split(include + '\n').join(includeData[fname] + '\n');
         if (incCount === 0) {
           return cb(null, input);


### PR DESCRIPTION
##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [ ] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
`doc`, `tools`

##### Description of change
<!-- provide a description of the change below this comment -->

I was picking up the guides generation from https://github.com/nodejs/node/pull/5408. While doing this I moved forward without using another external dependency. To re-use the html-path entirely wouldn't have been possible. So I refactored this to be more modular in style, and will continue to just introduce "target flags" guide < > html and  branching components accordingly.

Also a rather **critical** thing is, that up until this PR HTML generation was done via piping over stdout. I have refactored this to make a call to `fs.writeFile()`. This also leads to a increase possibly.

cc @nodejs/documentation 