### PR TITLE
build: fix dependency on missing header file 

### DIFF
--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -37,6 +37,7 @@
       'sources': [
         'common.gypi',
         'include/ares.h',
+        'include/ares_rules.h',
         'include/ares_version.h',
         'include/nameser.h',
         'src/ares_cancel.c',
@@ -83,7 +84,6 @@
         'src/ares_process.c',
         'src/ares_query.c',
         'src/ares__read_line.c',
-        'src/ares_rules.h',
         'src/ares_search.c',
         'src/ares_send.c',
         'src/ares_setup.h',

--- a/node.gyp
+++ b/node.gyp
@@ -316,7 +316,7 @@
             'src/inspector_agent.cc',
             'src/inspector_socket.cc',
             'src/inspector_socket.h',
-            'src/inspector-agent.h',
+            'src/inspector_agent.h',
           ],
           'dependencies': [
             'deps/v8_inspector/third_party/v8_inspector/platform/'


### PR DESCRIPTION
Apropos the change to deps/cares/cares.gyp, we are the maintainers of that file, it doesn't exist upstream.  It's an exception to the rule that changes to files under deps/ should go upstream first.

CI: https://ci.nodejs.org/job/node-test-pull-request/3497/