### PR TITLE
buffer: remove obsolete and confusing comment

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -212,9 +212,6 @@ function allocate(size) {
     alignPool();
     return b;
   } else {
-    // Even though this is checked above, the conditional is a safety net and
-    // sanity check to prevent any subsequent typed array allocation from not
-    // being zero filled.
     return createUnsafeBuffer(size);
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

If this aims to fix a regression or you’re adding a feature, make sure you also
write a test. If possible, include a benchmark that quantifies your changes.

Finally, read through our contributors guide and make adjustments as necessary:
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
buffer

##### Description of change
<!-- provide a description of the change below this comment -->

This comment applied to a line that was removed in https://github.com/nodejs/node/commit/dd67608bfdb3bef6e06a1965ecbfa51658c61b1b and is no longer relevant.

...Or so it seems. The reason for keeping it was possibly discussed in https://github.com/nodejs/node-private/pull/30, but I don't have access to it.