### PR TITLE
doc: add benchmark who-to-CC info

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -2,7 +2,7 @@
 
 | subsystem | maintainers |
 | --- | --- |
-| `benchamrk/*` | @nodejs/benchmarking, @mscdex, @bnoordhuis |
+| `benchmark/*` | @nodejs/benchmarking, @mscdex |
 | `bootstrap_node.js` | @fishrock123 |
 | `lib/assert` | @nodejs/testing |
 | `lib/buffer` | @nodejs/buffer |

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -2,6 +2,8 @@
 
 | subsystem | maintainers |
 | --- | --- |
+| `benchamrk/*` | @nodejs/benchmarking, @mscdex, @bnoordhuis |
+| `bootstrap_node.js` | @fishrock123 |
 | `lib/assert` | @nodejs/testing |
 | `lib/buffer` | @nodejs/buffer |
 | `lib/child_process` | @bnoordhuis, @cjihrig |
@@ -16,7 +18,6 @@
 | `lib/timers` | @fishrock123, @misterdjules |
 | `lib/util` | @bnoordhuis, @cjihrig, @evanlucas |
 | `lib/zlib` | @addaleax, @bnoordhuis, @indutny |
-| `bootstrap_node.js` | @fishrock123 |
 | `src/async-wrap.*` | @trevnorris |
 | `src/node_crypto.*` | @nodejs/crypto |
 | `test/*` | @nodejs/testing |


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc benchmark

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add `benchmark` to "Who to CC". Also, alphabetized the only non-alphabetized subsystem.

Added @nodejs/benchmarking because that *seems* to make sense.

Added @mscdex because if he shouldn't be there, no one should.

Added @bnoordhuis based on `git shortlog -n -s benchmark`.

Happy to remove any of those and add anyone else that makes sense, but this was my guess.