### PR TITLE
test: avoid connecting to :: in test-net-timeout

### DIFF
--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -1,4 +1,5 @@
 'use strict';
+const common = require('../common');
 // just like test/gc/http-client-timeout.js,
 // but using a net server/client instead
 
@@ -19,7 +20,6 @@ function serverHandler(sock) {
 
 const net = require('net');
 const weak = require('weak');
-require('../common');
 const assert = require('assert');
 const todo = 500;
 let done = 0;
@@ -29,7 +29,7 @@ let countGC = 0;
 console.log('We should do ' + todo + ' requests');
 
 var server = net.createServer(serverHandler);
-server.listen(0, getall);
+server.listen(0, common.localhostIPv4, getall);
 
 function getall() {
   if (count >= todo)


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

test
##### Description of change

Fixes #7291 

This test tries to connect to :: or 0.0.0.0, which resolves to localhost
on some platforms but not others. Change to specify localhost.

@quaidn I basically did what you suggested in https://github.com/nodejs/node/issues/7291#issuecomment-227985372, but used `common.hasIPv6` instead. 

@cjihrig I don't think this will make a difference to the changes you made to `gc/test-net-timeout.js`  a few days ago, but I'd appreciate a check.

cc @Trott 

EDIT: I would have replaced `server.address().address` with `'localhost'`, but until #7288 is resolved that can cause problems on some machines.

**_EDIT 2:_** Actually you can use `localhost`, as if you don't specify IPv4 or IPv6 `localhost` should resolve to `127.0.0.1` if `::1` isn't defined.