### PR TITLE
benchmark: fix hanging dgram/array-vs-concat.js

### DIFF
--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -68,6 +68,7 @@ function server() {
       var bytes = sent * len;
       var gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
+      process.exit(0);
     }, dur * 1000);
   });
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

bencmark, dgram

##### Description of change
<!-- Provide a description of the change below this comment. -->

Exit process so benchmark can continue.

`process.exit()` was removed previously at https://github.com/nodejs/node/commit/83432bfff1e21797e497aacf4c473db1345f6334#diff-1cc47d7eb19f32771e7d3f6d813eb92cL242

This change adds it back, but only in this benchmark and not in `benchmark/common.js`.

/cc @mscdex