### PR TITLE
repl: History file locking and other improvements

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -174,7 +174,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
       history = history.concat(parseData(data)).slice(0, repl.historySize);
     }
     const fd = fs.openSync(historyPath, 'a');
-    fs.writeSync(fd, history.join('\n'), 0, 'utf8');
+    fs.writeSync(fd, history.join('\n') + '\n', 0, 'utf8');
     fs.closeSync(fd);
   }
 }

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -174,6 +174,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
       history = history.concat(parseData(data)).slice(0, repl.historySize);
     }
     const fd = fs.openSync(historyPath, 'a');
+    fs.ftruncateSync(fd, 0);
     fs.writeSync(fd, history.join('\n') + '\n', 0, 'utf8');
     fs.closeSync(fd);
   }

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -10,10 +10,6 @@ const debug = require('util').debuglog('repl');
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
 
-// XXX(chrisdickinson): The 15ms debounce value is somewhat arbitrary.
-// The debounce is to guard against code pasted into the REPL.
-const kDebounceHistoryMS = 15;
-
 function createRepl(env, opts, cb) {
   if (typeof opts === 'function') {
     cb = opts;
@@ -65,6 +61,7 @@ function createRepl(env, opts, cb) {
 }
 
 function setupHistory(repl, historyPath, oldHistoryPath, ready) {
+  let initialHistoryLength = 0;
   // Empty string disables persistent history.
   if (typeof historyPath === 'string')
     historyPath = historyPath.trim();
@@ -88,9 +85,6 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     }
   }
 
-  var timer = null;
-  var writing = false;
-  var pending = false;
   repl.pause();
   // History files are conventionally not readable by others:
   // https://github.com/nodejs/node/issues/3392
@@ -121,7 +115,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
   }
 
   function parseData(data) {
-    return data.trim().split(/[\n\r]+/).slice(0, repl.historySize);
+    return data.toString().trim().split(/[\n\r]+/).slice(0, repl.historySize);
   }
 
   function onread(err, data) {
@@ -131,6 +125,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
 
     if (data) {
       repl.history = parseData(data);
+      initialHistoryLength = repl.history.length;
     } else if (oldHistoryPath === historyPath) {
       // If pre-v3.0, the user had set NODE_REPL_HISTORY_FILE to
       // ~/.node_repl_history, warn the user about it and proceed.
@@ -165,73 +160,22 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
         }
       }
     }
-    repl.on('line', online);
+    // Flush history on close
+    repl.on('close', flushHistory);
     repl.resume();
     ready(null, repl);
   }
 
