### PR TITLE
doc: fix typographic error in process doc

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -774,7 +774,7 @@ emitMyWarning();
 added: v0.7.7
 -->
 
-The `process.execArgv' property returns the set of Node.js-specific command-line
+The `process.execArgv` property returns the set of Node.js-specific command-line
 options passed when the Node.js process was launched. These options do not
 appear in the array returned by the [`process.argv`][] property, and do not
 include the Node.js executable, the name of the script, or any options following


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly a benchmark.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines


##### Affected core subsystem(s)
<!-- provide affected core subsystem(s) (like doc, cluster, crypto, etc) -->
doc

##### Description of change
<!-- provide a description of the change below this comment -->

An apostrophe was being used where a backtick was called for, resulting
in improper rendering.