### PR TITLE
build: drop unconditional openssl dep from cctest

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -749,12 +749,7 @@
     {
       'target_name': 'cctest',
       'type': 'executable',
-      'dependencies': [
-        'deps/openssl/openssl.gyp:openssl',
-        'deps/http_parser/http_parser.gyp:http_parser',
-        'deps/gtest/gtest.gyp:gtest',
-        'deps/uv/uv.gyp:libuv',
-      ],
+      'dependencies': [ 'deps/gtest/gtest.gyp:gtest' ],
       'include_dirs': [
         'src',
         'deps/v8/include'


### PR DESCRIPTION
Don't link in openssl when building `./configure --without-inspector`,
it's only used by the inspector cctests.  Ditto libuv and http_parser.

Fixes: #7478

CI: https://ci.nodejs.org/job/node-test-pull-request/3131/