### PR TITLE
http: optimize by corking outgoing requests

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -83,6 +83,10 @@ function OutgoingMessage() {
   this._headers = null;
   this._headerNames = {};
 
+  // When this is written to, it will cork for a tick. This represents
+  // whether the socket is corked for that reason or not.
+  this._corkedForWrite = false;
+
   this._onPendingData = null;
 }
 util.inherits(OutgoingMessage, Stream);
@@ -112,33 +116,26 @@ OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
 OutgoingMessage.prototype.destroy = function destroy(error) {
-  if (this.socket)
+  if (this.socket) {
+    // If the socket is corked from a write, uncork it before destroying it.
+    if (this._corkedForWrite)
+      this.socket.uncork();
+
     this.socket.destroy(error);
-  else
+  } else {
     this.once('socket', function(socket) {
       socket.destroy(error);
     });
+  }
 };
 
 
 // This abstract either writing directly to the socket or buffering it.
 OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
-  // This is a shameful hack to get the headers and first body chunk onto
-  // the same packet. Future versions of Node are going to take care of
-  // this at a lower level and in a more general way.
+  // Send the headers before the body. OutgoingMessage#write will cork
+  // the stream before calling #_send, batching them in the same packet.
   if (!this._headerSent) {
-    if (typeof data === 'string' &&
-        encoding !== 'hex' &&
-        encoding !== 'base64') {
-      data = this._header + data;
-    } else {
-      this.output.unshift(this._header);
-      this.outputEncodings.unshift('latin1');
-      this.outputCallbacks.unshift(null);
-      this.outputSize += this._header.length;
-      if (typeof this._onPendingData === 'function')
-        this._onPendingData(this._header.length);
-    }
+    this._writeRaw(this._header, 'latin1', null);
     this._headerSent = true;
   }
   return this._writeRaw(data, encoding, callback);
@@ -465,6 +462,14 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
   // signal the user to keep writing.
   if (chunk.length === 0) return true;
 
