### PR TITLE
test: remove flaky status IPv6 localhost tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,13 +12,6 @@ test-tick-processor     : PASS,FLAKY
 [$system==linux]
 test-tick-processor           : PASS,FLAKY
 
-# Flaky until https://github.com/nodejs/build/issues/415 is resolved.
-# On some of the buildbots, AAAA queries for localhost don't resolve
-# to an address and neither do any of the alternatives from the
-# localIPv6Hosts list from test/common.js.
-test-https-connect-address-family : PASS,FLAKY
-test-tls-connect-address-family : PASS,FLAKY
-
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test https tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

The issue of hosts that do not resolve `localhost` to `::1` is now
handled within the test itself, so there is no need for the flaky
designation.