### PR TITLE
vm: fix nested timeouts with inverse order + fix flaky test-vm-timeout

### DIFF
--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -99,7 +99,7 @@ void SigintWatchdog::Dispose() {
 
 
 SigintWatchdog::SigintWatchdog(v8::Isolate* isolate)
-    : isolate_(isolate), destroyed_(false) {
+    : isolate_(isolate), received_signal_(false), destroyed_(false) {
   // Register this watchdog with the global SIGINT/Ctrl+C listener.
   SigintWatchdogHelper::GetInstance()->Register(this);
   // Start the helper thread, if that has not already happened.
@@ -120,6 +120,7 @@ void SigintWatchdog::Destroy() {
 
 
 void SigintWatchdog::HandleSigint() {
+  received_signal_ = true;
   isolate_->TerminateExecution();
 }
 

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -46,11 +46,13 @@ class SigintWatchdog {
     void Dispose();
 
     v8::Isolate* isolate() { return isolate_; }
+    bool HasReceivedSignal() { return received_signal_; }
     void HandleSigint();
   private:
     void Destroy();
 
     v8::Isolate* isolate_;
+    bool received_signal_;
     bool destroyed_;
 };
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,8 +7,7 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-tick-processor : PASS,FLAKY
-test-vm-timeout     : PASS,FLAKY
+test-tick-processor     : PASS,FLAKY
 
 [$system==linux]
 test-tick-processor           : PASS,FLAKY

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -29,6 +29,6 @@ assert.throws(function() {
       vm.runInNewContext('while(true) {}', context, { timeout: timeout });
     }
   };
-  vm.runInNewContext('runInVM(10)', context, { timeout: 100 });
+  vm.runInNewContext('runInVM(10)', context, { timeout: 10000 });
   throw new Error('Test 5 failed');
 }, /Script execution timed out./);

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -32,3 +32,26 @@ assert.throws(function() {
   vm.runInNewContext('runInVM(10)', context, { timeout: 10000 });
   throw new Error('Test 5 failed');
 }, /Script execution timed out./);
+
+// Test 6: Nested vm timeouts, outer timeout is shorter and fires first.
+assert.throws(function() {
+  const context = {
+    runInVM: function(timeout) {
+      vm.runInNewContext('while(true) {}', context, { timeout: timeout });
+    }
+  };
+  vm.runInNewContext('runInVM(10000)', context, { timeout: 100 });
+  throw new Error('Test 6 failed');
+}, /Script execution timed out./);
+
+// Test 7: Nested vm timeouts, inner script throws an error.
+assert.throws(function() {
+  const context = {
+    runInVM: function(timeout) {
+      vm.runInNewContext('throw new Error(\'foobar\')', context, {
+        timeout: timeout
+      });
+    }
+  };
+  vm.runInNewContext('runInVM(10000)', context, { timeout: 100000 });
+}, /foobar/);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x]  the commit message follows commit guidelines

##### Affected core subsystem(s)

vm, test

##### Description of change

Fix #6727:

- I think @Trott is right in #6727 to assume the changed error message stems from the inner timeout in the test not checking whether it has witnessed its own timeout or the outer one.

- My best guess for why `test-vm-timeout` was flaky even before #6635 is that the outer timeout could interfere with handling of the inner timeout, e.g. during construction of the `Error` object that would be created. Increasing the outer timeout won’t have any adverse effects anyway.

/cc @bnoordhuis ?