### PR TITLE
test: fix test-vm-sigint flakiness

### DIFF
--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -25,13 +25,13 @@ if (process.argv[2] === 'child') {
 }
 
 process.env.REPL_TEST_PPID = process.pid;
-const child = spawn(process.execPath, [ __filename, 'child' ], {
-  stdio: [null, 'pipe', 'inherit']
-});
-
 process.on('SIGUSR2', common.mustCall(() => {
   process.kill(child.pid, 'SIGINT');
 }));
+
+const child = spawn(process.execPath, [ __filename, 'child' ], {
+  stdio: [null, 'pipe', 'inherit']
+});
 
 child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(signal, null);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Set the `SIGUSR2` handler before spawning the child process to make sure
the signal is always handled.

The test was sometimes crashing in my `OS X` box when running the test suite because of `SIGUSR2` not being handled.