### PR TITLE
test: handle IPv6 localhost issues within tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,13 +12,6 @@ test-tick-processor     : PASS,FLAKY
 [$system==linux]
 test-tick-processor           : PASS,FLAKY
 
-# Flaky until https://github.com/nodejs/build/issues/415 is resolved.
-# On some of the buildbots, AAAA queries for localhost don't resolve
-# to an address and neither do any of the alternatives from the
-# localIPv6Hosts list from test/common.js.
-test-https-connect-address-family : PASS,FLAKY
-test-tls-connect-address-family : PASS,FLAKY
-
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS

--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -36,8 +36,13 @@ function runTest() {
 }
 
 dns.lookup('localhost', {family: 6, all: true}, (err, addresses) => {
-  if (err)
+  if (err) {
+    if (err.code === 'ENOTFOUND') {
+      common.skip('localhost does not resolve to ::1');
+      return;
+    }
     throw err;
+  }
 
   if (addresses.some((val) => val.address === '::1'))
     runTest();

--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -35,8 +35,13 @@ function runTest() {
 }
 
 dns.lookup('localhost', {family: 6, all: true}, (err, addresses) => {
-  if (err)
+  if (err) {
+    if (err.code === 'ENOTFOUND') {
+      common.skip('localhost does not resolve to ::1');
+      return;
+    }
     throw err;
+  }
 
   if (addresses.some((val) => val.address === '::1'))
     runTest();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test https tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

The issue of hosts that do not resolve `localhost` to `::1` is now
handled within the tests. Remove flaky status for
test-https-connect-address-family and test-tls-connect-address-family.