### PR TITLE
doc: fix `added:` date for `NODE_REPL_HISTORY`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -280,7 +280,7 @@ with small-icu support.
 
 ### `NODE_REPL_HISTORY=file`
 <!-- YAML
-added: v5.0.0
+added: v3.0.0
 -->
 
 Path to the file used to store the persistent REPL history. The default path is


### PR DESCRIPTION
`NODE_REPL_HISTORY` was introduced in v3.0.0 (see e.g. 6faf17cb45e27cb6feeff4a0da1513ea99a68b58).

I noticed this while doing the conflict resolution for the backport in #7677, and I think I wanted to PR that against master right then, but ended up correcting the version in the backport – sorry for that.