### PR TITLE
test: Avoid usage of mixed IPV6 addresses

### DIFF
--- a/test/parallel/test-cluster-disconnect-handles.js
+++ b/test/parallel/test-cluster-disconnect-handles.js
@@ -92,7 +92,7 @@ if (cluster.isMaster) {
     debugger;
   };
   if (common.hasIPv6)
-    server.listen(cb);
+    server.listen(0, '::1', cb);
   else
     server.listen(0, common.localhostIPv4, cb);
   process.on('disconnect', process.exit);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test, cluster

##### Description of change

Please see [#7563](https://github.com/nodejs/node/issues/7563) for full details.

The test case test/parallel/test-cluster-disconnect-handles.js
fails in AIX due to the mixed-use of unspecified
and loopback addresses. This is not a problem in most platforms
but fails in AIX. (In Windows too, but does not manifest as the
test is omitted in Windows for a different reason).

There exists no documented evidence which supports the mixed use
of unspecified and loopback addresses.

While AIX strictly follows the IPV6 specification with respect to
unspecified address ('::') and loopback address ('::1'), the test
case latches on to the behavior exhibited by other platforms,
and hence it fails in AIX.

The proposed fix is to make it work in all platforms including
AIX by using the loopback address for the client to connect,
as that is the address at which the server listens.