### PR TITLE
buffer: fix creating from zero-length ArrayBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -260,7 +260,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
 
   const maxLength = obj.byteLength - byteOffset;
 
-  if (maxLength <= 0)
+  if (maxLength < 0)
     throw new RangeError("'offset' is out of bounds");
 
   if (length === undefined) {

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1458,3 +1458,8 @@ const ubuf = Buffer.allocUnsafeSlow(10);
 assert(ubuf);
 assert(ubuf.buffer);
 assert.equal(ubuf.buffer.byteLength, 10);
+
+// Regression test
+assert.doesNotThrow(() => {
+  Buffer.from(new ArrayBuffer());
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
buffer


##### Description of change
<!-- provide a description of the change below this comment -->

Fixes regression introduced in https://github.com/nodejs/node/commit/85ab4a5f1281c4e1dd06450ac7bd3250326267fa where creating a new Buffer from an empty ArrayBuffer would fail.

Initially found in #6893.

cc @trevnorris @addaleax @ChALkeR 