### PR TITLE
src: remove unused IsInt64() function

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -137,10 +137,6 @@ static void NewFSReqWrap(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-static inline bool IsInt64(double x) {
-  return x == static_cast<double>(static_cast<int64_t>(x));
-}
-
 static void After(uv_fs_t *req) {
   FSReqWrap* req_wrap = static_cast<FSReqWrap*>(req->data);
   CHECK_EQ(&req_wrap->req_, req);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change
The function `IsInt64()` in `node_file.cc` is no longer used, and was creating a warning at compile time. This commit removes the unused function.