### PR TITLE
test: use random ports where possible

### DIFF
--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -81,12 +81,12 @@ net.createServer(function(c) {
 net.createServer(function(c) {
   c.end();
   this.close(checkTLS);
-}).listen(common.PORT, function() {
-  net.connect(common.PORT, noop);
+}).listen(0, function() {
+  net.connect(this.address().port, noop);
 });
 
-dgram.createSocket('udp4').bind(common.PORT, function() {
-  this.send(Buffer.allocUnsafe(2), 0, 2, common.PORT, '::', () => {
+dgram.createSocket('udp4').bind(0, function() {
+  this.send(Buffer.allocUnsafe(2), 0, 2, this.address().port, '::', () => {
     this.close();
   });
 });
@@ -100,8 +100,9 @@ function checkTLS() {
     cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
   };
   const server = tls.createServer(options, noop)
-    .listen(common.PORT, function() {
-      tls.connect(common.PORT, { rejectUnauthorized: false }, function() {
+    .listen(0, function() {
+      const connectOpts = { rejectUnauthorized: false };
+      tls.connect(this.address().port, connectOpts, function() {
         this.destroy();
         server.close();
       });

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 const async_wrap = process.binding('async_wrap');
@@ -40,8 +40,8 @@ const server = net.createServer(function(c) {
     c.end();
     this.close();
   });
-}).listen(common.PORT, function() {
-  net.connect(common.PORT, noop);
+}).listen(0, function() {
+  net.connect(this.address().port, noop);
 });
 
 async_wrap.disable();

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 const async_wrap = process.binding('async_wrap');
@@ -40,8 +40,8 @@ const server = net.createServer(function(c) {
     c.end();
     this.close();
   });
-}).listen(common.PORT, function() {
-  net.connect(common.PORT, noop);
+}).listen(0, function() {
+  net.connect(this.address().port, noop);
 });
 
 

--- a/test/parallel/test-beforeexit-event.js
+++ b/test/parallel/test-beforeexit-event.js
@@ -1,7 +1,7 @@
 'use strict';
+require('../common');
 var assert = require('assert');
 var net = require('net');
-var common = require('../common');
 var revivals = 0;
 var deaths = 0;
 
@@ -29,7 +29,7 @@ function tryTimer() {
 function tryListen() {
   console.log('create a server');
   net.createServer()
-    .listen(common.PORT)
+    .listen(0)
     .on('listening', function() {
       revivals++;
       this.close();

--- a/test/parallel/test-child-process-disconnect.js
+++ b/test/parallel/test-child-process-disconnect.js
@@ -38,10 +38,10 @@ if (process.argv[2] === 'child') {
 
   // when the server is ready tell parent
   server.on('listening', function() {
-    process.send('ready');
+    process.send({ msg: 'ready', port: server.address().port });
   });
 
-  server.listen(common.PORT);
+  server.listen(0);
 
 } else {
   // testcase
@@ -65,11 +65,11 @@ if (process.argv[2] === 'child') {
   });
 
   // when child is listening
-  child.on('message', function(msg) {
-    if (msg === 'ready') {
+  child.on('message', function(obj) {
+    if (obj && obj.msg === 'ready') {
 
       // connect to child using TCP to know if disconnect was emitted
-      var socket = net.connect(common.PORT);
+      var socket = net.connect(obj.port);
 
       socket.on('data', function(data) {
         data = data.toString();

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -72,7 +72,7 @@ if (process.argv[2] === 'child') {
         msg,
         0,
         msg.length,
-        common.PORT,
+        server.address().port,
         '127.0.0.1',
         function(err) {
           if (err) throw err;
@@ -98,7 +98,7 @@ if (process.argv[2] === 'child') {
     client.close();
   };
 
-  server.bind(common.PORT, '127.0.0.1');
+  server.bind(0, '127.0.0.1');
 
   process.once('exit', function() {
     assert(parentGotMessage);

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -1,6 +1,6 @@
 'use strict';
-const assert = require('assert');
 require('../common');
+const assert = require('assert');
 const fork = require('child_process').fork;
 const net = require('net');
 

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -99,7 +99,7 @@ if (process.argv[2] === 'child') {
 
     var j = count, client;
     while (j--) {
-      client = net.connect(common.PORT, '127.0.0.1');
+      client = net.connect(this.address().port, '127.0.0.1');
       client.on('error', function() {
         // This can happen if we kill the child too early.
         // The client should still get a close event afterwards.
@@ -125,7 +125,7 @@ if (process.argv[2] === 'child') {
     child3.kill();
   }));
 
-  server.listen(common.PORT, '127.0.0.1');
+  server.listen(0, '127.0.0.1');
 
   var closeServer = function() {
     server.close();

--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -25,11 +25,11 @@ var server = net.createServer(function(s) {
   setTimeout(function() {
     s.destroy();
   }, 100);
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var worker = cluster.fork();
 
   function send(callback) {
-    var s = net.connect(common.PORT, function() {
+    var s = net.connect(server.address().port, function() {
       worker.send({}, s, callback);
     });
 

--- a/test/parallel/test-child-process-recv-handle.js
+++ b/test/parallel/test-child-process-recv-handle.js
@@ -24,7 +24,7 @@ function master() {
   });
   proc.stdout.on('data', function(data) {
     assert.equal(data, 'ok\r\n');
-    net.createServer(common.fail).listen(common.PORT, function() {
+    net.createServer(common.fail).listen(0, function() {
       handle = this._handle;
       proc.send('one');
       proc.send('two', handle);

--- a/test/parallel/test-child-process-send-keep-open.js
+++ b/test/parallel/test-child-process-send-keep-open.js
@@ -37,8 +37,8 @@ if (process.argv[2] !== 'child') {
     }));
   });
 
-  server.listen(common.PORT, () => {
-    const socket = net.connect(common.PORT, common.localhostIPv4);
+  server.listen(0, () => {
+    const socket = net.connect(server.address().port, common.localhostIPv4);
     socket.setEncoding('utf8');
     socket.on('data', (data) => result += data);
   });

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -20,7 +20,7 @@ s.on('exit', function() {
   handle.close();
 });
 
-net.createServer(common.fail).listen(common.PORT, function() {
+net.createServer(common.fail).listen(0, function() {
   handle = this._handle;
   assert.strictEqual(s.send('one', handle), true);
   assert.strictEqual(s.send('two', handle), true);

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -36,9 +36,9 @@ function verify() {
     .verify(certPem, 'asdfasdfas', 'base64');
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     verify();

--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -10,7 +10,9 @@ var family_ipv4 = 'IPv4';
 socket_ipv4.on('listening', function() {
   var address_ipv4 = socket_ipv4.address();
   assert.strictEqual(address_ipv4.address, common.localhostIPv4);
-  assert.strictEqual(address_ipv4.port, common.PORT);
+  assert.strictEqual(typeof address_ipv4.port, 'number');
+  assert.ok(isFinite(address_ipv4.port));
+  assert.ok(address_ipv4.port > 0);
   assert.strictEqual(address_ipv4.family, family_ipv4);
   socket_ipv4.close();
 });
@@ -20,7 +22,7 @@ socket_ipv4.on('error', function(e) {
   socket_ipv4.close();
 });
 
-socket_ipv4.bind(common.PORT, common.localhostIPv4);
+socket_ipv4.bind(0, common.localhostIPv4);
 
 // IPv6 Test
 var localhost_ipv6 = '::1';
@@ -30,7 +32,9 @@ var family_ipv6 = 'IPv6';
 socket_ipv6.on('listening', function() {
   var address_ipv6 = socket_ipv6.address();
   assert.strictEqual(address_ipv6.address, localhost_ipv6);
-  assert.strictEqual(address_ipv6.port, common.PORT);
+  assert.strictEqual(typeof address_ipv6.port, 'number');
+  assert.ok(isFinite(address_ipv6.port));
+  assert.ok(address_ipv6.port > 0);
   assert.strictEqual(address_ipv6.family, family_ipv6);
   socket_ipv6.close();
 });
@@ -40,4 +44,4 @@ socket_ipv6.on('error', function(e) {
   socket_ipv6.close();
 });
 
-socket_ipv6.bind(common.PORT, localhost_ipv6);
+socket_ipv6.bind(0, localhost_ipv6);

--- a/test/parallel/test-dgram-bind-default-address.js
+++ b/test/parallel/test-dgram-bind-default-address.js
@@ -9,8 +9,10 @@ if (common.inFreeBSDJail) {
   return;
 }
 
-dgram.createSocket('udp4').bind(common.PORT + 0, common.mustCall(function() {
-  assert.equal(this.address().port, common.PORT + 0);
+dgram.createSocket('udp4').bind(0, common.mustCall(function() {
+  assert.strictEqual(typeof this.address().port, 'number');
+  assert.ok(isFinite(this.address().port));
+  assert.ok(this.address().port > 0);
   assert.equal(this.address().address, '0.0.0.0');
   this.close();
 }));
@@ -20,8 +22,10 @@ if (!common.hasIPv6) {
   return;
 }
 
-dgram.createSocket('udp6').bind(common.PORT + 1, common.mustCall(function() {
-  assert.equal(this.address().port, common.PORT + 1);
+dgram.createSocket('udp6').bind(0, common.mustCall(function() {
+  assert.strictEqual(typeof this.address().port, 'number');
+  assert.ok(isFinite(this.address().port));
+  assert.ok(this.address().port > 0);
   var address = this.address().address;
   if (address === '::ffff:0.0.0.0')
     address = '::';

--- a/test/parallel/test-dgram-empty-packet.js
+++ b/test/parallel/test-dgram-empty-packet.js
@@ -13,27 +13,28 @@ if (process.platform === 'darwin') {
 
 client = dgram.createSocket('udp4');
 
-client.bind(common.PORT);
-
-function callback() {
-  callbacks++;
-  if (callbacks == 2) {
-    clearTimeout(timer);
-    client.close();
-  } else if (callbacks > 2) {
-    throw new Error('the callbacks should be called only two times');
+client.bind(0, function() {
+  function callback() {
+    callbacks++;
+    if (callbacks == 2) {
+      clearTimeout(timer);
+      client.close();
+    } else if (callbacks > 2) {
+      throw new Error('the callbacks should be called only two times');
+    }
   }
-}
 
-client.on('message', function(buffer, bytes) {
-  callback();
-});
-
-client.send(
-  Buffer.allocUnsafe(1), 0, 0, common.PORT, '127.0.0.1', (err, len) => {
+  client.on('message', function(buffer, bytes) {
     callback();
   });
 
-timer = setTimeout(function() {
-  throw new Error('Timeout');
-}, 200);
+  const port = this.address().port;
+  client.send(
+    Buffer.allocUnsafe(1), 0, 0, port, '127.0.0.1', (err, len) => {
+      callback();
+    });
+
+  timer = setTimeout(function() {
+    throw new Error('Timeout');
+  }, 200);
+});

--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -9,14 +9,14 @@ var socket_ipv4 = dgram.createSocket('udp4');
 socket_ipv4.on('listening', common.fail);
 
 socket_ipv4.on('error', common.mustCall(function(e) {
-  assert.equal(e.message, 'bind EADDRNOTAVAIL 1.1.1.1:' + common.PORT);
+  assert.strictEqual(e.port, undefined);
+  assert.equal(e.message, 'bind EADDRNOTAVAIL 1.1.1.1');
   assert.equal(e.address, '1.1.1.1');
-  assert.equal(e.port, common.PORT);
   assert.equal(e.code, 'EADDRNOTAVAIL');
   socket_ipv4.close();
 }));
 
-socket_ipv4.bind(common.PORT, '1.1.1.1');
+socket_ipv4.bind(0, '1.1.1.1');
 
 // IPv6 Test
 var socket_ipv6 = dgram.createSocket('udp6');
@@ -27,10 +27,10 @@ socket_ipv6.on('error', common.mustCall(function(e) {
   // EAFNOSUPPORT or EPROTONOSUPPORT means IPv6 is disabled on this system.
   var allowed = ['EADDRNOTAVAIL', 'EAFNOSUPPORT', 'EPROTONOSUPPORT'];
   assert.notEqual(allowed.indexOf(e.code), -1);
-  assert.equal(e.message, 'bind ' + e.code + ' 111::1:' + common.PORT);
+  assert.strictEqual(e.port, undefined);
+  assert.equal(e.message, 'bind ' + e.code + ' 111::1');
   assert.equal(e.address, '111::1');
-  assert.equal(e.port, common.PORT);
   socket_ipv6.close();
 }));
 
-socket_ipv6.bind(common.PORT, '111::1');
+socket_ipv6.bind(0, '111::1');

--- a/test/parallel/test-dgram-implicit-bind.js
+++ b/test/parallel/test-dgram-implicit-bind.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 
@@ -22,8 +22,9 @@ target.on('message', function(buf) {
 
 target.on('listening', function() {
   // Second .send() call should not throw a bind error.
-  source.send(Buffer.from('abc'), 0, 3, common.PORT, '127.0.0.1');
-  source.send(Buffer.from('def'), 0, 3, common.PORT, '127.0.0.1');
+  const port = this.address().port;
+  source.send(Buffer.from('abc'), 0, 3, port, '127.0.0.1');
+  source.send(Buffer.from('def'), 0, 3, port, '127.0.0.1');
 });
 
-target.bind(common.PORT);
+target.bind(0);

--- a/test/parallel/test-dgram-multicast-setTTL.js
+++ b/test/parallel/test-dgram-multicast-setTTL.js
@@ -1,11 +1,11 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
 let thrown = false;
 
-socket.bind(common.PORT);
+socket.bind(0);
 socket.on('listening', function() {
   socket.setMulticastTTL(16);
 

--- a/test/parallel/test-dgram-send-callback-multi-buffer.js
+++ b/test/parallel/test-dgram-send-callback-multi-buffer.js
@@ -19,7 +19,8 @@ const buf1 = Buffer.alloc(256, 'x');
 const buf2 = Buffer.alloc(256, 'y');
 
 client.on('listening', function() {
-  client.send([buf1, buf2], common.PORT, common.localhostIPv4, messageSent);
+  const port = this.address().port;
+  client.send([buf1, buf2], port, common.localhostIPv4, messageSent);
 });
 
 client.on('message', common.mustCall(function onMessage(buf, info) {
@@ -28,4 +29,4 @@ client.on('message', common.mustCall(function onMessage(buf, info) {
   client.close();
 }));
 
-client.bind(common.PORT);
+client.bind(0);

--- a/test/parallel/test-dgram-send-callback-recursive.js
+++ b/test/parallel/test-dgram-send-callback-recursive.js
@@ -9,17 +9,19 @@ let received = 0;
 let sent = 0;
 const limit = 10;
 let async = false;
+let port;
 
 function onsend() {
   if (sent++ < limit) {
-    client.send(
-      chunk, 0, chunk.length, common.PORT, common.localhostIPv4, onsend);
+    client.send(chunk, 0, chunk.length, port, common.localhostIPv4, onsend);
   } else {
     assert.strictEqual(async, true, 'Send should be asynchronous.');
   }
 }
 
 client.on('listening', function() {
+  port = this.address().port;
+
   setImmediate(function() {
     async = true;
   });
@@ -38,4 +40,4 @@ client.on('close', common.mustCall(function() {
   assert.equal(received, limit);
 }));
 
-client.bind(common.PORT);
+client.bind(0);

--- a/test/parallel/test-dgram-send-default-host.js
+++ b/test/parallel/test-dgram-send-default-host.js
@@ -14,10 +14,11 @@ const toSend = [Buffer.alloc(256, 'x'),
 const received = [];
 
 client.on('listening', common.mustCall(() => {
-  client.send(toSend[0], 0, toSend[0].length, common.PORT);
-  client.send(toSend[1], common.PORT);
-  client.send([toSend[2]], common.PORT);
-  client.send(toSend[3], 0, toSend[3].length, common.PORT);
+  const port = client.address().port;
+  client.send(toSend[0], 0, toSend[0].length, port);
+  client.send(toSend[1], port);
+  client.send([toSend[2]], port);
+  client.send(toSend[3], 0, toSend[3].length, port);
 }));
 
 client.on('message', common.mustCall((buf, info) => {
@@ -33,4 +34,4 @@ client.on('message', common.mustCall((buf, info) => {
   }
 }, toSend.length));
 
-client.bind(common.PORT);
+client.bind(0);

--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -23,7 +23,7 @@ client.on('message', common.mustCall(function onMessage(buf, info) {
 }));
 
 client.on('listening', function() {
-  client.send([], common.PORT, common.localhostIPv4);
+  client.send([], this.address().port, common.localhostIPv4);
 });
 
-client.bind(common.PORT);
+client.bind(0);

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -9,16 +9,18 @@ if (process.platform === 'darwin') {
 
 const client = dgram.createSocket('udp4');
 
-client.bind(common.PORT);
+client.bind(0, function() {
+  const port = this.address().port;
 
-client.on('message', common.mustCall(function onMessage(buffer, bytes) {
-  clearTimeout(timer);
-  client.close();
-}));
+  client.on('message', common.mustCall(function onMessage(buffer, bytes) {
+    clearTimeout(timer);
+    client.close();
+  }));
 
-const buf = Buffer.alloc(0);
-client.send(buf, 0, 0, common.PORT, '127.0.0.1', function(err, len) { });
+  const buf = Buffer.alloc(0);
+  client.send(buf, 0, 0, port, '127.0.0.1', function(err, len) { });
 
-const timer = setTimeout(function() {
-  throw new Error('Timeout');
-}, common.platformTimeout(200));
+  const timer = setTimeout(function() {
+    throw new Error('Timeout');
+  }, common.platformTimeout(200));
+});

--- a/test/parallel/test-dgram-send-multi-buffer-copy.js
+++ b/test/parallel/test-dgram-send-multi-buffer-copy.js
@@ -20,7 +20,7 @@ const buf2 = Buffer.alloc(256, 'y');
 
 client.on('listening', function() {
   const toSend = [buf1, buf2];
-  client.send(toSend, common.PORT, common.localhostIPv4, onMessage);
+  client.send(toSend, this.address().port, common.localhostIPv4, onMessage);
   toSend.splice(0, 2);
 });
 
@@ -30,4 +30,4 @@ client.on('message', common.mustCall(function onMessage(buf, info) {
   client.close();
 }));
 
-client.bind(common.PORT);
+client.bind(0);

--- a/test/parallel/test-dgram-setBroadcast.js
+++ b/test/parallel/test-dgram-setBroadcast.js
@@ -26,14 +26,14 @@ runTest((socket) => { socket.setBroadcast(true); }, /EBADF/);
 
 // Should not throw if broadcast set to false after binding.
 runTest((socket) => {
-  socket.bind(common.PORT, common.localhostIPv4, () => {
+  socket.bind(0, common.localhostIPv4, () => {
     socket.setBroadcast(false);
   });
 });
 
 // Should not throw if broadcast set to true after binding.
 runTest((socket) => {
-  socket.bind(common.PORT, common.localhostIPv4, () => {
+  socket.bind(0, common.localhostIPv4, () => {
     socket.setBroadcast(true);
   });
 });

--- a/test/parallel/test-dgram-setTTL.js
+++ b/test/parallel/test-dgram-setTTL.js
@@ -1,10 +1,10 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
 
-socket.bind(common.PORT);
+socket.bind(0);
 socket.on('listening', function() {
   var result = socket.setTTL(16);
   assert.strictEqual(result, 16);

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
-const server_port = common.PORT;
 const message_to_send = 'A message to send';
 
 const server = dgram.createSocket('udp4');
@@ -13,9 +12,10 @@ server.on('message', common.mustCall((msg, rinfo) => {
 }));
 server.on('listening', common.mustCall(() => {
   const client = dgram.createSocket('udp4');
+  const port = server.address().port;
   client.on('message', common.mustCall((msg, rinfo) => {
     assert.strictEqual(rinfo.address, common.localhostIPv4);
-    assert.strictEqual(rinfo.port, server_port);
+    assert.strictEqual(rinfo.port, port);
     assert.strictEqual(msg.toString(), message_to_send.toString());
     client.close();
     server.close();
@@ -23,10 +23,9 @@ server.on('listening', common.mustCall(() => {
   client.send(message_to_send,
               0,
               message_to_send.length,
-              server_port,
+              port,
               'localhost');
   client.on('close', common.mustCall(() => {}));
 }));
 server.on('close', common.mustCall(() => {}));
-server.bind(server_port);
-
+server.bind(0);

--- a/test/parallel/test-dgram-udp6-send-default-host.js
+++ b/test/parallel/test-dgram-udp6-send-default-host.js
@@ -19,10 +19,11 @@ const toSend = [Buffer.alloc(256, 'x'),
 const received = [];
 
 client.on('listening', common.mustCall(() => {
-  client.send(toSend[0], 0, toSend[0].length, common.PORT);
-  client.send(toSend[1], common.PORT);
-  client.send([toSend[2]], common.PORT);
-  client.send(toSend[3], 0, toSend[3].length, common.PORT);
+  const port = client.address().port;
+  client.send(toSend[0], 0, toSend[0].length, port);
+  client.send(toSend[1], port);
+  client.send([toSend[2]], port);
+  client.send(toSend[3], 0, toSend[3].length, port);
 }));
 
 client.on('message', common.mustCall((buf, info) => {
@@ -38,4 +39,4 @@ client.on('message', common.mustCall((buf, info) => {
   }
 }, toSend.length));
 
-client.bind(common.PORT);
+client.bind(0);

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -109,8 +109,8 @@ const tests = [
       const server = net.createServer(function(conn) {
         conn.pipe(conn);
       });
-      server.listen(common.PORT, common.localhostIPv4, function() {
-        const conn = net.connect(common.PORT, common.localhostIPv4);
+      server.listen(0, common.localhostIPv4, function() {
+        const conn = net.connect(this.address().port, common.localhostIPv4);
         conn.once('data', function() {
           throw new Error('ok');
         });

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -1,8 +1,8 @@
 'use strict';
+require('../common');
 var domain = require('domain');
 var http = require('http');
 var assert = require('assert');
-var common = require('../common');
 
 var objects = { foo: 'bar', baz: {}, num: 42, arr: [1, 2, 3] };
 objects.baz.asdf = objects;
@@ -37,10 +37,11 @@ var server = http.createServer(function(req, res) {
   });
 });
 
-server.listen(common.PORT, next);
+server.listen(0, next);
 
 function next() {
-  console.log('listening on localhost:%d', common.PORT);
+  const port = this.address().port;
+  console.log('listening on localhost:%d', port);
 
   var requests = 0;
   var responses = 0;
@@ -61,7 +62,7 @@ function next() {
       req.socket.destroy();
     });
 
-    var req = http.get({ host: 'localhost', port: common.PORT, path: p });
+    var req = http.get({ host: 'localhost', port: port, path: p });
     dom.add(req);
     req.on('response', function(res) {
       responses++;

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -72,7 +72,7 @@ function makeAssert(message) {
 {
   const assert = makeAssert('hasRef() not working on tcp_wrap');
   const net = require('net');
-  const server = net.createServer(() => {}).listen(common.PORT);
+  const server = net.createServer(() => {}).listen(0);
   assert(Object.getPrototypeOf(server._handle).hasOwnProperty('hasRef'), true);
   assert(server._handle.hasRef(), true);
   assert(server._unref, false);

--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 var net = require('net');
 
@@ -84,14 +84,17 @@ check([{
 
 function check(tests) {
   var test = tests[0];
-  if (test) http.createServer(server).listen(common.PORT, '127.0.0.1', client);
+  var server;
+  if (test) {
+    server = http.createServer(serverHandler).listen(0, '127.0.0.1', client);
+  }
   var current = 0;
 
   function next() {
     check(tests.slice(1));
   }
 
-  function server(req, res) {
+  function serverHandler(req, res) {
     if (current + 1 === test.responses.length) this.close();
     var ctx = test.responses[current];
     console.error('<  SERVER SENDING RESPONSE', ctx);
@@ -102,7 +105,8 @@ function check(tests) {
 
   function client() {
     if (current === test.requests.length) return next();
-    var conn = net.createConnection(common.PORT, '127.0.0.1', connected);
+    const port = server.address().port;
+    var conn = net.createConnection(port, '127.0.0.1', connected);
 
     function connected() {
       var ctx = test.requests[current];

--- a/test/parallel/test-http-1.0.js
+++ b/test/parallel/test-http-1.0.js
@@ -6,18 +6,15 @@ var http = require('http');
 
 var body = 'hello world\n';
 
-var common_port = common.PORT;
-
 function test(handler, request_generator, response_validator) {
-  var port = common_port++;
   var server = http.createServer(handler);
 
   var client_got_eof = false;
   var server_response = '';
 
-  server.listen(port);
+  server.listen(0);
   server.on('listening', function() {
-    var c = net.createConnection(port);
+    var c = net.createConnection(this.address().port);
 
     c.setEncoding('utf8');
 

--- a/test/parallel/test-http-abort-before-end.js
+++ b/test/parallel/test-http-abort-before-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 var assert = require('assert');
 
@@ -7,8 +7,12 @@ var server = http.createServer(function(req, res) {
   assert(false); // should not be called
 });
 
-server.listen(common.PORT, function() {
-  var req = http.request({method: 'GET', host: '127.0.0.1', port: common.PORT});
+server.listen(0, function() {
+  var req = http.request({
+    method: 'GET',
+    host: '127.0.0.1',
+    port: this.address().port
+  });
 
   req.on('error', function(ex) {
     // https://github.com/joyent/node/issues/1399#issuecomment-2597359

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 var assert = require('assert');
 
@@ -13,11 +13,10 @@ var server = http.Server(function(req, res) {
 
 var responseClose = false;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   http.get({
-    port: common.PORT,
+    port: this.address().port,
     headers: { connection: 'keep-alive' }
-
   }, function(res) {
     server.close();
 

--- a/test/parallel/test-http-abort-queued.js
+++ b/test/parallel/test-http-abort-queued.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 const assert = require('assert');
-const common = require('../common');
 const http = require('http');
 
 var complete;
@@ -19,7 +19,7 @@ var server = http.createServer(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   console.log('listen', server.address().port);
 
   var agent = new http.Agent({maxSockets: 1});

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -26,9 +26,9 @@ server.on('connect', function(req, socket, firstBodyChunk) {
     socket.end();
   });
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'CONNECT',
     path: 'google.com:80'
   });
@@ -46,7 +46,7 @@ server.listen(common.PORT, function() {
 
 function doRequest(i) {
   http.get({
-    port: common.PORT,
+    port: server.address().port,
     path: '/request' + i
   }, function(res) {
     console.error('Client got GET response');

--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -1,86 +1,86 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end('Hello World\n');
-}).listen(common.PORT);
+}).listen(0, function() {
+  var agent = new http.Agent({maxSockets: 1});
 
-var agent = new http.Agent({maxSockets: 1});
-
-agent.on('free', function(socket, host, port) {
-  console.log('freeing socket. destroyed? ', socket.destroyed);
-});
-
-var requestOptions = {
-  agent: agent,
-  host: 'localhost',
-  port: common.PORT,
-  path: '/'
-};
-
-var request1 = http.get(requestOptions, function(response) {
-  // assert request2 is queued in the agent
-  var key = agent.getName(requestOptions);
-  assert(agent.requests[key].length === 1);
-  console.log('got response1');
-  request1.socket.on('close', function() {
-    console.log('request1 socket closed');
+  agent.on('free', function(socket, host, port) {
+    console.log('freeing socket. destroyed? ', socket.destroyed);
   });
-  response.pipe(process.stdout);
-  response.on('end', function() {
-    console.log('response1 done');
-    /////////////////////////////////
-    //
-    // THE IMPORTANT PART
-    //
-    // It is possible for the socket to get destroyed and other work
-    // to run before the 'close' event fires because it happens on
-    // nextTick. This example is contrived because it destroys the
-    // socket manually at just the right time, but at Voxer we have
-    // seen cases where the socket is destroyed by non-user code
-    // then handed out again by an agent *before* the 'close' event
-    // is triggered.
-    request1.socket.destroy();
 
-    response.once('close', function() {
-      // assert request2 was removed from the queue
-      assert(!agent.requests[key]);
-      console.log("waiting for request2.onSocket's nextTick");
-      process.nextTick(function() {
-        // assert that the same socket was not assigned to request2,
-        // since it was destroyed.
-        assert(request1.socket !== request2.socket);
-        assert(!request2.socket.destroyed, 'the socket is destroyed');
+  var requestOptions = {
+    agent: agent,
+    host: 'localhost',
+    port: this.address().port,
+    path: '/'
+  };
+
+  var request1 = http.get(requestOptions, function(response) {
+    // assert request2 is queued in the agent
+    var key = agent.getName(requestOptions);
+    assert(agent.requests[key].length === 1);
+    console.log('got response1');
+    request1.socket.on('close', function() {
+      console.log('request1 socket closed');
+    });
+    response.pipe(process.stdout);
+    response.on('end', function() {
+      console.log('response1 done');
+      /////////////////////////////////
+      //
+      // THE IMPORTANT PART
+      //
+      // It is possible for the socket to get destroyed and other work
+      // to run before the 'close' event fires because it happens on
+      // nextTick. This example is contrived because it destroys the
+      // socket manually at just the right time, but at Voxer we have
+      // seen cases where the socket is destroyed by non-user code
+      // then handed out again by an agent *before* the 'close' event
+      // is triggered.
+      request1.socket.destroy();
+
+      response.once('close', function() {
+        // assert request2 was removed from the queue
+        assert(!agent.requests[key]);
+        console.log("waiting for request2.onSocket's nextTick");
+        process.nextTick(function() {
+          // assert that the same socket was not assigned to request2,
+          // since it was destroyed.
+          assert(request1.socket !== request2.socket);
+          assert(!request2.socket.destroyed, 'the socket is destroyed');
+        });
       });
     });
   });
-});
 
-var request2 = http.get(requestOptions, function(response) {
-  assert(!request2.socket.destroyed);
-  assert(request1.socket.destroyed);
-  // assert not reusing the same socket, since it was destroyed.
-  assert(request1.socket !== request2.socket);
-  console.log('got response2');
-  var gotClose = false;
-  var gotResponseEnd = false;
-  request2.socket.on('close', function() {
-    console.log('request2 socket closed');
-    gotClose = true;
-    done();
-  });
-  response.pipe(process.stdout);
-  response.on('end', function() {
-    console.log('response2 done');
-    gotResponseEnd = true;
-    done();
-  });
+  var request2 = http.get(requestOptions, function(response) {
+    assert(!request2.socket.destroyed);
+    assert(request1.socket.destroyed);
+    // assert not reusing the same socket, since it was destroyed.
+    assert(request1.socket !== request2.socket);
+    console.log('got response2');
+    var gotClose = false;
+    var gotResponseEnd = false;
+    request2.socket.on('close', function() {
+      console.log('request2 socket closed');
+      gotClose = true;
+      done();
+    });
+    response.pipe(process.stdout);
+    response.on('end', function() {
+      console.log('response2 done');
+      gotResponseEnd = true;
+      done();
+    });
 
-  function done() {
-    if (gotResponseEnd && gotClose)
-      server.close();
-  }
+    function done() {
+      if (gotResponseEnd && gotClose)
+        server.close();
+    }
+  });
 });

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -4,6 +4,8 @@ const assert = require('assert');
 const http = require('http');
 const Agent = require('_http_agent').Agent;
 
+let name;
+
 const agent = new Agent({
   keepAlive: true,
   keepAliveMsecs: 1000,
@@ -28,13 +30,11 @@ const server = http.createServer(function(req, res) {
 function get(path, callback) {
   return http.get({
     host: 'localhost',
-    port: common.PORT,
+    port: server.address().port,
     agent: agent,
     path: path
   }, callback);
 }
-
-const name = 'localhost:' + common.PORT + ':';
 
 function checkDataAndSockets(body) {
   assert.equal(body.toString(), 'hello world');
@@ -106,7 +106,8 @@ function done() {
   process.exit(0);
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  name = `localhost:${server.address().port}:`;
   // request first, and keep alive
   get('/first', function(res) {
     assert.equal(res.statusCode, 200);

--- a/test/parallel/test-http-agent-maxsockets-regress-4050.js
+++ b/test/parallel/test-http-agent-maxsockets-regress-4050.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -19,13 +19,13 @@ const server = http.createServer(function(req, res) {
 function get(path, callback) {
   return http.get({
     host: 'localhost',
-    port: common.PORT,
+    port: server.address().port,
     agent: agent,
     path: path
   }, callback);
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var finished = 0;
   const num_requests = 6;
   for (var i = 0; i < num_requests; i++) {

--- a/test/parallel/test-http-agent-maxsockets.js
+++ b/test/parallel/test-http-agent-maxsockets.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -17,7 +17,7 @@ var server = http.createServer(function(req, res) {
 function get(path, callback) {
   return http.get({
     host: 'localhost',
-    port: common.PORT,
+    port: server.address().port,
     agent: agent,
     path: path
   }, callback);
@@ -35,7 +35,7 @@ function done() {
   server.close();
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   get('/1', function(res) {
     assert.equal(res.statusCode, 200);
     res.resume();

--- a/test/parallel/test-http-agent-no-protocol.js
+++ b/test/parallel/test-http-agent-no-protocol.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
@@ -14,8 +14,8 @@ process.on('exit', function() {
 var server = http.createServer(function(req, res) {
   res.end();
   request++;
-}).listen(common.PORT, '127.0.0.1', function() {
-  var opts = url.parse('http://127.0.0.1:' + common.PORT + '/');
+}).listen(0, '127.0.0.1', function() {
+  var opts = url.parse(`http://127.0.0.1:${this.address().port}/`);
 
   // remove the `protocol` field… the `http` module should fall back
   // to "http:", as defined by the global, default `http.Agent` instance.

--- a/test/parallel/test-http-agent-null.js
+++ b/test/parallel/test-http-agent-null.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -13,7 +13,7 @@ process.on('exit', function() {
 var server = http.createServer(function(req, res) {
   request++;
   res.end();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var options = {
     agent: null,
     port: this.address().port

--- a/test/parallel/test-http-agent.js
+++ b/test/parallel/test-http-agent.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -12,11 +12,12 @@ var responses = 0;
 var N = 4;
 var M = 4;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  const port = this.address().port;
   for (var i = 0; i < N; i++) {
     setTimeout(function() {
       for (var j = 0; j < M; j++) {
-        http.get({ port: common.PORT, path: '/' }, function(res) {
+        http.get({ port: port, path: '/' }, function(res) {
           console.log('%d %d', responses, res.statusCode);
           if (++responses == N * M) {
             console.error('Received all responses, closing server');

--- a/test/parallel/test-http-allow-req-after-204-res.js
+++ b/test/parallel/test-http-allow-req-after-204-res.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 var assert = require('assert');
 
@@ -23,7 +23,7 @@ function nextRequest() {
   console.error('writing request: %s', method);
 
   var request = http.request({
-    port: common.PORT,
+    port: server.address().port,
     method: method,
     path: '/'
   }, function(response) {
@@ -43,4 +43,4 @@ function nextRequest() {
   request.end();
 }
 
-server.listen(common.PORT, nextRequest);
+server.listen(0, nextRequest);

--- a/test/parallel/test-http-automatic-headers.js
+++ b/test/parallel/test-http-automatic-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -9,12 +9,12 @@ var server = http.createServer(function(req, res) {
   res.setHeader('X-Content-Length', 'baz');
   res.end();
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
-  var agent = new http.Agent({ port: common.PORT, maxSockets: 1 });
+  var agent = new http.Agent({ port: this.address().port, maxSockets: 1 });
   http.get({
-    port: common.PORT,
+    port: this.address().port,
     path: '/hello',
     agent: agent
   }, function(res) {

--- a/test/parallel/test-http-bind-twice.js
+++ b/test/parallel/test-http-bind-twice.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -14,14 +14,13 @@ function dontCall() {
 }
 
 var server1 = http.createServer(dontCall);
-server1.listen(common.PORT, '127.0.0.1', function() {});
+server1.listen(0, '127.0.0.1', function() {
+  var server2 = http.createServer(dontCall);
+  server2.listen(this.address().port, '127.0.0.1', dontCall);
 
-var server2 = http.createServer(dontCall);
-server2.listen(common.PORT, '127.0.0.1', dontCall);
-
-server2.on('error', function(e) {
-  assert.equal(e.code, 'EADDRINUSE');
-  server1.close();
-  gotError = true;
+  server2.on('error', function(e) {
+    assert.equal(e.code, 'EADDRINUSE');
+    server1.close();
+    gotError = true;
+  });
 });
-

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -18,8 +18,8 @@ var server = http.createServer(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
-  var c = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var c = net.createConnection(this.address().port);
 
   c.on('connect', function() {
     c.write('GET /blah HTTP/1.1\r\n' +

--- a/test/parallel/test-http-buffer-sanity.js
+++ b/test/parallel/test-http-buffer-sanity.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -44,11 +44,11 @@ var web = http.Server(function(req, res) {
 
 var gotThanks = false;
 
-web.listen(common.PORT, function() {
+web.listen(0, function() {
   console.log('Making request');
 
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'GET',
     path: '/',
     headers: { 'content-length': buffer.length }

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -36,6 +36,6 @@ var httpServer = http.createServer(function(req, res) {
   res.end(body);
 });
 
-httpServer.listen(common.PORT, function() {
-  http.get({ port: common.PORT });
+httpServer.listen(0, function() {
+  http.get({ port: this.address().port });
 });

--- a/test/parallel/test-http-catch-uncaughtexception.js
+++ b/test/parallel/test-http-catch-uncaughtexception.js
@@ -13,8 +13,8 @@ process.on('uncaughtException', uncaughtCallback);
 const server = http.createServer(function(req, res) {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('bye');
-}).listen(common.PORT, function() {
-  http.get({ port: common.PORT }, function(res) {
+}).listen(0, function() {
+  http.get({ port: this.address().port }, function(res) {
     res.resume();
     throw new Error('get did fail');
   }).on('close', function() {

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -10,7 +10,7 @@ if (!common.hasCrypto) {
 if (process.argv[2] === 'request') {
   const http = require('http');
   const options = {
-    port: common.PORT,
+    port: +process.argv[3],
     path: '/'
   };
 
@@ -39,11 +39,13 @@ const http = require('http');
 const cp = require('child_process');
 
 const filename = require('path').join(common.tmpDir, 'big');
+let server;
 
 function executeRequest(cb) {
   cp.exec([process.execPath,
            __filename,
            'request',
+           server.address().port,
            '|',
            process.execPath,
            __filename,
@@ -64,7 +66,7 @@ const ddcmd = common.ddCommand(filename, 10240);
 
 cp.exec(ddcmd, function(err, stdout, stderr) {
   if (err) throw err;
-  const server = http.createServer(function(req, res) {
+  server = http.createServer(function(req, res) {
     res.writeHead(200);
 
     // Create the subprocess
@@ -87,7 +89,7 @@ cp.exec(ddcmd, function(err, stdout, stderr) {
 
   });
 
-  server.listen(common.PORT, () => {
+  server.listen(0, () => {
     executeRequest(() => server.close());
   });
 });

--- a/test/parallel/test-http-chunked-304.js
+++ b/test/parallel/test-http-chunked-304.js
@@ -23,8 +23,8 @@ function test(statusCode, next) {
     server.close();
   });
 
-  server.listen(common.PORT, function() {
-    var conn = net.createConnection(common.PORT, function() {
+  server.listen(0, function() {
+    var conn = net.createConnection(this.address().port, function() {
       conn.write('GET / HTTP/1.1\r\n\r\n');
 
       var resp = '';

--- a/test/parallel/test-http-chunked.js
+++ b/test/parallel/test-http-chunked.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -17,12 +17,12 @@ var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain; charset=utf8'});
   res.end(UTF8_STRING, 'utf8');
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var data = '';
   var get = http.get({
     path: '/',
     host: 'localhost',
-    port: common.PORT
+    port: this.address().port
   }, function(x) {
     x.setEncoding('utf8');
     x.on('data', function(c) {data += c;});

--- a/test/parallel/test-http-client-abort-event.js
+++ b/test/parallel/test-http-client-abort-event.js
@@ -1,14 +1,14 @@
 'use strict';
+require('../common');
 var assert = require('assert');
 var http = require('http');
-var common = require('../common');
 var server = http.createServer(function(req, res) {
   res.end();
 });
 var count = 0;
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = http.request({
-    port: common.PORT
+    port: this.address().port
   }, function() {
     assert(false, 'should not receive data');
   });

--- a/test/parallel/test-http-client-abort.js
+++ b/test/parallel/test-http-client-abort.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -27,12 +27,12 @@ var responses = 0;
 const N = 8;
 const requests = [];
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   console.log('Server listening.');
 
   for (var i = 0; i < N; i++) {
     console.log('Making client ' + i);
-    var options = { port: common.PORT, path: '/?id=' + i };
+    var options = { port: this.address().port, path: '/?id=' + i };
     var req = http.get(options, function(res) {
       console.log('Client response code ' + res.statusCode);
 

--- a/test/parallel/test-http-client-abort2.js
+++ b/test/parallel/test-http-client-abort2.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
   res.end('Hello');
 });
 
-server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+server.listen(0, function() {
+  var req = http.get({port: this.address().port}, function(res) {
     res.on('data', function(data) {
       req.abort();
       server.close();

--- a/test/parallel/test-http-client-agent.js
+++ b/test/parallel/test-http-client-agent.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var name = http.globalAgent.getName({ port: common.PORT });
+var name;
 var max = 3;
 var count = 0;
 
@@ -18,7 +18,8 @@ var server = http.Server(function(req, res) {
     res.end('Hello, World!');
   }
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  name = http.globalAgent.getName({ port: this.address().port });
   for (var i = 0; i < max; ++i) {
     request(i);
   }
@@ -26,7 +27,7 @@ server.listen(common.PORT, function() {
 
 function request(i) {
   var req = http.get({
-    port: common.PORT,
+    port: server.address().port,
     path: '/' + i
   }, function(res) {
     var socket = req.socket;

--- a/test/parallel/test-http-client-default-headers-exist.js
+++ b/test/parallel/test-http-client-default-headers-exist.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -36,11 +36,11 @@ var server = http.createServer(function(req, res) {
     server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   expectedMethods.forEach(function(method) {
     http.request({
       method: method,
-      port: common.PORT
+      port: server.address().port
     }).end();
   });
 });

--- a/test/parallel/test-http-client-encoding.js
+++ b/test/parallel/test-http-client-encoding.js
@@ -1,16 +1,16 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 var http = require('http');
 
 http.createServer(function(req, res) {
   res.end('ok\n');
   this.close();
-}).listen(common.PORT, test);
+}).listen(0, test);
 
 function test() {
   http.request({
-    port: common.PORT,
+    port: this.address().port,
     encoding: 'utf8'
   }, function(res) {
     res.pipe(process.stdout);

--- a/test/parallel/test-http-client-get-url.js
+++ b/test/parallel/test-http-client-get-url.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -15,8 +15,8 @@ var server = http.createServer(function(req, res) {
   seen_req = true;
 });
 
-server.listen(common.PORT, function() {
-  http.get('http://127.0.0.1:' + common.PORT + '/foo?bar');
+server.listen(0, function() {
+  http.get(`http://127.0.0.1:${this.address().port}/foo?bar`);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-http-client-parse-error.js
+++ b/test/parallel/test-http-client-parse-error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -17,11 +17,11 @@ net.createServer(function(c) {
     c.end('bad http - should trigger parse error\r\n');
     this.close();
   }
-}).listen(common.PORT, '127.0.0.1', function() {
+}).listen(0, '127.0.0.1', function() {
   for (var i = 0; i < 2; i++) {
     http.request({
       host: '127.0.0.1',
-      port: common.PORT,
+      port: this.address().port,
       method: 'GET',
       path: '/'
     }).on('error', function(e) {

--- a/test/parallel/test-http-client-race-2.js
+++ b/test/parallel/test-http-client-race-2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
@@ -27,14 +27,14 @@ var server = http.createServer(function(req, res) {
                 {'Content-Type': 'text/plain', 'Content-Length': body.length});
   res.end(body);
 });
-server.listen(common.PORT);
+server.listen(0);
 
 var body1 = '';
 var body2 = '';
 var body3 = '';
 
 server.on('listening', function() {
-  var client = http.createClient(common.PORT);
+  var client = http.createClient(this.address().port);
 
   //
   // Client #1 is assigned Parser #1
@@ -59,7 +59,7 @@ server.on('listening', function() {
         // parser that previously belonged to Client #1. But we're not finished
         // with Client #1 yet!
         //
-        var client2 = http.createClient(common.PORT);
+        var client2 = http.createClient(server.address().port);
 
         //
         // At this point, the bug would manifest itself and crash because the

--- a/test/parallel/test-http-client-race.js
+++ b/test/parallel/test-http-client-race.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
@@ -13,13 +13,13 @@ var server = http.createServer(function(req, res) {
                 {'Content-Type': 'text/plain', 'Content-Length': body.length});
   res.end(body);
 });
-server.listen(common.PORT);
+server.listen(0);
 
 var body1 = '';
 var body2 = '';
 
 server.on('listening', function() {
-  var req1 = http.request({ port: common.PORT, path: '/1' });
+  var req1 = http.request({ port: this.address().port, path: '/1' });
   req1.end();
   req1.on('response', function(res1) {
     res1.setEncoding('utf8');
@@ -29,7 +29,7 @@ server.on('listening', function() {
     });
 
     res1.on('end', function() {
-      var req2 = http.request({ port: common.PORT, path: '/2' });
+      var req2 = http.request({ port: server.address().port, path: '/2' });
       req2.end();
       req2.on('response', function(res2) {
         res2.setEncoding('utf8');

--- a/test/parallel/test-http-client-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-client-reject-chunked-with-content-length.js
@@ -13,11 +13,11 @@ const server = net.createServer((socket) => {
   socket.write(reqstr);
 });
 
-server.listen(common.PORT, () => {
+server.listen(0, () => {
   // The callback should not be called because the server is sending
   // both a Content-Length header and a Transfer-Encoding: chunked
   // header, which is a violation of the HTTP spec.
-  const req = http.get({port: common.PORT}, (res) => {
+  const req = http.get({port: server.address().port}, (res) => {
     assert.fail(null, null, 'callback should not be called');
   });
   req.on('error', common.mustCall((err) => {

--- a/test/parallel/test-http-client-reject-cr-no-lf.js
+++ b/test/parallel/test-http-client-reject-cr-no-lf.js
@@ -13,10 +13,10 @@ const server = net.createServer((socket) => {
   socket.write(reqstr);
 });
 
-server.listen(common.PORT, () => {
+server.listen(0, () => {
   // The callback should not be called because the server is sending a
   // header field that ends only in \r with no following \n
-  const req = http.get({port: common.PORT}, (res) => {
+  const req = http.get({port: server.address().port}, (res) => {
     assert.fail(null, null, 'callback should not be called');
   });
   req.on('error', common.mustCall((err) => {

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -8,7 +8,7 @@ var requests_sent = 0;
 var requests_done = 0;
 var options = {
   method: 'GET',
-  port: common.PORT,
+  port: undefined,
   host: '127.0.0.1',
 };
 
@@ -27,7 +27,8 @@ var server = http.createServer(function(req, res) {
   request_number += 1;
 });
 
-server.listen(options.port, options.host, function() {
+server.listen(0, options.host, function() {
+  options.port = this.address().port;
   var req;
 
   for (requests_sent = 0; requests_sent < 30; requests_sent += 1) {

--- a/test/parallel/test-http-client-timeout-event.js
+++ b/test/parallel/test-http-client-timeout-event.js
@@ -5,7 +5,7 @@ var http = require('http');
 
 var options = {
   method: 'GET',
-  port: common.PORT,
+  port: undefined,
   host: '127.0.0.1',
   path: '/'
 };
@@ -14,7 +14,8 @@ var server = http.createServer(function(req, res) {
   // this space intentionally left blank
 });
 
-server.listen(options.port, options.host, function() {
+server.listen(0, options.host, function() {
+  options.port = this.address().port;
   var req = http.request(options, function(res) {
     // this space intentionally left blank
   });

--- a/test/parallel/test-http-client-timeout-with-data.js
+++ b/test/parallel/test-http-client-timeout-with-data.js
@@ -13,7 +13,7 @@ process.on('exit', function() {
 
 const options = {
   method: 'GET',
-  port: common.PORT,
+  port: undefined,
   host: '127.0.0.1',
   path: '/'
 };
@@ -24,7 +24,8 @@ const server = http.createServer(function(req, res) {
   setTimeout(function() { res.end('*'); }, common.platformTimeout(100));
 });
 
-server.listen(options.port, options.host, function() {
+server.listen(0, options.host, function() {
+  options.port = this.address().port;
   const req = http.request(options, onresponse);
   req.end();
 

--- a/test/parallel/test-http-client-timeout.js
+++ b/test/parallel/test-http-client-timeout.js
@@ -1,11 +1,11 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
 var options = {
   method: 'GET',
-  port: common.PORT,
+  port: undefined,
   host: '127.0.0.1',
   path: '/'
 };
@@ -14,7 +14,8 @@ var server = http.createServer(function(req, res) {
   // this space intentionally left blank
 });
 
-server.listen(options.port, options.host, function() {
+server.listen(0, options.host, function() {
+  options.port = this.address().port;
   var req = http.request(options, function(res) {
     // this space intentionally left blank
   });

--- a/test/parallel/test-http-client-upload-buf.js
+++ b/test/parallel/test-http-client-upload-buf.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -23,11 +23,11 @@ var server = http.createServer(function(req, res) {
     res.end();
   });
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'POST',
     path: '/'
   }, function(res) {

--- a/test/parallel/test-http-client-upload.js
+++ b/test/parallel/test-http-client-upload.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -24,11 +24,11 @@ var server = http.createServer(function(req, res) {
     res.end();
   });
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'POST',
     path: '/'
   }, function(res) {

--- a/test/parallel/test-http-conn-reset.js
+++ b/test/parallel/test-http-conn-reset.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -8,7 +8,7 @@ var caughtError = false;
 
 var options = {
   host: '127.0.0.1',
-  port: common.PORT
+  port: undefined
 };
 
 // start a tcp server that closes incoming connections immediately
@@ -16,10 +16,11 @@ var server = net.createServer(function(client) {
   client.destroy();
   server.close();
 });
-server.listen(options.port, options.host, onListen);
+server.listen(0, options.host, onListen);
 
 // do a GET request, expect it to fail
 function onListen() {
+  options.port = this.address().port;
   var req = http.request(options, function(res) {
     assert.ok(false, 'this should never run');
   });

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -28,9 +28,9 @@ server.on('connect', common.mustCall(function(req, socket, firstBodyChunk) {
     socket.end(data);
   });
 }));
-server.listen(common.PORT, common.mustCall(function() {
+server.listen(0, common.mustCall(function() {
   const req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'CONNECT',
     path: 'example.com:443'
   }, function(res) {
@@ -43,7 +43,7 @@ server.listen(common.PORT, common.mustCall(function() {
     console.error('Client got CONNECT request');
 
     // Make sure this request got removed from the pool.
-    const name = 'localhost:' + common.PORT;
+    const name = 'localhost:' + server.address().port;
     assert(!http.globalAgent.sockets.hasOwnProperty(name));
     assert(!http.globalAgent.requests.hasOwnProperty(name));
 

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -25,9 +25,9 @@ server.on('connect', function(req, socket, firstBodyChunk) {
     socket.end(data);
   });
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'CONNECT',
     path: 'google.com:443'
   }, function(res) {
@@ -44,7 +44,7 @@ server.listen(common.PORT, function() {
     clientGotConnect = true;
 
     // Make sure this request got removed from the pool.
-    var name = 'localhost:' + common.PORT;
+    var name = 'localhost:' + server.address().port;
     assert(!http.globalAgent.sockets.hasOwnProperty(name));
     assert(!http.globalAgent.requests.hasOwnProperty(name));
 

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -46,11 +46,11 @@ var server = http.createServer(function(req, res) {
   if (totalRequests === receivedRequests) server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req;
 
   req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'POST',
     path: '/multiple-writes'
   });
@@ -63,7 +63,7 @@ server.listen(common.PORT, function() {
   });
 
   req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'POST',
     path: '/end-with-data'
   });
@@ -75,7 +75,7 @@ server.listen(common.PORT, function() {
   });
 
   req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'POST',
     path: '/empty'
   });

--- a/test/parallel/test-http-contentLength0.js
+++ b/test/parallel/test-http-contentLength0.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 
 // Simple test of Node's HTTP Client choking on a response
@@ -11,9 +11,9 @@ var s = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Length': '0 '});
   res.end();
 });
-s.listen(common.PORT, function() {
+s.listen(0, function() {
 
-  var request = http.request({ port: common.PORT }, function(response) {
+  var request = http.request({ port: this.address().port }, function(response) {
     console.log('STATUS: ' + response.statusCode);
     s.close();
     response.resume();

--- a/test/parallel/test-http-createConnection.js
+++ b/test/parallel/test-http-createConnection.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 
 const server = http.createServer(common.mustCall(function(req, res) {
   res.end();
-}, 4)).listen(common.PORT, '127.0.0.1', function() {
+}, 4)).listen(0, '127.0.0.1', function() {
   let fn = common.mustCall(createConnection);
   http.get({ createConnection: fn }, function(res) {
     res.resume();
@@ -33,17 +33,17 @@ const server = http.createServer(common.mustCall(function(req, res) {
 });
 
 function createConnection() {
-  return net.createConnection(common.PORT, '127.0.0.1');
+  return net.createConnection(server.address().port, '127.0.0.1');
 }
 
 function createConnectionAsync(options, cb) {
   setImmediate(function() {
-    cb(null, net.createConnection(common.PORT, '127.0.0.1'));
+    cb(null, net.createConnection(server.address().port, '127.0.0.1'));
   });
 }
 
 function createConnectionBoth1(options, cb) {
-  const socket = net.createConnection(common.PORT, '127.0.0.1');
+  const socket = net.createConnection(server.address().port, '127.0.0.1');
   setImmediate(function() {
     cb(null, socket);
   });
@@ -51,7 +51,7 @@ function createConnectionBoth1(options, cb) {
 }
 
 function createConnectionBoth2(options, cb) {
-  const socket = net.createConnection(common.PORT, '127.0.0.1');
+  const socket = net.createConnection(server.address().port, '127.0.0.1');
   cb(null, socket);
   return socket;
 }

--- a/test/parallel/test-http-date-header.js
+++ b/test/parallel/test-http-date-header.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -13,12 +13,12 @@ var server = http.createServer(function(req, res) {
   });
   res.end(testResBody);
 });
-server.listen(common.PORT);
+server.listen(0);
 
 
 server.addListener('listening', function() {
   var options = {
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET'
   };

--- a/test/parallel/test-http-default-encoding.js
+++ b/test/parallel/test-http-default-encoding.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -18,9 +18,9 @@ var server = http.Server(function(req, res) {
 
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   http.request({
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'POST'
   }, function(res) {

--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -1,8 +1,6 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
-const PORT = common.PORT;
-const SSLPORT = common.PORT + 1;
 const assert = require('assert');
 const hostExpect = 'localhost';
 const fs = require('fs');
@@ -29,18 +27,18 @@ process.on('exit', function() {
   console.log('ok');
 });
 
-http.globalAgent.defaultPort = PORT;
 http.createServer(function(req, res) {
   assert.equal(req.headers.host, hostExpect);
-  assert.equal(req.headers['x-port'], PORT);
+  assert.equal(req.headers['x-port'], this.address().port);
   res.writeHead(200);
   res.end('ok');
   this.close();
-}).listen(PORT, function() {
+}).listen(0, function() {
+  http.globalAgent.defaultPort = this.address().port;
   http.get({
     host: 'localhost',
     headers: {
-      'x-port': PORT
+      'x-port': this.address().port
     }
   }, function(res) {
     gotHttpResp = true;
@@ -49,19 +47,19 @@ http.createServer(function(req, res) {
 });
 
 if (common.hasCrypto) {
-  https.globalAgent.defaultPort = SSLPORT;
   https.createServer(options, function(req, res) {
     assert.equal(req.headers.host, hostExpect);
-    assert.equal(req.headers['x-port'], SSLPORT);
+    assert.equal(req.headers['x-port'], this.address().port);
     res.writeHead(200);
     res.end('ok');
     this.close();
-  }).listen(SSLPORT, function() {
+  }).listen(0, function() {
+    https.globalAgent.defaultPort = this.address().port;
     https.get({
       host: 'localhost',
       rejectUnauthorized: false,
       headers: {
-        'x-port': SSLPORT
+        'x-port': this.address().port
       }
     }, function(res) {
       gotHttpsResp = true;

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -12,9 +12,9 @@ var server = http.createServer(function(req, res) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'POST'
   });

--- a/test/parallel/test-http-double-content-length.js
+++ b/test/parallel/test-http-double-content-length.js
@@ -17,9 +17,9 @@ server.on('clientError', common.mustCall((err, socket) => {
   socket.destroy();
 }));
 
-server.listen(common.PORT, () => {
+server.listen(0, () => {
   const req = http.get({
-    port: common.PORT,
+    port: server.address().port,
     // Send two content-length header values.
     headers: {'Content-Length': [1, 2]}},
     (res) => {

--- a/test/parallel/test-http-end-throw-socket-handling.js
+++ b/test/parallel/test-http-end-throw-socket-handling.js
@@ -16,9 +16,9 @@ const server = http.createServer((req, res) => {
   res.end('ok');
 });
 
-server.listen(common.PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   for (let i = 0; i < 10; i++) {
-    const options = { port: common.PORT };
+    const options = { port: server.address().port };
     const req = http.request(options, (res) => {
       res.resume();
       res.on('end', common.mustCall(() => {

--- a/test/parallel/test-http-eof-on-connect.js
+++ b/test/parallel/test-http-eof-on-connect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var net = require('net');
 var http = require('http');
 
@@ -8,10 +8,10 @@ var http = require('http');
 // reproduceable on the first packet on the first connection to a server.
 
 var server = http.createServer(function(req, res) {});
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
-  net.createConnection(common.PORT).on('connect', function() {
+  net.createConnection(this.address().port).on('connect', function() {
     this.destroy();
   }).on('close', function() {
     server.close();

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
@@ -9,9 +9,9 @@ var server = http.createServer(function(req, res) {
   res.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   for (var i = 0; i < 4; i += 1) {
-    http.get({ port: common.PORT, path: '/busy/' + i });
+    http.get({ port: this.address().port, path: '/busy/' + i });
   }
 });
 

--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -28,12 +28,12 @@ server.on('checkContinue', function(req, res) {
     handler(req, res);
   }, 100);
 });
-server.listen(common.PORT);
+server.listen(0);
 
 
 server.on('listening', function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'POST',
     path: '/world',
     headers: { 'Expect': '100-continue' }

--- a/test/parallel/test-http-expect-handling.js
+++ b/test/parallel/test-http-expect-handling.js
@@ -13,11 +13,11 @@ const s = http.createServer(function(req, res) {
   throw new Error('this should never be executed');
 });
 
-s.listen(common.PORT, nextTest);
+s.listen(0, nextTest);
 
 function nextTest() {
   const options = {
-    port: common.PORT,
+    port: s.address().port,
     headers: { 'Expect': 'meoww' }
   };
 

--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -44,8 +44,8 @@ var server = net.createServer(function(socket) {
 });
 
 
-server.listen(common.PORT, function() {
-  http.get({ port: common.PORT }, function(res) {
+server.listen(0, function() {
+  http.get({ port: this.address().port }, function(res) {
     var buffer = '';
     console.log('Got res code: ' + res.statusCode);
 

--- a/test/parallel/test-http-flush-headers.js
+++ b/test/parallel/test-http-flush-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -9,11 +9,11 @@ server.on('request', function(req, res) {
   res.end('ok');
   server.close();
 });
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   const req = http.request({
     method: 'GET',
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
   });
   req.setHeader('foo', 'bar');
   req.flushHeaders();

--- a/test/parallel/test-http-flush-response-headers.js
+++ b/test/parallel/test-http-flush-response-headers.js
@@ -10,11 +10,11 @@ server.on('request', function(req, res) {
   res.flushHeaders();
   res.flushHeaders(); // Should be idempotent.
 });
-server.listen(common.PORT, common.localhostIPv4, function() {
+server.listen(0, common.localhostIPv4, function() {
   var req = http.request({
     method: 'GET',
     host: common.localhostIPv4,
-    port: common.PORT,
+    port: this.address().port,
   }, onResponse);
 
   req.end();

--- a/test/parallel/test-http-flush.js
+++ b/test/parallel/test-http-flush.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 
 http.createServer(function(req, res) {
   res.end('ok');
   this.close();
-}).listen(common.PORT, '127.0.0.1', function() {
+}).listen(0, '127.0.0.1', function() {
   var req = http.request({
     method: 'POST',
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
   });
   req.flush();  // Flush the request headers.
   req.flush();  // Should be idempotent.

--- a/test/parallel/test-http-full-response.js
+++ b/test/parallel/test-http-full-response.js
@@ -20,7 +20,7 @@ var server = http.createServer(function(req, res) {
 var runs = 0;
 
 function runAb(opts, callback) {
-  var command = 'ab ' + opts + ' http://127.0.0.1:' + common.PORT + '/';
+  var command = `ab ${opts} http://127.0.0.1:${server.address().port}/`;
   exec(command, function(err, stdout, stderr) {
     if (err) {
       if (/ab|apr/mi.test(stderr)) {
@@ -49,7 +49,7 @@ function runAb(opts, callback) {
   });
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   runAb('-c 1 -n 10', function() {
     console.log('-c 1 -n 10 okay');
 

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -34,13 +34,13 @@ var server = http.Server(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   for (var i = 0; i < total; i++) {
     (function() {
       var x = i;
 
       var opts = {
-        port: common.PORT,
+        port: server.address().port,
         headers: { connection: 'close' }
       };
 

--- a/test/parallel/test-http-head-request.js
+++ b/test/parallel/test-http-head-request.js
@@ -1,15 +1,11 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
-
 var body = 'hello world\n';
-var id = 0;
 
 function test(headers) {
-  var port = common.PORT + id++;
-
   var server = http.createServer(function(req, res) {
     console.error('req: %s headers: %j', req.method, headers);
     res.writeHead(200, headers);
@@ -19,9 +15,9 @@ function test(headers) {
 
   var gotEnd = false;
 
-  server.listen(port, function() {
+  server.listen(0, function() {
     var request = http.request({
-      port: port,
+      port: this.address().port,
       method: 'HEAD',
       path: '/'
     }, function(response) {

--- a/test/parallel/test-http-head-response-has-no-body-end.js
+++ b/test/parallel/test-http-head-response-has-no-body-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -12,13 +12,13 @@ var server = http.createServer(function(req, res) {
   res.writeHead(200);
   res.end('FAIL'); // broken: sends FAIL from hot path.
 });
-server.listen(common.PORT);
+server.listen(0);
 
 var responseComplete = false;
 
 server.on('listening', function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'HEAD',
     path: '/'
   }, function(res) {

--- a/test/parallel/test-http-head-response-has-no-body.js
+++ b/test/parallel/test-http-head-response-has-no-body.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -12,13 +12,13 @@ var server = http.createServer(function(req, res) {
   res.writeHead(200); // broken: defaults to TE chunked
   res.end();
 });
-server.listen(common.PORT);
+server.listen(0);
 
 var responseComplete = false;
 
 server.on('listening', function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'HEAD',
     path: '/'
   }, function(res) {

--- a/test/parallel/test-http-header-obstext.js
+++ b/test/parallel/test-http-header-obstext.js
@@ -7,9 +7,9 @@ const assert = require('assert');
 const server = http.createServer(common.mustCall((req, res) => {
   res.end('ok');
 }));
-server.listen(common.PORT, () => {
+server.listen(0, () => {
   http.get({
-    port: common.PORT,
+    port: server.address().port,
     headers: {'Test': 'Düsseldorf'}
   }, common.mustCall((res) => {
     assert.equal(res.statusCode, 200);

--- a/test/parallel/test-http-header-read.js
+++ b/test/parallel/test-http-header-read.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -23,10 +23,10 @@ var s = http.createServer(function(req, res) {
   );
 });
 
-s.listen(common.PORT, runTest);
+s.listen(0, runTest);
 
 function runTest() {
-  http.get({ port: common.PORT }, function(response) {
+  http.get({ port: this.address().port }, function(response) {
     response.on('end', function() {
       s.close();
     });

--- a/test/parallel/test-http-hex-write.js
+++ b/test/parallel/test-http-hex-write.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -20,8 +20,8 @@ http.createServer(function(q, s) {
   s.write('utf8\n');
   s.end();
   this.close();
-}).listen(common.PORT, function() {
-  http.request({ port: common.PORT }).on('response', function(res) {
+}).listen(0, function() {
+  http.request({ port: this.address().port }).on('response', function(res) {
     res.setEncoding('ascii');
     res.on('data', function(c) {
       data += c;

--- a/test/parallel/test-http-host-header-ipv6-fail.js
+++ b/test/parallel/test-http-host-header-ipv6-fail.js
@@ -14,12 +14,11 @@ const assert = require('assert');
 const http = require('http');
 
 const hostname = '::1';
-const port = common.PORT;
 
 function httpreq() {
   var req = http.request({
     host: hostname,
-    port: port,
+    port: server.address().port,
     path: '/',
     method: 'GET'
   });
@@ -37,4 +36,4 @@ const server = http.createServer(common.mustCall(function(req, res) {
   server.close(true);
 }));
 
-server.listen(port, hostname, () => httpreq());
+server.listen(0, hostname, () => httpreq());

--- a/test/parallel/test-http-host-headers.js
+++ b/test/parallel/test-http-host-headers.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 const http = require('http');
-const common = require('../common');
 const assert = require('assert');
 const httpServer = http.createServer(reqHandler);
 
@@ -9,7 +9,7 @@ function reqHandler(req, res) {
   if (req.url === '/setHostFalse5') {
     assert.equal(req.headers.host, undefined);
   } else {
-    assert.equal(req.headers.host, 'localhost:' + common.PORT,
+    assert.equal(req.headers.host, `localhost:${this.address().port}`,
                  'Wrong host header for req[' + req.url + ']: ' +
                  req.headers.host);
   }
@@ -26,8 +26,6 @@ testHttp();
 
 function testHttp() {
 
-  console.log('testing http on port ' + common.PORT);
-
   var counter = 0;
 
   function cb(res) {
@@ -39,8 +37,8 @@ function testHttp() {
     res.resume();
   }
 
-  httpServer.listen(common.PORT, function(er) {
-    console.error('listening on ' + common.PORT);
+  httpServer.listen(0, function(er) {
+    console.error(`test http server listening on ${this.address().port}`);
 
     if (er) throw er;
 
@@ -49,7 +47,7 @@ function testHttp() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower);
 
@@ -58,7 +56,7 @@ function testHttp() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -67,7 +65,7 @@ function testHttp() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -76,7 +74,7 @@ function testHttp() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -85,7 +83,7 @@ function testHttp() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
   });

--- a/test/parallel/test-http-incoming-pipelined-socket-destroy.js
+++ b/test/parallel/test-http-incoming-pipelined-socket-destroy.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 var http = require('http');
 var net = require('net');
@@ -40,16 +40,16 @@ var server = http.createServer(function(req, res) {
 function generator(seeds) {
   return seeds.map(function(r) {
     return 'GET /' + r + ' HTTP/1.1\r\n' +
-           'Host: localhost:' + common.PORT + '\r\n' +
+           `Host: localhost:${server.address().port}\r\n` +
            '\r\n' +
            '\r\n';
   }).join('');
 }
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var seeds = [ 3, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 ];
-  var client = net.connect({ port: common.PORT });
+  var client = net.connect({ port: this.address().port });
   var done = 0;
   server.on('requestDone', function() {
     if (++done == seeds.length) {

--- a/test/parallel/test-http-invalidheaderfield.js
+++ b/test/parallel/test-http-invalidheaderfield.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 const http = require('http');
@@ -16,16 +16,16 @@ const server = http.createServer(function(req, res) {
   }, TypeError);
   res.end('');
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
 
-  http.get({port: common.PORT}, function() {
+  http.get({port: this.address().port}, function() {
     ee.emit('done');
   });
 
   assert.throws(
     function() {
       var options = {
-        port: common.PORT,
+        port: server.address().port,
         headers: {'testing 123': 123}
       };
       http.get(options, function() {});
@@ -39,7 +39,7 @@ server.listen(common.PORT, function() {
   assert.doesNotThrow(
     function() {
       var options = {
-        port: common.PORT,
+        port: server.address().port,
         headers: {'testing_123': 123}
       };
       http.get(options, function() {

--- a/test/parallel/test-http-keep-alive-close-on-header.js
+++ b/test/parallel/test-http-keep-alive-close-on-header.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -15,14 +15,14 @@ var server = http.createServer(function(req, res) {
 var connectCount = 0;
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var agent = new http.Agent({ maxSockets: 1 });
-  var name = agent.getName({ port: common.PORT });
+  var name = agent.getName({ port: this.address().port });
   var request = http.request({
     method: 'GET',
     path: '/',
     headers: headers,
-    port: common.PORT,
+    port: this.address().port,
     agent: agent
   }, function(res) {
     assert.equal(1, agent.sockets[name].length);
@@ -39,7 +39,7 @@ server.listen(common.PORT, function() {
     method: 'GET',
     path: '/',
     headers: headers,
-    port: common.PORT,
+    port: this.address().port,
     agent: agent
   }, function(res) {
     assert.equal(1, agent.sockets[name].length);
@@ -55,7 +55,7 @@ server.listen(common.PORT, function() {
     method: 'GET',
     path: '/',
     headers: headers,
-    port: common.PORT,
+    port: this.address().port,
     agent: agent
   }, function(response) {
     response.on('end', function() {

--- a/test/parallel/test-http-keep-alive.js
+++ b/test/parallel/test-http-keep-alive.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -13,11 +13,12 @@ var server = http.createServer(function(req, res) {
 
 var agent = new http.Agent({maxSockets: 1});
 var headers = {'connection': 'keep-alive'};
-var name = agent.getName({ port: common.PORT });
+var name;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  name = agent.getName({ port: this.address().port });
   http.get({
-    path: '/', headers: headers, port: common.PORT, agent: agent
+    path: '/', headers: headers, port: this.address().port, agent: agent
   }, function(response) {
     assert.equal(agent.sockets[name].length, 1);
     assert.equal(agent.requests[name].length, 2);
@@ -25,7 +26,7 @@ server.listen(common.PORT, function() {
   });
 
   http.get({
-    path: '/', headers: headers, port: common.PORT, agent: agent
+    path: '/', headers: headers, port: this.address().port, agent: agent
   }, function(response) {
     assert.equal(agent.sockets[name].length, 1);
     assert.equal(agent.requests[name].length, 1);
@@ -33,7 +34,7 @@ server.listen(common.PORT, function() {
   });
 
   http.get({
-    path: '/', headers: headers, port: common.PORT, agent: agent
+    path: '/', headers: headers, port: this.address().port, agent: agent
   }, function(response) {
     response.on('end', function() {
       assert.equal(agent.sockets[name].length, 1);

--- a/test/parallel/test-http-keepalive-client.js
+++ b/test/parallel/test-http-keepalive-client.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -16,7 +16,9 @@ var server = http.createServer(function(req, res) {
 
   res.end(req.url);
 });
-server.listen(common.PORT);
+server.listen(0, function() {
+  makeRequest(expectRequests);
+});
 
 var agent = http.Agent({ keepAlive: true });
 
@@ -26,7 +28,6 @@ var expectRequests = 10;
 var actualRequests = 0;
 
 
-makeRequest(expectRequests);
 function makeRequest(n) {
   if (n === 0) {
     server.close();
@@ -35,7 +36,7 @@ function makeRequest(n) {
   }
 
   var req = http.request({
-    port: common.PORT,
+    port: server.address().port,
     agent: agent,
     path: '/' + n
   });

--- a/test/parallel/test-http-keepalive-maxsockets.js
+++ b/test/parallel/test-http-keepalive-maxsockets.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -12,75 +12,76 @@ var server = http.createServer(function(req, res) {
   }
   res.end(req.url);
 });
-server.listen(common.PORT);
+server.listen(0, function() {
+  var agent = http.Agent({
+    keepAlive: true,
+    maxSockets: 5,
+    maxFreeSockets: 2
+  });
 
-var agent = http.Agent({
-  keepAlive: true,
-  maxSockets: 5,
-  maxFreeSockets: 2
-});
-
-// make 10 requests in parallel,
-// then 10 more when they all finish.
-function makeReqs(n, cb) {
-  for (var i = 0; i < n; i++)
-    makeReq(i, then);
-
-  function then(er) {
-    if (er)
-      return cb(er);
-    else if (--n === 0)
-      setTimeout(cb, 100);
-  }
-}
-
-function makeReq(i, cb) {
-  http.request({
-    port: common.PORT,
-    path: '/' + i,
-    agent: agent
-  }, function(res) {
-    var data = '';
-    res.setEncoding('ascii');
-    res.on('data', function(c) {
-      data += c;
-    });
-    res.on('end', function() {
-      assert.equal(data, '/' + i);
-      cb();
-    });
-  }).end();
-}
-
-var closed = false;
-makeReqs(10, function(er) {
-  assert.ifError(er);
-  assert.equal(count(agent.freeSockets), 2);
-  assert.equal(count(agent.sockets), 0);
-  assert.equal(serverSockets.length, 5);
-
-  // now make 10 more reqs.
-  // should use the 2 free reqs from the pool first.
+  var closed = false;
   makeReqs(10, function(er) {
     assert.ifError(er);
     assert.equal(count(agent.freeSockets), 2);
     assert.equal(count(agent.sockets), 0);
-    assert.equal(serverSockets.length, 8);
+    assert.equal(serverSockets.length, 5);
 
-    agent.destroy();
-    server.close(function() {
-      closed = true;
+    // now make 10 more reqs.
+    // should use the 2 free reqs from the pool first.
+    makeReqs(10, function(er) {
+      assert.ifError(er);
+      assert.equal(count(agent.freeSockets), 2);
+      assert.equal(count(agent.sockets), 0);
+      assert.equal(serverSockets.length, 8);
+
+      agent.destroy();
+      server.close(function() {
+        closed = true;
+      });
     });
   });
+
+  process.on('exit', function() {
+    assert(closed);
+    console.log('ok');
+  });
+
+  // make 10 requests in parallel,
+  // then 10 more when they all finish.
+  function makeReqs(n, cb) {
+    for (var i = 0; i < n; i++)
+      makeReq(i, then);
+
+    function then(er) {
+      if (er)
+        return cb(er);
+      else if (--n === 0)
+        setTimeout(cb, 100);
+    }
+  }
+
+  function makeReq(i, cb) {
+    http.request({
+      port: server.address().port,
+      path: '/' + i,
+      agent: agent
+    }, function(res) {
+      var data = '';
+      res.setEncoding('ascii');
+      res.on('data', function(c) {
+        data += c;
+      });
+      res.on('end', function() {
+        assert.equal(data, '/' + i);
+        cb();
+      });
+    }).end();
+  }
+
+  function count(sockets) {
+    return Object.keys(sockets).reduce(function(n, name) {
+      return n + sockets[name].length;
+    }, 0);
+  }
 });
 
-function count(sockets) {
-  return Object.keys(sockets).reduce(function(n, name) {
-    return n + sockets[name].length;
-  }, 0);
-}
-
-process.on('exit', function() {
-  assert(closed);
-  console.log('ok');
-});

--- a/test/parallel/test-http-keepalive-request.js
+++ b/test/parallel/test-http-keepalive-request.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -16,7 +16,9 @@ var server = http.createServer(function(req, res) {
 
   res.end(req.url);
 });
-server.listen(common.PORT);
+server.listen(0, function() {
+  makeRequest(expectRequests);
+});
 
 var agent = http.Agent({ keepAlive: true });
 
@@ -26,7 +28,6 @@ var expectRequests = 10;
 var actualRequests = 0;
 
 
-makeRequest(expectRequests);
 function makeRequest(n) {
   if (n === 0) {
     server.close();
@@ -35,7 +36,7 @@ function makeRequest(n) {
   }
 
   var req = http.request({
-    port: common.PORT,
+    port: server.address().port,
     path: '/' + n,
     agent: agent
   });

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
@@ -37,8 +37,8 @@ var server = http.createServer(function(req, res) {
   req.resume();
 });
 
-server.listen(common.PORT, function() {
-  var client = http.createClient(common.PORT);
+server.listen(0, function() {
+  var client = http.createClient(this.address().port);
   var req = client.request('/hello', {'Accept': '*/*', 'Foo': 'bar'});
   setTimeout(function() {
     req.end();

--- a/test/parallel/test-http-listening.js
+++ b/test/parallel/test-http-listening.js
@@ -7,7 +7,7 @@ const server = http.createServer();
 
 assert.strictEqual(server.listening, false);
 
-server.listen(common.PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   assert.strictEqual(server.listening, true);
 
   server.close(common.mustCall(() => {

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -16,10 +16,10 @@ var server = http.createServer(function(req, res) {
   req.resume();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   http.request({
     host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     localAddress: invalidLocalAddress

--- a/test/parallel/test-http-localaddress.js
+++ b/test/parallel/test-http-localaddress.js
@@ -19,9 +19,9 @@ var server = http.createServer(function(req, res) {
   req.resume();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var options = { host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     localAddress: '127.0.0.2' };

--- a/test/parallel/test-http-malformed-request.js
+++ b/test/parallel/test-http-malformed-request.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -20,10 +20,10 @@ var server = http.createServer(function(req, res) {
 
   if (++nrequests_completed == nrequests_expected) server.close();
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
-  var c = net.createConnection(common.PORT);
+  var c = net.createConnection(this.address().port);
   c.on('connect', function() {
     c.write('GET /hello?foo=%99bar HTTP/1.1\r\n\r\n');
     c.end();

--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 // no warnings should happen!
 var trace = console.trace;
@@ -27,13 +27,13 @@ var server = http.createServer(function(req, res) {
   req.socket.destroy();
 });
 
-server.listen(common.PORT);
-
-var client = net.connect({ port: common.PORT, allowHalfOpen: true });
-for (var i = 0; i < numRequests; i++) {
-  client.write('GET / HTTP/1.1\r\n' +
-               'Host: some.host.name\r\n' +
-               '\r\n\r\n');
-}
-client.end();
-client.pipe(process.stdout);
+server.listen(0, function() {
+  var client = net.connect({ port: this.address().port, allowHalfOpen: true });
+  for (var i = 0; i < numRequests; i++) {
+    client.write('GET / HTTP/1.1\r\n' +
+                 'Host: some.host.name\r\n' +
+                 '\r\n\r\n');
+  }
+  client.end();
+  client.pipe(process.stdout);
+});

--- a/test/parallel/test-http-max-headers-count.js
+++ b/test/parallel/test-http-max-headers-count.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -32,7 +32,7 @@ var server = http.createServer(function(req, res) {
 });
 server.maxHeadersCount = max;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var maxAndExpected = [ // for client
     [20, 20],
     [1200, 1200],
@@ -44,7 +44,7 @@ server.listen(common.PORT, function() {
     var max = maxAndExpected[responses][0];
     var expected = maxAndExpected[responses][1];
     var req = http.request({
-      port: common.PORT,
+      port: server.address().port,
       headers: headers
     }, function(res) {
       assert.equal(Object.keys(res.headers).length, expected);

--- a/test/parallel/test-http-multi-line-headers.js
+++ b/test/parallel/test-http-multi-line-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -24,8 +24,8 @@ var server = net.createServer(function(conn) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
-  http.get({host: '127.0.0.1', port: common.PORT}, function(res) {
+server.listen(0, function() {
+  http.get({host: '127.0.0.1', port: this.address().port}, function(res) {
     assert.equal(res.headers['content-type'],
                  'text/plain; x-unix-mode=0600; name="hello.txt"');
     gotResponse = true;

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -61,7 +61,7 @@ var s = http.createServer(function(req, res) {
   res.end(content);
 });
 
-s.listen(common.PORT, nextTest);
+s.listen(0, nextTest);
 
 
 function nextTest() {
@@ -71,7 +71,7 @@ function nextTest() {
 
   var bufferedResponse = '';
 
-  http.get({ port: common.PORT }, function(response) {
+  http.get({ port: s.address().port }, function(response) {
     console.log('TEST: ' + test);
     console.log('STATUS: ' + response.statusCode);
     console.log('HEADERS: ');

--- a/test/parallel/test-http-no-content-length.js
+++ b/test/parallel/test-http-no-content-length.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -9,8 +9,8 @@ var body = '';
 var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
-}).listen(common.PORT, function() {
-  http.get({port: common.PORT}, function(res) {
+}).listen(0, function() {
+  http.get({port: this.address().port}, function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       body += chunk;

--- a/test/parallel/test-http-outgoing-finish.js
+++ b/test/parallel/test-http-outgoing-finish.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -10,9 +10,9 @@ http.createServer(function(req, res) {
     write(res);
   });
   this.close();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'PUT'
   });
   write(req);

--- a/test/parallel/test-http-parser-free.js
+++ b/test/parallel/test-http-parser-free.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var N = 100;
@@ -9,12 +9,12 @@ var server = http.createServer(function(req, res) {
   res.end('Hello');
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   http.globalAgent.maxSockets = 1;
   var parser;
   for (var i = 0; i < N; ++i) {
     (function makeRequest(i) {
-      var req = http.get({port: common.PORT}, function(res) {
+      var req = http.get({port: server.address().port}, function(res) {
         if (!parser) {
           parser = req.parser;
         } else {

--- a/test/parallel/test-http-pause-resume-one-end.js
+++ b/test/parallel/test-http-pause-resume-one-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -12,9 +12,9 @@ var server = http.Server(function(req, res) {
 
 var dataCount = 0, endCount = 0;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var opts = {
-    port: common.PORT,
+    port: this.address().port,
     headers: { connection: 'close' }
   };
 

--- a/test/parallel/test-http-pause.js
+++ b/test/parallel/test-http-pause.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -26,9 +26,9 @@ var server = http.createServer(function(req, res) {
   }, 100);
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'POST'
   }, function(res) {

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -18,13 +18,13 @@ var server = http.createServer(function(req, res) {
     res.writeHead(200);
     res.end();
   });
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   http.globalAgent.maxSockets = 1;
 
   for (var i = 0; i < 2; ++i) {
     (function(i) {
       var req = http.request({
-        port: common.PORT,
+        port: server.address().port,
         method: 'POST',
         headers: {
           'Content-Length': 5

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -54,9 +54,9 @@ function parent() {
     connections++;
   });
 
-  server.listen(common.PORT, function() {
+  server.listen(0, function() {
     const spawn = require('child_process').spawn;
-    const args = [__filename, 'child'];
+    const args = [__filename, 'child', this.address().port];
     const child = spawn(process.execPath, args, { stdio: 'inherit' });
     child.on('close', common.mustCall(function() {
       server.close();
@@ -75,10 +75,10 @@ function parent() {
 function child() {
   const net = require('net');
 
-  const conn = net.connect({ port: common.PORT });
+  const port = +process.argv[3];
+  const conn = net.connect({ port: port });
 
-  var req = 'GET / HTTP/1.1\r\nHost: localhost:' +
-            common.PORT + '\r\nAccept: */*\r\n\r\n';
+  var req = `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nAccept: */*\r\n\r\n`;
 
   req = new Array(10241).join(req);
 

--- a/test/parallel/test-http-pipeline-regr-2639.js
+++ b/test/parallel/test-http-pipeline-regr-2639.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
@@ -19,8 +19,8 @@ var server = http.createServer(function(req, res) {
   setTimeout(function() {
     res.end();
   }, (Math.random() * 100) | 0);
-}).listen(common.PORT, function() {
-  const s = net.connect(common.PORT);
+}).listen(0, function() {
+  const s = net.connect(this.address().port);
 
   var big = 'GET / HTTP/1.0\r\n\r\n'.repeat(COUNT);
 

--- a/test/parallel/test-http-pipeline-regr-3332.js
+++ b/test/parallel/test-http-pipeline-regr-3332.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
@@ -18,9 +18,9 @@ const server = http.createServer(function(req, res) {
       client.end();
     }
   });
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var req = new Array(COUNT + 1).join('GET / HTTP/1.1\r\n\r\n');
-  client = net.connect(common.PORT, function() {
+  client = net.connect(this.address().port, function() {
     client.write(req);
   });
 

--- a/test/parallel/test-http-pipeline-regr-3508.js
+++ b/test/parallel/test-http-pipeline-regr-3508.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const http = require('http');
 const net = require('net');
 
@@ -40,8 +40,8 @@ var server = http.createServer(function(req, res) {
     socket.end();
   });
   first.end('hello');
-}).listen(common.PORT, function() {
-  var s = net.connect(common.PORT);
+}).listen(0, function() {
+  var s = net.connect(this.address().port);
   more = function() {
     s.write('GET / HTTP/1.1\r\n\r\n');
   };

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -1,11 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
-
-var PROXY_PORT = common.PORT;
-var BACKEND_PORT = common.PORT + 1;
 
 var cookies = [
   'session_token=; path=/; expires=Sun, 15-Sep-2030 13:48:52 GMT',
@@ -26,7 +23,7 @@ var backend = http.createServer(function(req, res) {
 var proxy = http.createServer(function(req, res) {
   console.error('proxy req headers: ' + JSON.stringify(req.headers));
   http.get({
-    port: BACKEND_PORT,
+    port: backend.address().port,
     path: url.parse(req.url).pathname
   }, function(proxy_res) {
 
@@ -57,7 +54,7 @@ function startReq() {
   if (nlistening < 2) return;
 
   http.get({
-    port: PROXY_PORT,
+    port: proxy.address().port,
     path: '/test'
   }, function(res) {
     console.error('got res');
@@ -79,10 +76,10 @@ function startReq() {
 }
 
 console.error('listen proxy');
-proxy.listen(PROXY_PORT, startReq);
+proxy.listen(0, startReq);
 
 console.error('listen backend');
-backend.listen(BACKEND_PORT, startReq);
+backend.listen(0, startReq);
 
 process.on('exit', function() {
   assert.equal(body, 'hello world\n');

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -1,14 +1,13 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
 
 http.createServer(function(req, res) {
-  this.close();
   var expectRawHeaders = [
     'Host',
-    'localhost:' + common.PORT,
+    `localhost:${this.address().port}`,
     'transfer-ENCODING',
     'CHUNKED',
     'x-BaR',
@@ -17,12 +16,11 @@ http.createServer(function(req, res) {
     'close'
   ];
   var expectHeaders = {
-    host: 'localhost:' + common.PORT,
+    host: `localhost:${this.address().port}`,
     'transfer-encoding': 'CHUNKED',
     'x-bar': 'yoyoyo',
     connection: 'close'
   };
-
   var expectRawTrailers = [
     'x-bAr',
     'yOyOyOy',
@@ -33,8 +31,9 @@ http.createServer(function(req, res) {
     'X-baR',
     'OyOyOyO'
   ];
-
   var expectTrailers = { 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
+
+  this.close();
 
   assert.deepStrictEqual(req.rawHeaders, expectRawHeaders);
   assert.deepStrictEqual(req.headers, expectHeaders);
@@ -53,8 +52,8 @@ http.createServer(function(req, res) {
     ['X-foO', 'OxOxOxO']
   ]);
   res.end('x f o o');
-}).listen(common.PORT, function() {
-  var req = http.request({ port: common.PORT, path: '/' });
+}).listen(0, function() {
+  var req = http.request({ port: this.address().port, path: '/' });
   req.addTrailers([
     ['x-bAr', 'yOyOyOy'],
     ['x-baR', 'OyOyOyO'],

--- a/test/parallel/test-http-regr-gh-2821.js
+++ b/test/parallel/test-http-regr-gh-2821.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const http = require('http');
 
 const server = http.createServer(function(req, res) {
@@ -9,11 +9,11 @@ const server = http.createServer(function(req, res) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
 
   const req = http.request({
     method: 'POST',
-    port: common.PORT
+    port: this.address().port
   });
 
   const payload = Buffer.alloc(16390, 'Й');

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -27,8 +27,8 @@ process.on('exit', function() {
   console.log('ok');
 });
 
-server.listen(common.PORT, function() {
-  http.get({ port: common.PORT }, function(res) {
+server.listen(0, function() {
+  http.get({ port: this.address().port }, function(res) {
     assert.equal(200, res.statusCode);
     assert.deepStrictEqual(res.headers, { date: 'coffee o clock' });
 

--- a/test/parallel/test-http-request-dont-override-options.js
+++ b/test/parallel/test-http-request-dont-override-options.js
@@ -11,35 +11,36 @@ http.createServer(function(req, res) {
   res.end('ok');
 
   requests++;
-}).listen(common.PORT).unref();
+}).listen(0, function() {
+  var agent = new http.Agent();
+  agent.defaultPort = this.address().port;
 
-var agent = new http.Agent();
-agent.defaultPort = common.PORT;
+  // options marked as explicitly undefined for readability
+  // in this test, they should STAY undefined as options should not
+  // be mutable / modified
+  var options = {
+    host: undefined,
+    hostname: common.localhostIPv4,
+    port: undefined,
+    defaultPort: undefined,
+    path: undefined,
+    method: undefined,
+    agent: agent
+  };
 
-// options marked as explicitly undefined for readability
-// in this test, they should STAY undefined as options should not
-// be mutable / modified
-var options = {
-  host: undefined,
-  hostname: common.localhostIPv4,
-  port: undefined,
-  defaultPort: undefined,
-  path: undefined,
-  method: undefined,
-  agent: agent
-};
+  http.request(options, function(res) {
+    res.resume();
+  }).end();
 
-http.request(options, function(res) {
-  res.resume();
-}).end();
+  process.on('exit', function() {
+    assert.equal(requests, 1);
 
-process.on('exit', function() {
-  assert.equal(requests, 1);
+    assert.strictEqual(options.host, undefined);
+    assert.strictEqual(options.hostname, common.localhostIPv4);
+    assert.strictEqual(options.port, undefined);
+    assert.strictEqual(options.defaultPort, undefined);
+    assert.strictEqual(options.path, undefined);
+    assert.strictEqual(options.method, undefined);
+  });
+}).unref();
 
-  assert.strictEqual(options.host, undefined);
-  assert.strictEqual(options.hostname, common.localhostIPv4);
-  assert.strictEqual(options.port, undefined);
-  assert.strictEqual(options.defaultPort, undefined);
-  assert.strictEqual(options.path, undefined);
-  assert.strictEqual(options.method, undefined);
-});

--- a/test/parallel/test-http-request-end-twice.js
+++ b/test/parallel/test-http-request-end-twice.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -7,8 +7,8 @@ var server = http.Server(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end('hello world\n');
 });
-server.listen(common.PORT, function() {
-  var req = http.get({port: common.PORT}, function(res) {
+server.listen(0, function() {
+  var req = http.get({port: this.address().port}, function(res) {
     res.on('end', function() {
       assert.ok(!req.end());
       server.close();

--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -20,9 +20,9 @@ var server = http.Server(function(req, res) {
 
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   http.request({
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'POST'
   }, function(res) {

--- a/test/parallel/test-http-request-methods.js
+++ b/test/parallel/test-http-request-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -7,8 +7,6 @@ var http = require('http');
 // Test that the DELETE, PATCH and PURGE verbs get passed through correctly
 
 ['DELETE', 'PATCH', 'PURGE'].forEach(function(method, index) {
-  var port = common.PORT + index;
-
   var server_response = '';
   var received_method = null;
 
@@ -19,10 +17,10 @@ var http = require('http');
     res.write('world\n');
     res.end();
   });
-  server.listen(port);
+  server.listen(0);
 
   server.on('listening', function() {
-    var c = net.createConnection(port);
+    var c = net.createConnection(this.address().port);
 
     c.setEncoding('utf8');
 

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -17,8 +17,8 @@ var server = http.Server(function(req, res) {
   assert.equal(r, true, 'write after end should return true');
 });
 
-server.listen(common.PORT, function() {
-  http.get({port: common.PORT}, function(res) {
+server.listen(0, function() {
+  http.get({port: this.address().port}, function(res) {
     server.close();
   });
 });

--- a/test/parallel/test-http-res-write-end-dont-take-array.js
+++ b/test/parallel/test-http-res-write-end-dont-take-array.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -31,14 +31,14 @@ var server = http.createServer(function(req, res) {
   }
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   // just make a request, other tests handle responses
-  http.get({port: common.PORT}, function(res) {
+  http.get({port: this.address().port}, function(res) {
     res.resume();
     // lazy serial test, because we can only call end once per request
     test += 1;
     // do it again to test .end(Buffer);
-    http.get({port: common.PORT}, function(res) {
+    http.get({port: server.address().port}, function(res) {
       res.resume();
       server.close();
     });

--- a/test/parallel/test-http-response-close.js
+++ b/test/parallel/test-http-response-close.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -19,12 +19,12 @@ var server = http.createServer(function(req, res) {
     responseGotEnd = true;
   });
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
   console.error('make req');
   http.get({
-    port: common.PORT
+    port: this.address().port
   }, function(res) {
     console.error('got res');
     res.on('data', function(data) {

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -26,14 +26,14 @@ const server = http.createServer((req, res) => {
 
 var count = 0;
 
-server.listen(common.PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   for (let n = 1; n <= MAX_COUNT ; n++) {
     // This runs twice, the first time, the server will use
     // setHeader, the second time it uses writeHead. In either
     // case, the error handler must be called because the client
     // is not allowed to accept multiple content-length headers.
     http.get(
-      {port: common.PORT, headers: {'x-num': n}},
+      {port: server.address().port, headers: {'x-num': n}},
       (res) => {
         assert(false, 'client allowed multiple content-length headers.');
       }

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -46,7 +46,7 @@ const server = http.createServer(function(req, res) {
   res.end('ok');
 });
 
-server.listen(common.PORT, common.mustCall(function() {
+server.listen(0, common.mustCall(function() {
   var count = 0;
   for (let n = 1; n <= 2 ; n++) {
     // this runs twice, the first time, the server will use
@@ -56,7 +56,7 @@ server.listen(common.PORT, common.mustCall(function() {
     // value should be reported for the header fields listed
     // in the norepeat array.
     http.get(
-      {port: common.PORT, headers: {'x-num': n}},
+      {port: this.address().port, headers: {'x-num': n}},
       common.mustCall(function(res) {
         if (++count === 2) server.close();
         for (const name of norepeat) {

--- a/test/parallel/test-http-response-no-headers.js
+++ b/test/parallel/test-http-response-no-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -24,10 +24,10 @@ function test(httpVersion, callback) {
     conn.end(reply);
   });
 
-  server.listen(common.PORT, '127.0.0.1', function() {
+  server.listen(0, '127.0.0.1', function() {
     var options = {
       host: '127.0.0.1',
-      port: common.PORT
+      port: this.address().port
     };
 
     var req = http.get(options, function(res) {

--- a/test/parallel/test-http-response-readable.js
+++ b/test/parallel/test-http-response-readable.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -8,8 +8,8 @@ var testServer = new http.Server(function(req, res) {
   res.end('Hello world');
 });
 
-testServer.listen(common.PORT, function() {
-  http.get({ port: common.PORT }, function(res) {
+testServer.listen(0, function() {
+  http.get({ port: this.address().port }, function(res) {
     assert.equal(res.readable, true, 'res.readable initially true');
     res.on('end', function() {
       assert.equal(res.readable, false, 'res.readable set to false after end');

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -44,9 +44,9 @@ const server = http.createServer((req, res) => {
     server.close();
   res.end('ok');
 });
-server.listen(common.PORT, () => {
+server.listen(0, () => {
   const end = 'HTTP/1.1\r\n\r\n';
-  const client = net.connect({port: common.PORT}, () => {
+  const client = net.connect({port: server.address().port}, () => {
     client.write(`GET ${str} ${end}`);
     client.write(`GET / ${end}`);
     client.write(`GET / ${end}`);

--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -41,7 +41,10 @@ var server = net.createServer(function(connection) {
 var runTest = function(testCaseIndex) {
   var testCase = testCases[testCaseIndex];
 
-  http.get({ port: common.PORT, path: testCase.path }, function(response) {
+  http.get({
+    port: server.address().port,
+    path: testCase.path
+  }, function(response) {
     console.log('client: expected status message: ' + testCase.statusMessage);
     console.log('client: actual status message: ' + response.statusMessage);
     assert.equal(testCase.statusMessage, response.statusMessage);
@@ -60,7 +63,7 @@ var runTest = function(testCaseIndex) {
   });
 };
 
-server.listen(common.PORT, function() { runTest(0); });
+server.listen(0, function() { runTest(0); });
 
 process.on('exit', function() {
   assert.equal(testCases.length, testsComplete);

--- a/test/parallel/test-http-server-client-error.js
+++ b/test/parallel/test-http-server-client-error.js
@@ -15,10 +15,10 @@ server.on('clientError', common.mustCall(function(err, socket) {
   server.close();
 }));
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   function next() {
     // Invalid request
-    const client = net.connect(common.PORT);
+    const client = net.connect(server.address().port);
     client.end('Oopsie-doopsie\r\n');
 
     var chunks = '';
@@ -31,7 +31,7 @@ server.listen(common.PORT, function() {
   }
 
   // Normal request
-  http.get({ port: common.PORT, path: '/' }, function(res) {
+  http.get({ port: this.address().port, path: '/' }, function(res) {
     assert.equal(res.statusCode, 200);
     res.resume();
     res.once('end', next);

--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -19,9 +19,9 @@ const server = http.createServer((req, res) => {
   }));
 });
 
-server.listen(common.PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   const req = http.request({
-    port: common.PORT,
+    port: server.address().port,
     method: 'POST'
   }, (res) => {
     const interval = setInterval(() => {

--- a/test/parallel/test-http-server-multiheaders.js
+++ b/test/parallel/test-http-server-multiheaders.js
@@ -3,7 +3,7 @@
 // of the same header as per RFC2616: joining the handful of fields by ', '
 // that support it, and dropping duplicates for other fields.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -24,10 +24,10 @@ var srv = http.createServer(function(req, res) {
   srv.close();
 });
 
-srv.listen(common.PORT, function() {
+srv.listen(0, function() {
   http.get({
     host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     headers: [
       ['accept', 'abc'],

--- a/test/parallel/test-http-server-multiheaders2.js
+++ b/test/parallel/test-http-server-multiheaders2.js
@@ -3,7 +3,7 @@
 // of the same header as per RFC2616: joining the handful of fields by ', '
 // that support it, and dropping duplicates for other fields.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -76,10 +76,10 @@ var headers = []
   .concat(multipleAllowed.map(makeHeader('bar')))
   .concat(multipleForbidden.map(makeHeader('bar')));
 
-srv.listen(common.PORT, function() {
+srv.listen(0, function() {
   http.get({
     host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     headers: headers,
   });

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -17,8 +17,8 @@ server.on('clientError', common.mustCall((err) => {
   assert.equal(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
   server.close();
 }));
-server.listen(common.PORT, () => {
-  const client = net.connect({port: common.PORT}, () => {
+server.listen(0, () => {
+  const client = net.connect({port: server.address().port}, () => {
     client.write(reqstr);
     client.end();
   });

--- a/test/parallel/test-http-server-reject-cr-no-lf.js
+++ b/test/parallel/test-http-server-reject-cr-no-lf.js
@@ -19,8 +19,8 @@ server.on('clientError', common.mustCall((err) => {
   assert.equal(err.code, 'HPE_LF_EXPECTED');
   server.close();
 }));
-server.listen(common.PORT, () => {
-  const client = net.connect({port: common.PORT}, () => {
+server.listen(0, () => {
+  const client = net.connect({port: server.address().port}, () => {
     client.on('data', (chunk) => {
       assert.fail(null, null, 'this should not be called');
     });

--- a/test/parallel/test-http-server-stale-close.js
+++ b/test/parallel/test-http-server-stale-close.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var http = require('http');
 var util = require('util');
 var fork = require('child_process').fork;
 
-if (process.env.NODE_TEST_FORK) {
+if (process.env.NODE_TEST_FORK_PORT) {
   var req = http.request({
     headers: {'Content-Length': '42'},
     method: 'POST',
     host: '127.0.0.1',
-    port: common.PORT,
+    port: +process.env.NODE_TEST_FORK_PORT,
   }, process.exit);
   req.write('BAM');
   req.end();
@@ -23,9 +23,9 @@ else {
       res.end();
     });
   });
-  server.listen(common.PORT, function() {
+  server.listen(0, function() {
     fork(__filename, {
-      env: util._extend(process.env, {NODE_TEST_FORK: '1'})
+      env: util._extend(process.env, {NODE_TEST_FORK_PORT: this.address().port})
     });
   });
 }

--- a/test/parallel/test-http-server-unconsume.js
+++ b/test/parallel/test-http-server-unconsume.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -15,8 +15,8 @@ var server = http.createServer(function(req, res) {
   });
 
   server.close();
-}).listen(common.PORT, function() {
-  var socket = net.connect(common.PORT, function() {
+}).listen(0, function() {
+  var socket = net.connect(this.address().port, function() {
     socket.write('PUT / HTTP/1.1\r\n\r\n');
 
     socket.once('data', function() {

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -43,12 +43,12 @@ var server = http.createServer(function(req, res) {
   }, 1);
 
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.httpAllowHalfOpen = true;
 
 server.on('listening', function() {
-  var c = net.createConnection(common.PORT);
+  var c = net.createConnection(this.address().port);
 
   c.setEncoding('utf8');
 

--- a/test/parallel/test-http-set-cookies.js
+++ b/test/parallel/test-http-set-cookies.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -17,13 +17,13 @@ var server = http.createServer(function(req, res) {
     res.end('two\n');
   }
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
   //
   // one set-cookie header
   //
-  http.get({ port: common.PORT, path: '/one' }, function(res) {
+  http.get({ port: this.address().port, path: '/one' }, function(res) {
     // set-cookie headers are always return in an array.
     // even if there is only one.
     assert.deepStrictEqual(['A'], res.headers['set-cookie']);
@@ -42,7 +42,7 @@ server.on('listening', function() {
 
   // two set-cookie headers
 
-  http.get({ port: common.PORT, path: '/two' }, function(res) {
+  http.get({ port: this.address().port, path: '/two' }, function(res) {
     assert.deepStrictEqual(['A', 'B'], res.headers['set-cookie']);
     assert.equal('text/plain', res.headers['content-type']);
 

--- a/test/parallel/test-http-set-timeout.js
+++ b/test/parallel/test-http-set-timeout.js
@@ -15,14 +15,14 @@ var server = http.createServer(function(req, res) {
   });
 });
 
-server.listen(common.PORT, function() {
-  console.log('Server running at http://127.0.0.1:' + common.PORT + '/');
+server.listen(0, function() {
+  console.log(`Server running at http://127.0.0.1:${this.address().port}/`);
 
   var errorTimer = setTimeout(function() {
     throw new Error('Timeout was not successful');
   }, common.platformTimeout(2000));
 
-  var x = http.get({port: common.PORT, path: '/'});
+  var x = http.get({port: this.address().port, path: '/'});
   x.on('error', function() {
     clearTimeout(errorTimer);
     console.log('HTTP REQUEST COMPLETE (this is good)');

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -11,12 +11,12 @@ var server = http.createServer(function(req, res) {
   res.addTrailers({'x-foo': 'bar'});
   res.end('stuff' + '\n');
 });
-server.listen(common.PORT);
+server.listen(0);
 
 
 // first, we test an HTTP/1.0 request.
 server.on('listening', function() {
-  var c = net.createConnection(common.PORT);
+  var c = net.createConnection(this.address().port);
   var res_buffer = '';
 
   c.setEncoding('utf8');
@@ -44,7 +44,7 @@ server.on('listening', function() {
 
 // now, we test an HTTP/1.1 request.
 server.on('listening', function() {
-  var c = net.createConnection(common.PORT);
+  var c = net.createConnection(this.address().port);
   var res_buffer = '';
   var tid;
 
@@ -76,7 +76,11 @@ server.on('listening', function() {
 
 // now, see if the client sees the trailers.
 server.on('listening', function() {
-  http.get({ port: common.PORT, path: '/hello', headers: {} }, function(res) {
+  http.get({
+    port: this.address().port,
+    path: '/hello',
+    headers: {}
+  }, function(res) {
     res.on('end', function() {
       //console.log(res.trailers);
       assert.ok('x-foo' in res.trailers, 'Client doesn\'t see trailers.');

--- a/test/parallel/test-http-should-keep-alive.js
+++ b/test/parallel/test-http-should-keep-alive.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -27,9 +27,9 @@ http.globalAgent.maxSockets = 5;
 var server = net.createServer(function(socket) {
   socket.write(SERVER_RESPONSES[requests]);
   ++requests;
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   function makeRequest() {
-    var req = http.get({port: common.PORT}, function(res) {
+    var req = http.get({port: server.address().port}, function(res) {
       assert.equal(req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],
                    SERVER_RESPONSES[responses] + ' should ' +
                    (SHOULD_KEEP_ALIVE[responses] ? '' : 'not ') +

--- a/test/parallel/test-http-status-code.js
+++ b/test/parallel/test-http-status-code.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -18,7 +18,7 @@ var s = http.createServer(function(req, res) {
   res.end('hello world\n');
 });
 
-s.listen(common.PORT, nextTest);
+s.listen(0, nextTest);
 
 
 function nextTest() {
@@ -27,7 +27,7 @@ function nextTest() {
   }
   var test = tests[testIdx];
 
-  http.get({ port: common.PORT }, function(response) {
+  http.get({ port: s.address().port }, function(response) {
     console.log('client: expected status: ' + test);
     console.log('client: statusCode: ' + response.statusCode);
     assert.equal(response.statusCode, test);

--- a/test/parallel/test-http-status-message.js
+++ b/test/parallel/test-http-status-message.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -10,12 +10,12 @@ var s = http.createServer(function(req, res) {
   res.end('');
 });
 
-s.listen(common.PORT, test);
+s.listen(0, test);
 
 
 function test() {
   var bufs = [];
-  var client = net.connect(common.PORT, function() {
+  var client = net.connect(this.address().port, function() {
     client.write('GET / HTTP/1.1\r\nConnection: close\r\n\r\n');
   });
   client.on('data', function(chunk) {

--- a/test/parallel/test-http-timeout-overflow.js
+++ b/test/parallel/test-http-timeout-overflow.js
@@ -1,10 +1,9 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
 
-var port = common.PORT;
 var serverRequests = 0;
 var clientRequests = 0;
 
@@ -14,11 +13,11 @@ var server = http.createServer(function(req, res) {
   res.end('OK');
 });
 
-server.listen(port, function() {
+server.listen(0, function() {
   function callback() {}
 
   var req = http.request({
-    port: port,
+    port: this.address().port,
     path: '/',
     agent: false
   }, function(res) {

--- a/test/parallel/test-http-timeout.js
+++ b/test/parallel/test-http-timeout.js
@@ -1,9 +1,7 @@
 'use strict';
-var common = require('../common');
+require('../common');
 
 var http = require('http');
-
-var port = common.PORT;
 
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
@@ -12,7 +10,7 @@ var server = http.createServer(function(req, res) {
 
 var agent = new http.Agent({maxSockets: 1});
 
-server.listen(port, function() {
+server.listen(0, function() {
 
   for (var i = 0; i < 11; ++i) {
     createRequest().end();
@@ -24,7 +22,7 @@ server.listen(port, function() {
 
   function createRequest() {
     const req = http.request(
-      {port: port, path: '/', agent: agent},
+      {port: server.address().port, path: '/', agent: agent},
       function(res) {
         req.clearTimeout(callback);
 

--- a/test/parallel/test-http-upgrade-advertise.js
+++ b/test/parallel/test-http-upgrade-advertise.js
@@ -24,7 +24,7 @@ function fire() {
   });
 
   const req = http.request({
-    port: common.PORT,
+    port: server.address().port,
     path: '/',
     headers: test.headers
   }, function onResponse(res) {
@@ -51,4 +51,4 @@ const server = http.createServer(function(req, res) {
              'Connection: upgrade\r\n' +
              'Upgrade: h2c\r\n\r\n' +
              'ohai');
-}).listen(common.PORT, fire);
+}).listen(0, fire);

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -30,10 +30,10 @@ var srv = net.createServer(function(c) {
 
 var gotUpgrade = false;
 
-srv.listen(common.PORT, '127.0.0.1', function() {
+srv.listen(0, '127.0.0.1', function() {
 
   var options = {
-    port: common.PORT,
+    port: this.address().port,
     host: '127.0.0.1',
     headers: {
       'connection': 'upgrade',

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -30,10 +30,10 @@ var srv = net.createServer(function(c) {
 
 var gotUpgrade = false;
 
-srv.listen(common.PORT, '127.0.0.1', function() {
+srv.listen(0, '127.0.0.1', function() {
 
   var req = http.get({
-    port: common.PORT,
+    port: this.address().port,
     headers: {
       connection: 'upgrade',
       upgrade: 'websocket'

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -17,12 +17,15 @@ server.on('upgrade', function(req, socket, head) {
 
 var successCount = 0;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
 
   function upgradeRequest(fn) {
     console.log('req');
     var header = { 'Connection': 'Upgrade', 'Upgrade': 'Test' };
-    var request = http.request({ port: common.PORT, headers: header });
+    var request = http.request({
+      port: server.address().port,
+      headers: header
+    });
     var wasUpgrade = false;
 
     function onUpgrade(res, socket, head) {

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var util = require('util');
@@ -16,20 +16,19 @@ function createTestServer() {
 }
 
 function testServer() {
-  var server = this;
-  http.Server.call(server, function() {});
+  http.Server.call(this, function() {});
 
-  server.on('connection', function() {
+  this.on('connection', function() {
     requests_recv++;
   });
 
-  server.on('request', function(req, res) {
+  this.on('request', function(req, res) {
     res.writeHead(200, {'Content-Type': 'text/plain'});
     res.write('okay');
     res.end();
   });
 
-  server.on('upgrade', function(req, socket, upgradeHead) {
+  this.on('upgrade', function(req, socket, upgradeHead) {
     socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
                  'Upgrade: WebSocket\r\n' +
                  'Connection: Upgrade\r\n' +
@@ -60,8 +59,8 @@ function writeReq(socket, data, encoding) {
 /*-----------------------------------------------
   connection: Upgrade with listener
 -----------------------------------------------*/
-function test_upgrade_with_listener(_server) {
-  var conn = net.createConnection(common.PORT);
+function test_upgrade_with_listener() {
+  var conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
   var state = 0;
 
@@ -92,7 +91,7 @@ function test_upgrade_with_listener(_server) {
   conn.on('end', function() {
     assert.equal(2, state);
     conn.end();
-    _server.removeAllListeners('upgrade');
+    server.removeAllListeners('upgrade');
     test_upgrade_no_listener();
   });
 }
@@ -103,7 +102,7 @@ function test_upgrade_with_listener(_server) {
 var test_upgrade_no_listener_ended = false;
 
 function test_upgrade_no_listener() {
-  var conn = net.createConnection(common.PORT);
+  var conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
 
   conn.on('connect', function() {
@@ -128,7 +127,7 @@ function test_upgrade_no_listener() {
   connection: normal
 -----------------------------------------------*/
 function test_standard_http() {
-  var conn = net.createConnection(common.PORT);
+  var conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
 
   conn.on('connect', function() {
@@ -149,9 +148,9 @@ function test_standard_http() {
 
 var server = createTestServer();
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   // All tests get chained after this:
-  test_upgrade_with_listener(server);
+  test_upgrade_with_listener();
 });
 
 

--- a/test/parallel/test-http-upgrade-server2.js
+++ b/test/parallel/test-http-upgrade-server2.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -23,8 +23,8 @@ process.on('uncaughtException', function(e) {
 });
 
 
-server.listen(common.PORT, function() {
-  var c = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var c = net.createConnection(this.address().port);
 
   c.on('connect', function() {
     c.write('GET /blah HTTP/1.1\r\n' +

--- a/test/parallel/test-http-url.parse-auth-with-header-in-request.js
+++ b/test/parallel/test-http-url.parse-auth-with-header-in-request.js
@@ -1,15 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
-
-var testURL = url.parse('http://asdf:qwer@localhost:' + common.PORT);
-// the test here is if you set a specific authorization header in the
-// request we should not override that with basic auth
-testURL.headers = {
-  Authorization: 'NoAuthForYOU'
-};
 
 function check(request) {
   // the correct authorization header is be passed
@@ -24,7 +17,14 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  var testURL = url.parse(`http://asdf:qwer@localhost:${this.address().port}`);
+  // the test here is if you set a specific authorization header in the
+  // request we should not override that with basic auth
+  testURL.headers = {
+    Authorization: 'NoAuthForYOU'
+  };
+
   // make the request
   http.request(testURL).end();
 });

--- a/test/parallel/test-http-url.parse-auth.js
+++ b/test/parallel/test-http-url.parse-auth.js
@@ -1,11 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
-
-// username = "user", password = "pass:"
-var testURL = url.parse('http://user:pass%3A@localhost:' + common.PORT);
 
 function check(request) {
   // the correct authorization header is be passed
@@ -20,7 +17,11 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  const port = this.address().port;
+  // username = "user", password = "pass:"
+  var testURL = url.parse(`http://user:pass%3A@localhost:${port}`);
+
   // make the request
   http.request(testURL).end();
 });

--- a/test/parallel/test-http-url.parse-basic.js
+++ b/test/parallel/test-http-url.parse-basic.js
@@ -1,10 +1,10 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
-var testURL = url.parse('http://localhost:' + common.PORT);
+var testURL;
 
 // make sure the basics work
 function check(request) {
@@ -25,7 +25,9 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  testURL = url.parse(`http://localhost:${this.address().port}`);
+
   // make the request
   var clientRequest = http.request(testURL);
   // since there is a little magic with the agent

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -17,9 +17,6 @@ var httpsOptions = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var testURL = url.parse('https://localhost:' + common.PORT);
-testURL.rejectUnauthorized = false;
-
 function check(request) {
   // assert that I'm https
   assert.ok(request.socket._secureEstablished);
@@ -33,7 +30,10 @@ var server = https.createServer(httpsOptions, function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  var testURL = url.parse(`https://localhost:${this.address().port}`);
+  testURL.rejectUnauthorized = false;
+
   // make the request
   var clientRequest = https.request(testURL);
   // since there is a little magic with the agent

--- a/test/parallel/test-http-url.parse-path.js
+++ b/test/parallel/test-http-url.parse-path.js
@@ -1,10 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
-
-var testURL = url.parse('http://localhost:' + common.PORT + '/asdf');
 
 function check(request) {
   // a path should come over
@@ -19,7 +17,9 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  var testURL = url.parse(`http://localhost:${this.address().port}/asdf`);
+
   // make the request
   http.request(testURL).end();
 });

--- a/test/parallel/test-http-url.parse-post.js
+++ b/test/parallel/test-http-url.parse-post.js
@@ -1,11 +1,10 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
-var testURL = url.parse('http://localhost:' + common.PORT + '/asdf?qwer=zxcv');
-testURL.method = 'POST';
+var testURL;
 
 function check(request) {
   //url.parse should not mess with the method
@@ -25,7 +24,10 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  testURL = url.parse(`http://localhost:${this.address().port}/asdf?qwer=zxcv`);
+  testURL.method = 'POST';
+
   // make the request
   http.request(testURL).end();
 });

--- a/test/parallel/test-http-url.parse-search.js
+++ b/test/parallel/test-http-url.parse-search.js
@@ -1,10 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
-
-var testURL = url.parse('http://localhost:' + common.PORT + '/asdf?qwer=zxcv');
 
 function check(request) {
   // a path should come over with params
@@ -19,7 +17,10 @@ var server = http.createServer(function(request, response) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
+  const port = this.address().port;
+  var testURL = url.parse(`http://localhost:${port}/asdf?qwer=zxcv`);
+
   // make the request
   http.request(testURL).end();
 });

--- a/test/parallel/test-http-wget.js
+++ b/test/parallel/test-http-wget.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -29,10 +29,10 @@ var server = http.createServer(function(req, res) {
   res.write('world\n');
   res.end();
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
-  var c = net.createConnection(common.PORT);
+  var c = net.createConnection(this.address().port);
 
   c.setEncoding('utf8');
 

--- a/test/parallel/test-http-write-callbacks.js
+++ b/test/parallel/test-http-write-callbacks.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -50,9 +50,9 @@ server.on('checkContinue', function(req, res) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     method: 'PUT',
     headers: { 'expect': '100-continue' }
   });

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -24,8 +24,8 @@ process.on('exit', function() {
 });
 
 
-server.listen(common.PORT, function() {
-  http.get({ port: common.PORT }, function(res) {
+server.listen(0, function() {
+  http.get({ port: this.address().port }, function(res) {
     assert.equal(200, res.statusCode);
     res.setEncoding('ascii');
     res.on('data', function(chunk) {

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -34,10 +34,10 @@ var s = http.createServer(function(req, res) {
   res.end();
 });
 
-s.listen(common.PORT, runTest);
+s.listen(0, runTest);
 
 function runTest() {
-  http.get({ port: common.PORT }, function(response) {
+  http.get({ port: this.address().port }, function(response) {
     response.on('end', function() {
       assert.equal(response.headers['test'], '2');
       assert(response.rawHeaders.indexOf('Test') !== -1);

--- a/test/parallel/test-http-zero-length-write.js
+++ b/test/parallel/test-http-zero-length-write.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -53,8 +53,8 @@ var server = http.createServer(function(req, res) {
   server.close();
 });
 
-server.listen(common.PORT, function() {
-  var req = http.request({ port: common.PORT, method: 'POST' });
+server.listen(0, function() {
+  var req = http.request({ port: this.address().port, method: 'POST' });
   var actual = '';
   req.on('response', function(res) {
     res.setEncoding('utf8');

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
@@ -38,12 +38,12 @@ var server = http.Server(function(req, res) {
 
   //assert.equal('127.0.0.1', res.connection.remoteAddress);
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
-  var agent = new http.Agent({ port: common.PORT, maxSockets: 1 });
+  var agent = new http.Agent({ port: this.address().port, maxSockets: 1 });
   http.get({
-    port: common.PORT,
+    port: this.address().port,
     path: '/hello',
     headers: {'Accept': '*/*', 'Foo': 'bar'},
     agent: agent
@@ -57,7 +57,7 @@ server.on('listening', function() {
 
   setTimeout(function() {
     var req = http.request({
-      port: common.PORT,
+      port: server.address().port,
       method: 'POST',
       path: '/world',
       agent: agent

--- a/test/parallel/test-https-agent-disable-session-reuse.js
+++ b/test/parallel/test-https-agent-disable-session-reuse.js
@@ -28,12 +28,12 @@ const agent = new https.Agent({
 const server = https.createServer(options, function(req, res) {
   serverRequests++;
   res.end('ok');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var waiting = TOTAL_REQS;
   function request() {
     const options = {
       agent: agent,
-      port: common.PORT,
+      port: server.address().port,
       rejectUnauthorized: false
     };
 

--- a/test/parallel/test-https-agent-servername.js
+++ b/test/parallel/test-https-agent-servername.js
@@ -22,10 +22,10 @@ var server = https.Server(options, function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   https.get({
     path: '/',
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: true,
     servername: 'agent1',
     ca: options.ca

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -21,31 +21,32 @@ const options = {
 // Create TLS1.2 server
 https.createServer(options, function(req, res) {
   res.end('ohai');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   first(this);
 });
 
 // Do request and let agent cache the session
 function first(server) {
+  const port = server.address().port;
   const req = https.request({
-    port: common.PORT,
+    port: port,
     rejectUnauthorized: false
   }, function(res) {
     res.resume();
 
     server.close(function() {
-      faultyServer();
+      faultyServer(port);
     });
   });
   req.end();
 }
 
 // Create TLS1 server
-function faultyServer() {
+function faultyServer(port) {
   options.secureProtocol = 'TLSv1_method';
   https.createServer(options, function(req, res) {
     res.end('hello faulty');
-  }).listen(common.PORT, function() {
+  }).listen(port, function() {
     second(this);
   });
 }
@@ -53,7 +54,7 @@ function faultyServer() {
 // Attempt to request using cached session
 function second(server, session) {
   const req = https.request({
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: false
   }, function(res) {
     res.resume();
@@ -70,10 +71,10 @@ function second(server, session) {
   req.end();
 }
 
-// Try on more time - session should be evicted!
+// Try one more time - session should be evicted!
 function third(server) {
   const req = https.request({
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: false
   }, function(res) {
     res.resume();

--- a/test/parallel/test-https-agent-session-reuse.js
+++ b/test/parallel/test-https-agent-session-reuse.js
@@ -32,7 +32,7 @@ var server = https.createServer(options, function(req, res) {
 
   serverRequests++;
   res.end('ok');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var queue = [
     {
       name: 'first',
@@ -41,7 +41,7 @@ var server = https.createServer(options, function(req, res) {
       path: '/',
       servername: 'agent1',
       ca: ca,
-      port: common.PORT
+      port: this.address().port
     },
     {
       name: 'first-reuse',
@@ -50,7 +50,7 @@ var server = https.createServer(options, function(req, res) {
       path: '/',
       servername: 'agent1',
       ca: ca,
-      port: common.PORT
+      port: this.address().port
     },
     {
       name: 'cipher-change',
@@ -62,7 +62,7 @@ var server = https.createServer(options, function(req, res) {
       // Choose different cipher to use different cache entry
       ciphers: 'AES256-SHA',
       ca: ca,
-      port: common.PORT
+      port: this.address().port
     },
     // Change the ticket key to ensure session is updated in cache
     {
@@ -72,7 +72,7 @@ var server = https.createServer(options, function(req, res) {
       path: '/drop-key',
       servername: 'agent1',
       ca: ca,
-      port: common.PORT
+      port: this.address().port
     },
 
     // Ticket will be updated starting from this
@@ -83,7 +83,7 @@ var server = https.createServer(options, function(req, res) {
       path: '/',
       servername: 'agent1',
       ca: ca,
-      port: common.PORT
+      port: this.address().port
     },
     {
       name: 'after-drop-reuse',
@@ -92,7 +92,7 @@ var server = https.createServer(options, function(req, res) {
       path: '/',
       servername: 'agent1',
       ca: ca,
-      port: common.PORT
+      port: this.address().port
     }
   ];
 

--- a/test/parallel/test-https-agent-sni.js
+++ b/test/parallel/test-https-agent-sni.js
@@ -27,7 +27,7 @@ const server = https.Server(options, function(req, res) {
   res.end('hello world');
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   function expectResponse(id) {
     return common.mustCall(function(res) {
       res.resume();
@@ -43,7 +43,7 @@ server.listen(common.PORT, function() {
       agent: agent,
 
       path: '/',
-      port: common.PORT,
+      port: this.address().port,
       host: '127.0.0.1',
       servername: 'sni.' + j,
       rejectUnauthorized: false

--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -26,13 +26,13 @@ var responses = 0;
 var N = 4;
 var M = 4;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   for (var i = 0; i < N; i++) {
     setTimeout(function() {
       for (var j = 0; j < M; j++) {
         https.get({
           path: '/',
-          port: common.PORT,
+          port: server.address().port,
           rejectUnauthorized: false
         }, function(res) {
           res.resume();

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -27,9 +27,9 @@ var httpsServer = https.createServer(options, function(req, res) {
   res.end(body);
 });
 
-httpsServer.listen(common.PORT, function() {
+httpsServer.listen(0, function() {
   https.get({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   });
 });

--- a/test/parallel/test-https-client-checkServerIdentity.js
+++ b/test/parallel/test-https-client-checkServerIdentity.js
@@ -23,13 +23,13 @@ var server = https.createServer(options, function(req, res) {
   res.writeHead(200);
   res.end();
   req.resume();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   authorized();
 });
 
 function authorized() {
   var req = https.request({
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))]
   }, function(res) {
@@ -43,7 +43,7 @@ function authorized() {
 
 function override() {
   var options = {
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))],
     checkServerIdentity: function(host, cert) {

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -30,8 +30,8 @@ var server = https.createServer(options, function(req, res) {
   seen_req = true;
 });
 
-server.listen(common.PORT, function() {
-  https.get('https://127.0.0.1:' + common.PORT + '/foo?bar');
+server.listen(0, function() {
+  https.get(`https://127.0.0.1:${this.address().port}/foo?bar`);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-https-client-reject.js
+++ b/test/parallel/test-https-client-reject.js
@@ -23,13 +23,13 @@ var server = https.createServer(options, function(req, res) {
   res.writeHead(200);
   res.end();
   req.resume();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   unauthorized();
 });
 
 function unauthorized() {
   var req = https.request({
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: false
   }, function(res) {
     assert(!req.socket.authorized);
@@ -44,7 +44,7 @@ function unauthorized() {
 
 function rejectUnauthorized() {
   var options = {
-    port: common.PORT
+    port: server.address().port
   };
   options.agent = new https.Agent(options);
   var req = https.request(options, function(res) {
@@ -58,7 +58,7 @@ function rejectUnauthorized() {
 
 function authorized() {
   var options = {
-    port: common.PORT,
+    port: server.address().port,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))]
   };
   options.agent = new https.Agent(options);

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -28,11 +28,11 @@ var server = https.createServer(options, function(req, res) {
 });
 
 // start listening
-server.listen(common.PORT, function() {
+server.listen(0, function() {
 
   var session1 = null;
   var client1 = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     console.log('connect1');
@@ -47,7 +47,7 @@ server.listen(common.PORT, function() {
     console.log('close1');
 
     var opts = {
-      port: common.PORT,
+      port: server.address().port,
       rejectUnauthorized: false,
       session: session1
     };

--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -39,10 +39,10 @@ function shutdown() {
   }
 }
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var requestOptions = {
     hostname: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     rejectUnauthorized: false

--- a/test/parallel/test-https-connecting-to-http.js
+++ b/test/parallel/test-https-connecting-to-http.js
@@ -25,8 +25,8 @@ var server = http.createServer(function(req, res) {
 });
 
 
-server.listen(common.PORT, function() {
-  var req = https.get({ port: common.PORT }, function(res) {
+server.listen(0, function() {
+  var req = https.get({ port: this.address().port }, function(res) {
     resCount++;
   });
 

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -25,11 +25,11 @@ var server = https.createServer(options, function(req, res) {
   req.pipe(res);
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var resumed = false;
   var req = https.request({
     method: 'POST',
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function(res) {
     var timer;

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -51,10 +51,10 @@ var gotHeaders = false;
 var gotEnd = false;
 var bodyBuffer = '';
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   console.log('1) Making Request');
   https.get({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function(res) {
     server.close();

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -46,10 +46,10 @@ var server = https.createServer(options, function(req, res) {
   res.end(body);
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var args = ['s_client',
               '-quiet',
-              '-connect', '127.0.0.1:' + common.PORT,
+              '-connect', `127.0.0.1:${this.address().port}`,
               '-cert', join(common.fixturesDir, 'foafssl.crt'),
               '-key', join(common.fixturesDir, 'foafssl.key')];
 

--- a/test/parallel/test-https-host-headers.js
+++ b/test/parallel/test-https-host-headers.js
@@ -20,7 +20,7 @@ function reqHandler(req, res) {
   if (req.url === '/setHostFalse5') {
     assert.equal(req.headers.host, undefined);
   } else {
-    assert.equal(req.headers.host, 'localhost:' + common.PORT,
+    assert.equal(req.headers.host, `localhost:${this.address().port}`,
                  'Wrong host header for req[' + req.url + ']: ' +
                  req.headers.host);
   }
@@ -37,8 +37,6 @@ testHttps();
 
 function testHttps() {
 
-  console.log('testing https on port ' + common.PORT);
-
   var counter = 0;
 
   function cb(res) {
@@ -51,7 +49,9 @@ function testHttps() {
     res.resume();
   }
 
-  httpsServer.listen(common.PORT, function(er) {
+  httpsServer.listen(0, function(er) {
+    console.log(`test https server listening on port ${this.address().port}`);
+
     if (er) throw er;
 
     https.get({
@@ -59,7 +59,7 @@ function testHttps() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower);
 
@@ -68,7 +68,7 @@ function testHttps() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -77,7 +77,7 @@ function testHttps() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -86,7 +86,7 @@ function testHttps() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -95,7 +95,7 @@ function testHttps() {
       path: '/' + (counter++),
       host: 'localhost',
       //agent: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
 
@@ -104,7 +104,7 @@ function testHttps() {
       path: '/setHostFalse' + (counter++),
       host: 'localhost',
       setHost: false,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, cb).on('error', thrower).end();
   });

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -27,10 +27,10 @@ var server = https.createServer(options, function(req, res) {
   req.resume();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   https.request({
     host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     localAddress: invalidLocalAddress

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -30,10 +30,10 @@ var server = https.createServer(options, function(req, res) {
   req.resume();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var options = {
     host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     localAddress: '127.0.0.2',

--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -13,7 +13,7 @@ var pfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
 
 var options = {
   host: '127.0.0.1',
-  port: common.PORT,
+  port: undefined,
   path: '/',
   pfx: pfx,
   passphrase: 'sample',
@@ -28,7 +28,8 @@ var server = https.createServer(options, function(req, res) {
   res.end('OK');
 });
 
-server.listen(options.port, options.host, function() {
+server.listen(0, options.host, function() {
+  options.port = this.address().port;
   var data = '';
 
   https.get(options, function(res) {

--- a/test/parallel/test-https-req-split.js
+++ b/test/parallel/test-https-req-split.js
@@ -33,10 +33,10 @@ server.on('upgrade', function(req, socket, upgrade) {
   seen_req = true;
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var req = https.request({
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     agent: false,
     headers: {
       Connection: 'Upgrade',

--- a/test/parallel/test-https-resume-after-renew.js
+++ b/test/parallel/test-https-resume-after-renew.js
@@ -35,7 +35,7 @@ server._sharedCreds.context.onticketkeycallback = function(name, iv, enc) {
   return [ 1, hmac, aes, newName, newIV ];
 };
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var addr = this.address();
 
   function doReq(callback) {

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -42,18 +42,19 @@ test(function serverTimeout(cb) {
   var server = https.createServer(serverOptions, function(req, res) {
     // just do nothing, we should get a timeout event.
   });
-  server.listen(common.PORT);
-  var s = server.setTimeout(50, function(socket) {
-    caughtTimeout = true;
-    socket.destroy();
-    server.close();
-    cb();
+  server.listen(0, function() {
+    var s = server.setTimeout(50, function(socket) {
+      caughtTimeout = true;
+      socket.destroy();
+      server.close();
+      cb();
+    });
+    assert.ok(s instanceof https.Server);
+    https.get({
+      port: this.address().port,
+      rejectUnauthorized: false
+    }).on('error', function() {});
   });
-  assert.ok(s instanceof https.Server);
-  https.get({
-    port: common.PORT,
-    rejectUnauthorized: false
-  }).on('error', function() {});
 });
 
 test(function serverRequestTimeout(cb) {
@@ -70,15 +71,16 @@ test(function serverRequestTimeout(cb) {
       cb();
     });
   });
-  server.listen(common.PORT);
-  var req = https.request({
-    port: common.PORT,
-    method: 'POST',
-    rejectUnauthorized: false
+  server.listen(0, function() {
+    var req = https.request({
+      port: this.address().port,
+      method: 'POST',
+      rejectUnauthorized: false
+    });
+    req.on('error', function() {});
+    req.write('Hello');
+    // req is in progress
   });
-  req.on('error', function() {});
-  req.write('Hello');
-  // req is in progress
 });
 
 test(function serverResponseTimeout(cb) {
@@ -95,11 +97,12 @@ test(function serverResponseTimeout(cb) {
       cb();
     });
   });
-  server.listen(common.PORT);
-  https.get({
-    port: common.PORT,
-    rejectUnauthorized: false
-  }).on('error', function() {});
+  server.listen(0, function() {
+    https.get({
+      port: this.address().port,
+      rejectUnauthorized: false
+    }).on('error', function() {});
+  });
 });
 
 test(function serverRequestNotTimeoutAfterEnd(cb) {
@@ -123,11 +126,12 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
     server.close();
     cb();
   });
-  server.listen(common.PORT);
-  https.get({
-    port: common.PORT,
-    rejectUnauthorized: false
-  }).on('error', function() {});
+  server.listen(0, function() {
+    https.get({
+      port: this.address().port,
+      rejectUnauthorized: false
+    }).on('error', function() {});
+  });
 });
 
 test(function serverResponseTimeoutWithPipeline(cb) {
@@ -146,16 +150,17 @@ test(function serverResponseTimeoutWithPipeline(cb) {
     server.close();
     cb();
   });
-  server.listen(common.PORT);
-  var options = {
-    port: common.PORT,
-    allowHalfOpen: true,
-    rejectUnauthorized: false
-  };
-  var c = tls.connect(options, function() {
-    c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
-    c.write('GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n');
-    c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+  server.listen(0, function() {
+    var options = {
+      port: this.address().port,
+      allowHalfOpen: true,
+      rejectUnauthorized: false
+    };
+    var c = tls.connect(options, function() {
+      c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+      c.write('GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+      c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+    });
   });
 });
 
@@ -183,14 +188,15 @@ test(function idleTimeout(cb) {
     server.close();
     cb();
   });
-  server.listen(common.PORT);
-  var options = {
-    port: common.PORT,
-    allowHalfOpen: true,
-    rejectUnauthorized: false
-  };
-  tls.connect(options, function() {
-    this.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
-    // Keep-Alive
+  server.listen(0, function() {
+    var options = {
+      port: this.address().port,
+      allowHalfOpen: true,
+      rejectUnauthorized: false
+    };
+    tls.connect(options, function() {
+      this.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+      // Keep-Alive
+    });
   });
 });

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -34,11 +34,11 @@ const serverCallback = common.mustCall(function(req, res) {
 
 const server = https.createServer(options, serverCallback);
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   // Do a request ignoring the unauthorized server certs
   const noCertCheckOptions = {
     hostname: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     rejectUnauthorized: false
@@ -65,7 +65,7 @@ server.listen(common.PORT, function() {
   // Do a request that throws error due to the invalid server certs
   const checkCertOptions = {
     hostname: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET'
   };

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -27,9 +27,9 @@ var server_http = http.createServer(function(req, res) {
 });
 
 
-server_http.listen(common.PORT, function() {
+server_http.listen(0, function() {
   var req = http.request({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function(res) {
     server_http.close();
@@ -51,9 +51,9 @@ var server_https = https.createServer(options, function(req, res) {
   res.end(body);
 });
 
-server_https.listen(common.PORT + 1, function() {
+server_https.listen(0, function() {
   var req = https.request({
-    port: common.PORT + 1,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function(res) {
     server_https.close();

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -151,7 +151,6 @@ function makeReq(path, port, error, host, ca) {
 
 function allListening() {
   // ok, ready to start the tests!
-
   const port1 = server1.address().port;
   const port2 = server2.address().port;
   const port3 = server3.address().port;

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -27,10 +27,10 @@ server.on('secureConnection', function(cleartext) {
   assert.ok(s instanceof tls.TLSSocket);
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   tls.connect({
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   });
 });

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -35,6 +35,6 @@ server.on('clientError', function(err, conn) {
   conn.destroy();
 });
 
-server.listen(common.PORT, function() {
-  net.connect({ host: '127.0.0.1', port: common.PORT });
+server.listen(0, function() {
+  net.connect({ host: '127.0.0.1', port: this.address().port });
 });

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -17,10 +17,10 @@ var options = {
 // a server that never replies
 var server = https.createServer(options, function() {
   console.log('Got request.  Doing nothing.');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var req = https.request({
     host: 'localhost',
-    port: common.PORT,
+    port: this.address().port,
     path: '/',
     method: 'GET',
     rejectUnauthorized: false

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -13,8 +13,6 @@ var fs = require('fs');
 var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
 
-var PORT = common.PORT;
-
 // number of bytes discovered empirically to trigger the bug
 var data = Buffer.allocUnsafe(1024 * 32 + 1);
 
@@ -29,8 +27,8 @@ function httpsTest() {
     server.close();
   });
 
-  server.listen(PORT, function() {
-    var opts = { port: PORT, rejectUnauthorized: false };
+  server.listen(0, function() {
+    var opts = { port: this.address().port, rejectUnauthorized: false };
     https.get(opts).on('response', function(res) {
       test(res);
     });

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -3,7 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
-var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (common.isWindows) {
@@ -38,7 +37,7 @@ function test() {
     // now make sure that we can request to the child, then kill it.
     http.get({
       server: 'localhost',
-      port: PORT,
+      port: child.port,
       path: '/',
     }).on('response', function(res) {
       var s = '';
@@ -64,8 +63,8 @@ function parent() {
   var server = net.createServer(function(conn) {
     console.error('connection on parent');
     conn.end('hello from parent\n');
-  }).listen(PORT, function() {
-    console.error('server listening on %d', PORT);
+  }).listen(0, function() {
+    console.error('server listening on %d', this.address().port);
 
     var spawn = require('child_process').spawn;
     var child = spawn(process.execPath, [__filename, 'child'], {
@@ -73,7 +72,7 @@ function parent() {
       detached: true
     });
 
-    console.log('%j\n', { pid: child.pid });
+    console.log('%j\n', { pid: child.pid, port: this.address().port });
 
     // Now close the parent, so that the child is the only thing
     // referencing that handle.  Note that connections will still

--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var closed = false;
@@ -9,8 +9,8 @@ var server = net.createServer(function(s) {
   s.end();
 });
 
-server.listen(common.PORT, function() {
-  var c = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var c = net.createConnection(this.address().port);
   c.on('close', function() {
     console.error('connection closed');
     assert.strictEqual(c._handle, null);

--- a/test/parallel/test-net-binary.js
+++ b/test/parallel/test-net-binary.js
@@ -1,5 +1,5 @@
 /* eslint-disable strict */
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -22,14 +22,14 @@ var echoServer = net.Server(function(connection) {
     connection.end();
   });
 });
-echoServer.listen(common.PORT);
+echoServer.listen(0);
 
 var recv = '';
 
 echoServer.on('listening', function() {
   var j = 0;
   var c = net.createConnection({
-    port: common.PORT
+    port: this.address().port
   });
 
   c.setEncoding('latin1');

--- a/test/parallel/test-net-bind-twice.js
+++ b/test/parallel/test-net-bind-twice.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -14,13 +14,13 @@ function dontCall() {
 }
 
 var server1 = net.createServer(dontCall);
-server1.listen(common.PORT, '127.0.0.1', function() {});
+server1.listen(0, '127.0.0.1', function() {
+  var server2 = net.createServer(dontCall);
+  server2.listen(this.address().port, '127.0.0.1', dontCall);
 
-var server2 = net.createServer(dontCall);
-server2.listen(common.PORT, '127.0.0.1', dontCall);
-
-server2.on('error', function(e) {
-  assert.equal(e.code, 'EADDRINUSE');
-  server1.close();
-  gotError = true;
+  server2.on('error', function(e) {
+    assert.equal(e.code, 'EADDRINUSE');
+    server1.close();
+    gotError = true;
+  });
 });

--- a/test/parallel/test-net-buffersize.js
+++ b/test/parallel/test-net-buffersize.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -15,8 +15,8 @@ var server = net.createServer(function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
-  var client = net.connect(common.PORT);
+server.listen(0, function() {
+  var client = net.connect(this.address().port);
 
   client.on('finish', function() {
     assert.strictEqual(client.bufferSize, 0);

--- a/test/parallel/test-net-bytes-read.js
+++ b/test/parallel/test-net-bytes-read.js
@@ -9,7 +9,7 @@ const big = Buffer.alloc(1024 * 1024);
 const server = net.createServer((socket) => {
   socket.end(big);
   server.close();
-}).listen(common.PORT, () => {
+}).listen(0, () => {
   let prev = 0;
 
   function checkRaise(value) {
@@ -17,7 +17,7 @@ const server = net.createServer((socket) => {
     prev = value;
   }
 
-  const socket = net.connect(common.PORT, () => {
+  const socket = net.connect(server.address().port, () => {
     socket.on('data', (chunk) => {
       checkRaise(socket.bytesRead);
     });

--- a/test/parallel/test-net-bytes-stats.js
+++ b/test/parallel/test-net-bytes-stats.js
@@ -1,9 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var tcpPort = common.PORT;
 var bytesRead = 0;
 var bytesWritten = 0;
 var count = 0;
@@ -20,9 +19,9 @@ var tcp = net.Server(function(s) {
   });
 });
 
-tcp.listen(common.PORT, function doTest() {
+tcp.listen(0, function doTest() {
   console.error('listening');
-  var socket = net.createConnection(tcpPort);
+  var socket = net.createConnection(this.address().port);
 
   socket.on('connect', function() {
     count++;
@@ -45,7 +44,7 @@ tcp.listen(common.PORT, function doTest() {
     console.log('Bytes written: ' + bytesWritten);
     if (count < 2) {
       console.error('RECONNECTING');
-      socket.connect(tcpPort);
+      socket.connect(tcp.address().port);
     } else {
       tcp.close();
     }

--- a/test/parallel/test-net-can-reset-timeout.js
+++ b/test/parallel/test-net-can-reset-timeout.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var net = require('net');
-var common = require('../common');
 var assert = require('assert');
 
 var timeoutCount = 0;
@@ -25,8 +25,8 @@ var server = net.createServer(function(stream) {
   });
 });
 
-server.listen(common.PORT, function() {
-  var c = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var c = net.createConnection(this.address().port);
 
   c.on('data', function() {
     c.end();

--- a/test/parallel/test-net-connect-buffer.js
+++ b/test/parallel/test-net-connect-buffer.js
@@ -1,9 +1,8 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var tcpPort = common.PORT;
 var dataWritten = false;
 var connectHappened = false;
 
@@ -30,12 +29,12 @@ var tcp = net.Server(function(s) {
   });
 });
 
-tcp.listen(common.PORT, function() {
+tcp.listen(0, function() {
   var socket = net.Stream({ highWaterMark: 0 });
 
   console.log('Connecting to socket ');
 
-  socket.connect(tcpPort, function() {
+  socket.connect(this.address().port, function() {
     console.log('socket connected');
     connectHappened = true;
   });

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -19,12 +19,12 @@ const server = net.createServer({allowHalfOpen: true}, function(socket) {
   socket.end();
 });
 
-server.listen(common.PORT, '::1', tryConnect);
+server.listen(0, '::1', tryConnect);
 
 function tryConnect() {
   const client = net.connect({
     host: host,
-    port: common.PORT,
+    port: server.address().port,
     family: 6,
     allowHalfOpen: true
   }, function() {

--- a/test/parallel/test-net-connect-options.js
+++ b/test/parallel/test-net-connect-options.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -14,10 +14,10 @@ var server = net.createServer({allowHalfOpen: true}, function(socket) {
   socket.end();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var client = net.connect({
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     allowHalfOpen: true
   }, function() {
     console.error('client connect cb');

--- a/test/parallel/test-net-connect-paused-connection.js
+++ b/test/parallel/test-net-connect-paused-connection.js
@@ -1,15 +1,15 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 
 var net = require('net');
 
 net.createServer(function(conn) {
   conn.unref();
-}).listen(common.PORT).unref();
+}).listen(0, function() {
+  net.connect(this.address().port, 'localhost').pause();
 
-net.connect(common.PORT, 'localhost').pause();
-
-setTimeout(function() {
-  assert.fail(null, null, 'expected to exit');
-}, 1000).unref();
+  setTimeout(function() {
+    assert.fail(null, null, 'expected to exit');
+  }, 1000).unref();
+}).unref();

--- a/test/parallel/test-net-create-connection.js
+++ b/test/parallel/test-net-create-connection.js
@@ -1,10 +1,9 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const dns = require('dns');
 const net = require('net');
 
-const tcpPort = common.PORT;
 const expectedConnections = 7;
 var clientConnected = 0;
 var serverConnected = 0;
@@ -16,7 +15,7 @@ const server = net.createServer(function(socket) {
   }
 });
 
-server.listen(tcpPort, 'localhost', function() {
+server.listen(0, 'localhost', function() {
   function cb() {
     ++clientConnected;
   }
@@ -29,13 +28,13 @@ server.listen(tcpPort, 'localhost', function() {
     });
   }
 
-  net.createConnection(tcpPort).on('connect', cb);
-  net.createConnection(tcpPort, 'localhost').on('connect', cb);
-  net.createConnection(tcpPort, cb);
-  net.createConnection(tcpPort, 'localhost', cb);
-  net.createConnection(tcpPort + '', 'localhost', cb);
-  net.createConnection({port: tcpPort + ''}).on('connect', cb);
-  net.createConnection({port: '0x' + tcpPort.toString(16)}, cb);
+  net.createConnection(this.address().port).on('connect', cb);
+  net.createConnection(this.address().port, 'localhost').on('connect', cb);
+  net.createConnection(this.address().port, cb);
+  net.createConnection(this.address().port, 'localhost', cb);
+  net.createConnection(this.address().port + '', 'localhost', cb);
+  net.createConnection({port: this.address().port + ''}).on('connect', cb);
+  net.createConnection({port: '0x' + this.address().port.toString(16)}, cb);
 
   fail({
     port: true

--- a/test/parallel/test-net-dns-custom-lookup.js
+++ b/test/parallel/test-net-dns-custom-lookup.js
@@ -12,9 +12,9 @@ function check(addressType, cb) {
   });
 
   var address = addressType === 4 ? common.localhostIPv4 : '::1';
-  server.listen(common.PORT, address, function() {
+  server.listen(0, address, function() {
     net.connect({
-      port: common.PORT,
+      port: this.address().port,
       host: 'localhost',
       family: addressType,
       lookup: lookup

--- a/test/parallel/test-net-dns-lookup-skip.js
+++ b/test/parallel/test-net-dns-lookup-skip.js
@@ -9,8 +9,8 @@ function check(addressType) {
   });
 
   var address = addressType === 4 ? '127.0.0.1' : '::1';
-  server.listen(common.PORT, address, function() {
-    net.connect(common.PORT, address).on('lookup', common.fail);
+  server.listen(0, address, function() {
+    net.connect(this.address().port, address).on('lookup', common.fail);
   });
 }
 

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var ok = false;
@@ -9,8 +9,8 @@ var server = net.createServer(function(client) {
   server.close();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
-  net.connect(common.PORT, 'localhost')
+server.listen(0, '127.0.0.1', function() {
+  net.connect(this.address().port, 'localhost')
     .on('lookup', function(err, ip, type, host) {
       assert.equal(err, null);
       assert.equal(ip, '127.0.0.1');

--- a/test/parallel/test-net-during-close.js
+++ b/test/parallel/test-net-during-close.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var accessedProperties = false;
@@ -8,8 +8,8 @@ var server = net.createServer(function(socket) {
   socket.end();
 });
 
-server.listen(common.PORT, function() {
-  var client = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var client = net.createConnection(this.address().port);
   server.close();
   // server connection event has not yet fired
   // client is still attempting to connect

--- a/test/parallel/test-net-eaddrinuse.js
+++ b/test/parallel/test-net-eaddrinuse.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -7,9 +7,10 @@ var server1 = net.createServer(function(socket) {
 });
 var server2 = net.createServer(function(socket) {
 });
-server1.listen(common.PORT);
-server2.on('error', function(error) {
-  assert.equal(true, error.message.indexOf('EADDRINUSE') >= 0);
-  server1.close();
+server1.listen(0, function() {
+  server2.on('error', function(error) {
+    assert.equal(true, error.message.indexOf('EADDRINUSE') >= 0);
+    server1.close();
+  });
+  server2.listen(this.address().port);
 });
-server2.listen(common.PORT);

--- a/test/parallel/test-net-error-twice.js
+++ b/test/parallel/test-net-error-twice.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -27,8 +27,8 @@ var srv = net.createServer(function onConnection(conn) {
   });
   serverSocket = conn;
   ready();
-}).listen(common.PORT, function() {
-  var client = net.connect({ port: common.PORT });
+}).listen(0, function() {
+  var client = net.connect({ port: this.address().port });
 
   client.on('connect', function() {
     clientSocket = client;

--- a/test/parallel/test-net-keepalive.js
+++ b/test/parallel/test-net-keepalive.js
@@ -23,9 +23,9 @@ var echoServer = net.createServer(function(connection) {
     connection.end();
   });
 });
-echoServer.listen(common.PORT);
+echoServer.listen(0);
 
 echoServer.on('listening', function() {
-  clientConnection = net.createConnection(common.PORT);
+  clientConnection = net.createConnection(this.address().port);
   clientConnection.setTimeout(0);
 });

--- a/test/parallel/test-net-large-string.js
+++ b/test/parallel/test-net-large-string.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -18,8 +18,8 @@ var server = net.createServer(function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
-  var client = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var client = net.createConnection(this.address().port);
   client.on('end', function() {
     server.close();
   });

--- a/test/parallel/test-net-listen-close-server-callback-is-not-function.js
+++ b/test/parallel/test-net-listen-close-server-callback-is-not-function.js
@@ -1,6 +1,6 @@
 'use strict';
+require('../common');
 var assert = require('assert');
-var common = require('../common');
 var net = require('net');
 
 var server = net.createServer(assert.fail);
@@ -10,7 +10,7 @@ server.on('close', function() {
   ++closeEvents;
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   assert(false);
 });
 

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -1,11 +1,11 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
 var server = net.createServer(function(socket) {
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   assert(false);
 });
 server.on('error', function(error) {

--- a/test/parallel/test-net-listening.js
+++ b/test/parallel/test-net-listening.js
@@ -7,7 +7,7 @@ const server = net.createServer();
 
 assert.strictEqual(server.listening, false);
 
-server.listen(common.PORT, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   assert.strictEqual(server.listening, true);
 
   server.close(common.mustCall(() => {

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -7,16 +7,16 @@ var conns = 0;
 
 var server = net.createServer(function(socket) {
   conns++;
-  assert.equal(common.localhostIPv4, socket.localAddress);
-  assert.equal(socket.localPort, common.PORT);
+  assert.equal(socket.localAddress, common.localhostIPv4);
+  assert.equal(socket.localPort, this.address().port);
   socket.on('end', function() {
     server.close();
   });
   socket.resume();
 });
 
-server.listen(common.PORT, common.localhostIPv4, function() {
-  var client = net.createConnection(common.PORT, common.localhostIPv4);
+server.listen(0, common.localhostIPv4, function() {
+  var client = net.createConnection(this.address().port, common.localhostIPv4);
   client.on('connect', function() {
     client.end();
   });

--- a/test/parallel/test-net-localport.js
+++ b/test/parallel/test-net-localport.js
@@ -5,17 +5,17 @@ var net = require('net');
 
 var server = net.createServer(function(socket) {
   console.log(socket.remotePort);
-  assert.strictEqual(socket.remotePort, common.PORT + 1);
+  assert.strictEqual(socket.remotePort, common.PORT);
   socket.end();
   socket.on('close', function() {
     server.close();
   });
-}).listen(common.PORT).on('listening', function() {
+}).listen(0).on('listening', function() {
   var client = net.connect({
     host: '127.0.0.1',
-    port: common.PORT,
-    localPort: common.PORT + 1,
+    port: this.address().port,
+    localPort: common.PORT,
   }).on('connect', function() {
-    assert.strictEqual(client.localPort, common.PORT + 1);
+    assert.strictEqual(client.localPort, common.PORT);
   });
 });

--- a/test/parallel/test-net-pause-resume-connecting.js
+++ b/test/parallel/test-net-pause-resume-connecting.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -17,61 +17,60 @@ var server = net.createServer(function(conn) {
     server.close();
 });
 
-server.listen(common.PORT);
+server.listen(0, function() {
+  // Client 1
+  conn = require('net').createConnection(this.address().port, 'localhost');
+  conn.resume();
+  conn.on('data', onDataOk);
 
 
-// Client 1
-conn = require('net').createConnection(common.PORT, 'localhost');
-conn.resume();
-conn.on('data', onDataOk);
+  // Client 2
+  conn = require('net').createConnection(this.address().port, 'localhost');
+  conn.pause();
+  conn.resume();
+  conn.on('data', onDataOk);
 
 
-// Client 2
-conn = require('net').createConnection(common.PORT, 'localhost');
-conn.pause();
-conn.resume();
-conn.on('data', onDataOk);
+  // Client 3
+  conn = require('net').createConnection(this.address().port, 'localhost');
+  conn.pause();
+  conn.on('data', onDataError);
+  scheduleTearDown(conn);
 
 
-// Client 3
-conn = require('net').createConnection(common.PORT, 'localhost');
-conn.pause();
-conn.on('data', onDataError);
-scheduleTearDown(conn);
+  // Client 4
+  conn = require('net').createConnection(this.address().port, 'localhost');
+  conn.resume();
+  conn.pause();
+  conn.resume();
+  conn.on('data', onDataOk);
 
 
-// Client 4
-conn = require('net').createConnection(common.PORT, 'localhost');
-conn.resume();
-conn.pause();
-conn.resume();
-conn.on('data', onDataOk);
+  // Client 5
+  conn = require('net').createConnection(this.address().port, 'localhost');
+  conn.resume();
+  conn.resume();
+  conn.pause();
+  conn.on('data', onDataError);
+  scheduleTearDown(conn);
 
 
-// Client 5
-conn = require('net').createConnection(common.PORT, 'localhost');
-conn.resume();
-conn.resume();
-conn.pause();
-conn.on('data', onDataError);
-scheduleTearDown(conn);
+  // Client helper functions
+  function onDataError() {
+    assert(false);
+  }
 
+  function onDataOk() {
+    dataEvents++;
+  }
 
-// Client helper functions
-function onDataError() {
-  assert(false);
-}
-
-function onDataOk() {
-  dataEvents++;
-}
-
-function scheduleTearDown(conn) {
-  setTimeout(function() {
-    conn.removeAllListeners('data');
-    conn.resume();
-  }, 100);
-}
+  function scheduleTearDown(conn) {
+    setTimeout(function() {
+      conn.removeAllListeners('data');
+      conn.resume();
+    }, 100);
+  }
+});
 
 
 // Exit sanity checks

--- a/test/parallel/test-net-persistent-keepalive.js
+++ b/test/parallel/test-net-persistent-keepalive.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -21,7 +21,7 @@ var echoServer = net.createServer(function(connection) {
     connection.end();
   });
 });
-echoServer.listen(common.PORT);
+echoServer.listen(0);
 
 echoServer.on('listening', function() {
   clientConnection = new net.Socket();
@@ -29,6 +29,6 @@ echoServer.on('listening', function() {
   // and make sure it persists
   var s = clientConnection.setKeepAlive(true, 400);
   assert.ok(s instanceof net.Socket);
-  clientConnection.connect(common.PORT);
+  clientConnection.connect(this.address().port);
   clientConnection.setTimeout(0);
 });

--- a/test/parallel/test-net-persistent-nodelay.js
+++ b/test/parallel/test-net-persistent-nodelay.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var TCPWrap = process.binding('tcp_wrap').TCP;
@@ -7,7 +7,7 @@ var TCPWrap = process.binding('tcp_wrap').TCP;
 var echoServer = net.createServer(function(connection) {
   connection.end();
 });
-echoServer.listen(common.PORT);
+echoServer.listen(0);
 
 var callCount = 0;
 
@@ -26,7 +26,7 @@ echoServer.on('listening', function() {
 
   var s = sock1.setNoDelay();
   assert.ok(s instanceof net.Socket);
-  sock1.connect(common.PORT);
+  sock1.connect(this.address().port);
   sock1.on('end', function() {
     assert.equal(callCount, 1);
     echoServer.close();

--- a/test/parallel/test-net-persistent-ref-unref.js
+++ b/test/parallel/test-net-persistent-ref-unref.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var TCPWrap = process.binding('tcp_wrap').TCP;
@@ -25,13 +25,13 @@ TCPWrap.prototype.unref = function() {
   assert.equal(refCount, -1);
 };
 
-echoServer.listen(common.PORT);
+echoServer.listen(0);
 
 echoServer.on('listening', function() {
   var sock = new net.Socket();
   sock.unref();
   sock.ref();
-  sock.connect(common.PORT);
+  sock.connect(this.address().port);
   sock.on('end', function() {
     assert.equal(refCount, 0);
     echoServer.close();

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -49,7 +49,7 @@ function pingPongTest(port, host) {
     });
 
     socket.on('close', function() {
-      console.log('server socket.endd');
+      console.log('server socket.end');
       assert.equal(false, socket.writable);
       assert.equal(false, socket.readable);
       socket.server.close();
@@ -58,7 +58,9 @@ function pingPongTest(port, host) {
 
 
   server.listen(port, host, function() {
-    console.log('server listening on ' + port + ' ' + host);
+    if (this.address().port)
+      port = this.address().port;
+    console.log(`server listening on ${port} ${host}`);
 
     var client = net.createConnection(port, host);
 
@@ -108,10 +110,10 @@ function pingPongTest(port, host) {
 /* All are run at once, so run on different ports */
 common.refreshTmpDir();
 pingPongTest(common.PIPE);
-pingPongTest(common.PORT);
-pingPongTest(common.PORT + 1, 'localhost');
+pingPongTest(0);
+pingPongTest(0, 'localhost');
 if (common.hasIPv6)
-  pingPongTest(common.PORT + 2, '::1');
+  pingPongTest(0, '::1');
 
 process.on('exit', function() {
   if (common.hasIPv6)

--- a/test/parallel/test-net-reconnect.js
+++ b/test/parallel/test-net-reconnect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var net = require('net');
@@ -27,9 +27,9 @@ var server = net.createServer(function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   console.log('SERVER listening');
-  var client = net.createConnection(common.PORT);
+  var client = net.createConnection(this.address().port);
 
   client.setEncoding('UTF8');
 
@@ -54,7 +54,7 @@ server.listen(common.PORT, function() {
     console.log('CLIENT disconnect');
     assert.equal(false, had_error);
     if (disconnect_count++ < N)
-      client.connect(common.PORT); // reconnect
+      client.connect(server.address().port); // reconnect
     else
       server.close();
   });

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -17,7 +17,7 @@ var server = net.createServer(function(socket) {
   assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));
   assert.notEqual(-1, remoteFamilyCandidates.indexOf(socket.remoteFamily));
   assert.ok(socket.remotePort);
-  assert.notEqual(socket.remotePort, common.PORT);
+  assert.notEqual(socket.remotePort, this.address().port);
   socket.on('end', function() {
     if (++conns_closed == 2) server.close();
   });
@@ -28,13 +28,13 @@ var server = net.createServer(function(socket) {
   socket.resume();
 });
 
-server.listen(common.PORT, 'localhost', function() {
-  var client = net.createConnection(common.PORT, 'localhost');
-  var client2 = net.createConnection(common.PORT);
+server.listen(0, 'localhost', function() {
+  var client = net.createConnection(this.address().port, 'localhost');
+  var client2 = net.createConnection(this.address().port);
   client.on('connect', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(client.remoteAddress));
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(client.remoteFamily));
-    assert.equal(common.PORT, client.remotePort);
+    assert.equal(client.remotePort, server.address().port);
     client.end();
   });
   client.on('close', function() {
@@ -44,7 +44,7 @@ server.listen(common.PORT, 'localhost', function() {
   client2.on('connect', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
-    assert.equal(common.PORT, client2.remotePort);
+    assert.equal(client2.remotePort, server.address().port);
     client2.end();
   });
   client2.on('close', function() {

--- a/test/parallel/test-net-server-close.js
+++ b/test/parallel/test-net-server-close.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -32,7 +32,7 @@ server.on('close', function() {
   events.push('server');
 });
 
-server.listen(common.PORT, function() {
-  net.createConnection(common.PORT);
-  net.createConnection(common.PORT);
+server.listen(0, function() {
+  net.createConnection(this.address().port);
+  net.createConnection(this.address().port);
 });

--- a/test/parallel/test-net-server-listen-remove-callback.js
+++ b/test/parallel/test-net-server-listen-remove-callback.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -12,12 +12,12 @@ server.on('close', function() {
   assert.equal(0, listeners.length);
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   server.close();
 });
 
 server.once('close', function() {
-  server.listen(common.PORT + 1, function() {
+  server.listen(0, function() {
     server.close();
   });
 });

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var net = require('net');
@@ -21,7 +21,7 @@ var createConnection = function(index) {
   console.error('creating connection ' + index);
 
   return new Promise(function(resolve, reject) {
-    var connection = net.createConnection(common.PORT, function() {
+    var connection = net.createConnection(server.address().port, function() {
       var msg = '' + index;
       console.error('sending message: ' + msg);
       this.write(msg);
@@ -67,7 +67,7 @@ var server = net.createServer(function(socket) {
 
 server.maxConnections = 1;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   createConnection(0)
   .then(createConnection.bind(null, 1))
   .then(closeConnection.bind(null, 0))

--- a/test/parallel/test-net-server-max-connections.js
+++ b/test/parallel/test-net-server-max-connections.js
@@ -19,7 +19,7 @@ var server = net.createServer(function(connection) {
   waits.push(function() { connection.end(); });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   makeConnection(0);
 });
 
@@ -29,7 +29,7 @@ console.error('server.maxConnections = %d', server.maxConnections);
 
 
 function makeConnection(index) {
-  var c = net.createConnection(common.PORT);
+  var c = net.createConnection(server.address().port);
   var gotData = false;
 
   c.on('connect', function() {
@@ -78,7 +78,7 @@ function makeConnection(index) {
     // Retry if SmartOS and ECONNREFUSED. See
     // https://github.com/nodejs/node/issues/2663.
     if (common.isSunOS && (e.code === 'ECONNREFUSED')) {
-      c.connect(common.PORT);
+      c.connect(server.address().port);
     }
     console.error('error %d: %s', index, e);
   });

--- a/test/parallel/test-net-server-options.js
+++ b/test/parallel/test-net-server-options.js
@@ -1,7 +1,7 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
 assert.throws(function() { net.createServer('path'); }, TypeError);
-assert.throws(function() { net.createServer(common.PORT); }, TypeError);
+assert.throws(function() { net.createServer(0); }, TypeError);

--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -37,13 +37,13 @@ const server2ConnHandler = function(socket) {
 
 const server2 = net.createServer({pauseOnConnect: false}, server2ConnHandler);
 
-server1.listen(common.PORT, function() {
+server1.listen(0, function() {
   const clientHandler = common.mustCall(function() {
-    server2.listen(common.PORT + 1, function() {
-      net.createConnection({port: common.PORT + 1}).write(msg);
+    server2.listen(0, function() {
+      net.createConnection({port: this.address().port}).write(msg);
     });
   });
-  net.createConnection({port: common.PORT}).write(msg, clientHandler);
+  net.createConnection({port: this.address().port}).write(msg, clientHandler);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-net-server-try-ports.js
+++ b/test/parallel/test-net-server-try-ports.js
@@ -1,7 +1,7 @@
 'use strict';
 // This tests binds to one port, then attempts to start a server on that
 // port. It should be EADDRINUSE but be able to then bind to another port.
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -30,7 +30,7 @@ server2.on('error', function(e) {
     server2eaddrinuse = true;
   }
 
-  server2.listen(common.PORT + 1, function() {
+  server2.listen(0, function() {
     console.error('server2 listening');
     server2listening = true;
 
@@ -40,11 +40,11 @@ server2.on('error', function(e) {
 });
 
 
-server1.listen(common.PORT, function() {
+server1.listen(0, function() {
   console.error('server1 listening');
   server1listening = true;
   // This should make server2 emit EADDRINUSE
-  server2.listen(common.PORT);
+  server2.listen(this.address().port);
 });
 
 

--- a/test/parallel/test-net-server-unref.js
+++ b/test/parallel/test-net-server-unref.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var net = require('net');
 var closed = false;
 
 var s = net.createServer();
-s.listen(common.PORT);
+s.listen(0);
 s.unref();
 
 setTimeout(function() {

--- a/test/parallel/test-net-settimeout.js
+++ b/test/parallel/test-net-settimeout.js
@@ -12,20 +12,20 @@ const server = net.createServer(common.mustCall((c) => {
   c.write('hello');
 }));
 
-server.listen(common.PORT);
+server.listen(0, function() {
+  const socket = net.createConnection(this.address().port, 'localhost');
 
-const socket = net.createConnection(common.PORT, 'localhost');
+  const s = socket.setTimeout(T, () => {
+    common.fail('Socket timeout event is not expected to fire');
+  });
+  assert.ok(s instanceof net.Socket);
 
-const s = socket.setTimeout(T, () => {
-  common.fail('Socket timeout event is not expected to fire');
+  socket.on('data', common.mustCall(() => {
+    setTimeout(function() {
+      socket.destroy();
+      server.close();
+    }, T * 2);
+  }));
+
+  socket.setTimeout(0);
 });
-assert.ok(s instanceof net.Socket);
-
-socket.on('data', common.mustCall(() => {
-  setTimeout(function() {
-    socket.destroy();
-    server.close();
-  }, T * 2);
-}));
-
-socket.setTimeout(0);

--- a/test/parallel/test-net-socket-connecting.js
+++ b/test/parallel/test-net-socket-connecting.js
@@ -1,13 +1,13 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
 const server = net.createServer((conn) => {
   conn.end();
   server.close();
-}).listen(common.PORT, () => {
-  const client = net.connect(common.PORT, () => {
+}).listen(0, () => {
+  const client = net.connect(server.address().port, () => {
     assert.strictEqual(client.connecting, false);
 
     // Legacy getter

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -24,7 +24,7 @@ server.on('close', common.mustCall(() => {
   assert.strictEqual(2, conns);
 }));
 
-server.listen(common.PORT, common.localhostIPv4, connect);
+server.listen(0, common.localhostIPv4, connect);
 
 function connect() {
   if (conns === 2) {
@@ -34,7 +34,7 @@ function connect() {
 
   conns++;
   client.once('close', connect);
-  client.connect(common.PORT, common.localhostIPv4, () => {
+  client.connect(server.address().port, common.localhostIPv4, () => {
     clientLocalPorts.push(client.localPort);
   });
 }

--- a/test/parallel/test-net-socket-timeout-unref.js
+++ b/test/parallel/test-net-socket-timeout-unref.js
@@ -9,7 +9,7 @@ const server = net.createServer(function(c) {
   c.write('hello');
   c.unref();
 });
-server.listen(common.PORT);
+server.listen(0);
 server.unref();
 
 var connections = 0;
@@ -17,7 +17,7 @@ const sockets = [];
 const delays = [8, 5, 3, 6, 2, 4];
 
 delays.forEach(function(T) {
-  const socket = net.createConnection(common.PORT, 'localhost');
+  const socket = net.createConnection(server.address().port, 'localhost');
   socket.on('connect', common.mustCall(function() {
     if (++connections === delays.length) {
       sockets.forEach(function(s) {

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -31,8 +31,8 @@ for (let i = 0; i < validDelays.length; i++) {
 var timedout = false;
 
 var server = net.Server();
-server.listen(common.PORT, function() {
-  var socket = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var socket = net.createConnection(this.address().port);
   socket.setTimeout(100, function() {
     timedout = true;
     socket.destroy();

--- a/test/parallel/test-net-socket-write-error.js
+++ b/test/parallel/test-net-socket-write-error.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server = net.createServer().listen(common.PORT, connectToServer);
+const server = net.createServer().listen(0, connectToServer);
 
 function connectToServer() {
-  const client = net.createConnection(common.PORT, () => {
+  const client = net.createConnection(this.address().port, () => {
     assert.throws(() => {
       client.write(1337);
     }, /Invalid data, chunk must be a string or buffer, not number/);

--- a/test/parallel/test-net-stream.js
+++ b/test/parallel/test-net-stream.js
@@ -1,7 +1,6 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
-
 var net = require('net');
 
 var s = new net.Stream();
@@ -37,8 +36,8 @@ var server = net.createServer(function(socket) {
   }
   socket.end();
 
-}).listen(common.PORT, function() {
-  var conn = net.connect(common.PORT);
+}).listen(0, function() {
+  var conn = net.connect(this.address().port);
   conn.on('data', function(buf) {
     conn.pause();
     setTimeout(function() {

--- a/test/parallel/test-net-sync-cork.js
+++ b/test/parallel/test-net-sync-cork.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -9,8 +9,8 @@ const server = net.createServer(handle);
 const N = 100;
 const buf = Buffer.alloc(2, 'a');
 
-server.listen(common.PORT, function() {
-  const conn = net.connect(common.PORT);
+server.listen(0, function() {
+  const conn = net.connect(this.address().port);
 
   conn.on('connect', () => {
     let res = true;

--- a/test/parallel/test-net-write-after-close.js
+++ b/test/parallel/test-net-write-after-close.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -28,8 +28,8 @@ var server = net.createServer(function(socket) {
   }, 250);
 });
 
-server.listen(common.PORT, function() {
-  var client = net.connect(common.PORT, function() {
+server.listen(0, function() {
+  var client = net.connect(this.address().port, function() {
     client.end();
   });
 });

--- a/test/parallel/test-net-write-connect-write.js
+++ b/test/parallel/test-net-write-connect-write.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -7,8 +7,8 @@ var received = '';
 
 var server = net.createServer(function(socket) {
   socket.pipe(socket);
-}).listen(common.PORT, function() {
-  var conn = net.connect(common.PORT);
+}).listen(0, function() {
+  var conn = net.connect(this.address().port);
   conn.setEncoding('utf8');
   conn.write('before');
   conn.on('connect', function() {

--- a/test/parallel/test-net-write-slow.js
+++ b/test/parallel/test-net-write-slow.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -27,8 +27,8 @@ var server = net.createServer(function(socket) {
   }
   socket.end();
 
-}).listen(common.PORT, function() {
-  var conn = net.connect(common.PORT);
+}).listen(0, function() {
+  var conn = net.connect(this.address().port);
   conn.on('data', function(buf) {
     received += buf.length;
     conn.pause();

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -33,7 +33,7 @@ var server = http.createServer(function(req, res) {
     res.end();
   });
 });
-server.listen(common.PORT);
+server.listen(0);
 
 server.on('listening', function() {
   var cmd = common.ddCommand(filename, 10240);
@@ -46,7 +46,7 @@ server.on('listening', function() {
 
 function makeRequest() {
   var req = http.request({
-    port: common.PORT,
+    port: server.address().port,
     path: '/',
     method: 'POST'
   });

--- a/test/parallel/test-process-getactivehandles.js
+++ b/test/parallel/test-process-getactivehandles.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 const NUM = 8;
@@ -10,12 +10,12 @@ var clients_counter = 0;
 
 const server = net.createServer(function listener(c) {
   connections.push(c);
-}).listen(common.PORT, makeConnection);
+}).listen(0, makeConnection);
 
 
 function makeConnection() {
   if (clients_counter >= NUM) return;
-  net.connect(common.PORT, function connected() {
+  net.connect(server.address().port, function connected() {
     clientConnected(this);
     makeConnection();
   });

--- a/test/parallel/test-regress-GH-1531.js
+++ b/test/parallel/test-regress-GH-1531.js
@@ -22,12 +22,12 @@ var server = https.createServer(options, function(req, res) {
   res.end('hello world\n');
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   console.error('listening');
   https.get({
     agent: false,
     path: '/',
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function(res) {
     console.error(res.statusCode, res.headers);

--- a/test/parallel/test-regress-GH-746.js
+++ b/test/parallel/test-regress-GH-746.js
@@ -2,7 +2,7 @@
 // Just test that destroying stdin doesn't mess up listening on a server.
 // This is a regression test for GH-746.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -17,10 +17,10 @@ var server = net.createServer(function(socket) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   console.log('listening...');
 
-  net.createConnection(common.PORT);
+  net.createConnection(this.address().port);
 });
 
 

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -15,11 +15,12 @@ const server = net.createServer((conn) => {
 });
 
 const host = common.localhostIPv4;
-const port = common.PORT;
+const port = 0;
 const options = { host, port };
 
 var answer = '';
 server.listen(options, function() {
+  options.port = this.address().port;
   const conn = net.connect(options);
   conn.setEncoding('utf8');
   conn.on('data', (data) => answer += data);

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -342,10 +342,10 @@ function tcp_test() {
     repl.start(prompt_tcp, socket);
   });
 
-  server_tcp.listen(common.PORT, function() {
+  server_tcp.listen(0, function() {
     var read_buffer = '';
 
-    client_tcp = net.createConnection(common.PORT);
+    client_tcp = net.createConnection(this.address().port);
 
     client_tcp.on('connect', function() {
       assert.equal(true, client_tcp.readable);

--- a/test/parallel/test-socket-write-after-fin.js
+++ b/test/parallel/test-socket-write-after-fin.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var net = require('net');
 var serverData = '';
@@ -18,27 +18,27 @@ var server = net.createServer({ allowHalfOpen: true }, function(sock) {
     server.close();
   });
 });
-server.listen(common.PORT);
+server.listen(0, function() {
+  var sock = net.connect(this.address().port);
+  sock.setEncoding('utf8');
+  sock.on('data', function(c) {
+    clientData += c;
+  });
 
-var sock = net.connect(common.PORT);
-sock.setEncoding('utf8');
-sock.on('data', function(c) {
-  clientData += c;
+  sock.on('end', function() {
+    gotClientEnd = true;
+  });
+
+  process.on('exit', function() {
+    assert.equal(serverData, clientData);
+    assert.equal(serverData, 'hello1hello2hello3\nTHUNDERMUSCLE!');
+    assert(gotClientEnd);
+    assert(gotServerEnd);
+    console.log('ok');
+  });
+
+  sock.write('hello1');
+  sock.write('hello2');
+  sock.write('hello3\n');
+  sock.end('THUNDERMUSCLE!');
 });
-
-sock.on('end', function() {
-  gotClientEnd = true;
-});
-
-process.on('exit', function() {
-  assert.equal(serverData, clientData);
-  assert.equal(serverData, 'hello1hello2hello3\nTHUNDERMUSCLE!');
-  assert(gotClientEnd);
-  assert(gotServerEnd);
-  console.log('ok');
-});
-
-sock.write('hello1');
-sock.write('hello2');
-sock.write('hello3\n');
-sock.end('THUNDERMUSCLE!');

--- a/test/parallel/test-stream-base-no-abort.js
+++ b/test/parallel/test-stream-base-no-abort.js
@@ -46,8 +46,9 @@ const checkTLS = common.mustCall(function checkTLS() {
     cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
   };
   const server = tls.createServer(options, () => {})
-    .listen(common.PORT, function() {
-      tls.connect(common.PORT, { rejectUnauthorized: false }, function() {
+    .listen(0, function() {
+      const connectOpts = { rejectUnauthorized: false };
+      tls.connect(this.address().port, connectOpts, function() {
         this.destroy();
         server.close();
       });
@@ -55,7 +56,7 @@ const checkTLS = common.mustCall(function checkTLS() {
 });
 
 const checkTCP = common.mustCall(function checkTCP() {
-  net.createServer(() => {}).listen(common.PORT, function() {
+  net.createServer(() => {}).listen(0, function() {
     this.close(checkTLS);
   });
 });

--- a/test/parallel/test-stream2-httpclient-response-end.js
+++ b/test/parallel/test-stream2-httpclient-response-end.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 var msg = 'Hello';
@@ -8,8 +8,8 @@ var end_event = false;
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end(msg);
-}).listen(common.PORT, function() {
-  http.get({port: common.PORT}, function(res) {
+}).listen(0, function() {
+  http.get({port: this.address().port}, function(res) {
     var data = '';
     res.on('readable', function() {
       console.log('readable event');

--- a/test/parallel/test-tcp-wrap-connect.js
+++ b/test/parallel/test-tcp-wrap-connect.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var TCP = process.binding('tcp_wrap').TCP;
 var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
@@ -9,7 +9,7 @@ function makeConnection() {
   var client = new TCP();
 
   var req = new TCPConnectWrap();
-  var err = client.connect(req, '127.0.0.1', common.PORT);
+  var err = client.connect(req, '127.0.0.1', this.address().port);
   assert.equal(err, 0);
 
   req.oncomplete = function(status, client_, req_) {
@@ -51,7 +51,7 @@ var server = require('net').Server(function(s) {
   });
 });
 
-server.listen(common.PORT, makeConnection);
+server.listen(0, makeConnection);
 
 process.on('exit', function() {
   assert.equal(1, shutdownCount);

--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var TCP = process.binding('tcp_wrap').TCP;
@@ -7,8 +7,11 @@ var WriteWrap = process.binding('stream_wrap').WriteWrap;
 
 var server = new TCP();
 
-var r = server.bind('0.0.0.0', common.PORT);
+var r = server.bind('0.0.0.0', 0);
 assert.equal(0, r);
+var port = {};
+server.getsockname(port);
+port = port.port;
 
 server.listen(128);
 
@@ -80,7 +83,7 @@ server.onconnection = function(err, client) {
 
 var net = require('net');
 
-var c = net.createConnection(common.PORT);
+var c = net.createConnection(port);
 c.on('connect', function() {
   c.end('hello world');
 });

--- a/test/parallel/test-tcp-wrap.js
+++ b/test/parallel/test-tcp-wrap.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 
 var TCP = process.binding('tcp_wrap').TCP;
@@ -7,12 +7,14 @@ var uv = process.binding('uv');
 
 var handle = new TCP();
 
-// Should be able to bind to the common.PORT
-var err = handle.bind('0.0.0.0', common.PORT);
+// Should be able to bind to the port
+var err = handle.bind('0.0.0.0', 0);
 assert.equal(err, 0);
 
 // Should not be able to bind to the same port again
-err = handle.bind('0.0.0.0', common.PORT);
+var out = {};
+handle.getsockname(out);
+err = handle.bind('0.0.0.0', out.port);
 assert.equal(err, uv.UV_EINVAL);
 
 handle.close();

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -31,7 +31,7 @@ const server = net.createServer(function onClient(client) {
   }
 });
 
-server.listen(common.PORT, common.localhostIPv4, function() {
+server.listen(0, common.localhostIPv4, function() {
   var nbClientsEnded = 0;
 
   function addEndedClient(client) {
@@ -41,9 +41,9 @@ server.listen(common.PORT, common.localhostIPv4, function() {
     }
   }
 
-  const client1 = net.connect({ port: common.PORT });
+  const client1 = net.connect({ port: this.address().port });
   client1.on('end', addEndedClient);
 
-  const client2 = net.connect({ port: common.PORT });
+  const client2 = net.connect({ port: this.address().port });
   client2.on('end', addEndedClient);
 });

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -20,8 +20,8 @@ var server = tls.createServer({
     c.destroy();
     server.close();
   });
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, function() {
     requests++;

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -41,13 +41,13 @@ var server = tls.createServer(opts, function(s) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   sendClient();
 });
 
 
 function sendClient() {
-  var client = tls.connect(common.PORT, {
+  var client = tls.connect(server.address().port, {
     rejectUnauthorized: false
   });
   client.on('data', function(chunk) {
@@ -72,7 +72,7 @@ function sendClient() {
 
 function sendBADTLSRecord() {
   var BAD_RECORD = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-  var socket = net.connect(common.PORT);
+  var socket = net.connect(server.address().port);
   var client = tls.connect({
     socket: socket,
     rejectUnauthorized: false

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -30,9 +30,9 @@ var server = tls.Server({
   secureProtocol: 'TLSv1_2_server_method',
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert')
-}, null).listen(common.PORT, function() {
+}, null).listen(0, function() {
   var args = ['s_client', '-quiet', '-tls1_1',
-              '-connect', '127.0.0.1:' + common.PORT];
+              '-connect', `127.0.0.1:${this.address().port}`];
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -24,7 +24,6 @@ function loadPEM(n) {
   return fs.readFileSync(filenamePEM(n));
 }
 
-var serverPort = common.PORT;
 var serverIP = common.localhostIPv4;
 
 function checkResults(result, expected) {
@@ -43,13 +42,13 @@ function runTest(clientsOptions, serverOptions, cb) {
     results[index].server = {ALPN: c.alpnProtocol, NPN: c.npnProtocol};
   });
 
-  server.listen(serverPort, serverIP, function() {
+  server.listen(0, serverIP, function() {
     connectClient(clientsOptions);
   });
 
   function connectClient(options) {
     var opt = options.shift();
-    opt.port = serverPort;
+    opt.port = server.address().port;
     opt.host = serverIP;
     opt.rejectUnauthorized = false;
 

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -34,9 +34,9 @@ server.on('resumeSession', function(id, cb) {
   next();
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var clientOpts = {
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false,
     session: false
   };

--- a/test/parallel/test-tls-cert-regression.js
+++ b/test/parallel/test-tls-cert-regression.js
@@ -37,7 +37,7 @@ function test(cert, key, cb) {
   var server = tls.createServer({
     cert: cert,
     key: key
-  }).listen(common.PORT, function() {
+  }).listen(0, function() {
     server.close(cb);
   });
 }

--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -31,9 +31,9 @@ var server = tls.createServer(options, function(socket) {
 });
 
 // start listening
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var client = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     client.on('readable', function() {

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -50,9 +50,9 @@ function test(size, type, name, next) {
     if (next) next();
   });
 
-  server.listen(common.PORT, '127.0.0.1', function() {
+  server.listen(0, '127.0.0.1', function() {
     var client = tls.connect({
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, function() {
       var ekeyinfo = client.getEphemeralKeyInfo();

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -38,13 +38,13 @@ function test(size, err, next) {
     if (next) next();
   });
 
-  server.listen(common.PORT, '127.0.0.1', function() {
+  server.listen(0, '127.0.0.1', function() {
     // client set minimum DH parameter size to 2048 bits so that
     // it fails when it make a connection to the tls server where
     // dhparams is 1024 bits
     var client = tls.connect({
       minDHSize: 2048,
-      port: common.PORT,
+      port: this.address().port,
       rejectUnauthorized: false
     }, function() {
       nsuccess++;

--- a/test/parallel/test-tls-client-reject.js
+++ b/test/parallel/test-tls-client-reject.js
@@ -24,13 +24,13 @@ var server = tls.createServer(options, function(socket) {
     console.error(data.toString());
     assert.equal(data, 'ok');
   });
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   unauthorized();
 });
 
 function unauthorized() {
   var socket = tls.connect({
-    port: common.PORT,
+    port: server.address().port,
     servername: 'localhost',
     rejectUnauthorized: false
   }, function() {
@@ -45,7 +45,7 @@ function unauthorized() {
 }
 
 function rejectUnauthorized() {
-  var socket = tls.connect(common.PORT, {
+  var socket = tls.connect(server.address().port, {
     servername: 'localhost'
   }, function() {
     assert(false);
@@ -58,7 +58,7 @@ function rejectUnauthorized() {
 }
 
 function authorized() {
-  var socket = tls.connect(common.PORT, {
+  var socket = tls.connect(server.address().port, {
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))],
     servername: 'localhost'
   }, function() {

--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -28,11 +28,11 @@ var server = tls.Server(options, function(socket) {
 });
 
 // start listening
-server.listen(common.PORT, function() {
+server.listen(0, function() {
 
   var session1 = null;
   var client1 = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     console.log('connect1');
@@ -44,7 +44,7 @@ server.listen(common.PORT, function() {
     console.log('close1');
 
     var opts = {
-      port: common.PORT,
+      port: server.address().port,
       rejectUnauthorized: false,
       session: session1
     };

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -75,10 +75,11 @@ function testServers(index, servers, clientOptions, cb) {
     s.end('hello world\n');
   });
 
-  server.listen(common.PORT, function() {
+  server.listen(0, function() {
     var b = '';
 
     console.error('connecting...');
+    clientOptions.port = this.address().port;
     var client = tls.connect(clientOptions, function() {
       var authorized = client.authorized ||
                        hosterr.test(client.authorizationError);
@@ -109,7 +110,7 @@ function runTest(testIndex) {
   if (!tcase) return;
 
   var clientOptions = {
-    port: common.PORT,
+    port: undefined,
     ca: tcase.ca.map(loadPEM),
     key: loadPEM(tcase.key),
     cert: loadPEM(tcase.cert),

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -18,8 +18,8 @@ var server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 }, function(c) {
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, function() {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, function() {
     assert(false, 'should not be called');
   });
 

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -19,8 +19,8 @@ var server = tls.createServer({
   // Send close-notify without shutting down TCP socket
   if (c._handle.shutdownSSL() !== 1)
     c._handle.shutdownSSL();
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, function() {
     // Ensure that we receive 'end' event anyway

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -31,7 +31,7 @@ var testCases = [
       cert: loadPEM('agent7-cert')
     },
     clientOpts: {
-      port: common.PORT,
+      port: undefined,
       rejectUnauthorized: true,
       ca: [loadPEM('fake-cnnic-root-cert')]
     },
@@ -50,7 +50,7 @@ var testCases = [
       cert: loadPEM('agent6-cert')
     },
     clientOpts: {
-      port: common.PORT,
+      port: undefined,
       rejectUnauthorized: true
     },
     errorCode: 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY'
@@ -64,7 +64,8 @@ function runTest(tindex) {
 
   var server = tls.createServer(tcase.serverOpts, function(s) {
     s.resume();
-  }).listen(common.PORT, function() {
+  }).listen(0, function() {
+    tcase.clientOpts = this.address().port;
     var client = tls.connect(tcase.clientOpts);
     client.on('error', function(e) {
       assert.strictEqual(e.code, tcase.errorCode);

--- a/test/parallel/test-tls-connect-given-socket.js
+++ b/test/parallel/test-tls-connect-given-socket.js
@@ -23,7 +23,7 @@ var options = {
 var server = tls.createServer(options, function(socket) {
   serverConnected++;
   socket.end('Hello');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var waiting = 2;
   function establish(socket) {
     var client = tls.connect({
@@ -48,11 +48,11 @@ var server = tls.createServer(options, function(socket) {
   }
 
   // Immediate death socket
-  var immediateDeath = net.connect(common.PORT);
+  var immediateDeath = net.connect(this.address().port);
   establish(immediateDeath).destroy();
 
   // Outliving
-  var outlivingTCP = net.connect(common.PORT);
+  var outlivingTCP = net.connect(this.address().port);
   outlivingTCP.on('connect', function() {
     outlivingTLS.destroy();
     next();
@@ -61,12 +61,12 @@ var server = tls.createServer(options, function(socket) {
 
   function next() {
     // Already connected socket
-    var connected = net.connect(common.PORT, function() {
+    var connected = net.connect(server.address().port, function() {
       establish(connected);
     });
 
     // Connecting socket
-    var connecting = net.connect(common.PORT);
+    var connecting = net.connect(server.address().port);
     establish(connecting);
 
   }

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -20,16 +20,16 @@ var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 tls.createServer({
   key: key,
   cert: cert
-}).listen(common.PORT);
-
-var socket = tls.connect({
-  port: common.PORT,
-  ca: cert,
-  // No host set here. 'localhost' is the default,
-  // but tls.checkServerIdentity() breaks before the fix with:
-  // Error: Hostname/IP doesn't match certificate's altnames:
-  //   "Host: undefined. is not cert's CN: localhost"
-}, function() {
-  assert(socket.authorized);
-  process.exit();
+}).listen(0, function() {
+  var socket = tls.connect({
+    port: this.address().port,
+    ca: cert,
+    // No host set here. 'localhost' is the default,
+    // but tls.checkServerIdentity() breaks before the fix with:
+    // Error: Hostname/IP doesn't match certificate's altnames:
+    //   "Host: undefined. is not cert's CN: localhost"
+  }, function() {
+    assert(socket.authorized);
+    process.exit();
+  });
 });

--- a/test/parallel/test-tls-connect-secure-context.js
+++ b/test/parallel/test-tls-connect-secure-context.js
@@ -21,7 +21,7 @@ const server = tls.createServer({
   key: key
 }, function(c) {
   c.end();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   const secureContext = tls.createSecureContext({
     ca: ca
   });
@@ -29,7 +29,7 @@ const server = tls.createServer({
   const socket = tls.connect({
     secureContext: secureContext,
     servername: 'agent1',
-    port: common.PORT
+    port: this.address().port
   }, common.mustCall(function() {
     server.close();
     socket.end();

--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -31,9 +31,9 @@ var server = tls.Server(options, function(socket) {
   }
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var client1 = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     ++clientConnected;
@@ -41,7 +41,7 @@ server.listen(common.PORT, function() {
   });
 
   var client2 = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   });
   client2.on('secureConnect', function() {

--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -25,8 +25,8 @@ server = tls.createServer(options, function(s) {
     recv_bufs.push(c);
   });
 });
-server.listen(common.PORT, function() {
-  var raw = net.connect(common.PORT);
+server.listen(0, function() {
+  var raw = net.connect(this.address().port);
 
   var pending = false;
   raw.on('readable', function() {

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -34,8 +34,8 @@ var server = net.createServer(function(c) {
       s.destroy();
     });
   }, 200);
-}).listen(common.PORT, function() {
-  var c = net.connect({port: common.PORT}, function() {
+}).listen(0, function() {
+  var c = net.connect({port: this.address().port}, function() {
     c.write(bonkers);
   });
 });

--- a/test/parallel/test-tls-delayed-attach.js
+++ b/test/parallel/test-tls-delayed-attach.js
@@ -35,8 +35,8 @@ var server = net.createServer(function(c) {
       s.destroy();
     });
   }, 200);
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, function() {
     c.end(sent);

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -40,8 +40,8 @@ function test(keylen, expectedCipher, cb) {
     if (cb) cb();
   });
 
-  server.listen(common.PORT, '127.0.0.1', function() {
-    var args = ['s_client', '-connect', '127.0.0.1:' + common.PORT,
+  server.listen(0, '127.0.0.1', function() {
+    var args = ['s_client', '-connect', `127.0.0.1:${this.address().port}`,
                 '-cipher', ciphers];
 
     // for the performance and stability issue in s_client on Windows

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -29,9 +29,9 @@ var server = tls.createServer(options, function(conn) {
   nconns++;
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
-            ' -connect 127.0.0.1:' + common.PORT;
+            ` -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -32,9 +32,9 @@ var server = tls.createServer(options, function(conn) {
   nconns++;
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
-            ' -connect 127.0.0.1:' + common.PORT;
+            ` -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-econnreset.js
+++ b/test/parallel/test-tls-econnreset.js
@@ -54,10 +54,10 @@ var server = tls.createServer({ ca: ca, cert: cert, key: key }, function(conn) {
 }).on('tlsClientError', function(err, conn) {
   assert(!clientError && conn);
   clientError = err;
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var options = {
     ciphers: 'AES128-GCM-SHA256',
-    port: common.PORT,
+    port: this.address().port,
     ca: ca
   };
   tls.connect(options).on('error', function(err) {

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -27,9 +27,9 @@ const server = tls.createServer(options, (c) => {
 }).on('tlsClientError', common.mustCall((err, c) => {
   assert(/SSL_use_certificate:passed a null parameter/i.test(err.message));
   server.close();
-})).listen(common.PORT, common.mustCall(() => {
+})).listen(0, common.mustCall(() => {
   const c = tls.connect({
-    port: common.PORT,
+    port: server.address().port,
     rejectUnauthorized: false,
     servername: 'any.name'
   }, () => {

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -10,7 +10,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var PORT = common.PORT;
 var dir = common.fixturesDir;
 var options = { key: fs.readFileSync(dir + '/test_key.pem'),
                 cert: fs.readFileSync(dir + '/test_cert.pem'),
@@ -41,9 +40,9 @@ function onconnection(conn) {
   });
 }
 
-server.listen(PORT, function() {
+server.listen(0, function() {
   var chunk = Buffer.alloc(1024, 'x');
-  var opt = { port: PORT, rejectUnauthorized: false };
+  var opt = { port: this.address().port, rejectUnauthorized: false };
   var conn = tls.connect(opt, function() {
     conn.on('drain', ondrain);
     write();

--- a/test/parallel/test-tls-friendly-error-message.js
+++ b/test/parallel/test-tls-friendly-error-message.js
@@ -16,7 +16,7 @@ var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
 tls.createServer({ key: key, cert: cert }, function(conn) {
   conn.end();
   this.close();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var options = { port: this.address().port, rejectUnauthorized: true };
   tls.connect(options).on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'UNABLE_TO_VERIFY_LEAF_SIGNATURE');

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -28,10 +28,10 @@ var server = tls.createServer(options, function(cleartextStream) {
   nconns++;
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var client = tls.connect({
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     ciphers: cipher_list.join(':'),
     rejectUnauthorized: false
   }, function() {

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -23,12 +23,12 @@ const serverConfig = {
 
 const server = tls.createServer(serverConfig, common.mustCall(function() {
 
-}, clientConfigs.length)).listen(common.PORT, common.localhostIPv4, function() {
+}, clientConfigs.length)).listen(0, common.localhostIPv4, function() {
   let connected = 0;
   clientConfigs.forEach(function(v) {
     tls.connect({
       host: common.localhostIPv4,
-      port: common.PORT,
+      port: server.address().port,
       rejectUnauthorized: false,
       secureProtocol: v.secureProtocol
     }, common.mustCall(function() {

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -19,9 +19,9 @@ var server = tls.createServer({
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
   rejectUnauthorized: true
 }, function(c) {
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var c = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     ciphers: 'RC4'
   }, function() {
     assert(false, 'should not be called');

--- a/test/parallel/test-tls-hello-parser-failure.js
+++ b/test/parallel/test-tls-hello-parser-failure.js
@@ -20,8 +20,8 @@ var bonkers = Buffer.alloc(1024 * 1024, 42);
 
 var server = tls.createServer(options, function(c) {
 
-}).listen(common.PORT, function() {
-  var client = net.connect(common.PORT, function() {
+}).listen(0, function() {
+  var client = net.connect(this.address().port, function() {
     client.write(bonkers);
   });
 

--- a/test/parallel/test-tls-honorcipherorder.js
+++ b/test/parallel/test-tls-honorcipherorder.js
@@ -37,7 +37,7 @@ function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
     // it may hang for ~30 seconds in FIN_WAIT_1 state (at least on OSX).
     cleartextStream.end();
   });
-  server.listen(common.PORT, localhost, function() {
+  server.listen(0, localhost, function() {
     var coptions = {
       rejectUnauthorized: false,
       secureProtocol: SSL_Method
@@ -45,7 +45,8 @@ function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
     if (clientCipher) {
       coptions.ciphers = clientCipher;
     }
-    var client = tls.connect(common.PORT, localhost, coptions, function() {
+    const port = this.address().port;
+    var client = tls.connect(port, localhost, coptions, function() {
       var cipher = client.getCipher();
       client.end();
       server.close();

--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -42,8 +42,8 @@ b = tls.createServer(options, function(socket) {
   socket.end(body);
 });
 
-a.listen(common.PORT, function() {
-  b.listen(common.PORT + 1, function() {
+a.listen(0, function() {
+  b.listen(0, function() {
     options = {
       host: '127.0.0.1',
       port: a.address().port,

--- a/test/parallel/test-tls-interleave.js
+++ b/test/parallel/test-tls-interleave.js
@@ -10,7 +10,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var PORT = common.PORT;
 var dir = common.fixturesDir;
 var options = { key: fs.readFileSync(dir + '/test_key.pem'),
                 cert: fs.readFileSync(dir + '/test_cert.pem'),
@@ -27,8 +26,9 @@ var server = tls.createServer(options, function(c) {
   writes.forEach(function(str) {
     c.write(str);
   });
-}).listen(PORT, function() {
-  var c = tls.connect(PORT, { rejectUnauthorized: false }, function() {
+}).listen(0, function() {
+  const connectOpts = { rejectUnauthorized: false };
+  var c = tls.connect(this.address().port, connectOpts, function() {
     c.write('some client data');
     c.on('readable', function() {
       var data = c.read();

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -26,8 +26,8 @@ var server = tls.createServer({
   });
 
   server.close();
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, function() {
     c.on('data', function(chunk) {

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -24,8 +24,8 @@ var server = tls.createServer({
   console.log('new client');
   connected.server++;
   c.end('ohai');
-}).listen(common.PORT, function() {
-  var raw = net.connect(common.PORT);
+}).listen(0, function() {
+  var raw = net.connect(this.address().port);
 
   var pending = false;
   raw.on('readable', function() {

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -20,8 +20,8 @@ var server = tls.createServer(options, function(s) {
   s.pipe(s);
 });
 
-server.listen(common.PORT, function() {
-  var c = net.createConnection(common.PORT);
+server.listen(0, function() {
+  var c = net.createConnection(this.address().port);
 
   c.on('connect', function() {
     c.write('blah\nblah\nblah\n');

--- a/test/parallel/test-tls-junk-server.js
+++ b/test/parallel/test-tls-junk-server.js
@@ -18,8 +18,8 @@ const server = net.createServer(function(s) {
   });
 });
 
-server.listen(common.PORT, function() {
-  const req = https.request({ port: common.PORT });
+server.listen(0, function() {
+  const req = https.request({ port: this.address().port });
   req.end();
 
   req.once('error', common.mustCall(function(err) {

--- a/test/parallel/test-tls-legacy-onselect.js
+++ b/test/parallel/test-tls-legacy-onselect.js
@@ -20,9 +20,9 @@ var server = net.Server(function(raw) {
     success = true;
   });
   require('_tls_legacy').pipe(pair, raw);
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false,
     servername: 'server'
   }, function() {

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -27,8 +27,8 @@ var server = tls.createServer({
   assert(c.setMaxSendFragment(maxChunk));
 
   c.end(buf);
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, function() {
     c.on('data', function(chunk) {

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -24,13 +24,13 @@ var ciphers = [];
 
 var server = tls.createServer(options, function(conn) {
   conn.end('ok');
-}).listen(common.PORT, function() {
-  var ecdsa = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var ecdsa = tls.connect(this.address().port, {
     ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384',
     rejectUnauthorized: false
   }, function() {
     ciphers.push(ecdsa.getCipher());
-    var rsa = tls.connect(common.PORT, {
+    var rsa = tls.connect(server.address().port, {
       ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
       rejectUnauthorized: false
     }, function() {

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -10,6 +10,6 @@ var tls = require('tls');
 // Omitting the cert or pfx option to tls.createServer() should not throw.
 // AECDH-NULL-SHA is a no-authentication/no-encryption cipher and hence
 // doesn't need a certificate.
-tls.createServer({ ciphers: 'AECDH-NULL-SHA' }).listen(common.PORT, function() {
+tls.createServer({ ciphers: 'AECDH-NULL-SHA' }).listen(0, function() {
   this.close();
 });

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -19,8 +19,8 @@ var cert = null;
 
 var server = tls.createServer(options, function(conn) {
   conn.end('ok');
-}).listen(common.PORT, function() {
-  var c = tls.connect(common.PORT, {
+}).listen(0, function() {
+  var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, function() {
     c.on('end', common.mustCall(function() {

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -22,7 +22,7 @@ var server = tls.createServer({ cert: cert, key: key }, common.fail);
 var errors = [];
 var stderr = '';
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var address = this.address().address + ':' + this.address().port;
   var args = ['s_client',
               '-no_ssl2',

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -38,30 +38,28 @@ var serverOptions = {
   NPNProtocols: ['a', 'b', 'c']
 };
 
-var serverPort = common.PORT;
-
 var clientsOptions = [{
-  port: serverPort,
+  port: undefined,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
   NPNProtocols: ['a', 'b', 'c'],
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
   NPNProtocols: ['c', 'b', 'e'],
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: serverOptions.key,
   cert: serverOptions.cert,
   crl: serverOptions.crl,
@@ -75,10 +73,11 @@ const clientsResults = [];
 var server = tls.createServer(serverOptions, function(c) {
   serverResults.push(c.npnProtocol);
 });
-server.listen(serverPort, startTest);
+server.listen(0, startTest);
 
 function startTest() {
   function connectClient(options, callback) {
+    options.port = server.address().port;
     var client = tls.connect(options, function() {
       clientsResults.push(client.npnProtocol);
       client.destroy();

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -72,9 +72,9 @@ function test(testOptions, cb) {
                testOptions.response ? Buffer.from(testOptions.response) : null);
     }, 100);
   });
-  server.listen(common.PORT, function() {
+  server.listen(0, function() {
     var client = tls.connect({
-      port: common.PORT,
+      port: this.address().port,
       requestOCSP: testOptions.ocsp !== false,
       secureOptions: testOptions.ocsp === false ?
           SSL_OP_NO_TICKET : 0,

--- a/test/parallel/test-tls-on-empty-socket.js
+++ b/test/parallel/test-tls-on-empty-socket.js
@@ -18,7 +18,7 @@ var server = tls.createServer({
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 }, function(c) {
   c.end('hello');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var socket = new net.Socket();
 
   var s = tls.connect({
@@ -34,7 +34,7 @@ var server = tls.createServer({
     });
   });
 
-  socket.connect(common.PORT);
+  socket.connect(this.address().port);
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -26,9 +26,9 @@ var server = tls.Server({
 });
 
 var connectCount = 0;
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var c = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     key: key,
     passphrase: 'passphrase',
     cert: cert,
@@ -43,7 +43,7 @@ server.listen(common.PORT, function() {
 
 assert.throws(function() {
   tls.connect({
-    port: common.PORT,
+    port: server.address().port,
     key: key,
     passphrase: 'invalid',
     cert: cert,

--- a/test/parallel/test-tls-pause.js
+++ b/test/parallel/test-tls-pause.js
@@ -27,10 +27,10 @@ var server = tls.Server(options, function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var resumed = false;
   var client = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     console.error('connected');

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -22,9 +22,9 @@ var verified = false;
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var socket = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     var peerCert = socket.getPeerCertificate();

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -21,9 +21,9 @@ var verified = false;
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var socket = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     var peerCert = socket.getPeerCertificate();

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -22,9 +22,9 @@ var verified = false;
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var socket = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   }, function() {
     var peerCert = socket.getPeerCertificate();

--- a/test/parallel/test-tls-pfx-gh-5100-regr.js
+++ b/test/parallel/test-tls-pfx-gh-5100-regr.js
@@ -23,9 +23,9 @@ const server = tls.createServer({
 }, common.mustCall(function(c) {
   assert(c.authorizationError === null, 'authorizationError must be null');
   c.end();
-})).listen(common.PORT, function() {
+})).listen(0, function() {
   var client = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     pfx: pfx,
     passphrase: 'sample',
     rejectUnauthorized: false

--- a/test/parallel/test-tls-regr-gh-5108.js
+++ b/test/parallel/test-tls-regr-gh-5108.js
@@ -18,9 +18,9 @@ const options = {
 
 const server = tls.createServer(options, function(s) {
   s.end('hello');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   const opts = {
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   };
   const client = tls.connect(opts, function() {

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -28,9 +28,9 @@ var server = tls.Server(options, function(socket) {
   });
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   });
 });

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -91,10 +91,10 @@ var sentWorld = false;
 var gotWorld = false;
 var opensslExitCode = -1;
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   // To test use: openssl s_client -connect localhost:8000
 
-  var args = ['s_client', '-connect', '127.0.0.1:' + common.PORT];
+  var args = ['s_client', '-connect', `127.0.0.1:${this.address().port}`];
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-server-connection-server.js
+++ b/test/parallel/test-tls-server-connection-server.js
@@ -17,9 +17,9 @@ const options = {
 
 const server = tls.createServer(options, function(s) {
   s.end('hello');
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   const opts = {
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   };
 

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -317,6 +317,7 @@ function runTest(port, testIndex) {
   }
 
   server.listen(port, function() {
+    port = server.address().port;
     if (tcase.debug) {
       console.error(prefix + 'TLS server running on port ' + port);
     } else {
@@ -341,8 +342,8 @@ function runTest(port, testIndex) {
 
 
 var nextTest = 0;
-runTest(common.PORT, nextTest++);
-runTest(common.PORT + 1, nextTest++);
+runTest(0, nextTest++);
+runTest(0, nextTest++);
 
 
 process.on('exit', function() {

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -71,21 +71,21 @@ function doTest(testOptions, callback) {
     }, 100);
   });
 
-  var args = [
-    's_client',
-    '-tls1',
-    '-connect', 'localhost:' + common.PORT,
-    '-servername', 'ohgod',
-    '-key', join(common.fixturesDir, 'agent.key'),
-    '-cert', join(common.fixturesDir, 'agent.crt'),
-    '-reconnect'
-  ].concat(testOptions.tickets ? [] : '-no_ticket');
+  server.listen(0, function() {
+    var args = [
+      's_client',
+      '-tls1',
+      '-connect', `localhost:${this.address().port}`,
+      '-servername', 'ohgod',
+      '-key', join(common.fixturesDir, 'agent.key'),
+      '-cert', join(common.fixturesDir, 'agent.crt'),
+      '-reconnect'
+    ].concat(testOptions.tickets ? [] : '-no_ticket');
 
-  // for the performance and stability issue in s_client on Windows
-  if (common.isWindows)
-    args.push('-no_rand_screen');
+    // for the performance and stability issue in s_client on Windows
+    if (common.isWindows)
+      args.push('-no_rand_screen');
 
-  server.listen(common.PORT, function() {
     var client = spawn(common.opensslCli, args, {
       stdio: [ 0, 1, 'pipe' ]
     });

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -36,9 +36,9 @@ var server = tls.createServer(options, function(conn) {
   nconns++;
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
-            ' -connect 127.0.0.1:' + common.PORT;
+            ` -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -26,9 +26,9 @@ var server = tls.Server(options, function(socket) {
 });
 
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   var client = tls.connect({
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   });
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -60,38 +60,36 @@ var SNIContexts = {
   }
 };
 
-var serverPort = common.PORT;
-
 var clientsOptions = [{
-  port: serverPort,
+  port: undefined,
   key: loadPEM('agent1-key'),
   cert: loadPEM('agent1-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: loadPEM('agent4-key'),
   cert: loadPEM('agent4-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: loadPEM('agent2-key'),
   cert: loadPEM('agent2-cert'),
   ca: [loadPEM('ca2-cert')],
   servername: 'b.example.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: loadPEM('agent3-key'),
   cert: loadPEM('agent3-cert'),
   ca: [loadPEM('ca1-cert')],
   servername: 'c.wrong.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   key: loadPEM('agent3-key'),
   cert: loadPEM('agent3-cert'),
   ca: [loadPEM('ca1-cert')],
@@ -115,7 +113,7 @@ server.on('tlsClientError', function(err) {
   serverError = err.message;
 });
 
-server.listen(serverPort, startTest);
+server.listen(0, startTest);
 
 function startTest() {
   function connectClient(i, callback) {
@@ -123,6 +121,7 @@ function startTest() {
     clientError = null;
     serverError = null;
 
+    options.port = server.address().port;
     var client = tls.connect(options, function() {
       clientResults.push(
           /Hostname\/IP doesn't/.test(client.authorizationError || ''));

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -44,30 +44,28 @@ var SNIContexts = {
   }
 };
 
-var serverPort = common.PORT;
-
 var clientsOptions = [{
-  port: serverPort,
+  port: undefined,
   ca: [loadPEM('ca1-cert')],
   servername: 'a.example.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   ca: [loadPEM('ca2-cert')],
   servername: 'b.test.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   ca: [loadPEM('ca2-cert')],
   servername: 'a.b.test.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   ca: [loadPEM('ca1-cert')],
   servername: 'c.wrong.com',
   rejectUnauthorized: false
 }, {
-  port: serverPort,
+  port: undefined,
   ca: [loadPEM('ca1-cert')],
   servername: 'chain.example.com',
   rejectUnauthorized: false
@@ -84,7 +82,7 @@ server.addContext('a.example.com', SNIContexts['a.example.com']);
 server.addContext('*.test.com', SNIContexts['asterisk.test.com']);
 server.addContext('chain.example.com', SNIContexts['chain.example.com']);
 
-server.listen(serverPort, startTest);
+server.listen(0, startTest);
 
 function startTest() {
   var i = 0;
@@ -94,6 +92,7 @@ function startTest() {
       return server.close();
 
     var options = clientsOptions[i++];
+    options.port = server.address().port;
     var client = tls.connect(options, function() {
       clientResults.push(
         client.authorizationError &&

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -31,9 +31,9 @@ function testSocketOptions(socket, socketOptions) {
       assert.equal(received, sent);
       setImmediate(runTests);
     });
-  }).listen(common.PORT, function() {
+  }).listen(0, function() {
     const c = new tls.TLSSocket(socket, socketOptions);
-    c.connect(common.PORT, function() {
+    c.connect(this.address().port, function() {
       c.end(sent);
     });
   });

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -57,7 +57,7 @@ var servers = naturalServers.concat(naturalServers).concat(naturalServers);
 // Create one TCP server and balance sockets to multiple TLS server instances
 var shared = net.createServer(function(c) {
   servers.shift().emit('connection', c);
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   start(function() {
     shared.close();
   });
@@ -68,7 +68,7 @@ function start(callback) {
   var left = servers.length;
 
   function connect() {
-    var s = tls.connect(common.PORT, {
+    var s = tls.connect(shared.address().port, {
       session: sess,
       rejectUnauthorized: false
     }, function() {

--- a/test/parallel/test-tls-timeout-server-2.js
+++ b/test/parallel/test-tls-timeout-server-2.js
@@ -23,10 +23,10 @@ var server = tls.createServer(options, function(cleartext) {
   assert.ok(s instanceof tls.TLSSocket);
 });
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   tls.connect({
     host: '127.0.0.1',
-    port: common.PORT,
+    port: this.address().port,
     rejectUnauthorized: false
   });
 });

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -31,6 +31,6 @@ server.on('tlsClientError', function(err, conn) {
   clientErrors++;
 });
 
-server.listen(common.PORT, function() {
-  net.connect({ host: '127.0.0.1', port: common.PORT });
+server.listen(0, function() {
+  net.connect({ host: '127.0.0.1', port: this.address().port });
 });

--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -27,9 +27,8 @@ function test(ca, next) {
   server.addContext('agent3', { ca, cert, key });
 
   const host = common.localhostIPv4;
-  const port = common.PORT;
-  server.listen(port, host, function() {
-    tls.connect({ servername: 'agent3', host, port, ca });
+  server.listen(0, host, function() {
+    tls.connect({ servername: 'agent3', host, port: this.address().port, ca });
   });
 
   server.once('close', next);

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -26,8 +26,8 @@ var server = tls.createServer(options, function(c) {
   }, 150);
 });
 
-server.listen(common.PORT, function() {
-  var socket = net.connect(common.PORT, function() {
+server.listen(0, function() {
+  var socket = net.connect(this.address().port, function() {
     var s = socket.setTimeout(common.platformTimeout(240), function() {
       throw new Error('timeout');
     });

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -25,12 +25,12 @@ var server = tls.createServer({
     c.end();
     server.close();
   }, 20);
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var conn = tls.connect({
     cert: cert,
     key: key,
     rejectUnauthorized: false,
-    port: common.PORT
+    port: this.address().port
   }, function() {
     setTimeout(function() {
       conn.destroy();

--- a/test/parallel/test-zerolengthbufferbug.js
+++ b/test/parallel/test-zerolengthbufferbug.js
@@ -1,7 +1,7 @@
 'use strict';
 // Serving up a zero-length buffer should work.
 
-var common = require('../common');
+require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -16,8 +16,8 @@ var server = http.createServer(function(req, res) {
 var gotResponse = false;
 var resBodySize = 0;
 
-server.listen(common.PORT, function() {
-  http.get({ port: common.PORT }, function(res) {
+server.listen(0, function() {
+  http.get({ port: this.address().port }, function(res) {
     gotResponse = true;
 
     res.on('data', function(d) {


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

* test


##### Description of change

This helps to prevent issues where a failed test can keep a bound socket open long enough to cause other tests to fail with `EADDRINUSE` because the same port number is used.

I should note that this commit still leaves some tests unmodified (mostly `cluster`-related and `debugger`-related tests), because either #7043 needs to land first or the solution is a little trickier than with typical tests. There are also some tests that use `common.PORT` but they do not pass it to `.bind()` or `.listen()`, so those should be safe to keep as-is.