### PR TITLE
repl: default useGlobal to true

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -22,7 +22,7 @@ function createRepl(env, opts, cb) {
   opts = opts || {
     ignoreUndefined: false,
     terminal: process.stdout.isTTY,
-    useGlobal: false,
+    useGlobal: true,
     breakEvalOnSigint: true
   };
 

--- a/test/parallel/test-repl-require-context.js
+++ b/test/parallel/test-repl-require-context.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+const child = cp.spawn(process.execPath, ['--interactive']);
+const fixture = path.join(common.fixturesDir, 'is-object.js').replace(/\\/g,
+                                                                      '/');
+let output = '';
+
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (data) => {
+  output += data;
+});
+
+child.on('exit', common.mustCall(() => {
+  const results = output.split('\n').map((line) => {
+    return line.replace(/\w*>\w*/, '').trim();
+  });
+
+  assert.deepStrictEqual(results, ['undefined', 'true', 'true', '']);
+}));
+
+child.stdin.write('const isObject = (obj) => obj.constructor === Object;\n');
+child.stdin.write('isObject({});\n');
+child.stdin.write(`require('${fixture}').isObject({});\n`);
+child.stdin.write('.exit');
+child.stdin.end();


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
repl

##### Description of change
This is a partial revert of 15157c3c3d7594cefb7f5941cbe925657e7d88bd. This change lead to a regression that broke `require()` in the CLI REPL, as imported files were evaluated in a different context.

A known issue test is available in #7793, which I'll port over here as a normal test.