### PR TITLE
build: introduce configure --shared

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -13,6 +13,7 @@
 
     'node_shared%': 'false',
     'node_no_v8_platform%': 'false',
+    'node_no_bundled_v8%': 'false',
 
     'node_tag%': '',
     'uv_library%': 'static_library',
@@ -292,6 +293,9 @@
               }],
             ],
             'ldflags!': [ '-rdynamic' ],
+          }],
+          [ 'node_shared=="true"', {
+            'cflags': [ '-fPIC' ],
           }],
         ],
       }],

--- a/common.gypi
+++ b/common.gypi
@@ -14,6 +14,7 @@
     'node_shared%': 'false',
     'node_no_v8_platform%': 'false',
     'node_no_bundled_v8%': 'false',
+    'node_module_ver%': '',
 
     'node_tag%': '',
     'uv_library%': 'static_library',

--- a/common.gypi
+++ b/common.gypi
@@ -11,6 +11,9 @@
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
     'python%': 'python',
 
+    'node_shared%': 'false',
+    'node_no_v8_platform%': 'false',
+
     'node_tag%': '',
     'uv_library%': 'static_library',
 

--- a/common.gypi
+++ b/common.gypi
@@ -12,8 +12,8 @@
     'python%': 'python',
 
     'node_shared%': 'false',
-    'node_no_v8_platform%': 'false',
-    'node_no_bundled_v8%': 'false',
+    'node_use_v8_platform%': 'true',
+    'node_use_bundled_v8%': 'true',
     'node_module_ver%': '',
 
     'node_tag%': '',

--- a/common.gypi
+++ b/common.gypi
@@ -14,7 +14,7 @@
     'node_shared%': 'false',
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
-    'node_module_ver%': '',
+    'node_module_version%': '',
 
     'node_tag%': '',
     'uv_library%': 'static_library',

--- a/configure
+++ b/configure
@@ -430,16 +430,16 @@ parser.add_option('--shared',
     help='compile shared library for embedding node in another project. ' +
          '(This mode is not officially supported for regular applications)')
 
