### PR TITLE
src: don't include a null character in the WriteConsoleW call

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -253,7 +253,7 @@ static void PrintErrorString(const char* format, ...) {
   vsprintf(out.data(), format, ap);
 
   // Get required wide buffer size
-  n = MultiByteToWideChar(CP_UTF8, 0, out.data(), -1, nullptr, 0);
+  n = MultiByteToWideChar(CP_UTF8, 0, out.data(), n, nullptr, 0);
 
   std::vector<wchar_t> wbuf(n);
   MultiByteToWideChar(CP_UTF8, 0, out.data(), -1, wbuf.data(), n);

--- a/src/node.cc
+++ b/src/node.cc
@@ -253,11 +253,13 @@ static void PrintErrorString(const char* format, ...) {
   vsprintf(out.data(), format, ap);
 
   // Get required wide buffer size
-  n = MultiByteToWideChar(CP_UTF8, 0, out.data(), n, nullptr, 0);
+  n = MultiByteToWideChar(CP_UTF8, 0, out.data(), -1, nullptr, 0);
 
   std::vector<wchar_t> wbuf(n);
   MultiByteToWideChar(CP_UTF8, 0, out.data(), -1, wbuf.data(), n);
-  WriteConsoleW(stderr_handle, wbuf.data(), n, nullptr, nullptr);
+
+  // Don't include the null character in the output
+  WriteConsoleW(stderr_handle, wbuf.data(), n - 1, nullptr, nullptr);
 #else
   vfprintf(stderr, format, ap);
 #endif

--- a/src/node.cc
+++ b/src/node.cc
@@ -259,6 +259,7 @@ static void PrintErrorString(const char* format, ...) {
   MultiByteToWideChar(CP_UTF8, 0, out.data(), -1, wbuf.data(), n);
 
   // Don't include the null character in the output
+  CHECK_GT(n, 0);
   WriteConsoleW(stderr_handle, wbuf.data(), n - 1, nullptr, nullptr);
 #else
   vfprintf(stderr, format, ap);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
It seems if WriteConsoleW is called with a string that has a null character at the end, the console turns it into a space.

Fixes: https://github.com/nodejs/node/issues/7755