### PR TITLE
doc, punycode: soft-deprecation of the punycode module

### DIFF
--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -1,6 +1,11 @@
 # punycode
 
-    Stability: 2 - Stable
+    Stability: 0 - Deprecated
+
+**The version of the punycode module bundled in Node.js is being deprecated**.
+In a future major version of Node.js this module will be removed. Users
+currently depending on the `punycode` module should switch to using the
+userland-provided [Punycode.js][] module instead.
 
 The `punycode` module is a bundled version of the [Punycode.js][] module. It
 can be accessed using:


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

punycode,docs

##### Description of change

As discussed and agreed upon by the CTC, the punycode module bundled in core is soft-deprecated (docs only) for v7 with an eye towards hard-deprecation in v8 or later.

Refs: https://github.com/nodejs/node/pull/7552
/cc @nodejs/ctc 