### PR TITLE
doc: clarify "Reviewed-By" iff "LGTM"

### DIFF
--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -169,6 +169,7 @@ Landing a PR
     * `Reviewed-By: human <email>`
       * Easiest to use `git log` then do a search
       * (`/Name` + `enter` (+ `n` as much as you need to) in vim)
+      * Only include collaborators who have commented "LGTM"
     * `PR-URL: <full-pr-url>`
 * `git push upstream master`
     * close the original PR with "Landed in `<commit hash>`".


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

As per conversation with @Trott, make it clear that Reviewed-By lines
should only be added for collaborators who've actually put a LGTM on the
PR.