### PR TITLE
Micro refactoring sigintHandlersWrap method

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -84,11 +84,12 @@ exports.isContext = binding.isContext;
 function sigintHandlersWrap(fn) {
   // Using the internal list here to make sure `.once()` wrappers are used,
   // not the original ones.
-  let sigintListeners = process._events.SIGINT;
-  if (!Array.isArray(sigintListeners))
-    sigintListeners = sigintListeners ? [sigintListeners] : [];
-  else
-    sigintListeners = sigintListeners.slice();
+  const sigintListeners = process._events.SIGINT;
+  const asArray = (listeners) => listeners ? [listeners] : [];
+
+  const listeners = Array.isArray(sigintListeners)
+    ? sigintListeners.slice()
+    : asArray(sigintListeners);
 
   process.removeAllListeners('SIGINT');
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -84,12 +84,10 @@ exports.isContext = binding.isContext;
 function sigintHandlersWrap(fn) {
   // Using the internal list here to make sure `.once()` wrappers are used,
   // not the original ones.
-  const sigintListeners = process._events.SIGINT;
-  const asArray = (listeners) => listeners ? [listeners] : [];
-
+  const sigintListeners = process._events.SIGINT || [];
   const listeners = Array.isArray(sigintListeners)
     ? sigintListeners.slice()
-    : asArray(sigintListeners);
+    : [sigintListeners];
 
   process.removeAllListeners('SIGINT');
 
@@ -98,7 +96,7 @@ function sigintHandlersWrap(fn) {
   } finally {
     // Add using the public methods so that the `newListener` handler of
     // process can re-attach the listeners.
-    for (const listener of sigintListeners) {
+    for (const listener of listeners) {
       process.addListener('SIGINT', listener);
     }
   }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

vm
##### Description of change
- Removing extra if and else and use ternary operator instead
- Avoid reassigning of `sigintListeners` variable
- Extract new `asArray` function to handle transformation of `sigintListeners` to array
