### PR TITLE
cluster: don't send messages if no IPC channel

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -743,6 +743,9 @@ function workerInit() {
 var seq = 0;
 var callbacks = {};
 function sendHelper(proc, message, handle, cb) {
+  if (!proc.connected)
+    return false;
+
   // Mark message as internal. See INTERNAL_PREFIX in lib/child_process.js
   message = util._extend({ cmd: 'NODE_CLUSTER' }, message);
   if (cb) callbacks[seq] = cb;

--- a/test/parallel/test-cluster-process-disconnect.js
+++ b/test/parallel/test-cluster-process-disconnect.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+  worker.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0, 'worker did not exit normally');
+    assert.strictEqual(signal, null, 'worker did not exit normally');
+  }));
+} else {
+  const net = require('net');
+  const server = net.createServer();
+  server.listen(common.PORT, common.mustCall(() => {
+    process.disconnect();
+  }));
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
cluster

##### Description of change
<!-- provide a description of the change below this comment -->

Avoid sending messages if the IPC channel is already disconnected.
It avoids undesired errors when calling `process.disconnect` when there
are still pending IPC messages.

/cc @cjihrig @bnoordhuis 