### PR TITLE
test: remove unused var in net-server-try-ports

### DIFF
--- a/test/parallel/test-net-server-try-ports.js
+++ b/test/parallel/test-net-server-try-ports.js
@@ -5,19 +5,15 @@ require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var connections = 0;
-
 var server1listening = false;
 var server2listening = false;
 var server2eaddrinuse = false;
 
 var server1 = net.Server(function(socket) {
-  connections++;
   socket.destroy();
 });
 
 var server2 = net.Server(function(socket) {
-  connections++;
   socket.destroy();
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net

##### Description of change
<!-- Provide a description of the change below this comment. -->

`connections` is assigned but never used. Remove it.

(This was missed by the linter in previous versions of ESLint but is
flagged by the current version. Updating the linter is contingent on
this change or some similar remedy landing.)