### PR TITLE
doc,dgram: fix addMembership documentation

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -78,10 +78,11 @@ added: v0.6.9
 * `multicastAddress` {String}
 * `multicastInterface` {String}, Optional
 
-Tells the kernel to join a multicast group at the given `multicastAddress`
-using the `IP_ADD_MEMBERSHIP` socket option. If the `multicastInterface`
-argument is not specified, the operating system will try to add membership to
-all valid networking interfaces.
+Tells the kernel to join a multicast group at the given `multicastAddress` and
+`multicastInterface` using the `IP_ADD_MEMBERSHIP` socket option. If the
+`multicastInterface` argument is not specified, the operating system will choose
+one interface and will add membership to it. To add membership to every
+available interface, call `addMembership` multiple times, once per interface.
 
 ### socket.address()
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc,dgram

##### Description of change
<!-- provide a description of the change below this comment -->

Adding membership using `IP_ADD_MEMBERSHIP` with interface address set
to `INADDR_ANY` for `IPv4` or as an index of `0` for `IPv6` leads to
using only one interface selected by the operating system.

Fixes: https://github.com/nodejs/node/issues/1692

From Stevens _UNIX Network Programming_

> If the local interface is specified as the wildcard address for IPv4 ( INADDR_ANY ) or as an index of 0 for IPv6, then a single local interface is chosen by the kernel. 

On Windows from https://msdn.microsoft.com/en-us/library/windows/desktop/ms738695%28v=vs.85%29.aspx

> If this member specifies an IPv4 address of 0.0.0.0, the default IPv4 multicast interface is used. 