### PR TITLE
backport: update build-addons when node-gyp changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,10 @@ ADDONS_BINDING_GYPS := \
 		$(wildcard test/addons/*/binding.gyp))
 
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
-test/addons/.buildstamp: $(ADDONS_BINDING_GYPS) test/addons/.docbuildstamp
+# Depends on node-gyp package.json so that build-addons is (re)executed when
+# node-gyp is updated as part of an npm update.
+test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json \
+	$(ADDONS_BINDING_GYPS) test/addons/.docbuildstamp
 	# Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 	# embedded addons have been generated from the documentation.
 	for dirname in test/addons/*/; do \
@@ -154,7 +157,7 @@ test/addons/.buildstamp: $(ADDONS_BINDING_GYPS) test/addons/.docbuildstamp
 # if the subprocess touched anything so it pessimistically assumes that
 # .buildstamp and .docbuildstamp are out of date and need a rebuild.
 # Just goes to show that recursive make really is harmful...
-# TODO(bnoordhuis) Force rebuild after gyp or node-gyp update.
+# TODO(bnoordhuis) Force rebuild after gyp update.
 build-addons: $(NODE_EXE) test/addons/.buildstamp
 
 test-gc: all test/gc/node_modules/weak/build/Release/weakref.node


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build


##### Description of change
Backported from
https://github.com/nodejs/node/commit/99bf6face5a7eab6b600507c55b65b98033a4554

We can tell when `node-gyp` is changed by creating a prerequisite on
`deps/npm/node_modules/node-gyp/package.json`. The prerequisite is added
to the `test/addons/.buildstamp` since `build-addons` is .PHONY.

Testing for this change was entirely manual.

  $ make clean test-build # Initial build
  $ make test-build # Make sure build-addons doesn't rebuild
  $ touch deps/npm/node_modules/node-gyp/package.json # simulate change
  $ make test-build # Ensure build-addons rebuilds

Original PR-URL: https://github.com/nodejs/node/pull/6787