### PR TITLE
async_wrap: pass uid to JS as double

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -42,14 +42,14 @@ inline AsyncWrap::AsyncWrap(Environment* env,
   v8::HandleScope scope(env->isolate());
 
   v8::Local<v8::Value> argv[] = {
-    v8::Integer::New(env->isolate(), get_uid()),
+    v8::Number::New(env->isolate(), get_uid()),
     v8::Int32::New(env->isolate(), provider),
     Null(env->isolate()),
     Null(env->isolate())
   };
 
   if (parent != nullptr) {
-    argv[2] = v8::Integer::New(env->isolate(), parent->get_uid());
+    argv[2] = v8::Number::New(env->isolate(), parent->get_uid());
     argv[3] = parent->object();
   }
 
@@ -74,7 +74,7 @@ inline AsyncWrap::~AsyncWrap() {
   v8::Local<v8::Function> fn = env()->async_hooks_destroy_function();
   if (!fn.IsEmpty()) {
     v8::HandleScope scope(env()->isolate());
-    v8::Local<v8::Value> uid = v8::Integer::New(env()->isolate(), get_uid());
+    v8::Local<v8::Value> uid = v8::Number::New(env()->isolate(), get_uid());
     v8::TryCatch try_catch(env()->isolate());
     v8::MaybeLocal<v8::Value> ret =
         fn->Call(env()->context(), v8::Null(env()->isolate()), 1, &uid);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -18,6 +18,7 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
+using v8::Number;
 using v8::Object;
 using v8::RetainedObjectInfo;
 using v8::TryCatch;
@@ -197,7 +198,7 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
   Local<Function> post_fn = env()->async_hooks_post_function();
-  Local<Value> uid = Integer::New(env()->isolate(), get_uid());
+  Local<Value> uid = Number::New(env()->isolate(), get_uid());
   Local<Object> context = object();
   Local<Object> domain;
   bool has_domain = false;


### PR DESCRIPTION
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
`async_wrap`


##### Description of change

Passing the uid via v8::Integer::New() converts it to a uint32_t. Which
will trim the value early. Instead use v8::Number::New() to convert the
int64_t to a double so that JS can see the full 2^53 range of uid's.

No test was included because the only way to increase the uid is to create new handles, and creating more than a `uin32_t`'s worth of handles would take a while.

R=@bnoordhuis 
R=@AndreasMadsen 

CI: https://ci.nodejs.org/job/node-test-pull-request/2895/