+  // By corking the socket and uncorking after a tick, we manage to
+  // batch writes together, i.e. the header with the body.
+  if (this.connection && !this._corkedForWrite) {
+    this.connection.cork();
+    this._corkedForWrite = true;
+    process.nextTick(connectionCorkNT, this);
+  }
+
   var len, ret;
   if (this.chunkedEncoding) {
     if (typeof chunk === 'string' &&
@@ -481,10 +486,6 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
       else
         len = chunk.length;
 
-      if (this.connection && !this.connection.corked) {
-        this.connection.cork();
-        process.nextTick(connectionCorkNT, this.connection);
-      }
       this._send(len.toString(16), 'latin1', null);
       this._send(crlf_buf, null, null);
       this._send(chunk, encoding, null);
@@ -505,8 +506,9 @@ function writeAfterEndNT(self, err, callback) {
 }
 
 
-function connectionCorkNT(conn) {
-  conn.uncork();
+function connectionCorkNT(msg) {
+  msg.connection.uncork();
+  msg._corkedForWrite = false;
 }
 
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -155,10 +155,10 @@ function _writeRaw(data, encoding, callback) {
       connection.writable &&
       !connection.destroyed) {
     // There might be pending data in the this.output buffer.
-    var outputLength = this.output.length;
-    if (outputLength > 0) {
-      this._flushOutput(connection);
-    } else if (data.length === 0) {
+    this._flushOutput(connection);
+
+    // Avoid writing empty messages, but trigger the callback.
+    if (data.length === 0) {
       if (typeof callback === 'function')
         process.nextTick(callback);
       return true;
@@ -472,25 +472,16 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
 
   var len, ret;
   if (this.chunkedEncoding) {
-    if (typeof chunk === 'string' &&
-        encoding !== 'hex' &&
-        encoding !== 'base64' &&
-        encoding !== 'latin1') {
+    if (typeof chunk === 'string') {
       len = Buffer.byteLength(chunk, encoding);
-      chunk = len.toString(16) + CRLF + chunk + CRLF;
-      ret = this._send(chunk, encoding, callback);
     } else {
-      // buffer, or a non-toString-friendly encoding
-      if (typeof chunk === 'string')
-        len = Buffer.byteLength(chunk, encoding);
-      else
-        len = chunk.length;
-
-      this._send(len.toString(16), 'latin1', null);
-      this._send(crlf_buf, null, null);
-      this._send(chunk, encoding, null);
-      ret = this._send(crlf_buf, null, callback);
+      len = chunk.length;
     }
+
+    this._send(len.toString(16), 'latin1', null);
+    this._send(crlf_buf, null, null);
+    this._send(chunk, encoding, null);
+    ret = this._send(crlf_buf, null, callback);
   } else {
     ret = this._send(chunk, encoding, callback);
   }

--- a/test/parallel/test-http-write-write-destroy.js
+++ b/test/parallel/test-http-write-write-destroy.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Ensure that, in a corked response, calling .destroy() will flush what was
+// previously written completely rather than partially or none at all. It
+// also makes sure it's written in a single packet.
+
+var hasFlushed = false;
+
+var server = http.createServer(common.mustCall((req, res) => {
+  res.write('first.');
+  res.write('.second', function() {
+    // Set the flag to prove that all data has been written.
+    hasFlushed = true;
+  });
+
+  res.destroy();
+
+  // If the second callback from the .write() calls hasn't executed before
+  // the next tick, then the write has been buffered and was sent
+  // asynchronously. This means it wouldn't have been written regardless of
+  // corking, making the test irrelevant, so skip it.
+  process.nextTick(function() {
+    if (hasFlushed) return;
+
+    common.skip('.write() executed asynchronously');
+    process.exit(0);
+    return;
+  });
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+  // Send a request, and assert the response.
+  http.get({
+    port: server.address().port
+  }, (res) => {
+    var data = '';
+
+    // By ensuring that the 'data' event is only emitted once, we ensure that
+    // the socket was correctly corked and the data was batched.
+    res.on('data', common.mustCall(function(chunk) {
+      data += chunk.toString('latin1');
+    }, 2));
+
+    res.on('end', common.mustCall(function() {
+      assert.equal(data, 'first..second');
+
+      res.destroy();
+      server.close();
+    }));
+  });
+}));


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

http
##### Description of change

This commit optimizes outgoing HTTP responses by corking the socket upon each write and then uncorking on the next tick. By doing this we get to remove a "shameful hack" that is years old while at the same time fixing #7914 and getting some performance improvements.

The second commit is just a cleanup commit that makes nothing do even less nothing.
##### benchmarks!

```
                                                           improvement significant      p.value
 http/simple.js c=50 chunks=0 length=1024 type="buffer"         1.79 %             6.312062e-01
 http/simple.js c=50 chunks=0 length=1024 type="bytes"         -0.05 %             9.835961e-01
 http/simple.js c=50 chunks=0 length=102400 type="buffer"       5.62 %             1.250185e-01
 http/simple.js c=50 chunks=0 length=102400 type="bytes"      504.10 %         *** 3.837119e-12
 http/simple.js c=50 chunks=0 length=4 type="buffer"            6.68 %          ** 9.582778e-03
 http/simple.js c=50 chunks=0 length=4 type="bytes"            -5.70 %           * 3.114749e-02
 http/simple.js c=50 chunks=1 length=1024 type="buffer"         2.64 %             4.060173e-01
 http/simple.js c=50 chunks=1 length=1024 type="bytes"          7.69 %           * 2.072578e-02
 http/simple.js c=50 chunks=1 length=102400 type="buffer"       1.05 %             6.860244e-01
 http/simple.js c=50 chunks=1 length=102400 type="bytes"       43.97 %         *** 1.209619e-11
 http/simple.js c=50 chunks=1 length=4 type="buffer"            2.05 %             4.243028e-01
 http/simple.js c=50 chunks=1 length=4 type="bytes"             2.94 %             2.278701e-01
 http/simple.js c=50 chunks=4 length=1024 type="buffer"         3.99 %             1.028562e-01
 http/simple.js c=50 chunks=4 length=1024 type="bytes"         93.05 %         *** 6.741354e-16
 http/simple.js c=50 chunks=4 length=102400 type="buffer"      -0.67 %             8.158624e-01
 http/simple.js c=50 chunks=4 length=102400 type="bytes"       21.27 %         *** 2.395868e-05
 http/simple.js c=50 chunks=4 length=4 type="buffer"            1.20 %             7.638681e-01
 http/simple.js c=50 chunks=4 length=4 type="bytes"            83.91 %         *** 9.042857e-12
 http/simple.js c=500 chunks=0 length=1024 type="buffer"        3.91 %             2.187250e-01
 http/simple.js c=500 chunks=0 length=1024 type="bytes"        -3.62 %             2.884252e-01
 http/simple.js c=500 chunks=0 length=102400 type="buffer"      4.06 %             1.118611e-01
 http/simple.js c=500 chunks=0 length=102400 type="bytes"     462.59 %         *** 1.329366e-14
 http/simple.js c=500 chunks=0 length=4 type="buffer"           3.36 %             1.562332e-01
 http/simple.js c=500 chunks=0 length=4 type="bytes"           -6.84 %           * 2.868192e-02
 http/simple.js c=500 chunks=1 length=1024 type="buffer"        1.44 %             6.530913e-01
 http/simple.js c=500 chunks=1 length=1024 type="bytes"         7.24 %          ** 1.642590e-03
 http/simple.js c=500 chunks=1 length=102400 type="buffer"     -1.07 %             7.202359e-01
 http/simple.js c=500 chunks=1 length=102400 type="bytes"      38.69 %         *** 1.560892e-07
 http/simple.js c=500 chunks=1 length=4 type="buffer"           0.22 %             9.431102e-01
 http/simple.js c=500 chunks=1 length=4 type="bytes"            2.24 %             2.752881e-01
 http/simple.js c=500 chunks=4 length=1024 type="buffer"        4.81 %             1.307765e-01
 http/simple.js c=500 chunks=4 length=1024 type="bytes"        86.55 %         *** 9.028564e-15
 http/simple.js c=500 chunks=4 length=102400 type="buffer"      0.91 %             7.931741e-01
 http/simple.js c=500 chunks=4 length=102400 type="bytes"      11.95 %          ** 1.007196e-03
 http/simple.js c=500 chunks=4 length=4 type="buffer"           3.75 %             1.063908e-01
 http/simple.js c=500 chunks=4 length=4 type="bytes"           77.90 %         *** 2.854701e-10
```

CI: https://ci.nodejs.org/job/node-test-pull-request/3498/
