### PR TITLE
doc: more detail on when timers are executed

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -5,6 +5,40 @@
 All of the timer functions are globals.  You do not need to `require()`
 this module in order to use them.
 
+Timers set by [`setTimeout`][] and [`setInterval`][] are scheduled to run during
+a specific phase of the Node.js event loop. [`setImmediate`][] runs in a
+separate phase after I/O events and before timers.
+
+The execution of timers and callbacks created by [`setImmediate`][] set during
+execution of the input script ("script startup" in diagram below) will fire in
+a non-deterministic order.
+
+Overview of the Node.js event loop:
+```
+           +
+  +--------v--------+
+  | script startup  |
+  +--------+--------+
+           |
+  +--------v--------+
++->pending callbacks|
+| +--------+--------+
+|          |
+| +--------v--------+ +--------------------------------+
+| |      poll       <-+incoming connections, data, etc.|
+| +--------+--------+ +--------------------------------+
+|          |
+| +--------v--------+
+| |  setImmediate   |
+| +--------+--------+
+|          |
+| +--------v--------+
++-+     timers      |
+  +-----------------+
+
+```
+_note: [`process.nextTick`][] callbacks run at the end of every phase_
+
 ## clearImmediate(immediateObject)
 
 Stops an `immediateObject`, as created by [`setImmediate`][], from triggering.
@@ -86,6 +120,7 @@ Returns the timer.
 [`clearImmediate`]: timers.html#timers_clearimmediate_immediateobject
 [`clearInterval`]: timers.html#timers_clearinterval_intervalobject
 [`clearTimeout`]: timers.html#timers_cleartimeout_timeoutobject
+[`process.nextTick`]: process.html#process_process_nexttick_callback_arg
 [`setImmediate`]: timers.html#timers_setimmediate_callback_arg
 [`setInterval`]: timers.html#timers_setinterval_callback_delay_arg
 [`setTimeout`]: timers.html#timers_settimeout_callback_delay_arg


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change
<!-- provide a description of the change below this comment -->
This is an attempt to add information about when timers are executed in the event loop. I have no idea if this is correct. I've attempted to incorporate what I found in https://nodesource.com/blog/understanding-the-nodejs-event-loop/ and #7145.
