### PR TITLE
stream: avoid caching prepend check

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -13,13 +13,12 @@ var StringDecoder;
 
 util.inherits(Readable, Stream);
 
-var prependListener;
-if (typeof EE.prototype.prependListener === 'function') {
-  prependListener = function prependListener(emitter, event, fn) {
+function prependListener(emitter, event, fn) {
+  // Sadly this is not cacheable as some libraries bundle their own
+  // event emitter implementation with them.
+  if (typeof emitter.prependListener === 'function') {
     return emitter.prependListener(event, fn);
-  };
-} else {
-  prependListener = function prependListener(emitter, event, fn) {
+  } else {
     // This is a hack to make sure that our error handler is attached before any
     // userland ones.  NEVER DO THIS. This is here only because this code needs
     // to continue to work with older versions of Node.js that do not include
@@ -30,7 +29,7 @@ if (typeof EE.prototype.prependListener === 'function') {
       emitter._events[event].unshift(fn);
     else
       emitter._events[event] = [fn, emitter._events[event]];
-  };
+  }
 }
 
 function ReadableState(options, stream) {

--- a/test/parallel/test-stream-events-prepend.js
+++ b/test/parallel/test-stream-events-prepend.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const stream = require('stream');
+const util = require('util');
+
+function Writable() {
+  this.writable = true;
+  stream.Writable.call(this);
+  this.prependListener = undefined;
+}
+util.inherits(Writable, stream.Writable);
+Writable.prototype._write = function(chunk, end, cb) {
+  cb();
+};
+
+function Readable() {
+  this.readable = true;
+  stream.Readable.call(this);
+}
+util.inherits(Readable, stream.Readable);
+Readable.prototype._read = function() {
+  this.push(null);
+};
+
+const w = new Writable();
+w.on('pipe', common.mustCall(function() {}));
+
+const r = new Readable();
+r.pipe(w);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
    no but it failed before my change
- [x] tests and/or benchmarks are included

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
@nodejs/streams 

##### Description of change
<!-- Provide a description of the change below this comment. -->

This removes the cached check for EE.prototype.prependListener because we can't
have nice things. More specifically some libraries will bundle their own event
emitter implementation.