### PR TITLE
fs: execute mkdtemp's callback with no context

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1596,8 +1596,7 @@ fs.realpath = function realpath(path, options, callback) {
 };
 
 
-fs.mkdtemp = function(prefix, options, callback_) {
-  var callback = maybeCallback(callback_);
+fs.mkdtemp = function(prefix, options, callback) {
   if (!prefix || typeof prefix !== 'string')
     throw new TypeError('filename prefix is required');
 
@@ -1611,6 +1610,7 @@ fs.mkdtemp = function(prefix, options, callback_) {
   if (typeof options !== 'object')
     throw new TypeError('"options" must be a string or an object');
 
+  callback = makeCallback(callback);
   if (!nullCheck(prefix, callback)) {
     return;
   }

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -18,12 +18,19 @@ assert.equal(Buffer.byteLength(path.basename(utf8)),
              Buffer.byteLength('\u0222abc.XXXXXX'));
 assert(common.fileExists(utf8));
 
-fs.mkdtemp(
-    path.join(common.tmpDir, 'bar.'),
-    common.mustCall(function(err, folder) {
-      assert.ifError(err);
-      assert(common.fileExists(folder));
-    })
-);
+function handler(err, folder) {
+  assert.ifError(err);
+  assert(common.fileExists(folder));
+  assert.strictEqual(this, null);
+}
 
+fs.mkdtemp(path.join(common.tmpDir, 'bar.'), common.mustCall(handler));
+
+// Same test as above, but making sure that passing an options object doesn't
+// affect the way the callback function is handled.
+fs.mkdtemp(path.join(common.tmpDir, 'bar.'), {}, common.mustCall(handler));
+
+// Making sure that not passing a callback doesn't crash, as a default function
+// is passed internally.
 assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-')));
+assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-'), {}));


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

All the callback functions in `fs` module are supposed to be executed
with no context (`this` value should not be a valid object). But
`mkdtemp`'s callback will have the `FSReqWrap` object as the context.

Sample code to reproduce the problem

    'use strict';

    const fs = require('fs');
    fs.mkdtemp('/tmp/abcd', null, function() {
      console.log(this);
    });

This would print

    FSReqWrap { oncomplete: [Function] }

But that should have printed `null` and this patch fixes that.

cc @nodejs/fs 

-----

CI Run: https://ci.nodejs.org/job/node-test-pull-request/2865/