### PR TITLE
Do not copy value onto vm sandbox in strict mode

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -380,7 +380,19 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    ctx->sandbox()->Set(property, value);
+    bool is_declared =
+        ctx->global_proxy()->HasRealNamedProperty(ctx->context(),
+                                                  property).FromJust();
+    bool is_contextual_store = ctx->global_proxy() != args.This();
+
+    bool set_property_will_throw =
+        args.ShouldThrowOnError() &&
+        !is_declared &&
+        is_contextual_store;
+
+    if (!set_property_will_throw) {
+      ctx->sandbox()->Set(property, value);
+    }
   }
 
 

--- a/test/parallel/test-vm-strict-mode.js
+++ b/test/parallel/test-vm-strict-mode.js
@@ -1,0 +1,27 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+const ctx = vm.createContext();
+
+// Test strict mode inside a vm script, i.e., using an undefined variable
+// throws a ReferenceError. Also check that variables
+// that are not successfully set in the vm, must not be set
+// on the sandboxed context.
+
+vm.runInContext('w = 1;', ctx);
+assert.strictEqual(1, ctx.w);
+
+assert.throws(function() { vm.runInContext('"use strict"; x = 1;', ctx); },
+              /ReferenceError: x is not defined/);
+assert.strictEqual(undefined, ctx.x);
+
+vm.runInContext('"use strict"; var y = 1;', ctx);
+assert.strictEqual(1, ctx.y);
+
+vm.runInContext('"use strict"; this.z = 1;', ctx);
+assert.strictEqual(1, ctx.z);
+
+// w has been defined
+vm.runInContext('"use strict"; w = 2;', ctx);
+assert.strictEqual(2, ctx.w);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below req<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src 

##### Description of change
<!-- Provide a description of the change below this comment. -->

In vm, the setter interceptor should not copy a value onto the sandbox, if setting on
the global object will fail because we are in strict mode and the variable is not declared.

Fixes https://github.com/nodejs/node/issues/5344

/cc @bnoordhuis @hashseed @ofrobots 