### PR TITLE
test: remove modifcation to common.PORT

### DIFF
--- a/test/fixtures/clustered-server/app.js
+++ b/test/fixtures/clustered-server/app.js
@@ -31,5 +31,5 @@ if (cluster.isMaster) {
   }
 } else {
   var server = http.createServer(handleRequest);
-  server.listen(common.PORT+1000);
+  server.listen(common.PORT);
 }

--- a/test/parallel/test-debug-port-cluster.js
+++ b/test/parallel/test-debug-port-cluster.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-const PORT_MIN = common.PORT + 1; // fixture uses common.PORT
+const PORT_MIN = common.PORT + 1;  // The fixture uses common.PORT.
 const PORT_MAX = PORT_MIN + 2;
 
 const args = [

--- a/test/parallel/test-debug-port-cluster.js
+++ b/test/parallel/test-debug-port-cluster.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-const PORT_MIN = common.PORT;
+const PORT_MIN = common.PORT + 1; // fixture uses common.PORT
 const PORT_MAX = PORT_MIN + 2;
 
 const args = [

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 42;
+var port = common.PORT + 1; // fixture uses common.PORT
 var args = ['--debug-port=' + port,
             common.fixturesDir + '/clustered-server/app.js'];
 var options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 1; // fixture uses common.PORT
+var port = common.PORT + 1;  // The fixture uses common.PORT.
 var args = ['--debug-port=' + port,
             common.fixturesDir + '/clustered-server/app.js'];
 var options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test debugger

##### Description of change
<!-- provide a description of the change below this comment -->

A possibly-buggy fixture server uses `common.PORT+1000` for its port
rather than `common.PORT`. That could result in it clashing with other
ports if tests are run in parallel. The test runner increments
`common.PORT` by 100 for each running instance for tests. Change to use
common.PORT and have the tests that use the fixture start with
common.PORT+1 for anything they need.

Refs: https://github.com/nodejs/node/issues/6989