### PR TITLE
test: handle SmartOS bug in test-tls-session-cache

### DIFF
--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+const common = require('../common');
 
 if (!common.opensslCli) {
   common.skip('node compiled without OpenSSL CLI.');
@@ -18,17 +18,17 @@ doTest({ tickets: false }, function() {
 });
 
 function doTest(testOptions, callback) {
-  var assert = require('assert');
-  var tls = require('tls');
-  var fs = require('fs');
-  var join = require('path').join;
-  var spawn = require('child_process').spawn;
+  const assert = require('assert');
+  const tls = require('tls');
+  const fs = require('fs');
+  const join = require('path').join;
+  const spawn = require('child_process').spawn;
 
-  var keyFile = join(common.fixturesDir, 'agent.key');
-  var certFile = join(common.fixturesDir, 'agent.crt');
-  var key = fs.readFileSync(keyFile);
-  var cert = fs.readFileSync(certFile);
-  var options = {
+  const keyFile = join(common.fixturesDir, 'agent.key');
+  const certFile = join(common.fixturesDir, 'agent.crt');
+  const key = fs.readFileSync(keyFile);
+  const cert = fs.readFileSync(certFile);
+  const options = {
     key: key,
     cert: cert,
     ca: [cert],
@@ -38,7 +38,7 @@ function doTest(testOptions, callback) {
   var resumeCount = 0;
   var session;
 
-  var server = tls.createServer(options, function(cleartext) {
+  const server = tls.createServer(options, function(cleartext) {
     cleartext.on('error', function(er) {
       // We're ok with getting ECONNRESET in this test, but it's
       // timing-dependent, and thus unreliable. Any other errors
@@ -72,7 +72,7 @@ function doTest(testOptions, callback) {
   });
 
   server.listen(0, function() {
-    var args = [
+    const args = [
       's_client',
       '-tls1',
       '-connect', `localhost:${this.address().port}`,
@@ -86,21 +86,34 @@ function doTest(testOptions, callback) {
     if (common.isWindows)
       args.push('-no_rand_screen');
 
-    var client = spawn(common.opensslCli, args, {
-      stdio: [ 0, 1, 'pipe' ]
-    });
-    var err = '';
-    client.stderr.setEncoding('utf8');
-    client.stderr.on('data', function(chunk) {
-      err += chunk;
-    });
-    client.on('exit', function(code) {
-      console.error('done');
-      assert.equal(code, 0);
-      server.close(function() {
-        setTimeout(callback, 100);
+    function spawnClient() {
+      const client = spawn(common.opensslCli, args, {
+        stdio: [ 0, 1, 'pipe' ]
       });
-    });
+      var err = '';
+      client.stderr.setEncoding('utf8');
+      client.stderr.on('data', function(chunk) {
+        err += chunk;
+      });
+
+      client.on('exit', common.mustCall(function(code, signal) {
+        if (code !== 0) {
+          // If SmartOS and connection refused, then retry. See
+          // https://github.com/nodejs/node/issues/2663.
+          if (common.isSunOS && err.includes('Connection refused')) {
+            spawnClient();
+            return;
+          }
+          common.fail(`code: ${code}, signal: ${signal}, output: ${err}`);
+        }
+        assert.equal(code, 0);
+        server.close(common.mustCall(function() {
+          setTimeout(callback, 100);
+        }));
+      }));
+    }
+
+    spawnClient();
   });
 
   process.on('exit', function() {

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -101,8 +101,7 @@ function doTest(testOptions, callback) {
           // If SmartOS and connection refused, then retry. See
           // https://github.com/nodejs/node/issues/2663.
           if (common.isSunOS && err.includes('Connection refused')) {
-            // Reduce requestCount by one because we are re-trying.
-            --requestCount;
+            requestCount = 0;
             spawnClient();
             return;
           }

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -101,6 +101,8 @@ function doTest(testOptions, callback) {
           // If SmartOS and connection refused, then retry. See
           // https://github.com/nodejs/node/issues/2663.
           if (common.isSunOS && err.includes('Connection refused')) {
+            // Reduce requestCount by one because we are re-trying.
+            --requestCount;
             spawnClient();
             return;
           }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

Sometimes, a SmartOS bug results in ECONNREFUSED when trying to connect
to the TLS server that the test starts. Retry in that situation.

Fixes: https://github.com/nodejs/node/issues/5111
Refs: https://smartos.org/bugview/OS-2767