### PR TITLE
doc: update build instructions for Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -99,7 +99,7 @@ $ node -e "console.log('Hello from Node.js ' + process.version)"
 Prerequisites:
 
 * [Python 2.6 or 2.7](https://www.python.org/downloads/)
-* Either one of:
+* One of:
   * [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools)
   * [Visual Studio](https://www.visualstudio.com/) 2013 / 2015, all editions including the Community edition
   * [Visual Studio](https://www.visualstudio.com/) Express 2013 / 2015 for Desktop
@@ -120,7 +120,7 @@ To run the tests:
 To test if Node.js was built correctly:
 
 ```text
-> Release\node -e "console.log('Hello from Node.js ' + process.version)"
+> Release\node -e "console.log('Hello from Node.js', process.version)"
 ```
 
 ### Android / Android-based devices (e.g., Firefox OS)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -99,8 +99,10 @@ $ node -e "console.log('Hello from Node.js ' + process.version)"
 Prerequisites:
 
 * [Python 2.6 or 2.7](https://www.python.org/downloads/)
-* Visual Studio 2013 / 2015, all editions including the Community edition, or
-* Visual Studio Express 2013 / 2015 for Desktop
+* Either one of:
+  * [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools)
+  * [Visual Studio](https://www.visualstudio.com/) 2013 / 2015, all editions including the Community edition
+  * [Visual Studio](https://www.visualstudio.com/) Express 2013 / 2015 for Desktop
 * Basic Unix tools required for some tests,
   [Git for Windows](http://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.
@@ -117,8 +119,8 @@ To run the tests:
 
 To test if Node.js was built correctly:
 
-```
-$ node -e "console.log('Hello from Node.js ' + process.version)"
+```text
+> Release\node -e "console.log('Hello from Node.js ' + process.version)"
 ```
 
 ### Android / Android-based devices (e.g., Firefox OS)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

doc

##### Description of change
<!-- provide a description of the change below this comment -->

The Visual C++ Build Tools are supported to build Node on Windows and already used in CI, so they should be included in the build instructions.

Corrected the test command to run on Windows after compiling.

cc @nodejs/platform-windows 