### PR TITLE
test: fix hard coded deprecate message count

### DIFF
--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -9,6 +9,11 @@ if (!common.hasCrypto) {
 const crypto = require('crypto');
 const tls = require('tls');
 
+const expected = [
+  'crypto.Credentials is deprecated. Use tls.SecureContext instead.',
+  'crypto.createCredentials is deprecated. Use tls.createSecureContext instead.'
+];
+
 process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.name, 'DeprecationWarning');
   assert.notStrictEqual(expected.indexOf(warning.message), -1,
@@ -16,12 +21,7 @@ process.on('warning', common.mustCall((warning) => {
   // Remove a warning message after it is seen so that we guarantee that we get
   // each message only once.
   expected.splice(expected.indexOf(warning.message), 1);
-}, 2));
-
-var expected = [
-  'crypto.Credentials is deprecated. Use tls.SecureContext instead.',
-  'crypto.createCredentials is deprecated. Use tls.createSecureContext instead.'
-];
+}, expected.length));
 
 // Accessing the deprecated function is enough to trigger the warning event.
 // It does not need to be called. So the assert serves the purpose of both


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->
This PR fixes hard coded deprecate message count
