### PR TITLE
test: fix flaky test-net-write-slow

### DIFF
--- a/test/parallel/test-net-write-slow.js
+++ b/test/parallel/test-net-write-slow.js
@@ -11,7 +11,7 @@ var buf = Buffer.alloc(SIZE, 'a');
 
 var server = net.createServer(function(socket) {
   socket.setNoDelay();
-  socket.setTimeout(1000);
+  socket.setTimeout(9999);
   socket.on('timeout', function() {
     assert.fail(null, null, 'flushed: ' + flushed +
                 ', received: ' + received + '/' + SIZE * N);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net

##### Description of change
<!-- Provide a description of the change below this comment. -->

Increase socket timeout so that there is enough time to reliably run the
test on FreeBSD.

Fixes: https://github.com/nodejs/node/issues/7516