-
-  // ------ history listeners ------
-  function online() {
-    repl._flushing = true;
-
-    if (timer) {
-      clearTimeout(timer);
-    }
-
-    timer = setTimeout(flushHistory, kDebounceHistoryMS);
-  }
-
-  function handleError(e) {
-    pending = true;
-    debug(e);
-    repl.resume();
-    return;
-  }
-
   function flushHistory() {
-    timer = null;
-    if (writing) {
-      pending = true;
-      return;
+    const data = fs.readFileSync(historyPath, 'utf8');
+    const newLines = repl.history.length - initialHistoryLength;
+    let history = repl.history.slice(0, newLines);
+    if (data) {
+      history = history.concat(parseData(data)).slice(0, repl.historySize);
     }
-    fs.readFile(historyPath, (err, data) => {
-      const fileData = parseData(data.toString());
-      fileData.unshift(repl.history[0]);
-      fs.stat(historyPath, (err, stat) => {
-        if (err) {
-          return handleError(err);
-        }
-        fs.unlink(historyPath, (err) => {
-          if (err) {
-            return handleError(err);
-          }
-          fs.open(historyPath, 'ax', (err, fd) => {
-            if (err) {
-              return handleError(err);
-            }
-            writing = true;
-            fs.write(fd, fileData.join('\n'), stat.mode, 0, 'utf8', onwritten(fd));
-          });
-        });
-      });
-    });
-  }
-
-  function onwritten(fd) {
-    return (err, data) => {
-      fs.close(fd);
-      writing = false;
-      if (pending) {
-        pending = false;
-        online();
-      } else {
-        repl._flushing = Boolean(timer);
-        if (!repl._flushing) {
-          repl.emit('flushHistory');
-        }
-      }
-    };
+    const fd = fs.openSync(historyPath, 'a');
+    fs.writeSync(fd, history.join('\n'), 0, 'utf8');
+    fs.closeSync(fd);
   }
 }
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -66,7 +66,6 @@ function createRepl(env, opts, cb) {
 
 function setupHistory(repl, historyPath, oldHistoryPath, ready) {
   // Empty string disables persistent history.
-
   if (typeof historyPath === 'string')
     historyPath = historyPath.trim();
 
@@ -121,14 +120,17 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     fs.readFile(historyPath, 'utf8', onread);
   }
 
+  function parseData(data) {
+    return data.trim().split(/[\n\r]+/).slice(0, repl.historySize);
+  }
+
   function onread(err, data) {
     if (err) {
       return ready(err);
     }
 
     if (data) {
-      repl.history = data.trim().split(/[\n\r]+/)
-        .slice(0, repl.historySize);
+      repl.history = parseData(data);
     } else if (oldHistoryPath === historyPath) {
       // If pre-v3.0, the user had set NODE_REPL_HISTORY_FILE to
       // ~/.node_repl_history, warn the user about it and proceed.
@@ -180,22 +182,39 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     timer = setTimeout(flushHistory, kDebounceHistoryMS);
   }
 
+  function handleError(e) {
+    pending = true;
+    debug(e);
+    repl.resume();
+    return;
+  }
+
   function flushHistory() {
     timer = null;
     if (writing) {
       pending = true;
       return;
     }
-    fs.open(historyPath, 'a', (err, fd) => {
-      if (err) {
-        pending = true;
-        debug(err);
-        repl.resume();
-        console.log('Cannot open history file');
-        return;
-      }
-      writing = true;
-      fs.write(fd, repl.history.join('\n'), 0, 'utf8', onwritten(fd));
+    fs.readFile(historyPath, (err, data) => {
+      const fileData = parseData(data.toString());
+      fileData.unshift(repl.history[0]);
+      fs.stat(historyPath, (err, stat) => {
+        if (err) {
+          return handleError(err);
+        }
+        fs.unlink(historyPath, (err) => {
+          if (err) {
+            return handleError(err);
+          }
+          fs.open(historyPath, 'ax', (err, fd) => {
+            if (err) {
+              return handleError(err);
+            }
+            writing = true;
+            fs.write(fd, fileData.join('\n'), stat.mode, 0, 'utf8', onwritten(fd));
+          });
+        });
+      });
     });
   }
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -127,7 +127,8 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     }
 
     if (data) {
-      repl.history = data.split(/[\n\r]+/, repl.historySize);
+      repl.history = data.trim().split(/[\n\r]+/)
+        .reverse().slice(0, repl.historySize);
     } else if (oldHistoryPath === historyPath) {
       // If pre-v3.0, the user had set NODE_REPL_HISTORY_FILE to
       // ~/.node_repl_history, warn the user about it and proceed.
@@ -163,7 +164,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
       }
     }
 
-    fs.open(historyPath, 'w', onhandle);
+    fs.open(historyPath, 'a', onhandle);
   }
 
   function onhandle(err, hnd) {
@@ -172,13 +173,8 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     }
     repl._historyHandle = hnd;
     repl.on('line', online);
-
-    // reading the file data out erases it
-    repl.once('flushHistory', function() {
-      repl.resume();
-      ready(null, repl);
-    });
-    flushHistory();
+    repl.resume();
+    ready(null, repl);
   }
 
   // ------ history listeners ------
@@ -192,31 +188,49 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     timer = setTimeout(flushHistory, kDebounceHistoryMS);
   }
 
+  const historyLockFile = `${historyPath}.LCK`;
   function flushHistory() {
     timer = null;
     if (writing) {
       pending = true;
       return;
     }
-    writing = true;
-    const historyData = repl.history.join(os.EOL);
-    fs.write(repl._historyHandle, historyData, 0, 'utf8', onwritten);
+    // Ref: https://github.com/nodejs/node/issues/1634
+    // opening a file for exclusive write should be atomic
+    // on non-networked POSIX systems.
+    fs.open(historyLockFile, 'wx', (err, fd) => {
+      if (err && err.code === 'EEXIST') {
+        pending = true;
+        repl.resume();
+        return;
+      }
+      writing = true;
+      const lastLine = repl.history[0] + '\n';
+      fs.write(repl._historyHandle, lastLine, NaN, 'utf8', onwritten(fd));
+    });
   }
 
