### PR TITLE
benchmark: use autocannon instead of wrk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,10 +599,10 @@ ifeq ($(XZ), 0)
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/node-$(FULLVERSION)-$(OSTYPE)-$(ARCH).tar.xz.done"
 endif
 
-haswrk=$(shell which wrk > /dev/null 2>&1; echo $$?)
-wrk:
-ifneq ($(haswrk), 0)
-	@echo "please install wrk before proceeding. More information can be found in benchmark/README.md." >&2
+hasautocannon=$(shell which autocannon > /dev/null 2>&1; echo $$?)
+autocannon:
+ifneq ($(hasautocannon), 0)
+	@echo "please install autocannon before proceeding. More information can be found in benchmark/README.md." >&2
 	@exit 1
 endif
 
@@ -615,7 +615,7 @@ bench-crypto: all
 bench-tls: all
 	@$(NODE) benchmark/common.js tls
 
-bench-http: wrk all
+bench-http: autocannon all
 	@$(NODE) benchmark/common.js http
 
 bench-fs: all

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -12,6 +12,10 @@ being installed. You can do this by running:
 
 [autocannon]: https://github.com/mcollina/autocannon
 
+Autocannon is a Node script and will use Node executable that is in the path.
+If you want to compare two HTTP benchmark runs make sure that the Node version
+in the path is not altered.
+
 ## How to run tests
 
 There are three ways to run benchmark tests:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -5,15 +5,12 @@ Node.js APIs.
 
 ## Prerequisites
 
-Most of the http benchmarks require [`wrk`][wrk] and [`ab`][ab] (ApacheBench) being installed.
-These may be available through your preferred package manager.
+Most of the http benchmarks require [`autocannon`][autocannon] npm module
+being installed. You can do this by running:
 
-If they are not available:
-- `wrk` may easily be built [from source][wrk] via `make`.
-- `ab` is sometimes bundled in a package called `apache2-utils`.
+`npm install -g autocannon`
 
-[wrk]: https://github.com/wg/wrk
-[ab]: http://httpd.apache.org/docs/2.2/programs/ab.html
+[autocannon]: https://github.com/mcollina/autocannon
 
 ## How to run tests
 

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -20,8 +20,6 @@ function main(conf) {
   const http = require('http');
   var chunk = Buffer.alloc(conf.size, '8');
 
-  var args = ['-d', '10s', '-t', 8, '-c', conf.c];
-
   var server = http.createServer(function(req, res) {
     function send(left) {
       if (left === 0) return res.end();
@@ -34,7 +32,7 @@ function main(conf) {
   });
 
   server.listen(common.PORT, function() {
-    bench.http('/', args, function() {
+    bench.http('/', 10, conf.c, function() {
       server.close();
     });
   });

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -27,9 +27,8 @@ function main(conf) {
 
     setTimeout(function() {
       var path = '/' + conf.type + '/' + conf.length;
-      var args = ['-d', '10s', '-t', 8, '-c', conf.c];
 
-      bench.http(path, args, function() {
+      bench.http(path, 10, conf.c, function() {
         w1.destroy();
         w2.destroy();
       });

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -43,14 +43,13 @@ function main(conf) {
   }
 
   var method = conf.method === 'write' ? write : end;
-  var args = ['-d', '10s', '-t', 8, '-c', conf.c];
 
   var server = http.createServer(function(req, res) {
     method(res);
   });
 
   server.listen(common.PORT, function() {
-    bench.http('/', args, function() {
+    bench.http('/', 10, conf.c, function() {
       server.close();
     });
   });

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -15,9 +15,8 @@ function main(conf) {
   var server = require('../http_simple.js');
   setTimeout(function() {
     var path = '/' + conf.type + '/' + conf.length + '/' + conf.chunks;
-    var args = ['-d', '10s', '-t', 8, '-c', conf.c];
 
-    bench.http(path, args, function() {
+    bench.http(path, 10, conf.c, function() {
       server.close();
     });
   }, 2000);


### PR DESCRIPTION
(this continues the work from https://github.com/nodejs/node/pull/6949)

##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark

##### Description of change
Switches http benchmarks to use [autocannon npm module](https://github.com/mcollina/autocannon/) instead of `wrk`. This allows benchmarks to be executed on all supported platforms, including Windows. Running benchmarks with `wrk`[(gist)](https://gist.github.com/bzoz/1589c9fde40c859e11de30abef6a04bc) and `autocannon`[(gist)](https://gist.github.com/bzoz/33c0d405deab8d0eba4eb795b4e4f3e7) on a 2 core virtual machine gives very similar results.