### PR TITLE
tls: add host and port info to ECONNRESET errors

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1091,6 +1091,10 @@ exports.connect = function(/* [port, host], options, cb */) {
       socket._hadError = true;
       var error = new Error('socket hang up');
       error.code = 'ECONNRESET';
+      error.path = options.path;
+      error.host = options.host;
+      error.port = options.port;
+      error.localAddress = options.localAddress;
       socket.destroy(error);
     }
   }

--- a/test/parallel/test-tls-wrap-econnreset-localaddress.js
+++ b/test/parallel/test-tls-wrap-econnreset-localaddress.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+
+const server = net.createServer((c) => {
+  c.end();
+}).listen(common.mustCall(() => {
+  const port = server.address().port;
+
+  tls.connect({
+    port: port,
+    localAddress: common.localhostIPv4
+  }, common.localhostIPv4)
+    .once('error', common.mustCall((e) => {
+      assert.strictEqual(e.code, 'ECONNRESET');
+      assert.strictEqual(e.path, undefined);
+      assert.strictEqual(e.host, undefined);
+      assert.strictEqual(e.port, port);
+      assert.strictEqual(e.localAddress, common.localhostIPv4);
+      server.close();
+    }));
+}));

--- a/test/parallel/test-tls-wrap-econnreset-pipe.js
+++ b/test/parallel/test-tls-wrap-econnreset-pipe.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const tls = require('tls');
+const net = require('net');
+
+common.refreshTmpDir();
+
+const server = net.createServer((c) => {
+  c.end();
+}).listen(common.PIPE, common.mustCall(() => {
+  tls.connect({ path: common.PIPE })
+    .once('error', common.mustCall((e) => {
+      assert.strictEqual(e.code, 'ECONNRESET');
+      assert.strictEqual(e.path, common.PIPE);
+      assert.strictEqual(e.port, undefined);
+      assert.strictEqual(e.host, undefined);
+      assert.strictEqual(e.localAddress, undefined);
+      server.close();
+    }));
+}));

--- a/test/parallel/test-tls-wrap-econnreset-socket.js
+++ b/test/parallel/test-tls-wrap-econnreset-socket.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+
+const server = net.createServer((c) => {
+  c.end();
+}).listen(common.mustCall(() => {
+  const port = server.address().port;
+
+  const socket = new net.Socket();
+
+  tls.connect({ socket })
+    .once('error', common.mustCall((e) => {
+      assert.strictEqual(e.code, 'ECONNRESET');
+      assert.strictEqual(e.path, undefined);
+      assert.strictEqual(e.host, undefined);
+      assert.strictEqual(e.port, undefined);
+      assert.strictEqual(e.localAddress, undefined);
+      server.close();
+    }));
+
+  socket.connect(port);
+}));

--- a/test/parallel/test-tls-wrap-econnreset.js
+++ b/test/parallel/test-tls-wrap-econnreset.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+
+const server = net.createServer((c) => {
+  c.end();
+}).listen(common.mustCall(() => {
+  const port = server.address().port;
+
+  tls.connect(port, common.localhostIPv4)
+    .once('error', common.mustCall((e) => {
+      assert.strictEqual(e.code, 'ECONNRESET');
+      assert.strictEqual(e.path, undefined);
+      assert.strictEqual(e.host, common.localhostIPv4);
+      assert.strictEqual(e.port, port);
+      assert.strictEqual(e.localAddress, undefined);
+      server.close();
+    }));
+}));


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

TLS
##### Description of change

Add more information (host, port, path) to the "ECONNRESET" errors generated when the
socket hang ups before establishing the secure connection.

These kind of errors are really hard to troubleshoot without this info.
