### PR TITLE
src: disable stdio buffering

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -50,7 +50,10 @@ int wmain(int argc, wchar_t *wargv[]) {
 #else
 // UNIX
 int main(int argc, char *argv[]) {
-  setvbuf(stderr, NULL, _IOLBF, 1024);
+  // Disable stdio buffering, it interacts poorly with printf()
+  // calls elsewhere in the program (e.g., any logging from V8.)
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  setvbuf(stderr, nullptr, _IONBF, 0);
   return node::Start(argc, argv);
 }
 #endif

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,6 +22,7 @@ test-tls-connect-address-family : PASS,FLAKY
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS
+test-debug-signal-cluster         : PASS,FLAKY
 
 [$system==freebsd]
 


### PR DESCRIPTION
Disable stdio buffering, it interacts poorly with printf() calls from
elsewhere in the program (e.g., any logging from V8.)  Unbreaks among
other things the `--trace_debug_json` switch.

Undoes commit 0966ab9 ("src: force line buffering for stderr"), which
in retrospect is not a proper fix.  Turning on line buffering fixed a
flaky test on SmartOS but the test wasn't failing on other platforms,
where stderr wasn't line-buffered either.

Disabling buffering should be safe even when mixed with non-blocking
stdio I/O because libuv goes to great lengths to reopen the tty file
descriptors and falls back to blocking I/O when that fails.

R=@Trott?