### PR TITLE
cluster: remove bind() and self

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -128,12 +128,11 @@ function RoundRobinHandle(key, address, port, addressType, backlog, fd) {
   else
     this.server.listen(address);  // UNIX socket path.
 
-  var self = this;
-  this.server.once('listening', function() {
-    self.handle = self.server._handle;
-    self.handle.onconnection = self.distribute.bind(self);
-    self.server._handle = null;
-    self.server = null;
+  this.server.once('listening', () => {
+    this.handle = this.server._handle;
+    this.handle.onconnection = (err, handle) => this.distribute(err, handle);
+    this.server._handle = null;
+    this.server = null;
   });
 }
 
@@ -141,18 +140,17 @@ RoundRobinHandle.prototype.add = function(worker, send) {
   assert(worker.id in this.all === false);
   this.all[worker.id] = worker;
 
-  var self = this;
-  function done() {
-    if (self.handle.getsockname) {
+  const done = () => {
+    if (this.handle.getsockname) {
       var out = {};
-      self.handle.getsockname(out);
+      this.handle.getsockname(out);
       // TODO(bnoordhuis) Check err.
       send(null, { sockname: out }, null);
     } else {
       send(null, null, null);  // UNIX socket.
     }
-    self.handoff(worker);  // In case there are connections pending.
-  }
+    this.handoff(worker);  // In case there are connections pending.
+  };
 
   if (this.server === null) return done();
   // Still busy binding.
@@ -194,13 +192,13 @@ RoundRobinHandle.prototype.handoff = function(worker) {
     return;
   }
   var message = { act: 'newconn', key: this.key };
-  var self = this;
-  sendHelper(worker.process, message, handle, function(reply) {
+
+  sendHelper(worker.process, message, handle, (reply) => {
     if (reply.accepted)
       handle.close();
     else
-      self.distribute(0, handle);  // Worker is shutting down. Send to another.
-    self.handoff(worker);
+      this.distribute(0, handle);  // Worker is shutting down. Send to another.
+    this.handoff(worker);
   });
 };
 
@@ -415,7 +413,7 @@ function masterInit() {
   cluster.disconnect = function(cb) {
     var workers = Object.keys(cluster.workers);
     if (workers.length === 0) {
-      process.nextTick(intercom.emit.bind(intercom, 'disconnect'));
+      process.nextTick(() => intercom.emit('disconnect'));
     } else {
       for (var key in workers) {
         key = workers[key];
@@ -437,7 +435,7 @@ function masterInit() {
     signo = signo || 'SIGTERM';
     var proc = this.process;
     if (this.isConnected()) {
-      this.once('disconnect', proc.kill.bind(proc, signo));
+      this.once('disconnect', () => proc.kill(signo));
       this.disconnect();
       return;
     }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
cluster

##### Description of change
This commit removes the use of `self` and `bind()` from the `cluster` module in favor of arrow functions.