### PR TITLE
dgram: prefer strict equality

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -39,13 +39,13 @@ function lookup6(address, callback) {
 
 
 function newHandle(type) {
-  if (type == 'udp4') {
+  if (type === 'udp4') {
     const handle = new UDP();
     handle.lookup = lookup4;
     return handle;
   }
 
-  if (type == 'udp6') {
+  if (type === 'udp6') {
     const handle = new UDP();
     handle.lookup = lookup6;
     handle.bind = handle.bind6;
@@ -78,7 +78,7 @@ exports._createSocketHandle = function(address, port, addressType, fd, flags) {
 function Socket(type, listener) {
   EventEmitter.call(this);
 
-  if (typeof type === 'object') {
+  if (type !== null && typeof type === 'object') {
     var options = type;
     type = options.type;
   }
@@ -137,7 +137,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
 
   self._healthCheck();
 
-  if (this._bindState != BIND_STATE_UNBOUND)
+  if (this._bindState !== BIND_STATE_UNBOUND)
     throw new Error('Socket is already bound');
 
   this._bindState = BIND_STATE_BINDING;
@@ -346,7 +346,7 @@ Socket.prototype.send = function(buffer,
 
   self._healthCheck();
 
-  if (self._bindState == BIND_STATE_UNBOUND)
+  if (self._bindState === BIND_STATE_UNBOUND)
     self.bind({port: 0, exclusive: true}, null);
 
   if (list.length === 0)
@@ -354,7 +354,7 @@ Socket.prototype.send = function(buffer,
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.
-  if (self._bindState != BIND_STATE_BOUND) {
+  if (self._bindState !== BIND_STATE_BOUND) {
     enqueue(self, self.send.bind(self, list, port, address, callback));
     return;
   }

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -1,0 +1,36 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const invalidTypes = [
+  'test',
+  ['udp4'],
+  new String('udp4'),
+  1,
+  {},
+  true,
+  false,
+  null,
+  undefined
+];
+const validTypes = [
+  'udp4',
+  'udp6',
+  { type: 'udp4' },
+  { type: 'udp6' }
+];
+
+// Error must be thrown with invalid types
+invalidTypes.forEach((invalidType) => {
+  assert.throws(() => {
+    dgram.createSocket(invalidType);
+  }, /Bad socket type specified/);
+});
+
+// Error must not be thrown with valid types
+validTypes.forEach((validType) => {
+  assert.doesNotThrow(() => {
+    const socket = dgram.createSocket(validType);
+    socket.close();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dgram

##### Description of change
<!-- Provide a description of the change below this comment. -->

Enforces strict comparisons in dgram.
bindState should always be strictly equal to one of the defined constant states, and newHandle type is a string.