### PR TITLE
lib: use rest params over simple argument copy

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -639,18 +639,10 @@ ClientRequest.prototype.setTimeout = function(msecs, callback) {
   return this;
 };
 
-ClientRequest.prototype.setNoDelay = function() {
-  const argsLen = arguments.length;
-  const args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
+ClientRequest.prototype.setNoDelay = function(...args) {
   this._deferToConnect('setNoDelay', args);
 };
-ClientRequest.prototype.setSocketKeepAlive = function() {
-  const argsLen = arguments.length;
-  const args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
+ClientRequest.prototype.setSocketKeepAlive = function(...args) {
   this._deferToConnect('setKeepAlive', args);
 };
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -965,11 +965,7 @@ function normalizeConnectArgs(listArgs) {
   return (cb) ? [options, cb] : [options];
 }
 
-exports.connect = function(/* [port, host], options, cb */) {
-  const argsLen = arguments.length;
-  var args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
+exports.connect = function(...args /* [port, host], options, cb */) {
   args = normalizeConnectArgs(args);
   var options = args[0];
   var cb = args[1];

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -202,20 +202,15 @@ Domain.prototype.remove = function(ee) {
 };
 
 
-Domain.prototype.run = function(fn) {
+Domain.prototype.run = function(fn, ...args) {
   if (this._disposed)
     return;
 
   var ret;
 
   this.enter();
-  if (arguments.length >= 2) {
-    var len = arguments.length;
-    var args = new Array(len - 1);
 
-    for (var i = 1; i < len; i++)
-      args[i - 1] = arguments[i];
-
+  if (args.length > 0) {
     ret = fn.apply(this, args);
   } else {
     ret = fn.call(this);

--- a/lib/net.js
+++ b/lib/net.js
@@ -59,11 +59,7 @@ exports.createServer = function(options, connectionListener) {
 // connect(port, [host], [cb])
 // connect(path, [cb]);
 //
-exports.connect = exports.createConnection = function() {
-  const argsLen = arguments.length;
-  var args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
+exports.connect = exports.createConnection = function(...args) {
   args = normalizeConnectArgs(args);
   debug('createConnection', args);
   var s = new Socket(args[0]);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
lib

##### Description of change
This commit replaces straightforward copying of `arguments` with rest parameters.