### PR TITLE
build: export more openssl symbols

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -554,7 +554,8 @@
             'mkssldef_flags': [
               # Categories to export.
               '-CAES,BF,BIO,DES,DH,DSA,EC,ECDH,ECDSA,ENGINE,EVP,HMAC,MD4,MD5,'
-              'NEXTPROTONEG,PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,TLSEXT',
+              'NEXTPROTONEG,PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,SOCK,'
+              'STDIO,TLSEXT',
               # Defines.
               '-DWIN32',
               # Symbols to filter from the export list.


### PR DESCRIPTION
This makes the generated openssl.def include these additional symbols:

SSL_CTX_use_PrivateKey_file **<- I use this one**
SSL_CTX_use_RSAPrivateKey_file
SSL_CTX_use_certificate_chain_file **<- I use this one**
SSL_CTX_use_certificate_file
SSL_CTX_use_serverinfo_file
SSL_add_dir_cert_subjects_to_stack
SSL_add_file_cert_subjects_to_stack
SSL_load_client_CA_file
SSL_set_fd **<- I use this one**
SSL_set_rfd
SSL_set_wfd
SSL_use_PrivateKey_file
SSL_use_RSAPrivateKey_file
SSL_use_certificate_file
X509_STORE_load_locations
X509_STORE_set_default_paths
X509_load_cert_crl_file
X509_load_cert_file
X509_load_crl_file

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes

##### Affected core subsystem(s)
Windows build


##### Description of change
Export more OpenSSL symbols

