### PR TITLE
benchmark: add benchmark for url.format()

### DIFF
--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common.js');
+const url = require('url');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  type: 'one two'.split(' '),
+  n: [25e6]
+});
+
+function main(conf) {
+  const type = conf.type;
+  const n = conf.n | 0;
+
+  const inputs = {
+    one: {slashes: true, host: 'localhost'},
+    two: {protocol: 'file:', pathname: '/foo'},
+  };
+  const input = inputs[type] || '';
+
+  // Force-optimize url.format() so that the benchmark doesn't get
+  // disrupted by the optimizer kicking in halfway through.
+  for (const name in inputs)
+    url.format(inputs[name]);
+
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(url.format)');
+
+  bench.start();
+  for (var i = 0; i < n; i += 1)
+    url.format(input);
+  bench.end(n);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
benchmark url

##### Description of change
<!-- provide a description of the change below this comment -->

/cc @nodejs/benchmarking @mscdex @bnoordhuis 

Wrote this to check on impact of template strings and `startsWith()` in https://github.com/nodejs/node/pull/7234. Putting it in with the other benchmarks so that others can benefit from it and so that more knowledgable people can check that there isn't an error that invalidates the entire benchmark. It only has use cases that I'm specifically testing right now, but others can be easily added as needed or pro-actively.

Refs: https://github.com/nodejs/node/pull/7234