### PR TITLE
test: fix tests for non-crypto builds

### DIFF
--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const crypto = require('crypto');
 const dgram = require('dgram');

--- a/test/parallel/test-async-wrap-post-did-throw.js
+++ b/test/parallel/test-async-wrap-post-did-throw.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
 var asyncThrows = 0;

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const async_wrap = process.binding('async_wrap');
 const assert = require('assert');
 const crypto = require('crypto');

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -2,12 +2,12 @@
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
-var constants = require('crypto').constants;
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
+var constants = require('crypto').constants;
 var crypto = require('crypto');
 
 // Test certificates

--- a/test/parallel/test-http-invalid-urls.js
+++ b/test/parallel/test-http-invalid-urls.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const http = require('http');
 const https = require('https');

--- a/test/parallel/test-https-agent-getname.js
+++ b/test/parallel/test-https-agent-getname.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const https = require('https');
 

--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -1,5 +1,10 @@
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const https = require('https');
 

--- a/test/parallel/test-https-resume-after-renew.js
+++ b/test/parallel/test-https-resume-after-renew.js
@@ -1,5 +1,10 @@
 'use strict';
-var common = require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 var fs = require('fs');
 var https = require('https');
 var crypto = require('crypto');

--- a/test/parallel/test-net-access-byteswritten.js
+++ b/test/parallel/test-net-access-byteswritten.js
@@ -1,6 +1,10 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 const assert = require('assert');
 const net = require('net');
 const tls = require('tls');

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -1,5 +1,9 @@
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 
 const path = require('path');
 const spawn = require('child_process').spawn;

--- a/test/parallel/test-stream-base-no-abort.js
+++ b/test/parallel/test-stream-base-no-abort.js
@@ -1,9 +1,14 @@
 'use strict';
 
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const async_wrap = process.binding('async_wrap');
 const uv = process.binding('uv');
 const assert = require('assert');
-const common = require('../common');
 const dgram = require('dgram');
 const fs = require('fs');
 const net = require('net');

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -1,15 +1,14 @@
 'use strict';
 
-var common = require('../common');
-
-var path = require('path');
-var fs = require('fs');
-const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
-
+const common = require('../common');
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
+
+const path = require('path');
+const fs = require('fs');
+const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
 var tls = require('tls');
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const tls = require('tls');
 

--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -1,5 +1,10 @@
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const tls = require('tls');
 

--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -1,5 +1,10 @@
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const fs = require('fs');
 const tls = require('tls');

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -1,11 +1,11 @@
 'use strict';
+const common = require('../common');
 if (!process.features.tls_npn) {
   common.skip('node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
   return;
 }
 
-const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -1,6 +1,10 @@
 'use strict';
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 
-require('../common');
 const assert = require('assert');
 const tls = require('tls');
 

--- a/test/parallel/test-tls-securepair-fiftharg.js
+++ b/test/parallel/test-tls-securepair-fiftharg.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const assert = require('assert');
 const fs = require('fs');
 const tls = require('tls');

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -1,11 +1,11 @@
 'use strict';
+const common = require('../common');
 if (!process.features.tls_sni) {
   common.skip('node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
   return;
 }
 
-const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -1,11 +1,11 @@
 'use strict';
+const common = require('../common');
 if (!process.features.tls_sni) {
   common.skip('node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
   return;
 }
 
-const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 

--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const tls = require('tls');
 const fs = require('fs');
 

--- a/test/parallel/test-tls-wrap-no-abort.js
+++ b/test/parallel/test-tls-wrap-no-abort.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 const util = require('util');
 const TLSWrap = process.binding('tls_wrap').TLSWrap;
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Fix running the tests when node was compiled without crypto support. Some of these were introduced in 52bae222a3a8480b2, where `common` was used before it was required.

Regular CI: https://ci.nodejs.org/job/node-test-commit/3575/

/cc @nodejs/testing 