### PR TITLE
build: add --enable-d8 configure option

### DIFF
--- a/configure
+++ b/configure
@@ -248,6 +248,11 @@ parser.add_option('--release-urlbase',
          '`sourceUrl` and `headersUrl`. When compiling a release build, this '
          'will default to https://nodejs.org/download/release/')
 
+parser.add_option('--enable-d8',
+    action='store_true',
+    dest='enable_d8',
+    help=optparse.SUPPRESS_HELP)  # Unsupported, undocumented.
+
 parser.add_option('--v8-options',
     action='store',
     dest='v8_options',
@@ -835,8 +840,6 @@ def configure_node(o):
 
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   o['variables']['node_shared'] = b(options.shared)
-  o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
-  o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
   o['variables']['node_module_version'] = int(getmoduleversion.get_version())
 
   if options.linked_module:
@@ -884,6 +887,14 @@ def configure_v8(o):
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
+  o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
+  o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
+  o['variables']['node_enable_d8'] = b(options.enable_d8)
+  if options.enable_d8:
+    o['variables']['test_isolation_mode'] = 'noop'  # Needed by d8.gyp.
+  if options.without_bundled_v8 and options.enable_d8:
+    raise Exception('--enable-d8 is incompatible with --without-bundled-v8.')
+
 
 def configure_openssl(o):
   o['variables']['node_use_openssl'] = b(not options.without_ssl)

--- a/node.gyp
+++ b/node.gyp
@@ -248,6 +248,9 @@
             }]
           ],
         }],
+        [ 'node_enable_d8=="true"', {
+          'dependencies': [ 'deps/v8/src/d8.gyp:d8' ],
+        }],
         [ 'node_use_bundled_v8=="true"', {
           'dependencies': [
             'deps/v8/tools/gyp/v8.gyp:v8',


### PR DESCRIPTION
Add an option to the configure script for building d8.  Useful for
testing V8 standalone.