### PR TITLE
test: fix spurious EADDRINUSE in test-https-strict

### DIFF
--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -65,13 +65,9 @@ var server3 = server(options3);
 
 var listenWait = 0;
 
-var port = common.PORT;
-var port1 = port++;
-var port2 = port++;
-var port3 = port++;
-server1.listen(port1, listening());
-server2.listen(port2, listening());
-server3.listen(port3, listening());
+server1.listen(0, listening());
+server2.listen(0, listening());
+server3.listen(0, listening());
 
 var responseErrors = {};
 var expectResponseCount = 0;
@@ -131,9 +127,9 @@ function makeReq(path, port, error, host, ca) {
   }
   var req = https.get(options);
   expectResponseCount++;
-  var server = port === port1 ? server1
-      : port === port2 ? server2
-      : port === port3 ? server3
+  var server = port === server1.address().port ? server1
+      : port === server2.address().port ? server2
+      : port === server3.address().port ? server3
       : null;
 
   if (!server) throw new Error('invalid port: ' + port);
@@ -155,6 +151,10 @@ function makeReq(path, port, error, host, ca) {
 
 function allListening() {
   // ok, ready to start the tests!
+
+  const port1 = server1.address().port;
+  const port2 = server2.address().port;
+  const port3 = server3.address().port;
 
   // server1: host 'agent1', signed by ca1
   makeReq('/inv1', port1, 'UNABLE_TO_VERIFY_LEAF_SIGNATURE');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test https

##### Description of change
<!-- provide a description of the change below this comment -->

test-https-strict sometimes fails with EADDRINUSE in CI. Remove use of
common.PORT to make the test resistant from side effects from other
tests that may have not freed up the port.

Example CI failure: https://ci.nodejs.org/job/node-test-commit-osx/3545/nodes=osx1010/console

```
not ok 564 parallel/test-https-strict
# {}
# events.js:160
#       throw er; // Unhandled 'error' event
#       ^
# 
# Error: listen EADDRINUSE :::12448
#     at Object.exports._errnoException (util.js:1007:11)
#     at exports._exceptionWithHostPort (util.js:1030:20)
#     at Server._listen2 (net.js:1253:14)
#     at listen (net.js:1289:10)
#     at Server.listen (net.js:1385:5)
#     at Object.<anonymous> (/Users/iojs/build/workspace/node-test-commit-osx/nodes/osx1010/test/parallel/test-https-strict.js:74:9)
#     at Module._compile (module.js:541:32)
#     at Object.Module._extensions..js (module.js:550:10)
#     at Module.load (module.js:458:32)
#     at tryModuleLoad (module.js:417:12)
  ---
  duration_ms: 0.276
```

/cc @nodejs/testing @mscdex