### PR TITLE
core: normalize malloc, realloc 

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -142,7 +142,8 @@ static void ares_poll_close_cb(uv_handle_t* watcher) {
 
 /* Allocates and returns a new node_ares_task */
 static node_ares_task* ares_task_create(Environment* env, ares_socket_t sock) {
-  node_ares_task* task = static_cast<node_ares_task*>(malloc(sizeof(*task)));
+  node_ares_task* task =
+    static_cast<node_ares_task*>(node::Malloc(sizeof(*task)));
 
   if (task == nullptr) {
     /* Out of memory. */

--- a/src/node.cc
+++ b/src/node.cc
@@ -977,9 +977,9 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
 void* ArrayBufferAllocator::Allocate(size_t size) {
   if (zero_fill_field_ || zero_fill_all_buffers)
-    return calloc(size, 1);
+    return node::Calloc(size, 1);
   else
-    return malloc(size);
+    return node::Malloc(size);
 }
 
 static bool DomainHasErrorHandler(const Environment* env,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2279,7 +2279,7 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     size_t len = Buffer::Length(obj);
 
     // OpenSSL takes control of the pointer after accepting it
-    char* data = reinterpret_cast<char*>(malloc(len));
+    char* data = reinterpret_cast<char*>(node::Malloc(len));
     CHECK_NE(data, nullptr);
     memcpy(data, resp, len);
 
@@ -3330,7 +3330,7 @@ bool CipherBase::GetAuthTag(char** out, unsigned int* out_len) const {
   if (initialised_ || kind_ != kCipher || !auth_tag_)
     return false;
   *out_len = auth_tag_len_;
-  *out = static_cast<char*>(malloc(auth_tag_len_));
+  *out = static_cast<char*>(node::Malloc(auth_tag_len_));
   CHECK_NE(*out, nullptr);
   memcpy(*out, auth_tag_, auth_tag_len_);
   return true;
@@ -4906,7 +4906,7 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // NOTE: field_size is in bits
   int field_size = EC_GROUP_get_degree(ecdh->group_);
   size_t out_len = (field_size + 7) / 8;
-  char* out = static_cast<char*>(malloc(out_len));
+  char* out = static_cast<char*>(node::Malloc(out_len));
   CHECK_NE(out, nullptr);
 
   int r = ECDH_compute_key(out, out_len, pub, ecdh->key_, nullptr);
@@ -4942,7 +4942,7 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (size == 0)
     return env->ThrowError("Failed to get public key length");
 
-  unsigned char* out = static_cast<unsigned char*>(malloc(size));
+  unsigned char* out = static_cast<unsigned char*>(node::Malloc(size));
   CHECK_NE(out, nullptr);
 
   int r = EC_POINT_point2oct(ecdh->group_, pub, form, out, size, nullptr);
@@ -4968,7 +4968,7 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH private key");
 
   int size = BN_num_bytes(b);
-  unsigned char* out = static_cast<unsigned char*>(malloc(size));
+  unsigned char* out = static_cast<unsigned char*>(node::Malloc(size));
   CHECK_NE(out, nullptr);
 
   if (size != BN_bn2bin(b, out)) {
@@ -5099,7 +5099,7 @@ class PBKDF2Request : public AsyncWrap {
         saltlen_(saltlen),
         salt_(salt),
         keylen_(keylen),
-        key_(static_cast<char*>(malloc(keylen))),
+        key_(static_cast<char*>(node::Malloc(keylen))),
         iter_(iter) {
     if (key() == nullptr)
       FatalError("node::PBKDF2Request()", "Out of Memory");
@@ -5262,7 +5262,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
 
   THROW_AND_RETURN_IF_NOT_BUFFER(args[1], "Salt");
 
-  pass = static_cast<char*>(malloc(passlen));
+  pass = static_cast<char*>(node::Malloc(passlen));
   if (pass == nullptr) {
     FatalError("node::PBKDF2()", "Out of Memory");
   }
@@ -5274,7 +5274,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
     goto err;
   }
 
-  salt = static_cast<char*>(malloc(saltlen));
+  salt = static_cast<char*>(node::Malloc(saltlen));
   if (salt == nullptr) {
     FatalError("node::PBKDF2()", "Out of Memory");
   }
@@ -5367,7 +5367,7 @@ class RandomBytesRequest : public AsyncWrap {
       : AsyncWrap(env, object, AsyncWrap::PROVIDER_CRYPTO),
         error_(0),
         size_(size),
-        data_(static_cast<char*>(malloc(size))) {
+        data_(static_cast<char*>(node::Malloc(size))) {
     if (data() == nullptr)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
@@ -5596,7 +5596,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 
   if (num_curves) {
     alloc_size = sizeof(*curves) * num_curves;
-    curves = static_cast<EC_builtin_curve*>(malloc(alloc_size));
+    curves = static_cast<EC_builtin_curve*>(node::Malloc(alloc_size));
 
     CHECK_NE(curves, nullptr);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5368,7 +5368,7 @@ class RandomBytesRequest : public AsyncWrap {
         error_(0),
         size_(size),
         data_(static_cast<char*>(node::Malloc(size))) {
-    if (data() == nullptr)
+    if (data() == nullptr && size > 0)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
   }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -180,7 +180,8 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }
 
   virtual void* Allocate(size_t size);  // Defined in src/node.cc
-  virtual void* AllocateUninitialized(size_t size) { return malloc(size); }
+  virtual void* AllocateUninitialized(size_t size)
+    { return node::Malloc(size); }
   virtual void Free(void* data, size_t) { free(data); }
 
  private:

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -148,7 +148,7 @@ void StreamWrap::OnAlloc(uv_handle_t* handle,
 
 
 void StreamWrap::OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx) {
-  buf->base = static_cast<char*>(malloc(size));
+  buf->base = static_cast<char*>(node::Malloc(size));
   buf->len = size;
 
   if (buf->base == nullptr && size > 0) {
@@ -204,7 +204,7 @@ void StreamWrap::OnReadImpl(ssize_t nread,
     return;
   }
 
-  char* base = static_cast<char*>(realloc(buf->base, nread));
+  char* base = static_cast<char*>(node::Realloc(buf->base, nread));
   CHECK_LE(static_cast<size_t>(nread), buf->len);
 
   if (pending == UV_TCP) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -54,7 +54,7 @@ class ExternString: public ResourceType {
       return scope.Escape(String::Empty(isolate));
 
     TypeName* new_data =
-        static_cast<TypeName*>(malloc(length * sizeof(*new_data)));
+        static_cast<TypeName*>(node::Malloc(length * sizeof(*new_data)));
     if (new_data == nullptr) {
       return Local<String>();
     }
@@ -624,7 +624,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case ASCII:
       if (contains_non_ascii(buf, buflen)) {
-        char* out = static_cast<char*>(malloc(buflen));
+        char* out = static_cast<char*>(node::Malloc(buflen));
         if (out == nullptr) {
           return Local<String>();
         }
@@ -659,7 +659,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case BASE64: {
       size_t dlen = base64_encoded_size(buflen);
-      char* dst = static_cast<char*>(malloc(dlen));
+      char* dst = static_cast<char*>(node::Malloc(dlen));
       if (dst == nullptr) {
         return Local<String>();
       }
@@ -678,7 +678,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case HEX: {
       size_t dlen = buflen * 2;
-      char* dst = static_cast<char*>(malloc(dlen));
+      char* dst = static_cast<char*>(node::Malloc(dlen));
       if (dst == nullptr) {
         return Local<String>();
       }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -661,7 +661,7 @@ void TLSWrap::OnReadImpl(ssize_t nread,
 
 
 void TLSWrap::OnAllocSelf(size_t suggested_size, uv_buf_t* buf, void* ctx) {
-  buf->base = static_cast<char*>(malloc(suggested_size));
+  buf->base = static_cast<char*>(node::Malloc(suggested_size));
   CHECK_NE(buf->base, nullptr);
   buf->len = suggested_size;
 }

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -384,7 +384,7 @@ void UDPWrap::OnSend(uv_udp_send_t* req, int status) {
 void UDPWrap::OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
-  buf->base = static_cast<char*>(malloc(suggested_size));
+  buf->base = static_cast<char*>(node::Malloc(suggested_size));
   buf->len = suggested_size;
 
   if (buf->base == nullptr && suggested_size > 0) {
@@ -426,7 +426,7 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
     return;
   }
 
-  char* base = static_cast<char*>(realloc(buf->base, nread));
+  char* base = static_cast<char*>(node::Realloc(buf->base, nread));
   argv[2] = Buffer::New(env, base, nread).ToLocalChecked();
   argv[3] = AddressToJS(env, addr);
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -229,6 +229,32 @@ bool StringEqualNoCaseN(const char* a, const char* b, size_t length) {
   return true;
 }
 
+// These should be used in our code as opposed to the native
+// versions as they abstract out some platform and or
+// compiler version specific functionality
+// malloc(0) and realloc(ptr, 0) have implementation-defined behavior in
+// that the standard allows them to either return a unique pointer or a
+// nullptr for zero-sized allocation requests.  Normalize by always using
+// a nullptr.
+void* Realloc(void* pointer, size_t size) {
+  if (size == 0) {
+    free(pointer);
+    return nullptr;
+  }
+  return realloc(pointer, size);
+}
+
+// as per spec realloc behaves like malloc if passed nullptr
+void* Malloc(size_t size) {
+  return Realloc(nullptr, size);
+}
+
+void* Calloc(size_t n, size_t size) {
+  if ((n == 0) || (size == 0)) return nullptr;
+  CHECK_GE(n * size, n);  // Overflow guard.
+  return calloc(n, size);
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,17 @@
 
 namespace node {
 
+// These should be used in our code as opposed to the native
+// versions as they abstract out some platform and or
+// compiler version specific functionality
+// malloc(0) and realloc(ptr, 0) have implementation-defined behavior in
+// that the standard allows them to either return a unique pointer or a
+// nullptr for zero-sized allocation requests.  Normalize by always using
+// a nullptr.
+inline void* Realloc(void* pointer, size_t size);
+inline void* Malloc(size_t size);
+inline void* Calloc(size_t n, size_t size);
+
 #ifdef __GNUC__
 #define NO_RETURN __attribute__((noreturn))
 #else
@@ -300,7 +311,7 @@ class MaybeStackBuffer {
       // Guard against overflow.
       CHECK_LE(storage, sizeof(T) * storage);
 
-      buf_ = static_cast<T*>(malloc(sizeof(T) * storage));
+      buf_ = static_cast<T*>(Malloc(sizeof(T) * storage));
       CHECK_NE(buf_, nullptr);
     }
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -27,11 +27,6 @@ test-debug-signal-cluster         : PASS,FLAKY
 test-fs-watch-enoent                 : FAIL, PASS
 test-fs-watch-encoding               : FAIL, PASS
 
-# being worked under https://github.com/nodejs/node/pull/7564
-test-async-wrap-post-did-throw           : PASS, FLAKY
-test-async-wrap-throw-from-callback      : PASS, FLAKY
-test-crypto-random                       : PASS, FLAKY
-
 #being worked under https://github.com/nodejs/node/issues/7973
 test-stdio-closed                        : PASS, FLAKY
 


### PR DESCRIPTION
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

core

 malloc(0) and realloc(ptr, 0) have implementation-defined behavior in
 that the standard allows them to either return a unique pointer or a
 nullptr for zero-sized allocation requests.  Normalize by always using
 a nullptr.

    - Introduce node::malloc, node::realloc and node::calloc that should
      be used throught our source.
    - Update all existing node source files to use the new functions
      instead of the native allocation functions.


