### PR TITLE
benchmark: http parser optimization

### DIFF
--- a/deps/v8/src/utils.h
+++ b/deps/v8/src/utils.h
@@ -1208,8 +1208,7 @@ void CopyChars(sinkchar* dest, const sourcechar* src, size_t chars) {
 template <typename sourcechar, typename sinkchar>
 void CopyCharsUnsigned(sinkchar* dest, const sourcechar* src, size_t chars) {
   sinkchar* limit = dest + chars;
-  if ((sizeof(*dest) == sizeof(*src)) &&
-      (chars >= static_cast<int>(kMinComplexMemCopy / sizeof(*dest)))) {
+  if (sizeof(*dest) == sizeof(*src)) {
     MemCopy(dest, src, chars * sizeof(*dest));
   } else {
     while (dest < limit) *dest++ = static_cast<sinkchar>(*src++);


### PR DESCRIPTION
This change refers to http/bench-parser.js, and we also call is Http Parser benchmark. We propose the following change in Node.JS, in file deps/v8/src/utils.h: 
Old:
```C
template <typename sourcechar, typename sinkchar>
void CopyCharsUnsigned(sinkchar* dest, const sourcechar* src, size_t chars) {
 sinkchar* limit = dest + chars;
 if ((sizeof(*dest) == sizeof(*src)) &&
     (chars >= static_cast<int>(kMinComplexMemCopy / sizeof(*dest)))) {
   MemCopy(dest, src, chars * sizeof(*dest));
 } else {
   while (dest < limit) *dest++ = static_cast<sinkchar>(*src++);
 }
}
```
New:
```C
template <typename sourcechar, typename sinkchar>
void CopyCharsUnsigned(sinkchar* dest, const sourcechar* src, size_t chars) {
 sinkchar* limit = dest + chars;
 if (sizeof(*dest) == sizeof(*src))
{
   MemCopy(dest, src, chars * sizeof(*dest));
 } else {
   while (dest < limit) *dest++ = static_cast<sinkchar>(*src++);
 }
}
```

Please see the details in the attached file.
[MessageForTheCommunity.docx](https://github.com/nodejs/node/files/386806/MessageForTheCommunity.docx)






<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

The copy of several buffers could be optimized by using memcpy directly, instead of direct copying char after char.