### PR TITLE
Speedup canned small-icu build

### DIFF
--- a/configure
+++ b/configure
@@ -952,7 +952,10 @@ def configure_intl(o):
           print '\n ** Corrupted ZIP? Delete %s to retry download.\n' % targetfile
     return None
   icu_config = {
-    'variables': {}
+    'variables': {
+      'icu_small_canned': b(False),
+      'icu_need_swap': b(True),
+    }
   }
   icu_config_name = 'icu_config.gypi'
   def write_config(data, name):
@@ -1046,7 +1049,7 @@ def configure_intl(o):
 
   if (o['variables']['icu_small'] == b(True)) and using_default_locales and (not with_icu_source) and canned_icu_available:
     # OK- we can use the canned ICU.
-    icu_config['variables']['icu_small_canned'] = 1
+    icu_config['variables']['icu_small_canned'] = b(True)
     icu_full_path = canned_icu_dir
 
   # --with-icu-source processing
@@ -1144,6 +1147,9 @@ def configure_intl(o):
   # this is the input '.dat' file to use .. icudt*.dat
   # may be little-endian if from a icu-project.org tarball
   o['variables']['icu_data_in'] = icu_data_in
+  if icu_data_in.endswith('%s.dat' % icu_endianness):
+    # we may still swap, but mark that we can skip it if need be
+    icu_config['variables']['icu_need_swap'] = b(False)
   # this is the icudt*.dat file which node will be using (platform endianness)
   o['variables']['icu_data_file'] = icu_data_file
   if not os.path.isfile(icu_data_path):

--- a/tools/icu/icutrim.py
+++ b/tools/icu/icutrim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (C) 2014 IBM Corporation and Others. All Rights Reserved.
+# Copyright (C) 2014,2016 IBM Corporation and Others. All Rights Reserved.
 #
 # @author Steven R. Loomis <srl@icu-project.org>
 #
@@ -62,6 +62,10 @@ parser.add_option("-O","--outfile",
                     )  # required
 
 parser.add_option("-v","--verbose",
+                    action="count",
+                    default=0)
+
+parser.add_option("-K","--canned",
                     action="count",
                     default=0)
 
@@ -170,7 +174,14 @@ if(config.has_key("comment")):
 ## The first letter of endian_letter will be 'b' or 'l' for big or little
 endian_letter = options.endian[0]
 
-runcmd("icupkg", "-t%s %s %s""" % (endian_letter, options.datfile, outfile))
+if ( options.datfile.endswith("%s.dat" % endian_letter) ):
+    shutil.copyfile(options.datfile, outfile)
+else:
+    runcmd("icupkg", "-t%s %s %s""" % (endian_letter, options.datfile, outfile))
+
+if ( options.canned >  0 ):
+    print "Canned small ICU - no need to actually trim."
+    sys.exit(0)
 
 ## STEP 2 - get listing
 listfile = os.path.join(options.tmpdir,"icudata.lst")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX) and
- [x] `vcbuild test nosign` (Windows) passes
- [ ] test on big endian
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added
- [ ] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
##### Description of change

<!-- provide a description of the change below this comment -->

When:
- using canned,  small-icu (the default for configure && make)
- .. on little endian systems

we can avoid building some things we're currently building.

Namely, on the host toolchain side in this scenario, only genccode needs to be compiled,
and it doesn't need the i18n or io libraries

Fixes: https://github.com/nodejs/node/issues/7253
