### PR TITLE
benchmark: add microbenchmarks for ES Map

### DIFF
--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
   method: ['object', 'nullProtoObject', 'fakeMap', 'map'],
-  thousands: [100]
+  millions: [1]
 });
 
 function runObject(n) {
@@ -75,7 +75,7 @@ function runMap(n) {
 }
 
 function main(conf) {
-  const n = +conf.thousands * 1000;
+  const n = +conf.millions * 1e6;
 
   switch (conf.method) {
     case 'object':

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
   method: ['object', 'nullProtoObject', 'fakeMap', 'map'],
-  millions: [10]
+  thousands: [100]
 });
 
 function runObject(n) {
@@ -13,11 +13,11 @@ function runObject(n) {
   var i = 0;
   bench.start();
   for (; i < n; i++) {
-    m['i' + n] = n;
-    m['s' + n] = String(n);
-    assert.equal(m['i' + n], m['s' + n]);
-    m['i' + n] = undefined;
-    m['s' + n] = undefined;
+    m['i' + i] = i;
+    m['s' + i] = String(i);
+    assert.equal(m['i' + i], m['s' + i]);
+    m['i' + i] = undefined;
+    m['s' + i] = undefined;
   }
   bench.end(n / 1e6);
 }
@@ -27,11 +27,11 @@ function runNullProtoObject(n) {
   var i = 0;
   bench.start();
   for (; i < n; i++) {
-    m['i' + n] = n;
-    m['s' + n] = String(n);
-    assert.equal(m['i' + n], m['s' + n]);
-    m['i' + n] = undefined;
-    m['s' + n] = undefined;
+    m['i' + i] = i;
+    m['s' + i] = String(i);
+    assert.equal(m['i' + i], m['s' + i]);
+    m['i' + i] = undefined;
+    m['s' + i] = undefined;
   }
   bench.end(n / 1e6);
 }
@@ -51,11 +51,11 @@ function runFakeMap(n) {
   var i = 0;
   bench.start();
   for (; i < n; i++) {
-    m.set('i' + n, n);
-    m.set('s' + n, String(n));
-    assert.equal(m.get('i' + n), m.get('s' + n));
-    m.set('i' + n, undefined);
-    m.set('s' + n, undefined);
+    m.set('i' + i, i);
+    m.set('s' + i, String(i));
+    assert.equal(m.get('i' + i), m.get('s' + i));
+    m.set('i' + i, undefined);
+    m.set('s' + i, undefined);
   }
   bench.end(n / 1e6);
 }
@@ -65,17 +65,17 @@ function runMap(n) {
   var i = 0;
   bench.start();
   for (; i < n; i++) {
-    m.set('i' + n, n);
-    m.set('s' + n, String(n));
-    assert.equal(m.get('i' + n), m.get('s' + n));
-    m.set('i' + n, undefined);
-    m.set('s' + n, undefined);
+    m.set('i' + i, i);
+    m.set('s' + i, String(i));
+    assert.equal(m.get('i' + i), m.get('s' + i));
+    m.set('i' + i, undefined);
+    m.set('s' + i, undefined);
   }
   bench.end(n / 1e6);
 }
 
 function main(conf) {
-  const n = +conf.millions * 1e6;
+  const n = +conf.thousands * 1000;
 
   switch (conf.method) {
     case 'object':

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  method: ['object', 'nullProtoObject', 'fakeMap', 'map'],
+  millions: [10]
+});
+
+function runObject(n) {
+  const m = {};
+  var i = 0;
+  bench.start();
+  for (; i < n; i++) {
+    m['i' + n] = n;
+    m['s' + n] = String(n);
+    assert.equal(m['i' + n], m['s' + n]);
+    m['i' + n] = undefined;
+    m['s' + n] = undefined;
+  }
+  bench.end(n / 1e6);
+}
+
+function runNullProtoObject(n) {
+  const m = Object.create(null);
+  var i = 0;
+  bench.start();
+  for (; i < n; i++) {
+    m['i' + n] = n;
+    m['s' + n] = String(n);
+    assert.equal(m['i' + n], m['s' + n]);
+    m['i' + n] = undefined;
+    m['s' + n] = undefined;
+  }
+  bench.end(n / 1e6);
+}
+
+function fakeMap() {
+  const m = {};
+  return {
+    get(key) { return m['$' + key]; },
+    set(key, val) { m['$' + key] = val; },
+    get size() { return Object.keys(m).length; },
+    has(key) { return Object.prototype.hasOwnProperty.call(m, '$' + key); }
+  };
+}
+
+function runFakeMap(n) {
+  const m = fakeMap();
+  var i = 0;
+  bench.start();
+  for (; i < n; i++) {
+    m.set('i' + n, n);
+    m.set('s' + n, String(n));
+    assert.equal(m.get('i' + n), m.get('s' + n));
+    m.set('i' + n, undefined);
+    m.set('s' + n, undefined);
+  }
+  bench.end(n / 1e6);
+}
+
+function runMap(n) {
+  const m = new Map();
+  var i = 0;
+  bench.start();
+  for (; i < n; i++) {
+    m.set('i' + n, n);
+    m.set('s' + n, String(n));
+    assert.equal(m.get('i' + n), m.get('s' + n));
+    m.set('i' + n, undefined);
+    m.set('s' + n, undefined);
+  }
+  bench.end(n / 1e6);
+}
+
+function main(conf) {
+  const n = +conf.millions * 1e6;
+
+  switch (conf.method) {
+    case 'object':
+      runObject(n);
+      break;
+    case 'nullProtoObject':
+      runNullProtoObject(n);
+      break;
+    case 'fakeMap':
+      runFakeMap(n);
+      break;
+    case 'map':
+      runMap(n);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}


### PR DESCRIPTION
Given the discussion in #6102 about `Map` still being too slow to use I figured I'd see with a benchmark. @mscdex, @jasnell please review and let me know if you think this is valid.

```
es/map-bench.js method="pojo" millions="10": 1.07989
es/map-bench.js method="fakeMap" millions="10": 0.85223
es/map-bench.js method="map" millions="10": 1.77412
```

As for why the fakeMap test is faster ... I got nothing ...

------------------------------
Update after @fhinkel noticed a serious flaw:

v6

```
es/map-bench.js millions=1 method="object": 0.18984850416666324
es/map-bench.js millions=1 method="nullProtoObject": 0.16044478686078825
es/map-bench.js millions=1 method="fakeMap": 0.1311882248350222
es/map-bench.js millions=1 method="map": 0.3121014937928409
```

master

```
es/map-bench.js millions=1 method="object": 0.2220851555085364
es/map-bench.js millions=1 method="nullProtoObject": 0.19131381289232038
es/map-bench.js millions=1 method="fakeMap": 0.17931948397493905
es/map-bench.js millions=1 method="map": 0.28127750318241235
```

Times are ops/sec, so higher is better