### PR TITLE
test: remove non-incremental common.PORT changes

### DIFF
--- a/test/debugger/helper-debugger-repl.js
+++ b/test/debugger/helper-debugger-repl.js
@@ -4,7 +4,7 @@ var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
-var port = common.PORT + 1337;
+var port = common.PORT;
 
 var child;
 var buffer = '';

--- a/test/debugger/test-debugger-client.js
+++ b/test/debugger/test-debugger-client.js
@@ -4,7 +4,7 @@ var common = require('../common');
 var assert = require('assert');
 var debug = require('_debugger');
 
-var debugPort = common.PORT + 1337;
+var debugPort = common.PORT;
 debug.port = debugPort;
 var spawn = require('child_process').spawn;
 


### PR DESCRIPTION
##### Checklist
<!-- remove lines that do not apply to you -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test debugger

##### Description of change
<!-- provide a description of the change below this comment -->

Remove uses of `common.PORT + 1337` where `common.PORT` suffices.

Refs: https://github.com/nodejs/node/pull/6990