### PR TITLE
test: change duration_ms to duration

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -310,7 +310,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
       (duration.seconds + duration.days * 24 * 3600) * 10**6) / 10**6
 
     logger.info('  ---')
-    logger.info('  duration_ms: %d.%d' % (total_seconds, duration.microseconds / 1000))
+    logger.info('  duration: %d.%ds' % (total_seconds, duration.microseconds / 1000))
     logger.info('  ...')
 
   def Done(self):


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change

The test script (tools/test.py) logs duration as "duration_ms: x.y" this is confusing (as the duration is measured in seconds). This PR changes `duration_ms` to `duration`. It's a small change, but the `duration_ms` causes a lot of confusion to people who are new to the tests.

The only other use of `duration_ms` in the codebase is in [test/cctest/test-cpu-profiler.cc](https://github.com/nodejs/node/blob/b68827b1d1c20d0f3e0592734e845b87967a72bc/deps/v8/test/cctest/test-cpu-profiler.cc#L695) which I don't think should be affected by this change.

For background see @rvagg's comment - https://github.com/nodejs/node/pull/2393#issuecomment-132086711