### PR TITLE
os: api cleanup and deprecations

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -19,6 +19,8 @@ system.
 added: v0.5.0
 -->
 
+    Stability: 0 - Deprecated: Use [`process.arch`][] instead.
+
 Returns the operating system CPU architecture. Possible values are `'x64'`,
 `'arm'` and `'ia32'`. Returns the value of [`process.arch`][].
 
@@ -203,6 +205,7 @@ interfaces that have been assigned an address.
 <!-- YAML
 added: v0.5.0
 -->
+    Stability: 0 - Deprecated: Use [`process.platform`][] instead.
 
 Returns the operating system platform. Possible values are `'darwin'`,
 `'freebsd'`, `'linux'`, `'sunos'` or `'win32'`. Returns the value of

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -24,7 +24,7 @@ added: v0.5.0
 Returns the operating system CPU architecture. Possible values are `'x64'`,
 `'arm'` and `'ia32'`. Returns the value of [`process.arch`][].
 
-## os.BYTEORDER
+## os.byteOrder
 <!-- YAML
 added: 
 -->
@@ -125,7 +125,7 @@ added: v0.9.4
 deprecated: 
 -->
 
-    Stability: 0 - Deprecated: Use `os.BYTEORDER` instead.
+    Stability: 0 - Deprecated: Use `os.byteOrder` instead.
 
 Returns the endianness of the CPU. Possible values are `'BE'` for big endian
 or `'LE'` for little endian.

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -22,6 +22,14 @@ added: v0.5.0
 Returns the operating system CPU architecture. Possible values are `'x64'`,
 `'arm'` and `'ia32'`. Returns the value of [`process.arch`][].
 
+## os.BYTEORDER
+<!-- YAML
+added: 
+-->
+
+Specifies the endianness of the CPU. Possible values are `'BE'` for big endian
+or `'LE'` for little endian.
+
 ## os.constants
 
 Returns an object containing commonly used operating system specific constants
@@ -112,7 +120,10 @@ all processors are always 0.
 ## os.endianness()
 <!-- YAML
 added: v0.9.4
+deprecated: 
 -->
+
+    Stability: 0 - Deprecated: Use `os.BYTEORDER` instead.
 
 Returns the endianness of the CPU. Possible values are `'BE'` for big endian
 or `'LE'` for little endian.

--- a/lib/os.js
+++ b/lib/os.js
@@ -55,7 +55,8 @@ exports.tmpDir = exports.tmpdir;
 
 exports.EOL = isWindows ? '\r\n' : '\n';
 
-if (binding.isBigEndian)
-  exports.endianness = function() { return 'BE'; };
-else
-  exports.endianness = function() { return 'LE'; };
+exports.BYTEORDER = binding.isBigEndian ? 'BE' : 'LE';
+
+exports.endianness = internalUtil.deprecate(function() {
+  return exports.BYTEORDER;
+}, 'os.endianness() is deprecated. Use os.BYTEORDER instead.');

--- a/lib/os.js
+++ b/lib/os.js
@@ -53,11 +53,6 @@ exports.tmpdir = function() {
 
 exports.tmpDir = exports.tmpdir;
 
-exports.getNetworkInterfaces = internalUtil.deprecate(function() {
-  return exports.networkInterfaces();
-}, 'os.getNetworkInterfaces is deprecated. ' +
-   'Use os.networkInterfaces instead.');
-
 exports.EOL = isWindows ? '\r\n' : '\n';
 
 if (binding.isBigEndian)

--- a/lib/os.js
+++ b/lib/os.js
@@ -55,8 +55,8 @@ exports.tmpDir = exports.tmpdir;
 
 exports.EOL = isWindows ? '\r\n' : '\n';
 
-exports.BYTEORDER = binding.isBigEndian ? 'BE' : 'LE';
+exports.byteOrder = binding.isBigEndian ? 'BE' : 'LE';
 
 exports.endianness = internalUtil.deprecate(function() {
-  return exports.BYTEORDER;
-}, 'os.endianness() is deprecated. Use os.BYTEORDER instead.');
+  return exports.byteOrder;
+}, 'os.endianness() is deprecated. Use os.byteOrder instead.');

--- a/test/common.js
+++ b/test/common.js
@@ -22,7 +22,7 @@ exports.isWOW64 = exports.isWindows &&
 exports.isAix = process.platform === 'aix';
 exports.isLinuxPPCBE = (process.platform === 'linux') &&
                        (process.arch === 'ppc64') &&
-                       (os.BYTEORDER === 'BE');
+                       (os.byteOrder === 'BE');
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
 

--- a/test/common.js
+++ b/test/common.js
@@ -22,7 +22,7 @@ exports.isWOW64 = exports.isWindows &&
 exports.isAix = process.platform === 'aix';
 exports.isLinuxPPCBE = (process.platform === 'linux') &&
                        (process.arch === 'ppc64') &&
-                       (os.endianness() === 'BE');
+                       (os.BYTEORDER === 'BE');
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
 

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -92,7 +92,7 @@ testBufs('a\u0234b\u0235c\u0236', 4, -1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 4, 1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 12, 1, 'ucs2');
 assert.equal(Buffer.allocUnsafe(1).fill('\u0222', 'ucs2')[0],
-             os.BYTEORDER === 'LE' ? 0x22 : 0x02);
+             os.byteOrder === 'LE' ? 0x22 : 0x02);
 
 
 // HEX
@@ -227,7 +227,7 @@ function writeToFill(string, offset, end, encoding) {
   } while (offset < buf2.length);
 
   // Correction for UCS2 operations.
-  if (os.BYTEORDER === 'BE' && encoding === 'ucs2') {
+  if (os.byteOrder === 'BE' && encoding === 'ucs2') {
     for (var i = 0; i < buf2.length; i += 2) {
       var tmp = buf2[i];
       buf2[i] = buf2[i + 1];

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -92,7 +92,7 @@ testBufs('a\u0234b\u0235c\u0236', 4, -1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 4, 1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 12, 1, 'ucs2');
 assert.equal(Buffer.allocUnsafe(1).fill('\u0222', 'ucs2')[0],
-             os.endianness() === 'LE' ? 0x22 : 0x02);
+             os.BYTEORDER === 'LE' ? 0x22 : 0x02);
 
 
 // HEX
@@ -227,7 +227,7 @@ function writeToFill(string, offset, end, encoding) {
   } while (offset < buf2.length);
 
   // Correction for UCS2 operations.
-  if (os.endianness() === 'BE' && encoding === 'ucs2') {
+  if (os.BYTEORDER === 'BE' && encoding === 'ucs2') {
     for (var i = 0; i < buf2.length; i += 2) {
       var tmp = buf2[i];
       buf2[i] = buf2[i + 1];

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -39,7 +39,7 @@ if (common.isWindows) {
   assert.equal(os.tmpdir(), '/');
 }
 
-var endianness = os.BYTEORDER;
+var endianness = os.byteOrder;
 console.log('endianness = %s', endianness);
 assert.ok(/[BL]E/.test(endianness));
 

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -39,7 +39,7 @@ if (common.isWindows) {
   assert.equal(os.tmpdir(), '/');
 }
 
-var endianness = os.endianness();
+var endianness = os.BYTEORDER;
 console.log('endianness = %s', endianness);
 assert.ok(/[BL]E/.test(endianness));
 


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

os

##### Description of change

Does three things in separate commits

1. Remove the long deprecated os.getNetworkInterfaces alias
2. Replaces and deprecates os.endianness() with os.BYTEORDER property (internal uses updated accordingly)
3. Docs only deprecation of os.arch() and os.platform() since those simply return process.arch and process.platform