### PR TITLE
cluster: support stdio option for workers

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -626,6 +626,9 @@ values are `"rr"` and `"none"`.
     (Default=`process.argv.slice(2)`)
   * `silent` {Boolean} whether or not to send output to parent's stdio.
     (Default=`false`)
+  * `stdio` {Array} Configures the stdio of forked processes. Because the
+    cluster module relies on IPC to function, this configuration must contain an
+    `'ipc'` entry. When this option is provided, it overrides `silent`.
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
 
@@ -642,6 +645,8 @@ This object is not supposed to be changed or set manually, by you.
     (Default=`process.argv.slice(2)`)
   * `silent` {Boolean} whether or not to send output to parent's stdio.
     (Default=`false`)
+  * `stdio` {Array} Configures the stdio of forked processes. When this option
+    is provided, it overrides `silent`.
 
 `setupMaster` is used to change the default 'fork' behavior. Once called,
 the settings will be present in `cluster.settings`.

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -322,6 +322,7 @@ function masterInit() {
       env: workerEnv,
       silent: cluster.settings.silent,
       execArgv: execArgv,
+      stdio: cluster.settings.stdio,
       gid: cluster.settings.gid,
       uid: cluster.settings.uid
     });

--- a/test/parallel/test-cluster-fork-stdio.js
+++ b/test/parallel/test-cluster-fork-stdio.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isMaster) {
+  const buf = Buffer.from('foobar');
+
+  cluster.setupMaster({
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe']
+  });
+
+  const worker = cluster.fork();
+  const channel = worker.process.stdio[4];
+  let response = '';
+
+  worker.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+
+  channel.setEncoding('utf8');
+  channel.on('data', (data) => {
+    response += data;
+
+    if (response === buf.toString()) {
+      worker.disconnect();
+    }
+  });
+  channel.write(buf);
+} else {
+  const pipe = new net.Socket({ fd: 4 });
+
+  pipe.unref();
+  pipe.on('data', (data) => {
+    assert.ok(data instanceof Buffer);
+    pipe.write(data);
+  });
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
cluster

##### Description of change
This commit allows `setupMaster()` to configure the stdio channels for worker processes.

Refs: https://github.com/nodejs/node-v0.x-archive/issues/5727
Refs: https://github.com/nodejs/node/pull/7811