### PR TITLE
benchmark: `util._extend` vs `object.assign`

### DIFF
--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -31,7 +31,7 @@ function main(conf) {
   v8.setFlagsFromString('--allow_natives_syntax');
   eval(v8command);
 
-  var obj = {};
+  var obj = new Proxy({}, { set: function(a, b, c) { return true; } });
 
   bench.start();
   for (var j = 0; j < n; j += 1)

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -19,7 +19,7 @@ function main(conf) {
     v8command = '%OptimizeFunctionOnNextCall(util._extend)';
   } else if (conf.type === 'assign') {
     fn = Object.assign;
-    //Object.assign is built-in, cannot be optimized
+    // Object.assign is built-in, cannot be optimized
     v8command = '';
   }
 

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -5,21 +5,19 @@ const util = require('util');
 const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
-  type: ['util._extend', 'Object.assign',
-         'util._extend', 'Object.assign'],
+  type: ['extend', 'assign'],
   n: [10e4]
 });
 
-function main(params) {
+function main(conf) {
   let fn;
-  const n = params.n | 0;
+  const n = conf.n | 0;
   let v8command;
 
-  if (params.type == 'util._extend') {
+  if (conf.type === 'extend') {
     fn = util._extend;
     v8command = '%OptimizeFunctionOnNextCall(util._extend)';
-
-  } else if (params.type == 'Object.assign') {
+  } else if (conf.type === 'assign') {
     fn = Object.assign;
     //Object.assign is built-in, cannot be optimized
     v8command = '';
@@ -27,14 +25,16 @@ function main(params) {
 
   // Force-optimize the method to test so that the benchmark doesn't
   // get disrupted by the optimizer kicking in halfway through.
-  for (let i = 0; i < params.type.length * 10; i += 1)
+  for (var i = 0; i < conf.type.length * 10; i += 1)
     fn({}, process.env);
 
   v8.setFlagsFromString('--allow_natives_syntax');
   eval(v8command);
 
+  var obj = {};
+
   bench.start();
-  for (let i = 0; i < n; i += 1)
-    fn({}, process.env);
+  for (var j = 0; j < n; j += 1)
+    fn(obj, process.env);
   bench.end(n);
 }

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common.js');
+const util = require('util');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  type: ['util._extend', 'Object.assign',
+         'util._extend', 'Object.assign'],
+  n: [10e4]
+});
+
+function main(params) {
+  let fn;
+  const n = params.n | 0;
+  let v8command;
+
+  if (params.type == 'util._extend') {
+    fn = util._extend;
+    v8command = '%OptimizeFunctionOnNextCall(util._extend)';
+
+  } else if (params.type == 'Object.assign') {
+    fn = Object.assign;
+    //Object.assign is built-in, cannot be optimized
+    v8command = '';
+  }
+
+  // Force-optimize the method to test so that the benchmark doesn't
+  // get disrupted by the optimizer kicking in halfway through.
+  for (let i = 0; i < params.type.length * 10; i += 1)
+    fn({}, process.env);
+
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval(v8command);
+
+  bench.start();
+  for (let i = 0; i < n; i += 1)
+    fn({}, process.env);
+  bench.end(n);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
benchmark

##### Description of change
<!-- provide a description of the change below this comment -->

To copy the values of all enumerable properties from-
a source object to a target object, node still use-
`util._extend`, though newer standard `Object.assign`
is available. This is because `util._extend` is found to
be faster than `Object.assign`. This benchmark test is
to keep track of how performance compare.