### PR TITLE
lib: replace util._extend with object.assign

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -28,7 +28,7 @@ function Agent(options) {
   self.defaultPort = 80;
   self.protocol = 'http:';
 
-  self.options = util._extend({}, options);
+  self.options = Object.assign({}, options);
 
   // don't confuse net and make it think that we're connecting to a pipe
   self.options.path = null;
@@ -120,8 +120,8 @@ Agent.prototype.addRequest = function(req, options) {
     };
   }
 
-  options = util._extend({}, options);
-  options = util._extend(options, this.options);
+  options = Object.assign({}, options);
+  options = Object.assign(options, this.options);
 
   var name = this.getName(options);
   if (!this.sockets[name]) {
@@ -167,8 +167,8 @@ Agent.prototype.addRequest = function(req, options) {
 
 Agent.prototype.createSocket = function(req, options, cb) {
   var self = this;
-  options = util._extend({}, options);
-  options = util._extend(options, self.options);
+  options = Object.assign({}, options);
+  options = Object.assign(options, self.options);
 
   if (!options.servername) {
     options.servername = options.host;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -25,7 +25,7 @@ function ClientRequest(options, cb) {
       throw new Error('Unable to determine the domain name');
     }
   } else {
-    options = util._extend({}, options);
+    options = Object.assign({}, options);
   }
 
   var agent = options.agent;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -957,9 +957,9 @@ function normalizeConnectArgs(listArgs) {
   var cb = args[1];
 
   if (listArgs[1] !== null && typeof listArgs[1] === 'object') {
-    options = util._extend(options, listArgs[1]);
+    options = Object.assign(options, listArgs[1]);
   } else if (listArgs[2] !== null && typeof listArgs[2] === 'object') {
-    options = util._extend(options, listArgs[2]);
+    options = Object.assign(options, listArgs[2]);
   }
 
   return (cb) ? [options, cb] : [options];
@@ -981,7 +981,7 @@ exports.connect = function(/* [port, host], options, cb */) {
     minDHSize: 1024
   };
 
-  options = util._extend(defaults, options || {});
+  options = Object.assign(defaults, options || {});
   if (!options.keepAlive)
     options.singleUse = true;
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -22,12 +22,12 @@ exports.fork = function(modulePath /*, args, options*/) {
   var options, args, execArgv;
   if (Array.isArray(arguments[1])) {
     args = arguments[1];
-    options = util._extend({}, arguments[2]);
+    options = Object.assign({}, arguments[2]);
   } else if (arguments[1] && typeof arguments[1] !== 'object') {
     throw new TypeError('Incorrect value of args option');
   } else {
     args = [];
-    options = util._extend({}, arguments[1]);
+    options = Object.assign({}, arguments[1]);
   }
 
   // Prepare arguments for fork:
@@ -123,7 +123,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (pos < arguments.length && typeof arguments[pos] === 'object') {
-    options = util._extend(options, arguments[pos++]);
+    options = Object.assign(options, arguments[pos++]);
   } else if (pos < arguments.length && arguments[pos] == null) {
     pos++;
   }
@@ -426,7 +426,7 @@ function spawnSync(/*file, args, options*/) {
   options.stdio = _validateStdio(options.stdio || 'pipe', true).stdio;
 
   if (options.input) {
-    var stdin = options.stdio[0] = util._extend({}, options.stdio[0]);
+    var stdin = options.stdio[0] = Object.assign({}, options.stdio[0]);
     stdin.input = options.input;
   }
 
@@ -434,7 +434,7 @@ function spawnSync(/*file, args, options*/) {
   for (i = 0; i < options.stdio.length; i++) {
     var input = options.stdio[i] && options.stdio[i].input;
     if (input != null) {
-      var pipe = options.stdio[i] = util._extend({}, options.stdio[i]);
+      var pipe = options.stdio[i] = Object.assign({}, options.stdio[i]);
       if (Buffer.isBuffer(input))
         pipe.input = input;
       else if (typeof input === 'string')
@@ -466,7 +466,7 @@ function spawnSync(/*file, args, options*/) {
     result.error.spawnargs = opts.args.slice(1);
   }
 
-  util._extend(result, opts);
+  Object.assign(result, opts);
 
   return result;
 }
@@ -486,7 +486,7 @@ function checkExecSyncError(ret) {
       err = new Error(msg);
     }
 
-    util._extend(err, ret);
+    Object.assign(err, ret);
     return err;
   }
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -245,8 +245,8 @@ function masterInit() {
       execArgv: process.execArgv,
       silent: false
     };
-    settings = util._extend(settings, cluster.settings);
-    settings = util._extend(settings, options || {});
+    settings = Object.assign(settings, cluster.settings);
+    settings = Object.assign(settings, options || {});
     // Tell V8 to write profile data for each process to a separate file.
     // Without --logfile=v8-%p.log, everything ends up in a single, unusable
     // file. (Unusable because what V8 logs are memory addresses and each
@@ -298,11 +298,11 @@ function masterInit() {
   var debugPortOffset = 1;
 
   function createWorkerProcess(id, env) {
-    var workerEnv = util._extend({}, process.env);
+    var workerEnv = Object.assign({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
     var debugPort = 0;
 
-    workerEnv = util._extend(workerEnv, env);
+    workerEnv = Object.assign(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;
 
     for (var i = 0; i < execArgv.length; i++) {
@@ -502,7 +502,7 @@ function masterInit() {
 
     // Set custom server data
     handle.add(worker, function(errno, reply, handle) {
-      reply = util._extend({
+      reply = Object.assign({
         errno: errno,
         key: key,
         ack: message.seq,
@@ -580,7 +580,7 @@ function workerInit() {
     else
       indexes[indexesKey]++;
 
-    const message = util._extend({
+    const message = Object.assign({
       act: 'queryServer',
       index: indexes[indexesKey],
       data: null
@@ -649,7 +649,7 @@ function workerInit() {
     }
 
     function getsockname(out) {
-      if (key) util._extend(out, message.sockname);
+      if (key) Object.assign(out, message.sockname);
       return 0;
     }
 
@@ -744,7 +744,7 @@ var seq = 0;
 var callbacks = {};
 function sendHelper(proc, message, handle, cb) {
   // Mark message as internal. See INTERNAL_PREFIX in lib/child_process.js
-  message = util._extend({ cmd: 'NODE_CLUSTER' }, message);
+  message = Object.assign({ cmd: 'NODE_CLUSTER' }, message);
   if (cb) callbacks[seq] = cb;
   message.seq = seq;
   seq += 1;

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -232,7 +232,7 @@ function intercepted(_this, self, cb, fnargs) {
 
   if (fnargs[0] && fnargs[0] instanceof Error) {
     var er = fnargs[0];
-    util._extend(er, {
+    Object.assign(er, {
       domainBound: cb,
       domainThrown: false,
       domain: self

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1364,7 +1364,7 @@ fs.appendFile = function(path, data, options, callback_) {
   }
 
   if (!options.flag)
-    options = util._extend({ flag: 'a' }, options);
+    options = Object.assign({ flag: 'a' }, options);
 
   // force append behavior when using a supplied file descriptor
   if (isFd(path))
@@ -1383,7 +1383,7 @@ fs.appendFileSync = function(path, data, options) {
   }
 
   if (!options.flag)
-    options = util._extend({ flag: 'a' }, options);
+    options = Object.assign({ flag: 'a' }, options);
 
   // force append behavior when using a supplied file descriptor
   if (isFd(path))
@@ -1521,7 +1521,7 @@ fs.watchFile = function(filename, options, listener) {
   };
 
   if (options !== null && typeof options === 'object') {
-    options = util._extend(defaults, options);
+    options = Object.assign(defaults, options);
   } else {
     listener = options;
     options = defaults;

--- a/lib/https.js
+++ b/lib/https.js
@@ -73,7 +73,7 @@ function createConnection(port, host, options) {
     const session = this._getSession(options._agentKey);
     if (session) {
       debug('reuse session for %j', options._agentKey);
-      options = util._extend({
+      options = Object.assign({
         session: session
       }, options);
     }
@@ -193,7 +193,7 @@ exports.request = function(options, cb) {
       throw new Error('Unable to determine the domain name');
     }
   } else {
-    options = util._extend({}, options);
+    options = Object.assign({}, options);
   }
   options._defaultAgent = globalAgent;
   return http.request(options, cb);

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -17,7 +17,7 @@ function ReadStream(fd, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(fd, options);
 
-  options = util._extend({
+  options = Object.assign({
     highWaterMark: 0,
     readable: true,
     writable: false,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
http, tls, child-process, cluster, domain, fs, https, tty

##### Description of change
<!-- provide a description of the change below this comment -->

`Object.assign` is built-in and has some performance advantage-
 over the polyfill.

One thing to keep an eye is that `_extend` used to fail silently-
while `assign` throws an error. Let me know if there are any concerns-
or if the `pr` need to be split based on the components.
