### PR TITLE
fs: add bytesRead to ReadStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -181,6 +181,13 @@ added: v0.1.93
 Emitted when the `ReadStream`'s underlying file descriptor has been closed
 using the `fs.close()` method.
 
+### readStream.bytesRead
+<!-- YAML
+added: REPLACEME
+-->
+
+The number of bytes read so far.
+
 ### readStream.path
 <!-- YAML
 added: v0.1.93

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1679,6 +1679,7 @@ function ReadStream(path, options) {
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;
+  this.bytesRead = 0;
 
   if (this.start !== undefined) {
     if (typeof this.start !== 'number') {
@@ -1774,8 +1775,10 @@ ReadStream.prototype._read = function(n) {
       self.emit('error', er);
     } else {
       var b = null;
-      if (bytesRead > 0)
+      if (bytesRead > 0) {
+        self.bytesRead += bytesRead;
         b = thisPool.slice(start, start + bytesRead);
+      }
 
       self.push(b);
     }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

`fs`

##### Description of change

Add a property named `bytesRead` that exposes how many bytes that have currently been read from the file. This brings consistency with `WriteStream` that has `bytesWritten` and `net.Socket` which have both `bytesRead` and `bytesWritten`.

Fixes #7938