### PR TITLE
test: add known issue test for #7788

### DIFF
--- a/test/fixtures/is-object.js
+++ b/test/fixtures/is-object.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports.isObject = (obj) => obj.constructor === Object;

--- a/test/known_issues/test-repl-require-context.js
+++ b/test/known_issues/test-repl-require-context.js
@@ -1,0 +1,32 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/issues/7788
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const repl = require('repl');
+const stream = require('stream');
+const inputStream = new stream.PassThrough();
+const outputStream = new stream.PassThrough();
+const fixture = path.join(common.fixturesDir, 'is-object.js');
+const r = repl.start({
+  input: inputStream,
+  output: outputStream,
+  useGlobal: false
+});
+
+let output = '';
+outputStream.setEncoding('utf8');
+outputStream.on('data', (data) => output += data);
+
+r.on('exit', common.mustCall(() => {
+  const results = output.split('\n').map((line) => {
+    return line.replace(/\w*>\w*/, '').trim();
+  });
+
+  assert.deepStrictEqual(results, ['undefined', 'true', 'true', '']);
+}));
+
+inputStream.write('const isObject = (obj) => obj.constructor === Object;\n');
+inputStream.write('isObject({});\n');
+inputStream.write(`require('${fixture}').isObject({});\n`);
+r.close();


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
15157c3c3d7594cefb7f5941cbe925657e7d88bd changed the CLI REPL to default to `useGlobal: false` by default. This caused the regression seen in https://github.com/nodejs/node/issues/7788. This commit adds a known issue test while a proper resolution is determined.