### PR TITLE
repl: added support for custom completions.

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -382,8 +382,8 @@ added: v0.1.91
      `undefined`. Defaults to `false`.
   * `writer` {Function} The function to invoke to format the output of each
      command before writing to `output`. Defaults to [`util.inspect()`][].
-  * `completer` {Function} An optional function that will used for custom Tab
-     auto completion. See [`readline.InterfaceCompleter`][] for an example.
+  * `completer` {Function} An optional function used for custom Tab auto
+     completion. See [`readline.InterfaceCompleter`][] for an example.
   * `replMode` - A flag that specifies whether the default evaluator executes
     all JavaScript commands in strict mode, default mode, or a hybrid mode
     ("magic" mode.) Acceptable values are:

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -382,6 +382,8 @@ added: v0.1.91
      `undefined`. Defaults to `false`.
   * `writer` {Function} The function to invoke to format the output of each
      command before writing to `output`. Defaults to [`util.inspect()`][].
+  * `completer` {Function} An optional function that will used for custom Tab
+     auto completion. See [`readline.InterfaceCompleter`][] for an example.
   * `replMode` - A flag that specifies whether the default evaluator executes
     all JavaScript commands in strict mode, default mode, or a hybrid mode
     ("magic" mode.) Acceptable values are:
@@ -526,3 +528,4 @@ see: https://gist.github.com/2053342
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [here]: util.html#util_custom_inspect_function_on_objects
 [`readline.Interface`]: readline.html#readline_class_interface
