### PR TITLE
test: check types for http request and response

### DIFF
--- a/test/parallel/test-http-same-map.js
+++ b/test/parallel/test-http-same-map.js
@@ -1,0 +1,55 @@
+// Flags: --allow_natives_syntax
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server =
+    http.createServer(onrequest).listen(0, common.localhostIPv4, () => next(0));
+
+function onrequest(req, res) {
+  res.end('ok');
+  onrequest.requests.push(req);
+  onrequest.responses.push(res);
+}
+onrequest.requests = [];
+onrequest.responses = [];
+
+function next(n) {
+  const { address: host, port } = server.address();
+  const req = http.get({ host, port });
+  req.once('response', (res) => onresponse(n, req, res));
+}
+
+function onresponse(n, req, res) {
+  res.resume();
+
+  if (n < 3) {
+    res.once('end', () => next(n + 1));
+  } else {
+    server.close();
+  }
+
+  onresponse.requests.push(req);
+  onresponse.responses.push(res);
+}
+onresponse.requests = [];
+onresponse.responses = [];
+
+function allSame(list) {
+  assert(list.length >= 2);
+  // Use |elt| in no-op position to pacify eslint.
+  for (const elt of list) elt, eval('%DebugPrint(elt)');
+  for (const elt of list) elt, assert(eval('%HaveSameMap(list[0], elt)'));
+}
+
+process.on('exit', () => {
+  eval('%CollectGarbage(0)');
+  // TODO(bnoordhuis) Investigate why the first IncomingMessage ends up
+  // with a deprecated map.  The map is stable after the first request.
+  allSame(onrequest.requests.slice(1));
+  allSame(onrequest.responses);
+  allSame(onresponse.requests);
+  allSame(onresponse.responses);
+});


### PR DESCRIPTION
Add a basic regression test that checks if the map for IncomingMessage
and OutgoingMessage objects is stable over time.

The test is not exhaustive in that it doesn't try to establish whether
the transition path is the same on every request, it just checks that
objects in their final states have the same map.

To be investigated why the first (and only the first) ServerRequest
object ends up with a deprecated map, regardless of the number of
iterations.

Refs: #6294
CI: https://ci.nodejs.org/job/node-test-pull-request/2810/