### PR TITLE
buffer: runtime-deprecate Buffer constructor

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-class-assign */
 /* eslint-disable require-buffer */
 'use strict';
 
@@ -8,11 +7,7 @@ const { deprecate } = require('internal/util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
-class Buffer extends Uint8Array {}
-
-// to avoid code churn...
-const FastBuffer = Buffer;
-Buffer = DummyBuffer;
+const FastBuffer = (() => class Buffer extends Uint8Array {})();
 
 Buffer.prototype = FastBuffer.prototype;
 
@@ -70,7 +65,7 @@ const bufferDeprecationWarning =
  * specific needs. It's not likely that the Buffer constructors would ever
  * actually be removed.
  **/
-function DummyBuffer(arg, encodingOrOffset, length) {
+function Buffer(arg, encodingOrOffset, length) {
   bufferDeprecationWarning();
   // Common case.
   if (typeof arg === 'number') {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -3,6 +3,7 @@
 
 const binding = process.binding('buffer');
 const { isArrayBuffer } = process.binding('util');
+const { deprecate } = require('internal/util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
@@ -54,17 +55,19 @@ function alignPool() {
   }
 }
 
+const bufferDeprecationWarning =
+    deprecate(() => {}, 'Buffer constructor is deprecated. ' +
+      'Use Buffer.from, Buffer.allocUnsafe or Buffer.alloc instead.');
+
 /**
- * The Buffer() construtor is "soft deprecated" ... that is, it is deprecated
- * in the documentation and should not be used moving forward. Rather,
- * developers should use one of the three new factory APIs: Buffer.from(),
- * Buffer.allocUnsafe() or Buffer.alloc() based on their specific needs. There
- * is no hard deprecation because of the extent to which the Buffer constructor
- * is used in the ecosystem currently -- a hard deprecation would introduce too
- * much breakage at this time. It's not likely that the Buffer constructors
- * would ever actually be removed.
+ * The Buffer() construtor is deprecated ... that is, it should not be used
+ * moving forward. Rather, developers should use one of the three new factory
+ * APIs: Buffer.from(), Buffer.allocUnsafe() or Buffer.alloc() based on their
+ * specific needs. It's not likely that the Buffer constructors would ever
+ * actually be removed.
  **/
 function Buffer(arg, encodingOrOffset, length) {
+  bufferDeprecationWarning();
   // Common case.
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -100,6 +100,8 @@ Buffer.from = function(value, encodingOrOffset, length) {
   return fromObject(value);
 };
 
+Object.setPrototypeOf(Buffer, Uint8Array);
+
 function assertSize(size) {
   if (typeof size !== 'number') {
     const err = new TypeError('"size" argument must be a number');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-class-assign */
 /* eslint-disable require-buffer */
 'use strict';
 
@@ -7,9 +8,12 @@ const { deprecate } = require('internal/util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
-class FastBuffer extends Uint8Array {}
+class Buffer extends Uint8Array {}
 
-FastBuffer.prototype.constructor = Buffer;
+// to avoid code churn...
+const FastBuffer = Buffer;
+Buffer = DummyBuffer;
+
 Buffer.prototype = FastBuffer.prototype;
 
 exports.Buffer = Buffer;
@@ -66,7 +70,7 @@ const bufferDeprecationWarning =
  * specific needs. It's not likely that the Buffer constructors would ever
  * actually be removed.
  **/
-function Buffer(arg, encodingOrOffset, length) {
+function DummyBuffer(arg, encodingOrOffset, length) {
   bufferDeprecationWarning();
   // Common case.
   if (typeof arg === 'number') {
@@ -100,8 +104,6 @@ Buffer.from = function(value, encodingOrOffset, length) {
 
   return fromObject(value);
 };
-
-Object.setPrototypeOf(Buffer, Uint8Array);
 
 function assertSize(size) {
   if (typeof size !== 'number') {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests and code linting passes
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

buffer
##### Description of change

<!-- provide a description of the change below this comment -->
1. New Buffer API was introduced to prevent accidental data leakage and/or DoS (see https://github.com/nodejs/node/issues/4660). But there are older modules that haven't been updated and might still be vulnerable. Runtime deprecation encourages module authors to update to the new API, and the users to update their dependencies.
2. It is desirable that Buffer be a proper ES6 class that can be extended. However, parts of the deprecated Buffer API (such as creating a Buffer instance without `new`) make it impossible, while other parts (such as construction from a string) make it more complex. It will make things much simpler if the problematic deprecated parts are removed. But they need to be runtime-deprecated first.
