### PR TITLE
src: fix --without-inspector build

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3358,11 +3358,15 @@ static bool ParseDebugOpt(const char* arg) {
       PrintHelp();
       exit(12);
     }
+#if HAVE_INSPECTOR
     if (use_inspector) {
       inspector_port = port_int;
     } else {
+#endif
       debug_port = port_int;
+#if HAVE_INSPECTOR
     }
+#endif
   }
 
   return true;


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

src (v8_inspector?)

##### Description of change

`use_inspector` is not available if `HAVE_INSPECTOR` is false. Before this commit, one usage of it would show up as an undeclared identifier (introduced in a766ebf).