### PR TITLE
doc: delete non-existing zlib constants

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -266,13 +266,6 @@ Compression strategy.
 * `zlib.Z_FIXED`
 * `zlib.Z_DEFAULT_STRATEGY`
 
-Possible values of the data_type field.
-
-* `zlib.Z_BINARY`
-* `zlib.Z_TEXT`
-* `zlib.Z_ASCII`
-* `zlib.Z_UNKNOWN`
-
 The deflate compression method (the only one supported in this version).
 
 * `zlib.Z_DEFLATED`


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes #7204.

Some constants in the zlib docs are not in the actual code:

zlib.Z_BINARY
zlib.Z_TEXT
zlib.Z_ASCII
zlib.Z_UNKNOWN

Also handled in #7203, but that PR is marked as semver-major, so it will not land in v6.x.