### PR TITLE
fs: undeprecate existsSync; use access instead of stat for performance

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -597,8 +597,9 @@ deprecated: v1.0.0
 * `path` {String | Buffer}
 * `callback` {Function}
 
-Test whether or not the given path exists by checking with the file system.
-Then call the `callback` argument with either true or false.  Example:
+Test whether or not the given path exists and is accessible by checking
+with the file system. Then call the `callback` argument with either
+true or false.  Example:
 
 ```js
 fs.exists('/etc/passwd', (exists) => {
@@ -615,16 +616,12 @@ non-existent.
 ## fs.existsSync(path)
 <!-- YAML
 added: v0.1.21
-deprecated: v1.0.0
 -->
-
-> Stability: 0 - Deprecated: Use [`fs.statSync()`][] or [`fs.accessSync()`][]
-> instead.
 
 * `path` {String | Buffer}
 
 Synchronous version of [`fs.exists()`][].
-Returns `true` if the file exists, `false` otherwise.
+Returns `true` if the file exists and is accessible, `false` otherwise.
 
 ## fs.fchmod(fd, mode, callback)
 <!-- YAML

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -259,13 +259,11 @@ fs.exists = function(path, callback) {
 };
 
 fs.existsSync = function(path) {
-  try {
-    nullCheck(path);
-    binding.stat(pathModule._makeLong(path));
-    return true;
-  } catch (e) {
+  if (String(path).indexOf('\u0000') !== -1) {
     return false;
   }
+
+  return binding.accessibleSync(pathModule._makeLong(path), fs.F_OK);
 };
 
 fs.readFile = function(path, options, callback_) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -250,10 +250,8 @@ fs.accessSync = function(path, mode) {
 
 fs.exists = function(path, callback) {
   if (!nullCheck(path, cb)) return;
-  var req = new FSReqWrap();
-  req.oncomplete = cb;
-  binding.stat(pathModule._makeLong(path), req);
-  function cb(err, stats) {
+  fs.access(path, fs.F_OK, cb);
+  function cb(err) {
     if (callback) callback(err ? false : true);
   }
 };

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -27,6 +27,7 @@
 namespace node {
 
 using v8::Array;
+using v8::Boolean;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Function;
@@ -397,6 +398,30 @@ static void Access(const FunctionCallbackInfo<Value>& args) {
   } else {
     SYNC_CALL(access, *path, *path, mode);
   }
+}
+
+static void AccessibleSync(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  HandleScope scope(env->isolate());
+
+  if (args.Length() < 2)
+    return TYPE_ERROR("path and mode are required");
+  if (!args[1]->IsInt32())
+    return TYPE_ERROR("mode must be an integer");
+
+  BufferValue path(env->isolate(), args[0]);
+  ASSERT_PATH(path)
+
+  int mode = static_cast<int>(args[1]->Int32Value());
+
+  fs_req_wrap req_wrap;
+  env->PrintSyncTrace();
+  int err = uv_fs_access(
+    env->event_loop(), &req_wrap.req, *path, mode, nullptr);
+
+  bool failed = err < 0;
+
+  args.GetReturnValue().Set(Boolean::New(env->isolate(), !failed));
 }
 
 
@@ -1448,6 +1473,7 @@ void InitFs(Local<Object> target,
               env->NewFunctionTemplate(FSInitialize)->GetFunction());
 
   env->SetMethod(target, "access", Access);
+  env->SetMethod(target, "accessibleSync", AccessibleSync);
   env->SetMethod(target, "close", Close);
   env->SetMethod(target, "open", Open);
   env->SetMethod(target, "read", Read);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

1) Improve the performance of `existsSync` by using `access` without throwing an ignored exception.
2) Make `exists` faster by using `access` instead of `stat` (without returning an ignored stat result)
3) Undeprecate `existsSync` because there's no alternative method that doesn't throw an exception.