### PR TITLE
test: fix flaky test/fs-read-buffer-tostring-fail

### DIFF
--- a/test/parallel/test-fs-read-buffer-tostring-fail.js
+++ b/test/parallel/test-fs-read-buffer-tostring-fail.js
@@ -2,8 +2,8 @@
 
 const common = require('../common');
 
-const skipMessage = 'intensive toString tests due to memory confinements';
 if (!common.enoughTestMem) {
+  const skipMessage = 'intensive toString tests due to memory confinements';
   common.skip(skipMessage);
   return;
 }

--- a/test/parallel/test-fs-read-buffer-tostring-fail.js
+++ b/test/parallel/test-fs-read-buffer-tostring-fail.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const common = require('../common');
+
+const skipMessage = 'intensive toString tests due to memory confinements';
+if (!common.enoughTestMem) {
+  common.skip(skipMessage);
+  return;
+}
+
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test is memory intensive and times out occasionally on Raspberry Pi
devices in CI. Successful test runs take about 90 seconds, but the
devices time out after 120 seconds. That's not a lot of headroom. So
let's skip the test on devices that have only modest amounts of memory.