### PR TITLE
Backport for v4.x: test,win: skip addons/load-long-path on WOW64

### DIFF
--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
+if (common.isWOW64) {
+  common.skip('doesn\'t work on WOW64');
+  return;
+}
+
 common.refreshTmpDir();
 
 // make a path that is more than 260 chars long.

--- a/test/common.js
+++ b/test/common.js
@@ -17,6 +17,8 @@ exports.libDir = path.join(exports.testDir, '../lib');
 exports.tmpDirName = 'tmp';
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 exports.isWindows = process.platform === 'win32';
+exports.isWOW64 = exports.isWindows &&
+                  (process.env['PROCESSOR_ARCHITEW6432'] !== undefined);
 exports.isAix = process.platform === 'aix';
 exports.isLinuxPPCBE = (process.platform === 'linux') &&
                        (process.arch === 'ppc64') &&


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

@nodejs/lts, this is a clean backport of https://github.com/nodejs/node/pull/6675. 

Ref: https://github.com/nodejs/node/pull/6675#issuecomment-230265626
