### PR TITLE
New Buffer API backport to v4.x

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -23,16 +23,112 @@ would need to ever use `require('buffer')`.
 ```js
 const buf1 = new Buffer(10);
   // creates a buffer of length 10
+  // This is the same as Buffer.allocUnsafe(10), and the returned
+  // Buffer instance might contain old data that needs to be
+  // overwritten using either fill() or write().
 
 const buf2 = new Buffer([1,2,3]);
   // creates a buffer containing [01, 02, 03]
+  // This is the same as Buffer.from([1,2,3]).
 
 const buf3 = new Buffer('test');
   // creates a buffer containing ASCII bytes [74, 65, 73, 74]
+  // This is the same as Buffer.from('test').
 
 const buf4 = new Buffer('tést', 'utf8');
   // creates a buffer containing UTF8 bytes [74, c3, a9, 73, 74]
+  // This is the same as Buffer.from('tést', 'utf8').
+
+const buf5 = Buffer.alloc(10);
+  // Creates a zero-filled Buffer of length 10.
+
+const buf6 = Buffer.alloc(10, 1);
+  // Creates a Buffer of length 10, filled with 0x01.
+
+const buf7 = Buffer.allocUnsafe(10);
+  // Creates an uninitialized buffer of length 10.
+  // This is faster than calling Buffer.alloc() but the returned
+  // Buffer instance might contain old data that needs to be
+  // overwritten using either fill() or write().
+
+const buf8 = Buffer.from([1,2,3]);
+  // Creates a Buffer containing [01, 02, 03].
+
+const buf9 = Buffer.from('test');
+  // Creates a Buffer containing ASCII bytes [74, 65, 73, 74].
+
+const buf8 = Buffer.from('tést', 'utf8');
+  // Creates a Buffer containing UTF8 bytes [74, c3, a9, 73, 74].
 ```
+
+## `Buffer.from()`, `Buffer.alloc()`, and `Buffer.allocUnsafe()`
+
+Historically, `Buffer` instances have been created using the `Buffer`
+constructor function, which allocates the returned `Buffer`
+differently based on what arguments are provided:
+
+* Passing a number as the first argument to `Buffer()` (e.g. `new Buffer(10)`),
+  allocates a new `Buffer` object of the specified size. The memory allocated
+  for such `Buffer` instances is *not* initialized and *can contain sensitive
+  data*. Such `Buffer` objects *must* be initialized *manually* by using either
+  [`buf.fill(0)`][] or by writing to the `Buffer` completely. While this
+  behavior is *intentional* to improve performance, development experience has
+  demonstrated that a more explicit distinction is required between creating a
+  fast-but-uninitialized `Buffer` versus creating a slower-but-safer `Buffer`.
+* Passing a string, array, or `Buffer` as the first argument copies the
+  passed object's data into the `Buffer`.
+* Passing an `ArrayBuffer` returns a `Buffer` that shares allocated memory with
+  the given `ArrayBuffer`.
+
+Because the behavior of `new Buffer()` changes significantly based on the type
+of value passed as the first argument, applications that do not properly
+validate the input arguments passed to `new Buffer()`, or that fail to
+appropriately initialize newly allocated `Buffer` content, can inadvertently
+introduce security and reliability issues into their code.
+
+To make the creation of `Buffer` objects more reliable and less error prone,
+new `Buffer.from()`, `Buffer.alloc()`, and `Buffer.allocUnsafe()` methods have
+been introduced as an alternative means of creating `Buffer` instances.
+
+*Developers should migrate all existing uses of the `new Buffer()` constructors
+to one of these new APIs.*
+
+* [`Buffer.from(array)`][buffer_from_array] returns a new `Buffer` containing
+  a *copy* of the provided octets.
+* [`Buffer.from(arrayBuffer[, byteOffset [, length]])`][buffer_from_arraybuf]
+  returns a new `Buffer` that *shares* the same allocated memory as the given
+  `ArrayBuffer`.
+* [`Buffer.from(buffer)`][buffer_from_buffer] returns a new `Buffer`
+  containing a *copy* of the contents of the given `Buffer`.
+* [`Buffer.from(str[, encoding])`][buffer_from_string] returns a new `Buffer`
+  containing a *copy* of the provided string.
+* [`Buffer.alloc(size[, fill[, encoding]])`][buffer_alloc] returns a "filled"
+  `Buffer` instance of the specified size. This method can be significantly
+  slower than [`Buffer.allocUnsafe(size)`][buffer_allocunsafe] but ensures
+  that newly created `Buffer` instances never contain old and potentially
+  sensitive data.
+* [`Buffer.allocUnsafe(size)`][buffer_allocunsafe] and
+  [`Buffer.allocUnsafeSlow(size)`][buffer_allocunsafeslow] each return a
+  new `Buffer` of the specified `size` whose content *must* be initialized
+  using either [`buf.fill(0)`][] or written to completely.
+
+`Buffer` instances returned by `Buffer.allocUnsafe(size)` *may* be allocated
+off a shared internal memory pool if `size` is less than or equal to half
+`Buffer.poolSize`. Instances returned by `Buffer.allocUnsafeSlow(size)` *never*
+use the shared internal memory pool.
+
+### What makes `Buffer.allocUnsafe(size)` and `Buffer.allocUnsafeSlow(size)` "unsafe"?
+
+When calling `Buffer.allocUnsafe()` (and `Buffer.allocUnsafeSlow()`), the
+segment of allocated memory is *uninitialized* (it is not zeroed-out). While
+this design makes the allocation of memory quite fast, the allocated segment of
+memory might contain old data that is potentially sensitive. Using a `Buffer`
+created by `Buffer.allocUnsafe()` without *completely* overwriting the memory
+can allow this old data to be leaked when the `Buffer` memory is read.
+
+While there are clear performance advantages to using `Buffer.allocUnsafe()`,
+extra care *must* be taken in order to avoid introducing security
+vulnerabilities into an application.
 
 ## Buffers and Character Encodings
 
@@ -125,6 +221,21 @@ const buf = new Buffer(arr.buffer).slice(0, 16);
 console.log(buf.length);
   // Prints: 16
 ```
+
+The `Buffer.from()` and [`TypedArray.from()`][] (e.g.`Uint8Array.from()`) have
+different signatures and implementations. Specifically, the TypedArray variants
+accept a second argument that is a mapping function that is invoked on every
+element of the typed array:
+
+* `TypedArray.from(source[, mapFn[, thisArg]])`
+
+The `Buffer.from()` method, however, does not support the use of a mapping
+function:
+
+* [`Buffer.from(array)`][buffer_from_array]
+* [`Buffer.from(buffer)`][buffer_from_buffer]
+* [`Buffer.from(arrayBuffer)`][buffer_from_arraybuf]
+* [`Buffer.from(str[, encoding])`][buffer_from_string]
 
 ## Buffers and ES6 iteration
 
@@ -250,6 +361,138 @@ console.log(buf2.toString());
   // prints: this is a tést
 ```
 
