### PR TITLE
test: fix flaky test-http-server-consumed-timeout

### DIFF
--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer((req, res) => {
@@ -11,7 +10,7 @@ const server = http.createServer((req, res) => {
   res.flushHeaders();
 
   req.setTimeout(common.platformTimeout(200), () => {
-    assert(false, 'Should not happen');
+    common.fail('Request timeout should not fire');
   });
   req.resume();
   req.once('end', common.mustCall(() => {
@@ -30,7 +29,7 @@ server.listen(0, common.mustCall(() => {
     setTimeout(() => {
       clearInterval(interval);
       req.end();
-    }, common.platformTimeout(400));
+    }, common.platformTimeout(200));
   });
   req.write('.');
 }));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http

##### Description of change
<!-- Provide a description of the change below this comment. -->

Using identical timeout values appears to have eliminated the flakiness in the test.

Fixes: https://github.com/nodejs/node/issues/7643

With this change to the test **and** removing the fix in https://github.com/nodejs/node/pull/6286, everything fails (as it should): https://ci.nodejs.org/job/node-stress-single-test/804/ (Test run just once on each platform)

With this change to the test only, everything passes (as it should): https://ci.nodejs.org/job/node-stress-single-test/805/ (Test run 100 times on each platform)

And with this change, the test is not flaky on FreeBSD:
https://ci.nodejs.org/job/node-stress-single-test/806/nodes=freebsd10-64/console (9999 runs, 0 failures)

For comparison, the test is flaky on current master on FreeBSD:
https://ci.nodejs.org/job/node-stress-single-test/807/nodes=freebsd10-64/console
(also 9999 runs, 1 failure, so not the overwhelming results I was hoping for, but at least it wasn't 0 failures...)

/cc @indutny 

The flakiness is not terribly reproducible in the stress tests, but if it stands to reason that this reduces any race condition window, then it's probably worth doing.