### PR TITLE
test: fixes for more strict linting

### DIFF
--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -79,44 +79,64 @@ assert(!b.includes(Buffer.from('f'), 6));
 assert(!Buffer.from('ff').includes(Buffer.from('f'), 1, 'ucs2'));
 
 // test hex encoding
-assert(
-    Buffer.from(b.toString('hex'), 'hex')
-    .includes('64', 0, 'hex'));
-assert(
-    Buffer.from(b.toString('hex'), 'hex')
-    .includes(Buffer.from('64', 'hex'), 0, 'hex'));
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .includes('64', 0, 'hex'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .includes(Buffer.from('64', 'hex'), 0, 'hex'),
+  true
+);
 
 // test base64 encoding
-assert(
-    Buffer.from(b.toString('base64'), 'base64')
-    .includes('ZA==', 0, 'base64'));
-assert(
-    Buffer.from(b.toString('base64'), 'base64')
-    .includes(Buffer.from('ZA==', 'base64'), 0, 'base64'));
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .includes('ZA==', 0, 'base64'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .includes(Buffer.from('ZA==', 'base64'), 0, 'base64'),
+  true
+);
 
 // test ascii encoding
-assert(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .includes('d', 0, 'ascii'));
-assert(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .includes(Buffer.from('d', 'ascii'), 0, 'ascii'));
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .includes('d', 0, 'ascii'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .includes(Buffer.from('d', 'ascii'), 0, 'ascii'),
+  true
+);
 
 // test latin1 encoding
-assert(
-    Buffer.from(b.toString('latin1'), 'latin1')
-    .includes('d', 0, 'latin1'));
-assert(
-    Buffer.from(b.toString('latin1'), 'latin1')
-    .includes(Buffer.from('d', 'latin1'), 0, 'latin1'));
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .includes('d', 0, 'latin1'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .includes(Buffer.from('d', 'latin1'), 0, 'latin1'),
+  true
+);
 
 // test binary encoding
-assert(
-    Buffer.from(b.toString('binary'), 'binary')
-    .includes('d', 0, 'binary'));
-assert(
-    Buffer.from(b.toString('binary'), 'binary')
-    .includes(Buffer.from('d', 'binary'), 0, 'binary'));
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .includes('d', 0, 'binary'),
+  true
+);
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .includes(Buffer.from('d', 'binary'), 0, 'binary'),
+  true
+);
 
 
 // test usc2 encoding

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -79,62 +79,94 @@ assert.equal(b.indexOf(Buffer.from('f'), 6), -1);
 assert.equal(Buffer.from('ff').indexOf(Buffer.from('f'), 1, 'ucs2'), -1);
 
 // test hex encoding
-assert.equal(
-    Buffer.from(b.toString('hex'), 'hex')
-    .indexOf('64', 0, 'hex'), 3);
-assert.equal(
-    Buffer.from(b.toString('hex'), 'hex')
-    .indexOf(Buffer.from('64', 'hex'), 0, 'hex'), 3);
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .indexOf('64', 0, 'hex'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('hex'), 'hex')
+    .indexOf(Buffer.from('64', 'hex'), 0, 'hex'),
+  3
+);
 
 // test base64 encoding
-assert.equal(
-    Buffer.from(b.toString('base64'), 'base64')
-    .indexOf('ZA==', 0, 'base64'), 3);
-assert.equal(
-    Buffer.from(b.toString('base64'), 'base64')
-    .indexOf(Buffer.from('ZA==', 'base64'), 0, 'base64'), 3);
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .indexOf('ZA==', 0, 'base64'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('base64'), 'base64')
+    .indexOf(Buffer.from('ZA==', 'base64'), 0, 'base64'),
+  3
+);
 
 // test ascii encoding
-assert.equal(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .indexOf('d', 0, 'ascii'), 3);
-assert.equal(
-    Buffer.from(b.toString('ascii'), 'ascii')
-    .indexOf(Buffer.from('d', 'ascii'), 0, 'ascii'), 3);
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .indexOf('d', 0, 'ascii'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('ascii'), 'ascii')
+    .indexOf(Buffer.from('d', 'ascii'), 0, 'ascii'),
+  3
+);
 
 // test latin1 encoding
