### PR TITLE
build: Fix compile failure in backtrace_posix.cc

### DIFF
--- a/src/backtrace_posix.cc
+++ b/src/backtrace_posix.cc
@@ -4,7 +4,7 @@
 #include <features.h>
 #endif
 
-#if defined(__linux__) && !defined(__GLIBC__)
+#if defined(__linux__) && !defined(__GLIBC__) || defined(_AIX)
 #define HAVE_EXECINFO_H 0
 #else
 #define HAVE_EXECINFO_H 1


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
core


##### Description of change

Fix compile failure in backtrace_posix.c on AIX introduced by https://github.com/nodejs/node/pull/6734

