### PR TITLE
net: export isIPv4, isIPv6 directly from cares

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1582,14 +1582,10 @@ Server.prototype.unref = function() {
 exports.isIP = cares.isIP;
 
 
-exports.isIPv4 = function(input) {
-  return cares.isIPv4(input);
-};
+exports.isIPv4 = cares.isIPv4;
 
 
-exports.isIPv6 = function(input) {
-  return cares.isIPv6(input);
-};
+exports.isIPv6 = cares.isIPv6;
 
 
 if (process.platform === 'win32') {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

net

##### Description of change

The function objects encapsulating `isIPv4` and `isIPv6` are not
necessary. They can be directly exposed from `cares`.

CI Run: https://ci.nodejs.org/job/node-test-pull-request/3128/