### PR TITLE
test: really run addon tests on `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test: all
 	$(MAKE) build-addons
 	$(MAKE) cctest
 	$(PYTHON) tools/test.py --mode=release -J \
-		addon doctool known_issues message pseudo-tty parallel sequential
+		addons doctool known_issues message pseudo-tty parallel sequential
 	$(MAKE) lint
 
 test-parallel: all


### PR DESCRIPTION
Fix a `s/addon/addons/` typo in the Makefile.

CI: https://ci.nodejs.org/job/node-test-commit/3974/