### PR TITLE
readline: allow passing prompt to constructor

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -357,6 +357,7 @@ added: v0.1.98
     the history set this value to `0`. Defaults to `30`. This option makes sense
     only if `terminal` is set to `true` by the user or by an internal `output`
     check, otherwise the history caching mechanism is not initialized at all.
+  * `prompt` - the prompt string to use. Default: `'> '`
 
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.
@@ -467,9 +468,12 @@ implement a small command-line interface:
 
 ```js
 const readline = require('readline');
-const rl = readline.createInterface(process.stdin, process.stdout);
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: 'OHAI> '
+});
 
-rl.setPrompt('OHAI> ');
 rl.prompt();
 
 rl.on('line', (line) => {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -44,6 +44,7 @@ function Interface(input, output, completer, terminal) {
 
   EventEmitter.call(this);
   var historySize;
+  let prompt = '> ';
 
   if (arguments.length === 1) {
     // an options object was given
@@ -51,6 +52,9 @@ function Interface(input, output, completer, terminal) {
     completer = input.completer;
     terminal = input.terminal;
     historySize = input.historySize;
+    if (input.prompt !== undefined) {
+      prompt = input.prompt;
+    }
     input = input.input;
   }
 
@@ -87,7 +91,7 @@ function Interface(input, output, completer, terminal) {
     };
   }
 
-  this.setPrompt('> ');
+  this.setPrompt(prompt);
 
   this.terminal = !!terminal;
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -385,10 +385,9 @@ function REPLServer(prompt,
     output: self.outputStream,
     completer: complete,
     terminal: options.terminal,
-    historySize: options.historySize
+    historySize: options.historySize,
+    prompt
   });
-
-  self.setPrompt(prompt !== undefined ? prompt : '> ');
 
   this.commands = Object.create(null);
   defineDefaultCommands(this);
@@ -407,8 +406,6 @@ function REPLServer(prompt,
       return util.inspect(obj, showHidden, depth, true);
     };
   }
-
-  self.setPrompt(self._prompt);
 
   self.on('close', function() {
     self.emit('exit');


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
readline

##### Description of change

Previously, one would have to call `setPrompt` after calling
`rl.createInterface()`. Now, it the prompt string can be set by passing the
prompt property.