### PR TITLE
Backport 7176 for v6.x (buffer: fix creating from zero-length ArrayBuffer)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -259,7 +259,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
 
   const maxLength = obj.byteLength - byteOffset;
 
-  if (maxLength <= 0)
+  if (maxLength < 0)
     throw new RangeError("'offset' is out of bounds");
 
   if (length === undefined) {

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1458,3 +1458,8 @@ const ubuf = Buffer.allocUnsafeSlow(10);
 assert(ubuf);
 assert(ubuf.buffer);
 assert.equal(ubuf.buffer.byteLength, 10);
+
+// Regression test
+assert.doesNotThrow(() => {
+  Buffer.from(new ArrayBuffer());
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
buffer


##### Description of change
<!-- provide a description of the change below this comment -->

This is a backport of https://github.com/nodejs/node/pull/7176 for v6.x. Applied cleanly.