### PR TITLE
tls: avoid calling Buffer.byteLength multiple times

### DIFF
--- a/benchmark/tls/convertprotocols.js
+++ b/benchmark/tls/convertprotocols.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common.js');
+const tls = require('tls');
+
+const bench = common.createBenchmark(main, {
+  n: [1, 50000]
+});
+
+function main(conf) {
+  const n = +conf.n;
+
+  var i = 0;
+  var m = {};
+  common.v8ForceOptimization(
+    tls.convertNPNProtocols, ['ABC', 'XYZ123', 'FOO'], m);
+  bench.start();
+  for (; i < n; i++) tls.convertNPNProtocols(['ABC', 'XYZ123', 'FOO'], m);
+  bench.end(n);
+}

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -29,17 +29,19 @@ exports.getCiphers = internalUtil.cachedResult(() => {
 // Convert protocols array into valid OpenSSL protocols list
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")
 function convertProtocols(protocols) {
-  var buff = Buffer.allocUnsafe(protocols.reduce(function(p, c) {
-    return p + 1 + Buffer.byteLength(c);
+  const lens = Array(protocols.length);
+  const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
+    var len = Buffer.byteLength(c);
+    lens[i] = len;
+    return p + 1 + len;
   }, 0));
 
-  protocols.reduce(function(offset, c) {
-    var clen = Buffer.byteLength(c);
-    buff[offset] = clen;
-    buff.write(c, offset + 1);
-
-    return offset + 1 + clen;
-  }, 0);
+  var offset = 0;
+  for (var i = 0, c = protocols.length; i < c; i++) {
+    buff[offset++] = lens[i];
+    buff.write(protocols[i], offset);
+    offset += lens[i];
+  }
 
   return buff;
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

tls

##### Description of change

There's no reason to be calling Buffer.byteLength() twice. That's just silly.
Small perf improvement

Run 1:
tls/convertprotocols.js n=1     v6.2.1 = 11852,  new = 12204 ......  -2.89%
tls/convertprotocols.js n=50000 v6.2.1 = 515660, new = 570610 .....  -9.63%

Run 2:
tls/convertprotocols.js n=1     v6.2.1 = 11729,  new = 12045 ......  -2.62%
tls/convertprotocols.js n=50000 v6.2.1 = 512080, new = 637730 ..... -19.70%

@nodejs/crypto