### PR TITLE
test: fix flaky test-vm-sigint-existing-handler

### DIFF
--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -61,15 +61,16 @@ if (process.argv[2] === 'child') {
 }
 
 process.env.REPL_TEST_PPID = process.pid;
-const child = spawn(process.execPath, [ __filename, 'child' ], {
-  stdio: [null, 'inherit', 'inherit']
-});
 
 process.on('SIGUSR2', common.mustCall(() => {
   // First kill() breaks the while(true) loop, second one invokes the real
   // signal handlers.
   process.kill(child.pid, 'SIGINT');
 }, 3));
+
+const child = spawn(process.execPath, [ __filename, 'child' ], {
+  stdio: [null, 'inherit', 'inherit']
+});
 
 child.on('close', function(code, signal) {
   assert.strictEqual(signal, null);

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -70,7 +70,7 @@ process.on('SIGUSR2', common.mustCall(() => {
   process.kill(child.pid, 'SIGINT');
 }, 3));
 
-const child = spawn(process.execPath, [ __filename, 'child' ], {
+const child = spawn(process.execPath, [__filename, 'child'], {
   stdio: [null, 'inherit', 'inherit']
 });
 

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -62,6 +62,8 @@ if (process.argv[2] === 'child') {
 
 process.env.REPL_TEST_PPID = process.pid;
 
+// Set the `SIGUSR2` handler before spawning the child process to make sure
+// the signal is always handled.
 process.on('SIGUSR2', common.mustCall(() => {
   // First kill() breaks the while(true) loop, second one invokes the real
   // signal handlers.

--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -25,6 +25,9 @@ if (process.argv[2] === 'child') {
 }
 
 process.env.REPL_TEST_PPID = process.pid;
+
+// Set the `SIGUSR2` handler before spawning the child process to make sure
+// the signal is always handled.
 process.on('SIGUSR2', common.mustCall(() => {
   process.kill(child.pid, 'SIGINT');
 }));

--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -32,7 +32,7 @@ process.on('SIGUSR2', common.mustCall(() => {
   process.kill(child.pid, 'SIGINT');
 }));
 
-const child = spawn(process.execPath, [ __filename, 'child' ], {
+const child = spawn(process.execPath, [__filename, 'child'], {
   stdio: [null, 'pipe', 'inherit']
 });
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Set the `SIGUSR2` handler before spawning the child process to make sure the signal is always handled.

(Basically the same as https://github.com/nodejs/node/pull/7854)
Fixes: https://github.com/nodejs/node/issues/7981