### PR TITLE
build: split CI rules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,13 @@ test-all-valgrind: test-build
 CI_NATIVE_SUITES := addons
 CI_JS_SUITES := doctool known_issues message parallel pseudo-tty sequential
 
+# Build and test addons without building anything else
 test-ci-native: | test/addons/.buildstamp
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES)
 
+# This target should not use a native compiler at all
 test-ci-js:
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \

--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,7 @@ build-ci:
 	$(PYTHON) ./configure $(CONFIG_FLAGS)
 	$(MAKE)
 
-run-ci:
-	$(MAKE) build-ci
+run-ci: build-ci
 	$(MAKE) test-ci
 
 RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

build

##### Description of change
<!-- provide a description of the change below this comment -->

Some CI jobs compile Node and run the tests on different machines. This change enables collaborators to have finer control over what runs on these jobs, such as the exact suites to run. The test-ci rule was split into js and native, to allow for addons to be compiled only on the machines that are going to run them.

CI run for this change: https://ci.nodejs.org/view/All/job/node-test-commit/3754/
CI run of updated binary ARM job: https://ci.nodejs.org/view/All/job/reis-test-binary-arm/1/
This adds `doctool`, `known_issues` and `pseudo-tty` test suites.

No change is needed for Windows, since the current `vcbuild` is usable by the Windows fanned job.

:bangbang: @nodejs/lts This should land in all branches simultaneously. After the review runs its course here, I can land this in all `*-staging` branches. Is that ok?

cc @nodejs/jenkins-admins @nodejs/build @nodejs/testing 