### PR TITLE
src: remove unused internals from node.cc

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -722,47 +722,6 @@ const char *signo_string(int signo) {
 }
 
 
-// Convenience methods
-
-
-void ThrowError(v8::Isolate* isolate, const char* errmsg) {
-  Environment::GetCurrent(isolate)->ThrowError(errmsg);
-}
-
-
-void ThrowTypeError(v8::Isolate* isolate, const char* errmsg) {
-  Environment::GetCurrent(isolate)->ThrowTypeError(errmsg);
-}
-
-
-void ThrowRangeError(v8::Isolate* isolate, const char* errmsg) {
-  Environment::GetCurrent(isolate)->ThrowRangeError(errmsg);
-}
-
-
-void ThrowErrnoException(v8::Isolate* isolate,
-                         int errorno,
-                         const char* syscall,
-                         const char* message,
-                         const char* path) {
-  Environment::GetCurrent(isolate)->ThrowErrnoException(errorno,
-                                                        syscall,
-                                                        message,
-                                                        path);
-}
-
-
-void ThrowUVException(v8::Isolate* isolate,
-                      int errorno,
-                      const char* syscall,
-                      const char* message,
-                      const char* path,
-                      const char* dest) {
-  Environment::GetCurrent(isolate)
-      ->ThrowUVException(errorno, syscall, message, path, dest);
-}
-
-
 Local<Value> ErrnoException(Isolate* isolate,
                             int errorno,
                             const char *syscall,
@@ -1266,18 +1225,6 @@ Local<Value> MakeCallback(Environment* env,
   }
 
   return ret;
-}
-
-
-// Internal only.
-Local<Value> MakeCallback(Environment* env,
-                           Local<Object> recv,
-                           uint32_t index,
-                           int argc,
-                           Local<Value> argv[]) {
-  Local<Value> cb_v = recv->Get(index);
-  CHECK(cb_v->IsFunction());
-  return MakeCallback(env, recv.As<Value>(), cb_v.As<Function>(), argc, argv);
 }
 
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -58,13 +58,6 @@ v8::Local<v8::Value> MakeCallback(Environment* env,
 // Call with valid HandleScope and while inside Context scope.
 v8::Local<v8::Value> MakeCallback(Environment* env,
                                    v8::Local<v8::Object> recv,
-                                   uint32_t index,
-                                   int argc = 0,
-                                   v8::Local<v8::Value>* argv = nullptr);
-
-// Call with valid HandleScope and while inside Context scope.
-v8::Local<v8::Value> MakeCallback(Environment* env,
-                                   v8::Local<v8::Object> recv,
                                    v8::Local<v8::String> symbol,
                                    int argc = 0,
                                    v8::Local<v8::Value>* argv = nullptr);
@@ -192,21 +185,6 @@ inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
   *ret = static_cast<size_t>(tmp_i);
   return true;
 }
-
-void ThrowError(v8::Isolate* isolate, const char* errmsg);
-void ThrowTypeError(v8::Isolate* isolate, const char* errmsg);
-void ThrowRangeError(v8::Isolate* isolate, const char* errmsg);
-void ThrowErrnoException(v8::Isolate* isolate,
-                         int errorno,
-                         const char* syscall = nullptr,
-                         const char* message = nullptr,
-                         const char* path = nullptr);
-void ThrowUVException(v8::Isolate* isolate,
-                      int errorno,
-                      const char* syscall = nullptr,
-                      const char* message = nullptr,
-                      const char* path = nullptr,
-                      const char* dest = nullptr);
 
 class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  public:


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

Remove a couple of internal wrapper methods that are neither exported in the public headers nor used internally anywhere and imho have no real value being kept around.

CI: https://ci.nodejs.org/job/node-test-commit/3632/