### PR TITLE
Http: Improve `finish()` callback and code legibility (Fixes #7295)

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -546,13 +546,6 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
     return false;
   }
 
-  var finish = () => {
-    this.emit('finish');
-  }
-
-  if (typeof callback === 'function')
-    this.once('finish', callback);
-
   if (!this._header) {
     if (data) {
       if (typeof data === 'string')
@@ -578,6 +571,13 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   if (data) {
     // Normal body write.
     this.write(data, encoding);
+  }
+
+  if (typeof callback === 'function')
+    this.once('finish', callback);
+
+  var finish = () => {
+    this.emit('finish');
   }
 
   if (this._hasBody && this.chunkedEncoding) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -576,7 +576,7 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   if (typeof callback === 'function')
     this.once('finish', callback);
 
-  var finish = () => {
+  const finish = () => {
     this.emit('finish');
   };
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -578,7 +578,7 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
 
   var finish = () => {
     this.emit('finish');
-  }
+  };
 
   if (this._hasBody && this.chunkedEncoding) {
     ret = this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -546,9 +546,8 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
     return false;
   }
 
-  var self = this;
-  function finish() {
-    self.emit('finish');
+  var finish = () => {
+    this.emit('finish');
   }
 
   if (typeof callback === 'function')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
http

( Specifically `_http_outgoing.js`: `OutgoingMessage.prototype.end` method )

##### Description of change
<!-- provide a description of the change below this comment -->
1. Converted callback function to arrow function to take advantage of lexical `this`.
2. Gathered code relating to `finish` event together to improve code clarity.
3. See #7295 for further details.