### PR TITLE
doc: clarify tls.createServer's {cert, ca}

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -851,12 +851,12 @@ publicly trusted list of CAs as given in
   * `passphrase` {string} A string containing the passphrase for the private
     key or pfx.
   * `cert` {string|string[]|Buffer|Buffer[]} A string, `Buffer`, array of
-    strings, or array of `Buffer`s containing the certificate key of the server
-    in PEM format. (Required)
+    strings, or array of `Buffer`s containing the server's certificate chain
+    (server's certificate and intermediates) in PEM format. (Required)
   * `ca` {string|string[]|Buffer|Buffer[]} A string, `Buffer`, array of strings,
     or array of `Buffer`s of trusted certificates in PEM format. If this is
     omitted several well known "root" CAs (like VeriSign) will be used. These
-    are used to authorize connections.
+    are used to authorize connections. Useful for `requestCert` option.
   * `crl` {string|string[]} Either a string or array of strings of PEM encoded
     CRLs (Certificate Revocation List).
   * `ciphers` {string} A string describing the ciphers to use or exclude,
@@ -880,8 +880,8 @@ publicly trusted list of CAs as given in
   * `honorCipherOrder` {boolean} When choosing a cipher, use the server's
     preferences instead of the client preferences. Defaults to `true`.
   * `requestCert` {boolean} If `true` the server will request a certificate from
-    clients that connect and attempt to verify that certificate. Defaults to
-    `false`.
+    clients that connect and attempt to verify that certificate against
+    certificates provided in `ca` option. Defaults to `false`.
   * `rejectUnauthorized` {boolean} If `true` the server will reject any
     connection which is not authorized with the list of supplied CAs. This
     option only has an effect if `requestCert` is `true`. Defaults to `false`.
@@ -965,7 +965,7 @@ const fs = require('fs');
 
 const options = {
   key: fs.readFileSync('server-key.pem'),
-  cert: fs.readFileSync('server-cert.pem'),
+  cert: fs.readFileSync('server-cert-chain.pem'),
 
   // This is necessary only if using the client certificate authentication.
   requestCert: true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc
##### Description of change

<!-- provide a description of the change below this comment -->
1. clarity `cert` to match bottom-half
   in src/node_crypto.cc `setCert()` calls `SSL_CTX_use_certificate_chain()`
2. clarity `ca` is to be used with `requestCert`
