### PR TITLE
test: use common platform helpers everywhere

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -26,6 +26,8 @@ exports.isLinuxPPCBE = (process.platform === 'linux') &&
                        (os.endianness() === 'BE');
 exports.isSunOS = process.platform === 'sunos';
 exports.isFreeBSD = process.platform === 'freebsd';
+exports.isLinux = process.platform === 'linux';
+exports.isOSX = process.platform === 'darwin';
 
 exports.enoughTestMem = os.totalmem() > 0x40000000; /* 1 Gb */
 exports.rootDir = exports.isWindows ? 'c:\\' : '/';
@@ -61,7 +63,7 @@ function rmdirSync(p, originalEr) {
     if (e.code === 'ENOTDIR')
       throw originalEr;
     if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
-      const enc = process.platform === 'linux' ? 'buffer' : 'utf8';
+      const enc = exports.isLinux ? 'buffer' : 'utf8';
       fs.readdirSync(p, enc).forEach((f) => {
         if (f instanceof Buffer) {
           const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
@@ -91,7 +93,7 @@ var inFreeBSDJail = null;
 var localhostIPv4 = null;
 
 exports.localIPv6Hosts = ['localhost'];
-if (process.platform === 'linux') {
+if (exports.isLinux) {
   exports.localIPv6Hosts = [
     // Debian/Ubuntu
     'ip6-localhost',
@@ -110,7 +112,7 @@ Object.defineProperty(exports, 'inFreeBSDJail', {
   get: function() {
     if (inFreeBSDJail !== null) return inFreeBSDJail;
 
-    if (process.platform === 'freebsd' &&
+    if (exports.isFreeBSD &&
       child_process.execSync('sysctl -n security.jail.jailed').toString() ===
       '1\n') {
       inFreeBSDJail = true;
@@ -469,7 +471,7 @@ exports.nodeProcessAborted = function nodeProcessAborted(exitCode, signal) {
 
   // On Windows, v8's base::OS::Abort triggers an access violation,
   // which corresponds to exit code 3221225477 (0xC0000005)
-  if (process.platform === 'win32')
+  if (exports.isWindows)
     expectedExitCodes = [3221225477];
 
   // When using --abort-on-uncaught-exception, V8 will use

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -123,7 +123,7 @@ TEST(function test_lookup_ipv6_hint(done) {
   }, function(err, ip, family) {
     if (err) {
       // FreeBSD does not support V4MAPPED
-      if (process.platform === 'freebsd') {
+      if (common.isFreeBSD) {
         assert(err instanceof Error);
         assert.strictEqual(err.code, 'EAI_BADFLAGS');
         assert.strictEqual(err.hostname, 'www.google.com');

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const spawn = require('child_process').spawn;
 
 // Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
-if (process.platform === 'sunos' || common.isWindows || common.isAix) {
+if (common.isSunOS || common.isWindows || common.isAix) {
   common.skip('cannot rmdir current working directory');
   return;
 }

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 
 // Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
-if (process.platform === 'sunos' || common.isWindows || common.isAix) {
+if (common.isSunOS || common.isWindows || common.isAix) {
   common.skip('cannot rmdir current working directory');
   return;
 }

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 
 // Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
-if (process.platform === 'sunos' || common.isWindows || common.isAix) {
+if (common.isSunOS || common.isWindows || common.isAix) {
   common.skip('cannot rmdir current working directory');
   return;
 }

--- a/test/parallel/test-dgram-empty-packet.js
+++ b/test/parallel/test-dgram-empty-packet.js
@@ -6,7 +6,7 @@ var callbacks = 0;
 var client;
 var timer;
 
-if (process.platform === 'darwin') {
+if (common.isOSX) {
   common.skip('because of 17894467 Apple bug');
   return;
 }

--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
 
-if (process.platform === 'darwin') {
+if (common.isOSX) {
   common.skip('because of 17894467 Apple bug');
   return;
 }

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const dgram = require('dgram');
 
-if (process.platform === 'darwin') {
+if (common.isOSX) {
   common.skip('because of 17894467 Apple bug');
   return;
 }

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -233,7 +233,7 @@ if (process.argv[2] === 'child') {
 
   tests.forEach(function(test, testIndex) {
     var testCmd = '';
-    if (process.platform !== 'win32') {
+    if (!common.isWindows) {
       // Do not create core files, as it can take a lot of disk space on
       // continuous testing and developers' machines
       testCmd += 'ulimit -c 0 && ';

--- a/test/parallel/test-domain-no-error-handler-abort-on-uncaught.js
+++ b/test/parallel/test-domain-no-error-handler-abort-on-uncaught.js
@@ -144,7 +144,7 @@ if (process.argv[2] === 'child') {
 
   tests.forEach(function(test, testIndex) {
     var testCmd = '';
-    if (process.platform !== 'win32') {
+    if (!common.isWindows) {
       // Do not create core files, as it can take a lot of disk space on
       // continuous testing and developers' machines
       testCmd += 'ulimit -c 0 && ';

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -82,7 +82,7 @@ function runTestWithAbortOnUncaughtException() {
 function createTestCmdLine(options) {
   var testCmd = '';
 
-  if (process.platform !== 'win32') {
+  if (!common.isWindows) {
     // Do not create core files, as it can take a lot of disk space on
     // continuous testing and developers' machines
     testCmd += 'ulimit -c 0 && ';

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -93,7 +93,7 @@ if (process.argv[2] === 'child') {
       throwInDomainErrHandlerOpt = 'throwInDomainErrHandler';
 
     var cmdToExec = '';
-    if (process.platform !== 'win32') {
+    if (!common.isWindows) {
       // Do not create core files, as it can take a lot of disk space on
       // continuous testing and developers' machines
       cmdToExec += 'ulimit -c 0 && ';

--- a/test/parallel/test-fs-read-file-sync-hostname.js
+++ b/test/parallel/test-fs-read-file-sync-hostname.js
@@ -1,10 +1,14 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
 
-// test reading from hostname
-if (process.platform === 'linux2') {
-  var hostname = fs.readFileSync('/proc/sys/kernel/hostname');
-  assert.ok(hostname.length > 0);
+if (!common.isLinux) {
+  common.skip('Test is linux specific.');
+  return;
 }
+
+// Test to make sure reading a file under the /proc directory works. See:
+// https://groups.google.com/forum/#!topic/nodejs-dev/rxZ_RoH1Gn0
+const hostname = fs.readFileSync('/proc/sys/kernel/hostname');
+assert.ok(hostname.length > 0);

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const assert = require('assert');
 
-if (process.platform !== 'linux') {
+if (!common.isLinux) {
   common.skip('Test is linux specific.');
   return;
 }

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (!(process.platform === 'darwin' || common.isWindows)) {
+if (!(common.isOSX || common.isWindows)) {
   common.skip('recursive option is darwin/windows specific');
   return;
 }

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -71,7 +71,7 @@ var arch = os.arch();
 console.log('arch = ', arch);
 assert.ok(arch.length > 0);
 
-if (process.platform != 'sunos') {
+if (!common.isSunOS) {
   // not implemeneted yet
   assert.ok(os.loadavg().length > 0);
   assert.ok(os.freemem() > 0);

--- a/test/parallel/test-process-constants-noatime.js
+++ b/test/parallel/test-process-constants-noatime.js
@@ -1,10 +1,10 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const constants = process.binding('constants');
 
-if (process.platform === 'linux') {
+if (common.isLinux) {
   assert('O_NOATIME' in constants.fs);
   assert.strictEqual(constants.fs.O_NOATIME, 0x40000);
 } else {

--- a/test/parallel/test-process-getgroups.js
+++ b/test/parallel/test-process-getgroups.js
@@ -3,7 +3,7 @@ const common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 
-if (process.platform === 'darwin') {
+if (common.isOSX) {
   common.skip('Output of `id -G` is unreliable on Darwin.');
   return;
 }

--- a/test/parallel/test-repl-sigint-nested-eval.js
+++ b/test/parallel/test-repl-sigint-nested-eval.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const spawn = require('child_process').spawn;
 
-if (process.platform === 'win32') {
+if (common.isWindows) {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
   return;

--- a/test/parallel/test-repl-sigint.js
+++ b/test/parallel/test-repl-sigint.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const spawn = require('child_process').spawn;
 
-if (process.platform === 'win32') {
+if (common.isWindows) {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
   return;

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -1,9 +1,10 @@
 'use strict';
 // Original test written by Jakub Lekstan <kuebzky@gmail.com>
+const common = require('../common');
 
 require('../common');
 // FIXME add sunos support
-if ('linux freebsd darwin'.indexOf(process.platform) === -1) {
+if (!(common.isFreeBSD || common.isOSX || common.isLinux)) {
   console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
   return;
 }
@@ -26,7 +27,7 @@ exec('ps -p ' + process.pid + ' -o args=', function(error, stdout, stderr) {
   assert.equal(stderr, '');
 
   // freebsd always add ' (procname)' to the process title
-  if (process.platform === 'freebsd')
+  if (common.isFreeBSD)
     title += ` (${path.basename(process.execPath)})`;
 
   // omitting trailing whitespace and \n

--- a/test/parallel/test-util-sigint-watchdog.js
+++ b/test/parallel/test-util-sigint-watchdog.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const binding = process.binding('util');
 
-if (process.platform === 'win32') {
+if (common.isWindows) {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
   return;

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -5,7 +5,7 @@ const vm = require('vm');
 
 const spawn = require('child_process').spawn;
 
-if (process.platform === 'win32') {
+if (common.isWindows) {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
   return;

--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -5,7 +5,7 @@ const vm = require('vm');
 
 const spawn = require('child_process').spawn;
 
-if (process.platform === 'win32') {
+if (common.isWindows) {
   // No way to send CTRL_C_EVENT to processes from JS right now.
   common.skip('platform not supported');
   return;

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -94,9 +94,8 @@ pingPongTest(common.PORT, 'localhost');
 pingPongTest(common.PORT + 1, null);
 
 // This IPv6 isn't working on Solaris
-var solaris = /sunos/i.test(process.platform);
-if (!solaris) pingPongTest(common.PORT + 2, '::1');
+if (!common.isSunOS) pingPongTest(common.PORT + 2, '::1');
 
 process.on('exit', function() {
-  assert.equal(solaris ? 2 : 3, tests_run);
+  assert.equal(common.isSunOS ? 2 : 3, tests_run);
 });

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -5,8 +5,8 @@ var path = require('path');
 var fs = require('fs');
 
 var expectFilePath = common.isWindows ||
-                     process.platform === 'linux' ||
-                     process.platform === 'darwin';
+                     common.isLinux ||
+                     common.isOSX;
 
 var watchSeenOne = 0;
 var watchSeenTwo = 0;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Use the `common.isWindows`, `common.isFreeBSD` and `common.isSunOS` where possible. Add `common.isOSX` and `common.isLinux`.
Fix `test-fs-read-file-sync-hostname` as in its current form was not being run anywhere.

/cc @nodejs/testing 