### PR TITLE
fs: warn instead of throwing if no callback

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -83,6 +83,13 @@ function throwOptionsError(options) {
 }
 
 function rethrow() {
+  // TODO(thefourtheye) Throw error instead of warning in major version > 7
+  process.emitWarning(
+    'Calling an asynchronous function without callback is deprecated.',
+    'DeprecationWarning',
+    rethrow
+  );
+
   // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
   // is fairly slow to generate.
   if (DEBUG) {

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -1,7 +1,7 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
 
 function test(cb) {
   return function() {
@@ -13,16 +13,26 @@ function test(cb) {
 // Verify the case where a callback function is provided
 assert.doesNotThrow(test(function() {}));
 
-// Passing undefined calls rethrow() internally, which is fine
-assert.doesNotThrow(test(undefined));
+process.once('warning', common.mustCall((warning) => {
+  assert.strictEqual(
+    warning.message,
+    'Calling an asynchronous function without callback is deprecated.'
+  );
 
-// Anything else should throw
-assert.throws(test(null));
-assert.throws(test(true));
-assert.throws(test(false));
-assert.throws(test(1));
-assert.throws(test(0));
-assert.throws(test('foo'));
-assert.throws(test(/foo/));
-assert.throws(test([]));
-assert.throws(test({}));
+  invalidArgumentsTests();
+}));
+
+// Passing undefined/nothing calls rethrow() internally, which emits a warning
+assert.doesNotThrow(test());
+
+function invalidArgumentsTests() {
+  assert.throws(test(null));
+  assert.throws(test(true));
+  assert.throws(test(false));
+  assert.throws(test(1));
+  assert.throws(test(0));
+  assert.throws(test('foo'));
+  assert.throws(test(/foo/));
+  assert.throws(test([]));
+  assert.throws(test({}));
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

https://github.com/nodejs/node/commit/9359de9dd2eae06ed5afcb75dad9bd4c466eb69d
made sure that if no callback function is passed to asynchronous
functions, the system will throw.

But, this breaks a lot of existing modules including npm (Refer:
https://github.com/nodejs/node/pull/7846). Till all the necessary
dependencies use the async functions properly, no module can work.

So, this patch issues a deprecation warning, instead of throwing and
the throwing behaviour will be restored in the next major release.

---

cc @ChALkeR @nodejs/collaborators @nodejs/ctc