### PR TITLE
repl: disable Ctrl+C support on win32 for now

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -292,6 +292,7 @@ function REPLServer(prompt,
       // Temporarily disabled on Windows due to output problems that likely
       // result from the raw mode switches here, see
       // https://github.com/nodejs/node/issues/7837
+      // Setting NODE_REPL_CTRLC is meant as a temporary opt-in for debugging.
       if (self.breakEvalOnSigint &&
           (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
         // Start the SIGINT watchdog before entering raw mode so that a very

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -288,7 +288,12 @@ function REPLServer(prompt,
     if (!err) {
       // Unset raw mode during evaluation so that Ctrl+C raises a signal.
       let previouslyInRawMode;
-      if (self.breakEvalOnSigint) {
+
+      // Temporarily disabled on Windows due to output problems that likely
+      // result from the raw mode switches here, see
+      // https://github.com/nodejs/node/issues/7837
+      if (self.breakEvalOnSigint &&
+          (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
         // Start the SIGINT watchdog before entering raw mode so that a very
         // quick Ctrl+C doesn’t lead to aborting the process completely.
         utilBinding.startSigintWatchdog();
@@ -308,7 +313,8 @@ function REPLServer(prompt,
             result = script.runInContext(context, scriptOptions);
           }
         } finally {
-          if (self.breakEvalOnSigint) {
+          if (self.breakEvalOnSigint &&
+              (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
             // Reset terminal mode to its previous value.
             self._setRawMode(previouslyInRawMode);
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

repl

##### Description of change

Disable Windows support for interrupting REPL commands using Ctrl+C by default, because the switches from console raw mode and back have been interfering with printing the results of
evaluated expressions.

This is a temporary measure, since the underlying problem is very likely not related to this specific feature.

Ref: https://github.com/nodejs/node/issues/7837

/cc @joaocgreis 