### PR TITLE
Path Documentation Syntax Fixes

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -367,7 +367,7 @@ path.parse('/home/user/dir/file.txt')
 │ root │              │ name │ ext │
 "  /    home/user/dir / file  .txt "
 └──────┴──────────────┴──────┴─────┘
-(all spaces in the "" line should be ignored -- they're purely for formatting)
+(all spaces in the "" line should be ignored -- they are purely for formatting)
 ```
 
 On Windows:
@@ -391,7 +391,7 @@ path.parse('C:\\path\\dir\\file.txt')
 │ root │              │ name │ ext │
 " C:\      path\dir   \ file  .txt "
 └──────┴──────────────┴──────┴─────┘
-(all spaces in the "" line should be ignored -- they're purely for formatting)
+(all spaces in the "" line should be ignored -- they are purely for formatting)
 ```
 
 A [`TypeError`][] is thrown if `path` is not a string.


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Documentation for the Path module

##### Description of change
The single quote in the ```text area was causing the words after it to
be orange, when that probably isn't what was wanted. This issue doesn't
occur on github's markdown renderer, but it does exist on the Node
official website's docs.

<img width="1436" alt="screen shot 2016-07-20 at 11 43 30 pm" src="https://cloud.githubusercontent.com/assets/3885959/17012947/6fd6f2a8-4ed8-11e6-8297-0b207c14c007.png">

This fix makes is so escaping a quote in a text block isnt necessary