### PR TITLE
doc: add `added:` information for path

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -8,6 +8,9 @@ paths. The file system is not consulted to check whether paths are valid.
 Use `require('path')` to use this module.  The following methods are provided:
 
 ## path.basename(path[, ext])
+<!-- YAML
+added: v0.1.25
+-->
 
 Return the last portion of a path, similar to the Unix `basename` command.
 `path` must be a string. `ext`, if given, must also be a string.
@@ -23,6 +26,9 @@ path.basename('/foo/bar/baz/asdf/quux.html', '.html')
 ```
 
 ## path.delimiter
+<!-- YAML
+added: v0.9.3
+-->
 
 The platform-specific path delimiter, `;` or `':'`.
 
@@ -47,6 +53,9 @@ process.env.PATH.split(path.delimiter)
 ```
 
 ## path.dirname(path)
+<!-- YAML
+added: v0.1.16
+-->
 
 Return the directory name of a path, similar to the Unix `dirname` command.
 `path` must be a string.
@@ -59,6 +68,9 @@ path.dirname('/foo/bar/baz/asdf/quux')
 ```
 
 ## path.extname(path)
+<!-- YAML
+added: v0.1.25
+-->
 
 Return the extension of the path, from the last '.' to end of string
 in the last portion of the path.  If there is no '.' in the last portion
@@ -85,6 +97,9 @@ path.extname('.index')
 ```
 
 ## path.format(pathObject)
+<!-- YAML
+added: v0.11.15
+-->
 
 Returns a path string from an object. This is the opposite of [`path.parse`][].
 
@@ -154,6 +169,9 @@ path.format({
 ```
 
 ## path.isAbsolute(path)
+<!-- YAML
+added: v0.11.2
+-->
 
 Determines whether `path` is an absolute path. An absolute path will always
 resolve to the same location, regardless of the working directory. `path` must
@@ -182,6 +200,9 @@ path.isAbsolute('.')         // false
         returned.
 
 ## path.join([path1][, path2][, ...])
+<!-- YAML
+added: v0.1.16
+-->
 
 Join all arguments together and normalize the resulting path.
 
@@ -205,6 +226,9 @@ TypeError: Arguments to path.join must be strings
         current working directory.
 
 ## path.normalize(path)
+<!-- YAML
+added: v0.1.23
+-->
 
 Normalize a path, taking care of `'..'` and `'.'` parts. `path` must be a
 string.
@@ -224,6 +248,9 @@ path.normalize('/foo/bar//baz/asdf/quux/..')
         will be returned, which represents the current working directory.
 
 ## path.parse(path)
+<!-- YAML
+added: v0.11.15
+-->
 
 Returns an object from a path. `path` must be a string.
 
@@ -256,11 +283,17 @@ path.parse('C:\\path\\dir\\index.html')
 ```
 
 ## path.posix
+<!-- YAML
+added: v0.11.15
+-->
 
 Provide access to aforementioned `path` methods but always interact in a posix
 compatible way.
 
 ## path.relative(from, to)
+<!-- YAML
+added: v0.5.0
+-->
 
 Solve the relative path from `from` to `to`. `from` and `to` must be strings.
 
@@ -287,6 +320,9 @@ path.relative('/data/orandea/test/aaa', '/data/orandea/impl/bbb')
         both the paths are the same then a zero-length string will be returned.
 
 ## path.resolve([from ...], to)
+<!-- YAML
+added: v0.3.4
+-->
 
 Resolves `to` to an absolute path. All arguments must be strings.
 
@@ -331,6 +367,9 @@ path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
 ```
 
 ## path.sep
+<!-- YAML
+added: v0.7.9
+-->
 
 The platform-specific file separator. `'\\'` or `'/'`.
 
@@ -349,6 +388,9 @@ An example on Windows:
 ```
 
 ## path.win32
+<!-- YAML
+added: v0.11.15
+-->
 
 Provide access to aforementioned `path` methods but always interact in a win32
 compatible way.


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
doc, path

##### Description of change
Add `added:` information for path.

Got the information from git history mostly, I ignored previous path
methods attached to `node.path` (pre v0.1.16).

Ref: #6578