+[`readline.InterfaceCompleter`]: readline.html#readline_use_of_the_completer_function

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -389,7 +389,7 @@ function REPLServer(prompt,
   // Figure out which "complete" function to use.
   self.completer = (typeof options.completer === 'function')
     ? options.completer
-    : complete.bind(this);
+    : complete.bind(self);
 
   Interface.call(this, {
     input: self.inputStream,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -389,7 +389,7 @@ function REPLServer(prompt,
   // Figure out which "complete" function to use.
   self.completer = (typeof options.completer === 'function')
     ? options.completer
-    : complete.bind(self);
+    : complete;
 
   Interface.call(this, {
     input: self.inputStream,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -386,14 +386,15 @@ function REPLServer(prompt,
   self.bufferedCommand = '';
   self.lines.level = [];
 
-  function complete(text, callback) {
-    self.complete(text, callback);
-  }
+  // Figure out which "complete" function to use.
+  self.completer = (typeof options.completer === 'function')
+    ? options.completer
+    : complete.bind(this);
 
   Interface.call(this, {
     input: self.inputStream,
     output: self.outputStream,
-    completer: complete,
+    completer: self.completer,
     terminal: options.terminal,
     historySize: options.historySize,
     prompt
@@ -698,6 +699,10 @@ function filteredOwnPropertyNames(obj) {
   return Object.getOwnPropertyNames(obj).filter(intFilter);
 }
 
+REPLServer.prototype.complete = function() {
+  this.completer.apply(this, arguments);
+};
+
 // Provide a list of completions for the given leading text. This is
 // given to the readline interface for handling tab completion.
 //
@@ -708,7 +713,7 @@ function filteredOwnPropertyNames(obj) {
 //
 // Warning: This eval's code like "foo.bar.baz", so it will run property
 // getter code.
-REPLServer.prototype.complete = function(line, callback) {
+function complete(line, callback) {
   // There may be local variables to evaluate, try a nested REPL
   if (this.bufferedCommand !== undefined && this.bufferedCommand.length) {
     // Get a new array of inputed lines
@@ -967,7 +972,7 @@ REPLServer.prototype.complete = function(line, callback) {
 
     callback(null, [completions || [], completeOn]);
   }
-};
+}
 
 
 /**

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -17,7 +17,6 @@ var testMe = repl.start('', putIn);
 
 // Some errors are passed to the domain, but do not callback
 testMe._domain.on('error', function(err) {
-  console.log(err);
   assert.ifError(err);
 });
 

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -292,7 +292,7 @@ const testCustomCompleterSyncMode = repl.start({
   input: putIn,
   output: putIn,
   completer: function completerSyncMode(line) {
-    var hits = customCompletions.filter((c) => {
+    const hits = customCompletions.filter((c) => {
       return c.indexOf(line) === 0;
     });
     // Show all completions if none found.
@@ -324,7 +324,7 @@ const testCustomCompleterAsyncMode = repl.start({
   input: putIn,
   output: putIn,
   completer: function completerAsyncMode(line, callback) {
-    var hits = customCompletions.filter((c) => {
+    const hits = customCompletions.filter((c) => {
       return c.indexOf(line) === 0;
     });
     // Show all completions if none found.

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -2,7 +2,7 @@
 
 var common = require('../common');
 var assert = require('assert');
-var repl   = require('repl');
+var repl = require('repl');
 
 function getNoResultsFunction() {
   return common.mustCall((err, data) => {
@@ -11,13 +11,13 @@ function getNoResultsFunction() {
   });
 }
 
-var works   = [['inner.one'], 'inner.o'];
+var works = [['inner.one'], 'inner.o'];
 const putIn = new common.ArrayStream();
-var testMe  = repl.start('', putIn);
+var testMe = repl.start('', putIn);
 
 // Some errors are passed to the domain, but do not callback
-testMe._domain.on('error', function (err) {
-  console.log(err)
+testMe._domain.on('error', function(err) {
+  console.log(err);
   assert.ifError(err);
 });
 
@@ -29,13 +29,13 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-testMe.complete('console.lo', common.mustCall(function (error, data) {
+testMe.complete('console.lo', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['console.log'], 'console.lo']);
 }));
 
-// Tab Complete will return globaly scoped variables
+// Tab Complete will return globally scoped variables
 putIn.run(['};']);
-testMe.complete('inner.o', common.mustCall(function (error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -56,7 +56,7 @@ putIn.run([
   'var top = function() {',
   'var inner = {one:1};'
 ]);
-testMe.complete('inner.o', common.mustCall(function (error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -74,7 +74,7 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', common.mustCall(function (error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -88,7 +88,7 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', common.mustCall(function (error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -103,7 +103,7 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', common.mustCall(function (error, data) {
+testMe.complete('inner.o', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -153,48 +153,47 @@ putIn.run(['.clear']);
 putIn.run([
   'var str = "test";'
 ]);
-testMe.complete('str.len', common.mustCall(function (error, data) {
+testMe.complete('str.len', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['str.length'], 'str.len']);
 }));
 
 putIn.run(['.clear']);
 
 // tab completion should not break on spaces
-var spaceTimeout = setTimeout(function () {
+var spaceTimeout = setTimeout(function() {
   throw new Error('timeout');
 }, 1000);
 
-testMe.complete(' ', common.mustCall(function (error, data) {
+testMe.complete(' ', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [[], undefined]);
   clearTimeout(spaceTimeout);
 }));
 
 // tab completion should pick up the global "toString" object, and
 // any other properties up the "global" object's prototype chain
-testMe.complete('toSt', common.mustCall(function (error, data) {
+testMe.complete('toSt', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['toString'], 'toSt']);
 }));
 
 // Tab complete provides built in libs for require()
 putIn.run(['.clear']);
 
-testMe.complete('require(\'', common.mustCall(function (error, data) {
+testMe.complete('require(\'', common.mustCall(function(error, data) {
   assert.strictEqual(error, null);
-  repl._builtinLibs.forEach(function (lib) {
+  repl._builtinLibs.forEach(function(lib) {
     assert.notStrictEqual(data[0].indexOf(lib), -1, lib + ' not found');
   });
 }));
 
-testMe.complete('require(\'n', common.mustCall(function (error, data) {
+testMe.complete('require(\'n', common.mustCall(function(error, data) {
   assert.strictEqual(error, null);
   assert.strictEqual(data.length, 2);
   assert.strictEqual(data[1], 'n');
   assert.notStrictEqual(data[0].indexOf('net'), -1);
   // It's possible to pick up non-core modules too
-  data[0].forEach(function (completion) {
-    if (completion) {
+  data[0].forEach(function(completion) {
+    if (completion)
       assert(/^n/.test(completion));
-    }
   });
 }));
 
@@ -204,7 +203,7 @@ putIn.run(['.clear']);
 putIn.run([
   'var custom = "test";'
 ]);
-testMe.complete('cus', common.mustCall(function (error, data) {
+testMe.complete('cus', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['custom'], 'cus']);
 }));
 
@@ -216,7 +215,7 @@ putIn.run([
   'var proxy = new Proxy({}, {ownKeys: () => { throw new Error(); }});'
 ]);
 
-testMe.complete('proxy.', common.mustCall(function (error, data) {
+testMe.complete('proxy.', common.mustCall(function(error, data) {
   assert.strictEqual(error, null);
 }));
 
@@ -224,7 +223,7 @@ testMe.complete('proxy.', common.mustCall(function (error, data) {
 putIn.run(['.clear']);
 
 putIn.run(['var ary = [1,2,3];']);
-testMe.complete('ary.', common.mustCall(function (error, data) {
+testMe.complete('ary.', common.mustCall(function(error, data) {
   assert.strictEqual(data[0].indexOf('ary.0'), -1);
   assert.strictEqual(data[0].indexOf('ary.1'), -1);
   assert.strictEqual(data[0].indexOf('ary.2'), -1);
@@ -234,7 +233,7 @@ testMe.complete('ary.', common.mustCall(function (error, data) {
 putIn.run(['.clear']);
 putIn.run(['var obj = {1:"a","1a":"b",a:"b"};']);
 
-testMe.complete('obj.', common.mustCall(function (error, data) {
+testMe.complete('obj.', common.mustCall(function(error, data) {
   assert.strictEqual(data[0].indexOf('obj.1'), -1);
   assert.strictEqual(data[0].indexOf('obj.1a'), -1);
   assert.notStrictEqual(data[0].indexOf('obj.a'), -1);
@@ -271,17 +270,13 @@ testMe.complete('.b', common.mustCall((error, data) => {
 }));
 
 const testNonGlobal = repl.start({
-  input    : putIn,
-  output   : putIn,
+  input: putIn,
+  output: putIn,
   useGlobal: false
 });
 
-const builtins = [
-  [
-    'Infinity', '', 'Int16Array', 'Int32Array',
-    'Int8Array'
-  ], 'I'
-];
+const builtins = [['Infinity', '', 'Int16Array', 'Int32Array',
+                                 'Int8Array'], 'I'];
 
 if (typeof Intl === 'object') {
   builtins[0].push('Intl');
@@ -294,12 +289,12 @@ testNonGlobal.complete('I', common.mustCall((error, data) => {
 // Sync mode.
 const customCompletions = 'aaa aa1 aa2 bbb bb1 bb2 bb3 ccc ddd eee'.split(' ');
 const testCustomCompleterSyncMode = repl.start({
-  prompt   : '',
-  input    : putIn,
-  output   : putIn,
+  prompt: '',
+  input: putIn,
+  output: putIn,
   completer: function completerSyncMode(line) {
     var hits = customCompletions.filter((c) => {
-      return c.indexOf(line) === 0
+      return c.indexOf(line) === 0;
     });
     // Show all completions if none found.
     return [hits.length ? hits : customCompletions, line];
@@ -326,12 +321,12 @@ testCustomCompleterSyncMode.complete('a', common.mustCall((error, data) => {
 // To test custom completer function.
 // Async mode.
 const testCustomCompleterAsyncMode = repl.start({
-  prompt   : '',
-  input    : putIn,
-  output   : putIn,
+  prompt: '',
+  input: putIn,
+  output: putIn,
   completer: function completerAsyncMode(line, callback) {
     var hits = customCompletions.filter((c) => {
-      return c.indexOf(line) === 0
+      return c.indexOf(line) === 0;
     });
     // Show all completions if none found.
     callback(null, [hits.length ? hits : customCompletions, line]);

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -2,7 +2,7 @@
 
 var common = require('../common');
 var assert = require('assert');
-var repl = require('repl');
+var repl   = require('repl');
 
 function getNoResultsFunction() {
   return common.mustCall((err, data) => {
@@ -11,12 +11,13 @@ function getNoResultsFunction() {
   });
 }
 
-var works = [['inner.one'], 'inner.o'];
+var works   = [['inner.one'], 'inner.o'];
 const putIn = new common.ArrayStream();
-var testMe = repl.start('', putIn);
+var testMe  = repl.start('', putIn);
 
 // Some errors are passed to the domain, but do not callback
-testMe._domain.on('error', function(err) {
+testMe._domain.on('error', function (err) {
+  console.log(err)
   assert.ifError(err);
 });
 
@@ -28,13 +29,13 @@ putIn.run([
 ]);
 testMe.complete('inner.o', getNoResultsFunction());
 
-testMe.complete('console.lo', common.mustCall(function(error, data) {
+testMe.complete('console.lo', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, [['console.log'], 'console.lo']);
 }));
 
 // Tab Complete will return globaly scoped variables
 putIn.run(['};']);
-testMe.complete('inner.o', common.mustCall(function(error, data) {
+testMe.complete('inner.o', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -55,7 +56,7 @@ putIn.run([
   'var top = function() {',
   'var inner = {one:1};'
 ]);
-testMe.complete('inner.o', common.mustCall(function(error, data) {
+testMe.complete('inner.o', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -73,7 +74,7 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', common.mustCall(function(error, data) {
+testMe.complete('inner.o', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -87,7 +88,7 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', common.mustCall(function(error, data) {
+testMe.complete('inner.o', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -102,7 +103,7 @@ putIn.run([
   ' one:1',
   '};'
 ]);
-testMe.complete('inner.o', common.mustCall(function(error, data) {
+testMe.complete('inner.o', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -152,47 +153,48 @@ putIn.run(['.clear']);
 putIn.run([
   'var str = "test";'
 ]);
-testMe.complete('str.len', common.mustCall(function(error, data) {
+testMe.complete('str.len', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, [['str.length'], 'str.len']);
 }));
 
 putIn.run(['.clear']);
 
 // tab completion should not break on spaces
-var spaceTimeout = setTimeout(function() {
+var spaceTimeout = setTimeout(function () {
   throw new Error('timeout');
 }, 1000);
 
-testMe.complete(' ', common.mustCall(function(error, data) {
+testMe.complete(' ', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, [[], undefined]);
   clearTimeout(spaceTimeout);
 }));
 
 // tab completion should pick up the global "toString" object, and
 // any other properties up the "global" object's prototype chain
-testMe.complete('toSt', common.mustCall(function(error, data) {
+testMe.complete('toSt', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, [['toString'], 'toSt']);
 }));
 
 // Tab complete provides built in libs for require()
 putIn.run(['.clear']);
 
-testMe.complete('require(\'', common.mustCall(function(error, data) {
+testMe.complete('require(\'', common.mustCall(function (error, data) {
   assert.strictEqual(error, null);
-  repl._builtinLibs.forEach(function(lib) {
+  repl._builtinLibs.forEach(function (lib) {
     assert.notStrictEqual(data[0].indexOf(lib), -1, lib + ' not found');
   });
 }));
 
-testMe.complete('require(\'n', common.mustCall(function(error, data) {
+testMe.complete('require(\'n', common.mustCall(function (error, data) {
   assert.strictEqual(error, null);
   assert.strictEqual(data.length, 2);
   assert.strictEqual(data[1], 'n');
   assert.notStrictEqual(data[0].indexOf('net'), -1);
   // It's possible to pick up non-core modules too
-  data[0].forEach(function(completion) {
-    if (completion)
+  data[0].forEach(function (completion) {
+    if (completion) {
       assert(/^n/.test(completion));
+    }
   });
 }));
 
@@ -202,7 +204,7 @@ putIn.run(['.clear']);
 putIn.run([
   'var custom = "test";'
 ]);
-testMe.complete('cus', common.mustCall(function(error, data) {
+testMe.complete('cus', common.mustCall(function (error, data) {
   assert.deepStrictEqual(data, [['custom'], 'cus']);
 }));
 
@@ -214,7 +216,7 @@ putIn.run([
   'var proxy = new Proxy({}, {ownKeys: () => { throw new Error(); }});'
 ]);
 
-testMe.complete('proxy.', common.mustCall(function(error, data) {
+testMe.complete('proxy.', common.mustCall(function (error, data) {
   assert.strictEqual(error, null);
 }));
 
@@ -222,7 +224,7 @@ testMe.complete('proxy.', common.mustCall(function(error, data) {
 putIn.run(['.clear']);
 
 putIn.run(['var ary = [1,2,3];']);
-testMe.complete('ary.', common.mustCall(function(error, data) {
+testMe.complete('ary.', common.mustCall(function (error, data) {
   assert.strictEqual(data[0].indexOf('ary.0'), -1);
   assert.strictEqual(data[0].indexOf('ary.1'), -1);
   assert.strictEqual(data[0].indexOf('ary.2'), -1);
@@ -232,7 +234,7 @@ testMe.complete('ary.', common.mustCall(function(error, data) {
 putIn.run(['.clear']);
 putIn.run(['var obj = {1:"a","1a":"b",a:"b"};']);
 
-testMe.complete('obj.', common.mustCall(function(error, data) {
+testMe.complete('obj.', common.mustCall(function (error, data) {
   assert.strictEqual(data[0].indexOf('obj.1'), -1);
   assert.strictEqual(data[0].indexOf('obj.1a'), -1);
   assert.notStrictEqual(data[0].indexOf('obj.a'), -1);
@@ -269,17 +271,86 @@ testMe.complete('.b', common.mustCall((error, data) => {
 }));
 
 const testNonGlobal = repl.start({
-  input: putIn,
-  output: putIn,
+  input    : putIn,
+  output   : putIn,
   useGlobal: false
 });
 
-const builtins = [['Infinity', '', 'Int16Array', 'Int32Array',
-                                 'Int8Array'], 'I'];
+const builtins = [
+  [
+    'Infinity', '', 'Int16Array', 'Int32Array',
+    'Int8Array'
+  ], 'I'
+];
 
 if (typeof Intl === 'object') {
   builtins[0].push('Intl');
 }
 testNonGlobal.complete('I', common.mustCall((error, data) => {
   assert.deepStrictEqual(data, builtins);
+}));
+
+// To test custom completer function.
+// Sync mode.
+const customCompletions = 'aaa aa1 aa2 bbb bb1 bb2 bb3 ccc ddd eee'.split(' ');
+const testCustomCompleterSyncMode = repl.start({
+  prompt   : '',
+  input    : putIn,
+  output   : putIn,
+  completer: function completerSyncMode(line) {
+    var hits = customCompletions.filter((c) => {
+      return c.indexOf(line) === 0
+    });
+    // Show all completions if none found.
+    return [hits.length ? hits : customCompletions, line];
+  }
+});
+
+// On empty line should output all the custom completions
+// without complete anything.
+testCustomCompleterSyncMode.complete('', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [
+    customCompletions,
+    ''
+  ]);
+}));
+
+// On `a` should output `aaa aa1 aa2` and complete until `aa`.
+testCustomCompleterSyncMode.complete('a', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [
+    'aaa aa1 aa2'.split(' '),
+    'a'
+  ]);
+}));
+
+// To test custom completer function.
+// Async mode.
+const testCustomCompleterAsyncMode = repl.start({
+  prompt   : '',
+  input    : putIn,
+  output   : putIn,
+  completer: function completerAsyncMode(line, callback) {
+    var hits = customCompletions.filter((c) => {
+      return c.indexOf(line) === 0
+    });
+    // Show all completions if none found.
+    callback(null, [hits.length ? hits : customCompletions, line]);
+  }
+});
+
+// On empty line should output all the custom completions
+// without complete anything.
+testCustomCompleterAsyncMode.complete('', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [
+    customCompletions,
+    ''
+  ]);
+}));
+
+// On `a` should output `aaa aa1 aa2` and complete until `aa`.
+testCustomCompleterAsyncMode.complete('a', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [
+    'aaa aa1 aa2'.split(' '),
+    'a'
+  ]);
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes

It threw errors **but not** related to the new changes for what I can say.
I ran `./node ./test/parallel/./test/parallel/test-repl-tab-complete.js` and it does it OK. At the end is the error log JIC.

**UPDATE:**

It seems that is an issue with my dev environment, @lance (see in commets) ran the tests and they ran OK. 

- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
repl, doc


##### Description of change

_Original description of PR, since this is an old PR of mine to the extint v0.13.x, references of old PR at the end._

Currently I'm working on a project that uses the REPL to implement a mid complex CLI app found out that the REPL module doesn't have a way to override the default readline `complete()` function, which is used for TAB completions of commands.

I think that the REPL module can benefit from this addition, and specifically the repl applications that may wants to use this functionality.

I added the docs & tests, and the tests passed fine in my environment, this is just a little change, after all.

Simple usage example:

```js
var repl = require('repl')
  .start({
    terminal : true,
    completer: function completer(line) {
      var completions = 'aaa aa1 aa2 bbb ccc ddd eee'.split(' ');

      var hits = completions.filter(function (item) {
        return item.indexOf(line) == 0;
      });

      // Show all completions if none was found.
      return [
        hits.length
          ? hits
          : completions,
        line
      ];
    }
  });
```

References for the old PR:

https://github.com/nodejs/node-v0.x-archive/pull/8484

**Error thrown by `make -j4 test`:**

```
make -C out BUILDTYPE=Release V=1
make[1]: Entering directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out'
  touch _media_diosney_3E2AC0882AC03F21_Users_diosney_Documents_Dev_node_deps_v8_inspector_platform_v8_inspector_v8_inspector_gyp_protocol_sources_target_generateV8InspectorProtocolBackendSources.intermediate
  LD_LIBRARY_PATH=/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/lib.host:/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/v8_inspector/platform/v8_inspector; mkdir -p /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/obj/gen/blink/platform/v8_inspector/protocol; python ../inspector_protocol/CodeGenerator.py --protocol js_protocol.json --string_type String16 --export_macro PLATFORM_EXPORT --output_dir "/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/obj/gen/blink/platform/v8_inspector/protocol" --output_package platform/v8_inspector/protocol
rm _media_diosney_3E2AC0882AC03F21_Users_diosney_Documents_Dev_node_deps_v8_inspector_platform_v8_inspector_v8_inspector_gyp_protocol_sources_target_generateV8InspectorProtocolBackendSources.intermediate
make[1]: Leaving directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out'
ln -fs out/Release/node node
make build-addons
make[1]: Entering directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node'
make -C out BUILDTYPE=Release V=1
make[2]: Entering directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out'
  touch _media_diosney_3E2AC0882AC03F21_Users_diosney_Documents_Dev_node_deps_v8_inspector_platform_v8_inspector_v8_inspector_gyp_protocol_sources_target_generateV8InspectorProtocolBackendSources.intermediate
  LD_LIBRARY_PATH=/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/lib.host:/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/v8_inspector/platform/v8_inspector; mkdir -p /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/obj/gen/blink/platform/v8_inspector/protocol; python ../inspector_protocol/CodeGenerator.py --protocol js_protocol.json --string_type String16 --export_macro PLATFORM_EXPORT --output_dir "/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/obj/gen/blink/platform/v8_inspector/protocol" --output_package platform/v8_inspector/protocol
rm _media_diosney_3E2AC0882AC03F21_Users_diosney_Documents_Dev_node_deps_v8_inspector_platform_v8_inspector_v8_inspector_gyp_protocol_sources_target_generateV8InspectorProtocolBackendSources.intermediate
make[2]: Leaving directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out'
ln -fs out/Release/node node
make[1]: Leaving directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node'
make cctest
make[1]: Entering directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node'
make -C out BUILDTYPE=Release V=1
make[2]: Entering directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out'
  touch _media_diosney_3E2AC0882AC03F21_Users_diosney_Documents_Dev_node_deps_v8_inspector_platform_v8_inspector_v8_inspector_gyp_protocol_sources_target_generateV8InspectorProtocolBackendSources.intermediate
  LD_LIBRARY_PATH=/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/lib.host:/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../deps/v8_inspector/platform/v8_inspector; mkdir -p /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/obj/gen/blink/platform/v8_inspector/protocol; python ../inspector_protocol/CodeGenerator.py --protocol js_protocol.json --string_type String16 --export_macro PLATFORM_EXPORT --output_dir "/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out/Release/obj/gen/blink/platform/v8_inspector/protocol" --output_package platform/v8_inspector/protocol
rm _media_diosney_3E2AC0882AC03F21_Users_diosney_Documents_Dev_node_deps_v8_inspector_platform_v8_inspector_v8_inspector_gyp_protocol_sources_target_generateV8InspectorProtocolBackendSources.intermediate
make[2]: Leaving directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/out'
ln -fs out/Release/node node
Running main() from gtest_main.cc
[==========] Running 22 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 4 tests from UtilTest
[ RUN      ] UtilTest.ListHead
[       OK ] UtilTest.ListHead (0 ms)
[ RUN      ] UtilTest.StringEqualNoCase
[       OK ] UtilTest.StringEqualNoCase (0 ms)
[ RUN      ] UtilTest.StringEqualNoCaseN
[       OK ] UtilTest.StringEqualNoCaseN (0 ms)
[ RUN      ] UtilTest.ToLower
[       OK ] UtilTest.ToLower (0 ms)
[----------] 4 tests from UtilTest (0 ms total)

[----------] 18 tests from InspectorSocketTest
[ RUN      ] InspectorSocketTest.ReadsAndWritesInspectorMessage
[       OK ] InspectorSocketTest.ReadsAndWritesInspectorMessage (1 ms)
[ RUN      ] InspectorSocketTest.BufferEdgeCases
[       OK ] InspectorSocketTest.BufferEdgeCases (0 ms)
[ RUN      ] InspectorSocketTest.AcceptsRequestInSeveralWrites
[       OK ] InspectorSocketTest.AcceptsRequestInSeveralWrites (0 ms)
[ RUN      ] InspectorSocketTest.ExtraTextBeforeRequest
[       OK ] InspectorSocketTest.ExtraTextBeforeRequest (1 ms)
[ RUN      ] InspectorSocketTest.ExtraLettersBeforeRequest
[       OK ] InspectorSocketTest.ExtraLettersBeforeRequest (0 ms)
[ RUN      ] InspectorSocketTest.RequestWithoutKey
[       OK ] InspectorSocketTest.RequestWithoutKey (0 ms)
[ RUN      ] InspectorSocketTest.KillsConnectionOnProtocolViolation
[       OK ] InspectorSocketTest.KillsConnectionOnProtocolViolation (1 ms)
[ RUN      ] InspectorSocketTest.CanStopReadingFromInspector
[       OK ] InspectorSocketTest.CanStopReadingFromInspector (0 ms)
[ RUN      ] InspectorSocketTest.CloseDoesNotNotifyReadCallback
[       OK ] InspectorSocketTest.CloseDoesNotNotifyReadCallback (1 ms)
[ RUN      ] InspectorSocketTest.CloseWorksWithoutReadEnabled
[       OK ] InspectorSocketTest.CloseWorksWithoutReadEnabled (0 ms)
[ RUN      ] InspectorSocketTest.ReportsHttpGet
[       OK ] InspectorSocketTest.ReportsHttpGet (2 ms)
[ RUN      ] InspectorSocketTest.HandshakeCanBeCanceled
[       OK ] InspectorSocketTest.HandshakeCanBeCanceled (0 ms)
[ RUN      ] InspectorSocketTest.GetThenHandshake
[       OK ] InspectorSocketTest.GetThenHandshake (1 ms)
[ RUN      ] InspectorSocketTest.WriteBeforeHandshake
[       OK ] InspectorSocketTest.WriteBeforeHandshake (0 ms)
[ RUN      ] InspectorSocketTest.CleanupSocketAfterEOF
[       OK ] InspectorSocketTest.CleanupSocketAfterEOF (3 ms)
[ RUN      ] InspectorSocketTest.EOFBeforeHandshake
[       OK ] InspectorSocketTest.EOFBeforeHandshake (1 ms)
[ RUN      ] InspectorSocketTest.Send1Mb
[       OK ] InspectorSocketTest.Send1Mb (19 ms)
[ RUN      ] InspectorSocketTest.ErrorCleansUpTheSocket
[       OK ] InspectorSocketTest.ErrorCleansUpTheSocket (1 ms)
[----------] 18 tests from InspectorSocketTest (31 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 2 test cases ran. (31 ms total)
[  PASSED  ] 22 tests.
make[1]: Leaving directory '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node'
/usr/bin/python tools/test.py --mode=release -J \
        addon doctool known_issues message pseudo-tty parallel sequential
=== release test-child-process-uid-gid ===                                     
Path: parallel/test-child-process-uid-gid
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: Missing expected exception..
    at _throws (assert.js:337:5)
    at Function.assert.throws (assert.js:361:3)
    at Object.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-child-process-uid-gid.js:8:8)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:340:7)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-child-process-uid-gid.js
=== release test-fs-access ===                                                 
Path: parallel/test-fs-access
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: Got unwanted exception..
    at _throws (assert.js:348:5)
    at Function.assert.doesNotThrow (assert.js:366:3)
    at Object.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-access.js:105:8)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:340:7)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-access.js
=== release test-fs-append-file ===              
Path: parallel/test-fs-append-file
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 448 == 384
    at /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-append-file.js:84:12
    at FSReqWrap.oncomplete (fs.js:123:15)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-append-file.js
=== release test-fs-append-file-sync ===                    
Path: parallel/test-fs-append-file-sync
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 448 == 384
    at Object.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-append-file-sync.js:61:10)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:340:7)
    at startup (bootstrap_node.js:132:9)
    at bootstrap_node.js:455:3
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-append-file-sync.js
=== release test-fs-chmod ===                              
Path: parallel/test-fs-chmod
33279
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 420 == 511
    at /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-chmod.js:73:14
    at FSReqWrap.oncomplete (fs.js:123:15)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-chmod.js
=== release test-fs-readdir-ucs2 ===                                    
Path: parallel/test-fs-readdir-ucs2
fs.js:640
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: Unknown system error -84: Unknown system error -84, open '/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/tmp.3/=��'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-readdir-ucs2.js:19:17)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:340:7)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-readdir-ucs2.js
=== release test-fs-write-file ===                                       
Path: parallel/test-fs-write-file
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 448 == 384
    at /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-write-file.js:60:12
    at FSReqWrap.oncomplete (fs.js:123:15)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-write-file.js
=== release test-fs-write-file-sync ===                                  
Path: parallel/test-fs-write-file-sync
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 493 == 511
    at Object.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-write-file-sync.js:38:8)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:340:7)
    at startup (bootstrap_node.js:132:9)
    at bootstrap_node.js:455:3
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-fs-write-file-sync.js
=== release test-https-connect-address-family ===                              
Path: parallel/test-https-connect-address-family
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo EAI_AGAIN localhost:12346
    at Object.exports._errnoException (util.js:1007:11)
    at errnoException (dns.js:33:15)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:79:26)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-https-connect-address-family.js
=== release test-net-better-error-messages-port-hostname ===                   
Path: parallel/test-net-better-error-messages-port-hostname
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 'EAI_AGAIN' == 'ENOTFOUND'
    at Socket.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-net-better-error-messages-port-hostname.js:11:10)
    at Socket.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/common.js:407:15)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at connectErrorNT (net.js:1016:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-net-better-error-messages-port-hostname.js
=== release test-net-connect-immediate-finish ===                       
Path: parallel/test-net-connect-immediate-finish
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: 'EAI_AGAIN' === 'ENOTFOUND'
    at Socket.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-net-connect-immediate-finish.js:11:10)
    at Socket.<anonymous> (/media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/common.js:407:15)
    at Socket.g (events.js:286:16)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at connectErrorNT (net.js:1016:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-net-connect-immediate-finish.js
=== release test-repl-history-perm ===                                         
Path: parallel/test-repl-history-perm
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: REPL history file should be mode 0600
    at /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-repl-history-perm.js:40:10
    at /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/common.js:407:15
    at REPLServer.<anonymous> (internal/repl.js:180:7)
    at REPLServer.g (events.js:286:16)
    at emitNone (events.js:86:13)
    at REPLServer.emit (events.js:185:7)
    at onwritten (internal/repl.js:215:14)
    at FSReqWrap.wrapper [as oncomplete] (fs.js:747:5)
Command: out/Release/node --expose_internals /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-repl-history-perm.js
=== release test-tls-connect-address-family ===                                
Path: parallel/test-tls-connect-address-family
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo EAI_AGAIN localhost:12346
    at Object.exports._errnoException (util.js:1007:11)
    at errnoException (dns.js:33:15)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:79:26)
Command: out/Release/node /media/diosney/3E2AC0882AC03F21/Users/diosney/Documents/Dev/node/test/parallel/test-tls-connect-address-family.js
[01:28|% 100|+ 1146|-  13]: Done                                               
Makefile:118: recipe for target 'test' failed
make: *** [test] Error 1
