### PR TITLE
src: make Sec-WebSocket-Key check case-insensitive

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -1,4 +1,6 @@
 #include "inspector_socket.h"
+#include "util.h"
+#include "util-inl.h"
 
 #define NODE_WANT_INTERNALS 1
 #include "base64.h"
@@ -445,9 +447,10 @@ static int header_value_cb(http_parser* parser, const char* at, size_t length) {
   struct http_parsing_state_s* state = (struct http_parsing_state_s*)
       (reinterpret_cast<inspector_socket_t*>(parser->data))->http_parsing_state;
   state->parsing_value = true;
-  if (state->current_header && strncmp(state->current_header,
-                                       SEC_WEBSOCKET_KEY_HEADER,
-                                       sizeof(SEC_WEBSOCKET_KEY_HEADER)) == 0) {
+  if (state->current_header &&
+      node::StringEqualNoCaseN(state->current_header,
+                               SEC_WEBSOCKET_KEY_HEADER,
+                               sizeof(SEC_WEBSOCKET_KEY_HEADER))) {
     append(&state->ws_key, at, length);
   }
   return 0;

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -219,6 +219,16 @@ bool StringEqualNoCase(const char* a, const char* b) {
   return false;
 }
 
+bool StringEqualNoCaseN(const char* a, const char* b, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    if (ToLower(a[i]) != ToLower(b[i]))
+      return false;
+    if (a[i] == '\0')
+      return true;
+  }
+  return true;
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/util.h
+++ b/src/util.h
@@ -206,6 +206,9 @@ inline char ToLower(char c);
 // strcasecmp() is locale-sensitive.  Use StringEqualNoCase() instead.
 inline bool StringEqualNoCase(const char* a, const char* b);
 
+// strncasecmp() is locale-sensitive.  Use StringEqualNoCaseN() instead.
+inline bool StringEqualNoCaseN(const char* a, const char* b, size_t length);
+
 // Allocates an array of member type T. For up to kStackStorageSize items,
 // the stack is used, otherwise malloc().
 template <typename T, size_t kStackStorageSize = 1024>

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -68,6 +68,21 @@ TEST(UtilTest, StringEqualNoCase) {
   EXPECT_FALSE(StringEqualNoCase("equals", "equal"));
 }
 
+TEST(UtilTest, StringEqualNoCaseN) {
+  using node::StringEqualNoCaseN;
+  EXPECT_FALSE(StringEqualNoCaseN("a", "b", strlen("a")));
+  EXPECT_TRUE(StringEqualNoCaseN("", "", strlen("")));
+  EXPECT_TRUE(StringEqualNoCaseN("equal", "equal", strlen("equal")));
+  EXPECT_TRUE(StringEqualNoCaseN("equal", "EQUAL", strlen("equal")));
+  EXPECT_TRUE(StringEqualNoCaseN("EQUAL", "EQUAL", strlen("equal")));
+  EXPECT_TRUE(StringEqualNoCaseN("equal", "equals", strlen("equal")));
+  EXPECT_FALSE(StringEqualNoCaseN("equal", "equals", strlen("equals")));
+  EXPECT_TRUE(StringEqualNoCaseN("equals", "equal", strlen("equal")));
+  EXPECT_FALSE(StringEqualNoCaseN("equals", "equal", strlen("equals")));
+  EXPECT_TRUE(StringEqualNoCaseN("abc\0abc", "abc\0efg", strlen("abcdefgh")));
+  EXPECT_FALSE(StringEqualNoCaseN("abc\0abc", "abcd\0efg", strlen("abcdefgh")));
+}
+
 TEST(UtilTest, ToLower) {
   using node::ToLower;
   EXPECT_EQ('0', ToLower('0'));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
src

##### Description of change
<!-- provide a description of the change below this comment -->

Current case sensitive comparison is breaking netty-based WS clients.

replace strncmp with strncasecmp

Fixes: https://github.com/nodejs/node/issues/7247