### PR TITLE
build: adding config.gypi dep to addons/.buildstamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ ADDONS_BINDING_SOURCES := \
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
 # Depends on node-gyp package.json so that build-addons is (re)executed when
 # node-gyp is updated as part of an npm update.
-test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json \
+test/addons/.buildstamp: config.gypi \
+	deps/npm/node_modules/node-gyp/package.json \
 	$(ADDONS_BINDING_GYPS) $(ADDONS_BINDING_SOURCES) \
 	deps/uv/include/*.h deps/v8/include/*.h \
 	src/node.h src/node_buffer.h src/node_object_wrap.h \


### PR DESCRIPTION

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build

##### Description of change


Currently the build-addons target is called as part of the
test target, and it has test/addons/.buildstamp as a dependency.
When running `./configure --debug` and later switching/
updating branches you can be in a situation where the config.gypi
files in the addons build directories are using an incorrect
value for default_configuration. Currently this can happen and you
will get test errors as there are a few test that depend on the
value of default_configuration to be Release. When this happens
it might not be obvious to someone new to the project (like me)
to correct this state. This commit attempts to make it easier
to fix this.

The suggestion here is if you find yourself in the above situation
the the following steps would be preformed:

    1) make clean
    2) ./configure
    3) make -j4 test

The target distclean also calls clean-addons so that could be used
instead of clean in the above example. Also clean-addons could be
called directly if required.

This commit is related to #7860. Please see the dicussion in that
issue regarding the test using hard-coded paths.