### PR TITLE
src: fix memory leak with realloc

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -235,7 +235,13 @@ MaybeLocal<Object> New(Isolate* isolate,
       free(data);
       data = nullptr;
     } else if (actual < length) {
-      data = static_cast<char*>(realloc(data, actual));
+      void * allocated = realloc(data, actual);
+      if (allocated == NULL) {
+        free(data);
+        data = nullptr;
+      } else {
+        data = static_cast<char*>(allocated);
+      }
       CHECK_NE(data, nullptr);
     }
   }


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

If `realloc` fails to allocate, it will return a null pointer and that
is assigned to `data`. This would leave the data pointed by `data`
unfreed and lead to memory leak.

cc @bnoordhuis @trevnorris @indutny 