### PR TITLE
test: remove unused var in test-tls-server-verify

### DIFF
--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -256,8 +256,6 @@ function runTest(port, testIndex) {
     rejectUnauthorized: tcase.rejectUnauthorized
   };
 
-  var connections = 0;
-
   /*
    * If renegotiating - session might be resumed and openssl won't request
    * client's certificate (probably because of bug in the openssl)
@@ -292,7 +290,6 @@ function runTest(port, testIndex) {
       return;
     }
 
-    connections++;
     if (c.authorized) {
       console.error(prefix + '- authed connection: ' +
                     c.getPeerCertificate().subject.CN);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

`connections` is assigned but never used. Remove it.

(This was missed by the linter in previous versions of ESLint but is
flagged by the current version. Updating the linter is contingent on
this change or some similar remedy landing.)