### PR TITLE
deps: Add a way to create a function without a prototype

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -3241,6 +3241,7 @@ class PropertyCallbackInfo {
 
 typedef void (*FunctionCallback)(const FunctionCallbackInfo<Value>& info);
 
+enum class ConstructorBehavior { kThrow, kAllow };
 
 /**
  * A JavaScript function object (ECMA-262, 15.3).
@@ -3255,6 +3256,11 @@ class V8_EXPORT Function : public Object {
                                   FunctionCallback callback,
                                   Local<Value> data = Local<Value>(),
                                   int length = 0);
+  static MaybeLocal<Function> New(Local<Context> context,
+                                  FunctionCallback callback,
+                                  Local<Value> data,
+                                  int length,
+                                  ConstructorBehavior behavior);
   static V8_DEPRECATE_SOON(
       "Use maybe version",
       Local<Function> New(Isolate* isolate, FunctionCallback callback,
@@ -4478,6 +4484,9 @@ class V8_EXPORT FunctionTemplate : public Template {
       Isolate* isolate, FunctionCallback callback = 0,
       Local<Value> data = Local<Value>(),
       Local<Signature> signature = Local<Signature>(), int length = 0);
+  static Local<FunctionTemplate> New(
+      Isolate* isolate, FunctionCallback callback, Local<Value> data,
+      Local<Signature> signature, int length, ConstructorBehavior behavior);
 
   /**
    * Creates a function template with a fast handler. If a fast handler is set,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -1153,14 +1153,26 @@ Local<FunctionTemplate> FunctionTemplate::New(Isolate* isolate,
                                               v8::Local<Value> data,
                                               v8::Local<Signature> signature,
                                               int length) {
+  return New(
+      isolate, callback, data, signature, length, ConstructorBehavior::kAllow);
+}
+
+Local<FunctionTemplate> FunctionTemplate::New(Isolate* isolate,
+                                              FunctionCallback callback,
+                                              v8::Local<Value> data,
+                                              v8::Local<Signature> signature,
+                                              int length,
+                                              ConstructorBehavior behavior) {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
   // Changes to the environment cannot be captured in the snapshot. Expect no
   // function templates when the isolate is created for serialization.
   DCHECK(!i_isolate->serializer_enabled());
   LOG_API(i_isolate, "FunctionTemplate::New");
   ENTER_V8(i_isolate);
-  return FunctionTemplateNew(i_isolate, callback, nullptr, data, signature,
-                             length, false);
+  auto tmpl = FunctionTemplateNew(i_isolate, callback, nullptr, data, signature,
+                                  length, false);
+  if (behavior == ConstructorBehavior::kThrow) tmpl->RemovePrototype();
+  return tmpl;
 }
 
 
@@ -4449,14 +4461,20 @@ Local<v8::Value> Object::CallAsConstructor(int argc,
 MaybeLocal<Function> Function::New(Local<Context> context,
                                    FunctionCallback callback, Local<Value> data,
                                    int length) {
+  return New(context, callback, data, length, ConstructorBehavior::kAllow);
+}
+
+MaybeLocal<Function> Function::New(Local<Context> context,
+                                   FunctionCallback callback, Local<Value> data,
+                                   int length, ConstructorBehavior behavior) {
   i::Isolate* isolate = Utils::OpenHandle(*context)->GetIsolate();
   LOG_API(isolate, "Function::New");
   ENTER_V8(isolate);
-  return FunctionTemplateNew(isolate, callback, nullptr, data,
-                             Local<Signature>(), length, true)
-      ->GetFunction(context);
+  auto tmpl = FunctionTemplateNew(isolate, callback, nullptr, data,
+                                  Local<Signature>(), length, true);
+  if (behavior == ConstructorBehavior::kThrow) tmpl->RemovePrototype();
+  return tmpl->GetFunction(context);
 }
-
 
 Local<Function> Function::New(Isolate* v8_isolate, FunctionCallback callback,
                               Local<Value> data, int length) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
deps/v8

##### Description of change
This is an non-ABI breaking version port of
https://chromium.googlesource.com/v8/v8/+/46428e45e9982a7490685ff1af6ffe680096c1a4
which adds an API that will be used by the inspector code.