### PR TITLE
[WIP] lib: add initial mapproxy implementation and benchmark

### DIFF
--- a/benchmark/misc/mapproxy.js
+++ b/benchmark/misc/mapproxy.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const common = require('../common.js');
+const mp = require('internal/mapproxy');
+const assert = require('assert');
+
+var bench = common.createBenchmark(main, {
+  n: [100000],
+  m: ['nullproto', 'map', 'mapproxy']
+});
+
+function runNullProtoObject() {
+  const obj = Object.create(null);
+  obj.a = 'testing';
+  obj.b = 'this';
+  obj.c = 'thing';
+  delete obj.a;
+  delete obj.b;
+  assert.strictEqual(obj.c, 'thing');
+}
+
+function runMap() {
+  const map = new Map();
+  map.set('a', 'testing');
+  map.set('b', 'this');
+  map.set('c', 'thing');
+  map.delete('a');
+  map.delete('b');
+  assert.strictEqual(map.get('c'), 'thing');
+}
+
+function runMapProxy() {
+  const map = new Map();
+  const obj = mp.wrap(map);
+  obj.a = 'testing';
+  obj.b = 'this';
+  obj.c = 'thing';
+  delete obj.a;
+  delete obj.b;
+  assert.strictEqual(obj.c, 'thing');
+}
+
+function doNullProtoObject(n) {
+  common.v8ForceOptimization(runNullProtoObject);
+  bench.start();
+  for (var i = 0; i < n; i++)
+    runNullProtoObject();
+  bench.end(n);
+}
+
+function doMap(n) {
+  common.v8ForceOptimization(runMap);
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    runMap();
+  }
+  bench.end(n);
+}
+
+function doMapProxy(n) {
+  common.v8ForceOptimization(runMapProxy);
+  bench.start();
+  for (var i = 0; i < n; i++)
+    runMapProxy();
+  bench.end(n);
+}
+
+function main(conf) {
+  const n = conf.n;
+  const m = conf.m;
+  console.log(n);
+  switch (m) {
+    case 'nullproto':
+      return doNullProtoObject(n);
+    case 'map':
+      return doMap(n);
+    case 'mapproxy':
+      return doMapProxy(n);
+    default:
+      throw new Error('unexpected parameter ' + m);
+  }
+}

--- a/lib/internal/mapproxy.js
+++ b/lib/internal/mapproxy.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// A proxy object implementation that wraps a Map and makes it look and
+// act a close as possible to a dictionary-type object.
+
+const handler = {
+  getPrototypeOf(target) {
+    return Object.getPrototypeOf(target);
+  },
+  isExtensible(target) {
+    return true;
+  },
+  getOwnPropertyDescriptor(target, prop) {
+    if (!target.has(prop))
+      return;
+    return {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+      value: target.get(prop)
+    }
+  },
+  defineProperty(target, prop, descriptor) {
+    // Properties cannot be defined on these objects
+    // because the semantics do not carry through to
+    // the underlying Map appropriately.
+    throw new TypeError(
+      'Object.defineProperty is unsupported on this object.');
+  },
+  has(target, prop) {
+    return target.has(prop);
+  },
+  get(target, prop) {
+    if (target.has(prop))
+      return target.get(prop);
+    var fn = Object.prototype[prop];
+    if (typeof fn === 'function') {
+      return new Proxy(fn, {
+        apply(target, thisArg, argumentsList) {
+          return fn.apply(thisArg, argumentsList);
+        }
+      });
+    }
+    return fn;
+  },
+  set(target, prop, value) {
+    target.set(prop, value);
+    return true;
+  },
+  deleteProperty(target, prop) {
+    target.delete(prop);
+    return true;
+  },
+  ownKeys(target) {
+    return Array.from(target.keys());
+  }
+};
+
+function wrap(map) {
+  return new Proxy(map, handler);
+}
+
+exports.wrap = wrap;

--- a/lib/internal/mapproxy.js
+++ b/lib/internal/mapproxy.js
@@ -18,7 +18,7 @@ const handler = {
       configurable: true,
       writable: true,
       value: target.get(prop)
-    }
+    };
   },
   defineProperty(target, prop, descriptor) {
     // Properties cannot be defined on these objects

--- a/node.gyp
+++ b/node.gyp
@@ -78,6 +78,7 @@
       'lib/internal/freelist.js',
       'lib/internal/linkedlist.js',
       'lib/internal/net.js',
+      'lib/internal/mapproxy.js',
       'lib/internal/module.js',
       'lib/internal/process/next_tick.js',
       'lib/internal/process/promises.js',


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

internal

##### Description of change
Discussion around https://github.com/nodejs/node/pull/6102 has explored the
possibility that a Map based implementation may be better, but there are
backwards compatibility concerns over changing the API. This commit adds
and internal implementation of a Map proxy object that allows a Map instance
to act like it is an ordinary dictionary object as much as possible.

A benchmark is included to show the perf differences.

**This is a work in progress experiment that should not yet be landed.**

/cc @nodejs/ctc (@mscdex @ofrobots in particular)