### PR TITLE
test: verify cluster worker exit

### DIFF
--- a/test/parallel/test-cluster-disconnect-handles.js
+++ b/test/parallel/test-cluster-disconnect-handles.js
@@ -31,6 +31,10 @@ if (cluster.isMaster) {
   // scanner but is ignored by atoi(3).  Heinous hack.
   cluster.setupMaster({ execArgv: [`--debug=${common.PORT}.`] });
   const worker = cluster.fork();
+  worker.once('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0, 'worker did not exit normally');
+    assert.strictEqual(signal, null, 'worker did not exit normally');
+  }));
   worker.on('message', common.mustCall((message) => {
     assert.strictEqual(Array.isArray(message), true);
     assert.strictEqual(message[0], 'listening');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
`test-cluster-disconnect-handles` already includes logic that tries to cleanup any child processes when the test fails. This commit adds additional checks to verify that the child exited normally, and fails the test if that is not the case.

Refs: https://github.com/nodejs/node/issues/6988