### PR TITLE
http: wait for both prefinish/end to keepalive

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -195,6 +195,8 @@ function ClientRequest(options, cb) {
     self._flush();
     self = null;
   });
+
+  this._ended = false;
 }
 
 util.inherits(ClientRequest, OutgoingMessage);
@@ -466,6 +468,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 
   // add our listener first, so that we guarantee socket cleanup
   res.on('end', responseOnEnd);
+  req.on('prefinish', requestOnPrefinish);
   var handled = req.emit('response', res);
 
   // If the user did not listen for the 'response' event, then they
@@ -478,9 +481,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 }
 
 // client
-function responseOnEnd() {
-  var res = this;
-  var req = res.req;
+function responseKeepAlive(res, req) {
   var socket = req.socket;
 
   if (!req.shouldKeepAlive) {
@@ -502,6 +503,26 @@ function responseOnEnd() {
     // handlers have a chance to run.
     process.nextTick(emitFreeNT, socket);
   }
+}
+
+function responseOnEnd() {
+  const res = this;
+  const req = this.req;
+
+  req._ended = true;
+  if (!req.shouldKeepAlive || req.finished)
+    responseKeepAlive(res, req);
+}
+
+function requestOnPrefinish() {
+  const req = this;
+  const res = this.res;
+
+  if (!req.shouldKeepAlive)
+    return;
+
+  if (req._ended)
+    responseKeepAlive(res, req);
 }
 
 function emitFreeNT(socket) {

--- a/test/parallel/test-http-client-keep-alive-release-before-finish.js
+++ b/test/parallel/test-http-client-keep-alive-release-before-finish.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  res.end();
+}).listen(common.PORT, common.mustCall(() => {
+  const agent = new http.Agent({
+    maxSockets: 1,
+    keepAlive: true
+  });
+
+  const post = http.request({
+    agent: agent,
+    method: 'POST',
+    port: common.PORT,
+  }, common.mustCall((res) => {
+    res.resume();
+  }));
+
+  /* What happens here is that the server `end`s the response before we send
+   * `something`, and the client thought that this is a green light for sending
+   * next GET request
+   */
+  post.write(Buffer.alloc(16 * 1024).fill('X'));
+  setTimeout(() => {
+    post.end('something');
+  }, 100);
+
+  http.request({
+    agent: agent,
+    method: 'GET',
+    port: common.PORT,
+  }, common.mustCall((res) => {
+    server.close();
+    res.connection.end();
+  })).end();
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->


##### Description of change
<!-- provide a description of the change below this comment -->

When `free`ing the socket to be reused in keep-alive Agent wait for both
`prefinish` and `end` events. Otherwise the next request may be written
before the previous one has finished sending the body, leading to a
parser errors.

R= @nodejs/http 