### PR TITLE
src: renaming ares_task struct to node_ares_task

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -91,7 +91,7 @@ static void NewQueryReqWrap(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-static int cmp_ares_tasks(const ares_task_t* a, const ares_task_t* b) {
+static int cmp_ares_tasks(const node_ares_task* a, const node_ares_task* b) {
   if (a->sock < b->sock)
     return -1;
   if (a->sock > b->sock)
@@ -100,7 +100,7 @@ static int cmp_ares_tasks(const ares_task_t* a, const ares_task_t* b) {
 }
 
 
-RB_GENERATE_STATIC(ares_task_list, ares_task_t, node, cmp_ares_tasks)
+RB_GENERATE_STATIC(node_ares_task_list, node_ares_task, node, cmp_ares_tasks)
 
 
 
@@ -114,7 +114,7 @@ static void ares_timeout(uv_timer_t* handle) {
 
 
 static void ares_poll_cb(uv_poll_t* watcher, int status, int events) {
-  ares_task_t* task = ContainerOf(&ares_task_t::poll_watcher, watcher);
+  node_ares_task* task = ContainerOf(&node_ares_task::poll_watcher, watcher);
   Environment* env = task->env;
 
   /* Reset the idle timer */
@@ -135,15 +135,15 @@ static void ares_poll_cb(uv_poll_t* watcher, int status, int events) {
 
 
 static void ares_poll_close_cb(uv_handle_t* watcher) {
-  ares_task_t* task = ContainerOf(&ares_task_t::poll_watcher,
+  node_ares_task* task = ContainerOf(&node_ares_task::poll_watcher,
                                   reinterpret_cast<uv_poll_t*>(watcher));
   free(task);
 }
 
 
-/* Allocates and returns a new ares_task_t */
-static ares_task_t* ares_task_create(Environment* env, ares_socket_t sock) {
-  ares_task_t* task = static_cast<ares_task_t*>(malloc(sizeof(*task)));
+/* Allocates and returns a new node_ares_task */
+static node_ares_task* ares_task_create(Environment* env, ares_socket_t sock) {
+  node_ares_task* task = static_cast<node_ares_task*>(malloc(sizeof(*task)));
 
   if (task == nullptr) {
     /* Out of memory. */
@@ -169,11 +169,11 @@ static void ares_sockstate_cb(void* data,
                               int read,
                               int write) {
   Environment* env = static_cast<Environment*>(data);
-  ares_task_t* task;
+  node_ares_task* task;
 
-  ares_task_t lookup_task;
+  node_ares_task lookup_task;
   lookup_task.sock = sock;
-  task = RB_FIND(ares_task_list, env->cares_task_list(), &lookup_task);
+  task = RB_FIND(node_ares_task_list, env->cares_task_list(), &lookup_task);
 
   if (read || write) {
     if (!task) {
@@ -194,7 +194,7 @@ static void ares_sockstate_cb(void* data,
         return;
       }
 
-      RB_INSERT(ares_task_list, env->cares_task_list(), task);
+      RB_INSERT(node_ares_task_list, env->cares_task_list(), task);
     }
 
     /* This should never fail. If it fails anyway, the query will eventually */
@@ -210,7 +210,7 @@ static void ares_sockstate_cb(void* data,
     CHECK(task &&
           "When an ares socket is closed we should have a handle for it");
 
-    RB_REMOVE(ares_task_list, env->cares_task_list(), task);
+    RB_REMOVE(node_ares_task_list, env->cares_task_list(), task);
     uv_close(reinterpret_cast<uv_handle_t*>(&task->poll_watcher),
              ares_poll_close_cb);
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -349,7 +349,7 @@ inline ares_channel* Environment::cares_channel_ptr() {
   return &cares_channel_;
 }
 
-inline ares_task_list* Environment::cares_task_list() {
+inline node_ares_task_list* Environment::cares_task_list() {
   return &cares_task_list_;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -291,16 +291,14 @@ namespace node {
 
 class Environment;
 
-// TODO(bnoordhuis) Rename struct, the ares_ prefix implies it's part
-// of the c-ares API while the _t suffix implies it's a typedef.
-struct ares_task_t {
+struct node_ares_task {
   Environment* env;
   ares_socket_t sock;
   uv_poll_t poll_watcher;
-  RB_ENTRY(ares_task_t) node;
+  RB_ENTRY(node_ares_task) node;
 };
 
-RB_HEAD(ares_task_list, ares_task_t);
+RB_HEAD(node_ares_task_list, node_ares_task);
 
 class IsolateData {
  public:
@@ -484,7 +482,7 @@ class Environment {
   inline uv_timer_t* cares_timer_handle();
   inline ares_channel cares_channel();
   inline ares_channel* cares_channel_ptr();
-  inline ares_task_list* cares_task_list();
+  inline node_ares_task_list* cares_task_list();
   inline IsolateData* isolate_data() const;
 
   inline bool using_domains() const;
@@ -593,7 +591,7 @@ class Environment {
   const uint64_t timer_base_;
   uv_timer_t cares_timer_handle_;
   ares_channel cares_channel_;
-  ares_task_list cares_task_list_;
+  node_ares_task_list cares_task_list_;
   bool using_domains_;
   bool printed_error_;
   bool trace_sync_io_;


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
src


##### Description of change

This commit attempts to fix one of the items in
https://github.com/nodejs/node/issues/4641, which was to remove a TODO
comment from env.h regarding the naming of the ares_task_t struct.

Also, the struct ares_task_list was renamed to node_ares_task_list
following the same reasoning that is does not belong to the c-ares API.