### PR TITLE
Add test for HTTP client "aborted" event

### DIFF
--- a/test/parallel/test-http-client-aborted-event.js
+++ b/test/parallel/test-http-client-aborted-event.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+const server = http.Server(function(req, res) {
+  res.write('Part of my res.');
+  res.destroy();
+});
+
+server.listen(0, common.mustCall(function() {
+  http.get({
+    port: this.address().port,
+    headers: { connection: 'keep-alive' }
+  }, common.mustCall(function(res) {
+    server.close();
+    res.on('aborted', common.mustCall(function() {}));
+  }));
+}));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

None. A test for current `http`.
##### Description of change

Following on from #7270 to add a test for `aborted` events on `http.IncomingMessage` emitters from `http.request`. New test was derived from old [test/parallel/test-http-abort-client.js](https://github.com/nodejs/node/blob/86fdbe0c251ebb3cb715768c3a2c3bf3811dbbb4/test/parallel/test-http-abort-client.js).

cc @addaleax
