### PR TITLE
test: make test-child-process-fork-net more robust

### DIFF
--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const common = require('../common');
+require('../common');
 const fork = require('child_process').fork;
 const net = require('net');
 
@@ -91,7 +91,7 @@ if (process.argv[2] === 'child') {
       console.log('PARENT: server listening');
       child.send({what: 'server'}, server);
     });
-    server.listen(common.PORT);
+    server.listen(0);
 
     // handle client messages
     var messageHandlers = function(msg) {
@@ -100,7 +100,7 @@ if (process.argv[2] === 'child') {
         // make connections
         var socket;
         for (var i = 0; i < 4; i++) {
-          socket = net.connect(common.PORT, function() {
+          socket = net.connect(server.address().port, function() {
             console.log('CLIENT: connected');
           });
           socket.on('close', function() {
@@ -143,9 +143,9 @@ if (process.argv[2] === 'child') {
     //
     // An isolated test for this would be lovely, but for now, this
     // will have to do.
-    server.listen(common.PORT + 1, function() {
+    server.listen(0, function() {
       console.error('testSocket, listening');
-      var connect = net.connect(common.PORT + 1);
+      var connect = net.connect(server.address().port);
       var store = '';
       connect.on('data', function(chunk) {
         store += chunk;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test child_process

##### Description of change
<!-- provide a description of the change below this comment -->

test-child-process-fork-net will sometimes fail in CI with EADDRINUSE
because an earlier test failed to free common.PORT. Have the operating
system provide an available port instead.

Example failure: https://ci.nodejs.org/job/node-test-commit-freebsd/2679/nodes=freebsd10-64/consoleFull

```
not ok 55 parallel/test-child-process-fork-net
# events.js:160
#       throw er; // Unhandled 'error' event
#       ^
# 
# Error: listen EADDRINUSE :::12347
#     at Object.exports._errnoException (util.js:1007:11)
#     at exports._exceptionWithHostPort (util.js:1030:20)
#     at Server._listen2 (net.js:1253:14)
#     at listen (net.js:1289:10)
#     at Server.listen (net.js:1385:5)
#     at testSocket (/usr/home/iojs/build/workspace/node-test-commit-freebsd/nodes/freebsd10-64/test/parallel/test-child-process-fork-net.js:146:12)
#     at /usr/home/iojs/build/workspace/node-test-commit-freebsd/nodes/freebsd10-64/test/parallel/test-child-process-fork-net.js:172:7
#     at ChildProcess.messageHandlers (/usr/home/iojs/build/workspace/node-test-commit-freebsd/nodes/freebsd10-64/test/parallel/test-child-process-fork-net.js:117:9)
#     at emitTwo (events.js:106:13)
#     at ChildProcess.emit (events.js:191:7)
# PARENT: server listening
# CHILD: server listening
# PARENT: got connection
# PARENT: got connection
# CHILD: got connection
# PARENT: got connection
# CLIENT: connected
# CLIENT: connected
# CLIENT: connected
# CLIENT: connected
# CLIENT: closed
# CLIENT: closed
# CLIENT: closed
# CLIENT: closed
# PARENT: server closed
  ---
  duration_ms: 0.448
```

@mscdex @nodejs/testing 