### PR TITLE
repl: exponentiation operator SyntaxError

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -478,6 +478,19 @@ function REPLServer(prompt,
       evalCmd = evalCmd + '\n';
     }
 
+    // Exponentiation operator
+    if (cmd && cmd.split('').indexOf('*') !== -1) {
+
+      const cmdArray = cmd.split('');
+      const index = cmdArray.indexOf('*');
+
+      if (cmdArray[index + 1]) {
+        self.outputStream.write('SyntaxError: Unexpected token *\n');
+        finish(null);
+        return;
+      }
+    }
+
     debug('eval %j', evalCmd);
     self.eval(evalCmd, self.context, 'repl', finish);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [ ] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
repl

##### Description of change
<!-- provide a description of the change below this comment -->

**description:** https://github.com/nodejs/node/issues/7372
**more info:** https://github.com/nodejs/node/issues/7332

##### Cases to handle:
- [x] Inside a string literal
- [ ] Ignore if is inside a comment
- [x] Later in the command string

---------------------------
I don't know if this is the best implementation, I never look in the **repl.js** file before, I would love to hear some feedback.