-parser.add_option('--no-v8-platform',
+parser.add_option('--without-v8-platform',
     action='store_true',
-    dest='no_v8_platform',
+    dest='without_v8_platform',
     default=False,
     help='do not initialize v8 platform during node.js startup. ' +
          '(This mode is not officially supported for regular applications)')
 
-parser.add_option('--no-bundled-v8',
+parser.add_option('--without-bundled-v8',
     action='store_true',
-    dest='no_bundled_v8',
+    dest='without_bundled_v8',
     default=False,
     help='do not use V8 includes from the bundled deps folder. ' +
          '(This mode is not officially supported for regular applications)')
@@ -835,11 +835,9 @@ def configure_node(o):
 
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   o['variables']['node_shared'] = b(options.shared)
-  o['variables']['node_use_v8_platform'] = b(not options.no_v8_platform)
-  o['variables']['node_use_bundled_v8'] = b(not options.no_bundled_v8)
-  
-  if flavor == 'linux' and options.shared:
-    o['variables']['node_module_ver'] = getmoduleversion.get_version()
+  o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
+  o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
+  o['variables']['node_module_version'] = getmoduleversion.get_version()
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/configure
+++ b/configure
@@ -837,7 +837,7 @@ def configure_node(o):
   o['variables']['node_shared'] = b(options.shared)
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
-  o['variables']['node_module_version'] = getmoduleversion.get_version()
+  o['variables']['node_module_version'] = int(getmoduleversion.get_version())
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/configure
+++ b/configure
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.join(root_dir, 'tools', 'configure.d'))
 import nodedownload
 
 # imports in tools/
-sys.path.insert(0, os.path.join(root_dir, 'tools', ))
+sys.path.insert(0, os.path.join(root_dir, 'tools'))
 import getmoduleversion
 
 # parse our options

--- a/configure
+++ b/configure
@@ -432,6 +432,12 @@ parser.add_option('--no-v8-platform',
     help='do not initialize v8 platform during node.js startup. ' +
          '(This mode is not officially supported for regular applications)')
 
+parser.add_option('--no-bundled-v8',
+    action='store_true',
+    dest='no_bundled_v8',
+    help='do not use V8 includes from the bundled deps folder. ' +
+         '(This mode is not officially supported for regular applications)')
+
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -824,6 +830,7 @@ def configure_node(o):
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   o['variables']['node_shared'] = b(options.shared)
   o['variables']['node_no_v8_platform'] = b(options.no_v8_platform)
+  o['variables']['node_no_bundled_v8'] = b(options.no_bundled_v8)
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/configure
+++ b/configure
@@ -433,12 +433,14 @@ parser.add_option('--shared',
 parser.add_option('--no-v8-platform',
     action='store_true',
     dest='no_v8_platform',
+    default=False,
     help='do not initialize v8 platform during node.js startup. ' +
          '(This mode is not officially supported for regular applications)')
 
 parser.add_option('--no-bundled-v8',
     action='store_true',
     dest='no_bundled_v8',
+    default=False,
     help='do not use V8 includes from the bundled deps folder. ' +
          '(This mode is not officially supported for regular applications)')
 
@@ -833,8 +835,8 @@ def configure_node(o):
 
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   o['variables']['node_shared'] = b(options.shared)
-  o['variables']['node_no_v8_platform'] = b(options.no_v8_platform)
-  o['variables']['node_no_bundled_v8'] = b(options.no_bundled_v8)
+  o['variables']['node_use_v8_platform'] = b(not options.no_v8_platform)
+  o['variables']['node_use_bundled_v8'] = b(not options.no_bundled_v8)
   
   if flavor == 'linux' and options.shared:
     o['variables']['node_module_ver'] = getmoduleversion.get_version()

--- a/configure
+++ b/configure
@@ -24,6 +24,10 @@ from gyp.common import GetFlavor
 sys.path.insert(0, os.path.join(root_dir, 'tools', 'configure.d'))
 import nodedownload
 
+# imports in tools/
+sys.path.insert(0, os.path.join(root_dir, 'tools', ))
+import getmoduleversion
+
 # parse our options
 parser = optparse.OptionParser()
 
@@ -831,6 +835,9 @@ def configure_node(o):
   o['variables']['node_shared'] = b(options.shared)
   o['variables']['node_no_v8_platform'] = b(options.no_v8_platform)
   o['variables']['node_no_bundled_v8'] = b(options.no_bundled_v8)
+  
+  if flavor == 'linux' and options.shared:
+    o['variables']['node_module_ver'] = getmoduleversion.get_version()
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/configure
+++ b/configure
@@ -420,6 +420,18 @@ parser.add_option('--without-inspector',
     dest='without_inspector',
     help='disable experimental V8 inspector support')
 
+parser.add_option('--shared',
+    action='store_true',
+    dest='shared',
+    help='compile shared library for embedding node in another project. ' +
+         '(This mode is not officially supported for regular applications)')
+
+parser.add_option('--no-v8-platform',
+    action='store_true',
+    dest='no_v8_platform',
+    help='do not initialize v8 platform during node.js startup. ' +
+         '(This mode is not officially supported for regular applications)')
+
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -810,6 +822,8 @@ def configure_node(o):
     o['variables']['node_target_type'] = 'static_library'
 
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
+  o['variables']['node_shared'] = b(options.shared)
+  o['variables']['node_no_v8_platform'] = b(options.no_v8_platform)
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/node.gyp
+++ b/node.gyp
@@ -9,6 +9,7 @@
     'node_no_v8_platform%': 'false',
     'node_no_bundled_v8%': 'false',
     'node_shared%': 'false',
+    'node_module_ver%': '',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
     'node_shared_cares%': 'false',
@@ -233,6 +234,11 @@
         }, {
           'defines': [
             'NODE_SHARED_MODE',
+          ],
+          'conditions': [
+            [ 'node_module_ver!=""', {
+              'product_extension': 'so.<(node_module_ver)',
+            }]
           ],
         }],
         [ 'node_no_bundled_v8=="false"', {

--- a/node.gyp
+++ b/node.gyp
@@ -782,11 +782,6 @@
             'test/cctest/test_inspector_socket.cc'
           ]
         }],
