### PR TITLE
repl: Use displayErrors for SyntaxError

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -350,15 +350,14 @@ function REPLServer(prompt,
     debug('domain error');
     const top = replMap.get(self);
     internalUtil.decorateErrorStack(e);
-    if (e.stack && self.replMode === exports.REPL_MODE_STRICT) {
+    if (e instanceof SyntaxError && e.stack) {
+      // remove repl:line-number and stack trace
+      e.stack = e.stack
+                 .replace(/^repl:\d+\r?\n/, '')
+                 .replace(/^\s+at\s.*\n?/gm, '');
+    } else if (e.stack && self.replMode === exports.REPL_MODE_STRICT) {
       e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
                                 (_, pre, line) => pre + (line - 1));
-    }
-    if (e instanceof SyntaxError &&
-        e.stack &&
-        !e.stack.match(/^SyntaxError:/)) {
-      // remove filename:line-number
-      e.stack = e.stack.replace(/^.*?\n/, '');
     }
     top.outputStream.write((e.stack || e) + '\n');
     top.lineParser.reset();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -254,7 +254,7 @@ function REPLServer(prompt,
         }
         var script = vm.createScript(code, {
           filename: file,
-          displayErrors: false
+          displayErrors: true
         });
       } catch (e) {
         debug('parse error %j', code, e);
@@ -298,7 +298,7 @@ function REPLServer(prompt,
       try {
         try {
           const scriptOptions = {
-            displayErrors: false,
+            displayErrors: true,
             breakOnSigint: self.breakEvalOnSigint
           };
 
@@ -353,6 +353,12 @@ function REPLServer(prompt,
     if (e.stack && self.replMode === exports.REPL_MODE_STRICT) {
       e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
                                 (_, pre, line) => pre + (line - 1));
+    }
+    if (e instanceof SyntaxError &&
+        e.stack &&
+        !e.stack.match(/^SyntaxError:/)) {
+      // remove filename:line-number
+      e.stack = e.stack.replace(/^.*?\n/, '');
     }
     top.outputStream.write((e.stack || e) + '\n');
     top.lineParser.reset();

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -120,7 +120,7 @@ function error_test() {
       expect: prompt_unix },
     // But passing the same string to eval() should throw
     { client: client_unix, send: 'eval("function test_func() {")',
-      expect: /^SyntaxError: Unexpected end of input/ },
+      expect: /\bSyntaxError: Unexpected end of input/ },
     // Can handle multiline template literals
     { client: client_unix, send: '`io.js',
       expect: prompt_multiline },
@@ -149,35 +149,35 @@ function error_test() {
     // invalid input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{invalid: \\\'json\\\'}\');',
-      expect: /^SyntaxError: Unexpected token i/ },
+      expect: /\bSyntaxError: Unexpected token i/ },
     // end of input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'066\');',
-      expect: /^SyntaxError: Unexpected number/ },
+      expect: /\bSyntaxError: Unexpected number/ },
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{\');',
-      expect: /^SyntaxError: Unexpected end of JSON input/ },
+      expect: /\bSyntaxError: Unexpected end of JSON input/ },
     // invalid RegExps are a special case of syntax error,
     // should throw
     { client: client_unix, send: '/(/;',
-      expect: /^SyntaxError: Invalid regular expression\:/ },
+      expect: /\bSyntaxError: Invalid regular expression\:/ },
     // invalid RegExp modifiers are a special case of syntax error,
     // should throw (GH-4012)
     { client: client_unix, send: 'new RegExp("foo", "wrong modifier");',
-      expect: /^SyntaxError: Invalid flags supplied to RegExp constructor/ },
+      expect: /\bSyntaxError: Invalid flags supplied to RegExp constructor/ },
     // strict mode syntax errors should be caught (GH-5178)
     { client: client_unix, send: '(function() { "use strict"; return 0755; })()',
-      expect: /^SyntaxError: Octal literals are not allowed in strict mode/ },
+      expect: /\bSyntaxError: Octal literals are not allowed in strict mode/ },
     { client: client_unix, send: '(function(a, a, b) { "use strict"; return a + b + c; })()',
-      expect: /^SyntaxError: Duplicate parameter name not allowed in this context/ },
+      expect: /\bSyntaxError: Duplicate parameter name not allowed in this context/ },
     { client: client_unix, send: '(function() { "use strict"; with (this) {} })()',
-      expect: /^SyntaxError: Strict mode code may not include a with statement/ },
+      expect: /\bSyntaxError: Strict mode code may not include a with statement/ },
     { client: client_unix, send: '(function() { "use strict"; var x; delete x; })()',
-      expect: /^SyntaxError: Delete of an unqualified identifier in strict mode/ },
+      expect: /\bSyntaxError: Delete of an unqualified identifier in strict mode/ },
     { client: client_unix, send: '(function() { "use strict"; eval = 17; })()',
-      expect: /^SyntaxError: Unexpected eval or arguments in strict mode/ },
+      expect: /\bSyntaxError: Unexpected eval or arguments in strict mode/ },
     { client: client_unix, send: '(function() { "use strict"; if (true) function f() { } })()',
-      expect: /^SyntaxError: In strict mode code, functions can only be declared at top level or inside a block./ },
+      expect: /\bSyntaxError: In strict mode code, functions can only be declared at top level or inside a block./ },
     // Named functions can be used:
     { client: client_unix, send: 'function blah() { return 1; }',
       expect: prompt_unix },
