### PR TITLE
Document http "aborted" events

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -910,6 +910,13 @@ headers and data.
 It implements the [Readable Stream][] interface, as well as the
 following additional events, methods, and properties.
 
+### Event: 'aborted'
+
+`function () { }`
+
+Emitted when the request has been aborted by the client and the network
+socket has closed.
+
 ### Event: 'close'
 
 `function () { }`

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -219,6 +219,13 @@ The request implements the [Writable Stream][] interface. This is an
 Emitted when the request has been aborted by the client. This event is only
 emitted on the first call to `abort()`.
 
+### Event: 'aborted'
+
+`function () { }`
+
+Emitted when the request has been aborted by the server and the network
+socket has closed.
+
 ### Event: 'checkExpectation'
 
 `function (request, response) { }`


### PR DESCRIPTION
##### Checklist

- [ ] ~~`make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes~~ (This PR just adds doc)
- [ ] ~~a test and/or benchmark is included~~ (This PR just adds doc)
- [X] documentation is changed or added
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)
doc (for HTTP)

##### Description of change
This pull request follows on #6925 (in which @Fishrock123 and @dougwilson made key appearances) to document the `"aborted"` (as opposed to `"abort"`) events emitted on HTTP requests and responses on socket closure by the remote system.

A few links from the issue that seem most relevant:
- [HTTP client emitting `'aborted'` from the corresponding response (`req.res`)]( https://github.com/nodejs/node/blob/5b72f891a8b992cb4461c917a6ca59ed95e7b2a9/lib/_http_client.js#L272).
- [HTTP server emitting `'aborted'` from requests](https://github.com/nodejs/node/blob/5b72f891a8b992cb4461c917a6ca59ed95e7b2a9/lib/_http_server.js#L280).
- [The test for `'aborted'`](https://github.com/nodejs/node/blob/ef9778cb9bd8c841a9cd54c614fb53748e72686a/test/parallel/test-http-client-abort.js)

The last tests the event on `req` from the server point of view. I actually don't see a test checking the event from the client API. [This test](https://github.com/nodejs/node/blob/ef9778cb9bd8c841a9cd54c614fb53748e72686a/test/parallel/test-http-abort-client.js#L36) sets a handler on a `res` from an `http.get` call, but as far as I can tell there's no test verifying its functionality. I can try and cook one up if needed.

***Be Warned! This is my first PR to Node.js. I reread CONTRIBUTING, but probably screwed something up anyway. Many thanks to team for patience and understanding!***

This PR coming to you live from doc sprint at NodeConf Adventure.