### PR TITLE
repl: refine handling of illegal tokens

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1154,6 +1154,9 @@ REPLServer.prototype.convertToContext = function(cmd) {
   return cmd;
 };
 
+function bailOnIllegalToken(lp) {
+  return lp._literal === null && !lp.blockComment && !lp.regExpLiteral;
+}
 
 // If the error is that we've unexpectedly ended the input,
 // then let the user try to recover by adding more input.
@@ -1166,9 +1169,18 @@ function isRecoverableError(e, self) {
       return true;
     }
 
-    return message.startsWith('Unexpected end of input') ||
-      message.startsWith('Unexpected token') ||
-      message.startsWith('missing ) after argument list');
+    if (message.startsWith('Unexpected end of input'))
+      return true;
+
+    if (message.startsWith('Unexpected token')) {
+      if (message.includes('ILLEGAL') && bailOnIllegalToken(self.lineParser))
+        return false;
+      else
+        return true;
+    }
+
+    if (message.startsWith('missing ) after argument list'))
+      return true;
   }
   return false;
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1154,8 +1154,10 @@ REPLServer.prototype.convertToContext = function(cmd) {
   return cmd;
 };
 
-function bailOnIllegalToken(lp) {
-  return lp._literal === null && !lp.blockComment && !lp.regExpLiteral;
+function bailOnIllegalToken(parser) {
+  return parser._literal === null &&
+         !parser.blockComment &&
+         !parser.regExpLiteral;
 }
 
 // If the error is that we've unexpectedly ended the input,
@@ -1169,7 +1171,8 @@ function isRecoverableError(e, self) {
       return true;
     }
 
-    if (message.startsWith('Unexpected end of input'))
+    if (message.startsWith('Unexpected end of input') ||
+        message.startsWith('missing ) after argument list'))
       return true;
 
     if (message.startsWith('Unexpected token')) {
@@ -1178,9 +1181,6 @@ function isRecoverableError(e, self) {
       else
         return true;
     }
-
-    if (message.startsWith('missing ) after argument list'))
-      return true;
   }
   return false;
 }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -324,6 +324,10 @@ function error_test() {
             'undefined\n' + prompt_unix },
     { client: client_unix, send: '{ var x = 4; }',
       expect: 'undefined\n' + prompt_unix },
+    // Illegal token is not recoverable outside string literal, RegExp literal,
+    // or block comment. https://github.com/nodejs/node/issues/3611
+    { client: client_unix, send: 'a = 3.5e',
+      expect: /^SyntaxError: Unexpected token ILLEGAL/ },
   ]);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] a test and/or benchmark is included
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change
<!-- provide a description of the change below this comment -->

Illegal tokens are only recoverable in string literals, RegExp literals,
and block comments. If not in one of these constructs, immediately
return an error rather than giving the user false hope by giving them a
chance to try to recover.

Fixes: https://github.com/nodejs/node/issues/3611