### PR TITLE
events: allow unwraping #once handler in listeners

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -305,9 +305,15 @@ set by [`emitter.setMaxListeners(n)`][] or defaults to
 
 Returns the number of listeners listening to the event named `eventName`.
 
-### emitter.listeners(eventName)
+### emitter.listeners(eventName[, unwrapOnceListeners])
+
+* `eventName` {string|Symbol} The name of the event.
+* `unwrapOnceListeners` {Boolean} Flag indicating whether to unwrap listeners
+  attached via `.once()`.
 
 Returns a copy of the array of listeners for the event named `eventName`.
+If `unwrapOnceListeners` is set to `true`, listeners that were attached
+using `.once()` are returned as they were originally passed to `.once()`.
 
 ```js
 server.on('connection', (stream) => {

--- a/lib/events.js
+++ b/lib/events.js
@@ -413,7 +413,7 @@ EventEmitter.prototype.removeAllListeners =
       return this;
     };
 
-EventEmitter.prototype.listeners = function listeners(type) {
+EventEmitter.prototype.listeners = function listeners(type, unwrap) {
   var evlistener;
   var ret;
   var events = this._events;
@@ -422,12 +422,19 @@ EventEmitter.prototype.listeners = function listeners(type) {
     ret = [];
   else {
     evlistener = events[type];
-    if (!evlistener)
+    if (!evlistener) {
       ret = [];
-    else if (typeof evlistener === 'function')
-      ret = [evlistener];
-    else
-      ret = arrayClone(evlistener, evlistener.length);
+    } else if (typeof evlistener === 'function') {
+      if (unwrap)
+        ret = [evlistener.listener || evlistener];
+      else
+        ret = [evlistener];
+    } else {
+      if (unwrap)
+        ret = unwrapListeners(evlistener);
+      else
+        ret = arrayClone(evlistener, evlistener.length);
+    }
   }
 
   return ret;
@@ -474,4 +481,12 @@ function arrayClone(arr, i) {
   while (i--)
     copy[i] = arr[i];
   return copy;
+}
+
+function unwrapListeners(arr) {
+  const ret = new Array(arr.length);
+  for (var i = 0; i < ret.length; ++i) {
+    ret[i] = arr[i].listener || arr[i];
+  }
+  return ret;
 }

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -36,3 +36,31 @@ function listener2() {}
   assert.deepStrictEqual(ee.listeners('foo'), [listener, listener2]);
   assert.deepStrictEqual(eeListenersCopy, [listener]);
 }
+
+{
+  const ee = new events.EventEmitter();
+  ee.once('foo', listener);
+  assert.deepStrictEqual(ee.listeners('foo').map((fn) => fn.listener || fn),
+                         [listener]);
+}
+
+{
+  const ee = new events.EventEmitter();
+  ee.once('foo', listener);
+  assert.deepStrictEqual(ee.listeners('foo', true), [listener]);
+}
+
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  ee.once('foo', listener2);
+  assert.deepStrictEqual(ee.listeners('foo').map((fn) => fn.listener || fn),
+                         [listener, listener2]);
+}
+
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  ee.once('foo', listener2);
+  assert.deepStrictEqual(ee.listeners('foo', true), [listener, listener2]);
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

events

##### Description of change

De-semver-majorified variant of #6881: Instead of changing the return values of `.listeners()` unconditionally, adds an optional parameter that indicates which behaviour is desidered.

For `unwrapOnceListeners = true`, the array returned by `.listeners()` will include the handler functions as passed to `.once()`.

For `unwrapOnceListeners = false` (the default and the current behaviour), the array returned by `listeners()` will include the wrapper functions used by `.once()`, not the original functions that were passed in from userland. Use cases for this include temporarily disabling an event by removing all handlers and adding them back at a later point, where it would be undesirable to deal with the original event handlers.

Ref: https://github.com/nodejs/node/issues/6873
Ref: https://github.com/nodejs/node/issues/6881

CI: https://ci.nodejs.org/job/node-test-commit/3659/