### PR TITLE
lib,src: reset zero fill flag on exception

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -65,8 +65,15 @@ const zeroFill = bindingObj.zeroFill || [0];
 
 function createBuffer(size, noZeroFill) {
   if (noZeroFill)
-    zeroFill[0] = 0;  // Reset by the runtime.
-  const ui8 = new Uint8Array(size);
+    zeroFill[0] = 0;
+
+  try {
+    var ui8 = new Uint8Array(size);
+  } finally {
+    if (noZeroFill)
+      zeroFill[0] = 1;
+  }
+
   Object.setPrototypeOf(ui8, Buffer.prototype);
   return ui8;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -973,8 +973,8 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 void* ArrayBufferAllocator::Allocate(size_t size) {
   if (zero_fill_field_ || zero_fill_all_buffers)
     return calloc(size, 1);
-  zero_fill_field_ = 1;
-  return malloc(size);
+  else
+    return malloc(size);
 }
 
 static bool DomainHasErrorHandler(const Environment* env,

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1476,3 +1476,26 @@ assert.equal(SlowBuffer.prototype.offset, undefined);
   // Check pool offset after that by trying to write string into the pool.
   assert.doesNotThrow(() => Buffer.from('abc'));
 }
+
+
+// Test failed or zero-sized Buffer allocations not affecting typed arrays
+{
+  const zeroArray = new Uint32Array(10).fill(0);
+  const sizes = [1e10, 0, 0.1, -1, 'a', undefined, null, NaN];
+  const allocators = [
+    Buffer,
+    SlowBuffer,
+    Buffer.alloc,
+    Buffer.allocUnsafe,
+    Buffer.allocUnsafeSlow
+  ];
+  for (const allocator of allocators) {
+    for (const size of sizes) {
+      try {
+        allocator(size);
+      } catch (e) {
+        assert.deepStrictEqual(new Uint32Array(10), zeroArray);
+      }
+    }
+  }
+}


### PR DESCRIPTION
R=@Chalker.  I had to apply a small style fix-up to stop the linter from complaining.

I'm tagging this dont-land-on-anything but the test probably should be backported.

CI: https://ci.nodejs.org/job/node-test-pull-request/2891/