### PR TITLE
fs: use arrow functions for lexical `this`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1928,7 +1928,6 @@ WriteStream.prototype._writev = function(data, cb) {
       this._writev(data, cb);
     });
 
-  const self = this;
   const len = data.length;
   const chunks = new Array(len);
   var size = 0;
@@ -1940,12 +1939,12 @@ WriteStream.prototype._writev = function(data, cb) {
     size += chunk.length;
   }
 
-  writev(this.fd, chunks, this.pos, function(er, bytes) {
+  writev(this.fd, chunks, this.pos, (er, bytes) => {
     if (er) {
-      self.destroy();
+      this.destroy();
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1470,24 +1470,23 @@ fs.watch = function(filename, options, listener) {
 function StatWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new binding.StatWatcher();
 
   // uv_fs_poll is a little more powerful than ev_stat but we curb it for
   // the sake of backwards compatibility
   var oldStatus = -1;
 
-  this._handle.onchange = function(current, previous, newStatus) {
+  this._handle.onchange = (current, previous, newStatus) => {
     if (oldStatus === -1 &&
         newStatus === -1 &&
         current.nlink === previous.nlink) return;
 
     oldStatus = newStatus;
-    self.emit('change', current, previous);
+    this.emit('change', current, previous);
   };
 
-  this._handle.onstop = function() {
-    self.emit('stop');
+  this._handle.onstop = () => {
+    this.emit('stop');
   };
 }
 util.inherits(StatWatcher, EventEmitter);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1708,20 +1708,19 @@ function ReadStream(path, options) {
 fs.FileReadStream = fs.ReadStream; // support the legacy name
 
 ReadStream.prototype.open = function() {
-  var self = this;
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+  fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
-      self.emit('error', er);
+      this.emit('error', er);
       return;
     }
 
-    self.fd = fd;
-    self.emit('open', fd);
+    this.fd = fd;
+    this.emit('open', fd);
     // start the flow of data.
-    self.read();
+    this.read();
   });
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1786,7 +1786,16 @@ ReadStream.prototype.destroy = function() {
 
 
 ReadStream.prototype.close = function(cb) {
-  var self = this;
+  const close = (fd) => {
+    fs.close(fd || this.fd, (er) => {
+      if (er)
+        this.emit('error', er);
+      else
+        this.emit('close');
+    });
+    this.fd = null;
+  };
+
   if (cb)
     this.once('close', cb);
   if (this.closed || typeof this.fd !== 'number') {
@@ -1798,16 +1807,6 @@ ReadStream.prototype.close = function(cb) {
   }
   this.closed = true;
   close();
-
-  function close(fd) {
-    fs.close(fd || self.fd, function(er) {
-      if (er)
-        self.emit('error', er);
-      else
-        self.emit('close');
-    });
-    self.fd = null;
-  }
 };
 
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1894,15 +1894,14 @@ WriteStream.prototype._write = function(data, encoding, cb) {
       this._write(data, encoding, cb);
     });
 
-  var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+  fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1755,28 +1755,25 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
-  var self = this;
-  fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
-
-  // move the pool positions, and internal position for reading.
-  if (this.pos !== undefined)
-    this.pos += toRead;
-  pool.used += toRead;
-
-  function onread(er, bytesRead) {
+  fs.read(this.fd, pool, pool.used, toRead, this.pos, (er, bytesRead) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
-      self.emit('error', er);
+      this.emit('error', er);
     } else {
       var b = null;
       if (bytesRead > 0)
         b = thisPool.slice(start, start + bytesRead);
 
-      self.push(b);
+      this.push(b);
     }
-  }
+  });
+
+  // move the pool positions, and internal position for reading.
+  if (this.pos !== undefined)
+    this.pos += toRead;
+  pool.used += toRead;
 };
 
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1395,21 +1395,20 @@ fs.appendFileSync = function(path, data, options) {
 function FSWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new FSEvent();
   this._handle.owner = this;
 
-  this._handle.onchange = function(status, event, filename) {
+  this._handle.onchange = (status, event, filename) => {
     if (status < 0) {
-      self._handle.close();
+      this._handle.close();
       const error = !filename ?
           errnoException(status, 'Error watching file for changes:') :
           errnoException(status,
                          `Error watching file ${filename} for changes:`);
       error.filename = filename;
-      self.emit('error', error);
+      this.emit('error', error);
     } else {
-      self.emit('change', event, filename);
+      this.emit('change', event, filename);
     }
   };
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] the commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

fs

( specifically: `lib/fs.js` )
##### Description of change

<!-- provide a description of the change below this comment -->

Use arrow functions to replace multiple `var self = this; ... function() { self.whatever() }` pattern.

See #7414 for more details.
