### PR TITLE
http: specify _implicitHeader in OutgoingMessage

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -413,6 +413,9 @@ OutgoingMessage.prototype._renderHeaders = function() {
   return headers;
 };
 
+OutgoingMessage.prototype._implicitHeader = function() {
+  throw new Error('_implicitHeader() method is not implemented');
+};
 
 Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
   configurable: true,

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -1,0 +1,14 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const http = require('http');
+const OutgoingMessage = http.OutgoingMessage;
+const ClientRequest = http.ClientRequest;
+const ServerResponse = http.ServerResponse;
+
+assert.throws(OutgoingMessage.prototype._implicitHeader);
+assert.strictEqual(
+  typeof ClientRequest.prototype._implicitHeader, 'function');
+assert.strictEqual(
+  typeof ServerResponse.prototype._implicitHeader, 'function');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http

##### Description of change

I saw "lib/_http_outgoing.js" uses `_implicitHeader` function 3 times: [line1](https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L433), [line2](https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L558) and [line3](https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L680). But not searched this method defined at `OutgoingMessage.prototype`, found this method is defined at [its children](https://github.com/nodejs/node/blob/master/lib/_http_client.js#L215-L218).
