### PR TITLE
test: find IPv6 address from localhost names

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,13 +12,6 @@ test-tick-processor     : PASS,FLAKY
 [$system==linux]
 test-tick-processor           : PASS,FLAKY
 
-# Flaky until https://github.com/nodejs/build/issues/415 is resolved.
-# On some of the buildbots, AAAA queries for localhost don't resolve
-# to an address and neither do any of the alternatives from the
-# localIPv6Hosts list from test/common.js.
-test-https-connect-address-family : PASS,FLAKY
-test-tls-connect-address-family : PASS,FLAKY
-
 [$system==macos]
 
 [$system==solaris] # Also applies to SmartOS


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Try all the possible hostnames listed in `common.localIPv6Hosts` to get
an IPv6 address. If none of them give a valid address, skip the tests.

cc @nodejs/testing 