### PR TITLE
src: moving dispatch_debug_messages_async to Environment

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -247,6 +247,10 @@ inline uv_idle_t* Environment::immediate_idle_handle() {
   return &immediate_idle_handle_;
 }
 
+inline uv_async_t* Environment::dispatch_debug_messages_async() {
+  return &dispatch_debug_messages_async_;
+}
+
 inline void Environment::RegisterHandleCleanup(uv_handle_t* handle,
                                                HandleCleanupCb cb,
                                                void *arg) {

--- a/src/env.h
+++ b/src/env.h
@@ -467,6 +467,7 @@ class Environment {
   static inline Environment* from_immediate_check_handle(uv_check_t* handle);
   inline uv_check_t* immediate_check_handle();
   inline uv_idle_t* immediate_idle_handle();
+  inline uv_async_t* dispatch_debug_messages_async();
 
   // Register clean-up cb to be called on environment destruction.
   inline void RegisterHandleCleanup(uv_handle_t* handle,
@@ -586,6 +587,7 @@ class Environment {
   uv_idle_t immediate_idle_handle_;
   uv_prepare_t idle_prepare_handle_;
   uv_check_t idle_check_handle_;
+  uv_async_t dispatch_debug_messages_async_;
   AsyncHooks async_hooks_;
   DomainFlag domain_flag_;
   TickInfo tick_info_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -4266,7 +4266,7 @@ static void StartNodeInstance(void* arg) {
 
     Environment env(&isolate_data, context);
 
-    uv_async_init(uv_default_loop(),
+    uv_async_init(env.event_loop(),
                   env.dispatch_debug_messages_async(),
                   DispatchDebugMessagesAsyncCallback);
     uv_unref(reinterpret_cast<uv_handle_t*>(

--- a/src/node.cc
+++ b/src/node.cc
@@ -3768,7 +3768,7 @@ void DebugProcess(const FunctionCallbackInfo<Value>& args) {
 
 inline void* DebugSignalThreadMain(void* async_handler) {
   uv_async_t* dispatch_debug_messages_async =
-      reinterpret_cast<uv_async_t*>(async_handler);
+      static_cast<uv_async_t*>(async_handler);
   CHECK_NE(dispatch_debug_messages_async, nullptr);
   for (;;) {
     uv_sem_wait(&debug_semaphore);

--- a/src/node.cc
+++ b/src/node.cc
@@ -4271,7 +4271,7 @@ static void StartNodeInstance(void* arg) {
     uv_unref(reinterpret_cast<uv_handle_t*>(
              env.dispatch_debug_messages_async()));
 
-    if (!use_debug_agent) {
+    if (!instance_data->use_debug_agent()) {
       RegisterDebugSignalHandler(env.dispatch_debug_messages_async());
     }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -4263,7 +4263,6 @@ static void StartNodeInstance(void* arg) {
                              array_buffer_allocator.zero_fill_field());
     Local<Context> context = Context::New(isolate);
     Context::Scope context_scope(context);
-
     Environment env(&isolate_data, context);
 
     uv_async_init(env.event_loop(),

--- a/src/node.cc
+++ b/src/node.cc
@@ -3779,7 +3779,7 @@ inline void* DebugSignalThreadMain(void* async_handler) {
 
 
 static int RegisterDebugSignalHandler(
-        uv_async_t* dispatch_debug_messages_async) {
+    uv_async_t* dispatch_debug_messages_async) {
   // Start a watchdog thread for calling v8::Debug::DebugBreak() because
   // it's not safe to call directly from the signal handler, it can
   // deadlock with the thread it interrupts.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
src


##### Description of change
This commit attempts to fix one of the items in
https://github.com/nodejs/node/issues/4641, which was to move
dispatch_debug_messages_async to the Environment class.