### PR TITLE
src: fix --without-inspector build

### DIFF
--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -65,7 +65,7 @@ class SignalWrap : public HandleWrap {
     SignalWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
     int signum = args[0]->Int32Value();
-#if defined(__POSIX__) && defined(HAVE_INSPECTOR)
+#if defined(__POSIX__) && HAVE_INSPECTOR
     if (signum == SIGPROF) {
       Environment* env = Environment::GetCurrent(args);
       if (env->inspector_agent()->IsStarted()) {


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

Use `HAVE_INSPECTOR` as the 0/1 boolean macro that it is, as opposed to a defined/not-defined boolean.