### PR TITLE
Revert "test: change duration_ms to duration"

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -310,7 +310,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
       (duration.seconds + duration.days * 24 * 3600) * 10**6) / 10**6
 
     logger.info('  ---')
-    logger.info('  duration: %d.%ds' % (total_seconds, duration.microseconds / 1000))
+    logger.info('  duration_ms: %d.%d' % (total_seconds, duration.microseconds / 1000))
     logger.info('  ...')
 
   def Done(self):


### PR DESCRIPTION
Undoes the change made @ #7133 

I'm pretty sure we've had this discussion at least twice on GitHub already but I can't find either record unfortunately. Sorry I'm just catching up and saw this PR only now.

"duration_ms" is a TAP thing and yes it's confusing and doesn't read well but you have to interpret it as "duration including milliseconds", so it's "seconds.milliseconds". When you change it, TAP parsers don't pick it up properly.

Compare the CI run that was done specifically for #7133 prior to merging:

![screen shot 2016-06-08 at 4 38 17 pm](https://cloud.githubusercontent.com/assets/495647/15885015/7bdc5708-2d97-11e6-9826-3096ca6690cf.png)

With the run for that same slave machine done just one before without this change:

![screen shot 2016-06-08 at 4 37 44 pm](https://cloud.githubusercontent.com/assets/495647/15885020/9211c7ce-2d97-11e6-8f42-38b0759893ce.png)

So now we've lost timing information, which is important when looking for timeouts (if you use the parsed results, I use the raw console but I know a lot of people prefer the former).