### PR TITLE
timers: remove unused repeat param in timer_wrap

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -135,7 +135,7 @@ function insert(item, unrefed) {
     list._timer._list = list;
 
     if (unrefed === true) list._timer.unref();
-    list._timer.start(msecs, 0);
+    list._timer.start(msecs);
 
     lists[msecs] = list;
     list._timer[kOnTimeout] = listOnTimeout;
@@ -173,7 +173,7 @@ function listOnTimeout() {
       if (timeRemaining < 0) {
         timeRemaining = 0;
       }
-      this.start(timeRemaining, 0);
+      this.start(timeRemaining);
       debug('%d list wait because diff is %d', msecs, diff);
       return;
     }
@@ -430,7 +430,7 @@ exports.setInterval = function(callback, repeat) {
 
     // If timer is unref'd (or was - it's permanently removed from the list.)
     if (this._handle) {
-      this._handle.start(repeat, 0);
+      this._handle.start(repeat);
     } else {
       timer._idleTimeout = repeat;
       active(timer);
@@ -485,7 +485,7 @@ Timeout.prototype.unref = function() {
     this._handle = handle || new TimerWrap();
     this._handle.owner = this;
     this._handle[kOnTimeout] = unrefdHandle;
-    this._handle.start(delay, 0);
+    this._handle.start(delay);
     this._handle.domain = this.domain;
     this._handle.unref();
   }

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -75,8 +75,7 @@ class TimerWrap : public HandleWrap {
     CHECK(HandleWrap::IsAlive(wrap));
 
     int64_t timeout = args[0]->IntegerValue();
-    int64_t repeat = args[1]->IntegerValue();
-    int err = uv_timer_start(&wrap->handle_, OnTimeout, timeout, repeat);
+    int err = uv_timer_start(&wrap->handle_, OnTimeout, timeout, 0);
     args.GetReturnValue().Set(err);
   }
 

--- a/test/pummel/test-timer-wrap.js
+++ b/test/pummel/test-timer-wrap.js
@@ -6,7 +6,7 @@ var kOnTimeout = Timer.kOnTimeout;
 
 var t = new Timer();
 
-t.start(1000, 0);
+t.start(1000);
 
 t[kOnTimeout] = common.mustCall(function() {
   console.log('timeout');

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -42,7 +42,7 @@ monoTimer[Timer.kOnTimeout] = function() {
   assert(intervalFired);
 };
 
-monoTimer.start(300, 0);
+monoTimer.start(300);
 
 setTimeout(function() {
   timerFired = true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- timers

##### Description of change
<!-- Provide a description of the change below this comment. -->

The `repeat` param in `start(timeout, repeat)` was 0 in all callsites. Because this is an internal API, it can be safely removed.