### PR TITLE
test: http request - url.parse

### DIFF
--- a/test/parallel/test-http-url.parse-auth.js
+++ b/test/parallel/test-http-url.parse-auth.js
@@ -1,18 +1,17 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
-var url = require('url');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
 
 // username = "user", password = "pass:"
-var testURL = url.parse('http://user:pass%3A@localhost:' + common.PORT);
+const testUrl = `http://user:pass%3A@localhost:${common.PORT}`;
 
 function check(request) {
   // the correct authorization header is be passed
   assert.strictEqual(request.headers.authorization, 'Basic dXNlcjpwYXNzOg==');
 }
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer(function(request, response) {
   // run the check function
   check.call(this, request, response);
   response.writeHead(200, {});
@@ -22,5 +21,5 @@ var server = http.createServer(function(request, response) {
 
 server.listen(common.PORT, function() {
   // make the request
-  http.request(testURL).end();
+  http.request(testUrl).end();
 });

--- a/test/parallel/test-http-url.parse-basic.js
+++ b/test/parallel/test-http-url.parse-basic.js
@@ -1,10 +1,11 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
-var url = require('url');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const url = require('url');
 
-var testURL = url.parse('http://localhost:' + common.PORT);
+const testUrl = `http://localhost:${common.PORT}`;
+const testUrlObject = url.parse(testUrl);
 
 // make sure the basics work
 function check(request) {
@@ -14,10 +15,10 @@ function check(request) {
   assert.strictEqual(request.url, '/');
   // the host header should use the url.parse.hostname
   assert.strictEqual(request.headers.host,
-                     testURL.hostname + ':' + testURL.port);
+                     testUrlObject.hostname + ':' + testUrlObject.port);
 }
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer(function(request, response) {
   // run the check function
   check.call(this, request, response);
   response.writeHead(200, {});
@@ -27,7 +28,7 @@ var server = http.createServer(function(request, response) {
 
 server.listen(common.PORT, function() {
   // make the request
-  var clientRequest = http.request(testURL);
+  const clientRequest = http.request(testUrl);
   // since there is a little magic with the agent
   // make sure that an http request uses the http.Agent
   assert.ok(clientRequest.agent instanceof http.Agent);

--- a/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
+++ b/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
@@ -1,8 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var http = require('http');
-var url = require('url');
+const assert = require('assert');
+const http = require('http');
+const url = require('url');
 
 
 assert.throws(function() {
@@ -16,7 +16,7 @@ assert.throws(function() {
 });
 
 assert.throws(function() {
-  http.request(url.parse('mailto:asdf@asdf.com'));
+  http.request('mailto:asdf@asdf.com');
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "mailto:" not supported.' +
@@ -26,7 +26,7 @@ assert.throws(function() {
 });
 
 assert.throws(function() {
-  http.request(url.parse('ftp://www.example.com'));
+  http.request('ftp://www.example.com');
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "ftp:" not supported.' +
@@ -46,7 +46,7 @@ assert.throws(function() {
 });
 
 assert.throws(function() {
-  http.request(url.parse('xmpp:isaacschlueter@jabber.org'));
+  http.request('xmpp:isaacschlueter@jabber.org');
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "xmpp:" not supported.' +
@@ -56,7 +56,7 @@ assert.throws(function() {
 });
 
 assert.throws(function() {
-  http.request(url.parse('f://some.host/path'));
+  http.request('f://some.host/path');
 }, function(err) {
   if (err instanceof Error) {
     assert.strictEqual(err.message, 'Protocol "f:" not supported.' +

--- a/test/parallel/test-http-url.parse-path.js
+++ b/test/parallel/test-http-url.parse-path.js
@@ -1,17 +1,16 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
-var url = require('url');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
 
-var testURL = url.parse('http://localhost:' + common.PORT + '/asdf');
+const testUrl = `http://localhost:${common.PORT}/asdf`;
 
 function check(request) {
   // a path should come over
   assert.strictEqual(request.url, '/asdf');
 }
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer(function(request, response) {
   // run the check function
   check.call(this, request, response);
   response.writeHead(200, {});
@@ -21,5 +20,5 @@ var server = http.createServer(function(request, response) {
 
 server.listen(common.PORT, function() {
   // make the request
-  http.request(testURL).end();
+  http.request(testUrl).end();
 });

--- a/test/parallel/test-http-url.parse-search.js
+++ b/test/parallel/test-http-url.parse-search.js
@@ -1,17 +1,16 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
-var url = require('url');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
 
-var testURL = url.parse('http://localhost:' + common.PORT + '/asdf?qwer=zxcv');
+const testUrl = `http://localhost:${common.PORT}/asdf?qwer=zxcv`;
 
 function check(request) {
   // a path should come over with params
   assert.strictEqual(request.url, '/asdf?qwer=zxcv');
 }
 
-var server = http.createServer(function(request, response) {
+const server = http.createServer(function(request, response) {
   // run the check function
   check.call(this, request, response);
   response.writeHead(200, {});
@@ -21,5 +20,5 @@ var server = http.createServer(function(request, response) {
 
 server.listen(common.PORT, function() {
   // make the request
-  http.request(testURL).end();
+  http.request(testUrl).end();
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Run tests with `make -j4 test` on UNIX or `vcbuild test nosign` on Windows.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests and code linting passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
##### Description of change

<!-- provide a description of the change below this comment -->

http.request does the `url.parse` if the parameter is of type string.
So, whenever possible, the tests should let the http module's -
`request()`method to do the `url.parse()`.
