### PR TITLE
doc: improve usage of `zero`/`0`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -585,7 +585,7 @@ a listener for the `'listening'` event.  See also [`net.Server.listen(path)`][].
 Begin accepting connections on the specified `port` and `hostname`. If the
 `hostname` is omitted, the server will accept connections on any IPv6 address
 (`::`) when IPv6 is available, or any IPv4 address (`0.0.0.0`) otherwise. Use a
-port value of zero to have the operating system assign an available port.
+port value of `0` to have the operating system assign an available port.
 
 To listen to a unix socket, supply a filename instead of port and hostname.
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -183,7 +183,7 @@ code without properly recovering from the exception can cause additional
 unforeseen and unpredictable issues.
 
 Exceptions thrown from within the event handler will not be caught. Instead the
-process will exit with a non zero exit code and the stack trace will be printed.
+process will exit with a non-zero exit code and the stack trace will be printed.
 This is to avoid infinite recursion.
 
 Attempting to resume normally after an uncaught exception can be similar to


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->
@nodejs/documentation 
