### PR TITLE
docs: Added information on how to run the linter.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,12 +50,6 @@ To run the tests:
 $ make test
 ```
 
-To run only the linter (it will also run as part of `make test`):
-
-```text
-$ make lint
-```
-
 To run the native module tests:
 
 ```text

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,7 +50,7 @@ To run the tests:
 $ make test
 ```
 
-To run the linter:
+To run only the linter (it will also run as part of `make test`):
 
 ```text
 $ make lint

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,6 +50,12 @@ To run the tests:
 $ make test
 ```
 
+To run the linter:
+
+```text
+$ make lint
+```
+
 To run the native module tests:
 
 ```text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
 The linter will be run as part of `make test`, but it won't if any tests failed.
-However you can run it directly by executing:
+If you need to run it directly despite the failing tests, you can execute:
 
 ```text
 $ make lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,8 @@ $ ./configure && make -j8 test
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-You can check if the linter is happy by running:
+The linter will be run as part of `make test`, but you can test it directly 
+by running:
 
 ```text
 $ make lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,12 @@ $ ./configure && make -j8 test
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
+You can check if the linter is happy by running:
+
+```text
+$ make lint
+```
+
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,8 @@ $ ./configure && make -j8 test
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-The linter will be run as part of `make test`, but you can test it directly 
-by running:
+The linter will be run as part of `make test`, but it won't if any tests failed.
+However you can run it directly by executing:
 
 ```text
 $ make lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,12 +150,8 @@ $ ./configure && make -j8 test
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-The linter will be run as part of `make test`, but it won't if any tests failed.
-If you need to run it directly despite the failing tests, you can execute:
-
-```text
-$ make lint
-```
+Running `make test` will run the linter as well unless one or more tests fail.
+If you want to run the linter without running tests, you can use `make lint`.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
 Running `make test` will run the linter as well unless one or more tests fail.
-If you want to run the linter without running tests, you can use `make lint`.
+If you want to run the linter without running tests, use `make lint`.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc


##### Description of change

Right now there is no information in the building & testing docs on how to run the linter directly, which is useful so it can save time and separate tasks if one is checking only code style instead of checking the whole test suite.

