### PR TITLE
doc: correct args for cluster message event

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -485,8 +485,8 @@ The `addressType` is one of:
 
 ## Event: 'message'
 
-* `worker` {cluster.Worker}
 * `message` {Object}
+* `handle` {undefined|Object}
 
 Emitted when any worker receives a message.
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
This commit corrects the `cluster` `message` event signature.

Fixes: https://github.com/nodejs/node/issues/5764