### PR TITLE
build: turn on thin static archives

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -271,8 +271,9 @@
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++0x' ],
         'ldflags': [ '-rdynamic' ],
         'target_conditions': [
-          ['_type=="static_library"', {
-            'standalone_static_library': 1, # disable thin archive which needs binutils >= 2.19
+          # The 1990s toolchain on SmartOS can't handle thin archives.
+          ['_type=="static_library" and OS=="solaris"', {
+            'standalone_static_library': 1,
           }],
         ],
         'conditions': [

--- a/node.gyp
+++ b/node.gyp
@@ -366,7 +366,9 @@
                   'conditions': [
                     ['OS in "linux freebsd" and node_shared=="false"', {
                       'ldflags': [
-                        '-Wl,--whole-archive <(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
+                        '-Wl,--whole-archive,'
+                            '<(PRODUCT_DIR)/obj.target/deps/openssl/'
+                            '<(OPENSSL_PRODUCT)',
                         '-Wl,--no-whole-archive',
                       ],
                     }],


### PR DESCRIPTION
Thin archives were disabled in 2012 as a workaround (IIRC) for obsolete
tooling on one of Joyent's platforms.  The last binutils versions that
didn't support them was released in 2007 so I think it's safe to assume
we can drop support for that now.

Thin archives save space - it shrinks the size of PRODUCT_DIR by 30% -
and speed up the final linking step because it doesn't have to assemble
50 MB of static archives (twice! - first to create the archive, then to
copy it to PRODUCT_DIR).  The archives are just 3.5 MB now and no longer
copied around.

CI: https://ci.nodejs.org/job/node-test-pull-request/3515/