### PR TITLE
src: fix erroneous fallthrough in ParseEncoding()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ ADDONS_BINDING_GYPS := \
 
 ADDONS_BINDING_SOURCES := \
 	$(filter-out test/addons/??_*/*.cc, $(wildcard test/addons/*/*.cc)) \
-	$(filter-out test/addons/??_*/*.h, $(wildcard test/addons/*/*.h)) \
+	$(filter-out test/addons/??_*/*.h, $(wildcard test/addons/*/*.h))
 
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
 # Depends on node-gyp package.json so that build-addons is (re)executed when

--- a/Makefile
+++ b/Makefile
@@ -143,11 +143,15 @@ ADDONS_BINDING_GYPS := \
 	$(filter-out test/addons/??_*/binding.gyp, \
 		$(wildcard test/addons/*/binding.gyp))
 
+ADDONS_BINDING_SOURCES := \
+	$(filter-out test/addons/??_*/*.cc, $(wildcard test/addons/*/*.cc)) \
+	$(filter-out test/addons/??_*/*.h, $(wildcard test/addons/*/*.h)) \
+
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
 # Depends on node-gyp package.json so that build-addons is (re)executed when
 # node-gyp is updated as part of an npm update.
 test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json \
-	$(ADDONS_BINDING_GYPS) \
+	$(ADDONS_BINDING_GYPS) $(ADDONS_BINDING_SOURCES) \
 	deps/uv/include/*.h deps/v8/include/*.h \
 	src/node.h src/node_buffer.h src/node_object_wrap.h \
 	test/addons/.docbuildstamp

--- a/src/node.cc
+++ b/src/node.cc
@@ -1319,6 +1319,7 @@ enum encoding ParseEncoding(const char* encoding,
         if (strncmp(encoding + 2, "tin1", 4) == 0)
           return LATIN1;
       }
+      break;
     case 'b':
       // binary
       if (encoding[1] == 'i') {

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -1,0 +1,36 @@
+#include "node.h"
+#include "v8.h"
+
+namespace {
+
+#define ENCODING_MAP(V) \
+  V(ASCII)              \
+  V(BASE64)             \
+  V(BUFFER)             \
+  V(HEX)                \
+  V(LATIN1)             \
+  V(UCS2)               \
+  V(UTF8)               \
+
+void ParseEncoding(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  const node::encoding encoding =
+      node::ParseEncoding(args.GetIsolate(), args[0],
+                          static_cast<node::encoding>(-1));
+  const char* encoding_name = "UNKNOWN";
+#define V(name) if (encoding == node::name) encoding_name = #name;
+  ENCODING_MAP(V)
+#undef V
+  auto encoding_string =
+      v8::String::NewFromUtf8(args.GetIsolate(), encoding_name,
+                              v8::NewStringType::kNormal)
+      .ToLocalChecked();
+  args.GetReturnValue().Set(encoding_string);
+}
+
+void Initialize(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "parseEncoding", ParseEncoding);
+}
+
+}  // anonymous namespace
+
+NODE_MODULE(binding, Initialize);

--- a/test/addons/parse-encoding/binding.gyp
+++ b/test/addons/parse-encoding/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../../common');
+const assert = require('assert');
+const { parseEncoding } = require('./build/Release/binding');
+
+assert.strictEqual(parseEncoding(''), 'UNKNOWN');
+
+assert.strictEqual(parseEncoding('ascii'), 'ASCII');
+assert.strictEqual(parseEncoding('base64'), 'BASE64');
+assert.strictEqual(parseEncoding('binary'), 'LATIN1');
+assert.strictEqual(parseEncoding('buffer'), 'BUFFER');
+assert.strictEqual(parseEncoding('hex'), 'HEX');
+assert.strictEqual(parseEncoding('latin1'), 'LATIN1');
+assert.strictEqual(parseEncoding('ucs2'), 'UCS2');
+assert.strictEqual(parseEncoding('utf8'), 'UTF8');
+
+assert.strictEqual(parseEncoding('linary'), 'UNKNOWN');
+assert.strictEqual(parseEncoding('luffer'), 'UNKNOWN');


### PR DESCRIPTION
A missing 'break' statement unintentionally allowed "linary"
and "luffer" as alternatives for "binary" and "buffer".

Regression introduced in commit 54cc721 ("buffer: introduce latin1
encoding term".)

R=@trevnorris

CI: https://ci.nodejs.org/job/node-test-pull-request/2972/