### PR TITLE
test: listen on and connect to 127.0.0.1

### DIFF
--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -29,7 +29,7 @@ function server() {
       console.error('_socketEnd');
     });
     socket.write(content);
-  }).listen(common.PORT, function() {
+  }).listen(common.PORT, common.localhostIPv4, function() {
     console.log('listening');
   });
 }
@@ -37,7 +37,7 @@ function server() {
 function client() {
   var net = require('net');
   var client = net.connect({
-    host: 'localhost',
+    host: common.localhostIPv4,
     port: common.PORT
   }, function() {
     client.destroy();


### PR DESCRIPTION
Avoid transient DNS issues in test sequential/test-net-GH-5504 by using
the IP address instead of the 'localhost' host name.

Fixes: #6611 

Already got a LGTM: https://github.com/nodejs/node/issues/6611#issuecomment-230118541 :-)

CI: https://ci.nodejs.org/job/node-test-pull-request/3163/