### PR TITLE
doc: buffers are not sent over IPC with a socket

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -839,7 +839,8 @@ Applications should avoid using such messages or listening for
 The optional `sendHandle` argument that may be passed to `child.send()` is for
 passing a TCP server or socket object to the child process. The child will
 receive the object as the second argument passed to the callback function
-registered on the `process.on('message')` event.
+registered on the `process.on('message')` event. Any data that is received and
+buffered in the socket will not be sent to the child.
 
 The optional `callback` is a function that is invoked after the message is
 sent but before the child may have received it.  The function is called with a


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] the commit message follows commit guidelines

##### Affected core subsystem(s)
doc/child_process

##### Description of change
If a socket is sent to a child, any data that is buffered in the
socket will not be sent to the child. The child will only receive
data from the socket that is sent after the child has the socket.

##### PoC:
From https://github.com/nodejs/node/pull/6951:

```shell
$ node --version
v4.4.7
```
```js
$ cat m.js
const fork = require('child_process').fork
const net = require('net')

const cp = fork('./child.js')

net.createServer(c => {
  setTimeout(() => {
    cp.send({}, c)
  }, 500) // send the connection after a delay
}).listen(1234, () => {
  net.createConnection(1234, function() {
    var i = 0
    setInterval(() => {
      this.write(`${i++} `)
    }, 100) // start sending data before the connection is sent to the child
  })
})
```
```js
$ cat child.js 
process.on('message', (m, c) => {
  console.log('child: got connection')
  c.pipe(process.stdout)
})
```
```shell
$ node m.js
child: got connection
4 5 6 7 8 ^C
```