### PR TITLE
build: windows sharedlib support

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -78,11 +78,24 @@
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
             'ldflags': [ '-fPIE', '-pie' ]
+          }],
+          ['node_shared=="true"', {
+            'msvs_settings': {
+             'VCCLCompilerTool': {
+               'RuntimeLibrary': 3, # MultiThreadedDebugDLL (/MDd)
+             }
+            }
+          }],
+          ['node_shared=="false"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': 1 # MultiThreadedDebug (/MTd)
+              }
+            }
           }]
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 1, # static debug
             'Optimization': 0, # /Od, no optimization
             'MinimalRebuild': 'false',
             'OmitFramePointers': 'false',
@@ -115,11 +128,24 @@
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
             'ldflags': [ '-fPIE', '-pie' ]
+          }],
+          ['node_shared=="true"', {
+            'msvs_settings': {
+             'VCCLCompilerTool': {
+               'RuntimeLibrary': 2 # MultiThreadedDLL (/MD)
+             }
+            }
+          }],
+          ['node_shared=="false"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': 0 # MultiThreaded (/MT)
+              }
+            }
           }]
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 0, # static release
             'Optimization': 3, # /Ox, full optimization
             'FavorSizeOrSpeed': 1, # /Ot, favour speed over size
             'InlineFunctionExpansion': 2, # /Ob2, inline anything eligible

--- a/common.gypi
+++ b/common.gypi
@@ -12,6 +12,7 @@
     'python%': 'python',
 
     'node_shared%': 'false',
+    'force_dynamic_crt%': 0,
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
     'node_module_version%': '',

--- a/configure
+++ b/configure
@@ -889,7 +889,7 @@ def configure_v8(o):
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
-  o['variables']['force_dynamic_crt'] = int(options.shared)
+  o['variables']['force_dynamic_crt'] = 1 if options.shared else 0
   o['variables']['node_enable_d8'] = b(options.enable_d8)
   if options.enable_d8:
     o['variables']['test_isolation_mode'] = 'noop'  # Needed by d8.gyp.

--- a/configure
+++ b/configure
@@ -889,6 +889,7 @@ def configure_v8(o):
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
+  o['variables']['force_dynamic_crt'] = int(options.shared)
   o['variables']['node_enable_d8'] = b(options.enable_d8)
   if options.enable_d8:
     o['variables']['test_isolation_mode'] = 'noop'  # Needed by d8.gyp.

