### PR TITLE
doc: dns.resolve wrong callback addresses argument description.

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -174,7 +174,9 @@ Valid values for `rrtype` are:
  * `'NAPTR'` - name authority pointer record
 
 The `callback` function has arguments `(err, addresses)`. When successful,
-`addresses` will be an array. The type of each  item in `addresses` is
+`addresses` will be an array, except when resolving an SOA record which returns
+an object structured in the same manner as one returned by the
+[`dns.resolveSoa()`][] method. The type of each item in `addresses` is
 determined by the record type, and described in the documentation for the
 corresponding lookup methods.
 
@@ -437,6 +439,7 @@ uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 [`dns.lookup()`]: #dns_dns_lookup_hostname_options_callback
 [`dns.resolve()`]: #dns_dns_resolve_hostname_rrtype_callback
 [`dns.resolve4()`]: #dns_dns_resolve4_hostname_callback
+[`dns.resolveSoa()`]: #dns_dns_resolvesoa_hostname_callback
 [`Error`]: errors.html#errors_class_error
 [Implementation considerations section]: #dns_implementation_considerations
 [supported `getaddrinfo` flags]: #dns_supported_getaddrinfo_flags


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of Change

The dns.resolve documentation stated that an array of IP
addresses would be returned in the callback. This is true
for everything other than the SOA record which returns an object.
This fixes that documentation.

Fixes: https://github.com/nodejs/node/issues/6506