### PR TITLE
cluster: expose result of send()

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -61,7 +61,7 @@ Worker.prototype.kill = function() {
 };
 
 Worker.prototype.send = function() {
-  this.process.send.apply(this.process, arguments);
+  return this.process.send.apply(this.process, arguments);
 };
 
 Worker.prototype.isDead = function isDead() {
@@ -533,7 +533,7 @@ function masterInit() {
   }
 
   function send(worker, message, handle, cb) {
-    sendHelper(worker.process, message, handle, cb);
+    return sendHelper(worker.process, message, handle, cb);
   }
 }
 
@@ -701,7 +701,7 @@ function workerInit() {
   };
 
   function send(message, cb) {
-    sendHelper(process, message, null, cb);
+    return sendHelper(process, message, null, cb);
   }
 
   function _disconnect(masterInitiated) {
@@ -747,7 +747,7 @@ function sendHelper(proc, message, handle, cb) {
   if (cb) callbacks[seq] = cb;
   message.seq = seq;
   seq += 1;
-  proc.send(message, handle);
+  return proc.send(message, handle);
 }
 
 

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -4,11 +4,12 @@ var assert = require('assert');
 var cluster = require('cluster');
 
 if (cluster.isWorker) {
-  cluster.worker.send({
+  const result = cluster.worker.send({
     prop: process.env['cluster_test_prop'],
     overwrite: process.env['cluster_test_overwrite']
   });
 
+  assert.strictEqual(result, true);
 } else if (cluster.isMaster) {
 
   var checks = {

--- a/test/parallel/test-cluster-worker-events.js
+++ b/test/parallel/test-cluster-worker-events.js
@@ -14,7 +14,8 @@ if (cluster.isMaster) {
     process.exit(0);
   });
 
-  worker.send('SOME MESSAGE');
+  const result = worker.send('SOME MESSAGE');
+  assert.strictEqual(result, true);
 
   return;
 }


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
cluster

##### Description of change
There are several places in the `cluster` module where a version of `process.send()` is called, but the result is swallowed. Most of these cases are internal, but `Worker.prototype.send()`, which is publicly documented, also suffers from this problem. This commit exposes the return value to facilitate better error handling, and bring `Worker.prototype.send()` into compliance with the documentation.