### PR TITLE
documentation - fixed minor inconsistency

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -367,7 +367,7 @@ path.parse('/home/user/dir/file.txt')
 │ root │              │ name │ ext │
 "  /    home/user/dir / file  .txt "
 └──────┴──────────────┴──────┴─────┘
-(all spaces in the "" line should be ignored -- they're purely for formatting)
+(all spaces in the "" line should be ignored -- they are purely for formatting)
 ```
 
 On Windows:
@@ -391,7 +391,7 @@ path.parse('C:\\path\\dir\\file.txt')
 │ root │              │ name │ ext │
 " C:\      path\dir   \ file  .txt "
 └──────┴──────────────┴──────┴─────┘
-(all spaces in the "" line should be ignored -- they're purely for formatting)
+(all spaces in the "" line should be ignored -- they are purely for formatting)
 ```
 
 A [`TypeError`][] is thrown if `path` is not a string.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

The single quote in the ```text  area was causing the words after it to be orange, when that probably isn't what was wanted. This issue doesn't occur on github's markdown renderer, but it does exist on the Node official website's docs.

<img width="1436" alt="screen shot 2016-07-20 at 11 43 30 pm" src="https://cloud.githubusercontent.com/assets/3885959/17012489/47d89228-4ed5-11e6-8b22-62da880b4d8f.png">

This change removes having to worry about escaping a quote inside of a codeblock.