### PR TITLE
debug: use arrow functions for lexical `this`

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -66,11 +66,10 @@ Agent.prototype.onConnection = function onConnection(socket) {
   c.start();
   this.clients.push(c);
 
-  var self = this;
-  c.once('close', function() {
-    var index = self.clients.indexOf(c);
+  c.once('close', () => {
+    var index = this.clients.indexOf(c);
     assert(index !== -1);
-    self.clients.splice(index, 1);
+    this.clients.splice(index, 1);
   });
 };
 

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -96,9 +96,8 @@ function Client(agent, socket) {
 
   this.on('data', this.onCommand);
 
-  var self = this;
-  this.socket.on('close', function() {
-    self.destroy();
+  this.socket.on('close', () => {
+    this.destroy();
   });
 }
 util.inherits(Client, Transform);

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -50,9 +50,8 @@ function Agent() {
   this.binding = process._debugAPI;
   assert(this.binding, 'Debugger agent running without bindings!');
 
-  var self = this;
-  this.binding.onmessage = function(msg) {
-    self.clients.forEach(function(client) {
+  this.binding.onmessage = (msg) => {
+    this.clients.forEach((client) => {
       client.send({}, msg);
     });
   };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
debug

( specifically: `lib/_debug_agent.js` )

##### Description of change
<!-- provide a description of the change below this comment -->

Use arrow functions to replace 3x `var self = this; ... function() { self.whatever() }` pattern.

See #7414 for more details.