### PR TITLE
test,doc: clarify `buf.indexOf(num)` input range

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -982,7 +982,8 @@ Operates similar to [`Array#indexOf()`][] in that it returns either the
 starting index position of `value` in Buffer or `-1` if the Buffer does not
 contain `value`. The `value` can be a String, Buffer or Number. Strings are by
 default interpreted as UTF8. Buffers will use the entire Buffer (to compare a
-partial Buffer use [`buf.slice()`][]).  Numbers can range from 0 to 255.
+partial Buffer use [`buf.slice()`][]). Numbers will be interpreted as unsigned 8-bit
+integer values between `0` and `255`.
 
 ```js
 const buf = Buffer.from('this is a buffer');
@@ -1021,7 +1022,8 @@ added: v5.3.0
 Operates similar to [`Array#includes()`][]. The `value` can be a String, Buffer
 or Number. Strings are interpreted as UTF8 unless overridden with the
 `encoding` argument. Buffers will use the entire Buffer (to compare a partial
-Buffer use [`buf.slice()`][]). Numbers can range from 0 to 255.
+Buffer use [`buf.slice()`][]). Numbers will be interpreted as unsigned 8-bit
+integer values between `0` and `255`.
 
 The `byteOffset` indicates the index in `buf` where searching begins.
 

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -264,3 +264,19 @@ assert.throws(function() {
 assert.throws(function() {
   b.includes([]);
 });
+
+// test truncation of Number arguments to uint8
+{
+  const buf = Buffer.from('this is a test');
+  assert.ok(buf.includes(0x6973));
+  assert.ok(buf.includes(0x697320));
+  assert.ok(buf.includes(0x69732069));
+  assert.ok(buf.includes(0x697374657374));
+  assert.ok(buf.includes(0x69737374));
+  assert.ok(buf.includes(0x69737465));
+  assert.ok(buf.includes(0x69737465));
+  assert.ok(buf.includes(-140));
+  assert.ok(buf.includes(-152));
+  assert.ok(!buf.includes(0xff));
+  assert.ok(!buf.includes(0xffff));
+}

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -470,3 +470,19 @@ pattern = reallyLong.slice(0, 1000000);  // First 1/5th.
 assert.equal(3932160, reallyLong.lastIndexOf(pattern));
 pattern = reallyLong.slice(0, 2000000);  // first 2/5ths.
 assert.equal(0, reallyLong.lastIndexOf(pattern));
+
+// test truncation of Number arguments to uint8
+{
+  const buf = Buffer.from('this is a test');
+  assert.strictEqual(buf.indexOf(0x6973), 3);
+  assert.strictEqual(buf.indexOf(0x697320), 4);
+  assert.strictEqual(buf.indexOf(0x69732069), 2);
+  assert.strictEqual(buf.indexOf(0x697374657374), 0);
+  assert.strictEqual(buf.indexOf(0x69737374), 0);
+  assert.strictEqual(buf.indexOf(0x69737465), 11);
+  assert.strictEqual(buf.indexOf(0x69737465), 11);
+  assert.strictEqual(buf.indexOf(-140), 0);
+  assert.strictEqual(buf.indexOf(-152), 1);
+  assert.strictEqual(buf.indexOf(0xff), -1);
+  assert.strictEqual(buf.indexOf(0xffff), -1);
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Hopefully clarify the behaviour of `buffer.indexOf()` and `buffer.includes()` for numbers in that they will be truncated to uint8s.

Add tests for that behaviour.

Fixes: https://github.com/nodejs/node/issues/7591

CI: https://ci.nodejs.org/job/node-test-commit/4022/