### PR TITLE
build: don't link against liblog on host system

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -301,9 +301,13 @@
           }],
         ],
       }],
-      [ 'OS=="android"', {
-        'defines': ['_GLIBCXX_USE_C99_MATH'],
-        'libraries': [ '-llog' ],
+      ['OS=="android"', {
+        'target_conditions': [
+          ['_toolset=="target"', {
+            'defines': [ '_GLIBCXX_USE_C99_MATH' ],
+            'libraries': [ '-llog' ],
+          }],
+        ],
       }],
       ['OS=="mac"', {
         'defines': ['_DARWIN_USE_64_BIT_INODE=1'],


### PR DESCRIPTION
Don't link binaries that run on the host system against liblog, it
breaks cross-compiling for android.

Fixes: #7731 (note to self: link in commit log is wrong, fix before landing)
CI: https://ci.nodejs.org/job/node-test-pull-request/3315/