### PR TITLE
doc: reword ambigous docs for socket.setNoDelay

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1521,7 +1521,7 @@ There are a few special headers that should be noted.
 [`response.writeContinue()`]: #http_response_writecontinue
 [`response.writeHead()`]: #http_response_writehead_statuscode_statusmessage_headers
 [`socket.setKeepAlive()`]: net.html#net_socket_setkeepalive_enable_initialdelay
-[`socket.setNoDelay()`]: net.html#net_socket_setnodelay_nodelay
+[`socket.setNoDelay()`]: net.html#net_socket_setnodelay_enable
 [`socket.setTimeout()`]: net.html#net_socket_settimeout_timeout_callback
 [`TypeError`]: errors.html#errors_class_typeerror
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -625,15 +625,16 @@ initialDelay will leave the value unchanged from the default
 
 Returns `socket`.
 
-### socket.setNoDelay([noDelay])
+### socket.setNoDelay([enable])
 <!-- YAML
 added: v0.1.90
 -->
 
-Disables the Nagle algorithm. By default TCP connections use the Nagle
-algorithm, they buffer data before sending it off. Setting `true` for
-`noDelay` will immediately fire off data each time `socket.write()` is called.
-`noDelay` defaults to `true`.
+Sets `noDelay` option, which disables the Nagle algorithm. By default TCP
+connections use the Nagle algorithm, they buffer data before sending it off.
+Setting `true` for `noDelay` will immediately fire off data each time
+`socket.write()` is called.
+`enable` defaults to `true`.
 
 Returns `socket`.
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

doc
##### Description of change

Reworded description of `socket.setNoDelay` to make it clear that function parameter defaults to true and not the `noDelay` option itself.
See  nodejs/node-v0.x-archive#8929
