### PR TITLE
repl: don't override all internal repl defaults

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -5,7 +5,8 @@ const REPL = require('repl');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const debug = require('util').debuglog('repl');
+const util = require('util');
+const debug = util.debuglog('repl');
 
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
@@ -19,12 +20,12 @@ function createRepl(env, opts, cb) {
     cb = opts;
     opts = null;
   }
-  opts = opts || {
+  opts = util._extend({
     ignoreUndefined: false,
     terminal: process.stdout.isTTY,
     useGlobal: true,
     breakEvalOnSigint: true
-  };
+  }, opts);
 
   if (parseInt(env.NODE_NO_READLINE)) {
     opts.terminal = false;

--- a/test/common.js
+++ b/test/common.js
@@ -345,6 +345,11 @@ if (global.Symbol) {
   knownGlobals.push(Symbol);
 }
 
+function allowGlobals(...whitelist) {
+  knownGlobals = knownGlobals.concat(whitelist);
+}
+exports.allowGlobals = allowGlobals;
+
 function leakedGlobals() {
   var leaked = [];
 

--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -2,7 +2,7 @@
 
 // Flags: --expose-internals
 
-require('../common');
+const common = require('../common');
 const stream = require('stream');
 const REPL = require('internal/repl');
 const assert = require('assert');
@@ -46,6 +46,10 @@ function run(test) {
 
   REPL.createInternalRepl(env, opts, function(err, repl) {
     if (err) throw err;
+
+    // The REPL registers 'module' and 'require' globals
+    common.allowGlobals(repl.context.module, repl.context.require);
+
     assert.equal(expected.terminal, repl.terminal,
                  'Expected ' + inspect(expected) + ' with ' + inspect(env));
     assert.equal(expected.useColors, repl.useColors,

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -35,6 +35,10 @@ const replHistoryPath = path.join(common.tmpDir, '.node_repl_history');
 const checkResults = common.mustCall(function(err, r) {
   if (err)
     throw err;
+
+  // The REPL registers 'module' and 'require' globals
+  common.allowGlobals(r.context.module, r.context.require);
+
   r.input.end();
   const stat = fs.statSync(replHistoryPath);
   assert.strictEqual(

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -262,6 +262,9 @@ function runTest(assertCleaned) {
       throw err;
     }
 
+    // The REPL registers 'module' and 'require' globals
+    common.allowGlobals(repl.context.module, repl.context.require);
+
     repl.once('close', () => {
       if (repl._flushing) {
         repl.once('flushHistory', onClose);

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -7,8 +7,6 @@ const stream = require('stream');
 const repl = require('internal/repl');
 const assert = require('assert');
 
-common.globalCheck = false;
-
 // Array of [useGlobal, expectedResult] pairs
 const globalTestCases = [
   [false, 'undefined'],
@@ -19,6 +17,9 @@ const globalTestCases = [
 const globalTest = (useGlobal, cb, output) => (err, repl) => {
   if (err)
     return cb(err);
+
+  // The REPL registers 'module' and 'require' globals
+  common.allowGlobals(repl.context.module, repl.context.require);
 
   let str = '';
   output.on('data', (data) => (str += data));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
repl

##### Description of change
The `createInternalRepl()` method accepts an options object as an argument. However, if one is provided, it overrides all of the default options. This PR applies the options object to the defaults, only changing the values that are explicitly set.

The approach in this PR also adds a method to `test/common.js`, allowing specific global variables to be whitelisted. This is because the CLI REPL sets `useGlobal` to `true`, and then defines `module` and `require()` as globals. Alternative approaches could be to set `useGlobal` to `false` (which was what was silently happening before) or set `common.globalCheck` to `false`. I prefer the current approach because it is more representative of what happens in the real world, and still performs the global checks.