### PR TITLE
test: clean up test-buffer-badhex

### DIFF
--- a/test/parallel/test-buffer-badhex.js
+++ b/test/parallel/test-buffer-badhex.js
@@ -5,39 +5,45 @@ const Buffer = require('buffer').Buffer;
 
 // Test hex strings and bad hex strings
 {
-  const buf1 = Buffer.alloc(4);
-  assert.strictEqual(buf1.length, 4);
-  assert.deepStrictEqual(buf1, new Buffer([0, 0, 0, 0]));
-  assert.strictEqual(buf1.write('abcdxx', 0, 'hex'), 2);
-  assert.deepStrictEqual(buf1, new Buffer([0xab, 0xcd, 0x00, 0x00]));
-  assert.strictEqual(buf1.toString('hex'), 'abcd0000');
-  assert.strictEqual(buf1.write('abcdef01', 0, 'hex'), 4);
-  assert.deepStrictEqual(buf1, new Buffer([0xab, 0xcd, 0xef, 0x01]));
-  assert.strictEqual(buf1.toString('hex'), 'abcdef01');
+  const buf = Buffer.alloc(4);
+  assert.strictEqual(buf.length, 4);
+  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf.write('abcdxx', 0, 'hex'), 2);
+  assert.deepStrictEqual(buf, new Buffer([0xab, 0xcd, 0x00, 0x00]));
+  assert.strictEqual(buf.toString('hex'), 'abcd0000');
+  assert.strictEqual(buf.write('abcdef01', 0, 'hex'), 4);
+  assert.deepStrictEqual(buf, new Buffer([0xab, 0xcd, 0xef, 0x01]));
+  assert.strictEqual(buf.toString('hex'), 'abcdef01');
 
-  const buf2 = Buffer.from(buf1.toString('hex'), 'hex');
-  assert.strictEqual(buf1.toString('hex'), buf2.toString('hex'));
+  const copy = Buffer.from(buf.toString('hex'), 'hex');
+  assert.strictEqual(buf.toString('hex'), copy.toString('hex'));
+}
 
-  const buf3 = Buffer.alloc(5);
-  assert.strictEqual(buf3.write('abcdxx', 1, 'hex'), 2);
-  assert.strictEqual(buf3.toString('hex'), '00abcd0000');
+{
+  const buf = Buffer.alloc(5);
+  assert.strictEqual(buf.write('abcdxx', 1, 'hex'), 2);
+  assert.strictEqual(buf.toString('hex'), '00abcd0000');
+}
 
-  const buf4 = Buffer.alloc(4);
-  assert.deepStrictEqual(buf4, new Buffer([0, 0, 0, 0]));
-  assert.strictEqual(buf4.write('xxabcd', 0, 'hex'), 0);
-  assert.deepStrictEqual(buf4, new Buffer([0, 0, 0, 0]));
-  assert.strictEqual(buf4.write('xxab', 1, 'hex'), 0);
-  assert.deepStrictEqual(buf4, new Buffer([0, 0, 0, 0]));
-  assert.strictEqual(buf4.write('cdxxab', 0, 'hex'), 1);
-  assert.deepStrictEqual(buf4, new Buffer([0xcd, 0, 0, 0]));
+{
+  const buf = Buffer.alloc(4);
+  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf.write('xxabcd', 0, 'hex'), 0);
+  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf.write('xxab', 1, 'hex'), 0);
+  assert.deepStrictEqual(buf, new Buffer([0, 0, 0, 0]));
+  assert.strictEqual(buf.write('cdxxab', 0, 'hex'), 1);
+  assert.deepStrictEqual(buf, new Buffer([0xcd, 0, 0, 0]));
+}
 
-  const buf5 = Buffer.alloc(256);
+{
+  const buf = Buffer.alloc(256);
   for (let i = 0; i < 256; i++)
-    buf5[i] = i;
+    buf[i] = i;
 
-  const hex = buf5.toString('hex');
-  assert.deepStrictEqual(Buffer.from(hex, 'hex'), buf5);
+  const hex = buf.toString('hex');
+  assert.deepStrictEqual(Buffer.from(hex, 'hex'), buf);
 
   const badHex = hex.slice(0, 256) + 'xx' + hex.slice(256, 510);
-  assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf5.slice(0, 128));
+  assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf.slice(0, 128));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

This test was recently introduced in
151d316b99d56a4614c95cc59ea7a0c9c0f1928b
and could be cleaned up a bit.

Refs: https://github.com/nodejs/node/pull/7602

It is possible this is not worthwhile enough, but I feel it is stilly to have `bufX` all within a single closure.

R=@addaleax 
CI: https://ci.nodejs.org/job/node-test-pull-request/3323/