### PR TITLE
doc: Correct `added:` information for fs.access and fs.accessSync

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -302,7 +302,7 @@ argument to `fs.createWriteStream()`. If `path` is passed as a string, then
 
 ## fs.access(path[, mode], callback)
 <!-- YAML
-added: v1.0.0
+added: v0.11.15
 -->
 
 * `path` {String | Buffer}
@@ -336,7 +336,7 @@ fs.access('/etc/passwd', fs.constants.R_OK | fs.constants.W_OK, (err) => {
 
 ## fs.accessSync(path[, mode])
 <!-- YAML
-added: v0.1.93
+added: v0.11.15
 -->
 
 * `path` {String | Buffer}


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
doc


##### Description of change
From https://github.com/nodejs/node-gyp/pull/955#issuecomment-225661705 it looks like the `Added in:` values for `fs.access` and `fs.accessSync` are incorrect. From investigations it looks like `fs.access` and `fs.accessSync` were added to Node v0.11.15 via 2944934