### PR TITLE
[WIP] Update test-npm target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ deps/npm/node_modules/.bin/
 tools/faketime
 icu_config.gypi
 *.tap
+test-npm/
 
 # Xcode workspaces and project folders
 *.xcodeproj

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ test-known-issues: all
 	$(PYTHON) tools/test.py known_issues
 
 test-npm: $(NODE_EXE)
-	NODE=$(NODE) tools/test-npm.sh
+	NODE=$(NODE) tools/test-npm.sh -p=tap --logfile=test-npm.tap
 
 test-npm-publish: $(NODE_EXE)
 	npm_package_config_publishtest=true $(NODE) deps/npm/test/run.js

--- a/tools/test-npm.ps1
+++ b/tools/test-npm.ps1
@@ -1,0 +1,67 @@
+# Port of tools/test-npm.sh to windows
+
+# Handle parameters
+param (
+  [string]$progress = "classic",
+  [string]$logfile
+)
+
+# Always change the working directory to the project's root directory
+$dp0 = (Get-Item -Path ".\" -Verbose).FullName
+cd $~dp0\..
+
+# Use rmdir to get around long file path issues
+Cmd /C "rmdir /S /Q test-npm"
+Remove-Item test-npm.tap -ErrorAction SilentlyContinue
+
+# Make a copy of deps/npm to run the tests on
+Copy-Item deps\npm test-npm -Recurse
+cd test-npm
+
+# Do a rm first just in case deps/npm contained these
+Remove-Item npm-cache -Force -Recurse -ErrorAction SilentlyContinue
+Remove-Item npm-tmp -Force -Recurse -ErrorAction SilentlyContinue
+Remove-Item npm-prefix -Force -Recurse -ErrorAction SilentlyContinue
+Remove-Item npm-userconfig -Force -Recurse -ErrorAction SilentlyContinue
+Remove-Item npm-home -Force -Recurse -ErrorAction SilentlyContinue
+
+New-Item -ItemType directory -Path npm-cache
+New-Item -ItemType directory -Path npm-tmp
+New-Item -ItemType directory -Path npm-prefix
+New-Item -ItemType directory -Path npm-userconfig
+New-Item -ItemType directory -Path npm-home
+
+# Set some npm env variables to point to our new temporary folders
+$pwd = (Get-Item -Path ".\" -Verbose).FullName
+Set-Variable -Name npm_config_cache -value ("$pwd\npm-cache") -Scope Global
+Set-Variable -Name npm_config_prefix -value ("$pwd\npm-prefix") -Scope Global
+Set-Variable -Name npm_config_tmp -value ("$pwd\npm-tmp") -Scope Global
+Set-Variable -Name npm_config_userconfig -value ("$pwd\npm-userconfig") -Scope Global
+Set-Variable -Name home -value ("$pwd\npm-home") -Scope Global -Force
+
+# Ensure npm always uses the local node
+Set-Variable -Name NODEPATH -value (Get-Item -Path "..\Release" -Verbose).FullName
+$env:Path = ("$NODEPATH;$env:Path")
+Remove-Variable -Name NODEPATH -ErrorAction SilentlyContinue
+
+# Make sure the binaries from the non-dev-deps are available
+node cli.js rebuild
+# Install npm devDependencies and run npm's tests
+node cli.js install --ignore-scripts
+
+# Run the tests with logging if set
+if ($logfile -eq $null)
+{
+  node cli.js run test-node -- --reporter=$progress
+} else {
+  node cli.js run test-node -- --reporter=$progress  2>&1 | Tee-Object -FilePath "..\$logfile"
+}
+
+# Move npm-debug.log out of test-npm so it isn't cleaned up
+if (Test-Path -path "npm-debug.log") {
+  Move-Item npm-debug.log ..
+}
+
+# Clean up everything in one single shot
+cd ..
+Cmd /C "rmdir /S /Q test-npm"

--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -1,43 +1,71 @@
-#!/bin/bash
+#!/bin/bash -e
 
-set -e
+# Handle arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p|--progress) PROGRESS="$2"; shift ;;
+    -p=*) PROGRESS="${1#-p=}" ;;
+    --progress=*) PROGRESS="${1#--progress=}" ;;
+    --logfile) LOGFILE="$2"; shift ;;
+    --logfile=*) LOGFILE="${1#--logfile=}" ;;
+    *) echo "Unknown parameters $@" && exit 1;;
+  esac
+  shift
+done
 
-# always change the working directory to the project's root directory
+# Set default progress indicator to classic
+PROGRESS=${PROGRESS:-classic}
+
+# Always change the working directory to the project's root directory
 cd $(dirname $0)/..
 
-# pass a $NODE environment variable from something like Makefile
-# it should point to either ./node or ./node.exe, depending on the platform
+# Pass a $NODE environment variable from something like Makefile
+# It should be a relative path to the node binary, e.g. ./node
 if [ -z $NODE ]; then
-  echo "No node executable provided. Bailing." >&2
-  exit 0
+  echo "No \$NODE executable provided, defaulting to out/Release/node." >&2
+  NODE=out/Release/node
 fi
