### PR TITLE
doc: updating REPLACEME tag during release

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -145,11 +145,21 @@ is shown in **bold** in the index. When updating the index, please make sure
 to update the display accordingly by removing the bold styling from the previous
 release.
 
+#### Step 3: Update any REPLACEME tags in the docs
+
+If this release includes new APIs then it is necessary to document that they
+were first added in this version. The relevant commits should already include
+`REPLACEME` tags as per the example in the
+[docs README](../tools/doc/README.md). Check for these tags with
+`grep REPLACEME doc/api/*.md`, and substitute this node version with
+`sed -i "s/REPLACEME/$VERSION/g" doc/api/*.md` or
+`perl -pi -e "s/REPLACEME/$VERSION/g" doc/api/*.md`.
+
 ### 4. Create Release Commit
 
-The `CHANGELOG.md`, `doc/changelogs/CHANGELOG_*.md`, and `src/node_version.h` 
-changes should be the final commit that will be tagged for the release. When 
-committing these to git, use the following message format:
+The `CHANGELOG.md`, `doc/changelogs/CHANGELOG_*.md`, `src/node_version.h`, and
+`REPLACEME` changes should be the final commit that will be tagged for the
+release. When committing these to git, use the following message format:
 
 ```
 YYYY-MM-DD, Version x.y.z (Release Type)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add a paragraph to the releases.md guide to document replacing the
REPLACEME tag with the release version for new APIs.

Ref: https://github.com/nodejs/node/pull/6864#issuecomment-220301714, #6578 

@addaleax @claudiorodriguez @evanlucas 