### PR TITLE
benchmark: add --format csv option

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -30,7 +30,7 @@ function Benchmark(fn, options) {
 Benchmark.prototype._parseArgs = function(argv, options) {
   const cliOptions = Object.assign({}, options);
 
-  // Parse configuarion arguments
+  // Parse configuration arguments
   for (const arg of argv) {
     const match = arg.match(/^(.+?)=([\s\S]*)$/);
     if (!match || !match[1]) {
@@ -52,7 +52,7 @@ Benchmark.prototype._queue = function(options) {
   const queue = [];
   const keys = Object.keys(options);
 
-  // Perform a depth-first walk though all options to genereate a
+  // Perform a depth-first walk though all options to generate a
   // configuration list that contains all combinations.
   function recursive(keyIndex, prevConfig) {
     const key = keys[keyIndex];
@@ -171,9 +171,9 @@ Benchmark.prototype._run = function() {
 };
 
 Benchmark.prototype.start = function() {
-  if (this._started)
+  if (this._started) {
     throw new Error('Called start more than once in a single benchmark');
-
+  }
   this._started = true;
   this._time = process.hrtime();
 };
@@ -195,7 +195,7 @@ Benchmark.prototype.end = function(operations) {
 };
 
 function formatResult(data) {
-  // Construct confiuration string, " A=a, B=b, ..."
+  // Construct configuration string, " A=a, B=b, ..."
   let conf = '';
   for (const key of Object.keys(data.conf)) {
     conf += ' ' + key + '=' + JSON.stringify(data.conf[key]);

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -33,7 +33,8 @@ const benchmarks = cli.benchmarks();
 
 if (benchmarks.length === 0) {
   console.error('no benchmarks found');
-  process.exit(1);
+  process.exitCode = 1;
+  return;
 }
 
 // Create queue from the benchmarks list such both node versions are tested

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -65,7 +65,7 @@ console.log('"binary", "filename", "configuration", "rate", "time"');
     }
     conf = conf.slice(1);
 
-    // Escape qoutes (") for correct csv formatting
+    // Escape quotes (") for correct csv formatting
     conf = conf.replace(/"/g, '""');
 
     console.log(`"${job.binary}", "${job.filename}", "${conf}", ` +


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark

##### Description of change
<!-- Provide a description of the change below this comment. -->

Added the option of using --format csv when outputting data.