### PR TITLE
Add correct shared library naming on OS X

### DIFF
--- a/configure
+++ b/configure
@@ -840,7 +840,11 @@ def configure_node(o):
 
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
   o['variables']['node_shared'] = b(options.shared)
-  o['variables']['node_module_version'] = int(getmoduleversion.get_version())
+  node_module_version = getmoduleversion.get_version()
+  shlib_suffix = '%s.dylib' if sys.platform == 'darwin' else 'so.%s'
+  shlib_suffix %= node_module_version
+  o['variables']['node_module_version'] = int(node_module_version)
+  o['variables']['shlib_suffix'] = shlib_suffix
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module

--- a/node.gyp
+++ b/node.gyp
@@ -249,7 +249,7 @@
           ],
           'conditions': [
             [ 'node_module_version!="" and OS!="win"', {
-              'product_extension': 'so.<(node_module_version)',
+              'product_extension': '<(shlib_suffix)',
             }]
           ],
         }],

--- a/tools/install.py
+++ b/tools/install.py
@@ -118,10 +118,11 @@ def files(action):
     if is_windows:
       output_file += '.dll'
     else:
-      # GYP will output to lib.target, this is hardcoded in its source,
-      # see the _InstallableTargetInstallPath function.
-      output_prefix += 'lib.target/'
-      output_file = 'lib' + output_file + '.so.' + get_version()
+      output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
+      # GYP will output to lib.target except on OS X, this is hardcoded
+      # in its source - see the _InstallableTargetInstallPath function.
+      if sys.platform != 'darwin':
+        output_prefix += 'lib.target/'
 
   action([output_prefix + output_file], 'bin/' + output_file)
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Build system

##### Description of change
<!-- Provide a description of the change below this comment. -->

The build system currently creates a shared library on OS/X with the same name as on Linux
i.e. libnode.so.48. This is inconsistent with the conventions on OS/X which uses libnode.48.dylib
This change modifies the build process and install.py (used by make binary) to build with the
correct name on OS/X when the --shared configure parameter is used. Without these changes,
"make binary" with CONFIG_FLAGS=--shared fails on the install.py step