### PR TITLE
build: adds configure flag notargettype

### DIFF
--- a/configure
+++ b/configure
@@ -409,6 +409,11 @@ parser.add_option('--enable-static',
     dest='enable_static',
     help='build as static library')
 
+parser.add_option('--no-target-type',
+     action='store_true',
+     dest='no_target_type',
+     help='do not compile and link node core')
+
 parser.add_option('--no-browser-globals',
     action='store_true',
     dest='no_browser_globals',
@@ -740,6 +745,9 @@ def configure_node(o):
   if flavor == 'aix':
     o['variables']['node_core_target_name'] = 'node_base'
     o['variables']['node_target_type'] = 'static_library'
+
+  if options.no_target_type:
+    o['variables']['node_target_type'] = 'none'
 
   if target_arch in ('x86', 'x64', 'ia32', 'x32'):
     o['variables']['node_enable_v8_vtunejit'] = b(options.enable_vtune_profiling)

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -20,6 +20,7 @@ set noprojgen=
 set nobuild=
 set nosign=
 set nosnapshot=
+set notargettype=
 set test_args=
 set package=
 set msi=
@@ -55,6 +56,7 @@ if /i "%1"=="nosign"        set nosign=1&goto arg-ok
 if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
+if /i "%1"=="notargettype"  set notargettype=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% addons doctool known_issues message parallel sequential -J&set jslint=1&set build_addons=1&goto arg-ok
 if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap addons doctool known_issues message sequential parallel&set build_addons=1&goto arg-ok


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

`build`
##### Description of change

In the wake of #7440 in order to replace GYP https://github.com/nodejs/CTC/issues/2, this would be the first step. Effectively `./configure --no-target-type` will still compile any dependency and run `js2c`, but not let gyp `gcc src/*.cc -c -o out/*.o` and run the linker as last build step.

This can be used, as presented in the above PR, to build node-core with node itself. 

In order to fully compile without gyp, it's a long way, but definitely doable
