### PR TITLE
test: test isFullWidthCodePoint with invalid input

### DIFF
--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -328,7 +328,9 @@ function isWarned(emitter) {
   }
 
   // isFullWidthCodePoint() should return false for non-numeric values
-  assert.strictEqual(internalReadline.isFullWidthCodePoint('あ'), false);
+  [true, false, null, undefined, {}, [], 'あ'].forEach((v) => {
+    assert.strictEqual(internalReadline.isFullWidthCodePoint('あ'), false);
+  });
 
   // wide characters should be treated as two columns.
   assert.equal(internalReadline.isFullWidthCodePoint('a'.charCodeAt(0)), false);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -327,6 +327,9 @@ function isWarned(emitter) {
     rli.close();
   }
 
+  // isFullWidthCodePoint() should return false for non-numeric values
+  assert.strictEqual(internalReadline.isFullWidthCodePoint('あ'), false);
+
   // wide characters should be treated as two columns.
   assert.equal(internalReadline.isFullWidthCodePoint('a'.charCodeAt(0)), false);
   assert.equal(internalReadline.isFullWidthCodePoint('あ'.charCodeAt(0)), true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] a test and/or benchmark is included
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->

test readline

##### Description of change
<!-- provide a description of the change below this comment -->

Code coverage information shows that we are only testing the happy path
for the internal readlind `isFullWidthCodePoint()` function. Test it
with invalid input.