### PR TITLE
tools: remove unused variable

### DIFF
--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -17,13 +17,6 @@ let id = 0;
 // Just to make sure that all examples will be processed
 tokens.push({ type: 'heading' });
 
-var oldDirs = fs.readdirSync(verifyDir);
-oldDirs = oldDirs.filter(function(dir) {
-  return /^\d{2}_/.test(dir);
-}).map(function(dir) {
-  return path.resolve(verifyDir, dir);
-});
-
 for (var i = 0; i < tokens.length; i++) {
   var token = tokens[i];
   if (token.type === 'heading' && token.text) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

`oldDirs` is assigned but never used. Remove it.

(This was missed by the linter in previous versions of ESLint but is
flagged by the current version. Updating the linter is contingent on
this change or some similar remedy landing.)