### PR TITLE
test: remove `common.PORT` from gc tests

### DIFF
--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -8,9 +8,8 @@ function serverHandler(req, res) {
 
 const http = require('http');
 const weak = require('weak');
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const PORT = common.PORT;
 const todo = 500;
 let done = 0;
 let count = 0;
@@ -19,7 +18,7 @@ let countGC = 0;
 console.log('We should do ' + todo + ' requests');
 
 var server = http.createServer(serverHandler);
-server.listen(PORT, getall);
+server.listen(0, getall);
 
 function getall() {
   if (count >= todo)
@@ -34,7 +33,7 @@ function getall() {
     var req = http.get({
       hostname: 'localhost',
       pathname: '/',
-      port: PORT
+      port: server.address().port
     }, cb).on('error', cb);
 
     count++;

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -10,9 +10,8 @@ function serverHandler(req, res) {
 
 const http = require('http');
 const weak = require('weak');
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const PORT = common.PORT;
 const todo = 500;
 let done = 0;
 let count = 0;
@@ -21,7 +20,7 @@ let countGC = 0;
 console.log('We should do ' + todo + ' requests');
 
 var server = http.createServer(serverHandler);
-server.listen(PORT, runTest);
+server.listen(0, runTest);
 
 function getall() {
   if (count >= todo)
@@ -40,7 +39,7 @@ function getall() {
     var req = http.get({
       hostname: 'localhost',
       pathname: '/',
-      port: PORT
+      port: server.address().port
     }, cb).on('error', onerror);
 
     count++;

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -12,9 +12,8 @@ function serverHandler(req, res) {
 
 const http = require('http');
 const weak = require('weak');
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const PORT = common.PORT;
 const todo = 550;
 let done = 0;
 let count = 0;
@@ -23,7 +22,7 @@ let countGC = 0;
 console.log('We should do ' + todo + ' requests');
 
 var server = http.createServer(serverHandler);
-server.listen(PORT, getall);
+server.listen(0, getall);
 
 function getall() {
   if (count >= todo)
@@ -39,7 +38,7 @@ function getall() {
     var req = http.get({
       hostname: 'localhost',
       pathname: '/',
-      port: PORT
+      port: server.address().port
     }, cb);
     req.on('error', cb);
     req.setTimeout(10, function() {

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -8,9 +8,8 @@ function serverHandler(req, res) {
 
 const http = require('http');
 const weak = require('weak');
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const PORT = common.PORT;
 const todo = 500;
 let done = 0;
 let count = 0;
@@ -19,7 +18,7 @@ let countGC = 0;
 console.log('We should do ' + todo + ' requests');
 
 var server = http.createServer(serverHandler);
-server.listen(PORT, getall);
+server.listen(0, getall);
 
 
 function getall() {
@@ -37,7 +36,7 @@ function getall() {
     var req = http.get({
       hostname: 'localhost',
       pathname: '/',
-      port: PORT
+      port: server.address().port
     }, cb);
 
     count++;

--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -36,7 +36,7 @@ function getall() {
     return;
 
   (function() {
-    var req = net.connect(server.address().port, '127.0.0.1');
+    var req = net.connect(server.address().port, server.address().address);
     req.resume();
     req.setTimeout(10, function() {
       //console.log('timeout (expected)')

--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -19,9 +19,8 @@ function serverHandler(sock) {
 
 const net = require('net');
 const weak = require('weak');
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const PORT = common.PORT;
 const todo = 500;
 let done = 0;
 let count = 0;
@@ -30,14 +29,14 @@ let countGC = 0;
 console.log('We should do ' + todo + ' requests');
 
 var server = net.createServer(serverHandler);
-server.listen(PORT, getall);
+server.listen(0, getall);
 
 function getall() {
   if (count >= todo)
     return;
 
   (function() {
-    var req = net.connect(PORT, '127.0.0.1');
+    var req = net.connect(server.address().port, '127.0.0.1');
     req.resume();
     req.setTimeout(10, function() {
       //console.log('timeout (expected)')


### PR DESCRIPTION
##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test

##### Description of change
<!-- provide a description of the change below this comment -->

Allow the operating system to provide an arbitrary available port rather
than using `common.PORT`, as `common.PORT` makes it likely that a test
will fail with `EADDRINUSE` as a side effect of an earlier test.

R=@mscdex