### PR TITLE
Fix various overflows and UB in src/

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -693,15 +693,15 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   size_t max_length;
 
   CHECK_NOT_OOB(ParseArrayIndex(args[1], 0, &offset));
+  if (offset >= ts_obj_length)
+    return env->ThrowRangeError("Offset is out of bounds");
+
   CHECK_NOT_OOB(ParseArrayIndex(args[2], ts_obj_length - offset, &max_length));
 
   max_length = MIN(ts_obj_length - offset, max_length);
 
   if (max_length == 0)
     return args.GetReturnValue().Set(0);
-
-  if (offset >= ts_obj_length)
-    return env->ThrowRangeError("Offset is out of bounds");
 
   uint32_t written = StringBytes::Write(env->isolate(),
                                         ts_obj_data + offset,

--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -103,7 +103,7 @@ void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
 }
 
 
-void ClientHelloParser::ParseExtension(ClientHelloParser::ExtensionType type,
+void ClientHelloParser::ParseExtension(const uint16_t type,
                                        const uint8_t* data,
                                        size_t len) {
   // NOTE: In case of anything we're just returning back, ignoring the problem.
@@ -210,7 +210,7 @@ bool ClientHelloParser::ParseTLSClientHello(const uint8_t* data, size_t avail) {
     if (ext_off + ext_len > avail)
       return false;
 
-    ParseExtension(static_cast<ExtensionType>(ext_type),
+    ParseExtension(ext_type,
                    data + ext_off,
                    ext_len);
 

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -91,7 +91,7 @@ class ClientHelloParser {
 
   bool ParseRecordHeader(const uint8_t* data, size_t avail);
   void ParseHeader(const uint8_t* data, size_t avail);
-  void ParseExtension(ExtensionType type,
+  void ParseExtension(const uint16_t type,
                       const uint8_t* data,
                       size_t len);
   bool ParseTLSClientHello(const uint8_t* data, size_t avail);

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -404,7 +404,7 @@ size_t StringSearch<Char>::BoyerMooreSearch(
     } else {
       int gs_shift = good_suffix_shift[j + 1];
       int bc_occ = CharOccurrence(bad_char_occurence, c);
-      int shift = j - bc_occ;
+      int shift = static_cast<int>(j) - bc_occ;
       if (gs_shift > shift) {
         shift = gs_shift;
       }
@@ -494,12 +494,12 @@ size_t StringSearch<Char>::BoyerMooreHorspoolSearch(
   const size_t subject_length = subject.length();
   const size_t pattern_length = pattern.length();
   int* char_occurrences = search->bad_char_table();
-  int64_t badness = -pattern_length;
+  int64_t badness = -static_cast<int64_t>(pattern_length);
 
   // How bad we are doing without a good-suffix table.
   Char last_char = pattern[pattern_length - 1];
   int last_char_shift =
-      pattern_length - 1 -
+      static_cast<int>(pattern_length) - 1 -
       CharOccurrence(char_occurrences, static_cast<Char>(last_char));
 
   // Perform search
@@ -509,7 +509,7 @@ size_t StringSearch<Char>::BoyerMooreHorspoolSearch(
     int subject_char;
     while (last_char != (subject_char = subject[index + j])) {
       int bc_occ = CharOccurrence(char_occurrences, subject_char);
-      int shift = j - bc_occ;
+      int shift = static_cast<int>(j) - bc_occ;
       index += shift;
       badness += 1 - shift;  // at most zero, so badness cannot increase.
       if (index > subject_length - pattern_length) {
@@ -528,7 +528,7 @@ size_t StringSearch<Char>::BoyerMooreHorspoolSearch(
     // checked, and decreases by the number of characters we
     // can skip by shifting. It's a measure of how we are doing
     // compared to reading each character exactly once.
-    badness += (pattern_length - j) - last_char_shift;
+    badness += static_cast<int64_t>(pattern_length - j) - last_char_shift;
     if (badness > 0) {
       search->PopulateBoyerMooreTable();
       search->strategy_ = &BoyerMooreSearch;
@@ -602,7 +602,7 @@ size_t StringSearch<Char>::InitialSearch(
       if (j == pattern_length) {
         return i;
       }
-      badness += j;
+      badness += static_cast<int64_t>(j);
     } else {
       search->PopulateBoyerMooreHorspoolTable();
       search->strategy_ = &BoyerMooreHorspoolSearch;


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change

Fix various overflows and UB in src/

R= @bnoordhuis and/or @nodejs/collaborators 


---

NOTE: This doesn't fix:

```
../src/string_search.h:231:68: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
SUMMARY: AddressSanitizer: undefined-behavior ../src/string_search.h:231:68 in
../src/string_search.h:186:34: runtime error: index 18446744073709451866 out of bounds for type 'int [251]'
SUMMARY: AddressSanitizer: undefined-behavior ../src/string_search.h:186:34 in
../src/string_search.h:194:25: runtime error: index 18446744073709451866 out of bounds for type 'int [251]'
SUMMARY: AddressSanitizer: undefined-behavior ../src/string_search.h:194:25 in
```

I'm open to suggestions how it could be approached, though.