### PR TITLE
vm: don't print out arrow message for custom error

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1512,20 +1512,25 @@ void AppendExceptionLine(Environment* env,
   Local<String> arrow_str = String::NewFromUtf8(env->isolate(), arrow);
 
   const bool can_set_arrow = !arrow_str.IsEmpty() && !err_obj.IsEmpty();
-  if (can_set_arrow && (mode != FATAL_ERROR || err_obj->IsNativeError())) {
-    err_obj->SetPrivate(
-        env->context(),
-        env->arrow_message_private_symbol(),
-        arrow_str);
+  // If allocating arrow_str failed, print it out. There's not much else to do.
+  // If it's not an error, but something needs to be printed out because
+  // it's a fatal exception, also print it out from here.
+  // Otherwise, the arrow property will be attached to the object and handled
+  // by the caller.
+  if (!can_set_arrow || (mode == FATAL_ERROR && !err_obj->IsNativeError())) {
+    if (env->printed_error())
+      return;
+    env->set_printed_error(true);
+
+    uv_tty_reset_mode();
+    PrintErrorString("\n%s", arrow);
     return;
   }
 
-  // Allocation failed when called from ReportException(), just print it out.
-  if (env->printed_error())
-    return;
-  env->set_printed_error(true);
-  uv_tty_reset_mode();
-  PrintErrorString("\n%s", arrow);
+  err_obj->SetPrivate(
+      env->context(),
+      env->arrow_message_private_symbol(),
+      arrow_str);
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1527,10 +1527,10 @@ void AppendExceptionLine(Environment* env,
     return;
   }
 
-  err_obj->SetPrivate(
-      env->context(),
-      env->arrow_message_private_symbol(),
-      arrow_str);
+  CHECK(err_obj->SetPrivate(
+            env->context(),
+            env->arrow_message_private_symbol(),
+            arrow_str).FromMaybe(false));
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1424,7 +1424,7 @@ bool IsExceptionDecorated(Environment* env, Local<Value> er) {
 void AppendExceptionLine(Environment* env,
                          Local<Value> er,
                          Local<Message> message,
-                         bool handlingFatalError) {
+                         enum ErrorHandlingMode mode) {
   if (message.IsEmpty())
     return;
 
@@ -1511,8 +1511,8 @@ void AppendExceptionLine(Environment* env,
 
   Local<String> arrow_str = String::NewFromUtf8(env->isolate(), arrow);
 
-  if (!arrow_str.IsEmpty() && !err_obj.IsEmpty() &&
-      (!handlingFatalError || err_obj->IsNativeError())) {
+  const bool can_set_arrow = !arrow_str.IsEmpty() && !err_obj.IsEmpty();
+  if (can_set_arrow && (mode != FATAL_ERROR || err_obj->IsNativeError())) {
     err_obj->SetPrivate(
         env->context(),
         env->arrow_message_private_symbol(),
@@ -1534,7 +1534,7 @@ static void ReportException(Environment* env,
                             Local<Message> message) {
   HandleScope scope(env->isolate());
 
-  AppendExceptionLine(env, er, message, true);
+  AppendExceptionLine(env, er, message, FATAL_ERROR);
 
   Local<Value> trace_value;
   Local<Value> arrow;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -632,7 +632,7 @@ class ContextifyScript : public BaseObject {
     if (IsExceptionDecorated(env, err_obj))
       return;
 
-    AppendExceptionLine(env, exception, try_catch.Message());
+    AppendExceptionLine(env, exception, try_catch.Message(), CONTEXTIFY_ERROR);
     Local<Value> stack = err_obj->Get(env->stack_string());
     auto maybe_value =
         err_obj->GetPrivate(

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -137,10 +137,11 @@ constexpr size_t arraysize(const T(&)[N]) { return N; }
 
 bool IsExceptionDecorated(Environment* env, v8::Local<v8::Value> er);
 
+enum ErrorHandlingMode { FATAL_ERROR, CONTEXTIFY_ERROR };
 void AppendExceptionLine(Environment* env,
                          v8::Local<v8::Value> er,
                          v8::Local<v8::Message> message,
-                         bool handlingFatalError = false);
+                         enum ErrorHandlingMode mode);
 
 NO_RETURN void FatalError(const char* location, const char* message);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -139,7 +139,8 @@ bool IsExceptionDecorated(Environment* env, v8::Local<v8::Value> er);
 
 void AppendExceptionLine(Environment* env,
                          v8::Local<v8::Value> er,
-                         v8::Local<v8::Message> message);
+                         v8::Local<v8::Message> message,
+                         bool handlingFatalError = false);
 
 NO_RETURN void FatalError(const char* location, const char* message);
 

--- a/test/message/vm_caught_custom_runtime_error.js
+++ b/test/message/vm_caught_custom_runtime_error.js
@@ -1,0 +1,17 @@
+'use strict';
+require('../common');
+const vm = require('vm');
+
+console.error('beginning');
+
+// Regression test for https://github.com/nodejs/node/issues/7397:
+// This should not print out anything to stderr due to the error being caught.
+try {
+  vm.runInThisContext(`throw ({
+    name: 'MyCustomError',
+    message: 'This is a custom message'
+  })`, { filename: 'test.vm' });
+} catch (e) {
+}
+
+console.error('end');

--- a/test/message/vm_caught_custom_runtime_error.js
+++ b/test/message/vm_caught_custom_runtime_error.js
@@ -12,6 +12,7 @@ try {
     message: 'This is a custom message'
   })`, { filename: 'test.vm' });
 } catch (e) {
+  console.error('received error', e.name);
 }
 
 console.error('end');

--- a/test/message/vm_caught_custom_runtime_error.js
+++ b/test/message/vm_caught_custom_runtime_error.js
@@ -5,7 +5,7 @@ const vm = require('vm');
 console.error('beginning');
 
 // Regression test for https://github.com/nodejs/node/issues/7397:
-// This should not print out anything to stderr due to the error being caught.
+// vm.runInThisContext() should not print out anything to stderr by itself.
 try {
   vm.runInThisContext(`throw ({
     name: 'MyCustomError',

--- a/test/message/vm_caught_custom_runtime_error.out
+++ b/test/message/vm_caught_custom_runtime_error.out
@@ -1,0 +1,2 @@
+beginning
+end

--- a/test/message/vm_caught_custom_runtime_error.out
+++ b/test/message/vm_caught_custom_runtime_error.out
@@ -1,2 +1,3 @@
 beginning
+received error MyCustomError
 end


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)

vm

##### Description of change

In `AppendExceptionLine()`, which is used both by the `vm`
module and the uncaught exception handler, don’t print anything
to stderr when called from the `vm` module, even if the
thrown object is not a native error instance.

Fixes: https://github.com/nodejs/node/issues/7397