--- a/deps/v8/build/toolchain.gypi
+++ b/deps/v8/build/toolchain.gypi
@@ -1104,7 +1104,7 @@
           'VCCLCompilerTool': {
             'Optimization': '0',
             'conditions': [
-              ['component=="shared_library"', {
+              ['component=="shared_library" or node_shared=="true"', {
                 'RuntimeLibrary': '3',  # /MDd
               }, {
                 'RuntimeLibrary': '1',  # /MTd
@@ -1156,7 +1156,7 @@
             'StringPooling': 'true',
             'BasicRuntimeChecks': '0',
             'conditions': [
-              ['component=="shared_library"', {
+              ['component=="shared_library" or node_shared=="true"', {
                 'RuntimeLibrary': '3',  #/MDd
               }, {
                 'RuntimeLibrary': '1',  #/MTd
@@ -1347,7 +1347,7 @@
                 'FavorSizeOrSpeed': '0',
                 'StringPooling': 'true',
                 'conditions': [
-                  ['component=="shared_library"', {
+                  ['component=="shared_library" or node_shared=="true"', {
                     'RuntimeLibrary': '2',  #/MD
                   }, {
                     'RuntimeLibrary': '0',  #/MT

--- a/deps/v8/build/toolchain.gypi
+++ b/deps/v8/build/toolchain.gypi
@@ -39,7 +39,6 @@
     'ubsan_vptr%': 0,
     'v8_target_arch%': '<(target_arch)',
     'v8_host_byteorder%': '<!(python -c "import sys; print sys.byteorder")',
-    'force_dynamic_crt%': 0,
     # Native Client builds currently use the V8 ARM JIT and
     # arm/simulator-arm.cc to defer the significant effort required
     # for NaCl JIT support. The nacl_target_arch variable provides
@@ -1105,7 +1104,7 @@
           'VCCLCompilerTool': {
             'Optimization': '0',
             'conditions': [
-              ['component=="shared_library" or force_dynamic_crt==1', {
+              ['component=="shared_library"', {
                 'RuntimeLibrary': '3',  # /MDd
               }, {
                 'RuntimeLibrary': '1',  # /MTd
@@ -1157,7 +1156,7 @@
             'StringPooling': 'true',
             'BasicRuntimeChecks': '0',
             'conditions': [
-              ['component=="shared_library" or force_dynamic_crt==1', {
+              ['component=="shared_library"', {
                 'RuntimeLibrary': '3',  #/MDd
               }, {
                 'RuntimeLibrary': '1',  #/MTd
@@ -1348,7 +1347,7 @@
                 'FavorSizeOrSpeed': '0',
                 'StringPooling': 'true',
                 'conditions': [
-                  ['component=="shared_library" or force_dynamic_crt==1', {
+                  ['component=="shared_library"', {
                     'RuntimeLibrary': '2',  #/MD
                   }, {
                     'RuntimeLibrary': '0',  #/MT

--- a/deps/v8/build/toolchain.gypi
+++ b/deps/v8/build/toolchain.gypi
@@ -39,6 +39,7 @@
     'ubsan_vptr%': 0,
     'v8_target_arch%': '<(target_arch)',
     'v8_host_byteorder%': '<!(python -c "import sys; print sys.byteorder")',
+    'force_dynamic_crt%': 0,
     # Native Client builds currently use the V8 ARM JIT and
     # arm/simulator-arm.cc to defer the significant effort required
     # for NaCl JIT support. The nacl_target_arch variable provides
@@ -1104,7 +1105,7 @@
           'VCCLCompilerTool': {
             'Optimization': '0',
             'conditions': [
-              ['component=="shared_library" or node_shared=="true"', {
+              ['component=="shared_library" or force_dynamic_crt==1', {
                 'RuntimeLibrary': '3',  # /MDd
               }, {
                 'RuntimeLibrary': '1',  # /MTd
@@ -1156,7 +1157,7 @@
             'StringPooling': 'true',
             'BasicRuntimeChecks': '0',
             'conditions': [
-              ['component=="shared_library" or node_shared=="true"', {
+              ['component=="shared_library" or force_dynamic_crt==1', {
                 'RuntimeLibrary': '3',  #/MDd
               }, {
                 'RuntimeLibrary': '1',  #/MTd
@@ -1347,7 +1348,7 @@
                 'FavorSizeOrSpeed': '0',
                 'StringPooling': 'true',
                 'conditions': [
-                  ['component=="shared_library" or node_shared=="true"', {
+                  ['component=="shared_library" or force_dynamic_crt==1', {
                     'RuntimeLibrary': '2',  #/MD
                   }, {
                     'RuntimeLibrary': '0',  #/MT

--- a/node.gyp
+++ b/node.gyp
@@ -243,7 +243,7 @@
             'NODE_SHARED_MODE',
           ],
           'conditions': [
-            [ 'node_module_version!=""', {
+            [ 'node_module_version!="" and OS!="win"', {
               'product_extension': 'so.<(node_module_version)',
             }]
           ],

--- a/node.gyp
+++ b/node.gyp
@@ -9,6 +9,7 @@
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
+    'force_dynamic_crt%': 0,
     'node_module_version%': '',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -38,6 +38,7 @@ set build_release=
 set enable_vtune_arg=
 set configure_flags=
 set build_addons=
+set dll=
 
 :next-arg
 if "%1"=="" goto args-done

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -79,6 +79,7 @@ if /i "%1"=="without-intl"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
+if /i "%1"=="dll"           set dll=1&goto arg-ok
 
 echo Warning: ignoring invalid command line option `%1`.
 
@@ -108,6 +109,7 @@ if defined noperfctr set configure_flags=%configure_flags% --without-perfctr& se
 if defined release_urlbase set release_urlbase_arg=--release-urlbase=%release_urlbase%
 if defined download_arg set configure_flags=%configure_flags% %download_arg%
 if defined enable_vtune_arg set configure_flags=%configure_flags% --enable-vtune-profiling
+if defined dll set configure_flags=%configure_flags% --shared
 
 if "%i18n_arg%"=="full-icu" set configure_flags=%configure_flags% --with-intl=full-icu
 if "%i18n_arg%"=="small-icu" set configure_flags=%configure_flags% --with-intl=small-icu


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

build

##### Description of change
<!-- Provide a description of the change below this comment. -->

Following https://github.com/nodejs/node/pull/6994 the next step is to provide support for generating a DLL on Windows for people using Node.js as a shared library. This commit makes the necessary changes, but unfortunately it requires a floating patch to V8's gyp files. I do not believe there is any way around this issue, so I am opening the PR now to get some feedback on my approach.

Overview:
* Added "dll" option to vcbuild.bat
* Insure that Unix SO name is not used on Windows (i.e. produce a .dll file) 
* Insure that Node and its V8 dependency link against the Visual C++ Runtime dynamically.

The last point is very important. In Windows If different libraries you link use different versions of the C++ Runtime you will get a variety of issues that are well documented here: http://siomsystems.com/mixing-visual-studio-versions/. Note that this situation can occur in multiple ways:
* If different libraries in your program mix static and dynamic runtime libraries.
* If different libraries in your program mix versions of Visual Studio.
* If both situations above occur.

This also means that people using `node.dll` must also use the exact same Visual Studio version that Node was compiled with to build the program that links against the DLL. Further information is available here: https://www.softwariness.com/articles/visual-cpp-runtime-libraries/

The basic problem with V8 is that its gyp files are setup to always link statically against the C++ runtime unless V8 itself is being compiled as a shared library. The floating patch I provided is minimal and is inspired by https://github.com/qt/qtwebengine-chromium/commit/743a6413f3cc0a621865a81f06c6d7bed7b662c5.

