### PR TITLE
test: fix spawn on windows

### DIFF
--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -3,7 +3,11 @@ const cp = require('child_process');
 const common = require('../common');
 const assert = require('assert');
 
-const p = cp.spawn('echo');
+// Windows' `echo` command is a built-in shell command and not an external
+// executable like on *nix
+const opts = { shell: common.isWindows };
+
+const p = cp.spawn('echo', [], opts);
 
 p.on('close', common.mustCall(function(code, signal) {
   assert.strictEqual(code, 0);
@@ -15,7 +19,7 @@ p.stdout.read();
 
 function spawnWithReadable() {
   const buffer = [];
-  const p = cp.spawn('echo', ['123']);
+  const p = cp.spawn('echo', ['123'], opts);
   p.on('close', common.mustCall(function(code, signal) {
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

* test


##### Description of change

Most Windows systems do not have an external `echo` program installed, so any attempts to spawn `echo` as a child process will fail with `ENOENT`. This commit forces the use of the built-in `echo` provided by `cmd.exe`.

