### PR TITLE
deps: cherry-pick 2b4c9c1 from v8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 76
+#define V8_PATCH_LEVEL 77
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/test/cctest/test-platform.cc
+++ b/deps/v8/test/cctest/test-platform.cc
@@ -25,9 +25,9 @@ void GetStackPointer(const v8::FunctionCallbackInfo<v8::Value>& args) {
 #elif V8_HOST_ARCH_MIPS64
   __asm__ __volatile__("sd $sp, %0" : "=g"(sp_addr));
 #elif defined(__s390x__) || defined(_ARCH_S390X)
-  __asm__ __volatile__("stg 15, %0" : "=g"(sp_addr));
+  __asm__ __volatile__("stg 15, %0" : "=m"(sp_addr));
 #elif defined(__s390__) || defined(_ARCH_S390)
-  __asm__ __volatile__("st 15, %0" : "=g"(sp_addr));
+  __asm__ __volatile__("st 15, %0" : "=m"(sp_addr));
 #elif defined(__PPC64__) || defined(_ARCH_PPC64)
   __asm__ __volatile__("std 1, %0" : "=g"(sp_addr));
 #elif defined(__PPC__) || defined(_ARCH_PPC)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps

##### Description of change
<!-- Provide a description of the change below this comment. -->

Original commit message:

S390:Update inline asm constraint in test-platform
The GetStackPointer() routine in test-platform uses an inline
assembly code to store the current stack pointer value into a static
variable sp_addr.  The existing asm code for S390 uses an ST/STG
instruction, with the memory operand associated with the general ('=g')
constraint to sp_addr.

On GCC 4.8.5, the GCC compiler got confused and treated sp_addr as
an integer operand instead of memory operand, resulting in a store
being emitted that writes to an invalid meory location.

Given the specific store instructions being inlined here, we should
restict the sp_addr operand to explicitly be a memory operand using '=m'
instead of '=g'.

R=bmeurer@chromium.org,jkummerow@chormium.org,rmcilroy@chromium.org,yangguo@chromium.org
BUG=

Review-Url: https://codereview.chromium.org/2158523002
Cr-Commit-Position: refs/heads/master@{#37809}

Fixes: https://github.com/nodejs/node/issues/7659