### PR TITLE
Fixes #7742: src: --inspect notify contextDestroyed

### DIFF
--- a/deps/v8_inspector/third_party/v8_inspector/platform/v8_inspector/public/V8Inspector.cpp
+++ b/deps/v8_inspector/third_party/v8_inspector/platform/v8_inspector/public/V8Inspector.cpp
@@ -71,4 +71,9 @@ bool V8Inspector::canExecuteScripts()
     return true;
 }
 
+void V8Inspector::notifyContextDestroyed()
+{
+    m_debugger->contextDestroyed(m_context);
+}
+
 } // namespace blink

--- a/deps/v8_inspector/third_party/v8_inspector/platform/v8_inspector/public/V8Inspector.h
+++ b/deps/v8_inspector/third_party/v8_inspector/platform/v8_inspector/public/V8Inspector.h
@@ -33,6 +33,7 @@ public:
     void connectFrontend(protocol::FrontendChannel*);
     void disconnectFrontend();
     void dispatchMessageFromFrontend(const String16& message);
+    void notifyContextDestroyed();
 
 private:
     bool callingContextCanAccessContext(v8::Local<v8::Context> calling, v8::Local<v8::Context> target) override;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -381,6 +381,7 @@ bool AgentImpl::IsStarted() {
 void AgentImpl::WaitForDisconnect() {
   shutting_down_ = true;
   fprintf(stderr, "Waiting for the debugger to disconnect...\n");
+  inspector_->notifyContextDestroyed();
   inspector_->runMessageLoopOnPause(0);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

inspector
##### Description of change

<!-- Provide a description of the change below this comment. -->

When node --inspect is run, Runtime.contextDestroyed is fired before debugger goes into a wait loop. 

This signals the client that it can stop any profilers if they were running and disconnect

/cc @ofrobots @pavelfeldman 

I'm not familiar with v8 internals. What is the best way for V8Inspector to hold a context reference so it gets nicely garbage collected ?

I tried using a v8::Localv8::Context\* but that didn't work.
…
