### PR TITLE
test: mark test-vm-timeout flaky on windows

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,7 +7,8 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-tick-processor     : PASS,FLAKY
+test-tick-processor : PASS,FLAKY
+test-vm-timeout     : PASS,FLAKY
 
 [$system==linux]
 test-tick-processor           : PASS,FLAKY


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test vm

##### Description of change
<!-- provide a description of the change below this comment -->

Refs: https://github.com/nodejs/node/issues/6727

/cc @nodejs/testing 