-assert.equal(
-    Buffer.from(b.toString('latin1'), 'latin1')
-    .indexOf('d', 0, 'latin1'), 3);
-assert.equal(
-    Buffer.from(b.toString('latin1'), 'latin1')
-    .indexOf(Buffer.from('d', 'latin1'), 0, 'latin1'), 3);
-assert.equal(
-    Buffer.from('aa\u00e8aa', 'latin1')
-    .indexOf('\u00e8', 'latin1'), 2);
-assert.equal(
-    Buffer.from('\u00e8', 'latin1')
-    .indexOf('\u00e8', 'latin1'), 0);
-assert.equal(
-    Buffer.from('\u00e8', 'latin1')
-    .indexOf(Buffer.from('\u00e8', 'latin1'), 'latin1'), 0);
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .indexOf('d', 0, 'latin1'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('latin1'), 'latin1')
+    .indexOf(Buffer.from('d', 'latin1'), 0, 'latin1'),
+  3
+);
+assert.strictEqual(
+  Buffer.from('aa\u00e8aa', 'latin1')
+    .indexOf('\u00e8', 'latin1'),
+  2
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'latin1')
+    .indexOf('\u00e8', 'latin1'),
+  0
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'latin1')
+    .indexOf(Buffer.from('\u00e8', 'latin1'), 'latin1'),
+  0
+);
 
 // test binary encoding
