### PR TITLE
test: console constructor missing new keyword

### DIFF
--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -64,3 +64,8 @@ out.write = function(d) {
 };
 [1, 2, 3].forEach(c.log);
 assert.equal(3, called);
+
+// Console() detects if it is called without `new` keyword
+assert.doesNotThrow(function() {
+  Console(out, err);
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test console

##### Description of change
<!-- Provide a description of the change below this comment. -->

The `console.Console()` constructor function handles a missing `new`
keyword. This code is not exercised in the current tests. Add a test for
this.