### PR TITLE
benchmark: fix hanging test client-request-body

### DIFF
--- a/benchmark/http/client-request-body.js
+++ b/benchmark/http/client-request-body.js
@@ -15,6 +15,7 @@ function main(conf) {
   var dur = +conf.dur;
   var len = +conf.bytes;
 
+  var running = true;
   var encoding;
   var chunk;
   switch (conf.type) {
@@ -52,7 +53,9 @@ function main(conf) {
   function pummel() {
     var req = http.request(options, function(res) {
       nreqs++;
-      pummel();  // Line up next request.
+      if (running) {
+        pummel();  // Line up next request.
+      }
       res.resume();
     });
     if (conf.method === 'write') {
@@ -65,5 +68,7 @@ function main(conf) {
 
   function done() {
     bench.end(nreqs);
+    server.close();
+    running = false;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark


##### Description of change

Currently, this benchmark does not close the server it creates and
continues sending requests to the server after the benchmark has
completed. This causes the benchmark to hang.

This change cleans up the server and stops the sending of requests after
the benchmark has completed.