### PR TITLE
doc: fix cluster message event docs

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -516,7 +516,7 @@ The `addressType` is one of:
 * `message` {Object}
 * `handle` {undefined|Object}
 
-Emitted when any worker receives a message.
+Emitted when the cluster master receives a message from any worker.
 
 See [child_process event: 'message'][].
 


### PR DESCRIPTION
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc for cluster

##### Description of change
<!-- Provide a description of the change below this comment. -->

* cluster "message" is emitted when master, not worker, receives a message from a worker.

Fixes #7997.