### PR TITLE
Add two child-process stdio flush tests

### DIFF
--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -28,9 +28,11 @@ function spawnWithReadable() {
     spawnWithPipe();
   }));
   p.stdout.on('readable', function() {
-    let buf;
-    while (buf = this.read())
-      buffer.push(buf);
+    setImmediate(() => {
+      let buf;
+      while (buf = this.read())
+        buffer.push(buf);
+    });
   });
 }
 

--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -2,6 +2,7 @@
 const cp = require('child_process');
 const common = require('../common');
 const assert = require('assert');
+const stream = require('stream');
 
 // Windows' `echo` command is a built-in shell command and not an external
 // executable like on *nix
@@ -24,10 +25,40 @@ function spawnWithReadable() {
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
     assert.strictEqual(Buffer.concat(buffer).toString().trim(), '123');
+    spawnWithPipe();
   }));
   p.stdout.on('readable', function() {
     let buf;
     while (buf = this.read())
       buffer.push(buf);
   });
+}
+
+function spawnWithPipe() {
+  const buffer = [];
+  const through = new stream.PassThrough();
+  const p = cp.spawn('seq', [ '36000' ]);
+
+  const ret = [];
+  for (let i = 1; i <= 36000; i++) {
+    ret.push(i);
+  }
+
+  p.on('close', common.mustCall(function(code, signal) {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(Buffer.concat(buffer).toString().trim(), ret.join('\n'));
+  }));
+
+  p.on('exit', common.mustCall(function() {
+    setImmediate(function() {
+      through.on('readable', function() {
+        let buf;
+        while (buf = this.read())
+          buffer.push(buf);
+      });
+    });
+  }));
+
+  p.stdout.pipe(through);
 }


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

child-process
##### Description of change

Fixed a previous testcase that wasn't actually triggering the condition it tried to test. Added a new test that needs #7160 to be merged for it to pass. 
