### PR TITLE
src: remove unnecessary static_cast in tcp_wrap.cc

### DIFF
--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -277,8 +277,7 @@ void TCPWrap::OnConnection(uv_stream_t* handle, int status) {
 
   if (status == 0) {
     // Instantiate the client javascript object and handle.
-    Local<Object> client_obj =
-        Instantiate(env, static_cast<AsyncWrap*>(tcp_wrap));
+    Local<Object> client_obj = Instantiate(env, tcp_wrap);
 
     // Unwrap the client javascript object.
     TCPWrap* wrap = Unwrap<TCPWrap>(client_obj);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change

It looks like the cast might not be required as TCPWrap is of type AsyncWrap:
class TCPWrap : public StreamWrap
class StreamWrap : public HandleWrap, public StreamBase
class HandleWrap : public AsyncWrap