### PR TITLE
test: refresh the tmpdir before using

### DIFF
--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -10,6 +10,8 @@ if (common.isFreeBSD) {
   return;
 }
 
+common.refreshTmpDir();
+
 const fn = '新建文夹件.txt';
 const a = path.join(common.tmpDir, fn);
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
test fs

##### Description of change
<!-- provide a description of the change below this comment -->

Test fails if tmp dir does not exist when the test is run. Add `common.refreshTmpDir()` so that doesn't happen.
