### PR TITLE
Backporting Async Wrap changes

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -51,11 +51,15 @@ inline AsyncWrap::AsyncWrap(Environment* env,
     argv[3] = parent->object();
   }
 
+  v8::TryCatch try_catch(env->isolate());
+
   v8::MaybeLocal<v8::Value> ret =
       init_fn->Call(env->context(), object, arraysize(argv), argv);
 
-  if (ret.IsEmpty())
-    FatalError("node::AsyncWrap::AsyncWrap", "init hook threw");
+  if (ret.IsEmpty()) {
+    ClearFatalExceptionHandlers(env);
+    FatalException(env->isolate(), try_catch);
+  }
 
   bits_ |= 1;  // ran_init_callback() is true now.
 }
@@ -69,10 +73,13 @@ inline AsyncWrap::~AsyncWrap() {
   if (!fn.IsEmpty()) {
     v8::HandleScope scope(env()->isolate());
     v8::Local<v8::Value> uid = v8::Integer::New(env()->isolate(), get_uid());
+    v8::TryCatch try_catch(env()->isolate());
     v8::MaybeLocal<v8::Value> ret =
         fn->Call(env()->context(), v8::Null(env()->isolate()), 1, &uid);
-    if (ret.IsEmpty())
-      FatalError("node::AsyncWrap::~AsyncWrap", "destroy hook threw");
+    if (ret.IsEmpty()) {
+      ClearFatalExceptionHandlers(env());
+      FatalException(env()->isolate(), try_catch);
+    }
   }
 }
 

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -40,14 +40,14 @@ inline AsyncWrap::AsyncWrap(Environment* env,
   v8::HandleScope scope(env->isolate());
 
   v8::Local<v8::Value> argv[] = {
-    v8::Integer::New(env->isolate(), get_uid()),
+    v8::Number::New(env->isolate(), get_uid()),
     v8::Int32::New(env->isolate(), provider),
     Null(env->isolate()),
     Null(env->isolate())
   };
 
   if (parent != nullptr) {
-    argv[2] = v8::Integer::New(env->isolate(), parent->get_uid());
+    argv[2] = v8::Number::New(env->isolate(), parent->get_uid());
     argv[3] = parent->object();
   }
 
@@ -72,7 +72,7 @@ inline AsyncWrap::~AsyncWrap() {
   v8::Local<v8::Function> fn = env()->async_hooks_destroy_function();
   if (!fn.IsEmpty()) {
     v8::HandleScope scope(env()->isolate());
-    v8::Local<v8::Value> uid = v8::Integer::New(env()->isolate(), get_uid());
+    v8::Local<v8::Value> uid = v8::Number::New(env()->isolate(), get_uid());
     v8::TryCatch try_catch(env()->isolate());
     v8::MaybeLocal<v8::Value> ret =
         fn->Call(env()->context(), v8::Null(env()->isolate()), 1, &uid);

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -40,8 +40,8 @@ inline AsyncWrap::AsyncWrap(Environment* env,
   v8::HandleScope scope(env->isolate());
 
   v8::Local<v8::Value> argv[] = {
-    v8::Int32::New(env->isolate(), provider),
     v8::Integer::New(env->isolate(), get_uid()),
+    v8::Int32::New(env->isolate(), provider),
     Null(env->isolate())
   };
 

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -42,11 +42,14 @@ inline AsyncWrap::AsyncWrap(Environment* env,
   v8::Local<v8::Value> argv[] = {
     v8::Integer::New(env->isolate(), get_uid()),
     v8::Int32::New(env->isolate(), provider),
+    Null(env->isolate()),
     Null(env->isolate())
   };
 
-  if (parent != nullptr)
-    argv[2] = parent->object();
+  if (parent != nullptr) {
+    argv[2] = v8::Integer::New(env->isolate(), parent->get_uid());
+    argv[3] = parent->object();
+  }
 
   v8::MaybeLocal<v8::Value> ret =
       init_fn->Call(env->context(), object, arraysize(argv), argv);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -193,7 +193,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
     if (has_domain) {
       domain = domain_v.As<Object>();
       if (domain->Get(env()->disposed_string())->IsTrue())
-        return Undefined(env()->isolate());
+        return Local<Value>();
     }
   }
 
@@ -220,7 +220,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (ret.IsEmpty()) {
-    return Undefined(env()->isolate());
+    return ret;
   }
 
   if (has_domain) {
@@ -249,7 +249,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (env()->tick_callback_function()->Call(process, 0, nullptr).IsEmpty()) {
-    return Undefined(env()->isolate());
+    return Local<Value>();
   }
 
   return ret;

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -207,25 +207,22 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (ran_init_callback() && !pre_fn.IsEmpty()) {
-    try_catch.SetVerbose(false);
     pre_fn->Call(context, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::AsyncWrap::MakeCallback", "pre hook threw");
-    try_catch.SetVerbose(true);
   }
 
   Local<Value> ret = cb->Call(context, argc, argv);
 
-  if (try_catch.HasCaught()) {
-    return Undefined(env()->isolate());
-  }
-
   if (ran_init_callback() && !post_fn.IsEmpty()) {
-    try_catch.SetVerbose(false);
     post_fn->Call(context, 0, nullptr);
     if (try_catch.HasCaught())
       FatalError("node::AsyncWrap::MakeCallback", "post hook threw");
-    try_catch.SetVerbose(true);
+  }
+
+  // If the return value is empty then the callback threw.
+  if (ret.IsEmpty()) {
+    return Undefined(env()->isolate());
   }
 
   if (has_domain) {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -173,8 +173,8 @@ void LoadAsyncWrapperInfo(Environment* env) {
 
 
 Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
-                                      int argc,
-                                      Local<Value>* argv) {
+                                     int argc,
+                                     Local<Value>* argv) {
   CHECK(env()->context() == env()->isolate()->GetCurrentContext());
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
@@ -254,7 +254,6 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   env()->tick_callback_function()->Call(process, 0, nullptr);
 
   if (try_catch.HasCaught()) {
-    tick_info->set_last_threw(true);
     return Undefined(env()->isolate());
   }
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -181,7 +181,6 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   Local<Function> post_fn = env()->async_hooks_post_function();
   Local<Value> uid = Integer::New(env()->isolate(), get_uid());
   Local<Object> context = object();
-  Local<Object> process = env()->process_object();
   Local<Object> domain;
   bool has_domain = false;
 
@@ -233,15 +232,17 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
     }
   }
 
-  Environment::TickInfo* tick_info = env()->tick_info();
-
   if (callback_scope.in_makecallback()) {
     return ret;
   }
 
+  Environment::TickInfo* tick_info = env()->tick_info();
+
   if (tick_info->length() == 0) {
     env()->isolate()->RunMicrotasks();
   }
+
+  Local<Object> process = env()->process_object();
 
   if (tick_info->length() == 0) {
     tick_info->set_index(0);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -121,18 +121,35 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
 
   if (env->async_hooks()->callbacks_enabled())
     return env->ThrowError("hooks should not be set while also enabled");
+  if (!args[0]->IsObject())
+    return env->ThrowTypeError("first argument must be an object");
 
-  if (!args[0]->IsFunction())
+  Local<Object> fn_obj = args[0].As<Object>();
+
+  Local<Value> init_v = fn_obj->Get(
+      env->context(),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "init")).ToLocalChecked();
+  Local<Value> pre_v = fn_obj->Get(
+      env->context(),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "pre")).ToLocalChecked();
+  Local<Value> post_v = fn_obj->Get(
+      env->context(),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "post")).ToLocalChecked();
+  Local<Value> destroy_v = fn_obj->Get(
+      env->context(),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "destroy")).ToLocalChecked();
+
+  if (!init_v->IsFunction())
     return env->ThrowTypeError("init callback must be a function");
 
-  env->set_async_hooks_init_function(args[0].As<Function>());
+  env->set_async_hooks_init_function(init_v.As<Function>());
 
-  if (args[1]->IsFunction())
-    env->set_async_hooks_pre_function(args[1].As<Function>());
-  if (args[2]->IsFunction())
-    env->set_async_hooks_post_function(args[2].As<Function>());
-  if (args[3]->IsFunction())
-    env->set_async_hooks_destroy_function(args[3].As<Function>());
+  if (pre_v->IsFunction())
+    env->set_async_hooks_pre_function(pre_v.As<Function>());
+  if (post_v->IsFunction())
+    env->set_async_hooks_post_function(post_v.As<Function>());
+  if (destroy_v->IsFunction())
+    env->set_async_hooks_destroy_function(destroy_v.As<Function>());
 }
 
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -19,6 +19,7 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
+using v8::Number;
 using v8::Object;
 using v8::RetainedObjectInfo;
 using v8::TryCatch;
@@ -198,7 +199,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
   Local<Function> post_fn = env()->async_hooks_post_function();
-  Local<Value> uid = Integer::New(env()->isolate(), get_uid());
+  Local<Value> uid = Number::New(env()->isolate(), get_uid());
   Local<Object> context = object();
   Local<Object> domain;
   bool has_domain = false;

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -9,6 +9,7 @@
 #include "v8-profiler.h"
 
 using v8::Array;
+using v8::Boolean;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -231,7 +232,9 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   Local<Value> ret = cb->Call(context, argc, argv);
 
   if (ran_init_callback() && !post_fn.IsEmpty()) {
-    if (post_fn->Call(context, 1, &uid).IsEmpty())
+    Local<Value> did_throw = Boolean::New(env()->isolate(), ret.IsEmpty());
+    Local<Value> vals[] = { uid, did_throw };
+    if (post_fn->Call(context, arraysize(vals), vals).IsEmpty())
       FatalError("node::AsyncWrap::MakeCallback", "post hook threw");
   }
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -179,6 +179,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
   Local<Function> post_fn = env()->async_hooks_post_function();
+  Local<Value> uid = Integer::New(env()->isolate(), get_uid());
   Local<Object> context = object();
   Local<Object> process = env()->process_object();
   Local<Object> domain;
@@ -207,14 +208,14 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   }
 
   if (ran_init_callback() && !pre_fn.IsEmpty()) {
-    if (pre_fn->Call(context, 0, nullptr).IsEmpty())
+    if (pre_fn->Call(context, 1, &uid).IsEmpty())
       FatalError("node::AsyncWrap::MakeCallback", "pre hook threw");
   }
 
   Local<Value> ret = cb->Call(context, argc, argv);
 
   if (ran_init_callback() && !post_fn.IsEmpty()) {
-    if (post_fn->Call(context, 0, nullptr).IsEmpty())
+    if (post_fn->Call(context, 1, &uid).IsEmpty())
       FatalError("node::AsyncWrap::MakeCallback", "post hook threw");
   }
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -17,6 +17,7 @@ namespace node {
   V(FSREQWRAP)                                                                \
   V(GETADDRINFOREQWRAP)                                                       \
   V(GETNAMEINFOREQWRAP)                                                       \
+  V(HTTPPARSER)                                                               \
   V(JSSTREAM)                                                                 \
   V(PIPEWRAP)                                                                 \
   V(PIPECONNECTWRAP)                                                          \

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -118,7 +118,7 @@ inline uint32_t Environment::DomainFlag::count() const {
   return fields_[kCount];
 }
 
-inline Environment::TickInfo::TickInfo() : in_tick_(false), last_threw_(false) {
+inline Environment::TickInfo::TickInfo() : in_tick_(false) {
   for (int i = 0; i < kFieldsCount; ++i)
     fields_[i] = 0;
 }
@@ -139,10 +139,6 @@ inline uint32_t Environment::TickInfo::index() const {
   return fields_[kIndex];
 }
 
-inline bool Environment::TickInfo::last_threw() const {
-  return last_threw_;
-}
-
 inline uint32_t Environment::TickInfo::length() const {
   return fields_[kLength];
 }
@@ -153,10 +149,6 @@ inline void Environment::TickInfo::set_in_tick(bool value) {
 
 inline void Environment::TickInfo::set_index(uint32_t value) {
   fields_[kIndex] = value;
-}
-
-inline void Environment::TickInfo::set_last_threw(bool value) {
-  last_threw_ = value;
 }
 
 inline Environment::ArrayBufferAllocatorInfo::ArrayBufferAllocatorInfo() {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -118,7 +118,7 @@ inline uint32_t Environment::DomainFlag::count() const {
   return fields_[kCount];
 }
 
-inline Environment::TickInfo::TickInfo() : in_tick_(false) {
+inline Environment::TickInfo::TickInfo() {
   for (int i = 0; i < kFieldsCount; ++i)
     fields_[i] = 0;
 }
@@ -131,20 +131,12 @@ inline int Environment::TickInfo::fields_count() const {
   return kFieldsCount;
 }
 
-inline bool Environment::TickInfo::in_tick() const {
-  return in_tick_;
-}
-
 inline uint32_t Environment::TickInfo::index() const {
   return fields_[kIndex];
 }
 
 inline uint32_t Environment::TickInfo::length() const {
   return fields_[kLength];
-}
-
-inline void Environment::TickInfo::set_in_tick(bool value) {
-  in_tick_ = value;
 }
 
 inline void Environment::TickInfo::set_index(uint32_t value) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -95,7 +95,6 @@ inline Environment::AsyncCallbackScope::AsyncCallbackScope(Environment* env)
 
 inline Environment::AsyncCallbackScope::~AsyncCallbackScope() {
   env_->makecallback_cntr_--;
-  CHECK_GE(env_->makecallback_cntr_, 0);
 }
 
 inline bool Environment::AsyncCallbackScope::in_makecallback() {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -88,6 +88,20 @@ inline void Environment::AsyncHooks::set_enable_callbacks(uint32_t flag) {
   fields_[kEnableCallbacks] = flag;
 }
 
+inline Environment::AsyncCallbackScope::AsyncCallbackScope(Environment* env)
+    : env_(env) {
+  env_->makecallback_cntr_++;
+}
+
+inline Environment::AsyncCallbackScope::~AsyncCallbackScope() {
+  env_->makecallback_cntr_--;
+  CHECK_GE(env_->makecallback_cntr_, 0);
+}
+
+inline bool Environment::AsyncCallbackScope::in_makecallback() {
+  return env_->makecallback_cntr_ > 1;
+}
+
 inline Environment::DomainFlag::DomainFlag() {
   for (int i = 0; i < kFieldsCount; ++i) fields_[i] = 0;
 }
@@ -210,6 +224,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       using_domains_(false),
       printed_error_(false),
       trace_sync_io_(false),
+      makecallback_cntr_(0),
       async_wrap_uid_(0),
       debugger_agent_(this),
       http_parser_buffer_(nullptr),

--- a/src/env.cc
+++ b/src/env.cc
@@ -57,10 +57,10 @@ void Environment::PrintSyncTrace() const {
 }
 
 
-bool Environment::KickNextTick() {
+bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
   TickInfo* info = tick_info();
 
-  if (info->in_tick()) {
+  if (scope->in_makecallback()) {
     return true;
   }
 
@@ -73,14 +73,10 @@ bool Environment::KickNextTick() {
     return true;
   }
 
-  info->set_in_tick(true);
-
   // process nextTicks after call
   TryCatch try_catch;
   try_catch.SetVerbose(true);
   tick_callback_function()->Call(process_object(), 0, nullptr);
-
-  info->set_in_tick(false);
 
   if (try_catch.HasCaught()) {
     info->set_last_threw(true);

--- a/src/env.cc
+++ b/src/env.cc
@@ -57,27 +57,4 @@ void Environment::PrintSyncTrace() const {
   fflush(stderr);
 }
 
-
-bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
-  TickInfo* info = tick_info();
-
-  if (scope->in_makecallback()) {
-    return true;
-  }
-
-  if (info->length() == 0) {
-    isolate()->RunMicrotasks();
-  }
-
-  if (info->length() == 0) {
-    info->set_index(0);
-    return true;
-  }
-
-  Local<Value> ret =
-    tick_callback_function()->Call(process_object(), 0, nullptr);
-
-  return !ret.IsEmpty();
-}
-
 }  // namespace node

--- a/src/env.cc
+++ b/src/env.cc
@@ -74,12 +74,11 @@ bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
   }
 
   // process nextTicks after call
-  TryCatch try_catch;
+  TryCatch try_catch(isolate());
   try_catch.SetVerbose(true);
   tick_callback_function()->Call(process_object(), 0, nullptr);
 
   if (try_catch.HasCaught()) {
-    info->set_last_threw(true);
     return false;
   }
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -11,6 +11,7 @@ using v8::Message;
 using v8::StackFrame;
 using v8::StackTrace;
 using v8::TryCatch;
+using v8::Value;
 
 void Environment::PrintSyncTrace() const {
   if (!trace_sync_io_)
@@ -73,16 +74,10 @@ bool Environment::KickNextTick(Environment::AsyncCallbackScope* scope) {
     return true;
   }
 
-  // process nextTicks after call
-  TryCatch try_catch(isolate());
-  try_catch.SetVerbose(true);
-  tick_callback_function()->Call(process_object(), 0, nullptr);
+  Local<Value> ret =
+    tick_callback_function()->Call(process_object(), 0, nullptr);
 
-  if (try_catch.HasCaught()) {
-    return false;
-  }
-
-  return true;
+  return !ret.IsEmpty();
 }
 
 }  // namespace node

--- a/src/env.h
+++ b/src/env.h
@@ -332,12 +332,10 @@ class Environment {
     inline uint32_t* fields();
     inline int fields_count() const;
     inline bool in_tick() const;
-    inline bool last_threw() const;
     inline uint32_t index() const;
     inline uint32_t length() const;
     inline void set_in_tick(bool value);
     inline void set_index(uint32_t value);
-    inline void set_last_threw(bool value);
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -351,7 +349,6 @@ class Environment {
 
     uint32_t fields_[kFieldsCount];
     bool in_tick_;
-    bool last_threw_;
 
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };

--- a/src/env.h
+++ b/src/env.h
@@ -294,6 +294,19 @@ class Environment {
     DISALLOW_COPY_AND_ASSIGN(AsyncHooks);
   };
 
+  class AsyncCallbackScope {
+   public:
+    explicit AsyncCallbackScope(Environment* env);
+    ~AsyncCallbackScope();
+
+    inline bool in_makecallback();
+
+   private:
+    Environment* env_;
+
+    DISALLOW_COPY_AND_ASSIGN(AsyncCallbackScope);
+  };
+
   class DomainFlag {
    public:
     inline uint32_t* fields();
@@ -446,7 +459,7 @@ class Environment {
 
   inline int64_t get_async_wrap_uid();
 
-  bool KickNextTick();
+  bool KickNextTick(AsyncCallbackScope* scope);
 
   inline uint32_t* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(uint32_t* pointer);
@@ -541,6 +554,7 @@ class Environment {
   bool using_domains_;
   bool printed_error_;
   bool trace_sync_io_;
+  size_t makecallback_cntr_;
   int64_t async_wrap_uid_;
   debugger::Agent debugger_agent_;
 

--- a/src/env.h
+++ b/src/env.h
@@ -453,8 +453,6 @@ class Environment {
 
   inline int64_t get_async_wrap_uid();
 
-  bool KickNextTick(AsyncCallbackScope* scope);
-
   inline uint32_t* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(uint32_t* pointer);
 

--- a/src/env.h
+++ b/src/env.h
@@ -331,10 +331,8 @@ class Environment {
    public:
     inline uint32_t* fields();
     inline int fields_count() const;
-    inline bool in_tick() const;
     inline uint32_t index() const;
     inline uint32_t length() const;
-    inline void set_in_tick(bool value);
     inline void set_index(uint32_t value);
 
    private:
@@ -348,7 +346,6 @@ class Environment {
     };
 
     uint32_t fields_[kFieldsCount];
-    bool in_tick_;
 
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };

--- a/src/node.cc
+++ b/src/node.cc
@@ -1177,7 +1177,11 @@ Local<Value> MakeCallback(Environment* env,
   }
 
   if (ret.IsEmpty()) {
-    return Undefined(env->isolate());
+    if (callback_scope.in_makecallback())
+      return ret;
+    // NOTE: Undefined() is returned here for backwards compatibility.
+    else
+      return Undefined(env->isolate());
   }
 
   if (has_domain) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1154,33 +1154,28 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  TryCatch try_catch(env->isolate());
-  try_catch.SetVerbose(true);
-
   if (has_domain) {
     Local<Value> enter_v = domain->Get(env->enter_string());
     if (enter_v->IsFunction()) {
-        enter_v.As<Function>()->Call(domain, 0, nullptr);
-      if (try_catch.HasCaught())
-        return Undefined(env->isolate());
+      if (enter_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
+        FatalError("node::MakeCallback",
+                   "domain enter callback threw, please report this");
+      }
     }
   }
 
   if (ran_init_callback && !pre_fn.IsEmpty()) {
-    pre_fn->Call(object, 0, nullptr);
-    if (try_catch.HasCaught())
+    if (pre_fn->Call(object, 0, nullptr).IsEmpty())
       FatalError("node::MakeCallback", "pre hook threw");
   }
 
   Local<Value> ret = callback->Call(recv, argc, argv);
 
   if (ran_init_callback && !post_fn.IsEmpty()) {
-    post_fn->Call(object, 0, nullptr);
-    if (try_catch.HasCaught())
+    if (post_fn->Call(object, 0, nullptr).IsEmpty())
       FatalError("node::MakeCallback", "post hook threw");
   }
 
-  // If the return value is empty then the callback threw.
   if (ret.IsEmpty()) {
     return Undefined(env->isolate());
   }
@@ -1188,14 +1183,16 @@ Local<Value> MakeCallback(Environment* env,
   if (has_domain) {
     Local<Value> exit_v = domain->Get(env->exit_string());
     if (exit_v->IsFunction()) {
-      exit_v.As<Function>()->Call(domain, 0, nullptr);
-      if (try_catch.HasCaught())
-        return Undefined(env->isolate());
+      if (exit_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
+        FatalError("node::MakeCallback",
+                   "domain exit callback threw, please report this");
+      }
     }
   }
 
-  if (!env->KickNextTick(&callback_scope))
+  if (!env->KickNextTick(&callback_scope)) {
     return Undefined(env->isolate());
+  }
 
   return ret;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1172,7 +1172,12 @@ Local<Value> MakeCallback(Environment* env,
   Local<Value> ret = callback->Call(recv, argc, argv);
 
   if (ran_init_callback && !post_fn.IsEmpty()) {
-    if (post_fn->Call(object, 0, nullptr).IsEmpty())
+    Local<Value> did_throw = Boolean::New(env->isolate(), ret.IsEmpty());
+    // Currently there's no way to retrieve an uid from node::MakeCallback().
+    // This needs to be fixed.
+    Local<Value> vals[] =
+        { Undefined(env->isolate()).As<Value>(), did_throw };
+    if (post_fn->Call(object, arraysize(vals), vals).IsEmpty())
       FatalError("node::MakeCallback", "post hook threw");
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1132,6 +1132,8 @@ Local<Value> MakeCallback(Environment* env,
   bool ran_init_callback = false;
   bool has_domain = false;
 
+  Environment::AsyncCallbackScope callback_scope(env);
+
   // TODO(trevnorris): Adding "_asyncQueue" to the "this" in the init callback
   // is a horrible way to detect usage. Rethink how detection should happen.
   if (recv->IsObject()) {
@@ -1192,7 +1194,7 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  if (!env->KickNextTick())
+  if (!env->KickNextTick(&callback_scope))
     return Undefined(env->isolate());
 
   return ret;
@@ -4100,7 +4102,10 @@ static void StartNodeInstance(void* arg) {
     if (instance_data->use_debug_agent())
       StartDebug(env, debug_wait_connect);
 
-    LoadEnvironment(env);
+    {
+      Environment::AsyncCallbackScope callback_scope(env);
+      LoadEnvironment(env);
+    }
 
     env->set_trace_sync_io(trace_sync_io);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1177,11 +1177,10 @@ Local<Value> MakeCallback(Environment* env,
   }
 
   if (ret.IsEmpty()) {
-    if (callback_scope.in_makecallback())
-      return ret;
-    // NOTE: Undefined() is returned here for backwards compatibility.
-    else
-      return Undefined(env->isolate());
+    // NOTE: For backwards compatibility with public API we return Undefined()
+    // if the top level call threw.
+    return callback_scope.in_makecallback() ?
+        ret : Undefined(env->isolate()).As<Value>();
   }
 
   if (has_domain) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1119,10 +1119,10 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 
 
 Local<Value> MakeCallback(Environment* env,
-                           Local<Value> recv,
-                           const Local<Function> callback,
-                           int argc,
-                           Local<Value> argv[]) {
+                          Local<Value> recv,
+                          const Local<Function> callback,
+                          int argc,
+                          Local<Value> argv[]) {
   // If you hit this assertion, you forgot to enter the v8::Context first.
   CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
@@ -1154,7 +1154,7 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  TryCatch try_catch;
+  TryCatch try_catch(env->isolate());
   try_catch.SetVerbose(true);
 
   if (has_domain) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1194,7 +1194,23 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  if (!env->KickNextTick(&callback_scope)) {
+  if (callback_scope.in_makecallback()) {
+    return ret;
+  }
+
+  Environment::TickInfo* tick_info = env->tick_info();
+
+  if (tick_info->length() == 0) {
+    env->isolate()->RunMicrotasks();
+  }
+
+  Local<Object> process = env->process_object();
+
+  if (tick_info->length() == 0) {
+    tick_info->set_index(0);
+  }
+
+  if (env->tick_callback_function()->Call(process, 0, nullptr).IsEmpty()) {
     return Undefined(env->isolate());
   }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -588,8 +588,6 @@ class Parser : public AsyncWrap {
     if (!cb->IsFunction())
       return;
 
-    Environment::AsyncCallbackScope callback_scope(parser->env());
-
     // Hooks for GetCurrentBuffer
     parser->current_buffer_len_ = nread;
     parser->current_buffer_data_ = buf->base;
@@ -598,8 +596,6 @@ class Parser : public AsyncWrap {
 
     parser->current_buffer_len_ = 0;
     parser->current_buffer_data_ = nullptr;
-
-    parser->env()->KickNextTick(&callback_scope);
   }
 
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -579,6 +579,8 @@ class Parser : public BaseObject {
     if (!cb->IsFunction())
       return;
 
+    Environment::AsyncCallbackScope callback_scope(parser->env());
+
     // Hooks for GetCurrentBuffer
     parser->current_buffer_len_ = nread;
     parser->current_buffer_data_ = buf->base;
@@ -588,7 +590,7 @@ class Parser : public BaseObject {
     parser->current_buffer_len_ = 0;
     parser->current_buffer_data_ = nullptr;
 
-    parser->env()->KickNextTick();
+    parser->env()->KickNextTick(&callback_scope);
   }
 
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -69,8 +69,6 @@ v8::Local<v8::Value> MakeCallback(Environment* env,
                                    int argc = 0,
                                    v8::Local<v8::Value>* argv = nullptr);
 
-bool KickNextTick();
-
 // Convert a struct sockaddr to a { address: '1.2.3.4', port: 1234 } JS object.
 // Sets address and port properties on the info object and returns it.
 // If |info| is omitted, a new object is returned.

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -237,6 +237,11 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
   Environment* env_;
 };
 
+// Clear any domain and/or uncaughtException handlers to force the error's
+// propagation and shutdown the process. Use this to force the process to exit
+// by clearing all callbacks that could handle the error.
+void ClearFatalExceptionHandlers(Environment* env);
+
 enum NodeInstanceType { MAIN, WORKER };
 
 class NodeInstanceData {

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -1,0 +1,31 @@
+#include "node.h"
+#include "v8.h"
+
+#include "../../../src/util.h"
+
+using v8::Function;
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+namespace {
+
+void MakeCallback(const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsObject());
+  CHECK(args[1]->IsFunction());
+  Isolate* isolate = args.GetIsolate();
+  Local<Object> recv = args[0].As<Object>();
+  Local<Function> method = args[1].As<Function>();
+
+  node::MakeCallback(isolate, recv, method, 0, nullptr);
+}
+
+void Initialize(Local<Object> target) {
+  NODE_SET_METHOD(target, "makeCallback", MakeCallback);
+}
+
+}  // namespace anonymous
+
+NODE_MODULE(binding, Initialize)

--- a/test/addons/make-callback-recurse/binding.gyp
+++ b/test/addons/make-callback-recurse/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const domain = require('domain');
+const binding = require('./build/Release/binding');
+const makeCallback = binding.makeCallback;
+
+// Make sure this is run in the future.
+const mustCallCheckDomains = common.mustCall(checkDomains);
+
+
+// Make sure that using MakeCallback allows the error to propagate.
+assert.throws(function() {
+  makeCallback({}, function() {
+    throw new Error('hi from domain error');
+  });
+});
+
+
+// Check the execution order of the nextTickQueue and MicrotaskQueue in
+// relation to running multiple MakeCallback's from bootstrap,
+// node::MakeCallback() and node::AsyncWrap::MakeCallback().
+// TODO(trevnorris): Is there a way to verify this is being run during
+// bootstrap?
+(function verifyExecutionOrder(arg) {
+  const results_arr = [];
+
+  // Processing of the MicrotaskQueue is manually handled by node. They are not
+  // processed until after the nextTickQueue has been processed.
+  Promise.resolve(1).then(common.mustCall(function() {
+    results_arr.push(7);
+  }));
+
+  // The nextTick should run after all immediately invoked calls.
+  process.nextTick(common.mustCall(function() {
+    results_arr.push(3);
+
+    // Run same test again but while processing the nextTickQueue to make sure
+    // the following MakeCallback call breaks in the middle of processing the
+    // queue and allows the script to run normally.
+    process.nextTick(common.mustCall(function() {
+      results_arr.push(6);
+    }));
+
+    makeCallback({}, common.mustCall(function() {
+      results_arr.push(4);
+    }));
+
+    results_arr.push(5);
+  }));
+
+  results_arr.push(0);
+
+  // MakeCallback is calling the function immediately, but should then detect
+  // that a script is already in the middle of execution and return before
+  // either the nextTickQueue or MicrotaskQueue are processed.
+  makeCallback({}, common.mustCall(function() {
+    results_arr.push(1);
+  }));
+
+  // This should run before either the nextTickQueue or MicrotaskQueue are
+  // processed. Previously MakeCallback would not detect this circumstance
+  // and process them immediately.
+  results_arr.push(2);
+
+  setImmediate(common.mustCall(function() {
+    for (var i = 0; i < results_arr.length; i++) {
+      assert.equal(results_arr[i],
+                   i,
+                   `verifyExecutionOrder(${arg}) results: ${results_arr}`);
+    }
+    if (arg === 1) {
+      // The tests are first run on bootstrap during LoadEnvironment() in
+      // src/node.cc. Now run the tests through node::MakeCallback().
+      setImmediate(function() {
+        makeCallback({}, common.mustCall(function() {
+          verifyExecutionOrder(2);
+        }));
+      });
+    } else if (arg === 2) {
+      // setTimeout runs via the TimerWrap, which runs through
+      // AsyncWrap::MakeCallback(). Make sure there are no conflicts using
+      // node::MakeCallback() within it.
+      setTimeout(common.mustCall(function() {
+        verifyExecutionOrder(3);
+      }), 10);
+    } else if (arg === 3) {
+      mustCallCheckDomains();
+    } else {
+      throw new Error('UNREACHABLE');
+    }
+  }));
+}(1));
+
+
+function checkDomains() {
+  // Check that domains are properly entered/exited when called in multiple
+  // levels from both node::MakeCallback() and AsyncWrap::MakeCallback
+  setImmediate(common.mustCall(function() {
+    const d1 = domain.create();
+    const d2 = domain.create();
+    const d3 = domain.create();
+
+    makeCallback({ domain: d1 }, common.mustCall(function() {
+      assert.equal(d1, process.domain);
+      makeCallback({ domain: d2 }, common.mustCall(function() {
+        assert.equal(d2, process.domain);
+        makeCallback({ domain: d3 }, common.mustCall(function() {
+          assert.equal(d3, process.domain);
+        }));
+        assert.equal(d2, process.domain);
+      }));
+      assert.equal(d1, process.domain);
+    }));
+  }));
+
+  setTimeout(common.mustCall(function() {
+    const d1 = domain.create();
+    const d2 = domain.create();
+    const d3 = domain.create();
+
+    makeCallback({ domain: d1 }, common.mustCall(function() {
+      assert.equal(d1, process.domain);
+      makeCallback({ domain: d2 }, common.mustCall(function() {
+        assert.equal(d2, process.domain);
+        makeCallback({ domain: d3 }, common.mustCall(function() {
+          assert.equal(d3, process.domain);
+        }));
+        assert.equal(d2, process.domain);
+      }));
+      assert.equal(d1, process.domain);
+    }));
+  }), 1);
+
+  // Make sure nextTick, setImmediate and setTimeout can all recover properly
+  // after a thrown makeCallback call.
+  process.nextTick(common.mustCall(function() {
+    const d = domain.create();
+    d.on('error', common.mustCall(function(e) {
+      assert.equal(e.message, 'throw from domain 3');
+    }));
+    makeCallback({ domain: d }, function() {
+      throw new Error('throw from domain 3');
+    });
+    throw new Error('UNREACHABLE');
+  }));
+
+  setImmediate(common.mustCall(function() {
+    const d = domain.create();
+    d.on('error', common.mustCall(function(e) {
+      assert.equal(e.message, 'throw from domain 2');
+    }));
+    makeCallback({ domain: d }, function() {
+      throw new Error('throw from domain 2');
+    });
+    throw new Error('UNREACHABLE');
+  }));
+
+  setTimeout(common.mustCall(function() {
+    const d = domain.create();
+    d.on('error', common.mustCall(function(e) {
+      assert.equal(e.message, 'throw from domain 1');
+    }));
+    makeCallback({ domain: d }, function() {
+      throw new Error('throw from domain 1');
+    });
+    throw new Error('UNREACHABLE');
+  }));
+}

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -11,6 +11,7 @@ const tls = require('tls');
 const zlib = require('zlib');
 const ChildProcess = require('child_process').ChildProcess;
 const StreamWrap = require('_stream_wrap').StreamWrap;
+const HTTPParser = process.binding('http_parser').HTTPParser;
 const async_wrap = process.binding('async_wrap');
 const pkeys = Object.keys(async_wrap.Providers);
 
@@ -105,6 +106,8 @@ function checkTLS() {
 zlib.createGzip();
 
 new ChildProcess();
+
+new HTTPParser(HTTPParser.REQUEST);
 
 process.on('exit', function() {
   if (keyList.length !== 0) {

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -29,8 +29,8 @@ if (common.isAix) {
   }
 }
 
-function init(id) {
-  keyList = keyList.filter((e) => e != pkeys[id]);
+function init(id, provider) {
+  keyList = keyList.filter((e) => e != pkeys[provider]);
 }
 
 function noop() { }

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -36,7 +36,7 @@ function init(id, provider) {
 
 function noop() { }
 
-async_wrap.setupHooks(init, noop, noop);
+async_wrap.setupHooks({ init });
 
 async_wrap.enable();
 

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -30,7 +30,7 @@ function init(uid, type, parentUid, parentHandle) {
 
 function noop() { }
 
-async_wrap.setupHooks(init, noop, noop);
+async_wrap.setupHooks({ init });
 async_wrap.enable();
 
 const server = net.createServer(function(c) {

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -6,16 +6,23 @@ const net = require('net');
 const async_wrap = process.binding('async_wrap');
 const providers = Object.keys(async_wrap.Providers);
 
+const uidSymbol = Symbol('uid');
+
 let cntr = 0;
 let client;
 
-function init(id, type, parent) {
-  if (parent) {
+function init(uid, type, parentUid, parentHandle) {
+  this[uidSymbol] = uid;
+
+  if (parentHandle) {
     cntr++;
     // Cannot assert in init callback or will abort.
     process.nextTick(() => {
       assert.equal(providers[type], 'TCPWRAP');
-      assert.equal(parent, server._handle, 'server doesn\'t match parent');
+      assert.equal(parentUid, server._handle[uidSymbol],
+                   'server uid doesn\'t match parent uid');
+      assert.equal(parentHandle, server._handle,
+                   'server handle doesn\'t match parent handle');
       assert.equal(this, client._handle, 'client doesn\'t match context');
     });
   }

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -9,7 +9,7 @@ const providers = Object.keys(async_wrap.Providers);
 let cntr = 0;
 let client;
 
-function init(type, id, parent) {
+function init(id, type, parent) {
   if (parent) {
     cntr++;
     // Cannot assert in init callback or will abort.

--- a/test/parallel/test-async-wrap-post-did-throw.js
+++ b/test/parallel/test-async-wrap-post-did-throw.js
@@ -1,0 +1,34 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const async_wrap = process.binding('async_wrap');
+var asyncThrows = 0;
+var uncaughtExceptionCount = 0;
+
+process.on('uncaughtException', (e) => {
+  assert.equal(e.message, 'oh noes!', 'error messages do not match');
+});
+
+process.on('exit', () => {
+  process.removeAllListeners('uncaughtException');
+  assert.equal(uncaughtExceptionCount, 1);
+  assert.equal(uncaughtExceptionCount, asyncThrows);
+});
+
+function init() { }
+function post(id, threw) {
+  if (threw)
+    uncaughtExceptionCount++;
+}
+
+async_wrap.setupHooks({ init, post });
+async_wrap.enable();
+
+// Timers still aren't supported, so use crypto API.
+// It's also important that the callback not happen in a nextTick, like many
+// error events in core.
+require('crypto').randomBytes(0, () => {
+  asyncThrows++;
+  throw new Error('oh noes!');
+});

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -4,16 +4,25 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const async_wrap = process.binding('async_wrap');
+const providers = Object.keys(async_wrap.Providers);
+
+const uidSymbol = Symbol('uid');
 
 let cntr = 0;
 let client;
 
-function init(id, type, parent) {
-  if (parent) {
+function init(uid, type, parentUid, parentHandle) {
+  this[uidSymbol] = uid;
+
+  if (parentHandle) {
     cntr++;
     // Cannot assert in init callback or will abort.
     process.nextTick(() => {
-      assert.equal(parent, server._handle, 'server doesn\'t match parent');
+      assert.equal(providers[type], 'TCPWRAP');
+      assert.equal(parentUid, server._handle[uidSymbol],
+                   'server uid doesn\'t match parent uid');
+      assert.equal(parentHandle, server._handle,
+                   'server handle doesn\'t match parent handle');
       assert.equal(this, client._handle, 'client doesn\'t match context');
     });
   }

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -30,7 +30,7 @@ function init(uid, type, parentUid, parentHandle) {
 
 function noop() { }
 
-async_wrap.setupHooks(init, noop, noop);
+async_wrap.setupHooks({ init });
 async_wrap.enable();
 
 const server = net.createServer(function(c) {

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -8,7 +8,7 @@ const async_wrap = process.binding('async_wrap');
 let cntr = 0;
 let client;
 
-function init(type, id, parent) {
+function init(id, type, parent) {
   if (parent) {
     cntr++;
     // Cannot assert in init callback or will abort.

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -1,0 +1,68 @@
+'use strict';
+
+require('../common');
+const async_wrap = process.binding('async_wrap');
+const assert = require('assert');
+const crypto = require('crypto');
+const domain = require('domain');
+const spawn = require('child_process').spawn;
+const callbacks = [ 'init', 'pre', 'post', 'destroy' ];
+const toCall = process.argv[2];
+var msgCalled = 0;
+var msgReceived = 0;
+
+function init() {
+  if (toCall === 'init')
+    throw new Error('init');
+}
+function pre() {
+  if (toCall === 'pre')
+    throw new Error('pre');
+}
+function post() {
+  if (toCall === 'post')
+    throw new Error('post');
+}
+function destroy() {
+  if (toCall === 'destroy')
+    throw new Error('destroy');
+}
+
+if (typeof process.argv[2] === 'string') {
+  async_wrap.setupHooks({ init, pre, post, destroy });
+  async_wrap.enable();
+
+  process.on('uncaughtException', () => assert.ok(0, 'UNREACHABLE'));
+
+  const d = domain.create();
+  d.on('error', () => assert.ok(0, 'UNREACHABLE'));
+  d.run(() => {
+    // Using randomBytes because timers are not yet supported.
+    crypto.randomBytes(0, () => { });
+  });
+
+} else {
+
+  process.on('exit', (code) => {
+    assert.equal(msgCalled, callbacks.length);
+    assert.equal(msgCalled, msgReceived);
+  });
+
+  callbacks.forEach((item) => {
+    msgCalled++;
+
+    const child = spawn(process.execPath, [__filename, item]);
+    var errstring = '';
+
+    child.stderr.on('data', (data) => {
+      errstring += data.toString();
+    });
+
+    child.on('close', (code) => {
+      if (errstring.includes('Error: ' + item))
+        msgReceived++;
+
+      assert.equal(code, 1, `${item} closed with code ${code}`);
+    });
+  });
+}

--- a/test/parallel/test-async-wrap-throw-no-init.js
+++ b/test/parallel/test-async-wrap-throw-no-init.js
@@ -7,14 +7,14 @@ const async_wrap = process.binding('async_wrap');
 
 assert.throws(function() {
   async_wrap.setupHooks(null);
-}, /init callback must be a function/);
+}, /first argument must be an object/);
 
 assert.throws(function() {
   async_wrap.enable();
 }, /init callback is not assigned to a function/);
 
 // Should not throw
-async_wrap.setupHooks(() => {});
+async_wrap.setupHooks({ init: () => {} });
 async_wrap.enable();
 
 assert.throws(function() {

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
 
 const storage = new Map();
-async_wrap.setupHooks(init, pre, post, destroy);
+async_wrap.setupHooks({ init, pre, post, destroy });
 async_wrap.enable();
 
 function init(uid) {

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -9,7 +9,7 @@ const storage = new Map();
 async_wrap.setupHooks(init, pre, post, destroy);
 async_wrap.enable();
 
-function init(provider, uid) {
+function init(uid) {
   storage.set(uid, {
     init: true,
     pre: false,

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -1,0 +1,57 @@
+'use strict';
+
+require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const async_wrap = process.binding('async_wrap');
+
+const storage = new Map();
+async_wrap.setupHooks(init, pre, post, destroy);
+async_wrap.enable();
+
+function init(provider, uid) {
+  storage.set(uid, {
+    init: true,
+    pre: false,
+    post: false,
+    destroy: false
+  });
+}
+
+function pre(uid) {
+  storage.get(uid).pre = true;
+}
+
+function post(uid) {
+  storage.get(uid).post = true;
+}
+
+function destroy(uid) {
+  storage.get(uid).destroy = true;
+}
+
+fs.access(__filename, function(err) {
+  assert.ifError(err);
+});
+
+fs.access(__filename, function(err) {
+  assert.ifError(err);
+});
+
+async_wrap.disable();
+
+process.once('exit', function() {
+  assert.strictEqual(storage.size, 2);
+
+  for (const item of storage) {
+    const uid = item[0];
+    const value = item[1];
+    assert.strictEqual(typeof uid, 'number');
+    assert.deepStrictEqual(value, {
+      init: true,
+      pre: true,
+      post: true,
+      destroy: true
+    });
+  }
+});

--- a/test/parallel/test-http-catch-uncaughtexception.js
+++ b/test/parallel/test-http-catch-uncaughtexception.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const uncaughtCallback = common.mustCall(function(er) {
+  assert.equal(er.message, 'get did fail');
+});
+
+process.on('uncaughtException', uncaughtCallback);
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('bye');
+}).listen(common.PORT, function() {
+  http.get({ port: common.PORT }, function(res) {
+    res.resume();
+    throw new Error('get did fail');
+  }).on('close', function() {
+    server.close();
+  });
+});


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
src, http, http_parser, test, async_wrap

##### Description of change

Async Wrap in 4.x is very far behind and it creates a lot of issues, see the issue references in https://github.com/nodejs/LTS/issues/86. I recall in some discussion (I can't find it) that this shouldn't be straight forward, however it was actually really easy and all the tests passes. Am I missing something?

This backports the following changes:

1. https://github.com/nodejs/node/pull/4507 - src: fix MakeCallback error handling
2. https://github.com/nodejs/node/commit/b72dbdbe430ef83c73cf535bc0dabdba2a64b352 from  nodejs/node#5233 - src: remove unnecessary check
3. https://github.com/nodejs/node/pull/4600 - async_wrap: add uid argument to all asyncWrap hooks
4. https://github.com/nodejs/node/pull/5419 - http_parser: use `MakeCallback`
5. https://github.com/nodejs/node/pull/5591 - src,http: fix uncaughtException miss in http
6. https://github.com/nodejs/node/pull/5756 - Asyncwrap more

/cc @TheAlphaNerd @trevnorris 