### PR TITLE
build: Maximize the default V8 inliner flags values

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -16,7 +16,7 @@
     'node_shared_libuv%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
-    'node_v8_options%': '',
+    'node_v8_options%': '--max_inlined_nodes_cumulative=10000 --max_inlined_nodes=10000 -max_inlining_levels=15',
     'node_enable_v8_vtunejit%': 'false',
     'node_core_target_name%': 'node',
     'library_files': [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
build
The default values used for the V8 inliner are tuned for client-side workloads. For server side workloads, like the nodejs ones, using more aggresive flag values may improve performance
I have added a link to the collected data 
https://docs.google.com/spreadsheets/d/1Fx_Ia5dY9aVgzzhcobfsAsAjvt9HAfw1JrAYrTWDgn0/edit?usp=sharing


##### Description of change
<!-- Provide a description of the change below this comment. -->

Signed-off-by: Sorin Baltateanu <sorin.baltateanu@intel.com>