### PR TITLE
build: expose --trace_maps flag in release builds

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -25,6 +25,9 @@
     # Don't bake anything extra into the snapshot.
     'v8_use_external_startup_data%': 0,
 
+    # Make --trace_maps debug flag available in release builds.
+    'v8_trace_maps': 1,
+
     'conditions': [
       ['OS == "win"', {
         'os_posix': 0,


### PR DESCRIPTION
It adds minimal code to the binary with no runtime overhead when
disabled and can be helpful in debugging map transition issues.