### PR TITLE
tls, binding: backport of process.binding('config') and regression fix

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -375,6 +375,10 @@ An example of the possible output looks like:
 }
 ```
 
+*Note: the `process.config` property is **not** read-only and there are existing
+modules in the ecosystem that are known to extend, modify, or entirely replace
+the value of `process.config`.*
+
 ## process.connected
 
 * {Boolean} Set to false after `process.disconnect()` is called

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -19,7 +19,7 @@ const defaultSessionIdContext = getDefaultSessionIdContext();
 function getDefaultSessionIdContext() {
   var defaultText = process.argv.join(' ');
   /* SSL_MAX_SID_CTX_LENGTH is 128 bits */
-  if (process.config.variables.openssl_fips) {
+  if (process.binding('config').fipsMode) {
     return crypto.createHash('sha1')
       .update(defaultText)
       .digest('hex').slice(0, 32);

--- a/node.gyp
+++ b/node.gyp
@@ -124,6 +124,7 @@
         'src/js_stream.cc',
         'src/node.cc',
         'src/node_buffer.cc',
+        'src/node_config.cc',
         'src/node_constants.cc',
         'src/node_contextify.cc',
         'src/node_file.cc',

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -28,7 +28,10 @@ using v8::ReadOnly;
 void InitConfig(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
-  // Environment* env = Environment::GetCurrent(context);
+#ifdef NODE_FIPS_MODE
+  Environment* env = Environment::GetCurrent(context);
+  READONLY_BOOLEAN_PROPERTY("fipsMode");
+#endif
 }
 
 }  // namespace node

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,0 +1,36 @@
+#include "node.h"
+#include "env.h"
+#include "env-inl.h"
+#include "util.h"
+#include "util-inl.h"
+
+
+namespace node {
+
+using v8::Context;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+using v8::ReadOnly;
+
+// The config binding is used to provide an internal view of compile or runtime
+// config options that are required internally by lib/*.js code. This is an
+// alternative to dropping additional properties onto the process object as
+// has been the practice previously in node.cc.
+
+#define READONLY_BOOLEAN_PROPERTY(str)                                        \
+  do {                                                                        \
+    target->DefineOwnProperty(env->context(),                                 \
+                              OneByteString(env->isolate(), str),             \
+                              True(env->isolate()), ReadOnly).FromJust();     \
+  } while (0)
+
+void InitConfig(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
+  // Environment* env = Environment::GetCurrent(context);
+}
+
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(config, node::InitConfig)


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

process.binding, tls

##### Description of change

Cherry picks the addition of process.binding('config') to v4.x and fixes the regression in https://github.com/nodejs/node/issues/6114

/cc @TheAlphaNerd 