+### Class Method: Buffer.alloc(size[, fill[, encoding]])
+
+* `size` {Number}
+* `fill` {Value} Default: `undefined`
+* `encoding` {String} Default: `utf8`
+
+Allocates a new `Buffer` of `size` bytes. If `fill` is `undefined`, the
+`Buffer` will be *zero-filled*.
+
+```js
+const buf = Buffer.alloc(5);
+console.log(buf);
+  // <Buffer 00 00 00 00 00>
+```
+
+The `size` must be less than or equal to the value of
+`require('buffer').kMaxLength` (on 64-bit architectures, `kMaxLength` is
+`(2^31)-1`). Otherwise, a [`RangeError`][] is thrown. If a `size` less than 0
+is specified, a zero-length `Buffer` will be created.
+
+If `fill` is specified, the allocated `Buffer` will be initialized by calling
+`buf.fill(fill)`. See [`buf.fill()`][] for more information.
+
+```js
+const buf = Buffer.alloc(5, 'a');
+console.log(buf);
+  // <Buffer 61 61 61 61 61>
+```
+
+If both `fill` and `encoding` are specified, the allocated `Buffer` will be
+initialized by calling `buf.fill(fill, encoding)`. For example:
+
+```js
+const buf = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+console.log(buf);
+  // <Buffer 68 65 6c 6c 6f 20 77 6f 72 6c 64>
+```
+
+Calling `Buffer.alloc(size)` can be significantly slower than the alternative
+`Buffer.allocUnsafe(size)` but ensures that the newly created `Buffer` instance
+contents will *never contain sensitive data*.
+
+A `TypeError` will be thrown if `size` is not a number.
+
+### Class Method: Buffer.allocUnsafe(size)
+
+* `size` {Number}
+
+Allocates a new *non-zero-filled* `Buffer` of `size` bytes.  The `size` must
+be less than or equal to the value of `require('buffer').kMaxLength` (on 64-bit
+architectures, `kMaxLength` is `(2^31)-1`). Otherwise, a [`RangeError`][] is
+thrown. If a `size` less than 0 is specified, a zero-length `Buffer` will be
+created.
+
+The underlying memory for `Buffer` instances created in this way is *not
+initialized*. The contents of the newly created `Buffer` are unknown and
+*may contain sensitive data*. Use [`buf.fill(0)`][] to initialize such
+`Buffer` instances to zeroes.
+
+```js
+const buf = Buffer.allocUnsafe(5);
+console.log(buf);
+  // <Buffer 78 e0 82 02 01>
+  // (octets will be different, every time)
+buf.fill(0);
+console.log(buf);
+  // <Buffer 00 00 00 00 00>
+```
+
+A `TypeError` will be thrown if `size` is not a number.
+
+Note that the `Buffer` module pre-allocates an internal `Buffer` instance of
+size `Buffer.poolSize` that is used as a pool for the fast allocation of new
+`Buffer` instances created using `Buffer.allocUnsafe(size)` (and the
+`new Buffer(size)` constructor) only when `size` is less than or equal to
+`Buffer.poolSize >> 1` (floor of `Buffer.poolSize` divided by two). The default
+value of `Buffer.poolSize` is `8192` but can be modified.
+
+Use of this pre-allocated internal memory pool is a key difference between
+calling `Buffer.alloc(size, fill)` vs. `Buffer.allocUnsafe(size).fill(fill)`.
+Specifically, `Buffer.alloc(size, fill)` will *never* use the internal Buffer
+pool, while `Buffer.allocUnsafe(size).fill(fill)` *will* use the internal
+Buffer pool if `size` is less than or equal to half `Buffer.poolSize`. The
+difference is subtle but can be important when an application requires the
+additional performance that `Buffer.allocUnsafe(size)` provides.
+
+### Class Method: Buffer.allocUnsafeSlow(size)
+
+* `size` {Number}
+
+Allocates a new *non-zero-filled* and non-pooled `Buffer` of `size` bytes.  The
+`size` must be less than or equal to the value of
+`require('buffer').kMaxLength` (on 64-bit architectures, `kMaxLength` is
+`(2^31)-1`). Otherwise, a [`RangeError`][] is thrown. If a `size` less than 0
+is specified, a zero-length `Buffer` will be created.
+
+The underlying memory for `Buffer` instances created in this way is *not
+initialized*. The contents of the newly created `Buffer` are unknown and
+*may contain sensitive data*. Use [`buf.fill(0)`][] to initialize such
+`Buffer` instances to zeroes.
+
+When using `Buffer.allocUnsafe()` to allocate new `Buffer` instances,
+allocations under 4KB are, by default, sliced from a single pre-allocated
+`Buffer`. This allows applications to avoid the garbage collection overhead of
+creating many individually allocated Buffers. This approach improves both
+performance and memory usage by eliminating the need to track and cleanup as
+many `Persistent` objects.
+
+However, in the case where a developer may need to retain a small chunk of
+memory from a pool for an indeterminate amount of time, it may be appropriate
+to create an un-pooled Buffer instance using `Buffer.allocUnsafeSlow()` then
+copy out the relevant bits.
+
+```js
+// need to keep around a few small chunks of memory
+const store = [];
+
+socket.on('readable', () => {
+  const data = socket.read();
+  // allocate for retained data
+  const sb = Buffer.allocUnsafeSlow(10);
+  // copy the data into the new allocation
+  data.copy(sb, 0, 0, 10);
+  store.push(sb);
+});
+```
+
+Use of `Buffer.allocUnsafeSlow()` should be used only as a last resort *after*
+a developer has observed undue memory retention in their applications.
+
+A `TypeError` will be thrown if `size` is not a number.
+
 ### Class Method: Buffer.byteLength(string[, encoding])
 
 * `string` {String}
@@ -318,6 +561,90 @@ console.log(bufA.length);
 // <Buffer 00 00 00 00 ...>
 // 42
 ```
+
+### Class Method: Buffer.from(array)
+
+* `array` {Array}
+
+Allocates a new `Buffer` using an `array` of octets.
+
+```js
+const buf = Buffer.from([0x62,0x75,0x66,0x66,0x65,0x72]);
+  // creates a new Buffer containing ASCII bytes
+  // ['b','u','f','f','e','r']
+```
+
+A `TypeError` will be thrown if `array` is not an `Array`.
+
+### Class Method: Buffer.from(arrayBuffer)
+
+* `arrayBuffer` {ArrayBuffer} The `.buffer` property of a `TypedArray` or
+  a `new ArrayBuffer()`
+
+When passed a reference to the `.buffer` property of a `TypedArray` instance,
+the newly created `Buffer` will share the same allocated memory as the
+TypedArray.
+
+```js
+const arr = new Uint16Array(2);
+arr[0] = 5000;
+arr[1] = 4000;
+
+const buf = Buffer.from(arr.buffer); // shares the memory with arr;
+
+console.log(buf);
+  // Prints: <Buffer 88 13 a0 0f>
+
+// changing the TypedArray changes the Buffer also
+arr[1] = 6000;
+
+console.log(buf);
+  // Prints: <Buffer 88 13 70 17>
+```
+
+A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer`.
+
+### Class Method: Buffer.from(buffer)
+
+* `buffer` {Buffer}
+
+Copies the passed `buffer` data onto a new `Buffer` instance.
+
+```js
+const buf1 = Buffer.from('buffer');
+const buf2 = Buffer.from(buf1);
+
+buf1[0] = 0x61;
+console.log(buf1.toString());
+  // 'auffer'
+console.log(buf2.toString());
+  // 'buffer' (copy is not changed)
+```
+
+A `TypeError` will be thrown if `buffer` is not a `Buffer`.
+
+### Class Method: Buffer.from(str[, encoding])
+
+* `str` {String} String to encode.
+* `encoding` {String} Encoding to use, Default: `'utf8'`
+
+Creates a new `Buffer` containing the given JavaScript string `str`. If
+provided, the `encoding` parameter identifies the character encoding.
+If not provided, `encoding` defaults to `'utf8'`.
+
+```js
+const buf1 = Buffer.from('this is a tést');
+console.log(buf1.toString());
+  // prints: this is a tést
+console.log(buf1.toString('ascii'));
+  // prints: this is a tC)st
+
+const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+console.log(buf2.toString());
+  // prints: this is a tést
+```
+
+A `TypeError` will be thrown if `str` is not a string.
 
 ### Class Method: Buffer.isBuffer(obj)
 
