### PR TITLE
doc: fix typo in vm.runInNewContext() description

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -321,7 +321,7 @@ added: v0.3.1
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown.
 
-The `vm.runInContext()` first contextifies the given `sandbox` object (or
+The `vm.runInNewContext()` first contextifies the given `sandbox` object (or
 creates a new `sandbox` if passed as `undefined`), compiles the `code`, runs it
 within the context of the created context, then returns the result. Running code
 does not have access to the local scope.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes a typo in [`vm.runInNewContext()`](https://nodejs.org/docs/v6.3.1/api/vm.html#vm_vm_runinnewcontext_code_sandbox_options) description.