@@ -228,7 +228,7 @@ function error_test() {
       expect: 'Invalid REPL keyword\n' + prompt_unix },
     // fail when we are not inside a String and a line continuation is used
     { client: client_unix, send: '[] \\',
-      expect: /^SyntaxError: Invalid or unexpected token/ },
+      expect: /\bSyntaxError: Invalid or unexpected token/ },
     // do not fail when a String is created with line continuation
     { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
       expect: prompt_multiline + prompt_multiline +
@@ -327,12 +327,15 @@ function error_test() {
     // Illegal token is not recoverable outside string literal, RegExp literal,
     // or block comment. https://github.com/nodejs/node/issues/3611
     { client: client_unix, send: 'a = 3.5e',
-      expect: /^SyntaxError: Invalid or unexpected token/ },
+      expect: /\bSyntaxError: Invalid or unexpected token/ },
     // Mitigate https://github.com/nodejs/node/issues/548
     { client: client_unix, send: 'function name(){ return "node"; };name()',
       expect: "'node'\n" + prompt_unix },
     { client: client_unix, send: 'function name(){ return "nodejs"; };name()',
       expect: "'nodejs'\n" + prompt_unix },
+    // Avoid emitting filename:line-number for SyntaxError
+    { client: client_unix, send: 'a = 3.5e',
+      expect: /^(?!repl)/ },
   ]);
 }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -333,9 +333,12 @@ function error_test() {
       expect: "'node'\n" + prompt_unix },
     { client: client_unix, send: 'function name(){ return "nodejs"; };name()',
       expect: "'nodejs'\n" + prompt_unix },
-    // Avoid emitting filename:line-number for SyntaxError
+    // Avoid emitting repl:line-number for SyntaxError
     { client: client_unix, send: 'a = 3.5e',
       expect: /^(?!repl)/ },
+    // Avoid emitting stack trace
+    { client: client_unix, send: 'a = 3.5e',
+      expect: /^(?!\s+at\s)/ },
   ]);
 }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -338,7 +338,7 @@ function error_test() {
       expect: /^(?!repl)/ },
     // Avoid emitting stack trace
     { client: client_unix, send: 'a = 3.5e',
-      expect: /^(?!\s+at\s)/ },
+      expect: /^(?!\s+at\s)/gm },
   ]);
 }
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

Enabling `vm`'s `displayErrors` [option](https://github.com/nodejs/node/commit/57003520f83a9431dbef0dfce2edacf430923f20) to display code error with caret(`^`) sign
```js
node 🙈 ₹ git:(upstream ⚡ display-error-repl) ./node
> var 4;
var 4;
    ^
SyntaxError: Unexpected number
    at Object.exports.createScript (vm.js:47:10)
    at REPLServer.defaultEval (repl.js:255:25)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:495:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:188:7)
    at REPLServer.Interface._onLine (readline.js:231:10)
    at REPLServer.Interface._line (readline.js:573:8)
    at REPLServer.Interface._ttyWrite (readline.js:850:14)
>
```