@@ -1366,6 +1693,31 @@ socket.on('readable', () => {
 Use of `SlowBuffer` should be used only as a last resort *after* a developer
 has observed undue memory retention in their applications.
 
+### new SlowBuffer(size)
+
+* `size` Number
+
+Allocates a new `SlowBuffer` of `size` bytes.  The `size` must be less than
+or equal to the value of `require('buffer').kMaxLength` (on 64-bit
+architectures, `kMaxLength` is `(2^31)-1`). Otherwise, a [`RangeError`][] is
+thrown. If a `size` less than 0 is specified, a zero-length `SlowBuffer` will be
+created.
+
+The underlying memory for `SlowBuffer` instances is *not initialized*. The
+contents of a newly created `SlowBuffer` are unknown and could contain
+sensitive data. Use [`buf.fill(0)`][] to initialize a `SlowBuffer` to zeroes.
+
+```js
+const SlowBuffer = require('buffer').SlowBuffer;
+const buf = new SlowBuffer(5);
+console.log(buf);
+  // <Buffer 78 e0 82 02 01>
+  // (octets will be different, every time)
+buf.fill(0);
+console.log(buf);
+  // <Buffer 00 00 00 00 00>
+```
+
 [`Array#includes()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
 [`Array#indexOf()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
 [`buf.entries()`]: #buffer_buf_entries
@@ -1380,3 +1732,11 @@ has observed undue memory retention in their applications.
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
 [RFC 4648, Section 5]: https://tools.ietf.org/html/rfc4648#section-5
+[buffer_from_array]: #buffer_class_method_buffer_from_array
+[buffer_from_buffer]: #buffer_class_method_buffer_from_buffer
+[buffer_from_arraybuf]: #buffer_class_method_buffer_from_arraybuffer
+[buffer_from_string]: #buffer_class_method_buffer_from_str_encoding
+[buffer_allocunsafe]: #buffer_class_method_buffer_allocunsafe_size
+[buffer_allocunsafeslow]: #buffer_class_method_buffer_allocunsafeslow_size
+[buffer_alloc]: #buffer_class_method_buffer_alloc_size_fill_encoding
+[`TypedArray.from()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -79,8 +79,8 @@ Object.setPrototypeOf(SlowBuffer, Uint8Array);
 
 
 function allocate(size) {
-  if (size === 0) {
-    return createBuffer(size);
+  if (size <= 0) {
+    return createBuffer(0);
   }
   if (size < (Buffer.poolSize >>> 1)) {
     if (size > (poolSize - poolOffset))

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -65,8 +65,70 @@ function Buffer(arg, encoding) {
   return fromObject(arg);
 }
 
+/**
+ * Functionally equivalent to Buffer(arg, encoding) but throws a TypeError
+ * if value is a number.
+ * Buffer.from(str[, encoding])
+ * Buffer.from(array)
+ * Buffer.from(buffer)
+ * Buffer.from(arrayBuffer)
+ **/
+Buffer.from = function(value, encoding) {
+  if (typeof value === 'number')
+    throw new TypeError('"value" argument must not be a number');
+
+  if (typeof value === 'string') {
+    return fromString(value, encoding);
+  }
+
+  // Unusual.
+  return fromObject(value);
+};
+
 Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
 Object.setPrototypeOf(Buffer, Uint8Array);
+
+/**
+ * Creates a new filled Buffer instance.
+ * alloc(size[, fill[, encoding]])
+ **/
+Buffer.alloc = function(size, fill, encoding) {
+  if (typeof size !== 'number')
+    throw new TypeError('"size" argument must be a number');
+  if (size <= 0)
+    return createBuffer(size);
+  if (fill !== undefined) {
+    // Only pay attention to encoding if it's a string. This
+    // prevents accidentally sending in a number that would
+    // be interpretted as a start offset.
+    // Also, don't apply encoding if fill is a number.
+    if (typeof fill !== 'number' && typeof encoding === 'string')
+      fill = Buffer.from(fill, encoding);
+
+    return createBuffer(size, true).fill(fill);
+  }
+  return createBuffer(size);
+};
+
+/**
+ * Equivalent to Buffer(num), by default creates a non-zero-filled Buffer
+ * instance.
+ **/
+Buffer.allocUnsafe = function(size) {
+  if (typeof size !== 'number')
+    throw new TypeError('"size" argument must be a number');
+  return allocate(size);
+};
+
+/**
+ * Equivalent to SlowBuffer(num), by default creates a non-zero-filled
+ * Buffer instance that is not allocated off the pre-initialized pool.
+ **/
+Buffer.allocUnsafeSlow = function(size) {
+  if (typeof size !== 'number')
+    throw new TypeError('"size" argument must be a number');
+  return createBuffer(size, true);
+};
 
 function SlowBuffer(length) {
   if (+length != length)
@@ -430,7 +492,7 @@ function slowIndexOf(buffer, val, byteOffset, encoding) {
       case 'ascii':
       case 'hex':
         return binding.indexOfBuffer(
-            buffer, Buffer(val, encoding), byteOffset, encoding);
+            buffer, Buffer.from(val, encoding), byteOffset, encoding);
 
       default:
         if (loweredCase) {
@@ -484,6 +546,10 @@ Buffer.prototype.fill = function fill(val, start, end) {
     var code = val.charCodeAt(0);
     if (code < 256)
       val = code;
+  } else if (val.length === 0) {
+    // Previously, if val === '', the Buffer would not fill,
+    // which is rather surprising.
+    val = 0;
   }
 
   binding.fill(this, val, start, end);

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -8,7 +8,7 @@ var SlowBuffer = require('buffer').SlowBuffer;
 // counter to ensure unique value is always copied
 var cntr = 0;
 
-var b = Buffer(1024); // safe constructor
+var b = Buffer.alloc(1024);
 
 console.log('b.length == %d', b.length);
 assert.strictEqual(1024, b.length);
@@ -24,32 +24,32 @@ for (let i = 0; i < 1024; i++) {
   assert.strictEqual(i % 256, b[i]);
 }
 
-var c = new Buffer(512);
+var c = Buffer.alloc(512);
 console.log('c.length == %d', c.length);
 assert.strictEqual(512, c.length);
 
-var d = new Buffer([]);
+var d = Buffer.from([]);
 assert.strictEqual(0, d.length);
 
 var ui32 = new Uint32Array(4).fill(42);
-var e = Buffer(ui32);
+var e = Buffer.from(ui32);
 assert.deepEqual(ui32, e);
 
 // First check Buffer#fill() works as expected.
 
 assert.throws(function() {
-  Buffer(8).fill('a', -1);
+  Buffer.allocUnsafe(8).fill('a', -1);
 });
 
 assert.throws(function() {
-  Buffer(8).fill('a', 0, 9);
+  Buffer.allocUnsafe(8).fill('a', 0, 9);
 });
 
 // Make sure this doesn't hang indefinitely.
-Buffer(8).fill('');
+Buffer.allocUnsafe(8).fill('');
 
 {
-  const buf = new Buffer(64);
+  const buf = Buffer.allocUnsafe(64);
   buf.fill(10);
   for (let i = 0; i < buf.length; i++)
     assert.equal(buf[i], 10);
@@ -82,7 +82,7 @@ Buffer(8).fill('');
 }
 
 {
-  const buf = new Buffer(10);
+  const buf = Buffer.allocUnsafe(10);
   buf.fill('abc');
   assert.equal(buf.toString(), 'abcabcabca');
   buf.fill('է');
@@ -177,7 +177,7 @@ Buffer(8).fill('');
 }
 
 // copy string longer than buffer length (failure will segfault)
-var bb = new Buffer(10);
+var bb = Buffer.allocUnsafe(10);
 bb.fill('hello crazy world');
 
 
@@ -186,7 +186,7 @@ assert.doesNotThrow(() => { b.copy(c, 0, 100, 10); });
 
 // copy throws at negative sourceStart
 assert.throws(function() {
-  Buffer(5).copy(Buffer(5), 0, -1);
+  Buffer.allocUnsafe(5).copy(Buffer.allocUnsafe(5), 0, -1);
 }, RangeError);
 
 {
@@ -233,10 +233,10 @@ try {
 assert.strictEqual('Unknown encoding: invalid', caught_error.message);
 
 // try to create 0-length buffers
-new Buffer('');
-new Buffer('', 'ascii');
-new Buffer('', 'binary');
-new Buffer(0);
+Buffer.from('');
+Buffer.from('', 'ascii');
+Buffer.from('', 'binary');
+Buffer.alloc(0);
 
 // try to write a 0-length string beyond the end of b
 assert.throws(function() {
@@ -259,28 +259,97 @@ assert.throws(function() {
 }, RangeError);
 
 // try to copy 0 bytes worth of data into an empty buffer
-b.copy(new Buffer(0), 0, 0, 0);
+b.copy(Buffer.alloc(0), 0, 0, 0);
 
 // try to copy 0 bytes past the end of the target buffer
-b.copy(new Buffer(0), 1, 1, 1);
-b.copy(new Buffer(1), 1, 1, 1);
+b.copy(Buffer.alloc(0), 1, 1, 1);
+b.copy(Buffer.allocUnsafe(1), 1, 1, 1);
 
 // try to copy 0 bytes from past the end of the source buffer
-b.copy(new Buffer(1), 0, 2048, 2048);
+b.copy(Buffer.allocUnsafe(1), 0, 2048, 2048);
 
-// try to toString() a 0-length slice of a buffer, both within and without the
-// valid buffer range
-assert.equal(new Buffer('abc').toString('ascii', 0, 0), '');
-assert.equal(new Buffer('abc').toString('ascii', -100, -100), '');
-assert.equal(new Buffer('abc').toString('ascii', 100, 100), '');
+const rangeBuffer = Buffer.from('abc');
+
+// if start >= buffer's length, empty string will be returned
+assert.equal(rangeBuffer.toString('ascii', 3), '');
+//assert.equal(rangeBuffer.toString('ascii', +Infinity), ''); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', 3.14, 3), '');
+//assert.equal(rangeBuffer.toString('ascii', 'Infinity', 3), ''); // fails on 4.x
+
+// if end <= 0, empty string will be returned
+assert.equal(rangeBuffer.toString('ascii', 1, 0), '');
+//assert.equal(rangeBuffer.toString('ascii', 1, -1.2), ''); // fails on 4.x
+//assert.equal(rangeBuffer.toString('ascii', 1, -100), ''); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', 1, -Infinity), '');
+
+// if start < 0, start will be taken as zero
+//assert.equal(rangeBuffer.toString('ascii', -1, 3), 'abc'); // fails on 4.x
+//assert.equal(rangeBuffer.toString('ascii', -1.99, 3), 'abc'); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', -Infinity, 3), 'abc');
+//assert.equal(rangeBuffer.toString('ascii', '-1', 3), 'abc'); // fails on 4.x
+//assert.equal(rangeBuffer.toString('ascii', '-1.99', 3), 'abc'); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
+
+// if start is an invalid integer, start will be taken as zero
+assert.equal(rangeBuffer.toString('ascii', 'node.js', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', {}, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', [], 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', NaN, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', null, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', undefined, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', false, 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '', 3), 'abc');
+
+// but, if start is an integer when coerced, then it will be coerced and used.
+//assert.equal(rangeBuffer.toString('ascii', '-1', 3), 'abc'); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', '1', 3), 'bc');
+assert.equal(rangeBuffer.toString('ascii', '-Infinity', 3), 'abc');
+assert.equal(rangeBuffer.toString('ascii', '3', 3), '');
+assert.equal(rangeBuffer.toString('ascii', Number(3), 3), '');
+assert.equal(rangeBuffer.toString('ascii', '3.14', 3), '');
+assert.equal(rangeBuffer.toString('ascii', '1.99', 3), 'bc');
+//assert.equal(rangeBuffer.toString('ascii', '-1.99', 3), 'abc'); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', 1.99, 3), 'bc');
+assert.equal(rangeBuffer.toString('ascii', true, 3), 'bc');
+
+// if end > buffer's length, end will be taken as buffer's length
+assert.equal(rangeBuffer.toString('ascii', 0, 5), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, 6.99), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, Infinity), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '5'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '6.99'), 'abc');
+//assert.equal(rangeBuffer.toString('ascii', 0, 'Infinity'), 'abc'); // fails on 4.x
+
+// if end is an invalid integer, end will be taken as buffer's length
+assert.equal(rangeBuffer.toString('ascii', 0, 'node.js'), '');
+assert.equal(rangeBuffer.toString('ascii', 0, {}), '');
+assert.equal(rangeBuffer.toString('ascii', 0, NaN), '');
+assert.equal(rangeBuffer.toString('ascii', 0, undefined), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, null), '');
+assert.equal(rangeBuffer.toString('ascii', 0, []), '');
+assert.equal(rangeBuffer.toString('ascii', 0, false), '');
+assert.equal(rangeBuffer.toString('ascii', 0, ''), '');
+
+// but, if end is an integer when coerced, then it will be coerced and used.
+//assert.equal(rangeBuffer.toString('ascii', 0, '-1'), ''); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', 0, '1'), 'a');
+assert.equal(rangeBuffer.toString('ascii', 0, '-Infinity'), '');
+assert.equal(rangeBuffer.toString('ascii', 0, '3'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, Number(3)), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '3.14'), 'abc');
+assert.equal(rangeBuffer.toString('ascii', 0, '1.99'), 'a');
+//assert.equal(rangeBuffer.toString('ascii', 0, '-1.99'), ''); // fails on 4.x
+assert.equal(rangeBuffer.toString('ascii', 0, 1.99), 'a');
+assert.equal(rangeBuffer.toString('ascii', 0, true), 'a');
 
 // try toString() with a object as a encoding
-assert.equal(new Buffer('abc').toString({toString: function() {
+assert.equal(rangeBuffer.toString({toString: function() {
   return 'ascii';
 }}), 'abc');
 
 // testing for smart defaults and ability to pass string values as offset
-var writeTest = new Buffer('abcdes');
+var writeTest = Buffer.from('abcdes');
 writeTest.write('n', 'ascii');
 writeTest.write('o', 'ascii', '1');
 writeTest.write('d', '2', 'ascii');
@@ -350,7 +419,7 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 
 {
   // make sure only top level parent propagates from allocPool
-  const b = new Buffer(5);
+  const b = Buffer.allocUnsafe(5);
   const c = b.slice(0, 4);
   const d = c.slice(0, 2);
   assert.equal(b.parent, c.parent);
@@ -368,7 +437,7 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 {
   // Bug regression test
   const testValue = '\u00F6\u65E5\u672C\u8A9E'; // ö日本語
-  const buffer = new Buffer(32);
+  const buffer = Buffer.allocUnsafe(32);
   const size = buffer.write(testValue, 0, 'utf8');
   console.log('bytes written to buffer: ' + size);
   const slice = buffer.toString('utf8', 0, size);
@@ -377,7 +446,7 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 
 {
   // Test triple  slice
-  const a = new Buffer(8);
+  const a = Buffer.allocUnsafe(8);
   for (let i = 0; i < 8; i++) a[i] = i;
   const b = a.slice(4, 8);
   assert.equal(4, b[0]);
@@ -390,75 +459,78 @@ for (let i = 0; i < Buffer.byteLength(utf8String); i++) {
 }
 
 {
-  const d = new Buffer([23, 42, 255]);
+  const d = Buffer.from([23, 42, 255]);
   assert.equal(d.length, 3);
   assert.equal(d[0], 23);
   assert.equal(d[1], 42);
   assert.equal(d[2], 255);
-  assert.deepEqual(d, new Buffer(d));
+  assert.deepEqual(d, Buffer.from(d));
 }
 
 {
-  const e = new Buffer('über');
+  const e = Buffer.from('über');
   console.error('uber: \'%s\'', e.toString());
-  assert.deepEqual(e, new Buffer([195, 188, 98, 101, 114]));
+  assert.deepEqual(e, Buffer.from([195, 188, 98, 101, 114]));
 }
 
 {
-  const f = new Buffer('über', 'ascii');
+  const f = Buffer.from('über', 'ascii');
   console.error('f.length: %d     (should be 4)', f.length);
-  assert.deepEqual(f, new Buffer([252, 98, 101, 114]));
+  assert.deepEqual(f, Buffer.from([252, 98, 101, 114]));
 }
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
   {
-    const f = new Buffer('über', encoding);
+    const f = Buffer.from('über', encoding);
     console.error('f.length: %d     (should be 8)', f.length);
-    assert.deepEqual(f, new Buffer([252, 0, 98, 0, 101, 0, 114, 0]));
+    assert.deepEqual(f, Buffer.from([252, 0, 98, 0, 101, 0, 114, 0]));
   }
 
   {
-    const f = new Buffer('привет', encoding);
+    const f = Buffer.from('привет', encoding);
     console.error('f.length: %d     (should be 12)', f.length);
-    assert.deepEqual(f, new Buffer([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
+    assert.deepEqual(f,
+                     Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
     assert.equal(f.toString(encoding), 'привет');
   }
 
   {
-    const f = new Buffer([0, 0, 0, 0, 0]);
+    const f = Buffer.from([0, 0, 0, 0, 0]);
     assert.equal(f.length, 5);
     const size = f.write('あいうえお', encoding);
     console.error('bytes written to buffer: %d     (should be 4)', size);
     assert.equal(size, 4);
-    assert.deepEqual(f, new Buffer([0x42, 0x30, 0x44, 0x30, 0x00]));
+    assert.deepEqual(f, Buffer.from([0x42, 0x30, 0x44, 0x30, 0x00]));
   }
 });
 
 {
-  const f = new Buffer('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
+  const f = Buffer.from('\uD83D\uDC4D', 'utf-16le'); // THUMBS UP SIGN (U+1F44D)
   assert.equal(f.length, 4);
-  assert.deepEqual(f, new Buffer('3DD84DDC', 'hex'));
+  assert.deepEqual(f, Buffer.from('3DD84DDC', 'hex'));
 }
 
 
 var arrayIsh = {0: 0, 1: 1, 2: 2, 3: 3, length: 4};
-var g = new Buffer(arrayIsh);
-assert.deepEqual(g, new Buffer([0, 1, 2, 3]));
+var g = Buffer.from(arrayIsh);
+assert.deepEqual(g, Buffer.from([0, 1, 2, 3]));
 var strArrayIsh = {0: '0', 1: '1', 2: '2', 3: '3', length: 4};
-g = new Buffer(strArrayIsh);
-assert.deepEqual(g, new Buffer([0, 1, 2, 3]));
+g = Buffer.from(strArrayIsh);
+assert.deepEqual(g, Buffer.from([0, 1, 2, 3]));
 
 
 //
 // Test toString('base64')
 //
-assert.equal('TWFu', (new Buffer('Man')).toString('base64'));
+assert.equal('TWFu', (Buffer.from('Man')).toString('base64'));
 
 {
   // test that regular and URL-safe base64 both work
   const expected = [0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff];
-  assert.deepEqual(Buffer('//++/++/++//', 'base64'), Buffer(expected));
-  assert.deepEqual(Buffer('__--_--_--__', 'base64'), Buffer(expected));
+  assert.deepEqual(Buffer.from('//++/++/++//', 'base64'),
+                   Buffer.from(expected));
+  assert.deepEqual(Buffer.from('__--_--_--__', 'base64'),
+                   Buffer.from(expected));
 }
 
 {
@@ -475,9 +547,9 @@ assert.equal('TWFu', (new Buffer('Man')).toString('base64'));
                  'FuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBle' +
                  'GNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVh' +
                  'c3VyZS4=';
-  assert.equal(expected, (new Buffer(quote)).toString('base64'));
+  assert.equal(expected, (Buffer.from(quote)).toString('base64'));
 
-  let b = new Buffer(1024);
+  let b = Buffer.allocUnsafe(1024);
   let bytesWritten = b.write(expected, 0, 'base64');
   assert.equal(quote.length, bytesWritten);
   assert.equal(quote, b.toString('ascii', 0, quote.length));
@@ -489,14 +561,14 @@ assert.equal('TWFu', (new Buffer('Man')).toString('base64'));
                       expected.slice(180, 240) + ' \n' +
                       expected.slice(240, 300) + '\n' +
                       expected.slice(300, 360) + '\n';
-  b = new Buffer(1024);
+  b = Buffer.allocUnsafe(1024);
   bytesWritten = b.write(expectedWhite, 0, 'base64');
   assert.equal(quote.length, bytesWritten);
   assert.equal(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder on the constructor works
   // even in the presence of whitespace.
-  b = new Buffer(expectedWhite, 'base64');
+  b = Buffer.from(expectedWhite, 'base64');
   assert.equal(quote.length, b.length);
   assert.equal(quote, b.toString('ascii', 0, quote.length));
 
@@ -507,85 +579,86 @@ assert.equal('TWFu', (new Buffer('Man')).toString('base64'));
                         expected.slice(180, 240) + ' \x98' +
                         expected.slice(240, 300) + '\x03' +
                         expected.slice(300, 360);
-  b = new Buffer(expectedIllegal, 'base64');
+  b = Buffer.from(expectedIllegal, 'base64');
   assert.equal(quote.length, b.length);
   assert.equal(quote, b.toString('ascii', 0, quote.length));
 }
 
-assert.equal(new Buffer('', 'base64').toString(), '');
-assert.equal(new Buffer('K', 'base64').toString(), '');
+assert.equal(Buffer.from('', 'base64').toString(), '');
+assert.equal(Buffer.from('K', 'base64').toString(), '');
 
 // multiple-of-4 with padding
-assert.equal(new Buffer('Kg==', 'base64').toString(), '*');
-assert.equal(new Buffer('Kio=', 'base64').toString(), '**');
-assert.equal(new Buffer('Kioq', 'base64').toString(), '***');
-assert.equal(new Buffer('KioqKg==', 'base64').toString(), '****');
-assert.equal(new Buffer('KioqKio=', 'base64').toString(), '*****');
-assert.equal(new Buffer('KioqKioq', 'base64').toString(), '******');
-assert.equal(new Buffer('KioqKioqKg==', 'base64').toString(), '*******');
-assert.equal(new Buffer('KioqKioqKio=', 'base64').toString(), '********');
-assert.equal(new Buffer('KioqKioqKioq', 'base64').toString(), '*********');
-assert.equal(new Buffer('KioqKioqKioqKg==', 'base64').toString(),
+assert.equal(Buffer.from('Kg==', 'base64').toString(), '*');
+assert.equal(Buffer.from('Kio=', 'base64').toString(), '**');
+assert.equal(Buffer.from('Kioq', 'base64').toString(), '***');
+assert.equal(Buffer.from('KioqKg==', 'base64').toString(), '****');
+assert.equal(Buffer.from('KioqKio=', 'base64').toString(), '*****');
+assert.equal(Buffer.from('KioqKioq', 'base64').toString(), '******');
+assert.equal(Buffer.from('KioqKioqKg==', 'base64').toString(), '*******');
+assert.equal(Buffer.from('KioqKioqKio=', 'base64').toString(), '********');
+assert.equal(Buffer.from('KioqKioqKioq', 'base64').toString(), '*********');
+assert.equal(Buffer.from('KioqKioqKioqKg==', 'base64').toString(),
              '**********');
-assert.equal(new Buffer('KioqKioqKioqKio=', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKio=', 'base64').toString(),
              '***********');
-assert.equal(new Buffer('KioqKioqKioqKioq', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioq', 'base64').toString(),
              '************');
-assert.equal(new Buffer('KioqKioqKioqKioqKg==', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKg==', 'base64').toString(),
              '*************');
-assert.equal(new Buffer('KioqKioqKioqKioqKio=', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKio=', 'base64').toString(),
              '**************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioq', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioq', 'base64').toString(),
              '***************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKg==', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKg==', 'base64').toString(),
              '****************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKio=', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKio=', 'base64').toString(),
              '*****************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKioq', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioq', 'base64').toString(),
              '******************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKioqKg==', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKg==', 'base64').toString(),
              '*******************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKioqKio=', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKio=', 'base64').toString(),
              '********************');
 
 // no padding, not a multiple of 4
-assert.equal(new Buffer('Kg', 'base64').toString(), '*');
-assert.equal(new Buffer('Kio', 'base64').toString(), '**');
-assert.equal(new Buffer('KioqKg', 'base64').toString(), '****');
-assert.equal(new Buffer('KioqKio', 'base64').toString(), '*****');
-assert.equal(new Buffer('KioqKioqKg', 'base64').toString(), '*******');
-assert.equal(new Buffer('KioqKioqKio', 'base64').toString(), '********');
-assert.equal(new Buffer('KioqKioqKioqKg', 'base64').toString(), '**********');
-assert.equal(new Buffer('KioqKioqKioqKio', 'base64').toString(), '***********');
-assert.equal(new Buffer('KioqKioqKioqKioqKg', 'base64').toString(),
+assert.equal(Buffer.from('Kg', 'base64').toString(), '*');
+assert.equal(Buffer.from('Kio', 'base64').toString(), '**');
+assert.equal(Buffer.from('KioqKg', 'base64').toString(), '****');
+assert.equal(Buffer.from('KioqKio', 'base64').toString(), '*****');
+assert.equal(Buffer.from('KioqKioqKg', 'base64').toString(), '*******');
+assert.equal(Buffer.from('KioqKioqKio', 'base64').toString(), '********');
+assert.equal(Buffer.from('KioqKioqKioqKg', 'base64').toString(), '**********');
+assert.equal(Buffer.from('KioqKioqKioqKio', 'base64').toString(),
+             '***********');
+assert.equal(Buffer.from('KioqKioqKioqKioqKg', 'base64').toString(),
              '*************');
-assert.equal(new Buffer('KioqKioqKioqKioqKio', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKio', 'base64').toString(),
              '**************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKg', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKg', 'base64').toString(),
              '****************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKio', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKio', 'base64').toString(),
              '*****************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKioqKg', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKg', 'base64').toString(),
              '*******************');
-assert.equal(new Buffer('KioqKioqKioqKioqKioqKioqKio', 'base64').toString(),
+assert.equal(Buffer.from('KioqKioqKioqKioqKioqKioqKio', 'base64').toString(),
              '********************');
 
 // handle padding graciously, multiple-of-4 or not
-assert.equal(new Buffer('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw==',
+assert.equal(Buffer.from('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw==',
                         'base64').length, 32);
-assert.equal(new Buffer('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw=',
+assert.equal(Buffer.from('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw=',
                         'base64').length, 32);
-assert.equal(new Buffer('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw',
+assert.equal(Buffer.from('72INjkR5fchcxk9+VgdGPFJDxUBFR5/rMFsghgxADiw',
                         'base64').length, 32);
-assert.equal(new Buffer('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg==',
+assert.equal(Buffer.from('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg==',
                         'base64').length, 31);
-assert.equal(new Buffer('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg=',
+assert.equal(Buffer.from('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg=',
                         'base64').length, 31);
-assert.equal(new Buffer('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg',
+assert.equal(Buffer.from('w69jACy6BgZmaFvv96HG6MYksWytuZu3T1FvGnulPg',
                         'base64').length, 31);
 
 // This string encodes single '.' character in UTF-16
-var dot = new Buffer('//4uAA==', 'base64');
+var dot = Buffer.from('//4uAA==', 'base64');
 assert.equal(dot[0], 0xff);
 assert.equal(dot[1], 0xfe);
 assert.equal(dot[2], 0x2e);
@@ -597,7 +670,7 @@ assert.equal(dot.toString('base64'), '//4uAA==');
   //
   // https://github.com/joyent/node/issues/402
   const segments = ['TWFkbmVzcz8h', 'IFRoaXM=', 'IGlz', 'IG5vZGUuanMh'];
-  const b = new Buffer(64);
+  const b = Buffer.allocUnsafe(64);
   let pos = 0;
 
   for (let i = 0; i < segments.length; ++i) {
@@ -607,14 +680,17 @@ assert.equal(dot.toString('base64'), '//4uAA==');
 }
 
 // Regression test for https://github.com/nodejs/node/issues/3496.
-assert.equal(Buffer('=bad'.repeat(1e4), 'base64').length, 0);
+assert.equal(Buffer.from('=bad'.repeat(1e4), 'base64').length, 0);
 
 {
   // Creating buffers larger than pool size.
   const l = Buffer.poolSize + 5;
-  const s = 'h'.repeat(l);
+  let s = '';
+  for (let i = 0; i < l; i++) {
+    s += 'h';
+  }
 
-  const b = new Buffer(s);
+  const b = Buffer.from(s);
 
   for (let i = 0; i < l; i++) {
     assert.equal('h'.charCodeAt(0), b[i]);
@@ -627,16 +703,16 @@ assert.equal(Buffer('=bad'.repeat(1e4), 'base64').length, 0);
 
 {
   // Single argument slice
-  const b = new Buffer('abcde');
+  const b = Buffer.from('abcde');
   assert.equal('bcde', b.slice(1).toString());
 }
 
 // slice(0,0).length === 0
-assert.equal(0, Buffer('hello').slice(0, 0).length);
+assert.equal(0, Buffer.from('hello').slice(0, 0).length);
 
 // test hex toString
 console.log('Create hex string from buffer');
-var hexb = new Buffer(256);
+var hexb = Buffer.allocUnsafe(256);
 for (let i = 0; i < 256; i++) {
   hexb[i] = i;
 }
@@ -660,7 +736,7 @@ assert.equal(hexStr,
              'f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff');
 
 console.log('Create buffer from hex string');
-var hexb2 = new Buffer(hexStr, 'hex');
+var hexb2 = Buffer.from(hexStr, 'hex');
 for (let i = 0; i < 256; i++) {
   assert.equal(hexb2[i], hexb[i]);
 }
@@ -668,7 +744,7 @@ for (let i = 0; i < 256; i++) {
 {
   // test an invalid slice end.
   console.log('Try to slice off the end of the buffer');
-  const b = new Buffer([1, 2, 3, 4, 5]);
+  const b = Buffer.from([1, 2, 3, 4, 5]);
   const b2 = b.toString('hex', 1, 10000);
   const b3 = b.toString('hex', 1, 5);
   const b4 = b.toString('hex', 1);
@@ -678,7 +754,7 @@ for (let i = 0; i < 256; i++) {
 
 function buildBuffer(data) {
   if (Array.isArray(data)) {
-    var buffer = new Buffer(data.length);
+    var buffer = Buffer.allocUnsafe(data.length);
     data.forEach(function(v, k) {
       buffer[k] = v;
     });
@@ -744,17 +820,17 @@ assert.equal('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
   assert.equal(0x6f, z[1]);
 }
 
-assert.equal(0, Buffer('hello').slice(0, 0).length);
+assert.equal(0, Buffer.from('hello').slice(0, 0).length);
 
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
-  const b = new Buffer(10);
+  const b = Buffer.allocUnsafe(10);
   b.write('あいうえお', encoding);
   assert.equal(b.toString(encoding), 'あいうえお');
 });
 
 {
   // Binary encoding should write only one byte per character.
-  const b = Buffer([0xde, 0xad, 0xbe, 0xef]);
+  const b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
   let s = String.fromCharCode(0xffff);
   b.write(s, 0, 'binary');
   assert.equal(0xff, b[0]);
@@ -771,14 +847,14 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 
 {
   // #1210 Test UTF-8 string includes null character
-  let buf = new Buffer('\0');
+  let buf = Buffer.from('\0');
   assert.equal(buf.length, 1);
-  buf = new Buffer('\0\0');
+  buf = Buffer.from('\0\0');
   assert.equal(buf.length, 2);
 }
 
 {
-  const buf = new Buffer(2);
+  const buf = Buffer.allocUnsafe(2);
   let written = buf.write(''); // 0byte
   assert.equal(written, 0);
   written = buf.write('\0'); // 1byte (v8 adds null terminator)
@@ -794,7 +870,7 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 }
 
 {
-  const buf = new Buffer(10);
+  const buf = Buffer.allocUnsafe(10);
   written = buf.write('あいう'); // 3bytes * 3 (v8 adds null terminator)
   assert.equal(written, 9);
   written = buf.write('あいう\0'); // 3bytes * 3 + 1byte
@@ -803,7 +879,7 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 
 {
   // #243 Test write() with maxLength
-  const buf = new Buffer(4);
+  const buf = Buffer.allocUnsafe(4);
   buf.fill(0xFF);
   let written = buf.write('abcd', 1, 2, 'utf8');
   console.log(buf);
@@ -854,7 +930,7 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 
 {
   // test offset returns are correct
-  const b = new Buffer(16);
+  const b = Buffer.allocUnsafe(16);
   assert.equal(4, b.writeUInt32LE(0, 0));
   assert.equal(6, b.writeUInt16LE(0, 4));
   assert.equal(7, b.writeUInt8(0, 6));
@@ -866,7 +942,7 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
   // test unmatched surrogates not producing invalid utf8 output
   // ef bf bd = utf-8 representation of unicode replacement character
   // see https://codereview.chromium.org/121173009/
-  const buf = new Buffer('ab\ud800cd', 'utf8');
+  const buf = Buffer.from('ab\ud800cd', 'utf8');
   assert.equal(buf[0], 0x61);
   assert.equal(buf[1], 0x62);
   assert.equal(buf[2], 0xef);
@@ -878,7 +954,7 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 
 {
   // test for buffer overrun
-  const buf = new Buffer([0, 0, 0, 0, 0]); // length: 5
+  const buf = Buffer.from([0, 0, 0, 0, 0]); // length: 5
   var sub = buf.slice(0, 4);         // length: 4
   written = sub.write('12345', 'binary');
   assert.equal(written, 4);
@@ -889,32 +965,33 @@ assert.equal(0, Buffer('hello').slice(0, 0).length);
 // https://github.com/joyent/node/issues/1758
 
 // Call .fill() first, stops valgrind warning about uninitialized memory reads.
-Buffer(3.3).fill().toString(); // throws bad argument error in commit 43cb4ec
-assert.equal(Buffer(-1).length, 0);
-assert.equal(Buffer(NaN).length, 0);
-assert.equal(Buffer(3.3).length, 3);
-assert.equal(Buffer({length: 3.3}).length, 3);
-assert.equal(Buffer({length: 'BAM'}).length, 0);
+Buffer.allocUnsafe(3.3).fill().toString();
+// throws bad argument error in commit 43cb4ec
+assert.equal(Buffer.allocUnsafe(-1).length, 0);
+assert.equal(Buffer.allocUnsafe(NaN).length, 0);
+assert.equal(Buffer.allocUnsafe(3.3).length, 3);
+assert.equal(Buffer.from({length: 3.3}).length, 3);
+assert.equal(Buffer.from({length: 'BAM'}).length, 0);
 
 // Make sure that strings are not coerced to numbers.
-assert.equal(Buffer('99').length, 2);
-assert.equal(Buffer('13.37').length, 5);
+assert.equal(Buffer.from('99').length, 2);
+assert.equal(Buffer.from('13.37').length, 5);
 
 // Ensure that the length argument is respected.
 'ascii utf8 hex base64 binary'.split(' ').forEach(function(enc) {
-  assert.equal(Buffer(1).write('aaaaaa', 0, 1, enc), 1);
+  assert.equal(Buffer.allocUnsafe(1).write('aaaaaa', 0, 1, enc), 1);
 });
 
 {
   // Regression test, guard against buffer overrun in the base64 decoder.
-  const a = Buffer(3);
-  const b = Buffer('xxx');
+  const a = Buffer.allocUnsafe(3);
+  const b = Buffer.from('xxx');
   a.write('aaaaaaaa', 'base64');
   assert.equal(b.toString(), 'xxx');
 }
 
 // issue GH-3416
-Buffer(Buffer(0), 0, 0);
+Buffer.from(Buffer.alloc(0), 0, 0);
 
 [ 'hex',
   'utf8',
@@ -939,97 +1016,97 @@ Buffer(Buffer(0), 0, 0);
 
 // GH-5110
 (function() {
-  const buffer = new Buffer('test');
+  const buffer = Buffer.from('test');
   const string = JSON.stringify(buffer);
 
   assert.equal(string, '{"type":"Buffer","data":[116,101,115,116]}');
 
   assert.deepEqual(buffer, JSON.parse(string, function(key, value) {
     return value && value.type === 'Buffer'
-      ? new Buffer(value.data)
+      ? Buffer.from(value.data)
       : value;
   }));
 })();
 
 // issue GH-7849
 (function() {
-  var buf = new Buffer('test');
+  var buf = Buffer.from('test');
   var json = JSON.stringify(buf);
   var obj = JSON.parse(json);
-  var copy = new Buffer(obj);
+  var copy = Buffer.from(obj);
 
   assert(buf.equals(copy));
 })();
 
 // issue GH-4331
 assert.throws(function() {
-  new Buffer(0xFFFFFFFF);
+  Buffer.allocUnsafe(0xFFFFFFFF);
 }, RangeError);
 assert.throws(function() {
-  new Buffer(0xFFFFFFFFF);
+  Buffer.allocUnsafe(0xFFFFFFFFF);
 }, RangeError);
 
 
 // attempt to overflow buffers, similar to previous bug in array buffers
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer(8);
   buf.readFloatLE(0xffffffff);
 }, RangeError);
 
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.writeFloatLE(0.0, 0xffffffff);
 }, RangeError);
 
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.readFloatLE(0xffffffff);
 }, RangeError);
 
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.writeFloatLE(0.0, 0xffffffff);
 }, RangeError);
 
 
 // ensure negative values can't get past offset
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.readFloatLE(-1);
 }, RangeError);
 
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.writeFloatLE(0.0, -1);
 }, RangeError);
 
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.readFloatLE(-1);
 }, RangeError);
 
 assert.throws(function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.allocUnsafe(8);
   buf.writeFloatLE(0.0, -1);
 }, RangeError);
 
 // offset checks
 {
-  const buf = new Buffer(0);
+  const buf = Buffer.alloc(0);
 
   assert.throws(function() { buf.readUInt8(0); }, RangeError);
   assert.throws(function() { buf.readInt8(0); }, RangeError);
 }
 
 {
-  const buf = new Buffer([0xFF]);
+  const buf = Buffer.from([0xFF]);
 
   assert.equal(buf.readUInt8(0), 255);
   assert.equal(buf.readInt8(0), -1);
 }
 
 [16, 32].forEach(function(bits) {
-  var buf = new Buffer(bits / 8 - 1);
+  var buf = Buffer.allocUnsafe(bits / 8 - 1);
 
   assert.throws(function() { buf['readUInt' + bits + 'BE'](0); },
                 RangeError,
@@ -1049,7 +1126,7 @@ assert.throws(function() {
 });
 
 [16, 32].forEach(function(bits) {
-  var buf = new Buffer([0xFF, 0xFF, 0xFF, 0xFF]);
+  var buf = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]);
 
   assert.equal(buf['readUInt' + bits + 'BE'](0),
                 (0xFFFFFFFF >>> (32 - bits)));
@@ -1066,7 +1143,7 @@ assert.throws(function() {
 
 // test for common read(U)IntLE/BE
 (function() {
-  var buf = new Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+  var buf = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
 
   assert.equal(buf.readUIntLE(0, 1), 0x01);
   assert.equal(buf.readUIntBE(0, 1), 0x01);
@@ -1088,92 +1165,92 @@ assert.throws(function() {
 
 // test for common write(U)IntLE/BE
 (function() {
-  var buf = new Buffer(3);
+  var buf = Buffer.allocUnsafe(3);
   buf.writeUIntLE(0x123456, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.equal(buf.readUIntLE(0, 3), 0x123456);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeUIntBE(0x123456, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
   assert.equal(buf.readUIntBE(0, 3), 0x123456);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(0x123456, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0x56, 0x34, 0x12]);
   assert.equal(buf.readIntLE(0, 3), 0x123456);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(0x123456, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56]);
   assert.equal(buf.readIntBE(0, 3), 0x123456);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(-0x123456, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0xaa, 0xcb, 0xed]);
   assert.equal(buf.readIntLE(0, 3), -0x123456);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(-0x123456, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xaa]);
   assert.equal(buf.readIntBE(0, 3), -0x123456);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(-0x123400, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0x00, 0xcc, 0xed]);
   assert.equal(buf.readIntLE(0, 3), -0x123400);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(-0x123400, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0xed, 0xcc, 0x00]);
   assert.equal(buf.readIntBE(0, 3), -0x123400);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntLE(-0x120000, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0x00, 0x00, 0xee]);
   assert.equal(buf.readIntLE(0, 3), -0x120000);
 
-  buf = new Buffer(3);
+  buf = Buffer.allocUnsafe(3);
   buf.writeIntBE(-0x120000, 0, 3);
   assert.deepEqual(buf.toJSON().data, [0xee, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 3), -0x120000);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeUIntLE(0x1234567890, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
   assert.equal(buf.readUIntLE(0, 5), 0x1234567890);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeUIntBE(0x1234567890, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
   assert.equal(buf.readUIntBE(0, 5), 0x1234567890);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeIntLE(0x1234567890, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0x90, 0x78, 0x56, 0x34, 0x12]);
   assert.equal(buf.readIntLE(0, 5), 0x1234567890);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeIntBE(0x1234567890, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0x12, 0x34, 0x56, 0x78, 0x90]);
   assert.equal(buf.readIntBE(0, 5), 0x1234567890);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeIntLE(-0x1234567890, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0x70, 0x87, 0xa9, 0xcb, 0xed]);
   assert.equal(buf.readIntLE(0, 5), -0x1234567890);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeIntBE(-0x1234567890, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0xed, 0xcb, 0xa9, 0x87, 0x70]);
   assert.equal(buf.readIntBE(0, 5), -0x1234567890);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeIntLE(-0x0012000000, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0x00, 0x00, 0x00, 0xee, 0xff]);
   assert.equal(buf.readIntLE(0, 5), -0x0012000000);
 
-  buf = new Buffer(5);
+  buf = Buffer.allocUnsafe(5);
   buf.writeIntBE(-0x0012000000, 0, 5);
   assert.deepEqual(buf.toJSON().data, [0xff, 0xee, 0x00, 0x00, 0x00]);
   assert.equal(buf.readIntBE(0, 5), -0x0012000000);
@@ -1181,7 +1258,7 @@ assert.throws(function() {
 
 // test Buffer slice
 (function() {
-  var buf = new Buffer('0123456789');
+  var buf = Buffer.from('0123456789');
   assert.equal(buf.slice(-10, 10), '0123456789');
   assert.equal(buf.slice(-20, 10), '0123456789');
   assert.equal(buf.slice(-20, -10), '');
@@ -1214,8 +1291,8 @@ assert.throws(function() {
     assert.equal(buf.slice(0, -i), s.slice(0, -i));
   }
 
-  var utf16Buf = new Buffer('0123456789', 'utf16le');
-  assert.deepEqual(utf16Buf.slice(0, 6), Buffer('012', 'utf16le'));
+  var utf16Buf = Buffer.from('0123456789', 'utf16le');
+  assert.deepEqual(utf16Buf.slice(0, 6), Buffer.from('012', 'utf16le'));
 
   assert.equal(buf.slice('0', '1'), '0');
   assert.equal(buf.slice('-5', '10'), '56789');
@@ -1232,7 +1309,7 @@ assert.throws(function() {
 
 // Regression test for #5482: should throw but not assert in C++ land.
 assert.throws(function() {
-  Buffer('', 'buffer');
+  Buffer.from('', 'buffer');
 }, TypeError);
 
 // Regression test for #6111. Constructing a buffer from another buffer
@@ -1241,8 +1318,8 @@ assert.throws(function() {
   var a = [0];
   for (let i = 0; i < 7; ++i) a = a.concat(a);
   a = a.map(function(_, i) { return i; });
-  const b = Buffer(a);
-  const c = Buffer(b);
+  const b = Buffer.from(a);
+  const c = Buffer.from(b);
   assert.equal(b.length, a.length);
   assert.equal(c.length, a.length);
   for (let i = 0, k = a.length; i < k; ++i) {
@@ -1254,7 +1331,7 @@ assert.throws(function() {
 
 
 assert.throws(function() {
-  new Buffer((-1 >>> 0) + 1);
+  Buffer.allocUnsafe((-1 >>> 0) + 1);
 }, RangeError);
 
 assert.throws(function() {
@@ -1265,8 +1342,8 @@ if (common.hasCrypto) {
   // Test truncation after decode
   var crypto = require('crypto');
 
-  var b1 = new Buffer('YW55=======', 'base64');
-  var b2 = new Buffer('YW55', 'base64');
+  var b1 = Buffer.from('YW55=======', 'base64');
+  var b2 = Buffer.from('YW55', 'base64');
 
   assert.equal(
     crypto.createHash('sha1').update(b1).digest('hex'),
@@ -1278,9 +1355,9 @@ if (common.hasCrypto) {
 
 // Test Compare
 {
-  const b = new Buffer(1).fill('a');
-  const c = new Buffer(1).fill('c');
-  const d = new Buffer(2).fill('aa');
+  const b = Buffer.alloc(1, 'a');
+  const c = Buffer.alloc(1, 'c');
+  const d = Buffer.alloc(2, 'aa');
 
   assert.equal(b.compare(c), -1);
   assert.equal(c.compare(d), 1);
@@ -1294,32 +1371,32 @@ if (common.hasCrypto) {
   assert.equal(Buffer.compare(b, d), -1);
   assert.equal(Buffer.compare(c, c), 0);
 
-  assert.equal(Buffer.compare(Buffer(0), Buffer(0)), 0);
-  assert.equal(Buffer.compare(Buffer(0), Buffer(1)), -1);
-  assert.equal(Buffer.compare(Buffer(1), Buffer(0)), 1);
+  assert.equal(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
+  assert.equal(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
+  assert.equal(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 }
 
 assert.throws(function() {
-  var b = new Buffer(1);
+  var b = Buffer.allocUnsafe(1);
   Buffer.compare(b, 'abc');
 });
 
 assert.throws(function() {
-  var b = new Buffer(1);
+  var b = Buffer.allocUnsafe(1);
   Buffer.compare('abc', b);
 });
 
 assert.throws(function() {
-  var b = new Buffer(1);
+  var b = Buffer.allocUnsafe(1);
   b.compare('abc');
 });
 
 // Test Equals
 {
-  const b = new Buffer(5).fill('abcdf');
-  const c = new Buffer(5).fill('abcdf');
-  const d = new Buffer(5).fill('abcde');
-  const e = new Buffer(6).fill('abcdef');
+  const b = Buffer.alloc(5, 'abcdf');
+  const c = Buffer.alloc(5, 'abcdf');
+  const d = Buffer.alloc(5, 'abcde');
+  const e = Buffer.alloc(6, 'abcdef');
 
   assert.ok(b.equals(c));
   assert.ok(!c.equals(d));
@@ -1328,31 +1405,24 @@ assert.throws(function() {
 }
 
 assert.throws(function() {
-  var b = new Buffer(1);
+  var b = Buffer.allocUnsafe(1);
   b.equals('abc');
 });
 
 // Regression test for https://github.com/nodejs/node/issues/649.
-assert.throws(function() { Buffer(1422561062959).toString('utf8'); });
+assert.throws(function() {
+  Buffer.allocUnsafe(1422561062959).toString('utf8');
+});
 
 var ps = Buffer.poolSize;
 Buffer.poolSize = 0;
-assert.equal(Buffer(1).parent, undefined);
+assert.equal(Buffer.allocUnsafe(1).parent, undefined);
 Buffer.poolSize = ps;
 
 // Test Buffer.copy() segfault
 assert.throws(function() {
-  Buffer(10).copy();
+  Buffer.allocUnsafe(10).copy();
 });
-
-assert.throws(function() {
-  new Buffer();
-}, /must start with number, buffer, array or string/);
-
-assert.throws(function() {
-  new Buffer(null);
-}, /must start with number, buffer, array or string/);
-
 
 // Test prototype getters don't throw
 assert.equal(Buffer.prototype.parent, undefined);
@@ -1360,13 +1430,8 @@ assert.equal(Buffer.prototype.offset, undefined);
 assert.equal(SlowBuffer.prototype.parent, undefined);
 assert.equal(SlowBuffer.prototype.offset, undefined);
 
-{
-  // Test that large negative Buffer length inputs don't affect the pool offset.
-  assert.deepStrictEqual(Buffer(-Buffer.poolSize), Buffer.from(''));
-  assert.deepStrictEqual(Buffer(-100), Buffer.from(''));
-  assert.deepStrictEqual(Buffer.allocUnsafe(-Buffer.poolSize), Buffer.from(''));
-  assert.deepStrictEqual(Buffer.allocUnsafe(-100), Buffer.from(''));
-
-  // Check pool offset after that by trying to write string into the pool.
-  assert.doesNotThrow(() => Buffer.from('abc'));
-}
+// Unpooled buffer (replaces SlowBuffer)
+const ubuf = Buffer.allocUnsafeSlow(10);
+assert(ubuf);
+assert(ubuf.buffer);
+assert.equal(ubuf.buffer.byteLength, 10);

--- a/test/parallel/test-buffer-safe-unsafe.js
+++ b/test/parallel/test-buffer-safe-unsafe.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const safe = Buffer.alloc(10);
+
+function isZeroFilled(buf) {
+  for (let n = 0; n < buf.length; n++)
+    if (buf[n] > 0) return false;
+  return true;
+}
+
+assert(isZeroFilled(safe));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer


##### Description of change
    
This backports the new `Buffer.alloc()`, `Buffer.allocUnsafe()`, `Buffer.from()`, and `Buffer.allocUnsafeSlow()` APIs for v4.

Note: some backported tests are disabled, but those are not related to the new API.

Important: `Buffer.from(arrayBuffer[, byteOffset [, length]])` (as in 6.x) was not backported, I used `Buffer.from(arrayBuffer)` instead, that helped to significantly reduce the code changes.

Note that `--zero-fill-buffers` is not included here (see #5745 for that), also the encoding parameter for `.fill()` is not included.

Existing code changes are minor here, this is not invasive.

Only two changes in existing code:
 1. `.fill('')` now zero-fills,
 2. One call to `Buffer(string, encoding)` is replaced with `Buffer.from`.
 
 There is a typecheck in that code path, so the behaviour is identical. In fact it could be reverted back to `Buffer(string, encoding)` or even changed to `fromString(string, encoding)` — that would just affect the double checks.

All the other changes are additive, i.e. introduce new methods and don't change the existing ones.

I'm hoping that this and #5745 will make it into 4.5.0.

/cc @jasnell @nodejs/ctc @seishun 