### PR TITLE
tools: fix license builder to work with icu-small

### DIFF
--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -22,7 +22,7 @@ $(echo -e "$3" | sed -e 's/^/    /' -e 's/^    $//' -e 's/ *$//' | sed -e '/./,$
 }
 
 
-if ! [ -d "${rootdir}/deps/icu/" ]; then
+if ! [ -d "${rootdir}/deps/icu/" ] && ! [ -d "${rootdir}/deps/icu-small/" ]; then
   echo "ICU not installed, run configure to download it, e.g. ./configure --with-intl=small-icu --download=icu"
   exit 1
 fi
@@ -42,6 +42,16 @@ elif [ -f "${rootdir}/deps/icu/license.html" ]; then
   addlicense "ICU" "deps/icu" \
             "$(sed -e '1,/ICU License - ICU 1\.8\.1 and later/d' -e :a \
               -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' ${rootdir}/deps/icu/license.html)"
+elif [ -f "${rootdir}/deps/icu-small/LICENSE" ]; then
+  # ICU 57 and following. Drop the BOM
+  addlicense "ICU" "deps/icu-small" \
+            "$(sed -e '1s/^[^a-zA-Z ]*ICU/ICU/' -e :a \
+              -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' ${rootdir}/deps/icu-small/LICENSE)"
+elif [ -f "${rootdir}/deps/icu-small/license.html" ]; then
+  # ICU 56 and prior
+  addlicense "ICU" "deps/icu-small" \
+            "$(sed -e '1,/ICU License - ICU 1\.8\.1 and later/d' -e :a \
+              -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' ${rootdir}/deps/icu-small/license.html)"
 else
   echo "Could not find an ICU license file."
   exit 1


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
tools

##### Description of change
<!-- provide a description of the change below this comment -->

Currently the license builder is expecting the ICU package to be
found at `deps/icu`. ICU is now included by default and found at
`deps/icu-small`. This commit adds logic to find the license at the new
location.

This could likely be done in a more elegant way, but it works!

/cc @srl295 @jasnell 