### PR TITLE
repl: Mitigate vm #548 function redefinition issue

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -472,19 +472,7 @@ function REPLServer(prompt,
     }
 
     var evalCmd = self.bufferedCommand + cmd;
-    if (/^\s*\{/.test(evalCmd) && /\}\s*$/.test(evalCmd)) {
-      // It's confusing for `{ a : 1 }` to be interpreted as a block
-      // statement rather than an object literal.  So, we first try
-      // to wrap it in parentheses, so that it will be interpreted as
-      // an expression.
-      evalCmd = '(' + evalCmd + ')\n';
-      self.wrappedCmd = true;
-    } else {
-      // otherwise we just append a \n so that it will be either
-      // terminated, or continued onto the next expression if it's an
-      // unexpected end of input.
-      evalCmd = evalCmd + '\n';
-    }
+    evalCmd = preprocess(evalCmd);
 
     debug('eval %j', evalCmd);
     self.eval(evalCmd, self.context, 'repl', finish);
@@ -538,6 +526,26 @@ function REPLServer(prompt,
 
       // Display prompt again
       self.displayPrompt();
+    }
+
+    function preprocess(code) {
+      let cmd = code;
+      if (/^\s*\{/.test(cmd) && /\}\s*$/.test(cmd)) {
+        // It's confusing for `{ a : 1 }` to be interpreted as a block
+        // statement rather than an object literal.  So, we first try
+        // to wrap it in parentheses, so that it will be interpreted as
+        // an expression.
+        cmd = `(${cmd})`;
+        self.wrappedCmd = true;
+      } else {
+        // Mitigate vm #548 issue
+        cmd = cmd.replace(/^\s*function\s+([^(]+)/,
+                  (_, name) => `var ${name} = function ${name}`);
+      }
+      // Append a \n so that it will be either
+      // terminated, or continued onto the next expression if it's an
+      // unexpected end of input.
+      return `${cmd}\n`;
     }
   });
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -538,7 +538,7 @@ function REPLServer(prompt,
         cmd = `(${cmd})`;
         self.wrappedCmd = true;
       } else {
-        // Mitigate vm #548 issue
+        // Mitigate https://github.com/nodejs/node/issues/548
         cmd = cmd.replace(/^\s*function\s+([^(]+)/,
                   (_, name) => `var ${name} = function ${name}`);
       }

--- a/test/known_issues/test-repl-function-redefinition-edge-case.js
+++ b/test/known_issues/test-repl-function-redefinition-edge-case.js
@@ -15,7 +15,7 @@ r.input.emit('data', '.exit');
 
 const expected = '1\n[Function a]\n';
 const got = r.output.accumulator.join('');
-assert.equal(got, expected);
+assert.strictEqual(got, expected);
 
 function initRepl() {
   const input = new stream();
@@ -36,5 +36,3 @@ function initRepl() {
     prompt: ''
   });
 }
-
-

--- a/test/known_issues/test-repl-function-redefinition-edge-case.js
+++ b/test/known_issues/test-repl-function-redefinition-edge-case.js
@@ -1,0 +1,40 @@
+// Reference: https://github.com/nodejs/node/pull/7624
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const stream = require('stream');
+
+common.globalCheck = false;
+
+const r = initRepl();
+
+r.input.emit('data', 'function a() { return 42; } (1)\n');
+r.input.emit('data', 'a\n');
+r.input.emit('data', '.exit');
+
+const expected = '1\n[Function a]\n';
+const got = r.output.accumulator.join('');
+assert.equal(got, expected);
+
+function initRepl() {
+  const input = new stream();
+  input.write = input.pause = input.resume = () => {};
+  input.readable = true;
+
+  const output = new stream();
+  output.writable = true;
+  output.accumulator = [];
+
+  output.write = (data) => output.accumulator.push(data);
+
+  return repl.start({
+    input,
+    output,
+    useColors: false,
+    terminal: false,
+    prompt: ''
+  });
+}
+
+

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -328,7 +328,7 @@ function error_test() {
     // or block comment. https://github.com/nodejs/node/issues/3611
     { client: client_unix, send: 'a = 3.5e',
       expect: /^SyntaxError: Invalid or unexpected token/ },
-    // Mitigate #548 issue
+    // Mitigate https://github.com/nodejs/node/issues/548
     { client: client_unix, send: 'function name(){ return "node"; };name()',
       expect: "'node'\n" + prompt_unix },
     { client: client_unix, send: 'function name(){ return "nodejs"; };name()',

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -328,6 +328,11 @@ function error_test() {
     // or block comment. https://github.com/nodejs/node/issues/3611
     { client: client_unix, send: 'a = 3.5e',
       expect: /^SyntaxError: Invalid or unexpected token/ },
+    // Mitigate #548 issue
+    { client: client_unix, send: 'function name(){ return "node"; };name()',
+      expect: "'node'\n" + prompt_unix },
+    { client: client_unix, send: 'function name(){ return "nodejs"; };name()',
+      expect: "'nodejs'\n" + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

Transformed `function XXX(...)` to `var XXX = function XXX(...)` in order to mitigate vm #548 function redefinition issue

###### Before
```js
node 🙈 ₹ git:(master) ./node
> process.version
'v7.0.0-pre'
> function name() { return "node"; };
undefined
> name()
'node'
> function name() { return "nodejs"; };
undefined
> name()
'node'  // should be 'nodejs'
>
```

###### After
```js
node 🙈 ₹ git:(upstream ⚡ repl-tmp-548) ./node
> function name() { return "node"; };
undefined
> name()
'node'
> function name() { return "nodejs"; };
undefined
> name()
'nodejs'
>
```