### PR TITLE
doc: remove extra space in console.log examples

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -423,7 +423,7 @@ const addon = require('./build/Release/addon');
 
 var obj1 = addon('hello');
 var obj2 = addon('world');
-console.log(obj1.msg + ' ' + obj2.msg); // 'hello world'
+console.log(obj1.msg, obj2.msg); // 'hello world'
 ```
 
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -832,7 +832,7 @@ const spawn = require('child_process').spawn;
 
 let child = spawn('sh', ['-c',
   `node -e "setInterval(() => {
-      console.log(process.pid + 'is alive')
+      console.log(process.pid, 'is alive')
     }, 500);"`
   ], {
     stdio: ['inherit', 'inherit', 'inherit']

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -220,7 +220,7 @@ values similar to `printf(3)` (the arguments are all passed to
 var count = 5;
 console.log('count: %d', count);
   // Prints: count: 5, to stdout
-console.log('count: ', count);
+console.log('count:', count);
   // Prints: count: 5, to stdout
 ```
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -107,8 +107,8 @@ Example:
 const https = require('https');
 
 https.get('https://encrypted.google.com/', (res) => {
-  console.log('statusCode: ', res.statusCode);
-  console.log('headers: ', res.headers);
+  console.log('statusCode:', res.statusCode);
+  console.log('headers:', res.headers);
 
   res.on('data', (d) => {
     process.stdout.write(d);
@@ -151,8 +151,8 @@ var options = {
 };
 
 var req = https.request(options, (res) => {
-  console.log('statusCode: ', res.statusCode);
-  console.log('headers: ', res.headers);
+  console.log('statusCode:', res.statusCode);
+  console.log('headers:', res.headers);
 
   res.on('data', (d) => {
     process.stdout.write(d);

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -12,7 +12,7 @@ The contents of `foo.js`:
 
 ```js
 const circle = require('./circle.js');
-console.log( `The area of a circle of radius 4 is ${circle.area(4)}`);
+console.log(`The area of a circle of radius 4 is ${circle.area(4)}`);
 ```
 
 The contents of `circle.js`:

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -223,8 +223,8 @@ For example:
 
 ```js
 process.on('unhandledRejection', (reason, p) => {
-    console.log("Unhandled Rejection at: Promise", p, "reason:", reason);
-    // application specific logging, throwing an error, or other logic here
+  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+  // application specific logging, throwing an error, or other logic here
 });
 
 somePromise.then((res) => {

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -223,7 +223,7 @@ For example:
 
 ```js
 process.on('unhandledRejection', (reason, p) => {
-    console.log("Unhandled Rejection at: Promise ", p, " reason: ", reason);
+    console.log("Unhandled Rejection at: Promise", p, "reason:", reason);
     // application specific logging, throwing an error, or other logic here
 });
 

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -376,12 +376,12 @@ const vm = require('vm');
 var localVar = 'initial value';
 
 const vmResult = vm.runInThisContext('localVar = "vm";');
-console.log('vmResult: ', vmResult);
-console.log('localVar: ', localVar);
+console.log('vmResult:', vmResult);
+console.log('localVar:', localVar);
 
 const evalResult = eval('localVar = "eval";');
-console.log('evalResult: ', evalResult);
-console.log('localVar: ', localVar);
+console.log('evalResult:', evalResult);
+console.log('localVar:', localVar);
 
 // vmResult: 'vm', localVar: 'initial value'
 // evalResult: 'eval', localVar: 'eval'


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
This fixes the `console.log` example in the docs. Before this change, an extra space would be printed, which wouldn't match the example output. Now it's consistent.
