### PR TITLE
docs: add info about --auto-open flag w/ --inspect

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -193,4 +193,7 @@ e.g. `--inspect=9222` will accept DevTools connections on port 9222.
 To break on the first line of the application code, provide the `--debug-brk`
 flag in addition to `--inspect`.
 
+To open Chrome automatically, provide the `--auto-open` flag in addition to
+`--inspect`.
+
 [TCP-based protocol]: https://github.com/v8/v8/wiki/Debugging-Protocol


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

This feature doesn't actually work (AFAIK). This is mostly just my way of suggesting that we implement a CLI flag for it. I'd be happy to help with a little direction (first time contributor here).
