### PR TITLE
build: introduce `./configure --with-lto`

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -12,6 +12,7 @@
     'python%': 'python',
 
     'node_tag%': '',
+    'node_use_lto%': '',
     'uv_library%': 'static_library',
 
     'openssl_fips%': '',
@@ -290,6 +291,13 @@
             ],
             'ldflags!': [ '-rdynamic' ],
           }],
+          ['node_use_lto=="true"', {
+            'conditions': [ [ 'clang==1', {
+              'cflags': [ '-flto' ],
+            }, {
+              'cflags': [ '-flto=16' ],
+            } ] ],
+          }],
         ],
       }],
       [ 'OS=="android"', {
@@ -341,6 +349,13 @@
             'xcode_settings': {
               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
               'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++0x',  # -std=gnu++0x
+            },
+          }],
+          ['node_use_lto=="true"', {
+            'xcode_settings': {
+              'OTHER_CFLAGS': [
+                '-flto',
+              ],
             },
           }],
         ],

--- a/configure
+++ b/configure
@@ -297,6 +297,11 @@ parser.add_option('--with-lttng',
     dest='with_lttng',
     help='build with Lttng (Only available to Linux)')
 
+parser.add_option('--with-lto',
+    action='store_true',
+    dest='use_lto',
+    help='build with -flto flag (Link Time Optimization)')
+
 parser.add_option('--with-etw',
     action='store_true',
     dest='with_etw',
@@ -776,6 +781,8 @@ def configure_node(o):
     raise Exception('lttng is only supported on Linux.')
   else:
     o['variables']['node_use_lttng'] = 'false'
+
+  o['variables']['node_use_lto'] = b(options.use_lto)
 
   if options.no_ifaddrs:
     o['defines'] += ['SUNOS_NO_IFADDRS']


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

build
##### Description of change

<!-- provide a description of the change below this comment -->

build: introduce `./configure --with-lto`

Introduce `--with-lto` configure option to use Link Time Optimization
compiler pass in gcc/clang compilers.

This flag slightly improves performance of C/C++ heavy code:

```
tls/throughput.js dur="5" type="buf" size="2": ./out/Release/node-flto: 6.1295 ./out/Release/node: 5.6876 ....... 7.77%
tls/throughput.js dur="5" type="buf" size="1024": ./out/Release/node-flto: 1567 ./out/Release/node: 1455 ........ 7.70%
tls/throughput.js dur="5" type="buf" size="1048576": ./out/Release/node-flto: 4167.8 ./out/Release/node: 4026.7 . 3.50%
tls/throughput.js dur="5" type="asc" size="2": ./out/Release/node-flto: 5.5664 ./out/Release/node: 5.0363 ...... 10.52%
tls/throughput.js dur="5" type="asc" size="1024": ./out/Release/node-flto: 1462.2 ./out/Release/node: 1336.8 .... 9.38%
tls/throughput.js dur="5" type="asc" size="1048576": ./out/Release/node-flto: 3947.5 ./out/Release/node: 3847.4 . 2.60%
tls/throughput.js dur="5" type="utf" size="2": ./out/Release/node-flto: 5.5544 ./out/Release/node: 5.0786 ....... 9.37%
tls/throughput.js dur="5" type="utf" size="1024": ./out/Release/node-flto: 1328.5 ./out/Release/node: 1255.7 .... 5.80%
tls/throughput.js dur="5" type="utf" size="1048576": ./out/Release/node-flto: 3051.1 ./out/Release/node: 2985.1 . 2.21%
```

See: #7400

R= @bnoordhuis @nodejs/collaborators 