-  function onwritten(err, data) {
-    writing = false;
-    if (pending) {
-      pending = false;
-      online();
-    } else {
-      repl._flushing = Boolean(timer);
-      if (!repl._flushing) {
-        repl.emit('flushHistory');
+  function onwritten(fd) {
+    return (err, data) => {
+      writing = false;
+      if (pending) {
+        pending = false;
+        online();
+      } else {
+        repl._flushing = Boolean(timer);
+        if (!repl._flushing) {
+          repl.emit('flushHistory');
+        }
       }
-    }
+      unlockHistoryFile(fd);
+    };
+  }
+
+  function unlockHistoryFile(fd) {
+    fs.close(fd);
+    fs.unlink(historyLockFile);
   }
 }
-
 
 function _replHistoryMessage() {
   if (this.history.length === 0) {

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -128,7 +128,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
 
     if (data) {
       repl.history = data.trim().split(/[\n\r]+/)
-        .reverse().slice(0, repl.historySize);
+        .slice(0, repl.historySize);
     } else if (oldHistoryPath === historyPath) {
       // If pre-v3.0, the user had set NODE_REPL_HISTORY_FILE to
       // ~/.node_repl_history, warn the user about it and proceed.
@@ -163,19 +163,11 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
         }
       }
     }
-
-    fs.open(historyPath, 'a', onhandle);
-  }
-
-  function onhandle(err, hnd) {
-    if (err) {
-      return ready(err);
-    }
-    repl._historyHandle = hnd;
     repl.on('line', online);
     repl.resume();
     ready(null, repl);
   }
+
 
   // ------ history listeners ------
   function online() {
@@ -188,30 +180,28 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
     timer = setTimeout(flushHistory, kDebounceHistoryMS);
   }
 
