### PR TITLE
test: fix child_process testcase to actually detect regression

### DIFF
--- a/test/parallel/test-child-process-flush-stdio.js
+++ b/test/parallel/test-child-process-flush-stdio.js
@@ -26,8 +26,10 @@ function spawnWithReadable() {
     assert.strictEqual(Buffer.concat(buffer).toString().trim(), '123');
   }));
   p.stdout.on('readable', function() {
-    let buf;
-    while (buf = this.read())
-      buffer.push(buf);
+    setImmediate(() => {
+      let buf;
+      while (buf = this.read())
+        buffer.push(buf);
+    });
   });
 }


### PR DESCRIPTION
This is taken verbatim from #7257, with the original author not responding. After https://github.com/libuv/libuv/pull/611 changed the relative timing of events upon child process exit, the test case from https://github.com/nodejs/node/pull/5036 needs a `setImmediate()` inserted to actually detect the original regression.
