### PR TITLE
util: general improvements to util.inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -233,14 +233,11 @@ inspect.styles = {
 
 
 function stylizeWithColor(str, styleType) {
-  var style = inspect.styles[styleType];
+  const style = inspect.styles[styleType];
 
-  if (style) {
-    return '\u001b[' + inspect.colors[style][0] + 'm' + str +
-           '\u001b[' + inspect.colors[style][1] + 'm';
-  } else {
-    return str;
-  }
+  return style ?
+      `\u001b[${inspect.colors[style][0]}m${str}` +
+      `\u001b[${inspect.colors[style][1]}m` : str;
 }
 
 
@@ -253,8 +250,7 @@ function arrayToHash(array) {
   var hash = Object.create(null);
 
   for (var i = 0; i < array.length; i++) {
-    var val = array[i];
-    hash[val] = true;
+    hash[array[i]] = true;
   }
 
   return hash;
@@ -287,15 +283,11 @@ function ensureDebugIsInitialized() {
 
 function inspectPromise(p) {
   ensureDebugIsInitialized();
-  // Only create a mirror if the object is a Promise.
-  if (!binding.isPromise(p))
-    return null;
   const mirror = Debug.MakeMirror(p, true);
   return {status: mirror.status(), value: mirror.promiseValue().value_};
 }
 
-
-function formatValue(ctx, value, recurseTimes) {
+function formatProxy(ctx, value, recurseTimes) {
   if (ctx.showProxy &&
       ((typeof value === 'object' && value !== null) ||
        typeof value === 'function')) {
@@ -332,12 +324,12 @@ function formatValue(ctx, value, recurseTimes) {
       proxyCache.set(value, proxy);
     }
     if (proxy) {
-      return 'Proxy ' + formatValue(ctx, proxy, recurseTimes);
+      return `Proxy ${formatValue(ctx, proxy, recurseTimes)}`;
     }
   }
+}
 
-  // Provide a hook for user-specified inspect functions.
-  // Check that value is an object with an inspect function on it
+function formatCustomInspect(ctx, value, recurseTimes) {
   if (ctx.customInspect &&
       value &&
       typeof value.inspect === 'function' &&
@@ -351,12 +343,35 @@ function formatValue(ctx, value, recurseTimes) {
     }
     return ret;
   }
+}
+
+function handleDateRaw(value) {
+  var raw = value;
+  try {
+    // the .valueOf() call can fail for a multitude of reasons
+    if (!isDate(value))
+      raw = value.valueOf();
+  } catch (e) {
+    // ignore...
+  }
+  return raw;
+}
+
+function formatValue(ctx, value, recurseTimes) {
+  const proxyRet = formatProxy(ctx, value, recurseTimes);
+  if (proxyRet)
+    return proxyRet;
+
+  // Provide a hook for user-specified inspect functions.
+  // Check that value is an object with an inspect function on it
+  const customRet = formatCustomInspect(ctx, value, recurseTimes);
+  if (customRet)
+    return customRet;
 
   // Primitive types cannot have properties
-  var primitive = formatPrimitive(ctx, value);
-  if (primitive) {
+  const primitive = formatPrimitive(ctx, value);
+  if (primitive)
     return primitive;
-  }
 
   // Look up the keys of the object.
   var keys = Object.keys(value);
@@ -372,19 +387,12 @@ function formatValue(ctx, value, recurseTimes) {
   // a number which, when object has some additional user-stored `keys`,
   // will be printed out.
   var formatted;
-  var raw = value;
-  try {
-    // the .valueOf() call can fail for a multitude of reasons
-    if (!isDate(value))
-      raw = value.valueOf();
-  } catch (e) {
-    // ignore...
-  }
+  var raw = handleDateRaw(value);
 
   if (typeof raw === 'string') {
     // for boxed Strings, we have to remove the 0-n indexed entries,
     // since they just noisy up the output and are redundant
-    keys = keys.filter(function(key) {
+    keys = keys.filter((key) => {
       return !(key >= 0 && key < raw.length);
     });
   }
@@ -392,18 +400,16 @@ function formatValue(ctx, value, recurseTimes) {
   // Some type of object without properties can be shortcutted.
   if (keys.length === 0) {
     if (typeof value === 'function') {
-      var name = value.name ? ': ' + value.name : '';
-      return ctx.stylize('[Function' + name + ']', 'special');
+      const name = value.name ? `: ${value.name}` : '';
+      return ctx.stylize(`[Function${name}]`, 'special');
     }
     if (isRegExp(value)) {
       return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
     }
     if (isDate(value)) {
-      if (Number.isNaN(value.getTime())) {
-        return ctx.stylize(value.toString(), 'date');
-      } else {
-        return ctx.stylize(Date.prototype.toISOString.call(value), 'date');
-      }
+      return Number.isNaN(value.getTime()) ?
+          ctx.stylize(value.toString(), 'date') :
+          ctx.stylize(Date.prototype.toISOString.call(value), 'date');
     }
     if (isError(value)) {
       return formatError(value);
@@ -411,15 +417,15 @@ function formatValue(ctx, value, recurseTimes) {
     // now check the `raw` value to handle boxed primitives
     if (typeof raw === 'string') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[String: ' + formatted + ']', 'string');
+      return ctx.stylize(`[String: ${formatted}]`, 'string');
     }
     if (typeof raw === 'number') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[Number: ' + formatted + ']', 'number');
+      return ctx.stylize(`[Number: ${formatted}]`, 'number');
     }
     if (typeof raw === 'boolean') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[Boolean: ' + formatted + ']', 'boolean');
+      return ctx.stylize(`[Boolean: ${formatted}]`, 'boolean');
     }
     // Fast path for ArrayBuffer.  Can't do the same for DataView because it
     // has a non-primitive .buffer property that we need to recurse for.
@@ -445,129 +451,129 @@ function formatValue(ctx, value, recurseTimes) {
     braces = ['[', ']'];
     empty = value.length === 0;
     formatter = formatArray;
-  } else if (binding.isSet(value)) {
-    braces = ['{', '}'];
-    // With `showHidden`, `length` will display as a hidden property for
-    // arrays. For consistency's sake, do the same for `size`, even though this
-    // property isn't selected by Object.getOwnPropertyNames().
-    if (ctx.showHidden)
-      keys.unshift('size');
-    empty = value.size === 0;
-    formatter = formatSet;
-  } else if (binding.isMap(value)) {
-    braces = ['{', '}'];
-    // Ditto.
-    if (ctx.showHidden)
-      keys.unshift('size');
-    empty = value.size === 0;
-    formatter = formatMap;
-  } else if (binding.isArrayBuffer(value)) {
-    braces = ['{', '}'];
-    keys.unshift('byteLength');
-    visibleKeys.byteLength = true;
-  } else if (binding.isDataView(value)) {
-    braces = ['{', '}'];
-    // .buffer goes last, it's not a primitive like the others.
-    keys.unshift('byteLength', 'byteOffset', 'buffer');
-    visibleKeys.byteLength = true;
-    visibleKeys.byteOffset = true;
-    visibleKeys.buffer = true;
-  } else if (binding.isTypedArray(value)) {
-    braces = ['[', ']'];
-    formatter = formatTypedArray;
-    if (ctx.showHidden) {
-      // .buffer goes last, it's not a primitive like the others.
-      keys.unshift('BYTES_PER_ELEMENT',
-                   'length',
-                   'byteLength',
-                   'byteOffset',
-                   'buffer');
-    }
   } else if (simdFormatters &&
              typeof value.constructor === 'function' &&
              (formatter = simdFormatters.get(value.constructor))) {
     braces = ['[', ']'];
   } else {
-    var promiseInternals = inspectPromise(value);
-    if (promiseInternals) {
-      braces = ['{', '}'];
-      formatter = formatPromise;
-    } else {
-      if (binding.isMapIterator(value)) {
+    switch (binding.getType(value)) {
+      case 'isSet':
+        braces = ['{', '}'];
+        // With `showHidden`, `length` will display as a hidden property for
+        // arrays. For consistency's sake, do the same for `size`, even
+        // though this property isn't selected by
+        // Object.getOwnPropertyNames().
+        if (ctx.showHidden)
+          keys.unshift('size');
+        empty = value.size === 0;
+        formatter = formatSet;
+        break;
+      case 'isMap':
+        braces = ['{', '}'];
+        // Ditto.
+        if (ctx.showHidden)
+          keys.unshift('size');
+        empty = value.size === 0;
+        formatter = formatMap;
+        break;
+      case 'isArrayBuffer':
+        braces = ['{', '}'];
+        keys.unshift('byteLength');
+        visibleKeys.byteLength = true;
+        break;
+      case 'isDataView':
+        braces = ['{', '}'];
+        // .buffer goes last, it's not a primitive like the others.
+        keys.unshift('byteLength', 'byteOffset', 'buffer');
+        visibleKeys.byteLength = true;
+        visibleKeys.byteOffset = true;
+        visibleKeys.buffer = true;
+        break;
+      case 'isTypedArray':
+        braces = ['[', ']'];
+        formatter = formatTypedArray;
+        if (ctx.showHidden) {
+          // .buffer goes last, it's not a primitive like the others.
+          keys.unshift('BYTES_PER_ELEMENT',
+                       'length',
+                       'byteLength',
+                       'byteOffset',
+                       'buffer');
+        }
+        break;
+      case 'isMapIterator':
         constructor = { name: 'MapIterator' };
         braces = ['{', '}'];
         empty = false;
         formatter = formatCollectionIterator;
-      } else if (binding.isSetIterator(value)) {
+        break;
+      case 'isSetIterator':
         constructor = { name: 'SetIterator' };
         braces = ['{', '}'];
         empty = false;
         formatter = formatCollectionIterator;
-      } else {
-        // Unset the constructor to prevent "Object {...}" for ordinary objects.
+        break;
+      case 'isPromise':
+        braces = ['{', '}'];
+        formatter = formatPromise;
+        break;
+      default:
+        // Unset the constructor to prevent "Object {...}" for ordinary
+        // objects.
         if (constructor && constructor.name === 'Object')
           constructor = null;
         braces = ['{', '}'];
         empty = true;  // No other data than keys.
-      }
     }
   }
 
   empty = empty === true && keys.length === 0;
 
-  // Make functions say that they are functions
   if (typeof value === 'function') {
-    var n = value.name ? ': ' + value.name : '';
-    base = ' [Function' + n + ']';
+    // Make functions say that they are functions
+    var n = value.name ? `: ${value.name}` : '';
+    base = ` [Function${n}]`;
+  } else if (isRegExp(value)) {
+    // Make RegExps say that they are RegExps
+    base = ` ${RegExp.prototype.toString.call(value)}`;
+  } else if (isDate(value)) {
+    // Make dates with properties first say the date
+    base = ` ${Date.prototype.toISOString.call(value)}`;
+  } else if (isError(value)) {
+    // Make error with message first say the error
+    base = ` ${formatError(value)}`;
   }
 
-  // Make RegExps say that they are RegExps
-  if (isRegExp(value)) {
-    base = ' ' + RegExp.prototype.toString.call(value);
-  }
-
-  // Make dates with properties first say the date
-  if (isDate(value)) {
-    base = ' ' + Date.prototype.toISOString.call(value);
-  }
-
-  // Make error with message first say the error
-  if (isError(value)) {
-    base = ' ' + formatError(value);
-  }
-
-  // Make boxed primitive Strings look like such
-  if (typeof raw === 'string') {
-    formatted = formatPrimitiveNoColor(ctx, raw);
-    base = ' ' + '[String: ' + formatted + ']';
-  }
-
-  // Make boxed primitive Numbers look like such
-  if (typeof raw === 'number') {
-    formatted = formatPrimitiveNoColor(ctx, raw);
-    base = ' ' + '[Number: ' + formatted + ']';
-  }
-
-  // Make boxed primitive Booleans look like such
-  if (typeof raw === 'boolean') {
-    formatted = formatPrimitiveNoColor(ctx, raw);
-    base = ' ' + '[Boolean: ' + formatted + ']';
+  switch (typeof raw) {
+    case 'string':
+      // Make boxed primitive Strings look like such
+      formatted = formatPrimitiveNoColor(ctx, raw);
+      base = ` [String: ${formatted}]`;
+      break;
+    case 'number':
+      // Make boxed primitive Numbers look like such
+      formatted = formatPrimitiveNoColor(ctx, raw);
+      base = ` [Number: ${formatted}]`;
+      break;
+    case 'boolean':
+      // Make boxed primitive Booleans look like such
+      formatted = formatPrimitiveNoColor(ctx, raw);
+      base = ` [Boolean: ${formatted}]`;
+      break;
   }
 
   // Add constructor name if available
   if (base === '' && constructor)
-    braces[0] = constructor.name + ' ' + braces[0];
+    braces[0] = `${constructor.name} ${braces[0]}`;
 
   if (empty === true) {
-    return braces[0] + base + braces[1];
+    return `${braces[0]}${base}${braces[1]}`;
   }
 
   if (recurseTimes < 0) {
-    if (isRegExp(value)) {
-      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
-    } else {
-      return ctx.stylize('[Object]', 'special');
-    }
+    return isRegExp(value) ?
+        ctx.stylize(RegExp.prototype.toString.call(value), 'regexp') :
+        ctx.stylize('[Object]', 'special');
   }
 
   ctx.seen.push(value);
@@ -583,9 +589,9 @@ function formatValue(ctx, value, recurseTimes) {
 function formatNumber(ctx, value) {
   // Format -0 as '-0'. Strict equality won't distinguish 0 from -0,
   // so instead we use the fact that 1 / -0 < 0 whereas 1 / 0 > 0 .
-  if (value === 0 && 1 / value < 0)
-    return ctx.stylize('-0', 'number');
-  return ctx.stylize('' + value, 'number');
+  return (value === 0 && 1 / value < 0) ?
+      ctx.stylize('-0', 'number') :
+      ctx.stylize(`${value}`, 'number');
 }
 
 
@@ -597,24 +603,29 @@ function formatPrimitive(ctx, value) {
   if (value === null)
     return ctx.stylize('null', 'null');
 
-  var type = typeof value;
-
-  if (type === 'string') {
-    var simple = '\'' +
-                 JSON.stringify(value)
-                     .replace(/^"|"$/g, '')
-                     .replace(/'/g, "\\'")
-                     .replace(/\\"/g, '"') +
-                 '\'';
-    return ctx.stylize(simple, 'string');
+  switch (typeof value) {
+    case 'string':
+      const replacer = (match) => {
+        switch (match) {
+          case '"':
+            return '';
+          case "'":
+            return "\\'";
+          case '\\"':
+            return '"';
+        }
+      };
+      var simple =
+        `'${JSON.stringify(value).replace(/^"|"$|'|\"/g, replacer)}'`;
+      return ctx.stylize(simple, 'string');
+    case 'number':
+      return formatNumber(ctx, value);
+    case 'boolean':
+      return ctx.stylize(`${value}`, 'boolean');
+    case 'symbol':
+      // es6 symbol primitive
+      return ctx.stylize(value.toString(), 'symbol');
   }
-  if (type === 'number')
-    return formatNumber(ctx, value);
-  if (type === 'boolean')
-    return ctx.stylize('' + value, 'boolean');
-  // es6 symbol primitive
-  if (type === 'symbol')
-    return ctx.stylize(value.toString(), 'symbol');
 }
 
 
@@ -628,12 +639,12 @@ function formatPrimitiveNoColor(ctx, value) {
 
 
 function formatError(value) {
-  return value.stack || '[' + Error.prototype.toString.call(value) + ']';
+  return value.stack || `[${Error.prototype.toString.call(value)}]`;
 }
 
 
 function formatObject(ctx, value, recurseTimes, visibleKeys, keys) {
-  return keys.map(function(key) {
+  return keys.map((key) => {
     return formatProperty(ctx, value, recurseTimes, visibleKeys, key, false);
   });
 }
@@ -654,12 +665,12 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   if (remaining > 0) {
     output.push(`... ${remaining} more item${remaining > 1 ? 's' : ''}`);
   }
-  keys.forEach(function(key) {
+  for (const key of keys) {
     if (typeof key === 'symbol' || !key.match(/^\d+$/)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
           key, true));
     }
-  });
+  }
   return output;
 }
 
@@ -685,32 +696,30 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
 
 function formatSet(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
-  value.forEach(function(v) {
+  value.forEach((v) => {
     var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
-    var str = formatValue(ctx, v, nextRecurseTimes);
-    output.push(str);
+    output.push(formatValue(ctx, v, nextRecurseTimes));
   });
-  keys.forEach(function(key) {
+  for (const key of keys) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                key, false));
-  });
+  }
   return output;
 }
 
 
 function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
-  value.forEach(function(v, k) {
+  value.forEach((v, k) => {
     var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
-    var str = formatValue(ctx, k, nextRecurseTimes);
-    str += ' => ';
-    str += formatValue(ctx, v, nextRecurseTimes);
+    var str = formatValue(ctx, k, nextRecurseTimes) +
+              ` => ${formatValue(ctx, v, nextRecurseTimes)}`;
     output.push(str);
   });
-  keys.forEach(function(key) {
+  for (const key of keys) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                key, false));
-  });
+  }
   return output;
 }
 
@@ -735,53 +744,42 @@ function formatPromise(ctx, value, recurseTimes, visibleKeys, keys) {
     var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
     var str = formatValue(ctx, internals.value, nextRecurseTimes);
     if (internals.status === 'rejected') {
-      output.push('<rejected> ' + str);
+      output.push(`<rejected> ${str}`);
     } else {
       output.push(str);
     }
   }
-  keys.forEach(function(key) {
+  for (const key of keys) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                key, false));
-  });
+  }
   return output;
 }
 
 
 function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
-  var name, str, desc;
+  var name, desc;
   desc = Object.getOwnPropertyDescriptor(value, key) || { value: value[key] };
-  if (desc.get) {
-    if (desc.set) {
-      str = ctx.stylize('[Getter/Setter]', 'special');
-    } else {
-      str = ctx.stylize('[Getter]', 'special');
-    }
-  } else {
-    if (desc.set) {
-      str = ctx.stylize('[Setter]', 'special');
-    }
-  }
+  var str = desc.get ?
+              desc.set ?
+                ctx.stylize('[Getter/Setter]', 'special') :
+                ctx.stylize('[Getter]', 'special') :
+              desc.set ?
+                ctx.stylize('[Setter]', 'special') :
+                undefined;
   if (!hasOwnProperty(visibleKeys, key)) {
-    if (typeof key === 'symbol') {
-      name = '[' + ctx.stylize(key.toString(), 'symbol') + ']';
-    } else {
-      name = '[' + key + ']';
-    }
+    name = typeof key == 'symbol' ?
+            `[${ctx.stylize(key.toString(), 'symbol')}]` : `[${key}]`;
   }
   if (!str) {
     if (ctx.seen.indexOf(desc.value) < 0) {
-      if (recurseTimes === null) {
-        str = formatValue(ctx, desc.value, null);
-      } else {
-        str = formatValue(ctx, desc.value, recurseTimes - 1);
-      }
+      str = recurseTimes === null ?
+              formatValue(ctx, desc.value, null) :
+              formatValue(ctx, desc.value, recurseTimes - 1);
       if (str.indexOf('\n') > -1) {
-        if (array) {
-          str = str.replace(/\n/g, '\n  ');
-        } else {
-          str = str.replace(/(^|\n)/g, '\n   ');
-        }
+        str = array ?
+                str.replace(/\n/g, '\n  ') :
+                str.replace(/(^|\n)/g, '\n   ');
       }
     } else {
       str = ctx.stylize('[Circular]', 'special');
@@ -791,25 +789,29 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     if (array && key.match(/^\d+$/)) {
       return str;
     }
-    name = JSON.stringify('' + key);
+    name = JSON.stringify(`${key}`);
     if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-      name = name.substr(1, name.length - 2);
-      name = ctx.stylize(name, 'name');
+      name = ctx.stylize(name.substr(1, name.length - 2), 'name');
     } else {
-      name = name.replace(/'/g, "\\'")
-                 .replace(/\\"/g, '"')
-                 .replace(/(^"|"$)/g, "'")
-                 .replace(/\\\\/g, '\\');
+      const replacer = (match) => {
+        switch (match) {
+          case "'": return "\\'";
+          case '\\"' : return '"';
+          case '"': return "'";
+          case '\\\\': return '\\';
+        }
+      };
+      name = name.replace(/'|\\"|^"|"$|\\\\/g, replacer);
       name = ctx.stylize(name, 'string');
     }
   }
 
-  return name + ': ' + str;
+  return `${name}: ${str}`;
 }
 
 
 function reduceToSingleString(output, base, braces, breakLength) {
-  var length = output.reduce(function(prev, cur) {
+  const length = output.reduce(function(prev, cur) {
     return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
   }, 0);
 
@@ -818,14 +820,11 @@ function reduceToSingleString(output, base, braces, breakLength) {
            // If the opening "brace" is too large, like in the case of "Set {",
            // we need to force the first item to be on the next line or the
            // items will not line up correctly.
-           (base === '' && braces[0].length === 1 ? '' : base + '\n ') +
-           ' ' +
-           output.join(',\n  ') +
-           ' ' +
-           braces[1];
+           (base === '' && braces[0].length === 1 ? '' : `${base}\n `) +
+           ` ${output.join(',\n  ')} ${braces[1]}`;
   }
 
-  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
+  return `${braces[0]}${base} ${output.join(', ')} ${braces[1]}`;
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -235,9 +235,9 @@ inspect.styles = {
 function stylizeWithColor(str, styleType) {
   const style = inspect.styles[styleType];
 
-  return style ?
+  return !style ? str :
       `\u001b[${inspect.colors[style][0]}m${str}` +
-      `\u001b[${inspect.colors[style][1]}m` : str;
+      `\u001b[${inspect.colors[style][1]}m`;
 }
 
 
@@ -768,7 +768,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
                 ctx.stylize('[Setter]', 'special') :
                 undefined;
   if (!hasOwnProperty(visibleKeys, key)) {
-    name = typeof key == 'symbol' ?
+    name = typeof key === 'symbol' ?
             `[${ctx.stylize(key.toString(), 'symbol')}]` : `[${key}]`;
   }
   if (!str) {
@@ -789,7 +789,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     if (array && key.match(/^\d+$/)) {
       return str;
     }
-    name = JSON.stringify(`${key}`);
+    name = `"${key}"`;
     if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
       name = ctx.stylize(name.substr(1, name.length - 2), 'name');
     } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -605,18 +605,12 @@ function formatPrimitive(ctx, value) {
 
   switch (typeof value) {
     case 'string':
-      const replacer = (match) => {
-        switch (match) {
-          case '"':
-            return '';
-          case "'":
-            return "\\'";
-          case '\\"':
-            return '"';
-        }
-      };
-      var simple =
-        `'${JSON.stringify(value).replace(/^"|"$|'|\"/g, replacer)}'`;
+      var simple = '\'' +
+                   JSON.stringify(value)
+                       .replace(/^"|"$/g, '')
+                       .replace(/'/g, "\\'")
+                       .replace(/\\"/g, '"') +
+                   '\'';
       return ctx.stylize(simple, 'string');
     case 'number':
       return formatNumber(ctx, value);

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -40,6 +40,16 @@ using v8::Value;
   VALUE_METHOD_MAP(V)
 #undef V
 
+void GetType(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+#define V(lcname, ucname)                                                     \
+  if (args[0]->ucname())                                                      \
+    args.GetReturnValue().Set(FIXED_ONE_BYTE_STRING(env->isolate(), #lcname));
+  VALUE_METHOD_MAP(V)
+#undef V
+}
+
+
 static void GetProxyDetails(const FunctionCallbackInfo<Value>& args) {
   // Return undefined if it's not a proxy.
   if (!args[0]->IsProxy())
@@ -107,7 +117,6 @@ void StartSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-
 void StopSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
   bool had_pending_signals = SigintWatchdogHelper::GetInstance()->Stop();
   args.GetReturnValue().Set(had_pending_signals);
@@ -132,6 +141,7 @@ void Initialize(Local<Object> target,
   }
 #undef V
 
+  env->SetMethod(target, "getType", GetType);
   env->SetMethod(target, "getHiddenValue", GetHiddenValue);
   env->SetMethod(target, "setHiddenValue", SetHiddenValue);
   env->SetMethod(target, "getProxyDetails", GetProxyDetails);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util

##### Description of change
A number of general code improvements to util.inspect that yield an average perf improvement between 5-10%.

* Reduces number of binding calls
* Restructures parts for improved readability and code flow
* Elimination of some unnecessary branches
* Reduction in the number of String.prototype.replace calls
* Switch to using template strings where possible to reduce the number of concats

CI: https://ci.nodejs.org/job/node-test-pull-request/3176/