### PR TITLE
Fix py errors

### DIFF
--- a/tools/icu/shrink-icu-src.py
+++ b/tools/icu/shrink-icu-src.py
@@ -33,7 +33,7 @@ if os.path.isdir(options.icusmall):
     shutil.rmtree(options.icusmall)
 
 if not os.path.isdir(options.icusrc):
-    print 'Missing source ICU dir --icusrc=%' % (options.icusrc)
+    print 'Missing source ICU dir --icusrc=%s' % (options.icusrc)
     sys.exit(1)
 
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description of change

There are two fixes.

1. The `RunProcess` function returns four values, but it is unpacked over
three variables and this will fail at runtime. This patch unpacks the
fourth value on a dummy variable. - `tools/test.py`

2. The format specifier is incomplete and without this the program will
fail at runtime, with "incomplete format" error. - `tools/icu/shrink-icu-src.py`

cc @bnoordhuis @addaleax @jasnell 