### PR TITLE
src: guard against overflow in ParseArrayIndex()

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -207,6 +207,11 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
   if (tmp_i < 0)
     return false;
 
+  // Check that the result fits in a size_t.
+  const uint64_t kSizeMax = static_cast<uint64_t>(static_cast<size_t>(-1));
+  if (static_cast<uint64_t>(tmp_i) > kSizeMax)
+    return false;
+
   *ret = static_cast<size_t>(tmp_i);
   return true;
 }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -193,6 +193,25 @@ void CallbackInfo::WeakCallback(Isolate* isolate) {
 }
 
 
+// Parse index for external array data.
+inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
+                                            size_t def,
+                                            size_t* ret) {
+  if (arg->IsUndefined()) {
+    *ret = def;
+    return true;
+  }
+
+  int64_t tmp_i = arg->IntegerValue();
+
+  if (tmp_i < 0)
+    return false;
+
+  *ret = static_cast<size_t>(tmp_i);
+  return true;
+}
+
+
 // Buffer methods
 
 bool HasInstance(Local<Value> val) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -175,24 +175,6 @@ inline bool IsBigEndian() {
   return GetEndianness() == kBigEndian;
 }
 
-// parse index for external array data
-inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
-                                            size_t def,
-                                            size_t* ret) {
-  if (arg->IsUndefined()) {
-    *ret = def;
-    return true;
-  }
-
-  int64_t tmp_i = arg->IntegerValue();
-
-  if (tmp_i < 0)
-    return false;
-
-  *ret = static_cast<size_t>(tmp_i);
-  return true;
-}
-
 class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  public:
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1462,6 +1462,13 @@ assert.throws(function() {
   Buffer.from(new ArrayBuffer(0), -1 >>> 0);
 }, /RangeError: 'offset' is out of bounds/);
 
+// ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
+assert.throws(() => {
+  const a = Buffer(1).fill(0);
+  const b = Buffer(1).fill(0);
+  a.copy(b, 0, 0x100000000, 0x100000001);
+}), /out of range index/;
+
 // Unpooled buffer (replaces SlowBuffer)
 const ubuf = Buffer.allocUnsafeSlow(10);
 assert(ubuf);


### PR DESCRIPTION
ParseArrayIndex() would wrap around large (>=2^32) index values on
platforms where sizeof(int64_t) > sizeof(size_t).  Ensure that the
return value fits in a size_t.

CI: https://ci.nodejs.org/job/node-test-pull-request/3139/