### PR TITLE
Backport «buffer: ignore negative allocation lengths» to v5.x

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -163,8 +163,8 @@ Object.setPrototypeOf(SlowBuffer, Uint8Array);
 
 
 function allocate(size) {
-  if (size === 0) {
-    return createBuffer(size);
+  if (size <= 0) {
+    return createBuffer(0);
   }
   if (size < (Buffer.poolSize >>> 1)) {
     if (size > (poolSize - poolOffset))

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1438,3 +1438,14 @@ assert.equal(Buffer.prototype.parent, undefined);
 assert.equal(Buffer.prototype.offset, undefined);
 assert.equal(SlowBuffer.prototype.parent, undefined);
 assert.equal(SlowBuffer.prototype.offset, undefined);
+
+{
+  // Test that large negative Buffer length inputs don't affect the pool offset.
+  assert.deepStrictEqual(Buffer(-Buffer.poolSize), Buffer.from(''));
+  assert.deepStrictEqual(Buffer(-100), Buffer.from(''));
+  assert.deepStrictEqual(Buffer.allocUnsafe(-Buffer.poolSize), Buffer.from(''));
+  assert.deepStrictEqual(Buffer.allocUnsafe(-100), Buffer.from(''));
+
+  // Check pool offset after that by trying to write string into the pool.
+  assert.doesNotThrow(() => Buffer.from('abc'));
+}


### PR DESCRIPTION
This backports #7051 (by @addaleax) to v5.x.
It landed cleanly and is straightforward fix for #7047.

I originally included this in #7169 backport, but that one is semver-minor, and I'm not exactly sure if the next 5.x release will be a semver-minor, but I definitely want this to make it into the next 5.x release.

/cc @jasnell, you already reviewed this backport in #7169, but could you also leave a comment here?
Also /cc @TheAlphaNerd 