### PR TITLE
test: fix test-debug-port-numbers on OS X

### DIFF
--- a/test/parallel/test-debug-port-numbers.js
+++ b/test/parallel/test-debug-port-numbers.js
@@ -44,7 +44,9 @@ function kill(child) {
   try {
     process.kill(-child.pid);  // Kill process group.
   } catch (e) {
-    assert.strictEqual(e.code, 'ESRCH');  // Already gone.
+    // Generally ESRCH is returned when the process group is already gone. On
+    // some platforms such as OS X it may be EPERM though.
+    assert.ok((e.code === 'EPERM') || (e.code === 'ESRCH'));
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].

Run the test suite with: `make -j4 test` on UNIX or `vcbuild test nosign` on
Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test

##### Description of change
<!-- provide a description of the change below this comment -->

According to kill(2), kill returns `EPERM` error if when signalling a
process group any of the members could not be signaled.

Refs: https://github.com/nodejs/node/pull/7037