### PR TITLE
repl: deprecate unused function convertToContext

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1195,6 +1195,35 @@ function regexpEscape(s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
 
+
+/**
+ * Converts commands that use var and function <name>() to use the
+ * local exports.context when evaled. This provides a local context
+ * on the REPL.
+ *
+ * @param {String} cmd The cmd to convert.
+ * @return {String} The converted command.
+ */
+REPLServer.prototype.convertToContext = util.deprecate(function(cmd) {
+  const scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m;
+  const scopeFunc = /^\s*function\s*([_\w\$]+)/;
+  var matches;
+
+  // Replaces: var foo = "bar";  with: self.context.foo = bar;
+  matches = scopeVar.exec(cmd);
+  if (matches && matches.length === 3) {
+    return 'self.context.' + matches[1] + matches[2];
+  }
+
+  // Replaces: function foo() {};  with: foo = function foo() {};
+  matches = scopeFunc.exec(this.bufferedCommand);
+  if (matches && matches.length === 2) {
+    return matches[1] + ' = ' + this.bufferedCommand;
+  }
+
+  return cmd;
+}, 'replServer.convertToContext will be removed in v8.0.0');
+
 function bailOnIllegalToken(parser) {
   return parser._literal === null &&
          !parser.blockComment &&

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1204,6 +1204,8 @@ function regexpEscape(s) {
  * @param {String} cmd The cmd to convert.
  * @return {String} The converted command.
  */
+// TODO(princejwesley): Remove it prior to v8.0.0 release
+// Reference: https://github.com/nodejs/node/pull/7829
 REPLServer.prototype.convertToContext = util.deprecate(function(cmd) {
   const scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m;
   const scopeFunc = /^\s*function\s*([_\w\$]+)/;
@@ -1222,7 +1224,7 @@ REPLServer.prototype.convertToContext = util.deprecate(function(cmd) {
   }
 
   return cmd;
-}, 'replServer.convertToContext will be removed in v8.0.0');
+}, 'replServer.convertToContext will be removed after v7');
 
 function bailOnIllegalToken(parser) {
   return parser._literal === null &&

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1195,35 +1195,6 @@ function regexpEscape(s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
 
-
-/**
- * Converts commands that use var and function <name>() to use the
- * local exports.context when evaled. This provides a local context
- * on the REPL.
- *
- * @param {String} cmd The cmd to convert.
- * @return {String} The converted command.
- */
-REPLServer.prototype.convertToContext = function(cmd) {
-  const scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m;
-  const scopeFunc = /^\s*function\s*([_\w\$]+)/;
-  var matches;
-
-  // Replaces: var foo = "bar";  with: self.context.foo = bar;
-  matches = scopeVar.exec(cmd);
-  if (matches && matches.length === 3) {
-    return 'self.context.' + matches[1] + matches[2];
-  }
-
-  // Replaces: function foo() {};  with: foo = function foo() {};
-  matches = scopeFunc.exec(this.bufferedCommand);
-  if (matches && matches.length === 2) {
-    return matches[1] + ' = ' + this.bufferedCommand;
-  }
-
-  return cmd;
-};
-
 function bailOnIllegalToken(parser) {
   return parser._literal === null &&
          !parser.blockComment &&

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1224,7 +1224,7 @@ REPLServer.prototype.convertToContext = util.deprecate(function(cmd) {
   }
 
   return cmd;
-}, 'replServer.convertToContext will be removed after v7');
+}, 'replServer.convertToContext() is deprecated');
 
 function bailOnIllegalToken(parser) {
   return parser._literal === null &&

--- a/test/parallel/test-repl-deprecated.js
+++ b/test/parallel/test-repl-deprecated.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+const expected = [
+  'replServer.convertToContext() is deprecated'
+];
+
+process.on('warning', common.mustCall((warning) => {
+  assert.strictEqual(warning.name, 'DeprecationWarning');
+  assert.notStrictEqual(expected.indexOf(warning.message), -1,
+                        `unexpected error message: "${warning.message}"`);
+  // Remove a warning message after it is seen so that we guarantee that we get
+  // each message only once.
+  expected.splice(expected.indexOf(warning.message), 1);
+}, expected.length));
+
+// Create a dummy stream that does nothing
+const stream = new common.ArrayStream();
+
+const replServer = repl.start({
+  input: stream,
+  output: stream
+});
+
+const cmd = replServer.convertToContext('var name = "nodejs"');
+assert.strictEqual(cmd, 'self.context.name = "nodejs"');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl

##### Description of change
<!-- Provide a description of the change below this comment. -->
Remove unused function `convertToContext`
