### PR TITLE
doc: fix detached child stdio example

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -430,7 +430,7 @@ const spawn = require('child_process').spawn;
 
 const child = spawn(process.argv[0], ['child_program.js'], {
   detached: true,
-  stdio: ['ignore']
+  stdio: 'ignore'
 });
 
 child.unref();


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change

The example uses `['ignore']`, where `'ignore'` is intended. This commit drops the extra braces.

Fixes: https://github.com/nodejs/node/issues/7269
