### PR TITLE
buffer: ignore negative allocation lengths

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -199,8 +199,8 @@ Object.setPrototypeOf(SlowBuffer, Uint8Array);
 
 
 function allocate(size) {
-  if (size === 0) {
-    return createBuffer(size);
+  if (size <= 0) {
+    return createBuffer(0);
   }
   if (size < (Buffer.poolSize >>> 1)) {
     if (size > (poolSize - poolOffset))

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1465,3 +1465,14 @@ assert.equal(Buffer.prototype.parent, undefined);
 assert.equal(Buffer.prototype.offset, undefined);
 assert.equal(SlowBuffer.prototype.parent, undefined);
 assert.equal(SlowBuffer.prototype.offset, undefined);
+
+{
+  // Test that large negative Buffer length inputs don't affect the pool offset.
+  assert.deepStrictEqual(Buffer(-Buffer.poolSize), Buffer.from(''));
+  assert.deepStrictEqual(Buffer(-100), Buffer.from(''));
+  assert.deepStrictEqual(Buffer.allocUnsafe(-Buffer.poolSize), Buffer.from(''));
+  assert.deepStrictEqual(Buffer.allocUnsafe(-100), Buffer.from(''));
+
+  // Check pool offset after that by trying to write string into the pool.
+  assert.doesNotThrow(() => Buffer.from('abc'));
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Treat negative length arguments to `Buffer()`/`allocUnsafe()` as if they were zero so the allocation does not affect the pool’s offset.

Ref: https://github.com/nodejs/node/issues/7047

----------

I decided to not throw an error here because there’s at least one existing test expecting `Buffer(-1)` to not throw, but I’d like to make a semver-major follow-up PR for adding a `< 0` check to `assertSize`. (That would implement [this suggestion](https://github.com/nodejs/node/pull/5833#discussion_r59312968) by @thefourtheye, I think.)

/cc @nodejs/buffer 