-assert.equal(
-    Buffer.from(b.toString('binary'), 'binary')
-    .indexOf('d', 0, 'binary'), 3);
-assert.equal(
-    Buffer.from(b.toString('binary'), 'binary')
-    .indexOf(Buffer.from('d', 'binary'), 0, 'binary'), 3);
-assert.equal(
-    Buffer.from('aa\u00e8aa', 'binary')
-    .indexOf('\u00e8', 'binary'), 2);
-assert.equal(
-    Buffer.from('\u00e8', 'binary')
-    .indexOf('\u00e8', 'binary'), 0);
-assert.equal(
-    Buffer.from('\u00e8', 'binary')
-    .indexOf(Buffer.from('\u00e8', 'binary'), 'binary'), 0);
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .indexOf('d', 0, 'binary'),
+  3
+);
+assert.strictEqual(
+  Buffer.from(b.toString('binary'), 'binary')
+    .indexOf(Buffer.from('d', 'binary'), 0, 'binary'),
+  3
+);
+assert.strictEqual(
+  Buffer.from('aa\u00e8aa', 'binary')
+    .indexOf('\u00e8', 'binary'),
+  2
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'binary')
+    .indexOf('\u00e8', 'binary'),
+  0
+);
+assert.strictEqual(
+  Buffer.from('\u00e8', 'binary')
+    .indexOf(Buffer.from('\u00e8', 'binary'), 'binary'),
+  0
+);
 
 
 // test optional offset with passed encoding

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -29,20 +29,16 @@ checkForced();
 
 function checkUnforced() {
   cluster.fork()
-  .on('online', function() {
-    this.disconnect();
-  })
-  .on('exit', common.mustCall(function(status) {
-    assert.equal(status, SENTINEL);
-  }));
+    .on('online', function() { this.disconnect(); })
+    .on('exit', common.mustCall(function(status) {
+      assert.strictEqual(status, SENTINEL);
+    }));
 }
 
 function checkForced() {
   cluster.fork()
-  .on('online', function() {
-    this.process.disconnect();
-  })
-  .on('exit', common.mustCall(function(status) {
-    assert.equal(status, 0);
-  }));
+    .on('online', function() { this.process.disconnect(); })
+    .on('exit', common.mustCall(function(status) {
+      assert.strictEqual(status, 0);
+    }));
 }

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -324,19 +324,23 @@ var rfc2202_sha1 = [
 
 for (let i = 0, l = rfc2202_md5.length; i < l; i++) {
   if (!common.hasFipsCrypto) {
-    assert.equal(rfc2202_md5[i]['hmac'],
-                 crypto.createHmac('md5', rfc2202_md5[i]['key'])
-                     .update(rfc2202_md5[i]['data'])
-                     .digest('hex'),
-                 'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202');
+    assert.strictEqual(
+      rfc2202_md5[i]['hmac'],
+      crypto.createHmac('md5', rfc2202_md5[i]['key'])
+        .update(rfc2202_md5[i]['data'])
+        .digest('hex'),
+      'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202'
+    );
   }
 }
 for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
-  assert.equal(rfc2202_sha1[i]['hmac'],
-               crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
-                   .update(rfc2202_sha1[i]['data'])
-                   .digest('hex'),
-               'Test HMAC-SHA1 : Test case ' + (i + 1) + ' rfc 2202');
+  assert.strictEqual(
+    rfc2202_sha1[i]['hmac'],
+    crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
+      .update(rfc2202_sha1[i]['data'])
+      .digest('hex'),
+    'Test HMAC-SHA1 : Test case ' + (i + 1) + ' rfc 2202'
+  );
 }
 
 // Test hashing

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -351,17 +351,21 @@ var rfc2202_sha1 = [
 
 if (!common.hasFipsCrypto) {
   for (let i = 0, l = rfc2202_md5.length; i < l; i++) {
-    assert.equal(rfc2202_md5[i]['hmac'],
-                 crypto.createHmac('md5', rfc2202_md5[i]['key'])
-                     .update(rfc2202_md5[i]['data'])
-                     .digest('hex'),
-                 'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202');
+    assert.strictEqual(
+      rfc2202_md5[i]['hmac'],
+      crypto.createHmac('md5', rfc2202_md5[i]['key'])
+        .update(rfc2202_md5[i]['data'])
+        .digest('hex'),
+      'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202'
+    );
   }
 }
 for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
-  assert.equal(rfc2202_sha1[i]['hmac'],
-               crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
-                   .update(rfc2202_sha1[i]['data'])
-                   .digest('hex'),
-               'Test HMAC-SHA1 : Test case ' + (i + 1) + ' rfc 2202');
+  assert.strictEqual(
+    rfc2202_sha1[i]['hmac'],
+    crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
+      .update(rfc2202_sha1[i]['data'])
+      .digest('hex'),
+    'Test HMAC-SHA1 : Test case ' + (i + 1) + ' rfc 2202'
+  );
 }

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -69,12 +69,12 @@ server.maxConnections = 1;
 
 server.listen(0, function() {
   createConnection(0)
-  .then(createConnection.bind(null, 1))
-  .then(closeConnection.bind(null, 0))
-  .then(createConnection.bind(null, 2))
-  .then(createConnection.bind(null, 3))
-  .then(server.close.bind(server))
-  .then(closeConnection.bind(null, 2));
+    .then(createConnection.bind(null, 1))
+    .then(closeConnection.bind(null, 0))
+    .then(createConnection.bind(null, 2))
+    .then(createConnection.bind(null, 3))
+    .then(server.close.bind(server))
+    .then(closeConnection.bind(null, 2));
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -346,14 +346,22 @@ function isWarned(emitter) {
   assert.equal(internalReadline.getStringWidth('A\ud83c\ude00BC'), 5);
 
   // check if vt control chars are stripped
-  assert.equal(internalReadline
-               .stripVTControlCharacters('\u001b[31m> \u001b[39m'), '> ');
-  assert.equal(internalReadline
-               .stripVTControlCharacters('\u001b[31m> \u001b[39m> '), '> > ');
-  assert.equal(internalReadline
-               .stripVTControlCharacters('\u001b[31m\u001b[39m'), '');
-  assert.equal(internalReadline
-               .stripVTControlCharacters('> '), '> ');
+  assert.strictEqual(
+    internalReadline.stripVTControlCharacters('\u001b[31m> \u001b[39m'),
+    '> '
+  );
+  assert.strictEqual(
+    internalReadline.stripVTControlCharacters('\u001b[31m> \u001b[39m> '),
+    '> > '
+  );
+  assert.strictEqual(
+    internalReadline.stripVTControlCharacters('\u001b[31m\u001b[39m'),
+    ''
+  );
+  assert.strictEqual(
+    internalReadline.stripVTControlCharacters('> '),
+    '> '
+  );
   assert.equal(internalReadline.getStringWidth('\u001b[31m> \u001b[39m'), 2);
   assert.equal(internalReadline.getStringWidth('\u001b[31m> \u001b[39m> '), 4);
   assert.equal(internalReadline.getStringWidth('\u001b[31m\u001b[39m'), 0);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tools test

##### Description of change
<!-- Provide a description of the change below this comment. -->

A new version of ESLint flags chained properties on multiple lines that
were not flagged by the previous version of ESLint. In preparation for
turning that feature on, adjust alignment to that expected by linter.

WIP. Will probably update ESLint itself after <strike>3.2.1 is released, likely on Monday.</strike> a new version is released on August 12 (either 3.2.2 or 3.3.0). (The current 3.2.1 flags this issue a bit too liberally and would result in enormous churn.)

These changes seem to me to improve readability in most cases (especially the `readline` test file) and also provide an opportunity to change some instances of `assert.equal()` and `assert()` to `assert.strictEqual()`.