### PR TITLE
inspector: add inspector console support for native Console

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -226,13 +226,50 @@
   }
 
   function setupGlobalConsole() {
+    var inspectorConsole;
+    var wrapConsoleCall;
+    if (process.inspector) {
+      inspectorConsole = global.console;
+      wrapConsoleCall = process.inspector.wrapConsoleCall;
+      delete process.inspector;
+    }
+    var console;
     Object.defineProperty(global, 'console', {
       configurable: true,
       enumerable: true,
       get: function() {
-        return NativeModule.require('console');
+        if (!console) {
+          console = NativeModule.require('console');
+          installInspectorConsoleIfNeeded(console,
+                                          inspectorConsole,
+                                          wrapConsoleCall);
+        }
+        return console;
       }
     });
+  }
+
+  function installInspectorConsoleIfNeeded(console,
+                                           inspectorConsole,
+                                           wrapConsoleCall) {
+    if (!inspectorConsole)
+      return;
+    var config = {};
+    for (const key of Object.keys(console)) {
+      if (!inspectorConsole.hasOwnProperty(key))
+        continue;
+      // If node console has the same method as inspector console,
+      // then wrap these two methods into one. Native wrapper will preserve
+      // the original stack.
+      console[key] = wrapConsoleCall(inspectorConsole[key],
+                                     console[key],
+                                     config);
+    }
+    for (const key of Object.keys(inspectorConsole)) {
+      if (console.hasOwnProperty(key))
+        continue;
+      console[key] = inspectorConsole[key];
+    }
   }
 
   function setupProcessFatal() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
console

##### Description of change
<!-- Provide a description of the change below this comment. -->

When node is running with --inspect flag, default console.log,
console.warn and other methods call inspector console methods in
addition to current behaviour (dump formatted message to stderr
and stdout). Inspector console methods forward message to DevTools and
show its in DevTools Console with DevTools formatters. Inspector console
methods not presented on Node console will be added into it.

Only own methods on global.console object will be changed while
debugging session. User still able to redefine it, use console.Console
or change original methods on Console.prototype.