### PR TITLE
test: use common.fixturesDir almost everywhere

### DIFF
--- a/test/parallel/test-child-process-detached.js
+++ b/test/parallel/test-child-process-detached.js
@@ -1,10 +1,10 @@
 'use strict';
-require('../common');
+var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 
 var spawn = require('child_process').spawn;
-var childPath = path.join(__dirname, '..', 'fixtures',
+var childPath = path.join(common.fixturesDir,
                           'parent-process-nonpersistent.js');
 var persistentPid = -1;
 

--- a/test/parallel/test-delayed-require.js
+++ b/test/parallel/test-delayed-require.js
@@ -1,10 +1,11 @@
 'use strict';
-require('../common');
+var common = require('../common');
+var path = require('path');
 var assert = require('assert');
 
 var a;
 setTimeout(function() {
-  a = require('../fixtures/a');
+  a = require(path.join(common.fixturesDir, 'a'));
 }, 50);
 
 process.on('exit', function() {

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -1,5 +1,6 @@
 /* eslint-disable strict */
 var common = require('../common');
+var path = require('path');
 var assert = require('assert');
 
 common.globalCheck = false;
@@ -13,7 +14,7 @@ assert.equal('bar',
              baseBar, // eslint-disable-line no-undef
              'global.x -> x in base level not working');
 
-var module = require('../fixtures/global/plain');
+var module = require(path.join(common.fixturesDir, 'global', 'plain'));
 const fooBar = module.fooBar;
 
 assert.equal('foo', fooBar.foo, 'x -> global.x in sub level not working');

--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const hostExpect = 'localhost';
 const fs = require('fs');
 const path = require('path');
-const fixtures = path.resolve(__dirname, '../fixtures/keys');
+const fixtures = path.join(common.fixturesDir, 'keys');
 const options = {
   key: fs.readFileSync(fixtures + '/agent1-key.pem'),
   cert: fs.readFileSync(fixtures + '/agent1-cert.pem')

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -1,9 +1,10 @@
 'use strict';
-require('../common');
+var common = require('../common');
+var path = require('path');
 var assert = require('assert');
 
 assert.throws(function() {
   require('internal/freelist');
 });
 
-assert(require('../fixtures/internal-modules') === 42);
+assert(require(path.join(common.fixturesDir, 'internal-modules')) === 42);

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -22,7 +22,7 @@ const preloadOption = function(preloads) {
 };
 
 const fixture = function(name) {
-  return path.join(__dirname, '../fixtures/' + name);
+  return path.join(common.fixturesDir, name);
 };
 
 const fixtureA = fixture('printA.js');
@@ -138,7 +138,7 @@ childProcess.exec(nodeBinary + ' '
   });
 
 // https://github.com/nodejs/node/issues/1691
-process.chdir(path.join(__dirname, '../fixtures/'));
+process.chdir(common.fixturesDir);
 childProcess.exec(nodeBinary + ' '
   + '--expose_debug_as=v8debug '
   + '--require ' + fixture('cluster-preload.js') + ' '

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -70,7 +70,7 @@ const sameHistoryFilePaths = '\nThe old repl history file has the same name ' +
                              path.join(common.tmpDir, '.node_repl_history') +
                              ' and is empty.\nUsing it as is.\n';
 // File paths
-const fixtures = path.join(common.testDir, 'fixtures');
+const fixtures = common.fixturesDir;
 const historyFixturePath = path.join(fixtures, '.node_repl_history');
 const historyPath = path.join(common.tmpDir, '.fixture_copy_repl_history');
 const historyPathFail = path.join(common.tmpDir, '.node_repl\u0000_history');

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -17,7 +17,7 @@ common.ArrayStream.prototype.write = function(output) {
 
 const putIn = new common.ArrayStream();
 repl.start('', putIn);
-let file = path.resolve(__dirname, '../fixtures/syntax/bad_syntax');
+let file = path.join(common.fixturesDir, 'syntax', 'bad_syntax');
 
 if (common.isWindows)
   file = file.replace(/\\/g, '\\\\');

--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -1,9 +1,10 @@
 'use strict';
-require('../common');
+var common = require('../common');
+var path = require('path');
 var assert = require('assert');
 
 try {
-  require('../fixtures/invalid.json');
+  require(path.join(common.fixturesDir, 'invalid.json'));
 } catch (err) {
   var re = /test[\/\\]fixtures[\/\\]invalid.json: Unexpected string/;
   var i = err.message.match(re);

--- a/test/parallel/test-sync-fileread.js
+++ b/test/parallel/test-sync-fileread.js
@@ -1,9 +1,9 @@
 'use strict';
-require('../common');
+var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 
-var fixture = path.join(__dirname, '../fixtures/x.txt');
+var fixture = path.join(common.fixturesDir, 'x.txt');
 
 assert.equal('xyz\n', fs.readFileSync(fixture));

--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -2,13 +2,12 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
 const stream = require('stream');
 const net = require('net');
 
 var server;
-var cert_dir = path.resolve(__dirname, '../fixtures');
+var cert_dir = common.fixturesDir;
 var options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
                 cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
                 ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],

--- a/test/parallel/test-util-decorate-error-stack.js
+++ b/test/parallel/test-util-decorate-error-stack.js
@@ -1,6 +1,6 @@
 // Flags: --expose_internals
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 const spawnSync = require('child_process').spawnSync;
@@ -26,7 +26,7 @@ function checkStack(stack) {
 }
 let err;
 const badSyntaxPath =
-    path.resolve(__dirname, '..', 'fixtures', 'syntax', 'bad_syntax')
+    path.join(common.fixturesDir, 'syntax', 'bad_syntax')
         .replace(/\\/g, '\\\\');
 
 try {

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -1,7 +1,8 @@
 'use strict';
 // Flags: --expose_internals
 
-require('../common');
+const common = require('../common');
+const path = require('path');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 const spawnSync = require('child_process').spawnSync;
@@ -43,7 +44,7 @@ assert.strictEqual(internalUtil.getHiddenValue(obj, 'foo'), 'bar');
 let arrowMessage;
 
 try {
-  require('../fixtures/syntax/bad_syntax');
+  require(path.join(common.fixturesDir, 'syntax', 'bad_syntax'));
 } catch (err) {
   arrowMessage = internalUtil.getHiddenValue(err, 'node:arrowMessage');
 }

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -1,12 +1,12 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const depmod = require.resolve('../fixtures/deprecated.js');
+const depmod = require.resolve(common.fixturesDir + '/deprecated.js');
 const node = process.execPath;
 
 const depUserland =
-    require.resolve('../fixtures/deprecated-userland-function.js');
+    require.resolve(common.fixturesDir + '/deprecated-userland-function.js');
 
 const normal = [depmod];
 const noDep = ['--no-deprecation', depmod];

--- a/test/sequential/test-process-warnings.js
+++ b/test/sequential/test-process-warnings.js
@@ -1,9 +1,9 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const warnmod = require.resolve('../fixtures/warnings.js');
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
 const node = process.execPath;
 
 const normal = [warnmod];


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change

Updating tests to use `common.fixturesDir` whenever possible/reasonable.
Left out things like tests for `path` and `require.resolve`.