### PR TITLE
Fix segfault during GC #5900 (4.x)

### DIFF
--- a/deps/v8/src/hydrogen-instructions.cc
+++ b/deps/v8/src/hydrogen-instructions.cc
@@ -3825,12 +3825,12 @@ bool HAllocate::HandleSideEffectDominator(GVNFlag side_effect,
     }
   }
 
-  bool keep_new_space_iterable = FLAG_log_gc || FLAG_heap_stats;
+  bool keep_heap_iterable = FLAG_log_gc || FLAG_heap_stats;
 #ifdef VERIFY_HEAP
-  keep_new_space_iterable = keep_new_space_iterable || FLAG_verify_heap;
+  keep_heap_iterable = keep_heap_iterable || FLAG_verify_heap;
 #endif
 
-  if (keep_new_space_iterable && dominator_allocate->IsNewSpaceAllocation()) {
+  if (keep_heap_iterable) {
     dominator_allocate->MakePrefillWithFiller();
   } else {
     // TODO(hpayer): This is a short-term hack to make allocation mementos

--- a/deps/v8/src/hydrogen-instructions.cc
+++ b/deps/v8/src/hydrogen-instructions.cc
@@ -3693,6 +3693,11 @@ Representation HUnaryMathOperation::RepresentationFromInputs() {
 
 bool HAllocate::HandleSideEffectDominator(GVNFlag side_effect,
                                           HValue* dominator) {
+  if (IsOldSpaceAllocation()) {
+    // Do not fold old space allocations because the store buffer might need
+    // to iterate old space pages during scavenges on overflow.
+    return false;
+  }
   DCHECK(side_effect == kNewSpacePromotion);
   Zone* zone = block()->zone();
   Isolate* isolate = block()->isolate();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
deps: v8

##### Description of change
<!-- provide a description of the change below this comment -->

These two patches comprise a fix for #5900 – a segfault during GC that can happen under rare circumstances. The interesting part is that the one of the fixes never landed upstream in V8 because the bug doesn't exist in any active V8 branches.

The segfault occurs at the intersection of the following three conditions that are dependent on the allocation pattern of an application: A pretenured (1) allocation site has to be optimized into a merged allocation by the allocation folding optimization (2) and there needs to be overflow of the store buffer (3).

This second patch disables the allocation folding optimization for pretenured allocations. This may have some, hopefully negligible, performance impact on real world applications.

This also needs to be fixed in `v5.x`; but I'm not sure how much runway is left on that branch and whether it would give us sufficient feedback. Regardless, I think an independent determination can be made whether this is worth fixing on `v4.x` in the first place (given than the scenario is rare).

R=@nodejs/lts
/cc @nodejs/v8 

