### PR TITLE
repl: Enable tab completion for global properties when useGlobal is false

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -582,10 +582,20 @@ REPLServer.prototype.createContext = function() {
     context = global;
   } else {
     context = vm.createContext();
-    for (var i in global) context[i] = global[i];
-    context.console = new Console(this.outputStream);
-    context.global = context;
-    context.global.global = context;
+    const _console = new Console(this.outputStream);
+    Object.getOwnPropertyNames(global).forEach((name) => {
+      if (name === 'console') {
+        Object.defineProperty(context, name, {
+          configurable: true,
+          enumerable: true,
+          value: _console
+        });
+      }
+      else {
+        Object.defineProperty(context, name,
+          Object.getOwnPropertyDescriptor(global, name));
+      }
+    });
   }
 
   const module = new Module('<repl>');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -593,7 +593,6 @@ REPLServer.prototype.createContext = function() {
   } else {
     context = vm.createContext();
     context.global = context;
-    context.global.global = context;
     const _console = new Console(this.outputStream);
     Object.defineProperty(context, 'console', {
       configurable: true,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -39,6 +39,16 @@ const debug = util.debuglog('repl');
 const parentModule = module;
 const replMap = new WeakMap();
 
+const GLOBAL_OBJECT_PROPERTIES = ['NaN', 'Infinity', 'undefined',
+    'eval', 'parseInt', 'parseFloat', 'isNaN', 'isFinite', 'decodeURI',
+    'decodeURIComponent', 'encodeURI', 'encodeURIComponent',
+    'Object', 'Function', 'Array', 'String', 'Boolean', 'Number',
+    'Date', 'RegExp', 'Error', 'EvalError', 'RangeError',
+    'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
+    'Math', 'JSON'];
+const GLOBAL_OBJECT_PROPERTY_MAP = {};
+GLOBAL_OBJECT_PROPERTIES.forEach((p) => GLOBAL_OBJECT_PROPERTY_MAP[p] = p);
+
 try {
   // hack for require.resolve("./relative") to work properly.
   module.filename = path.resolve('repl');
@@ -582,19 +592,20 @@ REPLServer.prototype.createContext = function() {
     context = global;
   } else {
     context = vm.createContext();
+    context.global = context;
+    context.global.global = context;
     const _console = new Console(this.outputStream);
-    Object.getOwnPropertyNames(global).forEach((name) => {
-      if (name === 'console') {
-        Object.defineProperty(context, name, {
-          configurable: true,
-          enumerable: true,
-          value: _console
-        });
-      }
-      else {
-        Object.defineProperty(context, name,
-          Object.getOwnPropertyDescriptor(global, name));
-      }
+    Object.defineProperty(context, 'console', {
+      configurable: true,
+      enumerable: true,
+      get: () => _console
+    });
+    Object.getOwnPropertyNames(global).filter((name) => {
+      if (name === 'console' || name === 'global') return false;
+      return GLOBAL_OBJECT_PROPERTY_MAP[name] === undefined;
+    }).forEach((name) => {
+      Object.defineProperty(context, name,
+        Object.getOwnPropertyDescriptor(global, name));
     });
   }
 
@@ -1062,13 +1073,7 @@ REPLServer.prototype.memory = function memory(cmd) {
 function addStandardGlobals(completionGroups, filter) {
   // Global object properties
   // (http://www.ecma-international.org/publications/standards/Ecma-262.htm)
-  completionGroups.push(['NaN', 'Infinity', 'undefined',
-    'eval', 'parseInt', 'parseFloat', 'isNaN', 'isFinite', 'decodeURI',
-    'decodeURIComponent', 'encodeURI', 'encodeURIComponent',
-    'Object', 'Function', 'Array', 'String', 'Boolean', 'Number',
-    'Date', 'RegExp', 'Error', 'EvalError', 'RangeError',
-    'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
-    'Math', 'JSON']);
+  completionGroups.push(GLOBAL_OBJECT_PROPERTIES);
   // Common keywords. Exclude for completion on the empty string, b/c
   // they just get in the way.
   if (filter) {

--- a/test/parallel/test-repl-console.js
+++ b/test/parallel/test-repl-console.js
@@ -18,3 +18,6 @@ assert(r.context.console);
 
 // ensure that the repl console instance is not the global one
 assert.notStrictEqual(r.context.console, console);
+
+// ensure that the repl console instance does not have a setter
+assert.throws(() => r.context.console = 'foo', TypeError);

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -13,12 +13,6 @@ testContext(repl.start({
   useGlobal: false
 }));
 
-// Test when useGlobal is true
-repl.start({
-  input: stream,
-  output: stream
-});
-
 function testContext(repl) {
   const context = repl.createContext();
   // ensure that the repl context gets its own "console" instance

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+// Create a dummy stream that does nothing
+const stream = new common.ArrayStream();
+
+// Test when useGlobal is false
+testContext(repl.start({
+  input: stream,
+  output: stream,
+  useGlobal: false
+}));
+
+// Test when useGlobal is true
+repl.start({
+  input: stream,
+  output: stream
+});
+
+function testContext(repl) {
+  const context = repl.createContext();
+  // ensure that the repl context gets its own "console" instance
+  assert(context.console instanceof require('console').Console);
+
+  // ensure that the repl's global property is the context
+  assert(context.global === context);
+  assert(context.global.global === context);
+
+  // ensure that the repl console instance does not have a setter
+  assert.throws(() => context.console = 'foo');
+}

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -20,7 +20,6 @@ function testContext(repl) {
 
   // ensure that the repl's global property is the context
   assert(context.global === context);
-  assert(context.global.global === context);
 
   // ensure that the repl console instance does not have a setter
   assert.throws(() => context.console = 'foo');

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -267,3 +267,14 @@ putIn.run(['.clear']);
 testMe.complete('.b', common.mustCall((error, data) => {
   assert.deepStrictEqual(data, [['break'], 'b']);
 }));
+
+var testNonGlobal = repl.start({
+  input: putIn,
+  output: putIn,
+  useGlobal: false
+});
+
+testNonGlobal.complete('I', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [['Infinity', '', 'Int16Array', 'Int32Array',
+                                 'Int8Array', 'Intl'], 'I']);
+}));

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -268,7 +268,7 @@ testMe.complete('.b', common.mustCall((error, data) => {
   assert.deepStrictEqual(data, [['break'], 'b']);
 }));
 
-var testNonGlobal = repl.start({
+const testNonGlobal = repl.start({
   input: putIn,
   output: putIn,
   useGlobal: false

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -274,7 +274,12 @@ const testNonGlobal = repl.start({
   useGlobal: false
 });
 
+const builtins = [['Infinity', '', 'Int16Array', 'Int32Array',
+                                 'Int8Array'], 'I'];
+
+if (typeof Intl === 'object') {
+  builtins[0].push('Intl');
+}
 testNonGlobal.complete('I', common.mustCall((error, data) => {
-  assert.deepStrictEqual(data, [['Infinity', '', 'Int16Array', 'Int32Array',
-                                 'Int8Array', 'Intl'], 'I']);
+  assert.deepStrictEqual(data, builtins);
 }));


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [X] a test and/or benchmark is included
- [X] the commit message follows commit guidelines


##### Affected core subsystem(s)
repl

##### Description of change
When `useGlobal` is false, tab completion in the repl does not enumerate
global properties. Instead of just setting these properties blindly on
the global context, e.g.

    context[prop] = global[prop]

Use `Object.defineProperty` and the property descriptor found on
`global` for the new property in `context`.

Also addresses a previously unnoticed issue where `console` is writable
when `useGlobal` is false.

Ref: https://github.com/nodejs/node/issues/7353