### PR TITLE
build: export zlib symbols on Windows

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -370,8 +370,13 @@
                         '-Wl,--no-whole-archive',
                       ],
                     }],
+                    # openssl.def is based on zlib.def, zlib symbols
+                    # are always exported.
                     ['use_openssl_def==1', {
                       'sources': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
+                    }],
+                    ['OS=="win" and use_openssl_def==0', {
+                      'sources': ['deps/zlib/win32/zlib.def'],
                     }],
                   ],
                 }],
@@ -568,6 +573,8 @@
               '-X^DSO',
               '-X^_',
               '-X^private_',
+              # Base generated DEF on zlib.def
+              '-Bdeps/zlib/win32/zlib.def'
             ],
           },
           'conditions': [

--- a/tools/mkssldef.py
+++ b/tools/mkssldef.py
@@ -7,6 +7,7 @@ import sys
 categories = []
 defines = []
 excludes = []
+bases = []
 
 if __name__ == '__main__':
   out = sys.stdout
@@ -18,6 +19,7 @@ if __name__ == '__main__':
     elif option.startswith('-C'): categories += option[2:].split(',')
     elif option.startswith('-D'): defines += option[2:].split(',')
     elif option.startswith('-X'): excludes += option[2:].split(',')
+    elif option.startswith('-B'): bases += option[2:].split(',')
 
   excludes = map(re.compile, excludes)
   exported = []
@@ -39,6 +41,13 @@ if __name__ == '__main__':
       if not satisfy(meta[1], defines): continue
       if not satisfy(meta[3], categories): continue
       exported.append(name)
+
+  for filename in bases:
+    for line in open(filename).readlines():
+      line = line.strip()
+      if line == 'EXPORTS': continue
+      if line[0] == ';': continue
+      exported.append(line)
 
   print('EXPORTS', file=out)
   for name in sorted(exported): print('    ', name, file=out)


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build, addons


##### Description of change
Base the generated openssl.def on existing zlib.def. We cannot specify more than one DEF file per executable so we need to merge the two DEF files to expose both OpenSSL and Zlib functionality to addons.

If OpenSSL is not used, link against zlib.def itself.

@bnoordhuis knows about the mkssldef.py