### PR TITLE
deps: remove extra field from v8::HeapStatistics

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -5202,7 +5202,6 @@ class V8_EXPORT HeapStatistics {
   size_t total_available_size() { return total_available_size_; }
   size_t used_heap_size() { return used_heap_size_; }
   size_t heap_size_limit() { return heap_size_limit_; }
-  size_t malloced_memory() { return malloced_memory_; }
   size_t does_zap_garbage() { return does_zap_garbage_; }
 
  private:
@@ -5213,7 +5212,6 @@ class V8_EXPORT HeapStatistics {
   size_t used_heap_size_;
   size_t heap_size_limit_;
   bool does_zap_garbage_;
-  size_t malloced_memory_;
 
   friend class V8;
   friend class Isolate;

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -5526,8 +5526,7 @@ HeapStatistics::HeapStatistics()
       total_available_size_(0),
       used_heap_size_(0),
       heap_size_limit_(0),
-      does_zap_garbage_(0),
-      malloced_memory_(0) {}
+      does_zap_garbage_(0) {}
 
 HeapSpaceStatistics::HeapSpaceStatistics(): space_name_(0),
                                             space_size_(0),
@@ -7428,8 +7427,6 @@ void Isolate::GetHeapStatistics(HeapStatistics* heap_statistics) {
   heap_statistics->total_available_size_ = heap->Available();
   heap_statistics->used_heap_size_ = heap->SizeOfObjects();
   heap_statistics->heap_size_limit_ = heap->MaxReserved();
-  heap_statistics->malloced_memory_ =
-      isolate->allocator()->GetCurrentMemoryUsage();
   heap_statistics->does_zap_garbage_ = heap->ShouldZapGarbage();
 }
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

deps/v8

##### Description of change

Remove the `_malloced_memory` field from the `HeapStatistics` class to achieve full ABI compatibility with V8 5.0 (as far as I can tell).

This structure is probably not something used by addons anyway, since the information from that struct is already made available through Node’s `v8.getHeapStatistics()`, but better safe than sorry.

Ref: https://github.com/nodejs/node/pull/7016#issuecomment-229986752 (and it would need to be landed in v6 together with #7016).

/cc @ofrobots @nodejs/v8 