### PR TITLE
deps: update v8_inspector

### DIFF
--- a/deps/v8_inspector/platform/inspector_protocol/generate-inspector-protocol-version
+++ b/deps/v8_inspector/platform/inspector_protocol/generate-inspector-protocol-version
@@ -4,7 +4,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met:
-#
+# 
 #     * Redistributions of source code must retain the above copyright
 # notice, this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above
@@ -14,7 +14,7 @@
 #     * Neither the name of Google Inc. nor the names of its
 # contributors may be used to endorse or promote products derived from
 # this software without specific prior written permission.
-#
+# 
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # Inspector protocol validator.
-#
+# 
 # Tests that subsequent protocol changes are not breaking backwards compatibility.
 # Following violations are reported:
 #
@@ -39,7 +39,7 @@
 #   - Event has been removed
 #   - Required event parameter was removed or changed to optional
 #   - Parameter type has changed.
-#
+#   
 # For the parameters with composite types the above checks are also applied
 # recursively to every property of the type.
 #
@@ -197,7 +197,7 @@ def extract_type(typed_object, types_map, errors):
         ref = typed_object["$ref"]
         if not ref in types_map:
             errors.append("Can not resolve type: %s" % ref)
-            types_map[ref] = { "id": "<transient>", "type": "object" }
+            types_map[ref] = { "id": "<transient>", "type": "object" } 
         return types_map[ref]
 
 

--- a/deps/v8_inspector/platform/v8_inspector/InjectedScriptNative.cpp
+++ b/deps/v8_inspector/platform/v8_inspector/InjectedScriptNative.cpp
@@ -94,3 +94,4 @@ String16 InjectedScriptNative::groupName(int objectId) const
 }
 
 } // namespace blink
+

--- a/deps/v8_inspector/platform/v8_inspector/V8Compat.h
+++ b/deps/v8_inspector/platform/v8_inspector/V8Compat.h
@@ -7,7 +7,7 @@
 
 #include <v8.h>
 
-#if V8_MAJOR_VERSION < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 2)
+#if V8_MAJOR_VERSION < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 1)
 namespace v8 {
 
 // In standalone V8 inspector this is expected to be noop anyways...


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines

##### Description of change
<!-- provide a description of the change below this comment -->

Pick up latest commit of v8_inspector and inspector_protocol.
This brings back compatibility with V8 5.1.

R= @ofrobots 