### PR TITLE
src: don't use __builtin_bswap16() and friends

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -483,8 +483,7 @@ void StringSlice<UCS2>(const FunctionCallbackInfo<Value>& args) {
   // Node's "ucs2" encoding expects LE character data inside a Buffer, so we
   // need to reorder on BE platforms.  See http://nodejs.org/api/buffer.html
   // regarding Node's "ucs2" encoding specification.
-  const bool aligned = (reinterpret_cast<uintptr_t>(data) % sizeof(*buf) == 0);
-  if (IsLittleEndian() && !aligned) {
+  if (IsLittleEndian() && !IsAlignedTo<uint16_t>(data)) {
     // Make a copy to avoid unaligned accesses in v8::String::NewFromTwoByte().
     // This applies ONLY to little endian platforms, as misalignment will be
     // handled by a byte-swapping operation in StringBytes::Encode on

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -12,7 +12,6 @@
 
 #include <string.h>
 #include <limits.h>
-#include <utility>
 
 #define BUFFER_ID 0xB0E4
 
@@ -1174,13 +1173,8 @@ void Swap16(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_ARG(args[0], ts_obj);
-
   CHECK_EQ(ts_obj_length % 2, 0);
-
-  for (size_t i = 0; i < ts_obj_length; i += 2) {
-    std::swap(ts_obj_data[i], ts_obj_data[i + 1]);
-  }
-
+  SwapBytes16(ts_obj_data, ts_obj_data, ts_obj_length);
   args.GetReturnValue().Set(args[0]);
 }
 
@@ -1189,14 +1183,8 @@ void Swap32(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_ARG(args[0], ts_obj);
-
   CHECK_EQ(ts_obj_length % 4, 0);
-
-  for (size_t i = 0; i < ts_obj_length; i += 4) {
-    std::swap(ts_obj_data[i], ts_obj_data[i + 3]);
-    std::swap(ts_obj_data[i + 1], ts_obj_data[i + 2]);
-  }
-
+  SwapBytes32(ts_obj_data, ts_obj_data, ts_obj_length);
   args.GetReturnValue().Set(args[0]);
 }
 
@@ -1205,16 +1193,8 @@ void Swap64(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   SPREAD_ARG(args[0], ts_obj);
-
   CHECK_EQ(ts_obj_length % 8, 0);
-
-  for (size_t i = 0; i < ts_obj_length; i += 8) {
-    std::swap(ts_obj_data[i], ts_obj_data[i + 7]);
-    std::swap(ts_obj_data[i + 1], ts_obj_data[i + 6]);
-    std::swap(ts_obj_data[i + 2], ts_obj_data[i + 5]);
-    std::swap(ts_obj_data[i + 3], ts_obj_data[i + 4]);
-  }
-
+  SwapBytes64(ts_obj_data, ts_obj_data, ts_obj_length);
   args.GetReturnValue().Set(args[0]);
 }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -52,38 +52,6 @@
 #define BUFFER_MALLOC(length)                                               \
   zero_fill_all_buffers ? calloc(length, 1) : malloc(length)
 
-#if defined(__GNUC__) || defined(__clang__)
-#define BSWAP_INTRINSIC_2(x) __builtin_bswap16(x)
-#define BSWAP_INTRINSIC_4(x) __builtin_bswap32(x)
-#define BSWAP_INTRINSIC_8(x) __builtin_bswap64(x)
-#elif defined(__linux__)
-#include <byteswap.h>
-#define BSWAP_INTRINSIC_2(x) bswap_16(x)
-#define BSWAP_INTRINSIC_4(x) bswap_32(x)
-#define BSWAP_INTRINSIC_8(x) bswap_64(x)
-#elif defined(_MSC_VER)
-#include <intrin.h>
-#define BSWAP_INTRINSIC_2(x) _byteswap_ushort(x);
-#define BSWAP_INTRINSIC_4(x) _byteswap_ulong(x);
-#define BSWAP_INTRINSIC_8(x) _byteswap_uint64(x);
-#else
-#define BSWAP_INTRINSIC_2(x) ((x) << 8) | ((x) >> 8)
-#define BSWAP_INTRINSIC_4(x)                                                  \
-  (((x) & 0xFF) << 24) |                                                      \
-  (((x) & 0xFF00) << 8) |                                                     \
-  (((x) >> 8) & 0xFF00) |                                                     \
-  (((x) >> 24) & 0xFF)
-#define BSWAP_INTRINSIC_8(x)                                                  \
-  (((x) & 0xFF00000000000000ull) >> 56) |                                     \
-  (((x) & 0x00FF000000000000ull) >> 40) |                                     \
-  (((x) & 0x0000FF0000000000ull) >> 24) |                                     \
-  (((x) & 0x000000FF00000000ull) >> 8) |                                      \
-  (((x) & 0x00000000FF000000ull) << 8) |                                      \
-  (((x) & 0x0000000000FF0000ull) << 24) |                                     \
-  (((x) & 0x000000000000FF00ull) << 40) |                                     \
-  (((x) & 0x00000000000000FFull) << 56)
-#endif
-
 namespace node {
 
 // if true, all Buffer and SlowBuffer instances will automatically zero-fill
@@ -1209,18 +1177,8 @@ void Swap16(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(ts_obj_length % 2, 0);
 
-  int align = reinterpret_cast<uintptr_t>(ts_obj_data) % sizeof(uint16_t);
-
-  if (align == 0) {
-    uint16_t* data16 = reinterpret_cast<uint16_t*>(ts_obj_data);
-    size_t len16 = ts_obj_length / 2;
-    for (size_t i = 0; i < len16; i++) {
-      data16[i] = BSWAP_INTRINSIC_2(data16[i]);
-    }
-  } else {
-    for (size_t i = 0; i < ts_obj_length; i += 2) {
-      std::swap(ts_obj_data[i], ts_obj_data[i + 1]);
-    }
+  for (size_t i = 0; i < ts_obj_length; i += 2) {
+    std::swap(ts_obj_data[i], ts_obj_data[i + 1]);
   }
 
   args.GetReturnValue().Set(args[0]);
@@ -1234,19 +1192,9 @@ void Swap32(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(ts_obj_length % 4, 0);
 
-  int align = reinterpret_cast<uintptr_t>(ts_obj_data) % sizeof(uint32_t);
-
-  if (align == 0) {
-    uint32_t* data32 = reinterpret_cast<uint32_t*>(ts_obj_data);
-    size_t len32 = ts_obj_length / 4;
-    for (size_t i = 0; i < len32; i++) {
-      data32[i] = BSWAP_INTRINSIC_4(data32[i]);
-    }
-  } else {
-    for (size_t i = 0; i < ts_obj_length; i += 4) {
-      std::swap(ts_obj_data[i], ts_obj_data[i + 3]);
-      std::swap(ts_obj_data[i + 1], ts_obj_data[i + 2]);
-    }
+  for (size_t i = 0; i < ts_obj_length; i += 4) {
+    std::swap(ts_obj_data[i], ts_obj_data[i + 3]);
+    std::swap(ts_obj_data[i + 1], ts_obj_data[i + 2]);
   }
 
   args.GetReturnValue().Set(args[0]);
@@ -1260,21 +1208,11 @@ void Swap64(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(ts_obj_length % 8, 0);
 
-  int align = reinterpret_cast<uintptr_t>(ts_obj_data) % sizeof(uint64_t);
-
-  if (align == 0) {
-    uint64_t* data64 = reinterpret_cast<uint64_t*>(ts_obj_data);
-    size_t len32 = ts_obj_length / 8;
-    for (size_t i = 0; i < len32; i++) {
-      data64[i] = BSWAP_INTRINSIC_8(data64[i]);
-    }
-  } else {
-    for (size_t i = 0; i < ts_obj_length; i += 8) {
-      std::swap(ts_obj_data[i], ts_obj_data[i + 7]);
-      std::swap(ts_obj_data[i + 1], ts_obj_data[i + 6]);
-      std::swap(ts_obj_data[i + 2], ts_obj_data[i + 5]);
-      std::swap(ts_obj_data[i + 3], ts_obj_data[i + 4]);
-    }
+  for (size_t i = 0; i < ts_obj_length; i += 8) {
+    std::swap(ts_obj_data[i], ts_obj_data[i + 7]);
+    std::swap(ts_obj_data[i + 1], ts_obj_data[i + 6]);
+    std::swap(ts_obj_data[i + 2], ts_obj_data[i + 5]);
+    std::swap(ts_obj_data[i + 3], ts_obj_data[i + 4]);
   }
 
   args.GetReturnValue().Set(args[0]);

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "util.h"
+#include <string.h>  // memcpy()
 
 namespace node {
 
@@ -200,47 +201,69 @@ TypeName* Unwrap(v8::Local<v8::Object> object) {
   return static_cast<TypeName*>(pointer);
 }
 
-void SwapBytes16(char* dst, const char* src, size_t size) {
-  for (size_t i = 0; i < size; i += 2) {
-    char a = src[i + 0];
-    char b = src[i + 1];
-    dst[i + 0] = b;
-    dst[i + 1] = a;
+template <typename T, typename U>
+bool IsAlignedTo(const U* p) {
+  return reinterpret_cast<uintptr_t>(p) % sizeof(T) == 0;
+}
+
+uint16_t ByteSwap(uint16_t v) {
+  uint16_t a = (v >> 0) & 255;
+  uint16_t b = (v >> 8) & 255;
+  return (a << 8) | b;
+}
+
+uint32_t ByteSwap(uint32_t v) {
+  uint32_t a = (v >> 0) & 255;
+  uint32_t b = (v >> 8) & 255;
+  uint32_t c = (v >> 16) & 255;
+  uint32_t d = (v >> 24) & 255;
+  return (a << 24) | (b << 16) | (c << 8) | d;
+}
+
+uint64_t ByteSwap(uint64_t v) {
+  uint64_t a = (v >> 0) & 255;
+  uint64_t b = (v >> 8) & 255;
+  uint64_t c = (v >> 16) & 255;
+  uint64_t d = (v >> 24) & 255;
+  uint64_t e = (v >> 32) & 255;
+  uint64_t f = (v >> 40) & 255;
+  uint64_t g = (v >> 48) & 255;
+  uint64_t h = (v >> 56) & 255;
+  return (a << 56) | (b << 48) | (c << 40) | (d << 32) |
+         (e << 24) | (f << 16) | (g << 8) | h;
+}
+
+template <typename T>
+inline void DoSwapBytes(char* dst, const char* src, size_t size) {
+  for (size_t i = 0; i < size; i += sizeof(T)) {
+    T v;
+    memcpy(&v, &src[i], sizeof(v));
+    v = ByteSwap(v);
+    memcpy(&dst[i], &v, sizeof(v));
   }
+}
+
+template <typename T>
+void SwapBytes(char* dst, const char* src, size_t size) {
+  if (src == dst && IsAlignedTo<T>(dst)) {
+    // Hit the compiler over the head with the fact that the source
+    // and the destination are the same and is properly aligned.
+    DoSwapBytes<T>(dst, dst, size);
+  } else {
+    DoSwapBytes<T>(dst, src, size);
+  }
+}
+
+void SwapBytes16(char* dst, const char* src, size_t size) {
+  return SwapBytes<uint16_t>(dst, src, size);
 }
 
 void SwapBytes32(char* dst, const char* src, size_t size) {
-  for (size_t i = 0; i < size; i += 4) {
-    char a = src[i + 0];
-    char b = src[i + 1];
-    char c = src[i + 2];
-    char d = src[i + 3];
-    dst[i + 0] = d;
-    dst[i + 1] = c;
-    dst[i + 2] = b;
-    dst[i + 3] = a;
-  }
+  return SwapBytes<uint32_t>(dst, src, size);
 }
 
 void SwapBytes64(char* dst, const char* src, size_t size) {
-  for (size_t i = 0; i < size; i += 8) {
-    char a = src[i + 0];
-    char b = src[i + 1];
-    char c = src[i + 2];
-    char d = src[i + 3];
-    char e = src[i + 4];
-    char f = src[i + 5];
-    char g = src[i + 6];
-    char h = src[i + 7];
-    dst[i + 0] = h;
-    dst[i + 1] = g;
-    dst[i + 2] = f;
-    dst[i + 3] = e;
-    dst[i + 4] = d;
-    dst[i + 5] = c;
-    dst[i + 6] = b;
-    dst[i + 7] = a;
-  }
+  return SwapBytes<uint64_t>(dst, src, size);
 }
 
 char ToLower(char c) {

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -200,9 +200,47 @@ TypeName* Unwrap(v8::Local<v8::Object> object) {
   return static_cast<TypeName*>(pointer);
 }
 
-void SwapBytes(uint16_t* dst, const uint16_t* src, size_t buflen) {
-  for (size_t i = 0; i < buflen; i += 1)
-    dst[i] = (src[i] << 8) | (src[i] >> 8);
+void SwapBytes16(char* dst, const char* src, size_t size) {
+  for (size_t i = 0; i < size; i += 2) {
+    char a = src[i + 0];
+    char b = src[i + 1];
+    dst[i + 0] = b;
+    dst[i + 1] = a;
+  }
+}
+
+void SwapBytes32(char* dst, const char* src, size_t size) {
+  for (size_t i = 0; i < size; i += 4) {
+    char a = src[i + 0];
+    char b = src[i + 1];
+    char c = src[i + 2];
+    char d = src[i + 3];
+    dst[i + 0] = d;
+    dst[i + 1] = c;
+    dst[i + 2] = b;
+    dst[i + 3] = a;
+  }
+}
+
+void SwapBytes64(char* dst, const char* src, size_t size) {
+  for (size_t i = 0; i < size; i += 8) {
+    char a = src[i + 0];
+    char b = src[i + 1];
+    char c = src[i + 2];
+    char d = src[i + 3];
+    char e = src[i + 4];
+    char f = src[i + 5];
+    char g = src[i + 6];
+    char h = src[i + 7];
+    dst[i + 0] = h;
+    dst[i + 1] = g;
+    dst[i + 2] = f;
+    dst[i + 3] = e;
+    dst[i + 4] = d;
+    dst[i + 5] = c;
+    dst[i + 6] = b;
+    dst[i + 7] = a;
+  }
 }
 
 char ToLower(char c) {

--- a/src/util.h
+++ b/src/util.h
@@ -238,7 +238,11 @@ inline void ClearWrap(v8::Local<v8::Object> object);
 template <typename TypeName>
 inline TypeName* Unwrap(v8::Local<v8::Object> object);
 
-inline void SwapBytes(uint16_t* dst, const uint16_t* src, size_t buflen);
+// |src| and |dst| are allowed to overlap.  |size| is in bytes and must be
+// a multiple of the word size.
+inline void SwapBytes16(char* dst, const char* src, size_t size);
+inline void SwapBytes32(char* dst, const char* src, size_t size);
+inline void SwapBytes64(char* dst, const char* src, size_t size);
 
 // tolower() is locale-sensitive.  Use ToLower() instead.
 inline char ToLower(char c);

--- a/src/util.h
+++ b/src/util.h
@@ -238,6 +238,13 @@ inline void ClearWrap(v8::Local<v8::Object> object);
 template <typename TypeName>
 inline TypeName* Unwrap(v8::Local<v8::Object> object);
 
+template <typename T, typename U>
+inline bool IsAlignedTo(const U* p);
+
+inline uint16_t ByteSwap(uint16_t v);
+inline uint32_t ByteSwap(uint32_t v);
+inline uint64_t ByteSwap(uint64_t v);
+
 // |src| and |dst| are allowed to overlap.  |size| is in bytes and must be
 // a multiple of the word size.
 inline void SwapBytes16(char* dst, const char* src, size_t size);


### PR DESCRIPTION
Said builtins are not supported by older versions of apple-gcc, breaking
the build on OS X 10.8.

Fixes: #7618
Refs: #4290
Refs: #7157 

CI: https://ci.nodejs.org/job/node-test-pull-request/3235/