### PR TITLE
src: move and update comment about 'node.js' compilation.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3262,7 +3262,7 @@ void LoadEnvironment(Environment* env) {
   // static in node_natives.h by node_js2c. 'internal_bootstrap_node_native'
   // is the string containing that source code.
   Local<String> script_name = FIXED_ONE_BYTE_STRING(env->isolate(),
-          "bootstrap_node.js");
+                                                    "bootstrap_node.js");
   Local<Value> f_value = ExecuteString(env, MainSource(env), script_name);
   if (try_catch.HasCaught())  {
     ReportException(env, try_catch);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3261,7 +3261,8 @@ void LoadEnvironment(Environment* env) {
   // Execute the lib/internal/bootstrap_node.js file which was included as a
   // static in node_natives.h by node_js2c. 'internal_bootstrap_node_native'
   // is the string containing that source code.
-  Local<String> script_name = FIXED_ONE_BYTE_STRING(env->isolate(), "node.js");
+  Local<String> script_name = FIXED_ONE_BYTE_STRING(env->isolate(),
+          "bootstrap_node.js");
   Local<Value> f_value = ExecuteString(env, MainSource(env), script_name);
   if (try_catch.HasCaught())  {
     ReportException(env, try_catch);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3247,9 +3247,6 @@ void LoadEnvironment(Environment* env) {
   env->isolate()->SetFatalErrorHandler(node::OnFatalError);
   env->isolate()->AddMessageListener(OnMessage);
 
-  // Compile, execute the src/node.js file. (Which was included as static C
-  // string in node_natives.h. 'native_node' is the string containing that
-  // source code.)
 
   // The node.js file returns a function 'f'
   atexit(AtExit);
@@ -3261,6 +3258,9 @@ void LoadEnvironment(Environment* env) {
   // are not safe to ignore.
   try_catch.SetVerbose(false);
 
+  // Compile, execute the lib/internal/bootstrap_node.js file. (Which was
+  // included as static C string in node_natives.h.
+  // 'internal_bootstrap_node_native is the string containing that source code.)
   Local<String> script_name = FIXED_ONE_BYTE_STRING(env->isolate(), "node.js");
   Local<Value> f_value = ExecuteString(env, MainSource(env), script_name);
   if (try_catch.HasCaught())  {

--- a/src/node.cc
+++ b/src/node.cc
@@ -3258,9 +3258,9 @@ void LoadEnvironment(Environment* env) {
   // are not safe to ignore.
   try_catch.SetVerbose(false);
 
-  // Compile, execute the lib/internal/bootstrap_node.js file. (Which was
-  // included as static C string in node_natives.h.
-  // 'internal_bootstrap_node_native is the string containing that source code.)
+  // Execute the lib/internal/bootstrap_node.js file which was included as a
+  // static in node_natives.h by node_js2c. 'internal_bootstrap_node_native'
+  // is the string containing that source code.
   Local<String> script_name = FIXED_ONE_BYTE_STRING(env->isolate(), "node.js");
   Local<Value> f_value = ExecuteString(env, MainSource(env), script_name);
   if (try_catch.HasCaught())  {

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -12,4 +12,4 @@ RangeError: Invalid input
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*:*)
     at Module.runMain (module.js:*:*)
-    at run (node.js:*:*)
+    at run (bootstrap_node.js:*:*)

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -11,6 +11,6 @@ AssertionError: 1 == 2
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*:*)
     at Module.runMain (module.js:*:*)
-    at run (node.js:*:*)
-    at startup (node.js:*:*)
-    at node.js:*:*
+    at run (bootstrap_node.js:*:*)
+    at startup (bootstrap_node.js:*:*)
+    at bootstrap_node.js:*:*

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -6,7 +6,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 42
@@ -19,7 +19,7 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 [eval]:1
@@ -30,7 +30,7 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 100
@@ -42,7 +42,7 @@ ReferenceError: y is not defined
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 [eval]:1

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -7,6 +7,6 @@ ReferenceError: undefined_reference_error_maker is not defined
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
     at Module.runMain (module.js:*:*)
-    at run (node.js:*:*)
-    at startup (node.js:*:*)
-    at node.js:*:*
+    at run (bootstrap_node.js:*:*)
+    at startup (bootstrap_node.js:*:*)
+    at bootstrap_node.js:*:*

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -7,7 +7,7 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 42
@@ -21,7 +21,7 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 
@@ -33,7 +33,7 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 100
@@ -46,7 +46,7 @@ ReferenceError: y is not defined
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
+    at bootstrap_node.js:*:*
     at _combinedTickCallback (internal/process/next_tick.js:*:*)
     at process._tickCallback (internal/process/next_tick.js:*:*)
 

--- a/test/message/vm_display_runtime_error.out
+++ b/test/message/vm_display_runtime_error.out
@@ -13,4 +13,4 @@ Error: boo!
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
-    at run (node.js:*)
+    at run (bootstrap_node.js:*)

--- a/test/message/vm_display_syntax_error.out
+++ b/test/message/vm_display_syntax_error.out
@@ -12,8 +12,8 @@ SyntaxError: Unexpected number
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
-    at run (node.js:*)
-    at startup (node.js:*)
+    at run (bootstrap_node.js:*)
+    at startup (bootstrap_node.js:*)
 test.vm:1
 var 5;
     ^
@@ -26,5 +26,5 @@ SyntaxError: Unexpected number
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
-    at run (node.js:*)
-    at startup (node.js:*)
+    at run (bootstrap_node.js:*)
+    at startup (bootstrap_node.js:*)

--- a/test/message/vm_dont_display_runtime_error.out
+++ b/test/message/vm_dont_display_runtime_error.out
@@ -13,4 +13,4 @@ Error: boo!
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
-    at run (node.js:*)
+    at run (bootstrap_node.js:*)

--- a/test/message/vm_dont_display_syntax_error.out
+++ b/test/message/vm_dont_display_syntax_error.out
@@ -12,5 +12,5 @@ SyntaxError: Unexpected number
     at tryModuleLoad (module.js:*:*)
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
-    at run (node.js:*)
-    at startup (node.js:*)
+    at run (bootstrap_node.js:*)
+    at startup (bootstrap_node.js:*)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
src


##### Description of change
<!-- provide a description of the change below this comment -->

Currently the comment regarding execution of src/node.js seems to refer
to the file before the refactorings done in ec6af31. Also, it looks like
the comment itself might have "drifted" a little in the file.

Updated the comment to refer to the lib/internal/bootstrap_node.js file,
moved it closer to the compilation step, and updated the name that is
generated in node_natives.h.