### PR TITLE
test: revert fix test-net-* error code check

### DIFF
--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -3,12 +3,12 @@ var common = require('../common');
 var net = require('net');
 var assert = require('assert');
 
-var c = net.createConnection(common.PORT, '***');
+var c = net.createConnection(common.PORT, '...');
 
 c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
   assert.equal(e.code, 'ENOTFOUND');
   assert.equal(e.port, common.PORT);
-  assert.equal(e.hostname, '***');
+  assert.equal(e.hostname, '...');
 }));

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -3,14 +3,14 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const client = net.connect({host: '***', port: common.PORT});
+const client = net.connect({host: '...', port: common.PORT});
 
 client.once('error', common.mustCall(function(err) {
   assert(err);
   assert.strictEqual(err.code, err.errno);
   assert.strictEqual(err.code, 'ENOTFOUND');
   assert.strictEqual(err.host, err.hostname);
-  assert.strictEqual(err.host, '***');
+  assert.strictEqual(err.host, '...');
   assert.strictEqual(err.syscall, 'getaddrinfo');
 }));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

This reverts commit 0414d882ce425678fed879e07c5c5a98b8ef025d.

This is a super weird one. This commit landed with no problems with the
test suite. CI tested absolutely fine multiple times. As of June 30
2016 the test suite is now reliably failing on `test-net-*`.
This is extremely odd to be coming up after the release and multiple
test runs.

Weirdness aside, the revert brings the test suite back to a reliable
state. This may cause problems for testing on Alpine, this will need
to be revisited.