### PR TITLE
src: Only use the TR1 type_traits when targeting OSX<10.9

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -11,7 +11,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef __APPLE__
+// OSX 10.9 defaults to libc++ which provides a C++11 <type_traits> header.
+#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1090
+#define USE_TR1_TYPE_TRAITS
+#endif
+
+#ifdef USE_TR1_TYPE_TRAITS
 #include <tr1/type_traits>  // NOLINT(build/c++tr1)
 #else
 #include <type_traits>  // std::remove_reference
@@ -31,7 +36,7 @@ NO_RETURN void Abort();
 NO_RETURN void Assert(const char* const (*args)[4]);
 void DumpBacktrace(FILE* fp);
 
-#ifdef __APPLE__
+#ifdef USE_TR1_TYPE_TRAITS
 template <typename T> using remove_reference = std::tr1::remove_reference<T>;
 #else
 template <typename T> using remove_reference = std::remove_reference<T>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change
<!-- Provide a description of the change below this comment. -->
Mac OSX 10.9 has switched to using libc++ by default.  libc++
provides a C++11 &lt;type_traits&gt; implementation, so we only need
to use the TR1 version when targetting OSX 10.8 or 10.7.

This patch fixes build failures when using `-mmacosx-version-min=10.9` to build Node.