### PR TITLE
repl: don't crash if self is not in replMap

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -735,12 +735,12 @@ function complete(line, callback) {
     });
     var flat = new ArrayStream();         // make a new "input" stream
     var magic = new REPLServer('', flat); // make a nested REPL
+    replMap.set(magic, replMap.get(this));
     magic.context = magic.createContext();
     flat.run(tmp);                        // eval the flattened code
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand
     if (!magic.bufferedCommand) {
-      replMap.set(magic, replMap.get(this));
       return magic.complete(line, callback);
     }
   }

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -4,24 +4,24 @@ const common = require('../common');
 const assert = require('assert');
 const repl = require('repl');
 
-var referenceErrorCount = 0;
-
-common.ArrayStream.prototype.write = function(msg) {
-  if (msg.startsWith('ReferenceError: ')) {
-    referenceErrorCount++;
-  }
-};
+common.ArrayStream.prototype.write = function(msg) {};
 
 const putIn = new common.ArrayStream();
 const testMe = repl.start('', putIn);
 
 // https://github.com/nodejs/node/issues/3346
-// Tab-completion for an undefined variable inside a function should report a
-// ReferenceError.
+// Tab-completion should be empty
 putIn.run(['.clear']);
 putIn.run(['function () {']);
-testMe.complete('arguments.');
+testMe.complete('arguments.', common.mustCall((err, completions) => {
+  assert.strictEqual(err, null);
+  assert.deepStrictEqual(completions, [[], 'arguments.']);
+}));
 
-process.on('exit', function() {
-  assert.strictEqual(referenceErrorCount, 1);
-});
+putIn.run(['.clear']);
+putIn.run(['function () {']);
+putIn.run(['undef;']);
+testMe.complete('undef.', common.mustCall((err, completions) => {
+  assert.strictEqual(err, null);
+  assert.deepStrictEqual(completions, [[], 'undef.']);
+}));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

repl

##### Description of change

Fixes: https://github.com/nodejs/node/issues/7716

This fixes an undefined referenced. I am still trying to figure out why the undefined reference is occurring though, so marking as WIP.