### PR TITLE
tools: consistent .eslintrc formatting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@ env:
 rules:
   # Possible Errors
   # http://eslint.org/docs/rules/#possible-errors
-  comma-dangle: [2, "only-multiline"]
+  comma-dangle: [2, only-multiline]
   no-control-regex: 2
   no-debugger: 2
   no-dupe-args: 2
@@ -14,7 +14,7 @@ rules:
   no-empty-character-class: 2
   no-ex-assign: 2
   no-extra-boolean-cast: 2
-  no-extra-parens: [2, "functions"]
+  no-extra-parens: [2, functions]
   no-extra-semi: 2
   no-func-assign: 2
   no-invalid-regexp: 2
@@ -38,47 +38,47 @@ rules:
 
   # Strict Mode
   # http://eslint.org/docs/rules/#strict-mode
-  strict: [2, "global"]
+  strict: [2, global]
 
   # Variables
   # http://eslint.org/docs/rules/#variables
   no-delete-var: 2
   no-undef: 2
-  no-unused-vars: [2, {"args": "none"}]
+  no-unused-vars: [2, {args: none}]
 
   # Node.js and CommonJS
   # http://eslint.org/docs/rules/#nodejs-and-commonjs
   no-mixed-requires: 2
   no-new-require: 2
   no-path-concat: 2
-  no-restricted-modules: [2, "sys", "_linklist"]
+  no-restricted-modules: [2, sys, _linklist]
 
   # Stylistic Issues
   # http://eslint.org/docs/rules/#stylistic-issues
-  brace-style: [2, "1tbs", {allowSingleLine: true}]
+  brace-style: [2, 1tbs, {allowSingleLine: true}]
   comma-spacing: 2
   eol-last: 2
   indent: [2, 2, {SwitchCase: 1}]
-  key-spacing: [2, {mode: "minimum"}]
+  key-spacing: [2, {mode: minimum}]
   keyword-spacing: 2
-  linebreak-style: [2, "unix"]
+  linebreak-style: [2, unix]
   max-len: [2, 80, 2]
   new-parens: 2
   no-mixed-spaces-and-tabs: 2
   no-multiple-empty-lines: [2, {max: 2}]
   no-trailing-spaces: 2
-  quotes: [2, "single", "avoid-escape"]
+  quotes: [2, single, avoid-escape]
   semi: 2
-  space-before-blocks: [2, "always"]
-  space-before-function-paren: [2, "never"]
-  space-in-parens: [2, "never"]
+  space-before-blocks: [2, always]
+  space-before-function-paren: [2, never]
+  space-in-parens: [2, never]
   space-infix-ops: 2
   space-unary-ops: 2
 
   # ECMAScript 6
   # http://eslint.org/docs/rules/#ecmascript-6
-  arrow-parens: [2, "always"]
-  arrow-spacing: [2, {"before": true, "after": true}]
+  arrow-parens: [2, always]
+  arrow-spacing: [2, {before: true, after: true}]
   constructor-super: 2
   no-class-assign: 2
   no-confusing-arrow: 2
@@ -93,27 +93,27 @@ rules:
   align-function-arguments: 2
   align-multiline-assignment: 2
   assert-fail-single-argument: 2
-  new-with-error: [2, "Error", "RangeError", "TypeError", "SyntaxError", "ReferenceError"]
+  new-with-error: [2, Error, RangeError, TypeError, SyntaxError, ReferenceError]
   no-deepEqual: 2
   no-definegetter-definesetter: 2
 
 # Global scoped method and vars
 globals:
-  DTRACE_HTTP_CLIENT_REQUEST           : false
-  LTTNG_HTTP_CLIENT_REQUEST            : false
-  COUNTER_HTTP_CLIENT_REQUEST          : false
-  DTRACE_HTTP_CLIENT_RESPONSE          : false
-  LTTNG_HTTP_CLIENT_RESPONSE           : false
-  COUNTER_HTTP_CLIENT_RESPONSE         : false
-  DTRACE_HTTP_SERVER_REQUEST           : false
-  LTTNG_HTTP_SERVER_REQUEST            : false
-  COUNTER_HTTP_SERVER_REQUEST          : false
-  DTRACE_HTTP_SERVER_RESPONSE          : false
-  LTTNG_HTTP_SERVER_RESPONSE           : false
-  COUNTER_HTTP_SERVER_RESPONSE         : false
-  DTRACE_NET_STREAM_END                : false
-  LTTNG_NET_STREAM_END                 : false
-  COUNTER_NET_SERVER_CONNECTION_CLOSE  : false
-  DTRACE_NET_SERVER_CONNECTION         : false
-  LTTNG_NET_SERVER_CONNECTION          : false
-  COUNTER_NET_SERVER_CONNECTION        : false
+  COUNTER_HTTP_CLIENT_REQUEST: false
+  COUNTER_HTTP_CLIENT_RESPONSE: false
+  COUNTER_HTTP_SERVER_REQUEST: false
+  COUNTER_HTTP_SERVER_RESPONSE: false
+  COUNTER_NET_SERVER_CONNECTION: false
+  COUNTER_NET_SERVER_CONNECTION_CLOSE: false
+  DTRACE_HTTP_CLIENT_REQUEST: false
+  DTRACE_HTTP_CLIENT_RESPONSE: false
+  DTRACE_HTTP_SERVER_REQUEST: false
+  DTRACE_HTTP_SERVER_RESPONSE: false
+  DTRACE_NET_SERVER_CONNECTION: false
+  DTRACE_NET_STREAM_END: false
+  LTTNG_HTTP_CLIENT_REQUEST: false
+  LTTNG_HTTP_CLIENT_RESPONSE: false
+  LTTNG_HTTP_SERVER_REQUEST: false
+  LTTNG_HTTP_SERVER_RESPONSE: false
+  LTTNG_NET_SERVER_CONNECTION: false
+  LTTNG_NET_STREAM_END: false

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,4 +2,4 @@
 
 rules:
   ## common module is mandatory in tests
-  required-modules: [2, "common"]
+  required-modules: [2, common]


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tools

##### Description of change
All quotes in `.eslintrc` were unnecessary and inconsistently placed across the file. Additionally, format the `globals` to be consistent with the style of whitespace used in the file.
