### PR TITLE
lib: allow custom names for spawned processes

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -293,6 +293,8 @@ added: v0.1.90
 * `options` {Object}
   * `cwd` {String} Current working directory of the child process
   * `env` {Object} Environment key-value pairs
+  * `argv0` {String} Explicitly set the value of `argv[0]` sent to the child
+    process. This will be set to `command` if not specified.
   * `stdio` {Array|String} Child's stdio configuration. (See
     [`options.stdio`][`stdio`])
   * `detached` {Boolean} Prepare child to run independently of its parent
@@ -394,6 +396,14 @@ child.on('error', (err) => {
   console.log('Failed to start child process.');
 });
 ```
+
+*Note: Certain platforms (OS X, Linux) will use the value of `argv[0]` for the
+process title while others (Windows, SunOS) will use `command`.*
+
+*Note: Node.js currently overwrites `argv[0]` with `process.execPath` on
+startup, so `process.argv[0]` in a Node.js child process will not match the
+`argv0` parameter passed to `spawn` from the parent, retrieve it with the
+`process.argv0` property instead.*
 
 #### options.detached
 <!-- YAML

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -452,9 +452,10 @@ added: v0.1.27
 
 The `process.argv` property returns an array containing the command line
 arguments passed when the Node.js process was launched. The first element will
-be [`process.execPath`]. The second element will be the path to the
-JavaScript file being executed. The remaining elements will be any additional
-command line arguments.
+be [`process.execPath`]. See `process.argv0` if access to the original value of
+`argv[0]` is needed.  The second element will be the path to the JavaScript
+file being executed. The remaining elements will be any additional command line
+arguments.
 
 For example, assuming the following script for `process-args.js`:
 
@@ -479,6 +480,22 @@ Would generate the output:
 2: one
 3: two=three
 4: four
+```
+
+## process.argv0
+<!-- YAML
+added: REPLACEME
+-->
+
+The `process.argv0` property stores a read-only copy of the original value of
+`argv[0]` passed when Node.js starts.
+
+```js
+$ bash -c 'exec -a customArgv0 ./node'
+> process.argv[0]
+'/Volumes/code/external/node/out/Release/node'
+> process.argv0
+'customArgv0'
 ```
 
 ## process.chdir(directory)

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -347,7 +347,11 @@ function normalizeSpawnArguments(file /*, args, options*/) {
     }
   }
 
-  args.unshift(file);
+  if (typeof options.argv0 === 'string') {
+    args.unshift(options.argv0);
+  } else {
+    args.unshift(file);
+  }
 
   var env = options.env || process.env;
   var envPairs = [];

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -50,6 +50,11 @@
 
     _process.setupRawDebug();
 
+    Object.defineProperty(process, 'argv0', {
+      enumerable: true,
+      configurable: false,
+      value: process.argv[0]
+    });
     process.argv[0] = process.execPath;
 
     // There are various modes that Node can run in. The most common two

--- a/test/parallel/test-child-process-spawn-argv0.js
+++ b/test/parallel/test-child-process-spawn-argv0.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+// This test spawns itself with an argument to indicate when it is a child to
+// easily and portably print the value of argv[0]
+if (process.argv[2] === 'child') {
+  console.log(process.argv0);
+  return;
+}
+
+const noArgv0 = cp.spawnSync(process.execPath, [__filename, 'child']);
+assert.strictEqual(noArgv0.stdout.toString().trim(), process.execPath);
+
+const withArgv0 = cp.spawnSync(process.execPath, [__filename, 'child'],
+    {argv0: 'withArgv0'});
+assert.strictEqual(withArgv0.stdout.toString().trim(), 'withArgv0');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

`lib/child_process.js`

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add a `name` parameter to the `options` accepted by
`child_process.spawn` that sets the spawned process name (`argv[0]`)
to a custom value. The default behavior is unchanged if a `name`
parameter is not supplied.

It is useful to be able to set the name of a process you are spawning.
One motivating example is an application runner service that spawn
several other node applications. Instead of showing up as 20 different
`node` processes, the application runner can give them meaningful names.

While child processes can write `process.title` to change their name,
this has two limitations:
 - it requires modifying all child processes
 - it is limited to the length of the initial `argv[0]` in practice