### PR TITLE
benchmark: Repair the fs/readfile benchmark

### DIFF
--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -22,8 +22,10 @@ function main(conf) {
   data = null;
 
   var reads = 0;
+  var bench_ended = false;
   bench.start();
   setTimeout(function() {
+    bench_ended = true;
     bench.end(reads);
     try { fs.unlinkSync(filename); } catch (e) {}
   }, +conf.dur * 1000);
@@ -40,7 +42,8 @@ function main(conf) {
       throw new Error('wrong number of bytes returned');
 
     reads++;
-    read();
+    if (!bench_ended)
+      read();
   }
 
   var cur = +conf.concurrent;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
##### Description of change

<!-- Provide a description of the change below this comment. -->

The readfile benchmark of fs type was throwing an exception because the benchmark tried to read the file after it got unlinked at the end of the run.

Signed-off-by: Sorin Baltateanu sorin.baltateanu@intel.com
