### PR TITLE
buffer: do not crash in Debug build

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1229,7 +1229,7 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
     auto binding_object = args[1].As<Object>();
     auto array_buffer = ArrayBuffer::New(env->isolate(), zero_fill_field, 1);
     auto name = FIXED_ONE_BYTE_STRING(env->isolate(), "zeroFill");
-    auto value = Uint32Array::New(array_buffer, 0, 1);
+    auto value = Uint8Array::New(array_buffer, 0, 1);
     CHECK(binding_object->Set(env->context(), name, value).FromJust());
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change
<!-- provide a description of the change below this comment -->

In `SetupBufferJS` creating `Uint32Array` requires 4 bytes for
each entry, while the underlying `ArrayBuffer` was only 1 byte long. Use
`Uint8Array` instead.

R = @bnoordhuis (cleaning up after your commit 😉 )