### PR TITLE
assert: Fix deepEqual/deepStrictEqual on equivalent typed arrays

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -180,8 +180,12 @@ function _deepEqual(actual, expected, strict, memos) {
              pToString(actual) === pToString(expected) &&
              !(actual instanceof Float32Array ||
                actual instanceof Float64Array)) {
-    return compare(Buffer.from(actual.buffer),
-                   Buffer.from(expected.buffer)) === 0;
+    return compare(Buffer.from(actual.buffer,
+                               actual.byteOffset,
+                               actual.byteLength),
+                   Buffer.from(expected.buffer,
+                               expected.byteOffset,
+                               expected.byteLength)) === 0;
 
   // 7.5 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -26,7 +26,10 @@ const equalArrayPairs = [
   [new Int16Array([256]), new Uint16Array([256])],
   [new Float32Array([+0.0]), new Float32Array([-0.0])],
   [new Float64Array([+0.0]), new Float32Array([-0.0])],
-  [new Float64Array([+0.0]), new Float64Array([-0.0])]
+  [new Float64Array([+0.0]), new Float64Array([-0.0])],
+  [new Uint8Array([1, 2, 3, 4]).subarray(1), new Uint8Array([2, 3, 4])],
+  [new Uint16Array([1, 2, 3, 4]).subarray(1), new Uint16Array([2, 3, 4])],
+  [new Uint32Array([1, 2, 3, 4]).subarray(1, 3), new Uint32Array([2, 3])]
 ];
 
 const notEqualArrayPairs = [


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

assert

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fix #8001.

The typed array's underlying ArrayBuffer is used in `Buffer.from`.
Let's respect it's .byteOffset or .byteLength (i.e. position within the
parent ArrayBuffer).