### PR TITLE
src: fix ArrayBuffer size for zero fill flag

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1227,7 +1227,9 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
   if (auto zero_fill_field = env->isolate_data()->zero_fill_field()) {
     CHECK(args[1]->IsObject());
     auto binding_object = args[1].As<Object>();
-    auto array_buffer = ArrayBuffer::New(env->isolate(), zero_fill_field, 1);
+    auto array_buffer = ArrayBuffer::New(env->isolate(),
+                                         zero_fill_field,
+                                         sizeof(*zero_fill_field));
     auto name = FIXED_ONE_BYTE_STRING(env->isolate(), "zeroFill");
     auto value = Uint32Array::New(array_buffer, 0, 1);
     CHECK(binding_object->Set(env->context(), name, value).FromJust());


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Use `sizeof()` of the zero fill flag as the byte length of the `zeroFill` array buffer rather than `1`.

This fixes running debug builds, which have boundary checks for typed array creations from native code enabled.

Fixes: https://github.com/nodejs/node/issues/7140

Labelling this this as dont-land-* like #7082 itself.