### PR TITLE
util: inspect boxed symbols like other primitives

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -413,6 +413,10 @@ function formatValue(ctx, value, recurseTimes) {
       formatted = formatPrimitiveNoColor(ctx, raw);
       return ctx.stylize('[String: ' + formatted + ']', 'string');
     }
+    if (typeof raw === 'symbol') {
+      formatted = formatPrimitiveNoColor(ctx, raw);
+      return ctx.stylize('[Symbol: ' + formatted + ']', 'symbol');
+    }
     if (typeof raw === 'number') {
       formatted = formatPrimitiveNoColor(ctx, raw);
       return ctx.stylize('[Number: ' + formatted + ']', 'number');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -474,6 +474,7 @@ test_lines({
 
 // test boxed primitives output the correct values
 assert.equal(util.inspect(new String('test')), '[String: \'test\']');
+assert.equal(util.inspect(Object(Symbol('test'))), '[Symbol: Symbol(test)]');
 assert.equal(util.inspect(new Boolean(false)), '[Boolean: false]');
 assert.equal(util.inspect(new Boolean(true)), '[Boolean: true]');
 assert.equal(util.inspect(new Number(0)), '[Number: 0]');


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util

##### Description of change

Inspect boxed symbol objects in the same way other boxed primitives are inspected.

Fixes: https://github.com/nodejs/node/issues/7639

CI: https://ci.nodejs.org/job/node-test-commit/4039/