+
+# Ensure npm always uses the local node
+export PATH="$PWD/`dirname $NODE`:$PATH"
+unset NODE
 
 rm -rf test-npm
 
-# make a copy of deps/npm to run the tests on
+# Make a copy of deps/npm to run the tests on
 cp -r deps/npm test-npm
 
 cd test-npm
 
-# do a rm first just in case deps/npm contained these
-rm -rf npm-cache npm-tmp npm-prefix
-mkdir npm-cache npm-tmp npm-prefix
+# Do a rm first just in case deps/npm contained these
+rm -rf npm-cache npm-tmp npm-prefix npm-userconfig npm-home
+mkdir npm-cache npm-tmp npm-prefix npm-userconfig npm-home
 
-# set some npm env variables to point to our new temporary folders
+# Set some npm env variables to point to our new temporary folders
 export npm_config_cache="$(pwd)/npm-cache"
 export npm_config_prefix="$(pwd)/npm-prefix"
 export npm_config_tmp="$(pwd)/npm-tmp"
+export npm_config_userconfig="$(pwd)/npm-userconfig"
+export HOME="$(pwd)/npm-home"
 
-# ensure npm always uses the local node
-export PATH="$(../$NODE -p 'require("path").resolve("..")'):$PATH"
-unset NODE
-
-# make sure the binaries from the non-dev-deps are available
+# Make sure the binaries from the non-dev-deps are available
 node cli.js rebuild
-# install npm devDependencies and run npm's tests
+# Install npm devDependencies and run npm's tests
 node cli.js install --ignore-scripts
-# run the tests
-node cli.js run-script test-node
 
-# clean up everything one single shot
+# Run the tests with logging if set
+if [ -n "$LOGFILE" ]; then
+  echo "node cli.js run test-node -- --reporter=$PROGRESS | tee ../$LOGFILE"
+  node cli.js run test-node -- --reporter=$PROGRESS | tee ../$LOGFILE
+else
+  echo "node cli.js run test-node -- --reporter=$PROGRESS"
+  node cli.js run test-node -- --reporter=$PROGRESS
+fi
+
+# Move npm-debug.log up a directory if it exists
+if [ -f npm-debug.log ]; then
+  mv npm-debug.log ..
+fi
+
+# Clean up everything in one single shot
 cd .. && rm -rf test-npm

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -68,6 +68,7 @@ if /i "%1"=="test-tick-processor" set test_args=%test_args% tick-processor&goto 
 if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
 if /i "%1"=="test-all"      set test_args=%test_args% sequential parallel message gc inspector internet pummel&set buildnodeweak=1&set jslint=1&goto arg-ok
+if /i "%1"=="test-npm"      set test_args=%test_args% npm&goto arg-ok
 if /i "%1"=="test-known-issues" set test_args=%test_args% known_issues&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="jslint-ci"     set jslint_ci=1&goto arg-ok
@@ -334,6 +335,13 @@ goto run-tests
 
 :run-tests
 if "%test_args%"=="" goto jslint
+
+if "%test_args%"=="%test_args:npm=%" goto node-tests
+set test_args="%test_args:npm=%"
+powershell .\tools\test-npm.ps1 -progress tap -logfile test-npm.tap
+goto exit
+
+:node-tests
 if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
@@ -371,6 +379,7 @@ echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build
 echo   vcbuild.bat release msi    : builds release build and MSI installer package
 echo   vcbuild.bat test           : builds debug build and runs tests
+echo   vcbuild.bat test-npm       : builds debug build and runs test-npm.bat
 echo   vcbuild.bat build-release  : builds the release distribution as used by nodejs.org
 echo   vcbuild.bat enable-vtune   : builds nodejs with Intel VTune profiling support to profile JavaScript
 goto exit


### PR DESCRIPTION
##### Checklist
- [ ] `make -j4 test-npm` (UNIX), or `vcbuild test-npm` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

test, npm
##### Description of change

Update the test-npm script to generate tap output, and add a windows version. 

**N.B.** If the `deps/npm` change will be upstreamed in npm/npm#13735.

Ref: https://github.com/nodejs/build/issues/317

CI: https://ci.nodejs.org/view/All/job/gibfahn-test-npm/
Windows CI: https://ci.nodejs.org/job/gibfahn-test-npm-win

#### Known Issues

`test-npm` is currently failing due to https://github.com/npm/npm/issues/13457 which seems to be caused by https://github.com/nodejs/node/pull/7168 (see https://github.com/nodejs/node/pull/7168#issuecomment-234679659 for more info). 

I've also seen failures due to https://github.com/npm/npm/issues/12220.
#### Manual testing

~~Build [gibfahn:rebased-test-npm-fix](https://github.com/gibfahn/node/tree/rebased-test-npm-fix) to get the #7168 revert as well.~~ _Shouldn't be necessary now #7168 has landed_

~~On windows, do `set debug=1` to print the TAP output to stdout, otherwise it gets redirected to test-npm.tap (I haven't found a `tee` equivalent for batch).~~ _Now using powershell instead of batch which allows use of Tee-Object_

cc @TheAlphaNerd 
