### PR TITLE
domain: add message for dispose deprecation

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -314,4 +314,5 @@ Domain.prototype.dispose = util.deprecate(function() {
   // mark this domain as 'no longer relevant'
   // so that it can't be entered or activated.
   this._disposed = true;
-});
+}, 'Domain.dispose is deprecated. Recover from failed I/O actions explicitly ' +
+    'via error event handlers set on the domain instead.');


### PR DESCRIPTION
##### Checklist

- [X] tests and code linting passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)

* domain


##### Description of change

I noticed that `domain.dispose()` had no deprecation message set, so I just basically added the deprecation text from the docs.