-        [ 'node_shared=="false"', {
-          'dependencies': [
-            'deps/v8/tools/gyp/v8.gyp:v8',
-          ],
-        }],
         [ 'node_no_v8_platform=="false"', {
           'dependencies': [
             'deps/v8/tools/gyp/v8.gyp:v8_libplatform',

--- a/node.gyp
+++ b/node.gyp
@@ -9,7 +9,7 @@
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
-    'node_module_ver%': '',
+    'node_module_version%': '',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
     'node_shared_cares%': 'false',
@@ -236,8 +236,8 @@
             'NODE_SHARED_MODE',
           ],
           'conditions': [
-            [ 'node_module_ver!=""', {
-              'product_extension': 'so.<(node_module_ver)',
+            [ 'node_module_version!=""', {
+              'product_extension': 'so.<(node_module_version)',
             }]
           ],
         }],
@@ -250,9 +250,14 @@
             'deps/v8/tools/gyp/v8.gyp:v8',
             'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
           ],
+        }],
+        [ 'node_use_v8_platform=="true"', {
+          'defines': [
+            'NODE_NO_V8_PLATFORM=0',
+          ],
         }, {
           'defines': [
-            'NODE_NO_V8_PLATFORM',
+            'NODE_NO_V8_PLATFORM=1',
           ],
         }],
         [ 'node_tag!=""', {
@@ -347,7 +352,7 @@
                     ],
                   },
                   'conditions': [
-                    ['OS in "linux freebsd"' and 'node_shared=="false"', {
+                    ['OS in "linux freebsd" and node_shared=="false"', {
                       'ldflags': [
                         '-Wl,--whole-archive <(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
                         '-Wl,--no-whole-archive',

--- a/node.gyp
+++ b/node.gyp
@@ -7,6 +7,7 @@
     'node_use_perfctr%': 'false',
     'node_no_browser_globals%': 'false',
     'node_no_v8_platform%': 'false',
+    'node_no_bundled_v8%': 'false',
     'node_shared%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
@@ -223,9 +224,6 @@
 
       'conditions': [
         [ 'node_shared=="false"', {
-          'dependencies': [
-            'deps/v8/tools/gyp/v8.gyp:v8',
-          ],
           'msvs_settings': {
             'VCManifestTool': {
               'EmbedManifest': 'true',
@@ -236,16 +234,15 @@
           'defines': [
             'NODE_SHARED_MODE',
           ],
-          'libraries': [
-            '-lv8',
-          ],
         }],
-        [ 'node_no_v8_platform=="false"', {
+        [ 'node_no_bundled_v8=="false"', {
           'include_dirs': [
             'deps/v8', # include/v8_platform.h
           ],
+
           'dependencies': [
-            'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
+            'deps/v8/tools/gyp/v8.gyp:v8',
+            'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
           ],
         }, {
           'defines': [
@@ -515,7 +512,7 @@
           ],
         }],
         [ 'OS=="freebsd" or OS=="linux"', {
-          'ldflags': [ '-Wl,-z,noexecstack',
+          'ldflags': [ '-Wl,-z,noexecstack,--allow-multiple-definition',
                        '-Wl,--whole-archive <(V8_BASE)',
                        '-Wl,--no-whole-archive' ]
         }],
@@ -787,6 +784,12 @@
         [ 'node_no_v8_platform=="false"', {
           'dependencies': [
             'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
+          ],
+        }],
+        [ 'node_no_bundled_v8=="false"', {
+          'dependencies': [
+            'deps/v8/tools/gyp/v8.gyp:v8',
+            'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
           ],
         }],
       ]

--- a/node.gyp
+++ b/node.gyp
@@ -6,8 +6,8 @@
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',
     'node_no_browser_globals%': 'false',
-    'node_no_v8_platform%': 'false',
-    'node_no_bundled_v8%': 'false',
+    'node_use_v8_platform%': 'true',
+    'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
     'node_module_ver%': '',
     'node_shared_zlib%': 'false',
@@ -241,7 +241,7 @@
             }]
           ],
         }],
-        [ 'node_no_bundled_v8=="false"', {
+        [ 'node_use_bundled_v8=="true"', {
           'include_dirs': [
             'deps/v8', # include/v8_platform.h
           ],
@@ -283,7 +283,7 @@
               'defines': [ 'NODE_HAVE_SMALL_ICU=1' ],
           }]],
         }],
-        [ 'node_no_bundled_v8=="false" and \
+        [ 'node_use_bundled_v8=="true" and \
            node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
            target_arch=="ia32" or target_arch=="x32")', {
           'defines': [ 'NODE_ENABLE_VTUNE_PROFILING' ],
@@ -347,7 +347,7 @@
                     ],
                   },
                   'conditions': [
-                    ['OS in "linux freebsd"', {
+                    ['OS in "linux freebsd"' and 'node_shared=="false"', {
                       'ldflags': [
                         '-Wl,--whole-archive <(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
                         '-Wl,--no-whole-archive',
@@ -434,7 +434,7 @@
         [ 'node_no_browser_globals=="true"', {
           'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
         } ],
-        [ 'node_no_bundled_v8=="false" and v8_postmortem_support=="true"', {
+        [ 'node_use_bundled_v8=="true" and v8_postmortem_support=="true"', {
           'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],
           'conditions': [
             # -force_load is not applicable for the static library
@@ -517,8 +517,8 @@
             'NODE_PLATFORM="sunos"',
           ],
         }],
-        [ 'OS=="freebsd" or OS=="linux"', {
-          'ldflags': [ '-Wl,-z,noexecstack,--allow-multiple-definition',
+        [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"', {
+          'ldflags': [ '-Wl,-z,noexecstack',
                        '-Wl,--whole-archive <(V8_BASE)',
                        '-Wl,--no-whole-archive' ]
         }],
@@ -782,12 +782,12 @@
             'test/cctest/test_inspector_socket.cc'
           ]
         }],
-        [ 'node_no_v8_platform=="false"', {
+        [ 'node_use_v8_platform=="true"', {
           'dependencies': [
             'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
           ],
         }],
-        [ 'node_no_bundled_v8=="false"', {
+        [ 'node_use_bundled_v8=="true"', {
           'dependencies': [
             'deps/v8/tools/gyp/v8.gyp:v8',
             'deps/v8/tools/gyp/v8.gyp:v8_libplatform'

--- a/node.gyp
+++ b/node.gyp
@@ -6,6 +6,8 @@
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',
     'node_no_browser_globals%': 'false',
+    'node_no_v8_platform%': 'false',
+    'node_shared%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
     'node_shared_cares%': 'false',
@@ -14,7 +16,6 @@
     'node_shared_openssl%': 'false',
     'node_v8_options%': '',
     'node_enable_v8_vtunejit%': 'false',
-    'node_target_type%': 'executable',
     'node_core_target_name%': 'node',
     'library_files': [
       'lib/internal/bootstrap_node.js',
@@ -100,6 +101,13 @@
       'deps/v8/tools/SourceMap.js',
       'deps/v8/tools/tickprocessor-driver.js',
     ],
+    'conditions': [
+      [ 'node_shared=="true"', {
+        'node_target_type%': 'shared_library',
+      }, {
+        'node_target_type%': 'executable',
+      }],
+    ],
   },
 
   'targets': [
@@ -109,8 +117,6 @@
 
       'dependencies': [
         'node_js2c#host',
-        'deps/v8/tools/gyp/v8.gyp:v8',
-        'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
       ],
 
       'include_dirs': [
@@ -118,7 +124,6 @@
         'tools/msvs/genfiles',
         'deps/uv/src/ares',
         '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
-        'deps/v8' # include/v8_platform.h
       ],
 
       'sources': [
@@ -217,6 +222,36 @@
 
 
       'conditions': [
+        [ 'node_shared=="false"', {
+          'dependencies': [
+            'deps/v8/tools/gyp/v8.gyp:v8',
+          ],
+          'msvs_settings': {
+            'VCManifestTool': {
+              'EmbedManifest': 'true',
+              'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'
+            }
+          },
+        }, {
+          'defines': [
+            'NODE_SHARED_MODE',
+          ],
+          'libraries': [
+            '-lv8',
+          ],
+        }],
+        [ 'node_no_v8_platform=="false"', {
+          'include_dirs': [
+            'deps/v8', # include/v8_platform.h
+          ],
+          'dependencies': [
+            'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
+          ],
+        }, {
+          'defines': [
+            'NODE_NO_V8_PLATFORM',
+          ],
+        }],
         [ 'node_tag!=""', {
           'defines': [ 'NODE_TAG="<(node_tag)"' ],
         }],
@@ -245,7 +280,8 @@
               'defines': [ 'NODE_HAVE_SMALL_ICU=1' ],
           }]],
         }],
-        [ 'node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
+        [ 'node_no_bundled_v8=="false" and \
+           node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
            target_arch=="ia32" or target_arch=="x32")', {
           'defines': [ 'NODE_ENABLE_VTUNE_PROFILING' ],
           'dependencies': [
@@ -395,7 +431,7 @@
         [ 'node_no_browser_globals=="true"', {
           'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
         } ],
-        [ 'v8_postmortem_support=="true"', {
+        [ 'node_no_bundled_v8=="false" and v8_postmortem_support=="true"', {
           'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:postmortem-metadata' ],
           'conditions': [
             # -force_load is not applicable for the static library
@@ -487,12 +523,6 @@
           'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
         }],
       ],
-      'msvs_settings': {
-        'VCManifestTool': {
-          'EmbedManifest': 'true',
-          'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'
-        }
-      },
     },
     # generate ETW header and resource files
     {
@@ -718,8 +748,6 @@
         'deps/http_parser/http_parser.gyp:http_parser',
         'deps/gtest/gtest.gyp:gtest',
         'deps/uv/uv.gyp:libuv',
-        'deps/v8/tools/gyp/v8.gyp:v8',
-        'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
       ],
       'include_dirs': [
         'src',
@@ -750,7 +778,17 @@
             'src/inspector_socket.cc',
             'test/cctest/test_inspector_socket.cc'
           ]
-        }]
+        }],
+        [ 'node_shared=="false"', {
+          'dependencies': [
+            'deps/v8/tools/gyp/v8.gyp:v8',
+          ],
+        }],
+        [ 'node_no_v8_platform=="false"', {
+          'dependencies': [
+            'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
+          ],
+        }],
       ]
     }
   ], # end targets

--- a/node.gyp
+++ b/node.gyp
@@ -253,11 +253,11 @@
         }],
         [ 'node_use_v8_platform=="true"', {
           'defines': [
-            'NODE_NO_V8_PLATFORM=0',
+            'NODE_USE_V8_PLATFORM=1',
           ],
         }, {
           'defines': [
-            'NODE_NO_V8_PLATFORM=1',
+            'NODE_USE_V8_PLATFORM=0',
           ],
         }],
         [ 'node_tag!=""', {

--- a/src/node.cc
+++ b/src/node.cc
@@ -215,7 +215,7 @@ static struct {
   void Dispose() {}
 #if HAVE_INSPECTOR
   void StartInspector(Environment *env, int port, bool wait) {
-    env->ThrowError("Node compiled with NODE_NO_V8_PLATFORM");
+    env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
   }
 #endif  // HAVE_INSPECTOR
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -39,9 +39,9 @@
 #include "string_bytes.h"
 #include "util.h"
 #include "uv.h"
-#if !NODE_NO_V8_PLATFORM
+#if NODE_USE_V8_PLATFORM
 #include "libplatform/libplatform.h"
-#endif  // !NODE_NO_V8_PLATFORM
+#endif  // NODE_USE_V8_PLATFORM
 #include "v8-debug.h"
 #include "v8-profiler.h"
 #include "zlib.h"
@@ -187,16 +187,7 @@ static Mutex node_isolate_mutex;
 static v8::Isolate* node_isolate;
 
 static struct {
-#if NODE_NO_V8_PLATFORM
-  void Initialize(int thread_pool_size) {}
-  void PumpMessageLoop(Isolate* isolate) {}
-  void Dispose() {}
-#if HAVE_INSPECTOR
-  void StartInspector(Environment *env, int port, bool wait) {
-    env->ThrowError("Node compiled with NODE_NO_V8_PLATFORM");
-  }
-#endif  // HAVE_INSPECTOR
-#else  // !NODE_NO_V8_PLATFORM
+#if NODE_USE_V8_PLATFORM
   void Initialize(int thread_pool_size) {
     platform_ = v8::platform::CreateDefaultPlatform(thread_pool_size);
     V8::InitializePlatform(platform_);
@@ -218,7 +209,17 @@ static struct {
 #endif  // HAVE_INSPECTOR
 
   v8::Platform* platform_;
-#endif  // !NODE_NO_V8_PLATFORM
+#else  // !NODE_USE_V8_PLATFORM
+  void Initialize(int thread_pool_size) {}
+  void PumpMessageLoop(Isolate* isolate) {}
+  void Dispose() {}
+#if HAVE_INSPECTOR
+  void StartInspector(Environment *env, int port, bool wait) {
+    env->ThrowError("Node compiled with NODE_NO_V8_PLATFORM");
+  }
+#endif  // HAVE_INSPECTOR
+
+#endif  // !NODE_USE_V8_PLATFORM
 } v8_platform;
 
 #ifdef __POSIX__

--- a/src/node.cc
+++ b/src/node.cc
@@ -186,7 +186,7 @@ static uv_async_t dispatch_debug_messages_async;
 static Mutex node_isolate_mutex;
 static v8::Isolate* node_isolate;
 
-static struct {
+static struct v8_plat {
 #ifdef NODE_NO_V8_PLATFORM
   void Initialize(int thread_pool_size) {}
   void PumpMessageLoop(Isolate* isolate) {}
@@ -217,7 +217,7 @@ static struct {
   }
 #endif  // HAVE_INSPECTOR
 
-  static v8::Platform* platform;
+  v8::Platform* platform;
 #endif  // !NODE_NO_V8_PLATFORM
 } v8_platform;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -39,9 +39,9 @@
 #include "string_bytes.h"
 #include "util.h"
 #include "uv.h"
-#ifndef NODE_NO_V8_PLATFORM
+#if !NODE_NO_V8_PLATFORM
 #include "libplatform/libplatform.h"
-#endif  // NODE_NO_V8_PLATFORM
+#endif  // !NODE_NO_V8_PLATFORM
 #include "v8-debug.h"
 #include "v8-profiler.h"
 #include "zlib.h"
@@ -187,7 +187,7 @@ static Mutex node_isolate_mutex;
 static v8::Isolate* node_isolate;
 
 static struct {
-#ifdef NODE_NO_V8_PLATFORM
+#if NODE_NO_V8_PLATFORM
   void Initialize(int thread_pool_size) {}
   void PumpMessageLoop(Isolate* isolate) {}
   void Dispose() {}

--- a/src/node.cc
+++ b/src/node.cc
@@ -186,7 +186,7 @@ static uv_async_t dispatch_debug_messages_async;
 static Mutex node_isolate_mutex;
 static v8::Isolate* node_isolate;
 
-static struct v8_plat {
+static struct {
 #ifdef NODE_NO_V8_PLATFORM
   void Initialize(int thread_pool_size) {}
   void PumpMessageLoop(Isolate* isolate) {}
@@ -198,26 +198,26 @@ static struct v8_plat {
 #endif  // HAVE_INSPECTOR
 #else  // !NODE_NO_V8_PLATFORM
   void Initialize(int thread_pool_size) {
-    platform = v8::platform::CreateDefaultPlatform(thread_pool_size);
-    V8::InitializePlatform(platform);
+    platform_ = v8::platform::CreateDefaultPlatform(thread_pool_size);
+    V8::InitializePlatform(platform_);
   }
 
   void PumpMessageLoop(Isolate* isolate) {
-    v8::platform::PumpMessageLoop(platform, isolate);
+    v8::platform::PumpMessageLoop(platform_, isolate);
   }
 
   void Dispose() {
-    delete platform;
-    platform = nullptr;
+    delete platform_;
+    platform_ = nullptr;
   }
 
 #if HAVE_INSPECTOR
   void StartInspector(Environment *env, int port, bool wait) {
-    env->inspector_agent()->Start(platform, port, wait);
+    env->inspector_agent()->Start(platform_, port, wait);
   }
 #endif  // HAVE_INSPECTOR
 
-  v8::Platform* platform;
+  v8::Platform* platform_;
 #endif  // !NODE_NO_V8_PLATFORM
 } v8_platform;
 

--- a/src/node.h
+++ b/src/node.h
@@ -411,17 +411,23 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 # define NODE_MODULE_EXPORT __attribute__((visibility("default")))
 #endif
 
+#ifdef NODE_SHARED_MODE
+# define NODE_CTOR_PREFIX
+#else
+# define NODE_CTOR_PREFIX static
+#endif
+
 #if defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
 #define NODE_C_CTOR(fn)                                               \
-  static void __cdecl fn(void);                                       \
+  NODE_CTOR_PREFIX void __cdecl fn(void);                             \
   __declspec(dllexport, allocate(".CRT$XCU"))                         \
       void (__cdecl*fn ## _)(void) = fn;                              \
-  static void __cdecl fn(void)
+  NODE_CTOR_PREFIX void __cdecl fn(void)
 #else
 #define NODE_C_CTOR(fn)                                               \
-  static void fn(void) __attribute__((constructor));                  \
-  static void fn(void)
+  NODE_CTOR_PREFIX void fn(void) __attribute__((constructor));        \
+  NODE_CTOR_PREFIX void fn(void)
 #endif
 
 #define NODE_MODULE_X(modname, regfunc, priv, flags)                  \

--- a/test/parallel/test-module-version.js
+++ b/test/parallel/test-module-version.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+var assert = require('assert');
+
+// check for existence
+assert(process.config.variables.hasOwnProperty('node_module_version'));
+
+// ensure that `node_module_version` is an Integer > 0
+assert(Number.isInteger(process.config.variables.node_module_version));
+assert(process.config.variables.node_module_version > 0);

--- a/tools/getmoduleversion.py
+++ b/tools/getmoduleversion.py
@@ -1,0 +1,19 @@
+import os,re
+
+def get_version():
+  node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
+      'node_version.h')
+
+  f = open(node_version_h)
+
+  regex = '#define NODE_MODULE_VERSION [0-9]+'
+
+  for line in f:
+    if re.match(regex, line):
+      major = line.split()[2]
+      return major
+  
+  raise Exception("Could not find pattern matching '%s'" % regex)
+
+if __name__ == "__main__":
+  print get_version()

--- a/tools/getmoduleversion.py
+++ b/tools/getmoduleversion.py
@@ -2,7 +2,7 @@ import os,re
 
 def get_version():
   node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
-      'node_version.h')
+    'node_version.h')
 
   f = open(node_version_h)
 

--- a/tools/getmoduleversion.py
+++ b/tools/getmoduleversion.py
@@ -1,19 +1,22 @@
 import os,re
 
 def get_version():
-  node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
+  node_version_h = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'src',
     'node_version.h')
 
   f = open(node_version_h)
 
-  regex = '#define NODE_MODULE_VERSION [0-9]+'
+  regex = '^#define NODE_MODULE_VERSION [0-9]+'
 
   for line in f:
     if re.match(regex, line):
       major = line.split()[2]
       return major
   
-  raise Exception("Could not find pattern matching '%s'" % regex)
+  raise Exception('Could not find pattern matching %s' % regex)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   print get_version()

--- a/tools/getmoduleversion.py
+++ b/tools/getmoduleversion.py
@@ -1,4 +1,6 @@
-import os,re
+from __future__ import print_function
+import os
+import re
 
 def get_version():
   node_version_h = os.path.join(
@@ -19,4 +21,4 @@ def get_version():
   raise Exception('Could not find pattern matching %s' % regex)
 
 if __name__ == '__main__':
-  print get_version()
+  print(get_version())

--- a/tools/getnodeversion.py
+++ b/tools/getnodeversion.py
@@ -1,4 +1,5 @@
-import os,re
+import os
+import re
 
 node_version_h = os.path.join(
     os.path.dirname(__file__),

--- a/tools/getnodeversion.py
+++ b/tools/getnodeversion.py
@@ -1,16 +1,19 @@
 import os,re
 
-node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
+node_version_h = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'src',
     'node_version.h')
 
 f = open(node_version_h)
 
 for line in f:
-  if re.match('#define NODE_MAJOR_VERSION', line):
+  if re.match('^#define NODE_MAJOR_VERSION', line):
     major = line.split()[2]
-  if re.match('#define NODE_MINOR_VERSION', line):
+  if re.match('^#define NODE_MINOR_VERSION', line):
     minor = line.split()[2]
-  if re.match('#define NODE_PATCH_VERSION', line):
+  if re.match('^#define NODE_PATCH_VERSION', line):
     patch = line.split()[2]
 
 print '%(major)s.%(minor)s.%(patch)s'% locals()

--- a/tools/install.py
+++ b/tools/install.py
@@ -108,8 +108,17 @@ def subdir_files(path, dest, action):
 def files(action):
   is_windows = sys.platform == 'win32'
 
-  exeext = '.exe' if is_windows else ''
-  action(['out/Release/node' + exeext], 'bin/node' + exeext)
+  if 'false' == variables.get('node_shared') and is_windows:
+    output_file += '.exe'
+  else:
+    if is_windows:
+      output_file += '.dll'
+    else:
+      # GYP will output to lib.target, this is hardcoded in its source,
+      # see the _InstallableTargetInstallPath function.
+      output_file = 'lib.target/lib' + output_file + '.so'
+
+  action(['out/Release/' + output_file], 'bin/' + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')

--- a/tools/install.py
+++ b/tools/install.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import sys
+from getmoduleversion import get_version
 
 # set at init time
 node_prefix = '/usr/local' # PREFIX variable from Makefile
@@ -107,6 +108,8 @@ def subdir_files(path, dest, action):
 
 def files(action):
   is_windows = sys.platform == 'win32'
+  output_file = 'node'
+  output_prefix = 'out/Release/'
 
   if 'false' == variables.get('node_shared') and is_windows:
     output_file += '.exe'
@@ -116,9 +119,10 @@ def files(action):
     else:
       # GYP will output to lib.target, this is hardcoded in its source,
       # see the _InstallableTargetInstallPath function.
-      output_file = 'lib.target/lib' + output_file + '.so'
+      output_prefix += 'lib.target/'
+      output_file = 'lib' + output_file + '.so.' + get_version()
 
-  action(['out/Release/' + output_file], 'bin/' + output_file)
+  action([output_prefix + output_file], 'bin/' + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')

--- a/tools/install.py
+++ b/tools/install.py
@@ -111,8 +111,9 @@ def files(action):
   output_file = 'node'
   output_prefix = 'out/Release/'
 
-  if 'false' == variables.get('node_shared') and is_windows:
-    output_file += '.exe'
+  if 'false' == variables.get('node_shared'):
+    if is_windows:
+      output_file += '.exe'
   else:
     if is_windows:
       output_file += '.dll'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

build, configure

##### Description of change
<!-- provide a description of the change below this comment -->

This PR is the continuation of https://github.com/nodejs/node/pull/5918 where the originator (@indutny) agreed that I can take over this task in order to land the changes as soon as possible.

The PR consists of two commits, the original one from https://github.com/nodejs/node/pull/5918 which adds "[a] configure flag for building shared library that could be used to embed Node.js in some application (like Electron)" and a second commit that modifies the following aspects:

- Use the "--shared" configure flag to build a shared library.
- Use the "--no-bundled-v8" flag to exclude V8 headers from the deps/ folder, this option is useful to Electron which provides its own copy of V8.
- Use the "--no-v8-platform" flag to avoid initializing the V8 platform inside Node (useful for some embedders).
- Insure that "./configure --shared && make" works and produces a useable libnode.so for anyone (i.e. decouple --shared from Electron's build system).

I intend to land both commits in the PR at the same time (the original one from @indutny and my changes on top of it) to maintain a clear history/ownership of the work. If anyone feels strongly about this approach either way, please let me know.

All these options are provided as-is for embedders are not officially supported at this time, as indicated in the documentation.

**Future changes:**

This PR is concerned with Linux only - once this PR is landed a separate PR will be made to resolve issues related to building a DLL on Windows.