### PR TITLE
deps: update V8 to 5.1.281.75

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 69
+#define V8_PATCH_LEVEL 75
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -3241,6 +3241,7 @@ class PropertyCallbackInfo {
 
 typedef void (*FunctionCallback)(const FunctionCallbackInfo<Value>& info);
 
+enum class ConstructorBehavior { kThrow, kAllow };
 
 /**
  * A JavaScript function object (ECMA-262, 15.3).
@@ -3255,6 +3256,11 @@ class V8_EXPORT Function : public Object {
                                   FunctionCallback callback,
                                   Local<Value> data = Local<Value>(),
                                   int length = 0);
+  static MaybeLocal<Function> New(Local<Context> context,
+                                  FunctionCallback callback,
+                                  Local<Value> data,
+                                  int length,
+                                  ConstructorBehavior behavior);
   static V8_DEPRECATE_SOON(
       "Use maybe version",
       Local<Function> New(Isolate* isolate, FunctionCallback callback,
@@ -4478,6 +4484,9 @@ class V8_EXPORT FunctionTemplate : public Template {
       Isolate* isolate, FunctionCallback callback = 0,
       Local<Value> data = Local<Value>(),
       Local<Signature> signature = Local<Signature>(), int length = 0);
+  static Local<FunctionTemplate> New(
+      Isolate* isolate, FunctionCallback callback, Local<Value> data,
+      Local<Signature> signature, int length, ConstructorBehavior behavior);
 
   /**
    * Creates a function template with a fast handler. If a fast handler is set,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -1153,14 +1153,26 @@ Local<FunctionTemplate> FunctionTemplate::New(Isolate* isolate,
                                               v8::Local<Value> data,
                                               v8::Local<Signature> signature,
                                               int length) {
+  return New(
+      isolate, callback, data, signature, length, ConstructorBehavior::kAllow);
+}
+
+Local<FunctionTemplate> FunctionTemplate::New(Isolate* isolate,
+                                              FunctionCallback callback,
+                                              v8::Local<Value> data,
+                                              v8::Local<Signature> signature,
+                                              int length,
+                                              ConstructorBehavior behavior) {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
   // Changes to the environment cannot be captured in the snapshot. Expect no
   // function templates when the isolate is created for serialization.
   DCHECK(!i_isolate->serializer_enabled());
   LOG_API(i_isolate, "FunctionTemplate::New");
   ENTER_V8(i_isolate);
-  return FunctionTemplateNew(i_isolate, callback, nullptr, data, signature,
-                             length, false);
+  auto tmpl = FunctionTemplateNew(i_isolate, callback, nullptr, data, signature,
+                                  length, false);
+  if (behavior == ConstructorBehavior::kThrow) tmpl->RemovePrototype();
+  return tmpl;
 }
 
 
@@ -4449,14 +4461,20 @@ Local<v8::Value> Object::CallAsConstructor(int argc,
 MaybeLocal<Function> Function::New(Local<Context> context,
                                    FunctionCallback callback, Local<Value> data,
                                    int length) {
+  return New(context, callback, data, length, ConstructorBehavior::kAllow);
+}
+
+MaybeLocal<Function> Function::New(Local<Context> context,
+                                   FunctionCallback callback, Local<Value> data,
+                                   int length, ConstructorBehavior behavior) {
   i::Isolate* isolate = Utils::OpenHandle(*context)->GetIsolate();
   LOG_API(isolate, "Function::New");
   ENTER_V8(isolate);
-  return FunctionTemplateNew(isolate, callback, nullptr, data,
-                             Local<Signature>(), length, true)
-      ->GetFunction(context);
+  auto tmpl = FunctionTemplateNew(isolate, callback, nullptr, data,
+                                  Local<Signature>(), length, true);
+  if (behavior == ConstructorBehavior::kThrow) tmpl->RemovePrototype();
+  return tmpl->GetFunction(context);
 }
-
 
 Local<Function> Function::New(Isolate* v8_isolate, FunctionCallback callback,
                               Local<Value> data, int length) {

--- a/deps/v8/src/compiler/js-create-lowering.cc
+++ b/deps/v8/src/compiler/js-create-lowering.cc
@@ -471,6 +471,9 @@ Reduction JSCreateLowering::ReduceNewArray(Node* node, Node* length,
   PretenureFlag pretenure = site->GetPretenureMode();
   ElementsKind elements_kind = site->GetElementsKind();
   DCHECK(IsFastElementsKind(elements_kind));
+  if (NodeProperties::GetType(length)->Max() > 0) {
+    elements_kind = GetHoleyElementsKind(elements_kind);
+  }
   dependencies()->AssumeTenuringDecision(site);
   dependencies()->AssumeTransitionStable(site);
 

--- a/deps/v8/src/crankshaft/hydrogen.cc
+++ b/deps/v8/src/crankshaft/hydrogen.cc
@@ -8428,6 +8428,10 @@ bool HOptimizedGraphBuilder::TryInline(Handle<JSFunction> target,
     TraceInline(target, caller, "parse failure");
     return false;
   }
+  if (target_shared->dont_crankshaft()) {
+    TraceInline(target, caller, "ParseAndAnalyze found incompatibility");
+    return false;
+  }
 
   if (target_info.scope()->num_heap_slots() > 0) {
     TraceInline(target, caller, "target has context-allocated variables");

--- a/deps/v8/src/log.cc
+++ b/deps/v8/src/log.cc
@@ -242,10 +242,6 @@ class PerfBasicLogger : public CodeEventLogger {
   static const char kFilenameFormatString[];
   static const int kFilenameBufferPadding;
 
-  // File buffer size of the low-level log. We don't use the default to
-  // minimize the associated overhead.
-  static const int kLogBufferSize = 2 * MB;
-
   FILE* perf_output_handle_;
 };
 
@@ -266,7 +262,7 @@ PerfBasicLogger::PerfBasicLogger()
   perf_output_handle_ =
       base::OS::FOpen(perf_dump_name.start(), base::OS::LogFileOpenMode);
   CHECK_NOT_NULL(perf_output_handle_);
-  setvbuf(perf_output_handle_, NULL, _IOFBF, kLogBufferSize);
+  setvbuf(perf_output_handle_, NULL, _IOLBF, 0);
 }
 
 
@@ -332,10 +328,6 @@ class LowLevelLogger : public CodeEventLogger {
   // Extension added to V8 log file name to get the low-level log name.
   static const char kLogExt[];
 
-  // File buffer size of the low-level log. We don't use the default to
-  // minimize the associated overhead.
-  static const int kLogBufferSize = 2 * MB;
-
   void LogCodeInfo();
   void LogWriteBytes(const char* bytes, int size);
 
@@ -360,7 +352,7 @@ LowLevelLogger::LowLevelLogger(const char* name)
   MemCopy(ll_name.start() + len, kLogExt, sizeof(kLogExt));
   ll_output_handle_ =
       base::OS::FOpen(ll_name.start(), base::OS::LogFileOpenMode);
-  setvbuf(ll_output_handle_, NULL, _IOFBF, kLogBufferSize);
+  setvbuf(ll_output_handle_, NULL, _IOLBF, 0);
 
   LogCodeInfo();
 }

--- a/deps/v8/src/runtime/runtime-scopes.cc
+++ b/deps/v8/src/runtime/runtime-scopes.cc
@@ -648,7 +648,7 @@ RUNTIME_FUNCTION(Runtime_NewRestParameter) {
   {
     DisallowHeapAllocation no_gc;
     FixedArray* elements = FixedArray::cast(result->elements());
-    WriteBarrierMode mode = result->GetWriteBarrierMode(no_gc);
+    WriteBarrierMode mode = elements->GetWriteBarrierMode(no_gc);
     for (int i = 0; i < num_elements; i++) {
       elements->set(i, *arguments[i + start_index], mode);
     }

--- a/deps/v8/test/mjsunit/compiler/regress-621147.js
+++ b/deps/v8/test/mjsunit/compiler/regress-621147.js
@@ -1,0 +1,29 @@
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --turbo-filter=test2
+
+function test(n) {
+  return Array(n);
+}
+
+function test2() {
+  return test(2);
+}
+
+function test3(a) {
+  a[0] = 1;
+}
+
+test(0);
+
+var smi_array = [1,2];
+smi_array[2] = 3;
+test3(smi_array);
+
+%OptimizeFunctionOnNextCall(test2);
+
+var broken_array = test2();
+test3(broken_array);
+1+broken_array[0];

--- a/deps/v8/test/mjsunit/mjsunit.status
+++ b/deps/v8/test/mjsunit/mjsunit.status
@@ -758,6 +758,14 @@
   'regress/regress-1132': [SKIP],
 }],  # 'arch == ppc and simulator_run == True'
 
+['arch == ppc64', {
+
+  # stack overflow
+  'big-array-literal': [SKIP],
+}],  # 'arch == ppc64'
+
+##############################################################################
+
 ##############################################################################
 ['ignition == True', {
   # TODO(yangguo,4690): assertion failures in debugger tests.

--- a/deps/v8/test/mjsunit/regress/regress-5033.js
+++ b/deps/v8/test/mjsunit/regress/regress-5033.js
@@ -1,0 +1,21 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+var test = function() {
+  var t = Date.now();  // Just any non-constant double value.
+  var o = {
+    ['p']: 1,
+    t
+  };
+};
+
+function caller() {
+  test();
+}
+caller();
+caller();
+%OptimizeFunctionOnNextCall(caller);
+caller();


### PR DESCRIPTION
Pick up the latest branch-head for V8 5.1.  Introduces a semver-minor
overload of v8::Function::New() for use by v8_inspector.

Refs: #7586

R=@nodejs/v8

CI: https://ci.nodejs.org/job/node-test-pull-request/3220/
CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/184/