### PR TITLE
test: s/assert.fail/common.fail as appropriate

### DIFF
--- a/test/internet/test-dgram-send-cb-quelches-error.js
+++ b/test/internet/test-dgram-send-cb-quelches-error.js
@@ -28,7 +28,7 @@ function callbackOnly(err) {
 }
 
 function onEvent(err) {
-  assert.fail(null, null, 'Error should not be emitted if there is callback');
+  common.fail('Error should not be emitted if there is callback');
 }
 
 function onError(err) {

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var EventEmitter = require('events').EventEmitter;
@@ -14,12 +14,12 @@ assert(fl.length === 0);
 assert(!(e._events instanceof Object));
 assert.deepStrictEqual(Object.keys(e._events), []);
 
-e.on('foo', assert.fail);
+e.on('foo', common.fail);
 fl = e.listeners('foo');
-assert(e._events.foo === assert.fail);
+assert(e._events.foo === common.fail);
 assert(Array.isArray(fl));
 assert(fl.length === 1);
-assert(fl[0] === assert.fail);
+assert(fl[0] === common.fail);
 
 e.listeners('bar');
 
@@ -28,12 +28,12 @@ fl = e.listeners('foo');
 
 assert(Array.isArray(e._events.foo));
 assert(e._events.foo.length === 2);
-assert(e._events.foo[0] === assert.fail);
+assert(e._events.foo[0] === common.fail);
 assert(e._events.foo[1] === assert.ok);
 
 assert(Array.isArray(fl));
 assert(fl.length === 2);
-assert(fl[0] === assert.fail);
+assert(fl[0] === common.fail);
 assert(fl[1] === assert.ok);
 
 console.log('ok');

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var events = require('events');
 
@@ -16,7 +16,7 @@ e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
 
 var remove = function() {
-  assert.fail(1, 0, 'once->foo should not be emitted', '!');
+  common.fail('once->foo should not be emitted');
 };
 
 e.once('foo', remove);

--- a/test/parallel/test-http-client-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-client-reject-chunked-with-content-length.js
@@ -18,7 +18,7 @@ server.listen(0, () => {
   // both a Content-Length header and a Transfer-Encoding: chunked
   // header, which is a violation of the HTTP spec.
   const req = http.get({port: server.address().port}, (res) => {
-    assert.fail(null, null, 'callback should not be called');
+    common.fail('callback should not be called');
   });
   req.on('error', common.mustCall((err) => {
     assert(/^Parse Error/.test(err.message));

--- a/test/parallel/test-http-client-reject-cr-no-lf.js
+++ b/test/parallel/test-http-client-reject-cr-no-lf.js
@@ -17,7 +17,7 @@ server.listen(0, () => {
   // The callback should not be called because the server is sending a
   // header field that ends only in \r with no following \n
   const req = http.get({port: server.address().port}, (res) => {
-    assert.fail(null, null, 'callback should not be called');
+    common.fail('callback should not be called');
   });
   req.on('error', common.mustCall((err) => {
     assert(/^Parse Error/.test(err.message));

--- a/test/parallel/test-http-createConnection.js
+++ b/test/parallel/test-http-createConnection.js
@@ -21,7 +21,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
           res.resume();
           fn = common.mustCall(createConnectionError);
           http.get({ createConnection: fn }, function(res) {
-            assert.fail(null, null, 'Unexpected response callback');
+            common.fail('Unexpected response callback');
           }).on('error', common.mustCall(function(err) {
             assert.equal(err.message, 'Could not create socket');
             server.close();

--- a/test/parallel/test-http-double-content-length.js
+++ b/test/parallel/test-http-double-content-length.js
@@ -23,8 +23,7 @@ server.listen(0, () => {
     // Send two content-length header values.
     headers: {'Content-Length': [1, 2]}},
     (res) => {
-      assert.fail(null, null, 'an error should have occurred');
-      server.close();
+      common.fail('an error should have occurred');
     }
   );
   req.on('error', common.mustCall(() => {

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -24,7 +24,7 @@ server.listen(0, '127.0.0.1', function() {
     method: 'GET',
     localAddress: invalidLocalAddress
   }, function(res) {
-    assert.fail(null, null, 'unexpectedly got response from server');
+    common.fail('unexpectedly got response from server');
   }).on('error', function(e) {
     console.log('client got error: ' + e.message);
     gotError = true;

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -19,7 +19,7 @@ const server = http.createServer((req, res) => {
       res.writeHead(200, {'content-length': [1, 2]});
       break;
     default:
-      assert.fail(null, null, 'should never get here');
+      common.fail('should never get here');
   }
   res.end('ok');
 });

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -38,7 +38,7 @@ const server = http.createServer((req, res) => {
       }));
       break;
     default:
-      assert.fail(null, null, 'should not get to here.');
+      common.fail('should not get to here.');
   }
   if (count === 3)
     server.close();

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -10,7 +10,7 @@ const reqstr = 'POST / HTTP/1.1\r\n' +
                'Transfer-Encoding: chunked\r\n\r\n';
 
 const server = http.createServer((req, res) => {
-  assert.fail(null, null, 'callback should not be invoked');
+  common.fail('callback should not be invoked');
 });
 server.on('clientError', common.mustCall((err) => {
   assert(/^Parse Error/.test(err.message));
@@ -25,7 +25,7 @@ server.listen(0, () => {
   client.on('data', (data) => {
     // Should not get to this point because the server should simply
     // close the connection without returning any data.
-    assert.fail(null, null, 'no data should be returned by the server');
+    common.fail('no data should be returned by the server');
   });
   client.on('end', common.mustCall(() => {}));
 });

--- a/test/parallel/test-http-server-reject-cr-no-lf.js
+++ b/test/parallel/test-http-server-reject-cr-no-lf.js
@@ -12,7 +12,7 @@ const str = 'GET / HTTP/1.1\r\n' +
 
 
 const server = http.createServer((req, res) => {
-  assert.fail(null, null, 'this should not be called');
+  common.fail('this should not be called');
 });
 server.on('clientError', common.mustCall((err) => {
   assert(/^Parse Error/.test(err.message));
@@ -22,7 +22,7 @@ server.on('clientError', common.mustCall((err) => {
 server.listen(0, () => {
   const client = net.connect({port: server.address().port}, () => {
     client.on('data', (chunk) => {
-      assert.fail(null, null, 'this should not be called');
+      common.fail('this should not be called');
     });
     client.on('end', common.mustCall(() => {
       server.close();

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -35,7 +35,7 @@ server.listen(0, '127.0.0.1', function() {
     method: 'GET',
     localAddress: invalidLocalAddress
   }, function(res) {
-    assert.fail(null, null, 'unexpectedly got response from server');
+    common.fail('unexpectedly got response from server');
   }).on('error', function(e) {
     console.log('client got error: ' + e.message);
     gotError = true;

--- a/test/parallel/test-net-connect-immediate-destroy.js
+++ b/test/parallel/test-net-connect-immediate-destroy.js
@@ -1,8 +1,7 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
-const socket = net.connect(common.PORT, common.localhostIPv4, assert.fail);
-socket.on('error', assert.fail);
+const socket = net.connect(common.PORT, common.localhostIPv4, common.fail);
+socket.on('error', common.fail);
 socket.destroy();

--- a/test/parallel/test-net-connect-paused-connection.js
+++ b/test/parallel/test-net-connect-paused-connection.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 
 var net = require('net');
 
@@ -10,6 +9,6 @@ net.createServer(function(conn) {
   net.connect(this.address().port, 'localhost').pause();
 
   setTimeout(function() {
-    assert.fail(null, null, 'expected to exit');
+    common.fail('expected to exit');
   }, 1000).unref();
 }).unref();

--- a/test/parallel/test-net-listen-close-server-callback-is-not-function.js
+++ b/test/parallel/test-net-listen-close-server-callback-is-not-function.js
@@ -1,18 +1,16 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var server = net.createServer(assert.fail);
+var server = net.createServer(common.fail);
 var closeEvents = 0;
 
 server.on('close', function() {
   ++closeEvents;
 });
 
-server.listen(0, function() {
-  assert(false);
-});
+server.listen(0, common.fail);
 
 server.close('bad argument');
 

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -17,12 +17,12 @@ net.Server().listen({ port: '' + common.PORT }, close);
   '-Infinity'
 ].forEach(function(port) {
   assert.throws(function() {
-    net.Server().listen({ port: port }, assert.fail);
+    net.Server().listen({ port: port }, common.fail);
   }, /"port" argument must be >= 0 and < 65536/i);
 });
 
 [null, true, false].forEach(function(port) {
   assert.throws(function() {
-    net.Server().listen({ port: port }, assert.fail);
+    net.Server().listen({ port: port }, common.fail);
   }, /invalid listen argument/i);
 });

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var net = require('net');
@@ -86,5 +86,5 @@ process.on('exit', function() {
 
 process.on('unhandledRejection', function() {
   console.error('promise rejected');
-  assert.fail(null, null, 'A promise in the chain rejected');
+  common.fail('A promise in the chain rejected');
 });

--- a/test/parallel/test-net-write-slow.js
+++ b/test/parallel/test-net-write-slow.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
@@ -13,8 +13,7 @@ var server = net.createServer(function(socket) {
   socket.setNoDelay();
   socket.setTimeout(9999);
   socket.on('timeout', function() {
-    assert.fail(null, null, 'flushed: ' + flushed +
-                ', received: ' + received + '/' + SIZE * N);
+    common.fail(`flushed: ${flushed}, received: ${received}/${SIZE * N}`);
   });
 
   for (var i = 0; i < N; ++i) {

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 
@@ -169,7 +169,7 @@ function checkErrors(path) {
       return;
     }
 
-    assert.fail(null, null, 'should have thrown');
+    common.fail('should have thrown');
   });
 }
 

--- a/test/parallel/test-process-exit-from-before-exit.js
+++ b/test/parallel/test-process-exit-from-before-exit.js
@@ -1,9 +1,8 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 
 process.on('beforeExit', common.mustCall(function() {
-  setTimeout(assert.fail, 5);
+  setTimeout(common.fail, 5);
   process.exit(0);  // Should execute immediately even if we schedule new work.
-  assert.fail();
+  common.fail();
 }));

--- a/test/parallel/test-repl-reset-event.js
+++ b/test/parallel/test-repl-reset-event.js
@@ -42,7 +42,7 @@ function testResetGlobal(cb) {
 }
 
 var timeout = setTimeout(function() {
-  assert.fail(null, null, 'Timeout, REPL did not emit reset events');
+  common.fail('Timeout, REPL did not emit reset events');
 }, 5000);
 
 testReset(function() {

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var repl = require('repl');
 var zlib = require('zlib');
@@ -10,9 +10,7 @@ var testMe = repl.start('', putIn, function(cmd, context, filename, callback) {
   callback(null, cmd);
 });
 
-testMe._domain.on('error', function(e) {
-  assert.fail();
-});
+testMe._domain.on('error', common.fail);
 
 testMe.complete('', function(err, results) {
   assert.equal(err, null);

--- a/test/parallel/test-spawn-cmd-named-pipe.js
+++ b/test/parallel/test-spawn-cmd-named-pipe.js
@@ -39,7 +39,7 @@ if (!process.argv[2]) {
 
   const comspec = process.env['comspec'];
   if (!comspec || comspec.length === 0) {
-    assert.fail(null, null, 'Failed to get COMSPEC');
+    common.fail('Failed to get COMSPEC');
   }
 
   const args = ['/c', process.execPath, __filename, 'child',

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var R = require('_stream_readable');
 var W = require('_stream_writable');
 var assert = require('assert');
@@ -33,5 +33,5 @@ src.on('end', function() {
 src.pipe(dst);
 
 timeout = setTimeout(function() {
-  assert.fail(null, null, 'timed out waiting for _write');
+  common.fail('timed out waiting for _write');
 }, 100);

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -75,7 +75,7 @@ function testDHE2048() {
 
 testDHE1024();
 
-assert.throws(() => test(512, true, assert.fail),
+assert.throws(() => test(512, true, common.fail),
               /DH parameter is less than 1024 bits/);
 
 [0, -1, -Infinity, NaN].forEach((minDHSize) => {

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -44,8 +44,7 @@ proc.on('error', common.mustCall(function(err) {
 }));
 
 proc.on('exit', function() {
-  const msg = '"exit" should not be emitted (the process never spawned!)';
-  assert.fail(null, null, msg);
+  common.fail('"exit" should not be emitted (the process never spawned!)');
 });
 
 // close one fd for LSan


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Many tests use `assert.fail(null, null, msg)` where it would be simpler to use `common.fail(msg)`. This is largely because `common.fail()` is fairly new. This commit makes the replacement when applicable.

R= @nodejs/testing 