### PR TITLE
Fix child process stdio data loss with slow piped consumers

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -221,8 +221,11 @@ util.inherits(ChildProcess, EventEmitter);
 function flushStdio(subprocess) {
   if (subprocess.stdio == null) return;
   subprocess.stdio.forEach(function(stream, fd, stdio) {
-    if (!stream || !stream.readable || stream._readableState.readableListening)
+    if (!stream || !stream.readable ||
+        stream._readableState.readableListening ||
+        stream._readableState.pipesCount > 0) {
       return;
+    }
     stream.resume();
   });
 }

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -24,9 +24,11 @@ function spawnWithReadable() {
     spawnWithPipe();
   }));
   p.stdout.on('readable', function() {
-    let buf;
-    while (buf = this.read())
-      buffer.push(buf);
+    setImmediate(() => {
+      let buf;
+      while (buf = this.read())
+        buffer.push(buf);
+    });
   });
 }
 

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -2,6 +2,7 @@
 const cp = require('child_process');
 const common = require('../common');
 const assert = require('assert');
+const stream = require('stream');
 
 const p = cp.spawn('echo');
 
@@ -20,10 +21,40 @@ function spawnWithReadable() {
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
     assert.strictEqual(Buffer.concat(buffer).toString().trim(), '123');
+    spawnWithPipe();
   }));
   p.stdout.on('readable', function() {
     let buf;
     while (buf = this.read())
       buffer.push(buf);
   });
+}
+
+function spawnWithPipe() {
+  const buffer = [];
+  const through = new stream.PassThrough();
+  const p = cp.spawn('seq', [ '36000' ]);
+
+  const ret = [];
+  for (let i = 1; i <= 36000; i++) {
+    ret.push(i);
+  }
+
+  p.on('close', common.mustCall(function(code, signal) {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(Buffer.concat(buffer).toString().trim(), ret.join('\n'));
+  }));
+
+  p.on('exit', common.mustCall(function() {
+    setImmediate(function() {
+      through.on('readable', function() {
+        let buf;
+        while (buf = this.read())
+          buffer.push(buf);
+      });
+    });
+  }));
+
+  p.stdout.pipe(through);
 }


### PR DESCRIPTION
##### Checklist

- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [ ] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)

* child-process


##### Description of change

The `flushStdio()` checks if there are readable handlers attached to the stdio streams to prevent data loss but it doesn't check if there are piped consumers. Change it so that it checks `pipesCount` too.

I also fixed the previous testcase on the same issue to actually catch the regression as it would previously pass regardless of what flushStdio was doing.

Fixes #7184 
