### PR TITLE
doc: Clean up roff source in manpage

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -1,10 +1,26 @@
 .TH NODE 1 2016 Node.js Node.js
 
-.\ This is a man page comment.
-.\ Man page syntax (actually troff syntax) is somewhat obscure, but the
-.\ important part is is that .<letter> specifies <letter>'s syntax for that
-.\ line, and \f<letter> specifies it for the characters that follow.
-.\ See http://liw.fi/manpages/ for more info.
+.\" This is a man page comment.
+.
+.\" Man page syntax (actually troff syntax) is somewhat obscure, but the
+.\" important part is is that .<letter> specifies <letter>'s syntax for that
+.\" line, and \f<letter> specifies it for the characters that follow.
+.
+.\" .B   Bold line
+.\" .I   Italic line (Rendered as underlined text in terminals)
+.\" .BI  Alternating bold/italics without spaces between arguments.
+.\"      Use `\ ` to include an "unpaddable" (literal) space in the output.
+.\" .RI  Alternating roman/italic
+.
+.\" See http://liw.fi/manpages/ for an overview, or http://www.troff.org/54.pdf
+.\" for detailed language reference.
+.de ur
+.nr CF \\n(.f
+.ft 4
+\\$1
+.ft \\n(CF
+..
+
 
 .SH NAME
 
@@ -12,17 +28,27 @@ node \- Server-side JavaScript runtime
 
 
 .SH SYNOPSIS
-
+.fi
+.
 .B node
-[\fIoptions\fR] [\fIv8 options\fR]
-[\fIscript.js\fR | \fB\-e \fR"\fIscript\fR"]
-[\fIarguments\fR]
+.RI [ options ]
+.RI [ v8\ options ]
+.RI [ script.js \ |
+.B -e 
+.RI \&" script \&"]
+.RI [ arguments ]
 .br
+.
 .B node debug
-[\fIscript.js\fR | \fB\-e \fR"\fIscript\fR" | \fI<host>:<port>\fR] \fI...
+.RI [ script.js " | "
+.B \-e
+.RI \&" script \&"\ |
+.IR <host>:<port> ]
+.I ...
 .br
+.
 .B node
-[\fB\-\-v8-options\fR]
+.RB [ \-\-v8-options ]
 
 Execute without arguments to start the REPL.
 
@@ -172,14 +198,20 @@ value to an empty string ("" or " ") disables persistent REPL history.
 
 .SH RESOURCES AND DOCUMENTATION
 
-Website: \fBhttps://nodejs.org/\fR
+Website:
+.ur https://nodejs.org/
 
-Documentation: \fBhttps://nodejs.org/api/\fR
+Documentation:
+.ur https://nodejs.org/api/
 
-GitHub repository & Issue Tracker: \fBhttps://github.com/nodejs/node\fR
+GitHub repository & Issue Tracker:
+.ur https://github.com/nodejs/node
 
-Mailing list: \fBhttp://groups.google.com/group/nodejs\fR
+Mailing list:
+.ur http://groups.google.com/group/nodejs
 
-IRC (general questions): \fBchat.freenode.net #node.js\fR
+IRC (general questions):
+.ur "chat.freenode.net #node.js"
 
-IRC (node core development): \fBchat.freenode.net #node-dev\fR
+IRC (node core development):
+.ur "chat.freenode.net #node-dev"

--- a/doc/node.1
+++ b/doc/node.1
@@ -14,6 +14,8 @@
 .
 .\" See http://liw.fi/manpages/ for an overview, or http://www.troff.org/54.pdf
 .\" for detailed language reference.
+.
+.\" Macro to display an underlined URL in bold
 .de ur
 .nr CF \\n(.f
 .ft 4

--- a/doc/node.1
+++ b/doc/node.1
@@ -1,20 +1,20 @@
 .TH NODE 1 2016 Node.js Node.js
 
 .\" This is a man page comment.
-.
+
 .\" Man page syntax (actually roff syntax) is somewhat obscure, but the
 .\" important part is is that .<letter> specifies <letter>'s syntax for that
 .\" line, and \f<letter> specifies it for the characters that follow.
-.
+
 .\" .B   Bold line
 .\" .I   Italic line (Rendered as underlined text in terminals)
 .\" .BI  Alternating bold/italics without spaces between arguments.
 .\"      Use `\ ` to include an "unpaddable" (literal) space in the output.
 .\" .RI  Alternating roman/italic
-.
+
 .\" See http://liw.fi/manpages/ for an overview, or http://www.troff.org/54.pdf
 .\" for detailed language reference.
-.
+
 .\" Macro to display an underlined URL in bold
 .de ur
 .nr CF \\n(.f
@@ -30,7 +30,7 @@ node \- Server-side JavaScript runtime
 
 
 .SH SYNOPSIS
-.
+
 .B node
 .RI [ options ]
 .RI [ v8\ options ]
@@ -39,7 +39,6 @@ node \- Server-side JavaScript runtime
 .RI \&" script \&"]
 .RI [ arguments ]
 .br
-.
 .B node debug
 .RI [ script.js " | "
 .B \-e
@@ -47,7 +46,6 @@ node \- Server-side JavaScript runtime
 .IR <host>:<port> ]
 .I ...
 .br
-.
 .B node
 .RB [ \-\-v8-options ]
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -34,7 +34,7 @@ node \- Server-side JavaScript runtime
 .RI [ options ]
 .RI [ v8\ options ]
 .RI [ script.js \ |
-.B -e 
+.B -e
 .RI \&" script \&"]
 .RI [ arguments ]
 .br

--- a/doc/node.1
+++ b/doc/node.1
@@ -30,7 +30,6 @@ node \- Server-side JavaScript runtime
 
 
 .SH SYNOPSIS
-.fi
 .
 .B node
 .RI [ options ]

--- a/doc/node.1
+++ b/doc/node.1
@@ -2,7 +2,7 @@
 
 .\" This is a man page comment.
 .
-.\" Man page syntax (actually troff syntax) is somewhat obscure, but the
+.\" Man page syntax (actually roff syntax) is somewhat obscure, but the
 .\" important part is is that .<letter> specifies <letter>'s syntax for that
 .\" line, and \f<letter> specifies it for the characters that follow.
 .


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
I was [prompted](https://github.com/nodejs/node/commit/f9e6191f8582e0ec6f1ff64da454988423e0cb89#commitcomment-18330687) to submit a PR to make some trivial corrections to Node's manpage source. While I was there, I took the liberty of tidying up some of the source to make things less noisy to the uninitiated.

The only noticeable change is the addition of underlines to the URLs in the footer:

<img src="https://cloud.githubusercontent.com/assets/2346707/17022981/54ca7004-4f94-11e6-8bbf-87b304c82d67.png" width="457" alt="Figure 1" />

This stays more consistent with existing manual-page formatting, which usually employs underlines to pronounce URLs in text.

If you prefer I revert that addition, please advise if I should do so as a separate commit, or through `--amend` / `push -f`.

/cc @Fishrock123
