### PR TITLE
src: suppress coverity message

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -209,6 +209,7 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
 
   // Check that the result fits in a size_t.
   const uint64_t kSizeMax = static_cast<uint64_t>(static_cast<size_t>(-1));
+  // coverity[pointless_expression]
   if (static_cast<uint64_t>(tmp_i) > kSizeMax)
     return false;
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change
Coverity marked a change in 630096b as a constant expression. However, on platforms where `sizeof(int64_t) > sizeof(size_t)`, this should not be the case. This commit flags the comparison
as OK to coverity.

**Disclaimer**: I have no idea how to test this with coverity. I put this together based on existing code in core and some Googling.

R= @bnoordhuis 