### PR TITLE
doc: align breakEvalOnSigint - repl option

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -393,8 +393,8 @@ added: v0.1.91
     * `repl.REPL_MODE_MAGIC` - attempt to evaluates expressions in default
       mode.  If expressions fail to parse, re-try in strict mode.
   * `breakEvalOnSigint` - Stop evaluating the current piece of code when
-      `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
-      with a custom `eval` function. Defaults to `false`.
+    `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
+    with a custom `eval` function. Defaults to `false`.
 
 The `repl.start()` method creates and starts a `repl.REPLServer` instance.
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -392,7 +392,7 @@ added: v0.1.91
       equivalent to prefacing every repl statement with `'use strict'`.
     * `repl.REPL_MODE_MAGIC` - attempt to evaluates expressions in default
       mode.  If expressions fail to parse, re-try in strict mode.
-    * `breakEvalOnSigint` - Stop evaluating the current piece of code when
+  * `breakEvalOnSigint` - Stop evaluating the current piece of code when
       `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
       with a custom `eval` function. Defaults to `false`.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->
`breakEvalOnSigint` option is wrongly aligned inside `replMode`.

![image](https://cloud.githubusercontent.com/assets/1622515/17076439/372f10b8-50cf-11e6-8fa3-7e8a174e5543.png)

