### PR TITLE
doc: use `git-secure-tag` for release tags

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -218,7 +218,7 @@ Tag summaries have a predictable format, look at a recent tag to see, `git tag -
 
 Install `git-secure-tag` npm module:
 
-```sh
+```console
 $ npm install -g git-secure-tag
 ```
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -218,7 +218,7 @@ Tag summaries have a predictable format, look at a recent tag to see, `git tag -
 
 Install `git-secure-tag` npm module:
 
-```
+```sh
 $ npm install -g git-secure-tag
 ```
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -216,10 +216,16 @@ Once you have produced builds that you're happy with, create a new tag. By waiti
 
 Tag summaries have a predictable format, look at a recent tag to see, `git tag -v v6.0.0`. The message should look something like `2016-04-26 Node.js v6.0.0 (Current) Release`.
 
+Install `git-secure-tag` npm module:
+
+```
+$ npm install -g git-secure-tag
+```
+
 Create a tag using the following command:
 
 ```sh
-$ git tag <vx.y.z> <commit-sha> -sm 'YYYY-MM-DD Node.js vx.y.z (Release Type) Release'
+$ git secure-tag <vx.y.z> <commit-sha> -sm 'YYYY-MM-DD Node.js vx.y.z (Release Type) Release'
 ```
 
 The tag **must** be signed using the GPG key that's listed for you on the project README.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

`git-secure-tag` recursively constructs an SHA-512 digest out of the
git tree, and puts the hash from the tree's root into the tag
annotation. This hash provides better integrity guarantees than the
default SHA-1 merkle tree that git uses.

Fix: #7579