### PR TITLE
Clarify "fs.readFile", "fs.appendFile", "fs.writeFile" doc…

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -379,7 +379,7 @@ fs.appendFile('message.txt', 'data to append', 'utf8', callback);
 Any specified file descriptor has to have been opened for appending.
 
 _Note: If a file descriptor is specified as the `file`, it will not be closed 
-automatically. If a filename is specified as the `file`, internally opened 
+automatically. If a filename is specified as the `file`, the internally opened 
 file descriptor will be closed automatically._
 
 ## fs.appendFileSync(file, data[, options])
@@ -1133,7 +1133,7 @@ fs.readFile('/etc/passwd', 'utf8', callback);
 Any specified file descriptor has to support reading.
 
 _Note: If a file descriptor is specified as the `file`, it will not be closed 
-automatically. If a filename is specified as the `file`, internally opened 
+automatically. If a filename is specified as the `file`, the internally opened 
 file descriptor will be closed automatically._
 
 ## fs.readFileSync(file[, options])
@@ -1667,7 +1667,7 @@ without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.
 
 _Note: If a file descriptor is specified as the `file`, it will not be closed 
-automatically. If a filename is specified as the `file`, internally opened 
+automatically. If a filename is specified as the `file`, the internally opened 
 file descriptor will be closed automatically._
 
 ## fs.writeFileSync(file, data[, options])

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -378,7 +378,9 @@ fs.appendFile('message.txt', 'data to append', 'utf8', callback);
 
 Any specified file descriptor has to have been opened for appending.
 
-_Note: Specified file descriptors will not be closed automatically._
+_Note: If a file descriptor is specified as the 'file', it will not be closed automatically._
+
+_Note: If a filename is specified as the 'file', internally opened file descriptor will be closed automatically._
 
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
@@ -1130,7 +1132,9 @@ fs.readFile('/etc/passwd', 'utf8', callback);
 
 Any specified file descriptor has to support reading.
 
-_Note: Specified file descriptors will not be closed automatically._
+_Note: If a file descriptor is specified as the 'file', it will not be closed automatically._
+
+_Note: If a filename is specified as the 'file', internally opened file descriptor will be closed automatically._
 
 ## fs.readFileSync(file[, options])
 <!-- YAML
@@ -1662,7 +1666,9 @@ Note that it is unsafe to use `fs.writeFile` multiple times on the same file
 without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.
 
-_Note: Specified file descriptors will not be closed automatically._
+_Note: If a file descriptor is specified as the 'file', it will not be closed automatically._
+
+_Note: If a filename is specified as the 'file', internally opened file descriptor will be closed automatically._
 
 ## fs.writeFileSync(file, data[, options])
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -378,9 +378,9 @@ fs.appendFile('message.txt', 'data to append', 'utf8', callback);
 
 Any specified file descriptor has to have been opened for appending.
 
-_Note: If a file descriptor is specified as the 'file', it will not be closed automatically._
+_Note: If a file descriptor is specified as the `file`, it will not be closed automatically._
 
-_Note: If a filename is specified as the 'file', internally opened file descriptor will be closed automatically._
+_Note: If a filename is specified as the `file`, internally opened file descriptor will be closed automatically._
 
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
@@ -1132,9 +1132,9 @@ fs.readFile('/etc/passwd', 'utf8', callback);
 
 Any specified file descriptor has to support reading.
 
-_Note: If a file descriptor is specified as the 'file', it will not be closed automatically._
+_Note: If a file descriptor is specified as the `file`, it will not be closed automatically._
 
-_Note: If a filename is specified as the 'file', internally opened file descriptor will be closed automatically._
+_Note: If a filename is specified as the `file`, internally opened file descriptor will be closed automatically._
 
 ## fs.readFileSync(file[, options])
 <!-- YAML
@@ -1666,9 +1666,9 @@ Note that it is unsafe to use `fs.writeFile` multiple times on the same file
 without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.
 
-_Note: If a file descriptor is specified as the 'file', it will not be closed automatically._
+_Note: If a file descriptor is specified as the `file`, it will not be closed automatically._
 
-_Note: If a filename is specified as the 'file', internally opened file descriptor will be closed automatically._
+_Note: If a filename is specified as the `file`, internally opened file descriptor will be closed automatically._
 
 ## fs.writeFileSync(file, data[, options])
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -378,9 +378,9 @@ fs.appendFile('message.txt', 'data to append', 'utf8', callback);
 
 Any specified file descriptor has to have been opened for appending.
 
-_Note: If a file descriptor is specified as the `file`, it will not be closed automatically._
-
-_Note: If a filename is specified as the `file`, internally opened file descriptor will be closed automatically._
+_Note: If a file descriptor is specified as the `file`, it will not be closed 
+automatically. If a filename is specified as the `file`, internally opened 
+file descriptor will be closed automatically._
 
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
@@ -1132,9 +1132,9 @@ fs.readFile('/etc/passwd', 'utf8', callback);
 
 Any specified file descriptor has to support reading.
 
-_Note: If a file descriptor is specified as the `file`, it will not be closed automatically._
-
-_Note: If a filename is specified as the `file`, internally opened file descriptor will be closed automatically._
+_Note: If a file descriptor is specified as the `file`, it will not be closed 
+automatically. If a filename is specified as the `file`, internally opened 
+file descriptor will be closed automatically._
 
 ## fs.readFileSync(file[, options])
 <!-- YAML
@@ -1666,9 +1666,9 @@ Note that it is unsafe to use `fs.writeFile` multiple times on the same file
 without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.
 
-_Note: If a file descriptor is specified as the `file`, it will not be closed automatically._
-
-_Note: If a filename is specified as the `file`, internally opened file descriptor will be closed automatically._
+_Note: If a file descriptor is specified as the `file`, it will not be closed 
+automatically. If a filename is specified as the `file`, internally opened 
+file descriptor will be closed automatically._
 
 ## fs.writeFileSync(file, data[, options])
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -379,8 +379,7 @@ fs.appendFile('message.txt', 'data to append', 'utf8', callback);
 Any specified file descriptor has to have been opened for appending.
 
 _Note: If a file descriptor is specified as the `file`, it will not be closed 
-automatically. If a filename is specified as the `file`, the internally opened 
-file descriptor will be closed automatically._
+automatically._
 
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
@@ -1133,8 +1132,7 @@ fs.readFile('/etc/passwd', 'utf8', callback);
 Any specified file descriptor has to support reading.
 
 _Note: If a file descriptor is specified as the `file`, it will not be closed 
-automatically. If a filename is specified as the `file`, the internally opened 
-file descriptor will be closed automatically._
+automatically._
 
 ## fs.readFileSync(file[, options])
 <!-- YAML
@@ -1667,8 +1665,7 @@ without waiting for the callback. For this scenario,
 `fs.createWriteStream` is strongly recommended.
 
 _Note: If a file descriptor is specified as the `file`, it will not be closed 
-automatically. If a filename is specified as the `file`, the internally opened 
-file descriptor will be closed automatically._
+automatically._
 
 ## fs.writeFileSync(file, data[, options])
 <!-- YAML


### PR DESCRIPTION
##### Description of change
"fs.readFile", "fs.appendFile", "fs.writeFile" documentation is made less confusing regarding when does the automatic closing of file descriptors occur.