### PR TITLE
build: add node_module_version to config.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -179,7 +179,11 @@
       }],
       [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-pthread', ],
-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
+        'cflags_cc': [
+          '-fno-delete-null-pointer-checks',
+          '-fno-exceptions',
+          '-fno-rtti',
+        ],
         'ldflags': [ '-pthread', '-rdynamic' ],
         'target_conditions': [
           ['_type=="static_library"', {

--- a/configure
+++ b/configure
@@ -546,6 +546,8 @@ def configure_node(o):
   else:
     o['variables']['node_tag'] = ''
 
+  o['variables']['node_module_version'] = 11
+
 
 def configure_libz(o):
   o['variables']['node_shared_zlib'] = b(options.shared_zlib)

--- a/node.gyp
+++ b/node.gyp
@@ -13,6 +13,7 @@
     'node_use_openssl%': 'true',
     'node_use_systemtap%': 'false',
     'node_shared_openssl%': 'false',
+    'node_module_version%': '',
     'library_files': [
       'src/node.js',
       'lib/_debugger.js',

--- a/test/simple/test-module-version.js
+++ b/test/simple/test-module-version.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+var assert = require('assert');
+
+// Check for existence
+assert(process.config.variables.hasOwnProperty('node_module_version'));
+
+// Ensure that `node_module_version` is an Integer
+assert(!Number.isNaN(parseInt(process.config.variables.node_module_version)));
+assert.strictEqual(process.config.variables.node_module_version, 11);


### PR DESCRIPTION
Enable targetting of a different node version than
the currently running one when building binary modules.

This is extracted from nodejs/node@410296c37

PR-URL: https://github.com/nodejs/node-gyp/pull/855
