### PR TITLE
benchmark: fix child-process-exec-stdout on win

### DIFF
--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -1,7 +1,12 @@
 'use strict';
 const common = require('../common.js');
+
+var messagesLength = [64, 256, 1024, 4096];
+// Windows does not support that long arguments
+if (process.platform !== 'win32')
+  messagesLength.push(32768);
 const bench = common.createBenchmark(main, {
-  len: [64, 256, 1024, 4096, 32768],
+  len: messagesLength,
   dur: [5]
 });
 


### PR DESCRIPTION
##### Checklist
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark

##### Description of change

This benchmark fails on Windows when trying to execute command which
is more than 32k in size. This commits skips this one case when running
under Windows.

cc @nodejs/benchmarking