### PR TITLE
tools: increase lint coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,7 @@ lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*/
 test/fixtures
-test/**/node_modules
 test/disabled
 test/tmp*/
-tools/doc/node_modules
+tools/eslint
+**/node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,4 @@ test/fixtures
 test/disabled
 test/tmp*/
 tools/eslint
-**/node_modules
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -678,13 +678,11 @@ bench-idle:
 	$(NODE) benchmark/idle_clients.js &
 
 jslint:
-	$(NODE) tools/jslint.js -J benchmark lib src test tools/doc \
-	  tools/eslint-rules tools/jslint.js
+	$(NODE) tools/jslint.js -J benchmark lib src test tools
 
 jslint-ci:
 	$(NODE) tools/jslint.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
-		benchmark lib src test tools/doc \
-		tools/eslint-rules tools/jslint.js
+		benchmark lib src test tools
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_root_certs.h

--- a/tools/license2rtf.js
+++ b/tools/license2rtf.js
@@ -1,7 +1,8 @@
+'use strict';
 
 var assert = require('assert'),
-    Stream = require('stream'),
-    inherits = require('util').inherits;
+  Stream = require('stream'),
+  inherits = require('util').inherits;
 
 
 /*
@@ -9,7 +10,7 @@ var assert = require('assert'),
  */
 function LineSplitter() {
   var self = this,
-      buffer = "";
+    buffer = '';
 
   Stream.call(this);
   this.writable = true;
@@ -39,32 +40,30 @@ inherits(LineSplitter, Stream);
  */
 function ParagraphParser() {
   var self = this,
-      block_is_license_block = false,
-      block_has_c_style_comment,
-      is_first_line_in_paragraph,
-      paragraph_line_indent,
-      paragraph;
+    block_is_license_block = false,
+    block_has_c_style_comment,
+    paragraph_line_indent,
+    paragraph;
 
-   Stream.call(this);
-   this.writable = true;
+  Stream.call(this);
+  this.writable = true;
 
-   resetBlock(false);
+  resetBlock(false);
 
-   this.write = function(data) {
-     parseLine(data + '');
-     return true;
-   };
+  this.write = function(data) {
+    parseLine(data + '');
+    return true;
+  };
 
-   this.end = function(data) {
-     if (data) {
-       parseLine(data + '');
-     }
-     flushParagraph();
-     self.emit('end');
-   };
+  this.end = function(data) {
+    if (data) {
+      parseLine(data + '');
+    }
+    flushParagraph();
+    self.emit('end');
+  };
 
   function resetParagraph() {
-    is_first_line_in_paragraph = true;
     paragraph_line_indent = -1;
 
     paragraph = {
@@ -165,8 +164,6 @@ function ParagraphParser() {
 
     if (line)
       paragraph.lines.push(line);
-
-    is_first_line_in_paragraph = false;
   }
 }
 inherits(ParagraphParser, Stream);
@@ -185,15 +182,15 @@ function Unwrapper() {
 
   this.write = function(paragraph) {
     var lines = paragraph.lines,
-        break_after = [],
-        i;
+      break_after = [],
+      i;
 
     for (i = 0; i < lines.length - 1; i++) {
       var line = lines[i];
 
       // When a line is really short, the line was probably kept separate for a
       // reason.
-      if (line.length < 50)  {
+      if (line.length < 50) {
         // If the first word on the next line really didn't fit after the line,
         // it probably was just ordinary wrapping after all.
         var next_first_word_length = lines[i + 1].replace(/\s.*$/, '').length;
@@ -203,7 +200,7 @@ function Unwrapper() {
       }
     }
 
-    for (i = 0; i < lines.length - 1; ) {
+    for (i = 0; i < lines.length - 1;) {
       if (!break_after[i]) {
         lines[i] += ' ' + lines.splice(i + 1, 1)[0];
       } else {
@@ -234,7 +231,7 @@ inherits(Unwrapper, Stream);
  */
 function RtfGenerator() {
   var self = this,
-      did_write_anything = false;
+    did_write_anything = false;
 
   Stream.call(this);
   this.writable = true;
@@ -246,10 +243,10 @@ function RtfGenerator() {
     }
 
     var li = paragraph.li,
-        level = paragraph.level + (li ? 1 : 0),
-        lic = paragraph.in_license_block;
+      level = paragraph.level + (li ? 1 : 0),
+      lic = paragraph.in_license_block;
 
-    var rtf = "\\pard";
+    var rtf = '\\pard';
     rtf += '\\sa150\\sl300\\slmult1';
     if (level > 0)
       rtf += '\\li' + (level * 240);
@@ -290,18 +287,19 @@ function RtfGenerator() {
   function rtfEscape(string) {
     return string
       .replace(/[\\\{\}]/g, function(m) {
-       return '\\' + m;
+        return '\\' + m;
       })
       .replace(/\t/g, function() {
         return '\\tab ';
       })
+      // eslint-disable-next-line no-control-regex
       .replace(/[\x00-\x1f\x7f-\xff]/g, function(m) {
         return '\\\'' + toHex(m.charCodeAt(0), 2);
       })
       .replace(/\ufeff/g, '')
       .replace(/[\u0100-\uffff]/g, function(m) {
         return '\\u' + toHex(m.charCodeAt(0), 4) + '?';
-     });
+      });
   }
 
   function emitHeader() {
@@ -318,11 +316,11 @@ inherits(RtfGenerator, Stream);
 
 
 var stdin = process.stdin,
-    stdout = process.stdout,
-    line_splitter = new LineSplitter(),
-    paragraph_parser = new ParagraphParser(),
-    unwrapper = new Unwrapper(),
-    rtf_generator = new RtfGenerator();
+  stdout = process.stdout,
+  line_splitter = new LineSplitter(),
+  paragraph_parser = new ParagraphParser(),
+  unwrapper = new Unwrapper(),
+  rtf_generator = new RtfGenerator();
 
 stdin.setEncoding('utf-8');
 stdin.resume();

--- a/tools/license2rtf.js
+++ b/tools/license2rtf.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var assert = require('assert'),
-  Stream = require('stream'),
-  inherits = require('util').inherits;
+const assert = require('assert');
+const Stream = require('stream');
+const inherits = require('util').inherits;
 
 
 /*
  * This filter consumes a stream of characters and emits one string per line.
  */
 function LineSplitter() {
-  var self = this,
-    buffer = '';
+  const self = this;
+  var buffer = '';
 
   Stream.call(this);
   this.writable = true;
@@ -39,11 +39,11 @@ inherits(LineSplitter, Stream);
  * This filter consumes lines and emits paragraph objects.
  */
 function ParagraphParser() {
-  var self = this,
-    block_is_license_block = false,
-    block_has_c_style_comment,
-    paragraph_line_indent,
-    paragraph;
+  const self = this;
+  var block_is_license_block = false;
+  var block_has_c_style_comment;
+  var paragraph_line_indent;
+  var paragraph;
 
   Stream.call(this);
   this.writable = true;
@@ -181,9 +181,9 @@ function Unwrapper() {
   this.writable = true;
 
   this.write = function(paragraph) {
-    var lines = paragraph.lines,
-      break_after = [],
-      i;
+    var lines = paragraph.lines;
+    var break_after = [];
+    var i;
 
     for (i = 0; i < lines.length - 1; i++) {
       var line = lines[i];
@@ -230,8 +230,8 @@ inherits(Unwrapper, Stream);
  * This filter generates an rtf document from a stream of paragraph objects.
  */
 function RtfGenerator() {
-  var self = this,
-    did_write_anything = false;
+  const self = this;
+  var did_write_anything = false;
 
   Stream.call(this);
   this.writable = true;
@@ -242,9 +242,9 @@ function RtfGenerator() {
       did_write_anything = true;
     }
 
-    var li = paragraph.li,
-      level = paragraph.level + (li ? 1 : 0),
-      lic = paragraph.in_license_block;
+    var li = paragraph.li;
+    var level = paragraph.level + (li ? 1 : 0);
+    var lic = paragraph.in_license_block;
 
     var rtf = '\\pard';
     rtf += '\\sa150\\sl300\\slmult1';
@@ -315,12 +315,12 @@ function RtfGenerator() {
 inherits(RtfGenerator, Stream);
 
 
-var stdin = process.stdin,
-  stdout = process.stdout,
-  line_splitter = new LineSplitter(),
-  paragraph_parser = new ParagraphParser(),
-  unwrapper = new Unwrapper(),
-  rtf_generator = new RtfGenerator();
+const stdin = process.stdin;
+const stdout = process.stdout;
+const line_splitter = new LineSplitter();
+const paragraph_parser = new ParagraphParser();
+const unwrapper = new Unwrapper();
+const rtf_generator = new RtfGenerator();
 
 stdin.setEncoding('utf-8');
 stdin.resume();

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -348,12 +348,12 @@ if defined jslint_ci goto jslint-ci
 if not defined jslint goto exit
 if not exist tools\eslint\bin\eslint.js goto no-lint
 echo running jslint
-%config%\node tools\jslint.js -J benchmark lib src test tools\doc tools\eslint-rules tools\jslint.js
+%config%\node tools\jslint.js -J benchmark lib src test tools
 goto exit
 
 :jslint-ci
 echo running jslint-ci
-%config%\node tools\jslint.js -J -f tap -o test-eslint.tap benchmark lib src test tools\doc tools\eslint-rules tools\jslint.js
+%config%\node tools\jslint.js -J -f tap -o test-eslint.tap benchmark lib src test tools
 goto exit
 
 :no-lint


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

Extend linting to tools/license2rtf.js and any other JS that gets added
to the `tools` directory by default.

This incidentally simplifies lint invocation and .eslintignore file.