### PR TITLE
benchmark: Repair http chunked benchmark

### DIFF
--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -18,7 +18,7 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   const http = require('http');
-  var chunk = Buffer.alloc(conf.size, '8');
+  var chunk = Buffer.alloc(+conf.size, '8');
 
   var args = ['-d', '10s', '-t', 8, '-c', conf.c];
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark

##### Description of change
Cast to number the configuration size before passing it to the buffer constructor.

When running the http chunked benchmark the following exception occurs:
buffer.js:110
    throw err;
    ^

TypeError: "size" argument must be a number
    at Function.Buffer.alloc (buffer.js:119:3)
    at Benchmark.main [as fn] (/builds/2016-07-06_02-55-00/node/benchmark/http/chunked.js:21:22)
    at Benchmark._run (/builds/2016-07-06_02-55-00/node/benchmark/common.js:139:17)
    at /builds/2016-07-06_02-55-00/node/benchmark/common.js:96:10
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:577:11)
    at run (bootstrap_node.js:340:7)
    at startup (bootstrap_node.js:132:9)
    at bootstrap_node.js:455:3


Signed-off-by: Sorin Baltateanu <sorin.baltateanu@intel.com>