### PR TITLE
inspector: fix inspector hung while disconnecting

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -288,6 +288,7 @@ class V8NodeInspector : public blink::V8Inspector {
       return;
     terminated_ = false;
     running_nested_loop_ = true;
+    agent_->DispatchMessages();
     do {
       {
         Mutex::ScopedLock scoped_lock(agent_->pause_lock_);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

If user during stepping make some actions (e.g. stepOver native call)
that requests program break and disconnect DevTools frontend then
AgentImpl won't be disconnected until other message from frontend.

The root of issue:
1. Inspector requests program break.
2. User requests disconnect (e.g. refresh page with DevTools frontend).
3. On program break V8Inspector call runMessageLoopOnPause on
V8NodeInspector.
4. Message loop will wait until next message from frontend.
5. After message Agent will be disconnected.
We need to ignore runMessageLoopOnPause on step 3 during disconnecting.