### PR TITLE
test: skip doctool tests when js-yaml is missing

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -5,6 +5,13 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+// The doctool currently uses js-yaml from the tool/eslint/ tree.
+try {
+  require('../../tools/eslint/node_modules/js-yaml');
+} catch (e) {
+  return common.skip('missing js-yaml (eslint not present)');
+}
+
 const processIncludes = require('../../tools/doc/preprocess.js');
 const html = require('../../tools/doc/html.js');
 

--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -5,6 +5,13 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+// The doctool currently uses js-yaml from the tool/eslint/ tree.
+try {
+  require('../../tools/eslint/node_modules/js-yaml');
+} catch (e) {
+  return common.skip('missing js-yaml (eslint not present)');
+}
+
 const json = require('../../tools/doc/json.js');
 
 // Outputs valid json with the expected fields when given simple markdown


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Skip the doctool tests when js-yaml, which is currently `require()`d from the eslint source tree, is missing. This can happen, for example, because eslint is not included in the release source tarballs.

Fixes: https://github.com/nodejs/node/issues/7201
Ref (introduced in): https://github.com/nodejs/node/pull/6495

CI: https://ci.nodejs.org/job/node-test-commit/3692/