### PR TITLE
test: remove unused var from child-process-fork

### DIFF
--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -7,12 +7,9 @@ var args = ['foo', 'bar'];
 var n = fork(common.fixturesDir + '/child-process-spawn-node.js', args);
 assert.deepStrictEqual(args, ['foo', 'bar']);
 
-var messageCount = 0;
-
 n.on('message', function(m) {
   console.log('PARENT got message:', m);
   assert.ok(m.foo);
-  messageCount++;
 });
 
 // https://github.com/joyent/node/issues/2355 - JSON.stringify(undefined)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process

##### Description of change
<!-- Provide a description of the change below this comment. -->

`messageCount` is assigned, but never used. Remove it.

(This was missed by the linter in previous versions of ESLint but is
flagged by the current version. Updating the linter is contingent on
this change or some similar remedy landing.)