### PR TITLE
test: speed up test-net-reconnect-error

### DIFF
--- a/test/parallel/test-net-reconnect-error.js
+++ b/test/parallel/test-net-reconnect-error.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 var net = require('net');
 var assert = require('assert');
-var N = 50;
+var N = 20;
 var client_error_count = 0;
 var disconnect_count = 0;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test takes 50 seconds on some of the project's Windows CI
infrastructure. Reducing the test repetitions from 50 to 20 trims that
to about 20 seconds. Tests will timeout at 60 seconds, so this helps
keep the test reliable. (There was a timeout on CI today when testing an
unrelated code change.)

Refs: https://github.com/nodejs/node/pull/7827#issuecomment-235476222