### PR TITLE
debugger: remove obsolete setTimeout

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -829,7 +829,7 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  setImmediate(() => { this.run(() => { this.resume; }); });
+  setImmediate(() => { this.run(); });
 }
 
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -829,13 +829,9 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  // XXX Need to figure out why we need this delay
-  setTimeout(function() {
-
-    self.run(function() {
-      self.resume();
-    });
-  }, 10);
+  self.run(function() {
+    self.resume();
+  });
 }
 
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -829,9 +829,7 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  self.run(function() {
-    self.resume();
-  });
+  setImmediate(() => { self.run(function() { self.resume(); }); });
 }
 
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -829,7 +829,7 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  setImmediate(() => { self.run(function() { self.resume(); }); });
+  setImmediate(() => { this.run(() => { this.resume; }); });
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
debugger

##### Description of change
<!-- provide a description of the change below this comment -->

Remove obsolete `setTimeout()` introduced in 3148f1400. The fix for the
problem is in b266074347. (For the record, I mostly don't know what I'm
talking about here but am summarizing from an IRC #node-dev conversation
with @indutny on 04-Jun-2016.)

R=@indutny