### PR TITLE
repl: Remove magic mode

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -385,13 +385,11 @@ added: v0.1.91
   * `completer` {Function} An optional function used for custom Tab auto
      completion. See [`readline.InterfaceCompleter`][] for an example.
   * `replMode` - A flag that specifies whether the default evaluator executes
-    all JavaScript commands in strict mode, default mode, or a hybrid mode
-    ("magic" mode.) Acceptable values are:
+    all JavaScript commands in strict mode or sloppy mode.
+    Acceptable values are:
     * `repl.REPL_MODE_SLOPPY` - evaluates expressions in sloppy mode.
     * `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is
       equivalent to prefacing every repl statement with `'use strict'`.
-    * `repl.REPL_MODE_MAGIC` - attempt to evaluates expressions in default
-      mode.  If expressions fail to parse, re-try in strict mode.
     * `breakEvalOnSigint` - Stop evaluating the current piece of code when
       `SIGINT` is received, i.e. `Ctrl+C` is pressed. This cannot be used together
       with a custom `eval` function. Defaults to `false`.
@@ -427,9 +425,8 @@ environment variables:
    REPL history. Whitespace will be trimmed from the value.
  - `NODE_REPL_HISTORY_SIZE` - Defaults to `1000`. Controls how many lines of
    history will be persisted if history is available. Must be a positive number.
- - `NODE_REPL_MODE` - May be any of `sloppy`, `strict`, or `magic`. Defaults
-   to `magic`, which will automatically run "strict mode only" statements in
-   strict mode.
+ - `NODE_REPL_MODE` - `sloppy` or `strict` mode. Defaults
+   to `sloppy`.
 
 ### Persistent History
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -39,7 +39,7 @@ function createRepl(env, opts, cb) {
   opts.replMode = {
     'strict': REPL.REPL_MODE_STRICT,
     'sloppy': REPL.REPL_MODE_SLOPPY,
-    'magic': REPL.REPL_MODE_MAGIC,
+    'magic': REPL.REPL_MODE_MAGIC
   }[String(env.NODE_REPL_MODE).toLowerCase().trim()];
 
   if (opts.replMode === undefined) {

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -39,6 +39,7 @@ function createRepl(env, opts, cb) {
   opts.replMode = {
     'strict': REPL.REPL_MODE_STRICT,
     'sloppy': REPL.REPL_MODE_SLOPPY,
+    'magic': REPL.REPL_MODE_MAGIC,
   }[String(env.NODE_REPL_MODE).toLowerCase().trim()];
 
   if (opts.replMode === undefined) {

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -39,11 +39,10 @@ function createRepl(env, opts, cb) {
   opts.replMode = {
     'strict': REPL.REPL_MODE_STRICT,
     'sloppy': REPL.REPL_MODE_SLOPPY,
-    'magic': REPL.REPL_MODE_MAGIC
   }[String(env.NODE_REPL_MODE).toLowerCase().trim()];
 
   if (opts.replMode === undefined) {
-    opts.replMode = REPL.REPL_MODE_MAGIC;
+    opts.replMode = REPL.REPL_MODE_SLOPPY;
   }
 
   const historySize = Number(env.NODE_REPL_HISTORY_SIZE);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -543,6 +543,11 @@ function REPLServer(prompt,
     self.displayPrompt(true);
   });
 
+  if (self.replMode === exports.REPL_MODE_MAGIC) {
+    self.outputStream.write(
+      'magic mode is deprecated. Switched to sloppy mode\n');
+    self.replMode = exports.REPL_MODE_SLOPPY;
+  }
   self.displayPrompt();
 }
 inherits(REPLServer, Interface);
@@ -550,6 +555,7 @@ exports.REPLServer = REPLServer;
 
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
 exports.REPL_MODE_STRICT = Symbol('repl-strict');
+exports.REPL_MODE_MAGIC = Symbol('repl-magic');
 
 // prompt is a string to print on each line for the prompt,
 // source is a stream to use for I/O, defaulting to stdin/stdout.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -78,10 +78,6 @@ exports.writer = util.inspect;
 exports._builtinLibs = internalModule.builtinLibs;
 
 
-const BLOCK_SCOPED_ERROR = 'Block-scoped declarations (let, const, function, ' +
-                           'class) not yet supported outside strict mode';
-
-
 class LineParser {
 
   constructor() {
@@ -238,7 +234,7 @@ function REPLServer(prompt,
   eval_ = eval_ || defaultEval;
 
   function defaultEval(code, context, file, cb) {
-    var err, result, retry = false, input = code, wrappedErr;
+    var err, result, input = code, wrappedErr;
     // first, create the Script object to check the syntax
 
     if (code === '\n')
@@ -247,7 +243,7 @@ function REPLServer(prompt,
     while (true) {
       try {
         if (!/^\s*$/.test(code) &&
-            (self.replMode === exports.REPL_MODE_STRICT || retry)) {
+            (self.replMode === exports.REPL_MODE_STRICT)) {
           // "void 0" keeps the repl from returning "use strict" as the
           // result value for let/const statements.
           code = `'use strict'; void 0;\n${code}`;
@@ -258,17 +254,11 @@ function REPLServer(prompt,
         });
       } catch (e) {
         debug('parse error %j', code, e);
-        if (self.replMode === exports.REPL_MODE_MAGIC &&
-            e.message === BLOCK_SCOPED_ERROR &&
-            !retry || self.wrappedCmd) {
-          if (self.wrappedCmd) {
-            self.wrappedCmd = false;
-            // unwrap and try again
-            code = `${input.substring(1, input.length - 2)}\n`;
-            wrappedErr = e;
-          } else {
-            retry = true;
-          }
+        if (self.wrappedCmd) {
+          self.wrappedCmd = false;
+          // unwrap and try again
+          code = `${input.substring(1, input.length - 2)}\n`;
+          wrappedErr = e;
           continue;
         }
         // preserve original error for wrapped command
@@ -560,7 +550,6 @@ exports.REPLServer = REPLServer;
 
 exports.REPL_MODE_SLOPPY = Symbol('repl-sloppy');
 exports.REPL_MODE_STRICT = Symbol('repl-strict');
-exports.REPL_MODE_MAGIC = Symbol('repl-magic');
 
 // prompt is a string to print on each line for the prompt,
 // source is a stream to use for I/O, defaulting to stdin/stdout.

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -9,7 +9,6 @@ common.globalCheck = false;
 var tests = [
   testSloppyMode,
   testStrictMode,
-  testAutoMode
 ];
 
 tests.forEach(function(test) {
@@ -39,21 +38,6 @@ function testStrictMode() {
   `.trim() + '\n');
   assert.ok(/ReferenceError: x is not defined/.test(
       cli.output.accumulator.join('')));
