### PR TITLE
Update inspector ready message to be vendor agnostic

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -32,10 +32,7 @@ const char DEVTOOLS_PATH[] = "/node";
 
 void PrintDebuggerReadyMessage(int port) {
   fprintf(stderr, "Debugger listening on port %d.\n"
-    "To start debugging, open the following URL in Chrome:\n"
-    "    chrome-devtools://devtools/remote/serve_file/"
-    "@521e5b7e2b7cc66b4006a8a54cb9c4e57494a5ef/inspector.html?"
-    "experiments=true&v8only=true&ws=localhost:%d/node\n", port, port);
+    "To start debugging, open your preferred debugging tool, and select this process.", port);
 }
 
 bool AcceptsConnection(inspector_socket_t* socket, const char* path) {


### PR DESCRIPTION
##### Checklist
- [x] tests and code linting passes
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
v8inspector

##### Description of change

Per concern raised in [Add v8_inspector support](https://github.com/nodejs/node/pull/6792#issuecomment-221272659), this PR updates the inspector ready message to be vendor agnostic, and removes the Chrome DevTools specific URL, that requires Node users to install and use Chrome as the preferred debugging tool.

##### Principle behind

The principle for this change, is that Node as a runtime, shouldn't favor one debugging tool or vendor, but the --inspect flag should simply expose a **generic debugging** endpoint that's **discoverable** by tools such as Chrome DevTools, Node-inspector, VS Code and others.

It's a fact that Chrome is cross platform browser and could be installed for potentially all node users, but the same argument can be used for other debugging tools such as VS Code, Sublime and others, and those tools aren't being favored by Node, so neither should Chrome DevTools.

If the argument is the convenience, this could just be achieved by Google or any other vendor providing a CLI that launches `node --inspect` and launches the specific tool connecting to the specific node process.

Think `node-chrome-debug index.js` -> `node --inspect index.js` + `opens chrome-devtools://devtools/` in Chrome. Collaboration with the [node-inspector](https://github.com/node-inspector/node-inspector) could be an ideal candidate for this.

(Ping @boneskull, @ofrobots, @pavelfeldman, @joshgav, @rvagg)
