### PR TITLE
repl: tab completion for defined commands

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -724,11 +724,11 @@ REPLServer.prototype.complete = function(line, callback) {
 
   // REPL commands (e.g. ".break").
   var match = null;
-  match = line.match(/^\s*(\.\w*)$/);
+  match = line.match(/^\s*\.(\w*)$/);
   if (match) {
     completionGroups.push(Object.keys(this.commands));
     completeOn = match[1];
-    if (match[1].length > 1) {
+    if (match[1].length) {
       filter = match[1];
     }
 

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -260,3 +260,10 @@ putIn.run(['.clear']);
 testMe.complete('var log = console.lo', common.mustCall((error, data) => {
   assert.deepStrictEqual(data, [['console.log'], 'console.lo']);
 }));
+
+// tab completion for defined commands
+putIn.run(['.clear']);
+
+testMe.complete('.b', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [['break'], 'b']);
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
repl

##### Description of change
<!-- provide a description of the change below this comment -->

Tab completion is not working for REPL defined commands
```js
> .<<TAB>>
break  clear  exit   help   load   save

>.b<<TAB>>  // no tab completion
```
