### PR TITLE
deps: backport 7dfb5beeec from V8 upstream

### DIFF
--- a/deps/v8/src/crankshaft/hydrogen-instructions.cc
+++ b/deps/v8/src/crankshaft/hydrogen-instructions.cc
@@ -1283,7 +1283,6 @@ namespace {
 String* TypeOfString(HConstant* constant, Isolate* isolate) {
   Heap* heap = isolate->heap();
   if (constant->HasNumberValue()) return heap->number_string();
-  if (constant->IsUndetectable()) return heap->undefined_string();
   if (constant->HasStringValue()) return heap->string_string();
   switch (constant->GetInstanceType()) {
     case ODDBALL_TYPE: {
@@ -1312,6 +1311,7 @@ String* TypeOfString(HConstant* constant, Isolate* isolate) {
       return nullptr;
     }
     default:
+      if (constant->IsUndetectable()) return heap->undefined_string();
       if (constant->IsCallable()) return heap->function_string();
       return heap->object_string();
   }

--- a/deps/v8/test/mjsunit/regress/regress-opt-typeof-null.js
+++ b/deps/v8/test/mjsunit/regress/regress-opt-typeof-null.js
@@ -1,0 +1,12 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function f() {
+  return typeof null === "object";
+};
+
+%OptimizeFunctionOnNextCall(f);
+assertTrue(f());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
deps

##### Description of change
<!-- provide a description of the change below this comment -->

This commit backports a fix to a JIT bug in V8.
After 100 or so comparisons `typeof null ==="undefined"` is returning
`true` instead of `false`.

Original commit message:

	Fix 'typeof null' canonicalization in crankshaft

	BUG=

	Review URL: https://codereview.chromium.org/1912553002

	Cr-Commit-Position: refs/heads/master@{#35699}