### PR TITLE
cluster: rewrite debug ports consistently

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -299,6 +299,7 @@ function masterInit() {
   function createWorkerProcess(id, env) {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
+    var debugPort = 0;
 
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;
@@ -307,8 +308,11 @@ function masterInit() {
       var match = execArgv[i].match(/^(--debug|--debug-(brk|port))(=\d+)?$/);
 
       if (match) {
-        const debugPort = process.debugPort + debugPortOffset;
-        ++debugPortOffset;
+        if (debugPort === 0) {
+          debugPort = process.debugPort + debugPortOffset;
+          ++debugPortOffset;
+        }
+
         execArgv[i] = match[1] + '=' + debugPort;
       }
     }

--- a/test/parallel/test-cluster-debug-port.js
+++ b/test/parallel/test-cluster-debug-port.js
@@ -22,6 +22,11 @@ if (cluster.isMaster) {
     portSet: process.debugPort + 1
   }).on('exit', checkExitCode);
 
+  cluster.setupMaster({
+    execArgv: [`--debug-port=${process.debugPort}`,
+               `--debug=${process.debugPort}`]
+  });
+
   console.log('forked worker should have --debug-port, with offset = 2');
   cluster.fork({
     portSet: process.debugPort + 2


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
cluster

##### Description of change
When debug flags are passed to clustered applications, the debug port is rewritten for each worker process to avoid collisions. Prior to this commit, each debug flag would get a unique value. This commit reworks the logic to assign the same port value to all debug flags for a single worker.

I'm not 100% sure if this is actually a bug, or desirable behavior. However, the question came up in https://github.com/nodejs/node/pull/6792#issuecomment-222366233, so I decided to take a shot at solving it.