### PR TITLE
deps: no /safeseh for ml64.exe

### DIFF
--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -121,15 +121,17 @@
         }], # end of conditions of openssl_no_asm
         ['OS=="win"', {
           'defines' : ['<@(openssl_defines_all_win)'],
+        }, {
+          'defines' : ['<@(openssl_defines_all_non_win)']
+        }],
+        ['target_arch=="ia32" and OS=="win"', {
           'msvs_settings': {
             'MASM': {
               # Use /safeseh, see commit: 01fa5ee
               'UseSafeExceptionHandlers': 'true',
             },
           },
-        }, {
-          'defines' : ['<@(openssl_defines_all_non_win)']
-        }]
+        }],
       ],
       'include_dirs': ['<@(openssl_include_dirs)'],
       'direct_dependent_settings': {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

deps

##### Description of change
<!-- Provide a description of the change below this comment. -->

`ml64.exe` doesn't support `/safeseh` option. Do not attempt to use it
if `target_arch=="x64"`.

See: https://msdn.microsoft.com/en-us/library/s0ksfwcf.aspx