### PR TITLE
tools: add remark-lint configuration in .remarkrc

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,35 @@
+{
+  "plugins": {
+    "remark-lint": {
+      "code-block-style": false,
+      "definition-case": false,
+      "emphasis-marker": false,
+      "first-heading-level": false,
+      "heading-increment": false,
+      "list-item-content-indent": false,
+      "list-item-bullet-indent": false,
+      "list-item-indent": false,
+      "list-item-spacing": false,
+      "maximum-heading-length": false,
+      "maximum-line-length": false,
+      "no-consecutive-blank-lines": false,
+      "no-duplicate-headings": false,
+      "no-emphasis-as-heading": false,
+      "no-file-name-articles": false,
+      "no-file-name-irregular-characters": false,
+      "no-heading-punctuation": false,
+      "no-html": false,
+      "no-inline-padding": false,
+      "no-shell-dollars": false,
+      "no-shortcut-reference-link": false,
+      "no-literal-urls": false,
+      "no-missing-blank-lines": false,
+      "no-multiple-toplevel-headings": false,
+      "no-undefined-references": false,
+      "ordered-list-marker-style": false,
+      "ordered-list-marker-value": false,
+      "table-pipe-alignment": false,
+      "unordered-list-marker-style": false
+    }
+  }
+}

--- a/doc/ctc-meetings/2016-07-13.md
+++ b/doc/ctc-meetings/2016-07-13.md
@@ -169,7 +169,7 @@ ELOOP issue has been resolved. Windows problem being addressed in another PR. Ma
 
 ### http: don't inherit from Object.prototype [#6102](https://github.com/nodejs/node/pull/6102)
 
-@mscdex: Prevent clash of header names with properties inherited from Object (e.g., __proto__). An object with a null prototype is already being used for the same purpose in `querystring.parse` since v6 release.
+@mscdex: Prevent clash of header names with properties inherited from Object (e.g., `__proto__`). An object with a null prototype is already being used for the same purpose in `querystring.parse` since v6 release.
 
 @mscdex: Some have suggested cherry-picking some methods from Object such as `toString`:
 


### PR DESCRIPTION
##### Checklist
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tools, doc

##### Description of change

Specifies the configuration for [remark-lint](https://github.com/wooorm/remark-lint), a markdown linter.

This configuration will not cause any warnings on any of the currently present `*.md` files (ignoring thirdparty), once https://github.com/nodejs/node/pull/7727 lands (hence blocked now).

It is useful not only for possible future tooling that would check the markdown files syntax, but also as a configuration for editor plugins, e.g. linter-markdown for atom-linter.

Issues fixed in #7637 and #7727 were mostly found using remark-lint.

/cc @nodejs/documentation @addaleax @silverwind @mscdex @Fishrock123.
