### PR TITLE
inspector: process.exit should wait for inspector

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -187,6 +187,7 @@ static v8::Platform* default_platform;
 
 #ifdef __POSIX__
 static uv_sem_t debug_semaphore;
+static const unsigned kMaxSignal = 32;
 #endif
 
 static void PrintErrorString(const char* format, ...) {
@@ -2094,7 +2095,29 @@ static void InitGroups(const FunctionCallbackInfo<Value>& args) {
 #endif  // __POSIX__ && !defined(__ANDROID__)
 
 
+static void WaitForInspectorDisconnect(Environment* env) {
+#if HAVE_INSPECTOR
+  if (env->inspector_agent()->IsConnected()) {
+    // Restore signal dispositions, the app is done and is no longer
+    // capable of handling signals.
+#ifdef __POSIX__
+    struct sigaction act;
+    memset(&act, 0, sizeof(act));
+    for (unsigned nr = 1; nr < kMaxSignal; nr += 1) {
+      if (nr == SIGKILL || nr == SIGSTOP || nr == SIGPROF)
+        continue;
+      act.sa_handler = (nr == SIGPIPE) ? SIG_IGN : SIG_DFL;
+      CHECK_EQ(0, sigaction(nr, &act, nullptr));
+    }
+#endif
+    env->inspector_agent()->WaitForDisconnect();
+  }
+#endif
+}
+
+
 void Exit(const FunctionCallbackInfo<Value>& args) {
+  WaitForInspectorDisconnect(Environment::GetCurrent(args));
   exit(args[0]->Int32Value());
 }
 
@@ -3987,7 +4010,7 @@ inline void PlatformInit() {
   // The hard-coded upper limit is because NSIG is not very reliable; on Linux,
   // it evaluates to 32, 34 or 64, depending on whether RT signals are enabled.
   // Counting up to SIGRTMIN doesn't work for the same reason.
-  for (unsigned nr = 1; nr < 32; nr += 1) {
+  for (unsigned nr = 1; nr < kMaxSignal; nr += 1) {
     if (nr == SIGKILL || nr == SIGSTOP)
       continue;
     act.sa_handler = (nr == SIGPIPE) ? SIG_IGN : SIG_DFL;
@@ -4297,24 +4320,7 @@ static void StartNodeInstance(void* arg) {
       instance_data->set_exit_code(exit_code);
     RunAtExit(&env);
 
-#if HAVE_INSPECTOR
-    if (env.inspector_agent()->IsConnected()) {
-      // Restore signal dispositions, the app is done and is no longer
-      // capable of handling signals.
-#ifdef __POSIX__
-      struct sigaction act;
-      memset(&act, 0, sizeof(act));
-      for (unsigned nr = 1; nr < 32; nr += 1) {
-        if (nr == SIGKILL || nr == SIGSTOP || nr == SIGPROF)
-          continue;
-        act.sa_handler = (nr == SIGPIPE) ? SIG_IGN : SIG_DFL;
-        CHECK_EQ(0, sigaction(nr, &act, nullptr));
-      }
-#endif
-      env.inspector_agent()->WaitForDisconnect();
-    }
-#endif
-
+    WaitForInspectorDisconnect(&env);
 #if defined(LEAK_SANITIZER)
     __lsan_do_leak_check();
 #endif


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
inspector


##### Description of change
Waits for the inspector frontend to detach when process.exit is called. This enables the user to analyse the profiling information.

Fixes: nodejs/node#7088