### PR TITLE
doc: fix header depth of util.isSymbol

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -580,7 +580,7 @@ util.isString(5);
   // false
 ```
 
-## util.isSymbol(object)
+### util.isSymbol(object)
 
     Stability: 0 - Deprecated
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc (util)

##### Description of change

Header depth of util.isSymbol was off by one.

