### PR TITLE
fs: create callback before nullCheck call

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -224,16 +224,15 @@ fs.access = function(path, mode, callback) {
   if (typeof mode === 'function') {
     callback = mode;
     mode = fs.F_OK;
-  } else if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
   }
 
+  callback = makeCallback(callback);
   if (!nullCheck(path, callback))
     return;
 
   mode = mode | 0;
   var req = new FSReqWrap();
-  req.oncomplete = makeCallback(callback);
+  req.oncomplete = callback;
   binding.access(pathModule._makeLong(path), mode, req);
 };
 
@@ -249,6 +248,7 @@ fs.accessSync = function(path, mode) {
 };
 
 fs.exists = function(path, callback) {
+  callback = makeCallback(callback);
   if (!nullCheck(path, cb)) return;
   var req = new FSReqWrap();
   req.oncomplete = cb;

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -94,14 +94,6 @@ assert.throws(function() {
   fs.access(100, fs.F_OK, function(err) {});
 }, /path must be a string or Buffer/);
 
-assert.throws(function() {
-  fs.access(__filename, fs.F_OK);
-}, /"callback" argument must be a function/);
-
-assert.throws(function() {
-  fs.access(__filename, fs.F_OK, {});
-}, /"callback" argument must be a function/);
-
 assert.doesNotThrow(function() {
   fs.accessSync(__filename);
 });


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

The callback function creation should happen before the `nullCheck`,
because it might invoke the callback to indicate errors.

This was pointed out by @cjihrig, in https://github.com/nodejs/node/pull/7068#discussion_r65582102

cc @nodejs/fs