### PR TITLE
v4.x: src: make sure Utf8Value always zero-terminates

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -5,6 +5,10 @@ namespace node {
 
 Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value)
     : length_(0), str_(str_st_) {
+  // Make sure result is always zero-terminated, even if conversion to string
+  // fails.
+  str_st_[0] = '\0';
+
   if (value.IsEmpty())
     return;
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

Make sure dereferencing a `Utf8Value` instance always returns a zero-terminated string, even if the conversion to string failed.

The corresponding bugfix in the master branch happened in 44a40325da40 (https://github.com/nodejs/node/pull/6357).