### PR TITLE
Child.send boolean

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -48,7 +48,7 @@ Worker.prototype.kill = function() {
 };
 
 Worker.prototype.send = function() {
-  this.process.send.apply(this.process, arguments);
+  return this.process.send.apply(this.process, arguments);
 };
 
 Worker.prototype.isDead = function isDead() {
@@ -518,7 +518,7 @@ function masterInit() {
   }
 
   function send(worker, message, handle, cb) {
-    sendHelper(worker.process, message, handle, cb);
+    return sendHelper(worker.process, message, handle, cb);
   }
 }
 
@@ -684,7 +684,7 @@ function workerInit() {
   };
 
   function send(message, cb) {
-    sendHelper(process, message, null, cb);
+    return sendHelper(process, message, null, cb);
   }
 
   function _disconnect(masterInitiated) {
@@ -732,7 +732,7 @@ function sendHelper(proc, message, handle, cb) {
   if (cb) callbacks[seq] = cb;
   message.seq = seq;
   seq += 1;
-  proc.send(message, handle);
+  return proc.send(message, handle);
 }
 
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -504,8 +504,7 @@ function setupChannel(target, channel) {
       handle = undefined;
     }
     if (this.connected) {
-      this._send(message, handle, false, callback);
-      return;
+      return this._send(message, handle, false, callback);
     }
     const ex = new Error('channel closed');
     if (typeof callback === 'function') {
@@ -513,6 +512,7 @@ function setupChannel(target, channel) {
     } else {
       this.emit('error', ex);  // FIXME(bnoordhuis) Defer to next tick.
     }
+    return false;
   };
 
   target._send = function(message, handle, swallowErrors, callback) {
@@ -577,7 +577,7 @@ function setupChannel(target, channel) {
         handle: null,
         message: message,
       });
-      return;
+      return this._handleQueue.length === 1;
     }
 
     var req = new WriteWrap();

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -1,0 +1,9 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fork = require('child_process').fork;
+
+const n = fork(common.fixturesDir + '/empty.js');
+
+const rv = n.send({ hello: 'world' });
+assert.strictEqual(rv, true);

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -4,11 +4,12 @@ var assert = require('assert');
 var cluster = require('cluster');
 
 if (cluster.isWorker) {
-  cluster.worker.send({
+  const result = cluster.worker.send({
     prop: process.env['cluster_test_prop'],
     overwrite: process.env['cluster_test_overwrite']
   });
 
+  assert.strictEqual(result, true);
 } else if (cluster.isMaster) {
 
   var checks = {

--- a/test/parallel/test-cluster-worker-events.js
+++ b/test/parallel/test-cluster-worker-events.js
@@ -14,7 +14,8 @@ if (cluster.isMaster) {
     process.exit(0);
   });
 
-  worker.send('SOME MESSAGE');
+  const result = worker.send('SOME MESSAGE');
+  assert.strictEqual(result, true);
 
   return;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib, doc, cluster

##### Description of change
<!-- Provide a description of the change below this comment. -->
This is a backport of #3516 and #6998 

Originally it was decided to not land #3516 into v4.x as it is semver minor. I would like to ping @nodejs/lts to reconsider as it would appear that the behavior change is accurate to the documentation. Further #6998 also makes a fix based on the documentation that relies on #3516 

It may turn out that we do not wish to make a subtle change like this, especially if it can break people in prod. As such I will be running citgm against this to see if there are any obvious failures. If citgm + ci are both green I think we should consider backporting. It is inline with our documentation and will make subtle behavior equivalent in v4 and v6.