### PR TITLE
doc: remove cluster.setupMaster() myth

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -632,9 +632,6 @@ values are `"rr"` and `"none"`.
 After calling `.setupMaster()` (or `.fork()`) this settings object will contain
 the settings, including the default values.
 
-It is effectively frozen after being set, because `.setupMaster()` can
-only be called once.
-
 This object is not supposed to be changed or set manually, by you.
 
 ## cluster.setupMaster([settings])


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
`cluster.setupMaster()` can be called more than once. Core even has tests for this functionality. This commit removes an incorrect statement to the contrary from the documentation.

Closes #7156