-  const historyLockFile = `${historyPath}.LCK`;
   function flushHistory() {
     timer = null;
     if (writing) {
       pending = true;
       return;
     }
-    // Ref: https://github.com/nodejs/node/issues/1634
-    // opening a file for exclusive write should be atomic
-    // on non-networked POSIX systems.
-    fs.open(historyLockFile, 'wx', (err, fd) => {
-      if (err && err.code === 'EEXIST') {
+    fs.open(historyPath, 'a', (err, fd) => {
+      if (err) {
         pending = true;
+        debug(err);
         repl.resume();
+        console.log('Cannot open history file');
         return;
       }
       writing = true;
-      const lastLine = repl.history[0] + '\n';
-      fs.write(repl._historyHandle, lastLine, NaN, 'utf8', onwritten(fd));
+      fs.write(fd, repl.history.join('\n'), 0, 'utf8', onwritten(fd));
     });
   }
 
   function onwritten(fd) {
     return (err, data) => {
+      fs.close(fd);
       writing = false;
       if (pending) {
         pending = false;
@@ -222,13 +212,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
           repl.emit('flushHistory');
         }
       }
-      unlockHistoryFile(fd);
     };
-  }
-
-  function unlockHistoryFile(fd) {
-    fs.close(fd);
-    fs.unlink(historyLockFile);
   }
 }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -370,7 +370,7 @@ function REPLServer(prompt,
   self.setPrompt(self._prompt);
 
   self.on('close', function() {
-    self.emit('exit');
+    process.nextTick(() => self.emit('exit'));
   });
 
   var sawSIGINT = false;
@@ -525,14 +525,6 @@ exports.start = function(prompt,
 };
 
 REPLServer.prototype.close = function replClose() {
-  if (this.terminal && this._flushing && !this._closingOnFlush) {
-    this._closingOnFlush = true;
-    this.once('flushHistory', () =>
-      Interface.prototype.close.call(this)
-    );
-
-    return;
-  }
   process.nextTick(() =>
     Interface.prototype.close.call(this)
   );

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -155,7 +155,7 @@ const tests = [
     env: {},
     test: [UP, UP, ENTER],
     expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\n',
-                prompt]
+               prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
@@ -208,7 +208,8 @@ function cleanupTmpFile() {
 
 // Copy our fixture to the tmp directory
 fs.createReadStream(historyFixturePath)
-  .pipe(fs.createWriteStream(historyPath)).on('unpipe', runTest);
+  .pipe(fs.createWriteStream(historyPath)).on('unpipe',
+  common.mustCall(runTest));
 
 function runTest(assertCleaned) {
   const opts = tests.shift();
@@ -261,7 +262,7 @@ function runTest(assertCleaned) {
       throw err;
     }
 
-    repl.once('exit', onExit);
+    repl.once('exit', common.mustCall(onExit));
 
     function onExit() {
       const cleaned = after ? after() : cleanupTmpFile();

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -189,7 +189,6 @@ const tests = [
 ];
 const numtests = tests.length;
 
-
 var testsNotRan = tests.length;
 
 process.on('beforeExit', () =>
@@ -209,7 +208,7 @@ function cleanupTmpFile() {
 
 // Copy our fixture to the tmp directory
 fs.createReadStream(historyFixturePath)
-  .pipe(fs.createWriteStream(historyPath)).on('unpipe', () => runTest());
+  .pipe(fs.createWriteStream(historyPath)).on('unpipe', runTest);
 
 function runTest(assertCleaned) {
   const opts = tests.shift();
@@ -247,7 +246,7 @@ function runTest(assertCleaned) {
         try {
           assert.strictEqual(output, expected.shift());
         } catch (err) {
-          console.error(`Failed test # ${numtests - tests.length}`);
+          console.error(`Failed test # ${numtests - tests.length}. ${err}`);
           throw err;
         }
         next();
@@ -262,16 +261,9 @@ function runTest(assertCleaned) {
       throw err;
     }
 
-    repl.once('close', () => {
-      if (repl._flushing) {
-        repl.once('flushHistory', onClose);
-        return;
-      }
+    repl.once('exit', onExit);
 
-      onClose();
-    });
-
-    function onClose() {
+    function onExit() {
       const cleaned = after ? after() : cleanupTmpFile();
 
       try {

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -115,19 +115,19 @@ const tests = [
   {
     env: { NODE_REPL_HISTORY: historyPath },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_FILE: oldHistoryPath },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_FILE: '' },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
   },
   {
     env: {},
@@ -154,14 +154,13 @@ const tests = [
   { // Requires the above testcase
     env: {},
     test: [UP, UP, ENTER],
-    expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\n',
-               prompt]
+    expected: [prompt, prompt + '\'42\'', '\'42\'\n', prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_SIZE: 1 },
     test: [UP, UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
   },
   {
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath,

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -115,19 +115,19 @@ const tests = [
   {
     env: { NODE_REPL_HISTORY: historyPath },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
+    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_FILE: oldHistoryPath },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
+    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_FILE: '' },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
+    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
   },
   {
     env: {},
@@ -154,13 +154,14 @@ const tests = [
   { // Requires the above testcase
     env: {},
     test: [UP, UP, ENTER],
-    expected: [prompt, prompt + '\'42\'', '\'42\'\n', prompt]
+    expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\n',
+                prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_SIZE: 1 },
     test: [UP, UP, CLEAR],
-    expected: [prompt, prompt + '\'Stay Fresh~\'', prompt]
+    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
   },
   {
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath,


### PR DESCRIPTION
##### Checklist
- [X] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [X] the commit message follows commit guidelines
##### Affected core subsystem(s)

repl
##### Description of change

There are several open issues regarding the repl's history file, and it
turns out that these issues are all somewhat related.

The code changes here started as basic file locking to prevent
simultaneous writes on the history file. This led to the realization
that the history file was rewritten in its entirety for each expression
evaluated in the repl. This, of course, meant that interleaving writes
between multiple processes wasn't really possible. To make that happen
the file needs to be open for writing with `'a'` instead of `'w'`.

As it turns out, changing this call to `fs.open()` to use `'a'` also
should fix a problem with `.node_repl_history` being hidden on Windows
systems (see https://github.com/nodejs/node/issues/5261). Although, I do
not have a Windows box to test against.

Benefits:
- Don't rewrite the entire history file for every evaluated expression.
- Don't lose all but the last NODE_HISTORY_FILE_SIZE number of lines on
  repl startup.
- No history file corruption from simultaneous writes by multiple
  processes.
- History is interleaved for multiple processes in a single history.
- In theory fixes a known issue on Windows.

Ref: https://github.com/nodejs/node/issues/5261
Ref: https://github.com/nodejs/node/issues/1634
Ref: https://github.com/nodejs/node/issues/3928
Ref: https://github.com/nodejs/node/pull/4313

repl: Add file locking for repl history file.

Adds a .node_repl_history.LCK file to prevent concurrent writes to the
NODE_REPL_HISTORY file from different processes.

repl: Adjust tests for reverse order of log file.

Since the repl now stores history as most recent last, the tests have
been adjusted to account for that.
##### Remaining work

Existing tests have been adjusted to account for the fact that the repl now appends log file data. But no tests have been written yet which exercise the interleaving of repl history from two separate instances. I'm working on it, but it has been a little tricky. I wanted to get this PR submitted as a placeholder, and if the direction I'm taking is OK, then I'll finish up the test. 

I don't think this requires a documentation change, because these are mostly bug fixes and improvements. But there is the fact that the history file is now reversed. It's not currently documented how the history file should look, and I think this is probably not necessary to document. But I wasn't sure, so I left the checkbox there and unchecked.
