### PR TITLE
test: increase RAM requirement for intensive tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -27,7 +27,7 @@ exports.isLinuxPPCBE = (process.platform === 'linux') &&
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
 
-exports.enoughTestMem = os.totalmem() > 0x20000000; /* 512MB */
+exports.enoughTestMem = os.totalmem() > 0x40000000; /* 1 Gb */
 exports.rootDir = exports.isWindows ? 'c:\\' : '/';
 
 function rimrafSync(p) {

--- a/test/parallel/test-fs-readfile-tostring-fail.js
+++ b/test/parallel/test-fs-readfile-tostring-fail.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const common = require('../common');
+
+if (!common.enoughTestMem) {
+  const skipMessage = 'intensive toString tests due to memory confinements';
+  common.skip(skipMessage);
+  return;
+}
+
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

test-fs-read-buffer-tostring-fail and test-fs-readfile-tostring-fail
have been timing out on Raspberry Pi 3 devices on the continuous
integration server. These devices have 1 Gb of RAM and the tests are
memory intensive. Previous checks for memory intensive tests used a 512
Mb cut-off, but that was probably instituted when we only had Pi 1
devices.

Consequently, this change increases the threshold for memory-intensive
tests to 1 Gb and adds that threshold to test-fs-readfile-tostring-fail.