### PR TITLE
test: avoid IPv6 hostname conflict in windows

### DIFF
--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -36,7 +36,12 @@ function getall() {
   if (count >= todo)
     return;
 
-  const req = net.connect(server.address().port, server.address().address);
+  if(server.address().family === 'IPv4') {
+    var req = net.connect(server.address().port, '127.0.0.1');
+  }
+  else {
+    var req = net.connect(server.address().port, '::1');
+  }
   req.resume();
   req.setTimeout(10, function() {
     req.destroy();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x ] commit message follows commit guidelines
##### Affected core subsystem(s)

windows, cluster

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
##### Description of change

<!-- Provide a description of the change below this comment. -->

The test case test/gc/test-net-timeout.js
fails in Windows due to the mixed-use of unspecified
and loopback addresses. This is not a problem in most
platforms but fails in Windows.

A detailed test report describes the platform differences
(https://github.com/nodejs/node/issues/7728)
and the general direction suggested is to fix the tests
according to their platform specific requirements
