### PR TITLE
benchmark: remove unused variables

### DIFF
--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -41,7 +41,6 @@ var dgram = require('dgram');
 
 function server() {
   var sent = 0;
-  var received = 0;
   var socket = dgram.createSocket('udp4');
 
   var onsend = type === 'concat' ? onsendConcat : onsendMulti;
@@ -69,10 +68,6 @@ function server() {
       var gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
     }, dur * 1000);
-  });
-
-  socket.on('message', function(buf, rinfo) {
-    received++;
   });
 
   socket.bind(PORT);

--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -50,8 +50,6 @@ function main(conf) {
     }
   }
 
-  var success = 0;
-  var failure = 0;
   var min = 10;
   var size = 0;
   var mod = 317;
@@ -69,14 +67,12 @@ function main(conf) {
       if ((d.length === pattern.length && d === pattern) ||
           (d.length > pattern.length &&
            d.slice(0, pattern.length) === pattern)) {
-        success += 1;
         did = true;
       } else {
         pattern = 'HTTP/1.1 ';
         if ((d.length === pattern.length && d === pattern) ||
             (d.length > pattern.length &&
              d.slice(0, pattern.length) === pattern)) {
-          failure += 1;
           did = true;
         }
       }

--- a/benchmark/static_http_server.js
+++ b/benchmark/static_http_server.js
@@ -6,7 +6,6 @@ var port = 12346;
 var n = 700;
 var bytes = 1024 * 5;
 
-var requests = 0;
 var responses = 0;
 
 var body = 'C'.repeat(bytes);
@@ -37,6 +36,5 @@ server.listen(port, function() {
       });
     });
     req.id = i;
-    requests++;
   }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

benchmark dgram http

##### Description of change
<!-- Provide a description of the change below this comment. -->

Remove variables that are assigned but never used.

(This was missed by the linter in previous versions of ESLint but is
flagged by the current version. Updating the linter is contingent on
this change or some similar remedy landing.)