### PR TITLE
test: remove unused var from stream2 test

### DIFF
--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -19,10 +19,8 @@ r.on('end', function() {
 
 var w = new Stream();
 w.writable = true;
-var writes = 0;
 var buffered = 0;
 w.write = function(c) {
-  writes += c.length;
   buffered += c.length;
   process.nextTick(drain);
   return false;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test stream

##### Description of change
<!-- Provide a description of the change below this comment. -->

`writes` is assigned but never used. Remove it.

(This was missed by the linter in previous versions of ESLint but is
flagged by the current version. Updating the linter is contingent on
this change or some similar remedy landing.)