### PR TITLE
http: add host and port info to ECONNRESET errors

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -28,6 +28,8 @@ function ClientRequest(options, cb) {
     options = util._extend({}, options);
   }
 
+  self._requestOptions = options;
+
   var agent = options.agent;
   var defaultAgent = options._defaultAgent || Agent.globalAgent;
   if (agent === false) {
@@ -248,9 +250,15 @@ function emitAbortNT(self) {
 }
 
 
-function createHangUpError() {
+function createHangUpError(req) {
   var error = new Error('socket hang up');
   error.code = 'ECONNRESET';
+  if (req._requestOptions.socketPath) {
+    error.path = req._requestOptions.socketPath;
+  } else {
+    error.host = req._requestOptions.host;
+    error.port = req._requestOptions.port;
+  }
   return error;
 }
 
@@ -281,7 +289,7 @@ function socketCloseListener() {
     // This socket error fired before we started to
     // receive a response. The error needs to
     // fire on the request.
-    req.emit('error', createHangUpError());
+    req.emit('error', createHangUpError(req));
     req.socket._hadError = true;
   }
 
@@ -341,7 +349,7 @@ function socketOnEnd() {
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
-    req.emit('error', createHangUpError());
+    req.emit('error', createHangUpError(req));
     req.socket._hadError = true;
   }
   if (parser) {

--- a/test/parallel/test-http-econnreset-pipe.js
+++ b/test/parallel/test-http-econnreset-pipe.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+common.refreshTmpDir();
+
+const server = net.createServer((c) => {
+  c.end();
+});
+
+server.listen(common.PIPE, common.mustCall(() => {
+  http.request({ socketPath: common.PIPE, path: '/', method: 'GET' })
+    .once('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ECONNRESET');
+      assert.strictEqual(err.port, undefined);
+      assert.strictEqual(err.host, undefined);
+      assert.strictEqual(err.path, common.PIPE);
+      server.close();
+    }));
+}));

--- a/test/parallel/test-http-econnreset.js
+++ b/test/parallel/test-http-econnreset.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+const server = net.createServer((c) => {
+  c.end();
+});
+
+server.listen(common.mustCall(() => {
+  const port = server.address().port;
+
+  http.get({ port: port, path: '/', host: common.localhostIPv4 })
+    .once('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ECONNRESET');
+      assert.strictEqual(err.port, port);
+      assert.strictEqual(err.host, common.localhostIPv4);
+      assert.strictEqual(err.path, undefined);
+      server.close();
+    }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

http
##### Description of change

Add more information to the "ECONNRESET" errors generated on HTTP when the
socket hang ups before receiving a response.

These kind of errors are really hard to troubleshoot without this info.

This change is similar to #7476.
