### PR TITLE
build: respect --shared-* flags for inspector deps

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -826,14 +826,26 @@
 
       'conditions': [
         ['v8_inspector=="true"', {
-          'dependencies': [
-            'deps/openssl/openssl.gyp:openssl',
-            'deps/http_parser/http_parser.gyp:http_parser',
-            'deps/uv/uv.gyp:libuv'
-          ],
           'sources': [
             'src/inspector_socket.cc',
             'test/cctest/test_inspector_socket.cc'
+          ],
+          'conditions': [
+            [ 'node_shared_openssl=="false"', {
+              'dependencies': [
+                'deps/openssl/openssl.gyp:openssl'
+              ]
+            }],
+            [ 'node_shared_http_parser=="false"', {
+              'dependencies': [
+                'deps/http_parser/http_parser.gyp:http_parser'
+              ]
+            }],
+            [ 'node_shared_libuv=="false"', {
+              'dependencies': [
+                'deps/uv/uv.gyp:libuv'
+              ]
+            }]
           ]
         }],
         [ 'node_use_v8_platform=="true"', {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build

##### Description of change

Don't build openssl/http_parser/libuv for v8_inspector if corresponding `--shared-*` flags were passed to the `./configure` script.

Fixes: https://github.com/nodejs/node/issues/7478

`./configure --shared-openssl --without-intl --shared-http-parser; make -j4 test` works and doesn't build openssl and http-parser even with v8_inspector enabled.

#7486 fixed that only for the case when `--without-inspector` was passed.

CI: https://ci.nodejs.org/job/node-test-pull-request/3194/

/cc @bnoordhuis @ofrobots 