### PR TITLE
src: add /json/protocol endpoint to inspector

### DIFF
--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -12,6 +12,7 @@
         {
           'target_name': 'zlib',
           'type': 'static_library',
+          'defines': [ 'ZLIB_CONST' ],
           'sources': [
             'adler32.c',
             'compress.c',
@@ -44,6 +45,7 @@
             '.',
           ],
           'direct_dependent_settings': {
+            'defines': [ 'ZLIB_CONST' ],
             'include_dirs': [
               '.',
             ],
@@ -72,10 +74,12 @@
           'direct_dependent_settings': {
             'defines': [
               'USE_SYSTEM_ZLIB',
+              'ZLIB_CONST',
             ],
           },
           'defines': [
             'USE_SYSTEM_ZLIB',
+            'ZLIB_CONST',
           ],
           'link_settings': {
             'libraries': [

--- a/node.gyp
+++ b/node.gyp
@@ -323,6 +323,7 @@
           'dependencies': [
             'deps/v8_inspector/third_party/v8_inspector/platform/'
                 'v8_inspector/v8_inspector.gyp:v8_inspector_stl',
+            'v8_inspector_compress_protocol_json#host',
           ],
           'include_dirs': [
             'deps/v8_inspector/third_party/v8_inspector',
@@ -650,6 +651,34 @@
           ],
         } ]
       ]
+    },
+    {
+      'target_name': 'v8_inspector_compress_protocol_json',
+      'type': 'none',
+      'toolsets': ['host'],
+      'conditions': [
+        [ 'v8_inspector=="true"', {
+          'actions': [
+            {
+              'action_name': 'v8_inspector_compress_protocol_json',
+              'process_outputs_as_sources': 1,
+              'inputs': [
+                'deps/v8_inspector/third_party/'
+                    'v8_inspector/platform/v8_inspector/js_protocol.json',
+              ],
+              'outputs': [
+                '<(SHARED_INTERMEDIATE_DIR)/v8_inspector_protocol_json.h',
+              ],
+              'action': [
+                'python',
+                'tools/compress_json.py',
+                '<@(_inputs)',
+                '<@(_outputs)',
+              ],
+            },
+          ],
+        }],
+      ],
     },
     {
       'target_name': 'node_js2c',

--- a/test/common.js
+++ b/test/common.js
@@ -16,6 +16,7 @@ exports.testDir = __dirname;
 exports.fixturesDir = path.join(exports.testDir, 'fixtures');
 exports.libDir = path.join(exports.testDir, '../lib');
 exports.tmpDirName = 'tmp';
+// PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 exports.isWindows = process.platform === 'win32';
 exports.isWOW64 = exports.isWindows &&

--- a/test/parallel/test-v8-inspector-json-protocol.js
+++ b/test/parallel/test-v8-inspector-json-protocol.js
@@ -1,0 +1,22 @@
+// Flags: --inspect={PORT}
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const options = {
+  path: '/json/protocol',
+  port: common.PORT,
+  host: common.localhostIPv4,
+};
+
+http.get(options, common.mustCall((res) => {
+  let body = '';
+  res.setEncoding('utf8');
+  res.on('data', (data) => body += data);
+  res.on('end', common.mustCall(() => {
+    assert(body.length > 0);
+    assert.deepStrictEqual(JSON.stringify(JSON.parse(body)), body);
+  }));
+}));

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -61,7 +61,10 @@ class SimpleTestCase(test.TestCase):
     source = open(self.file).read()
     flags_match = FLAGS_PATTERN.search(source)
     if flags_match:
-      result += flags_match.group(1).strip().split()
+      # PORT should match the definition in test/common.js.
+      env = { 'PORT': int(os.getenv('NODE_COMMON_PORT', '12346')) }
+      env['PORT'] += self.thread_id * 100
+      result += flags_match.group(1).strip().format(**env).split()
     files_match = FILES_PATTERN.search(source);
     additional_files = []
     if files_match:

--- a/tools/compress_json.py
+++ b/tools/compress_json.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import json
+import struct
+import sys
+import zlib
+
+if __name__ == '__main__':
+  fp = open(sys.argv[1])
+  obj = json.load(fp)
+  text = json.dumps(obj, separators=(',', ':'))
+  data = zlib.compress(text, zlib.Z_BEST_COMPRESSION)
+
+  # To make decompression a little easier, we prepend the compressed data
+  # with the size of the uncompressed data as a 24 bits BE unsigned integer.
+  assert len(text) < 1 << 24, 'Uncompressed JSON must be < 16 MB.'
+  data = struct.pack('>I', len(text))[1:4] + data
+
+  step = 20
+  slices = (data[i:i+step] for i in xrange(0, len(data), step))
+  slices = map(lambda s: ','.join(str(ord(c)) for c in s), slices)
+  text = ',\n'.join(slices)
+
+  fp = open(sys.argv[2], 'w')
+  fp.write(text)


### PR DESCRIPTION
Embed the compressed and minified protocol.json from the bundled
v8_inspector and make it available through the /json/protocol endpoint.

Refs: nodejs/diagnostics#52
CI: https://ci.nodejs.org/job/node-test-pull-request/3133/
EDIT: https://ci.nodejs.org/job/node-test-pull-request/3135/