### PR TITLE
util: allow deprecate on classes

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -46,7 +46,7 @@ environment variable. For example: `NODE_DEBUG=fs,net,tls`.
 
 ## util.deprecate(function, string)
 
-The `util.deprecate()` method wraps the given `function` in such a way that
+The `util.deprecate()` method wraps the given `function` or class in such a way that
 it is marked as deprecated.
 
 ```js

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -60,7 +60,16 @@ exports._deprecate = function(fn, msg) {
   var warned = false;
   function deprecated() {
     warned = exports.printDeprecationMessage(msg, warned, deprecated);
+    if (new.target) {
+      return Reflect.construct(fn, arguments, new.target);
+    }
     return fn.apply(this, arguments);
+  }
+
+  // the wrapper will keep the same prototype as fn to maintain prototype chain
+  Object.setPrototypeOf(deprecated, fn);
+  if (fn.prototype) {
+    Object.setPrototypeOf(deprecated.prototype, fn.prototype);
   }
 
   return deprecated;

--- a/test/fixtures/deprecated-userland-class.js
+++ b/test/fixtures/deprecated-userland-class.js
@@ -1,0 +1,12 @@
+const util = require('util');
+const assert = require('assert');
+
+class deprecatedClass {
+}
+
+const deprecated = util.deprecate(deprecatedClass, 'deprecatedClass is deprecated.');
+
+const instance = new deprecated();
+
+assert(instance instanceof deprecated);
+assert(instance instanceof deprecatedClass);

--- a/test/fixtures/deprecated-userland-subclass.js
+++ b/test/fixtures/deprecated-userland-subclass.js
@@ -1,0 +1,19 @@
+const util = require('util');
+const assert = require('assert');
+
+class deprecatedClass {
+}
+
+const deprecated = util.deprecate(deprecatedClass, 'deprecatedClass is deprecated.');
+
+class subclass extends deprecated {
+  constructor() {
+    super();
+  }
+}
+
+const instance = new subclass();
+
+assert(instance instanceof subclass);
+assert(instance instanceof deprecated);
+assert(instance instanceof deprecatedClass);

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -5,8 +5,14 @@ const execFile = require('child_process').execFile;
 const depmod = require.resolve(common.fixturesDir + '/deprecated.js');
 const node = process.execPath;
 
-const depUserland =
-    require.resolve(common.fixturesDir + '/deprecated-userland-function.js');
+const depUserlandFunction =
+  require.resolve(common.fixturesDir + '/deprecated-userland-function.js');
+
+const depUserlandClass =
+  require.resolve(common.fixturesDir + '/deprecated-userland-class.js');
+
+const depUserlandSubClass =
+  require.resolve(common.fixturesDir + '/deprecated-userland-subclass.js');
 
 const normal = [depmod];
 const noDep = ['--no-deprecation', depmod];
@@ -39,10 +45,22 @@ execFile(node, traceDep, function(er, stdout, stderr) {
   console.log('trace ok');
 });
 
-execFile(node, [depUserland], function(er, stdout, stderr) {
+execFile(node, [depUserlandFunction], function(er, stdout, stderr) {
   console.error('normal: testing deprecated userland function');
   assert.equal(er, null);
   assert.equal(stdout, '');
   assert(/deprecatedFunction is deprecated/.test(stderr));
   console.error('normal: ok');
+});
+
+execFile(node, [depUserlandClass], function(er, stdout, stderr) {
+  assert.strictEqual(er, null);
+  assert.strictEqual(stdout, '');
+  assert(/deprecatedClass is deprecated/.test(stderr));
+});
+
+execFile(node, [depUserlandSubClass], function(er, stdout, stderr) {
+  assert.strictEqual(er, null);
+  assert.strictEqual(stdout, '');
+  assert(/deprecatedClass is deprecated/.test(stderr));
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
* util

##### Description of change
<!-- Provide a description of the change below this comment. -->

Classes objects cannot be called without new. util.deprecate executes 'fn.apply'. Classes cannot be deprecated with util.deprecate.

This uses 'new.target' to detect (when process is defined) calls to constructor to allow deprecate on class.