-  cli.output.accumulator.length = 0;
-
-  cli.input.emit('data', `
-    let y = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), 'undefined\n> ');
-}
-
-function testAutoMode() {
-  var cli = initRepl(repl.REPL_MODE_MAGIC);
-
-  cli.input.emit('data', `
-    x = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), '> 3\n> ');
   cli.output.accumulator.length = 0;
 
   cli.input.emit('data', `

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -49,8 +49,21 @@ function testStrictMode() {
 
 function testAutoMode() {
   var cli = initRepl(repl.REPL_MODE_MAGIC);
+
   assert.equal(cli.output.accumulator.join(''),
     'magic mode is deprecated. Switched to sloppy mode\n> ');
+  cli.output.accumulator.length = 0;
+
+  cli.input.emit('data', `
+    x = 3
+  `.trim() + '\n');
+  assert.equal(cli.output.accumulator.join(''), '3\n> ');
+  cli.output.accumulator.length = 0;
+
+  cli.input.emit('data', `
+    let y = 3
+  `.trim() + '\n');
+  assert.equal(cli.output.accumulator.join(''), 'undefined\n> ');
 }
 
 function initRepl(mode) {

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -9,6 +9,7 @@ common.globalCheck = false;
 var tests = [
   testSloppyMode,
   testStrictMode,
+  testAutoMode
 ];
 
 tests.forEach(function(test) {
@@ -44,6 +45,12 @@ function testStrictMode() {
     let y = 3
   `.trim() + '\n');
   assert.equal(cli.output.accumulator.join(''), 'undefined\n> ');
+}
+
+function testAutoMode() {
+  var cli = initRepl(repl.REPL_MODE_MAGIC);
+  assert.equal(cli.output.accumulator.join(''),
+    'magic mode is deprecated. Switched to sloppy mode\n> ');
 }
 
 function initRepl(mode) {

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -46,7 +46,8 @@ var r2 = repl.start({
   ignoreUndefined: true,
   eval: evaler,
   writer: writer,
-  replMode: repl.REPL_MODE_STRICT
+  replMode: repl.REPL_MODE_STRICT,
+  historySize: 50
 });
 assert.equal(r2.input, stream);
 assert.equal(r2.output, stream);
@@ -65,18 +66,7 @@ assert.equal(r2.rli.output, stream);
 assert.equal(r2.rli.input, r2.inputStream);
 assert.equal(r2.rli.output, r2.outputStream);
 assert.equal(r2.rli.terminal, false);
-
-// testing out "magic" replMode
-var r3 = repl.start({
-  input: stream,
-  output: stream,
-  writer: writer,
-  replMode: repl.REPL_MODE_MAGIC,
-  historySize: 50
-});
-
-assert.equal(r3.replMode, repl.REPL_MODE_MAGIC);
-assert.equal(r3.historySize, 50);
+assert.equal(r2.historySize, 50);
 
 // Verify that defaults are used when no arguments are provided
 const r4 = repl.start();

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -94,6 +94,7 @@ function testMagicMode() {
           `);
 
   assertOutput(r.output, [
+    'magic mode is deprecated. Switched to sloppy mode',
     'undefined',
     '10',
     '10',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, repl
##### Description of change

<!-- Provide a description of the change below this comment. -->

Currently `magic` mode retries the executed command with `'use strict';` only when the [`BLOCK_SCOPED_ERROR`](https://github.com/nodejs/node/blob/master/lib/repl.js#L81) is thrown and v8 is no longer emitting [`BLOCK_SCOPED_ERROR`](https://github.com/nodejs/node/blob/master/lib/repl.js#L81).

From the v8 [4.9 release](http://v8project.blogspot.in/2016/01/v8-release-49.html?m=1) note,

> **Classes & lexical declarations in sloppy mode**
> V8 has supported lexical declarations (let, const, block-local function) and classes since versions 4.1 and 4.2 respectively, but so far strict mode has been required in order to use them. As of V8 release 4.9, all of these features are now enabled outside of strict mode as well, per the ES2015 spec. This makes prototyping in the DevTools Console much easier, although we encourage developers in general to upgrade to strict mode for new code.

Also IMHO, `magic` mode is tightly coupled with  JS engine's(v8) implementation. 
