### PR TITLE
test: fix flaky test-tls-wrap-timeout

### DIFF
--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -37,6 +37,7 @@ server.listen(0, () => {
     });
     assert.ok(s instanceof net.Socket);
 
+    assert.notStrictEqual(socket._idleTimeout, -1);
     lastIdleStart = socket._idleStart;
 
     const tsocket = tls.connect({

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -17,18 +17,15 @@ var options = {
 };
 
 var server = tls.createServer(options, function(c) {
-  setTimeout(function() {
-    c.write('hello');
-    setTimeout(function() {
-      c.destroy();
-      server.close();
-    }, 150);
-  }, 150);
+  c.write('hello');
+  c.destroy();
+  server.close();
 });
 
+var socket;
 server.listen(0, function() {
-  var socket = net.connect(this.address().port, function() {
-    var s = socket.setTimeout(common.platformTimeout(240), function() {
+  socket = net.connect(this.address().port, function() {
+    var s = socket.setTimeout(Number.MAX_VALUE, function() {
       throw new Error('timeout');
     });
     assert.ok(s instanceof net.Socket);
@@ -39,4 +36,8 @@ server.listen(0, function() {
     });
     tsocket.resume();
   });
+});
+
+process.on('exit', () => {
+  assert.strictEqual(socket._idleTimeout, -1);
 });

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -18,11 +18,11 @@ const options = {
 
 const server = tls.createServer(options, common.mustCall((c) => {
   setImmediate(() => {
-    c.write('hello');
-    setImmediate(() => {
-      c.destroy();
-      server.close();
-      assert(lastIdleStart < socket._idleStart);
+    c.write('hello', () => {
+      setImmediate(() => {
+        c.destroy();
+        server.close();
+      });
     });
   });
 }));
@@ -49,4 +49,5 @@ server.listen(0, () => {
 
 process.on('exit', () => {
   assert.strictEqual(socket._idleTimeout, -1);
+  assert(lastIdleStart < socket._idleStart);
 });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

Competing timers were causing a race condition and thus the test was
flaky. Instead, we check an object property on process exit.

Fixes: https://github.com/nodejs/node/issues/7650

/cc @indutny @nodejs/testing @somekittens