### PR TITLE
tools: make the progress bar spacing consistent

### DIFF
--- a/tools/jslint.js
+++ b/tools/jslint.js
@@ -215,10 +215,10 @@ if (cluster.isMaster) {
     const elapsed = process.hrtime(startTime)[0];
     const mins = padString(Math.floor(elapsed / 60), 2, '0');
     const secs = padString(elapsed % 60, 2, '0');
-    const passed = padString(successes, 6, ' ');
-    const failed = padString(failures, 6, ' ');
+    const passed = padString(successes, 4, ' ');
+    const failed = padString(failures, 4, ' ');
     var pct = Math.ceil(((totalPaths - paths.length) / totalPaths) * 100);
-    pct = padString(pct, 3, ' ');
+    pct = padString(pct, 4, ' ');
 
     var line = `[${mins}:${secs}|%${pct}|+${passed}|-${failed}]: ${curPath}`;
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -379,7 +379,7 @@ class ColorProgressIndicator(CompactProgressIndicator):
 
   def __init__(self, cases, flaky_tests_mode):
     templates = {
-      'status_line': "[%(mins)02i:%(secs)02i|\033[34m%%%(remaining) 4d\033[0m|\033[32m+%(passed) 4d\033[0m|\033[31m-%(failed) 4d\033[0m]: %(test)s",
+      'status_line': "[%(mins)02i:%(secs)02i|\033[34m%%%(remaining)4d\033[0m|\033[32m+%(passed)4d\033[0m|\033[31m-%(failed)4d\033[0m]: %(test)s",
       'stdout': "\033[1m%s\033[0m",
       'stderr': "\033[31m%s\033[0m",
     }
@@ -393,7 +393,7 @@ class MonochromeProgressIndicator(CompactProgressIndicator):
 
   def __init__(self, cases, flaky_tests_mode):
     templates = {
-      'status_line': "[%(mins)02i:%(secs)02i|%%%(remaining) 4d|+%(passed) 4d|-%(failed) 4d]: %(test)s",
+      'status_line': "[%(mins)02i:%(secs)02i|%%%(remaining)4d|+%(passed)4d|-%(failed)4d]: %(test)s",
       'stdout': '%s',
       'stderr': '%s',
       'clear': lambda last_line_length: ("\r" + (" " * last_line_length) + "\r"),


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description of change

As it is, the `tools/test.py` will produce a progressbar like this

    [01:00|% 100|+ 1189|-   0]: Done

but the `tools/jslint.js` will produce a progressbar like this

    [00:04|%100|+  1639|-     0]: Done

The space between percentage completed is not consistent. This patch
makes sure that both of them use four character spacing, for all the
parts in the progress bar.