### PR TITLE
src: temporary fix for AIX malloc issue

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -462,6 +462,7 @@
         [ 'OS=="aix"', {
           'defines': [
             '_LINUX_SOURCE_COMPAT',
+            '_ALL_SOURCE',
           ],
         }],
         [ 'OS=="solaris"', {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -143,7 +143,7 @@ static void ares_poll_close_cb(uv_handle_t* watcher) {
 
 /* Allocates and returns a new ares_task_t */
 static ares_task_t* ares_task_create(Environment* env, ares_socket_t sock) {
-  ares_task_t* task = static_cast<ares_task_t*>(malloc(sizeof(*task)));
+  ares_task_t* task = static_cast<ares_task_t*>(NODE_MALLOC(sizeof(*task)));
 
   if (task == nullptr) {
     /* Out of memory. */

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -59,7 +59,7 @@ void DisconnectAndDisposeIO(inspector_socket_t* socket) {
 
 void OnBufferAlloc(uv_handle_t* handle, size_t len, uv_buf_t* buf) {
   if (len > 0) {
-    buf->base = static_cast<char*>(malloc(len));
+    buf->base = static_cast<char*>(NODE_MALLOC(len));
     CHECK_NE(buf->base, nullptr);
   }
   buf->len = len;

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -108,12 +108,13 @@ static int write_to_client(inspector_socket_t* inspector,
 #endif
 
   // Freed in write_request_cleanup
-  uv_buf_t* buf = reinterpret_cast<uv_buf_t*>(malloc(sizeof(uv_buf_t)));
-  uv_write_t* req = reinterpret_cast<uv_write_t*>(malloc(sizeof(uv_write_t)));
+  uv_buf_t* buf = reinterpret_cast<uv_buf_t*>(NODE_MALLOC(sizeof(uv_buf_t)));
+  uv_write_t* req =
+      reinterpret_cast<uv_write_t*>(NODE_MALLOC(sizeof(uv_write_t)));
   CHECK_NE(buf, nullptr);
   CHECK_NE(req, nullptr);
   memset(req, 0, sizeof(*req));
-  buf->base = reinterpret_cast<char*>(malloc(len));
+  buf->base = reinterpret_cast<char*>(NODE_MALLOC(len));
 
   CHECK_NE(buf->base, nullptr);
 
@@ -338,7 +339,7 @@ static void prepare_buffer(uv_handle_t* stream, size_t len, uv_buf_t* buf) {
                    BUFFER_GROWTH_CHUNK_SIZE *
                    BUFFER_GROWTH_CHUNK_SIZE;
     inspector->buffer_size = new_size;
-    inspector->buffer = reinterpret_cast<char*>(realloc(inspector->buffer,
+    inspector->buffer = reinterpret_cast<char*>(NODE_REALLOC(inspector->buffer,
                                         inspector->buffer_size));
     ASSERT_NE(inspector->buffer, nullptr);
   }
@@ -415,7 +416,7 @@ static void generate_accept_string(const char* client_key, char* buffer) {
   size_t key_len = strlen(client_key);
   size_t magic_len = sizeof(ws_magic) - 1;
 
-  char* buf = reinterpret_cast<char*>(malloc(key_len + magic_len));
+  char* buf = reinterpret_cast<char*>(NODE_MALLOC(key_len + magic_len));
   CHECK_NE(buf, nullptr);
   memcpy(buf, client_key, key_len);
   memcpy(buf + key_len, ws_magic, magic_len);
@@ -432,7 +433,7 @@ static void append(char** value, const char* string, size_t length) {
   int current_len = *value ? strlen(*value) : 0;
   int new_len = current_len + length;
   int adjusted = (new_len / INCREMENT + 1) * INCREMENT;
-  *value = reinterpret_cast<char*>(realloc(*value, adjusted));
+  *value = reinterpret_cast<char*>(NODE_REALLOC(*value, adjusted));
   memcpy(*value + current_len, string, length);
   (*value)[new_len] = '\0';
 }
@@ -473,7 +474,8 @@ static int path_cb(http_parser* parser, const char* at, size_t length) {
 static void handshake_complete(inspector_socket_t* inspector) {
   uv_read_stop(reinterpret_cast<uv_stream_t*>(&inspector->client));
   handshake_cb callback = inspector->http_parsing_state->callback;
-  inspector->ws_state = (struct ws_state_s*) malloc(sizeof(struct ws_state_s));
+  inspector->ws_state =
+      (struct ws_state_s*) NODE_MALLOC(sizeof(struct ws_state_s));
   ASSERT_NE(nullptr, inspector->ws_state);
   memset(inspector->ws_state, 0, sizeof(struct ws_state_s));
   inspector->last_read_end = 0;

--- a/src/node.cc
+++ b/src/node.cc
@@ -932,9 +932,9 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
 void* ArrayBufferAllocator::Allocate(size_t size) {
   if (zero_fill_field_ || zero_fill_all_buffers)
-    return calloc(size, 1);
+    return NODE_CALLOC(size, 1);
   else
-    return malloc(size);
+    return NODE_MALLOC(size);
 }
 
 static bool DomainHasErrorHandler(const Environment* env,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -49,7 +49,7 @@
   size_t length = end - start;
 
 #define BUFFER_MALLOC(length)                                               \
-  zero_fill_all_buffers ? calloc(length, 1) : malloc(length)
+  zero_fill_all_buffers ? NODE_CALLOC(length, 1) : NODE_MALLOC(length)
 
 #define SWAP_BYTES(arr, a, b)                                               \
   do {                                                                      \
@@ -235,7 +235,7 @@ MaybeLocal<Object> New(Isolate* isolate,
       free(data);
       data = nullptr;
     } else if (actual < length) {
-      data = static_cast<char*>(realloc(data, actual));
+      data = static_cast<char*>(NODE_REALLOC(data, actual));
       CHECK_NE(data, nullptr);
     }
   }
@@ -314,7 +314,7 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
   void* new_data;
   if (length > 0) {
     CHECK_NE(data, nullptr);
-    new_data = malloc(length);
+    new_data = NODE_MALLOC(length);
     if (new_data == nullptr)
       return Local<Object>();
     memcpy(new_data, data, length);
@@ -1036,7 +1036,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
                           offset,
                           is_forward);
   } else if (enc == LATIN1) {
-    uint8_t* needle_data = static_cast<uint8_t*>(malloc(needle_length));
+    uint8_t* needle_data = static_cast<uint8_t*>(NODE_MALLOC(needle_length));
     if (needle_data == nullptr) {
       return args.GetReturnValue().Set(-1);
     }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2289,7 +2289,7 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     size_t len = Buffer::Length(obj);
 
     // OpenSSL takes control of the pointer after accepting it
-    char* data = reinterpret_cast<char*>(malloc(len));
+    char* data = reinterpret_cast<char*>(NODE_MALLOC(len));
     CHECK_NE(data, nullptr);
     memcpy(data, resp, len);
 
@@ -3328,7 +3328,7 @@ bool CipherBase::GetAuthTag(char** out, unsigned int* out_len) const {
   if (initialised_ || kind_ != kCipher || !auth_tag_)
     return false;
   *out_len = auth_tag_len_;
-  *out = static_cast<char*>(malloc(auth_tag_len_));
+  *out = static_cast<char*>(NODE_MALLOC(auth_tag_len_));
   CHECK_NE(*out, nullptr);
   memcpy(*out, auth_tag_, auth_tag_len_);
   return true;
@@ -4907,7 +4907,7 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // NOTE: field_size is in bits
   int field_size = EC_GROUP_get_degree(ecdh->group_);
   size_t out_len = (field_size + 7) / 8;
-  char* out = static_cast<char*>(malloc(out_len));
+  char* out = static_cast<char*>(NODE_MALLOC(out_len));
   CHECK_NE(out, nullptr);
 
   int r = ECDH_compute_key(out, out_len, pub, ecdh->key_, nullptr);
@@ -4943,7 +4943,7 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (size == 0)
     return env->ThrowError("Failed to get public key length");
 
-  unsigned char* out = static_cast<unsigned char*>(malloc(size));
+  unsigned char* out = static_cast<unsigned char*>(NODE_MALLOC(size));
   CHECK_NE(out, nullptr);
 
   int r = EC_POINT_point2oct(ecdh->group_, pub, form, out, size, nullptr);
@@ -4969,7 +4969,7 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH private key");
 
   int size = BN_num_bytes(b);
-  unsigned char* out = static_cast<unsigned char*>(malloc(size));
+  unsigned char* out = static_cast<unsigned char*>(NODE_MALLOC(size));
   CHECK_NE(out, nullptr);
 
   if (size != BN_bn2bin(b, out)) {
@@ -5100,7 +5100,7 @@ class PBKDF2Request : public AsyncWrap {
         saltlen_(saltlen),
         salt_(salt),
         keylen_(keylen),
-        key_(static_cast<char*>(malloc(keylen))),
+        key_(static_cast<char*>(NODE_MALLOC(keylen))),
         iter_(iter) {
     if (key() == nullptr)
       FatalError("node::PBKDF2Request()", "Out of Memory");
@@ -5263,7 +5263,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
 
   THROW_AND_RETURN_IF_NOT_BUFFER(args[1], "Salt");
 
-  pass = static_cast<char*>(malloc(passlen));
+  pass = static_cast<char*>(NODE_MALLOC(passlen));
   if (pass == nullptr) {
     FatalError("node::PBKDF2()", "Out of Memory");
   }
@@ -5275,7 +5275,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
     goto err;
   }
 
-  salt = static_cast<char*>(malloc(saltlen));
+  salt = static_cast<char*>(NODE_MALLOC(saltlen));
   if (salt == nullptr) {
     FatalError("node::PBKDF2()", "Out of Memory");
   }
@@ -5368,7 +5368,7 @@ class RandomBytesRequest : public AsyncWrap {
       : AsyncWrap(env, object, AsyncWrap::PROVIDER_CRYPTO),
         error_(0),
         size_(size),
-        data_(static_cast<char*>(malloc(size))) {
+        data_(static_cast<char*>(NODE_MALLOC(size))) {
     if (data() == nullptr)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
@@ -5597,7 +5597,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 
   if (num_curves) {
     alloc_size = sizeof(*curves) * num_curves;
-    curves = static_cast<EC_builtin_curve*>(malloc(alloc_size));
+    curves = static_cast<EC_builtin_curve*>(NODE_MALLOC(alloc_size));
 
     CHECK_NE(curves, nullptr);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -198,7 +198,7 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }
 
   virtual void* Allocate(size_t size);  // Defined in src/node.cc
-  virtual void* AllocateUninitialized(size_t size) { return malloc(size); }
+  virtual void* AllocateUninitialized(size_t size) { return NODE_MALLOC(size); }
   virtual void Free(void* data, size_t) { free(data); }
 
  private:

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -149,7 +149,7 @@ void StreamWrap::OnAlloc(uv_handle_t* handle,
 
 
 void StreamWrap::OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx) {
-  buf->base = static_cast<char*>(malloc(size));
+  buf->base = static_cast<char*>(NODE_MALLOC(size));
   buf->len = size;
 
   if (buf->base == nullptr && size > 0) {
@@ -205,7 +205,7 @@ void StreamWrap::OnReadImpl(ssize_t nread,
     return;
   }
 
-  char* base = static_cast<char*>(realloc(buf->base, nread));
+  char* base = static_cast<char*>(NODE_REALLOC(buf->base, nread));
   CHECK_LE(static_cast<size_t>(nread), buf->len);
 
   if (pending == UV_TCP) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -54,7 +54,7 @@ class ExternString: public ResourceType {
         return scope.Escape(String::Empty(isolate));
 
       TypeName* new_data =
-          static_cast<TypeName*>(malloc(length * sizeof(*new_data)));
+          static_cast<TypeName*>(NODE_MALLOC(length * sizeof(*new_data)));
       if (new_data == nullptr) {
         return Local<String>();
       }
@@ -613,7 +613,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case ASCII:
       if (contains_non_ascii(buf, buflen)) {
-        char* out = static_cast<char*>(malloc(buflen));
+        char* out = static_cast<char*>(NODE_MALLOC(buflen));
         if (out == nullptr) {
           return Local<String>();
         }
@@ -648,7 +648,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case BASE64: {
       size_t dlen = base64_encoded_size(buflen);
-      char* dst = static_cast<char*>(malloc(dlen));
+      char* dst = static_cast<char*>(NODE_MALLOC(dlen));
       if (dst == nullptr) {
         return Local<String>();
       }
@@ -667,7 +667,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case HEX: {
       size_t dlen = buflen * 2;
-      char* dst = static_cast<char*>(malloc(dlen));
+      char* dst = static_cast<char*>(NODE_MALLOC(dlen));
       if (dst == nullptr) {
         return Local<String>();
       }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -662,7 +662,7 @@ void TLSWrap::OnReadImpl(ssize_t nread,
 
 
 void TLSWrap::OnAllocSelf(size_t suggested_size, uv_buf_t* buf, void* ctx) {
-  buf->base = static_cast<char*>(malloc(suggested_size));
+  buf->base = static_cast<char*>(NODE_MALLOC(suggested_size));
   CHECK_NE(buf->base, nullptr);
   buf->len = suggested_size;
 }

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -386,7 +386,7 @@ void UDPWrap::OnSend(uv_udp_send_t* req, int status) {
 void UDPWrap::OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
-  buf->base = static_cast<char*>(malloc(suggested_size));
+  buf->base = static_cast<char*>(NODE_MALLOC(suggested_size));
   buf->len = suggested_size;
 
   if (buf->base == nullptr && suggested_size > 0) {
@@ -428,7 +428,7 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
     return;
   }
 
-  char* base = static_cast<char*>(realloc(buf->base, nread));
+  char* base = static_cast<char*>(NODE_REALLOC(buf->base, nread));
   argv[2] = Buffer::New(env, base, nread).ToLocalChecked();
   argv[3] = AddressToJS(env, addr);
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);

--- a/src/util.h
+++ b/src/util.h
@@ -16,6 +16,28 @@
 #include <type_traits>  // std::remove_reference
 #endif
 
+#ifdef _AIX
+#ifdef _cplusplus
+extern "C" {
+#endif
+extern void *aix_malloc(size_t) __asm__("__linux_malloc");
+extern void *aix_calloc(size_t, size_t) __asm__("__linux_calloc");
+extern void *aix_realloc(void *, size_t) __asm__("__linux_realloc");
+extern void *aix_valloc(size_t) __asm__("__linux_valloc");
+#ifdef _cplusplus
+}
+#endif
+#define NODE_MALLOC(x) aix_malloc(x)
+#define NODE_CALLOC(x, y) aix_calloc(x, y)
+#define NODE_REALLOC(x, y) aix_realloc(x, y)
+#define NODE_VALLOC(x) aix_valloc(x)
+#else
+#define NODE_MALLOC(x) malloc(x)
+#define NODE_CALLOC(x, y) calloc(x, y)
+#define NODE_REALLOC(x, y) realloc(x, y)
+#define NODE_VALLOC(x) valloc(x)
+#endif
+
 namespace node {
 
 #ifdef __APPLE__
@@ -245,7 +267,7 @@ class MaybeStackBuffer {
         // Guard against overflow.
         CHECK_LE(storage, sizeof(T) * storage);
 
-        buf_ = static_cast<T*>(malloc(sizeof(T) * storage));
+        buf_ = static_cast<T*>(NODE_MALLOC(sizeof(T) * storage));
         CHECK_NE(buf_, nullptr);
       }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
src

##### Description of change
<!-- provide a description of the change below this comment -->

With the introduction of the v8 inspector the following tests started to
fail on AIX:
test-async-wrap-post-did-throw
test-async-wrap-throw-from-callback
test-crypto-random

The reason for the failures was a `malloc(0)` issue. On GNU compatible
`malloc` a `malloc(0)` returns a vaild pointer, but on AIX it returns
a null pointer which is considered to be a failure in node.

In order to get a GNU compatible `malloc` AIX requires the following
flags to be defined:
`_LINUX_SOURCE_COMPAT`
`_ALL_SOURCE`

However regardless of these flags, the STL headers undefine `malloc`
and replace it with a non GNU compatible `malloc`. This is a temporary
workaround until the AIX team for gcc release an update that fixes this
behaviour.

For more information (and also fixes): https://github.com/nodejs/node/issues/7080

AIX CI run: https://ci.nodejs.org/job/node-test-commit-aix/210/