### PR TITLE
v6.x backport of 'latin1' encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ ADDONS_BINDING_GYPS := \
 
 ADDONS_BINDING_SOURCES := \
 	$(filter-out test/addons/??_*/*.cc, $(wildcard test/addons/*/*.cc)) \
-	$(filter-out test/addons/??_*/*.h, $(wildcard test/addons/*/*.h)) \
+	$(filter-out test/addons/??_*/*.h, $(wildcard test/addons/*/*.h))
 
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
 # Depends on node-gyp package.json so that build-addons is (re)executed when

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -165,11 +165,21 @@ The character encodings currently supported by Node.js include:
   this encoding will also correctly accept "URL and Filename Safe Alphabet" as
   specified in [RFC 4648, Section 5].
 
-* `'binary'` - A way of encoding the buffer into a one-byte (`latin-1`)
-  encoded string. The string `'latin-1'` is not supported. Instead, pass
-  `'binary'` to use `'latin-1'` encoding.
+* `'latin1'` - A way of encoding the buffer into a one-byte encoded string
+  (as defined by the IANA in [RFC1345](https://tools.ietf.org/html/rfc1345),
+  page 63, to be the Latin-1 supplement block and C0/C1 control codes).
+
+* `'binary'` - (deprecated) A way of encoding the buffer into a one-byte
+  (`latin1`) encoded string.
 
 * `'hex'` - Encode each byte as two hexadecimal characters.
+
+_Note_: Today's browsers follow the [WHATWG
+spec](https://encoding.spec.whatwg.org/) that aliases both `latin1` and
+`iso-8859-1` to `win-1252`. Meaning, while doing something like `http.get()`,
+if the returned charset is one of those listed in the WHATWG spec it's possible
+that the server actually returned `win-1252` encoded data, and using `latin1`
+encoding may incorrectly decode the graphical characters.
 
 ## Buffers and TypedArray
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -169,8 +169,7 @@ The character encodings currently supported by Node.js include:
   (as defined by the IANA in [RFC1345](https://tools.ietf.org/html/rfc1345),
   page 63, to be the Latin-1 supplement block and C0/C1 control codes).
 
-* `'binary'` - (deprecated) A way of encoding the buffer into a one-byte
-  (`latin1`) encoded string.
+* `'binary'` - Alias for `latin1`.
 
 * `'hex'` - Encode each byte as two hexadecimal characters.
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -160,7 +160,7 @@ console.log(encrypted);
 ### cipher.final([output_encoding])
 
 Returns any remaining enciphered contents. If `output_encoding`
-parameter is one of `'binary'`, `'base64'` or `'hex'`, a string is returned.
+parameter is one of `'latin1'`, `'base64'` or `'hex'`, a string is returned.
 If an `output_encoding` is not provided, a [`Buffer`][] is returned.
 
 Once the `cipher.final()` method has been called, the `Cipher` object can no
@@ -198,13 +198,13 @@ The `cipher.setAutoPadding()` method must be called before [`cipher.final()`][].
 ### cipher.update(data[, input_encoding][, output_encoding])
 
 Updates the cipher with `data`. If the `input_encoding` argument is given,
-it's value must be one of `'utf8'`, `'ascii'`, or `'binary'` and the `data`
+it's value must be one of `'utf8'`, `'ascii'`, or `'latin1'` and the `data`
 argument is a string using the specified encoding. If the `input_encoding`
 argument is not given, `data` must be a [`Buffer`][]. If `data` is a
 [`Buffer`][] then `input_encoding` is ignored.
 
 The `output_encoding` specifies the output format of the enciphered
-data, and can be `'binary'`, `'base64'` or `'hex'`. If the `output_encoding`
+data, and can be `'latin1'`, `'base64'` or `'hex'`. If the `output_encoding`
 is specified, a string using the specified encoding is returned. If no
 `output_encoding` is provided, a [`Buffer`][] is returned.
 
@@ -277,7 +277,7 @@ console.log(decrypted);
 ### decipher.final([output_encoding])
 
 Returns any remaining deciphered contents. If `output_encoding`
-parameter is one of `'binary'`, `'base64'` or `'hex'`, a string is returned.
+parameter is one of `'latin1'`, `'base64'` or `'hex'`, a string is returned.
 If an `output_encoding` is not provided, a [`Buffer`][] is returned.
 
 Once the `decipher.final()` method has been called, the `Decipher` object can
@@ -313,13 +313,13 @@ The `decipher.setAutoPadding()` method must be called before
 ### decipher.update(data[, input_encoding][, output_encoding])
 
 Updates the decipher with `data`. If the `input_encoding` argument is given,
-it's value must be one of `'binary'`, `'base64'`, or `'hex'` and the `data`
+it's value must be one of `'latin1'`, `'base64'`, or `'hex'` and the `data`
 argument is a string using the specified encoding. If the `input_encoding`
 argument is not given, `data` must be a [`Buffer`][]. If `data` is a
 [`Buffer`][] then `input_encoding` is ignored.
 
 The `output_encoding` specifies the output format of the enciphered
-data, and can be `'binary'`, `'ascii'` or `'utf8'`. If the `output_encoding`
+data, and can be `'latin1'`, `'ascii'` or `'utf8'`. If the `output_encoding`
 is specified, a string using the specified encoding is returned. If no
 `output_encoding` is provided, a [`Buffer`][] is returned.
 
@@ -361,7 +361,7 @@ Computes the shared secret using `other_public_key` as the other
 party's public key and returns the computed shared secret. The supplied
 key is interpreted using the specified `input_encoding`, and secret is
 encoded using specified `output_encoding`. Encodings can be
-`'binary'`, `'hex'`, or `'base64'`. If the `input_encoding` is not
+`'latin1'`, `'hex'`, or `'base64'`. If the `input_encoding` is not
 provided, `other_public_key` is expected to be a [`Buffer`][].
 
 If `output_encoding` is given a string is returned; otherwise, a
@@ -371,45 +371,45 @@ If `output_encoding` is given a string is returned; otherwise, a
 
 Generates private and public Diffie-Hellman key values, and returns
 the public key in the specified `encoding`. This key should be
-transferred to the other party. Encoding can be `'binary'`, `'hex'`,
+transferred to the other party. Encoding can be `'latin1'`, `'hex'`,
 or `'base64'`. If `encoding` is provided a string is returned; otherwise a
 [`Buffer`][] is returned.
 
 ### diffieHellman.getGenerator([encoding])
 
 Returns the Diffie-Hellman generator in the specified `encoding`, which can
-be `'binary'`, `'hex'`, or `'base64'`. If  `encoding` is provided a string is
+be `'latin1'`, `'hex'`, or `'base64'`. If  `encoding` is provided a string is
 returned; otherwise a [`Buffer`][] is returned.
 
 ### diffieHellman.getPrime([encoding])
 
 Returns the Diffie-Hellman prime in the specified `encoding`, which can
-be `'binary'`, `'hex'`, or `'base64'`. If `encoding` is provided a string is
+be `'latin1'`, `'hex'`, or `'base64'`. If `encoding` is provided a string is
 returned; otherwise a [`Buffer`][] is returned.
 
 ### diffieHellman.getPrivateKey([encoding])
 
 Returns the Diffie-Hellman private key in the specified `encoding`,
-which can be `'binary'`, `'hex'`, or `'base64'`. If `encoding` is provided a
+which can be `'latin1'`, `'hex'`, or `'base64'`. If `encoding` is provided a
 string is returned; otherwise a [`Buffer`][] is returned.
 
 ### diffieHellman.getPublicKey([encoding])
 
 Returns the Diffie-Hellman public key in the specified `encoding`, which
-can be `'binary'`, `'hex'`, or `'base64'`. If `encoding` is provided a
+can be `'latin1'`, `'hex'`, or `'base64'`. If `encoding` is provided a
 string is returned; otherwise a [`Buffer`][] is returned.
 
 ### diffieHellman.setPrivateKey(private_key[, encoding])
 
 Sets the Diffie-Hellman private key. If the `encoding` argument is provided
-and is either `'binary'`, `'hex'`, or `'base64'`, `private_key` is expected
+and is either `'latin1'`, `'hex'`, or `'base64'`, `private_key` is expected
 to be a string. If no `encoding` is provided, `private_key` is expected
 to be a [`Buffer`][].
 
 ### diffieHellman.setPublicKey(public_key[, encoding])
 
 Sets the Diffie-Hellman public key. If the `encoding` argument is provided
-and is either `'binary'`, `'hex'` or `'base64'`, `public_key` is expected
+and is either `'latin1'`, `'hex'` or `'base64'`, `public_key` is expected
 to be a string. If no `encoding` is provided, `public_key` is expected
 to be a [`Buffer`][].
 
@@ -460,7 +460,7 @@ Computes the shared secret using `other_public_key` as the other
 party's public key and returns the computed shared secret. The supplied
 key is interpreted using specified `input_encoding`, and the returned secret
 is encoded using the specified `output_encoding`. Encodings can be
-`'binary'`, `'hex'`, or `'base64'`. If the `input_encoding` is not
+`'latin1'`, `'hex'`, or `'base64'`. If the `input_encoding` is not
 provided, `other_public_key` is expected to be a [`Buffer`][].
 
 If `output_encoding` is given a string will be returned; otherwise a
@@ -476,14 +476,14 @@ The `format` arguments specifies point encoding and can be `'compressed'`,
 `'uncompressed'`, or `'hybrid'`. If `format` is not specified, the point will
 be returned in `'uncompressed'` format.
 
-The `encoding` argument can be `'binary'`, `'hex'`, or `'base64'`. If
+The `encoding` argument can be `'latin1'`, `'hex'`, or `'base64'`. If
 `encoding` is provided a string is returned; otherwise a [`Buffer`][]
 is returned.
 
 ### ecdh.getPrivateKey([encoding])
 
 Returns the EC Diffie-Hellman private key in the specified `encoding`,
-which can be `'binary'`, `'hex'`, or `'base64'`. If `encoding` is provided
+which can be `'latin1'`, `'hex'`, or `'base64'`. If `encoding` is provided
 a string is returned; otherwise a [`Buffer`][] is returned.
 
 ### ecdh.getPublicKey([encoding[, format]])
@@ -495,13 +495,13 @@ The `format` argument specifies point encoding and can be `'compressed'`,
 `'uncompressed'`, or `'hybrid'`. If `format` is not specified the point will be
 returned in `'uncompressed'` format.
 
-The `encoding` argument can be `'binary'`, `'hex'`, or `'base64'`. If
+The `encoding` argument can be `'latin1'`, `'hex'`, or `'base64'`. If
 `encoding` is specified, a string is returned; otherwise a [`Buffer`][] is
 returned.
 
 ### ecdh.setPrivateKey(private_key[, encoding])
 
-Sets the EC Diffie-Hellman private key. The `encoding` can be `'binary'`,
+Sets the EC Diffie-Hellman private key. The `encoding` can be `'latin1'`,
 `'hex'` or `'base64'`. If `encoding` is provided, `private_key` is expected
 to be a string; otherwise `private_key` is expected to be a [`Buffer`][]. If
 `private_key` is not valid for the curve specified when the `ECDH` object was
@@ -512,7 +512,7 @@ public point (key) is also generated and set in the ECDH object.
 
     Stability: 0 - Deprecated
 
-Sets the EC Diffie-Hellman public key. Key encoding can be `'binary'`,
+Sets the EC Diffie-Hellman public key. Key encoding can be `'latin1'`,
 `'hex'` or `'base64'`. If `encoding` is provided `public_key` is expected to
 be a string; otherwise a [`Buffer`][] is expected.
 
@@ -604,7 +604,7 @@ console.log(hash.digest('hex'));
 ### hash.digest([encoding])
 
 Calculates the digest of all of the data passed to be hashed (using the
-[`hash.update()`][] method). The `encoding` can be `'hex'`, `'binary'` or
+[`hash.update()`][] method). The `encoding` can be `'hex'`, `'latin1'` or
 `'base64'`. If `encoding` is provided a string will be returned; otherwise
 a [`Buffer`][] is returned.
 
@@ -615,7 +615,7 @@ called. Multiple calls will cause an error to be thrown.
 
 Updates the hash content with the given `data`, the encoding of which
 is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
-`'binary'`. If `encoding` is not provided, and the `data` is a string, an
+`'latin1'`. If `encoding` is not provided, and the `data` is a string, an
 encoding of `'utf8'` is enforced. If `data` is a [`Buffer`][] then
 `input_encoding` is ignored.
 
@@ -678,7 +678,7 @@ console.log(hmac.digest('hex'));
 ### hmac.digest([encoding])
 
 Calculates the HMAC digest of all of the data passed using [`hmac.update()`][].
-The `encoding` can be `'hex'`, `'binary'` or `'base64'`. If `encoding` is
+The `encoding` can be `'hex'`, `'latin1'` or `'base64'`. If `encoding` is
 provided a string is returned; otherwise a [`Buffer`][] is returned;
 
 The `Hmac` object can not be used again after `hmac.digest()` has been
@@ -688,7 +688,7 @@ called. Multiple calls to `hmac.digest()` will result in an error being thrown.
 
 Updates the `Hmac` content with the given `data`, the encoding of which
 is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
-`'binary'`. If `encoding` is not provided, and the `data` is a string, an
+`'latin1'`. If `encoding` is not provided, and the `data` is a string, an
 encoding of `'utf8'` is enforced. If `data` is a [`Buffer`][] then
 `input_encoding` is ignored.
 
@@ -768,7 +768,7 @@ object, it is interpreted as a hash containing two properties:
 * `key` : {String} - PEM encoded private key
 * `passphrase` : {String} - passphrase for the private key
 
-The `output_format` can specify one of `'binary'`, `'hex'` or `'base64'`. If
+The `output_format` can specify one of `'latin1'`, `'hex'` or `'base64'`. If
 `output_format` is provided a string is returned; otherwise a [`Buffer`][] is
 returned.
 
@@ -779,7 +779,7 @@ called. Multiple calls to `sign.sign()` will result in an error being thrown.
 
 Updates the `Sign` content with the given `data`, the encoding of which
 is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
-`'binary'`. If `encoding` is not provided, and the `data` is a string, an
+`'latin1'`. If `encoding` is not provided, and the `data` is a string, an
 encoding of `'utf8'` is enforced. If `data` is a [`Buffer`][] then
 `input_encoding` is ignored.
 
@@ -831,7 +831,7 @@ console.log(verify.verify(public_key, signature));
 
 Updates the `Verify` content with the given `data`, the encoding of which
 is given in `input_encoding` and can be `'utf8'`, `'ascii'` or
-`'binary'`. If `encoding` is not provided, and the `data` is a string, an
+`'latin1'`. If `encoding` is not provided, and the `data` is a string, an
 encoding of `'utf8'` is enforced. If `data` is a [`Buffer`][] then
 `input_encoding` is ignored.
 
@@ -843,7 +843,7 @@ Verifies the provided data using the given `object` and `signature`.
 The `object` argument is a string containing a PEM encoded object, which can be
 one an RSA public key, a DSA public key, or an X.509 certificate.
 The `signature` argument is the previously calculated signature for the data, in
-the `signature_format` which can be `'binary'`, `'hex'` or `'base64'`.
+the `signature_format` which can be `'latin1'`, `'hex'` or `'base64'`.
 If a `signature_format` is specified, the `signature` is expected to be a
 string; otherwise `signature` is expected to be a [`Buffer`][].
 
@@ -869,7 +869,7 @@ or [buffers][`Buffer`]. The default value is `'buffer'`, which makes methods
 default to [`Buffer`][] objects.
 
 The `crypto.DEFAULT_ENCODING` mechanism is provided for backwards compatibility
-with legacy programs that expect `'binary'` to be the default encoding.
+with legacy programs that expect `'latin1'` to be the default encoding.
 
 New applications should expect the default to be `'buffer'`. This property may
 become deprecated in a future Node.js release.
@@ -889,7 +889,7 @@ recent OpenSSL releases, `openssl list-cipher-algorithms` will display the
 available cipher algorithms.
 
 The `password` is used to derive the cipher key and initialization vector (IV).
-The value must be either a `'binary'` encoded string or a [`Buffer`][].
+The value must be either a `'latin1'` encoded string or a [`Buffer`][].
 
 The implementation of `crypto.createCipher()` derives keys using the OpenSSL
 function [`EVP_BytesToKey`][] with the digest algorithm set to MD5, one
@@ -913,7 +913,7 @@ recent OpenSSL releases, `openssl list-cipher-algorithms` will display the
 available cipher algorithms.
 
 The `key` is the raw key used by the `algorithm` and `iv` is an
-[initialization vector][]. Both arguments must be `'binary'` encoded strings or
+[initialization vector][]. Both arguments must be `'latin1'` encoded strings or
 [buffers][`Buffer`].
 
 ### crypto.createCredentials(details)
@@ -968,7 +968,7 @@ recent OpenSSL releases, `openssl list-cipher-algorithms` will display the
 available cipher algorithms.
 
 The `key` is the raw key used by the `algorithm` and `iv` is an
-[initialization vector][]. Both arguments must be `'binary'` encoded strings or
+[initialization vector][]. Both arguments must be `'latin1'` encoded strings or
 [buffers][`Buffer`].
 
 ### crypto.createDiffieHellman(prime[, prime_encoding][, generator][, generator_encoding])
@@ -979,7 +979,7 @@ optional specific `generator`.
 The `generator` argument can be a number, string, or [`Buffer`][]. If
 `generator` is not specified, the value `2` is used.
 
-The `prime_encoding` and `generator_encoding` arguments can be `'binary'`,
+The `prime_encoding` and `generator_encoding` arguments can be `'latin1'`,
 `'hex'`, or `'base64'`.
 
 If `prime_encoding` is specified, `prime` is expected to be a string; otherwise
@@ -1345,7 +1345,7 @@ unified Stream API, and before there were [`Buffer`][] objects for handling
 binary data. As such, the many of the `crypto` defined classes have methods not
 typically found on other Node.js classes that implement the [streams][stream]
 API (e.g. `update()`, `final()`, or `digest()`). Also, many methods accepted
-and returned `'binary'` encoded strings by default rather than Buffers. This
+and returned `'latin1'` encoded strings by default rather than Buffers. This
 default was changed after Node.js v0.8 to use [`Buffer`][] objects by default
 instead.
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -130,7 +130,7 @@ OutgoingMessage.prototype._send = function(data, encoding, callback) {
       data = this._header + data;
     } else {
       this.output.unshift(this._header);
-      this.outputEncodings.unshift('binary');
+      this.outputEncodings.unshift('latin1');
       this.outputCallbacks.unshift(null);
       this.outputSize += this._header.length;
       if (typeof this._onPendingData === 'function')
@@ -453,7 +453,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
     if (typeof chunk === 'string' &&
         encoding !== 'hex' &&
         encoding !== 'base64' &&
-        encoding !== 'binary') {
+        encoding !== 'latin1') {
       len = Buffer.byteLength(chunk, encoding);
       chunk = len.toString(16) + CRLF + chunk + CRLF;
       ret = this._send(chunk, encoding, callback);
@@ -468,7 +468,7 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
         this.connection.cork();
         process.nextTick(connectionCorkNT, this.connection);
       }
-      this._send(len.toString(16), 'binary', null);
+      this._send(len.toString(16), 'latin1', null);
       this._send(crlf_buf, null, null);
       this._send(chunk, encoding, null);
       ret = this._send(crlf_buf, null, callback);
@@ -581,10 +581,10 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   };
 
   if (this._hasBody && this.chunkedEncoding) {
-    ret = this._send('0\r\n' + this._trailer + '\r\n', 'binary', finish);
+    ret = this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
   } else {
     // Force a flush, HACK.
-    ret = this._send('', 'binary', finish);
+    ret = this._send('', 'latin1', finish);
   }
 
   if (this.connection && data)

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -608,7 +608,7 @@ TLSSocket.prototype.setServername = function(name) {
 
 TLSSocket.prototype.setSession = function(session) {
   if (typeof session === 'string')
-    session = Buffer.from(session, 'binary');
+    session = Buffer.from(session, 'latin1');
   this._handle.setSession(session);
 };
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -289,6 +289,7 @@ Buffer.isEncoding = function(encoding) {
       case 'utf8':
       case 'utf-8':
       case 'ascii':
+      case 'latin1':
       case 'binary':
       case 'base64':
       case 'ucs2':
@@ -366,6 +367,7 @@ function byteLength(string, encoding) {
   for (;;) {
     switch (encoding) {
       case 'ascii':
+      case 'latin1':
       case 'binary':
         return len;
 
@@ -467,8 +469,9 @@ function slowToString(encoding, start, end) {
       case 'ascii':
         return this.asciiSlice(start, end);
 
+      case 'latin1':
       case 'binary':
-        return this.binarySlice(start, end);
+        return this.latin1Slice(start, end);
 
       case 'base64':
         return this.base64Slice(start, end);
@@ -616,6 +619,7 @@ function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
       case 'ucs-2':
       case 'utf16le':
       case 'utf-16le':
+      case 'latin1':
       case 'binary':
         return binding.indexOfString(buffer, val, byteOffset, encoding, dir);
 
@@ -759,8 +763,9 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       case 'ascii':
         return this.asciiWrite(string, offset, length);
 
+      case 'latin1':
       case 'binary':
-        return this.binaryWrite(string, offset, length);
+        return this.latin1Write(string, offset, length);
 
       case 'base64':
         // Warning: maxLength not taken into account in base64Write

--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -22,7 +22,7 @@ util.inherits(LazyTransform, stream.Transform);
     get: function() {
       stream.Transform.call(this, this._options);
       this._writableState.decodeStrings = false;
-      this._writableState.defaultEncoding = 'binary';
+      this._writableState.defaultEncoding = 'latin1';
       return this[prop];
     },
     set: function(val) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -726,8 +726,9 @@ Socket.prototype._write = function(data, encoding, cb) {
 
 function createWriteReq(req, handle, data, encoding) {
   switch (encoding) {
+    case 'latin1':
     case 'binary':
-      return handle.writeBinaryString(req, data);
+      return handle.writeLatin1String(req, data);
 
     case 'buffer':
       return handle.writeBuffer(req, data);

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -19,6 +19,7 @@ function normalizeEncoding(enc) {
         return 'utf16le';
       case 'base64':
       case 'ascii':
+      case 'latin1':
       case 'binary':
       case 'hex':
         return enc;
@@ -272,7 +273,7 @@ function base64End(buf) {
   return r;
 }
 
-// Pass bytes on through for single-byte encodings (e.g. ascii, binary, hex)
+// Pass bytes on through for single-byte encodings (e.g. ascii, latin1, hex)
 function simpleWrite(buf) {
   return buf.toString(this.encoding);
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1416,6 +1416,7 @@ enum encoding ParseEncoding(const char* encoding,
         if (strncmp(encoding + 2, "tin1", 4) == 0)
           return LATIN1;
       }
+      break;
     case 'b':
       // binary
       if (encoding[1] == 'i') {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1454,7 +1454,7 @@ enum encoding ParseEncoding(const char* encoding,
   } else if (StringEqualNoCase(encoding, "latin1")) {
     return LATIN1;
   } else if (StringEqualNoCase(encoding, "binary")) {
-    return BINARY;
+    return LATIN1;  // BINARY is a deprecated alias of LATIN1.
   } else if (StringEqualNoCase(encoding, "buffer")) {
     return BUFFER;
   } else if (StringEqualNoCase(encoding, "hex")) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1493,13 +1493,6 @@ ssize_t DecodeBytes(Isolate* isolate,
                     enum encoding encoding) {
   HandleScope scope(isolate);
 
-  if (val->IsArray()) {
-    fprintf(stderr, "'raw' encoding (array of integers) has been removed. "
-                    "Use 'latin1'.\n");
-    UNREACHABLE();
-    return -1;
-  }
-
   return StringBytes::Size(isolate, val, encoding);
 }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1410,11 +1410,17 @@ enum encoding ParseEncoding(const char* encoding,
           return UCS2;
       }
       break;
+    case 'l':
+      // latin1
+      if (encoding[1] == 'a') {
+        if (strncmp(encoding + 2, "tin1", 4) == 0)
+          return LATIN1;
+      }
     case 'b':
       // binary
       if (encoding[1] == 'i') {
         if (strncmp(encoding + 2, "nary", 4) == 0)
-          return BINARY;
+          return LATIN1;
 
       // buffer
       } else if (encoding[1] == 'u') {
@@ -1444,6 +1450,8 @@ enum encoding ParseEncoding(const char* encoding,
     return UCS2;
   } else if (StringEqualNoCase(encoding, "utf-16le")) {
     return UCS2;
+  } else if (StringEqualNoCase(encoding, "latin1")) {
+    return LATIN1;
   } else if (StringEqualNoCase(encoding, "binary")) {
     return BINARY;
   } else if (StringEqualNoCase(encoding, "buffer")) {
@@ -1487,7 +1495,7 @@ ssize_t DecodeBytes(Isolate* isolate,
 
   if (val->IsArray()) {
     fprintf(stderr, "'raw' encoding (array of integers) has been removed. "
-                    "Use 'binary'.\n");
+                    "Use 'latin1'.\n");
     UNREACHABLE();
     return -1;
   }

--- a/src/node.h
+++ b/src/node.h
@@ -284,7 +284,9 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
 }
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 
-enum encoding {ASCII, UTF8, BASE64, UCS2, LATIN1, BINARY, HEX, BUFFER};
+// BINARY is a deprecated alias of LATIN1.
+enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER, LATIN1 = BINARY};
+
 NODE_EXTERN enum encoding ParseEncoding(
     v8::Isolate* isolate,
     v8::Local<v8::Value> encoding_v,

--- a/src/node.h
+++ b/src/node.h
@@ -284,15 +284,15 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
 }
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 
-enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
+enum encoding {ASCII, UTF8, BASE64, UCS2, LATIN1, BINARY, HEX, BUFFER};
 NODE_EXTERN enum encoding ParseEncoding(
     v8::Isolate* isolate,
     v8::Local<v8::Value> encoding_v,
-    enum encoding default_encoding = BINARY);
+    enum encoding default_encoding = LATIN1);
 NODE_DEPRECATED("Use ParseEncoding(isolate, ...)",
                 inline enum encoding ParseEncoding(
       v8::Local<v8::Value> encoding_v,
-      enum encoding default_encoding = BINARY) {
+      enum encoding default_encoding = LATIN1) {
   return ParseEncoding(v8::Isolate::GetCurrent(), encoding_v, default_encoding);
 })
 
@@ -308,7 +308,7 @@ NODE_DEPRECATED("Use FatalException(isolate, ...)",
 NODE_EXTERN v8::Local<v8::Value> Encode(v8::Isolate* isolate,
                                         const char* buf,
                                         size_t len,
-                                        enum encoding encoding = BINARY);
+                                        enum encoding encoding = LATIN1);
 
 // The input buffer should be in host endianness.
 NODE_EXTERN v8::Local<v8::Value> Encode(v8::Isolate* isolate,
@@ -319,7 +319,7 @@ NODE_DEPRECATED("Use Encode(isolate, ...)",
                 inline v8::Local<v8::Value> Encode(
     const void* buf,
     size_t len,
-    enum encoding encoding = BINARY) {
+    enum encoding encoding = LATIN1) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   if (encoding == UCS2) {
     assert(reinterpret_cast<uintptr_t>(buf) % sizeof(uint16_t) == 0 &&
@@ -333,11 +333,11 @@ NODE_DEPRECATED("Use Encode(isolate, ...)",
 // Returns -1 if the handle was not valid for decoding
 NODE_EXTERN ssize_t DecodeBytes(v8::Isolate* isolate,
                                 v8::Local<v8::Value>,
-                                enum encoding encoding = BINARY);
+                                enum encoding encoding = LATIN1);
 NODE_DEPRECATED("Use DecodeBytes(isolate, ...)",
                 inline ssize_t DecodeBytes(
     v8::Local<v8::Value> val,
-    enum encoding encoding = BINARY) {
+    enum encoding encoding = LATIN1) {
   return DecodeBytes(v8::Isolate::GetCurrent(), val, encoding);
 })
 
@@ -346,12 +346,12 @@ NODE_EXTERN ssize_t DecodeWrite(v8::Isolate* isolate,
                                 char* buf,
                                 size_t buflen,
                                 v8::Local<v8::Value>,
-                                enum encoding encoding = BINARY);
+                                enum encoding encoding = LATIN1);
 NODE_DEPRECATED("Use DecodeWrite(isolate, ...)",
                 inline ssize_t DecodeWrite(char* buf,
                                            size_t buflen,
                                            v8::Local<v8::Value> val,
-                                           enum encoding encoding = BINARY) {
+                                           enum encoding encoding = LATIN1) {
   return DecodeWrite(v8::Isolate::GetCurrent(), buf, buflen, val, encoding);
 })
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -517,8 +517,8 @@ void StringSlice<UCS2>(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void BinarySlice(const FunctionCallbackInfo<Value>& args) {
-  StringSlice<BINARY>(args);
+void Latin1Slice(const FunctionCallbackInfo<Value>& args) {
+  StringSlice<LATIN1>(args);
 }
 
 
@@ -718,8 +718,8 @@ void Base64Write(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void BinaryWrite(const FunctionCallbackInfo<Value>& args) {
-  StringWrite<BINARY>(args);
+void Latin1Write(const FunctionCallbackInfo<Value>& args) {
+  StringWrite<LATIN1>(args);
 }
 
 
@@ -1061,7 +1061,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
                           needle_length,
                           offset,
                           is_forward);
-  } else if (enc == BINARY) {
+  } else if (enc == LATIN1) {
     uint8_t* needle_data = static_cast<uint8_t*>(malloc(needle_length));
     if (needle_data == nullptr) {
       return args.GetReturnValue().Set(-1);
@@ -1266,14 +1266,14 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 
   env->SetMethod(proto, "asciiSlice", AsciiSlice);
   env->SetMethod(proto, "base64Slice", Base64Slice);
-  env->SetMethod(proto, "binarySlice", BinarySlice);
+  env->SetMethod(proto, "latin1Slice", Latin1Slice);
   env->SetMethod(proto, "hexSlice", HexSlice);
   env->SetMethod(proto, "ucs2Slice", Ucs2Slice);
   env->SetMethod(proto, "utf8Slice", Utf8Slice);
 
   env->SetMethod(proto, "asciiWrite", AsciiWrite);
   env->SetMethod(proto, "base64Write", Base64Write);
-  env->SetMethod(proto, "binaryWrite", BinaryWrite);
+  env->SetMethod(proto, "latin1Write", Latin1Write);
   env->SetMethod(proto, "hexWrite", HexWrite);
   env->SetMethod(proto, "ucs2Write", Ucs2Write);
   env->SetMethod(proto, "utf8Write", Utf8Write);

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -71,8 +71,8 @@ void StreamBase::AddMethods(Environment* env,
                       "writeUcs2String",
                       JSMethod<Base, &StreamBase::WriteString<UCS2> >);
   env->SetProtoMethod(t,
-                      "writeBinaryString",
-                      JSMethod<Base, &StreamBase::WriteString<BINARY> >);
+                      "writeLatin1String",
+                      JSMethod<Base, &StreamBase::WriteString<LATIN1> >);
 }
 
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -33,7 +33,7 @@ template int StreamBase::WriteString<UTF8>(
     const FunctionCallbackInfo<Value>& args);
 template int StreamBase::WriteString<UCS2>(
     const FunctionCallbackInfo<Value>& args);
-template int StreamBase::WriteString<BINARY>(
+template int StreamBase::WriteString<LATIN1>(
     const FunctionCallbackInfo<Value>& args);
 
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -282,6 +282,7 @@ size_t StringBytes::Write(Isolate* isolate,
 
   switch (encoding) {
     case ASCII:
+    case LATIN1:
     case BINARY:
       if (is_extern && str->IsOneByte()) {
         memcpy(buf, data, nbytes);
@@ -387,15 +388,17 @@ size_t StringBytes::StorageSize(Isolate* isolate,
   size_t data_size = 0;
   bool is_buffer = Buffer::HasInstance(val);
 
-  if (is_buffer && (encoding == BUFFER || encoding == BINARY)) {
+  if (is_buffer &&
+      (encoding == BUFFER || encoding == BINARY || encoding == LATIN1)) {
     return Buffer::Length(val);
   }
 
   Local<String> str = val->ToString(isolate);
 
   switch (encoding) {
-    case BINARY:
     case ASCII:
+    case LATIN1:
+    case BINARY:
       data_size = str->Length();
       break;
 
@@ -436,7 +439,8 @@ size_t StringBytes::Size(Isolate* isolate,
   size_t data_size = 0;
   bool is_buffer = Buffer::HasInstance(val);
 
-  if (is_buffer && (encoding == BUFFER || encoding == BINARY))
+  if (is_buffer &&
+      (encoding == BUFFER || encoding == BINARY || encoding == LATIN1))
     return Buffer::Length(val);
 
   const char* data;
@@ -446,8 +450,9 @@ size_t StringBytes::Size(Isolate* isolate,
   Local<String> str = val->ToString(isolate);
 
   switch (encoding) {
-    case BINARY:
     case ASCII:
+    case LATIN1:
+    case BINARY:
       data_size = str->Length();
       break;
 
@@ -650,6 +655,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
                                 buflen);
       break;
 
+    case LATIN1:
     case BINARY:
       if (buflen < EXTERN_APEX)
         val = OneByteString(isolate, buf, buflen);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -283,7 +283,6 @@ size_t StringBytes::Write(Isolate* isolate,
   switch (encoding) {
     case ASCII:
     case LATIN1:
-    case BINARY:
       if (is_extern && str->IsOneByte()) {
         memcpy(buf, data, nbytes);
       } else {
@@ -388,8 +387,7 @@ size_t StringBytes::StorageSize(Isolate* isolate,
   size_t data_size = 0;
   bool is_buffer = Buffer::HasInstance(val);
 
-  if (is_buffer &&
-      (encoding == BUFFER || encoding == BINARY || encoding == LATIN1)) {
+  if (is_buffer && (encoding == BUFFER || encoding == LATIN1)) {
     return Buffer::Length(val);
   }
 
@@ -398,7 +396,6 @@ size_t StringBytes::StorageSize(Isolate* isolate,
   switch (encoding) {
     case ASCII:
     case LATIN1:
-    case BINARY:
       data_size = str->Length();
       break;
 
@@ -439,8 +436,7 @@ size_t StringBytes::Size(Isolate* isolate,
   size_t data_size = 0;
   bool is_buffer = Buffer::HasInstance(val);
 
-  if (is_buffer &&
-      (encoding == BUFFER || encoding == BINARY || encoding == LATIN1))
+  if (is_buffer && (encoding == BUFFER || encoding == LATIN1))
     return Buffer::Length(val);
 
   const char* data;
@@ -452,7 +448,6 @@ size_t StringBytes::Size(Isolate* isolate,
   switch (encoding) {
     case ASCII:
     case LATIN1:
-    case BINARY:
       data_size = str->Length();
       break;
 
@@ -656,7 +651,6 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
       break;
 
     case LATIN1:
-    case BINARY:
       if (buflen < EXTERN_APEX)
         val = OneByteString(isolate, buf, buflen);
       else

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -12,6 +12,8 @@ namespace {
   V(UCS2)               \
   V(UTF8)               \
 
+static_assert(node::BINARY == node::LATIN1, "BINARY == LATIN1");
+
 void ParseEncoding(const v8::FunctionCallbackInfo<v8::Value>& args) {
   const node::encoding encoding =
       node::ParseEncoding(args.GetIsolate(), args[0],

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -1,0 +1,36 @@
+#include "node.h"
+#include "v8.h"
+
+namespace {
+
+#define ENCODING_MAP(V) \
+  V(ASCII)              \
+  V(BASE64)             \
+  V(BUFFER)             \
+  V(HEX)                \
+  V(LATIN1)             \
+  V(UCS2)               \
+  V(UTF8)               \
+
+void ParseEncoding(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  const node::encoding encoding =
+      node::ParseEncoding(args.GetIsolate(), args[0],
+                          static_cast<node::encoding>(-1));
+  const char* encoding_name = "UNKNOWN";
+#define V(name) if (encoding == node::name) encoding_name = #name;
+  ENCODING_MAP(V)
+#undef V
+  auto encoding_string =
+      v8::String::NewFromUtf8(args.GetIsolate(), encoding_name,
+                              v8::NewStringType::kNormal)
+      .ToLocalChecked();
+  args.GetReturnValue().Set(encoding_string);
+}
+
+void Initialize(v8::Local<v8::Object> target) {
+  NODE_SET_METHOD(target, "parseEncoding", ParseEncoding);
+}
+
+}  // anonymous namespace
+
+NODE_MODULE(binding, Initialize);

--- a/test/addons/parse-encoding/binding.gyp
+++ b/test/addons/parse-encoding/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../../common');
+const assert = require('assert');
+const { parseEncoding } = require('./build/Release/binding');
+
+assert.strictEqual(parseEncoding(''), 'UNKNOWN');
+
+assert.strictEqual(parseEncoding('ascii'), 'ASCII');
+assert.strictEqual(parseEncoding('base64'), 'BASE64');
+assert.strictEqual(parseEncoding('binary'), 'LATIN1');
+assert.strictEqual(parseEncoding('buffer'), 'BUFFER');
+assert.strictEqual(parseEncoding('hex'), 'HEX');
+assert.strictEqual(parseEncoding('latin1'), 'LATIN1');
+assert.strictEqual(parseEncoding('ucs2'), 'UCS2');
+assert.strictEqual(parseEncoding('utf8'), 'UTF8');
+
+assert.strictEqual(parseEncoding('linary'), 'UNKNOWN');
+assert.strictEqual(parseEncoding('luffer'), 'UNKNOWN');

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
@@ -29,5 +29,5 @@ if (!binding.ensureAllocation(2 * kStringMaxLength)) {
   return;
 }
 
-const maxString = buf.toString('binary');
+const maxString = buf.toString('latin1');
 assert.equal(maxString.length, kStringMaxLength);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -30,13 +30,13 @@ if (!binding.ensureAllocation(2 * kStringMaxLength)) {
 }
 
 assert.throws(function() {
-  buf.toString('binary');
+  buf.toString('latin1');
 }, /"toString\(\)" failed/);
 
-var maxString = buf.toString('binary', 1);
+var maxString = buf.toString('latin1', 1);
 assert.equal(maxString.length, kStringMaxLength);
 // Free the memory early instead of at the end of the next assignment
 maxString = undefined;
 
-maxString = buf.toString('binary', 0, kStringMaxLength);
+maxString = buf.toString('latin1', 0, kStringMaxLength);
 assert.equal(maxString.length, kStringMaxLength);

--- a/test/disabled/tls_server.js
+++ b/test/disabled/tls_server.js
@@ -19,7 +19,7 @@ try {
 var i = 0;
 var server = net.createServer(function(connection) {
   connection.setSecure(credentials);
-  connection.setEncoding('binary');
+  connection.setEncoding('latin1');
 
   connection.on('secure', function() {
     //console.log('Secure');

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -235,7 +235,7 @@ assert.strictEqual('Unknown encoding: invalid', caught_error.message);
 // try to create 0-length buffers
 Buffer.from('');
 Buffer.from('', 'ascii');
-Buffer.from('', 'binary');
+Buffer.from('', 'latin1');
 Buffer.alloc(0);
 Buffer.allocUnsafe(0);
 
@@ -689,7 +689,7 @@ assert.equal(dot.toString('base64'), '//4uAA==');
   for (let i = 0; i < segments.length; ++i) {
     pos += b.write(segments[i], pos, 'base64');
   }
-  assert.equal(b.toString('binary', 0, pos), 'Madness?! This is node.js!');
+  assert.equal(b.toString('latin1', 0, pos), 'Madness?! This is node.js!');
 }
 
 // Regression test for https://github.com/nodejs/node/issues/3496.
@@ -845,13 +845,13 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
   // Binary encoding should write only one byte per character.
   const b = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
   let s = String.fromCharCode(0xffff);
-  b.write(s, 0, 'binary');
+  b.write(s, 0, 'latin1');
   assert.equal(0xff, b[0]);
   assert.equal(0xad, b[1]);
   assert.equal(0xbe, b[2]);
   assert.equal(0xef, b[3]);
   s = String.fromCharCode(0xaaee);
-  b.write(s, 0, 'binary');
+  b.write(s, 0, 'latin1');
   assert.equal(0xee, b[0]);
   assert.equal(0xad, b[1]);
   assert.equal(0xbe, b[2]);
@@ -969,7 +969,7 @@ assert.equal(0, Buffer.from('hello').slice(0, 0).length);
   // test for buffer overrun
   const buf = Buffer.from([0, 0, 0, 0, 0]); // length: 5
   var sub = buf.slice(0, 4);         // length: 4
-  written = sub.write('12345', 'binary');
+  written = sub.write('12345', 'latin1');
   assert.equal(written, 4);
   assert.equal(buf[4], 0);
 }
@@ -992,7 +992,7 @@ assert.equal(Buffer.from('99').length, 2);
 assert.equal(Buffer.from('13.37').length, 5);
 
 // Ensure that the length argument is respected.
-'ascii utf8 hex base64 binary'.split(' ').forEach(function(enc) {
+'ascii utf8 hex base64 latin1'.split(' ').forEach(function(enc) {
   assert.equal(Buffer.allocUnsafe(1).write('aaaaaa', 0, 1, enc), 1);
 });
 
@@ -1011,6 +1011,7 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
   'utf8',
   'utf-8',
   'ascii',
+  'latin1',
   'binary',
   'base64',
   'ucs2',

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -6,9 +6,9 @@ var Buffer = require('buffer').Buffer;
 var SlowBuffer = require('buffer').SlowBuffer;
 
 // coerce values to string
-assert.equal(Buffer.byteLength(32, 'binary'), 2);
+assert.equal(Buffer.byteLength(32, 'latin1'), 2);
 assert.equal(Buffer.byteLength(NaN, 'utf8'), 3);
-assert.equal(Buffer.byteLength({}, 'binary'), 15);
+assert.equal(Buffer.byteLength({}, 'latin1'), 15);
 assert.equal(Buffer.byteLength(), 9);
 
 var buff = new Buffer(10);
@@ -80,6 +80,7 @@ assert.equal(Buffer.byteLength('aaaa==', 'base64'), 3);
 assert.equal(Buffer.byteLength('Il était tué'), 14);
 assert.equal(Buffer.byteLength('Il était tué', 'utf8'), 14);
 assert.equal(Buffer.byteLength('Il était tué', 'ascii'), 12);
+assert.equal(Buffer.byteLength('Il était tué', 'latin1'), 12);
 assert.equal(Buffer.byteLength('Il était tué', 'binary'), 12);
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
   assert.equal(24, Buffer.byteLength('Il était tué', encoding));

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -73,6 +73,27 @@ testBufs('a\u0234b\u0235c\u0236', 4, 1, 'binary');
 testBufs('a\u0234b\u0235c\u0236', 12, 1, 'binary');
 
 
+// LATIN1
+testBufs('abc', 'latin1');
+testBufs('\u0222aa', 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 'latin1');
+testBufs('abc', 4, 'latin1');
+testBufs('abc', 5, 'latin1');
+testBufs('abc', SIZE, 'latin1');
+testBufs('\u0222aa', 2, 'latin1');
+testBufs('\u0222aa', 8, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 4, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 12, 'latin1');
+testBufs('abc', 4, -1, 'latin1');
+testBufs('abc', 4, 1, 'latin1');
+testBufs('abc', 5, 1, 'latin1');
+testBufs('\u0222aa', 2, -1, 'latin1');
+testBufs('\u0222aa', 8, 1, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 4, -1, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 4, 1, 'latin1');
+testBufs('a\u0234b\u0235c\u0236', 12, 1, 'latin1');
+
+
 // UCS2
 testBufs('abc', 'ucs2');
 testBufs('\u0222aa', 'ucs2');

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -102,6 +102,14 @@ assert(
     Buffer.from(b.toString('ascii'), 'ascii')
     .includes(Buffer.from('d', 'ascii'), 0, 'ascii'));
 
+// test latin1 encoding
+assert(
+    Buffer.from(b.toString('latin1'), 'latin1')
+    .includes('d', 0, 'latin1'));
+assert(
+    Buffer.from(b.toString('latin1'), 'latin1')
+    .includes(Buffer.from('d', 'latin1'), 0, 'latin1'));
+
 // test binary encoding
 assert(
     Buffer.from(b.toString('binary'), 'binary')

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -102,6 +102,23 @@ assert.equal(
     Buffer.from(b.toString('ascii'), 'ascii')
     .indexOf(Buffer.from('d', 'ascii'), 0, 'ascii'), 3);
 
+// test latin1 encoding
+assert.equal(
+    Buffer.from(b.toString('latin1'), 'latin1')
+    .indexOf('d', 0, 'latin1'), 3);
+assert.equal(
+    Buffer.from(b.toString('latin1'), 'latin1')
+    .indexOf(Buffer.from('d', 'latin1'), 0, 'latin1'), 3);
+assert.equal(
+    Buffer.from('aa\u00e8aa', 'latin1')
+    .indexOf('\u00e8', 'latin1'), 2);
+assert.equal(
+    Buffer.from('\u00e8', 'latin1')
+    .indexOf('\u00e8', 'latin1'), 0);
+assert.equal(
+    Buffer.from('\u00e8', 'latin1')
+    .indexOf(Buffer.from('\u00e8', 'latin1'), 'latin1'), 0);
+
 // test binary encoding
 assert.equal(
     Buffer.from(b.toString('binary'), 'binary')
@@ -357,20 +374,24 @@ assert.equal(b.lastIndexOf('b', [2]), 1);
 // Test needles longer than the haystack.
 assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'ucs2'), -1);
 assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'utf8'), -1);
+assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'latin1'), -1);
 assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 'binary'), -1);
 assert.strictEqual(b.lastIndexOf(Buffer.from('aaaaaaaaaaaaaaa')), -1);
 assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 2, 'ucs2'), -1);
 assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 3, 'utf8'), -1);
+assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 5, 'latin1'), -1);
 assert.strictEqual(b.lastIndexOf('aaaaaaaaaaaaaaa', 5, 'binary'), -1);
 assert.strictEqual(b.lastIndexOf(Buffer.from('aaaaaaaaaaaaaaa'), 7), -1);
 
 // 你好 expands to a total of 6 bytes using UTF-8 and 4 bytes using UTF-16
 assert.strictEqual(buf_bc.lastIndexOf('你好', 'ucs2'), -1);
 assert.strictEqual(buf_bc.lastIndexOf('你好', 'utf8'), -1);
+assert.strictEqual(buf_bc.lastIndexOf('你好', 'latin1'), -1);
 assert.strictEqual(buf_bc.lastIndexOf('你好', 'binary'), -1);
 assert.strictEqual(buf_bc.lastIndexOf(Buffer.from('你好')), -1);
 assert.strictEqual(buf_bc.lastIndexOf('你好', 2, 'ucs2'), -1);
 assert.strictEqual(buf_bc.lastIndexOf('你好', 3, 'utf8'), -1);
+assert.strictEqual(buf_bc.lastIndexOf('你好', 5, 'latin1'), -1);
 assert.strictEqual(buf_bc.lastIndexOf('你好', 5, 'binary'), -1);
 assert.strictEqual(buf_bc.lastIndexOf(Buffer.from('你好'), 7), -1);
 
@@ -395,6 +416,7 @@ assert.equal(-1, bufferString.lastIndexOf('a ', -28));
 // but in a part of the buffer that does not make search to search
 // due do length constraints.
 const abInUCS2 = Buffer.from('ab', 'ucs2');
+assert.strictEqual(-1, Buffer.from('µaaaa¶bbbb', 'latin1').lastIndexOf('µ'));
 assert.strictEqual(-1, Buffer.from('µaaaa¶bbbb', 'binary').lastIndexOf('µ'));
 assert.strictEqual(-1, Buffer.from('bc').lastIndexOf('ab'));
 assert.strictEqual(-1, Buffer.from('abc').lastIndexOf('qa'));

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -14,7 +14,7 @@ var crypto = require('crypto');
 var tls = require('tls');
 const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
 
-crypto.DEFAULT_ENCODING = 'binary';
+crypto.DEFAULT_ENCODING = 'latin1';
 
 var fs = require('fs');
 var path = require('path');
@@ -346,11 +346,11 @@ var a3 = crypto.createHash('sha512').update('Test123').digest(); // binary
 var a4 = crypto.createHash('sha1').update('Test123').digest('buffer');
 
 if (!common.hasFipsCrypto) {
-  var a0 = crypto.createHash('md5').update('Test123').digest('binary');
+  var a0 = crypto.createHash('md5').update('Test123').digest('latin1');
   assert.equal(
     a0,
     'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca\u00bd\u008c',
-    'Test MD5 as binary'
+    'Test MD5 as latin1'
   );
 }
 
@@ -364,7 +364,7 @@ assert.equal(a3, '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
                  '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
                  '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
                  '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
-             'Test SHA512 as assumed binary');
+             'Test SHA512 as assumed latin1');
 
 assert.deepStrictEqual(
   a4,
@@ -530,7 +530,7 @@ var dh2 = crypto.createDiffieHellman(p1, 'base64');
 var key1 = dh1.generateKeys();
 var key2 = dh2.generateKeys('hex');
 var secret1 = dh1.computeSecret(key2, 'hex', 'base64');
-var secret2 = dh2.computeSecret(key1, 'binary', 'buffer');
+var secret2 = dh2.computeSecret(key1, 'latin1', 'buffer');
 
 assert.equal(secret1, secret2.toString('base64'));
 

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -17,7 +17,7 @@ var dh2 = crypto.createDiffieHellman(p1, 'buffer');
 var key1 = dh1.generateKeys();
 var key2 = dh2.generateKeys('hex');
 var secret1 = dh1.computeSecret(key2, 'hex', 'base64');
-var secret2 = dh2.computeSecret(key1, 'binary', 'buffer');
+var secret2 = dh2.computeSecret(key1, 'latin1', 'buffer');
 
 assert.equal(secret1, secret2.toString('base64'));
 assert.equal(dh1.verifyError, 0);
@@ -155,7 +155,7 @@ const ecdh2 = crypto.createECDH('prime256v1');
 key1 = ecdh1.generateKeys();
 key2 = ecdh2.generateKeys('hex');
 secret1 = ecdh1.computeSecret(key2, 'hex', 'base64');
-secret2 = ecdh2.computeSecret(key1, 'binary', 'buffer');
+secret2 = ecdh2.computeSecret(key1, 'latin1', 'buffer');
 
 assert.equal(secret1, secret2.toString('base64'));
 
@@ -176,7 +176,7 @@ const ecdh3 = crypto.createECDH('secp256k1');
 const key3 = ecdh3.generateKeys();
 
 assert.throws(function() {
-  ecdh2.computeSecret(key3, 'binary', 'buffer');
+  ecdh2.computeSecret(key3, 'latin1', 'buffer');
 });
 
 // ECDH should allow .setPrivateKey()/.setPublicKey()

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -38,11 +38,11 @@ a8.end();
 a8 = a8.read();
 
 if (!common.hasFipsCrypto) {
-  var a0 = crypto.createHash('md5').update('Test123').digest('binary');
+  var a0 = crypto.createHash('md5').update('Test123').digest('latin1');
   assert.equal(
     a0,
     'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca\u00bd\u008c',
-    'Test MD5 as binary'
+    'Test MD5 as latin1'
   );
 }
 assert.equal(a1, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
@@ -56,7 +56,7 @@ assert.deepStrictEqual(
     '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
     '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
     '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
-    'binary'),
+    'latin1'),
   'Test SHA512 as assumed buffer');
 assert.deepStrictEqual(
   a4,
@@ -102,7 +102,7 @@ assert.equal(
 
 assert.notEqual(
     hutf8,
-    crypto.createHash('sha512').update('УТФ-8 text', 'binary').digest('hex'));
+    crypto.createHash('sha512').update('УТФ-8 text', 'latin1').digest('hex'));
 
 var h3 = crypto.createHash('sha256');
 h3.digest();

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -18,13 +18,13 @@ function aes256(decipherFinal) {
   function encrypt(val, pad) {
     var c = crypto.createCipheriv('aes256', key, iv);
     c.setAutoPadding(pad);
-    return c.update(val, 'utf8', 'binary') + c.final('binary');
+    return c.update(val, 'utf8', 'latin1') + c.final('latin1');
   }
 
   function decrypt(val, pad) {
     var c = crypto.createDecipheriv('aes256', key, iv);
     c.setAutoPadding(pad);
-    return c.update(val, 'binary', 'utf8') + c[decipherFinal]('utf8');
+    return c.update(val, 'latin1', 'utf8') + c[decipherFinal]('utf8');
   }
 
   // echo 0123456789abcdef0123456789abcdef \

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -65,7 +65,7 @@ function dec(encd, pad) {
   var decrypt = crypto.createDecipheriv(CIPHER_NAME, KEY_PLAIN, IV_PLAIN);
   decrypt.setAutoPadding(pad);
   var plain = decrypt.update(encd, 'hex');
-  plain += decrypt.final('binary');
+  plain += decrypt.final('latin1');
   return plain;
 }
 

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -13,10 +13,10 @@ var crypto = require('crypto');
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
   var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha256');
-  assert.equal(actual.toString('binary'), expected);
+  assert.equal(actual.toString('latin1'), expected);
 
   crypto.pbkdf2(password, salt, iterations, keylen, 'sha256', (err, actual) => {
-    assert.equal(actual.toString('binary'), expected);
+    assert.equal(actual.toString('latin1'), expected);
   });
 }
 

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -33,23 +33,23 @@ var keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
 {
   const s2 = crypto.createSign('RSA-SHA256')
                    .update('Test123')
-                   .sign(keyPem, 'binary');
+                   .sign(keyPem, 'latin1');
   let s2stream = crypto.createSign('RSA-SHA256');
   s2stream.end('Test123');
-  s2stream = s2stream.sign(keyPem, 'binary');
+  s2stream = s2stream.sign(keyPem, 'latin1');
   assert.equal(s2, s2stream, 'Stream produces same output');
 
   let verified = crypto.createVerify('RSA-SHA256')
                        .update('Test')
                        .update('123')
-                       .verify(certPem, s2, 'binary');
-  assert.strictEqual(verified, true, 'sign and verify (binary)');
+                       .verify(certPem, s2, 'latin1');
+  assert.strictEqual(verified, true, 'sign and verify (latin1)');
 
   const verStream = crypto.createVerify('RSA-SHA256');
   verStream.write('Tes');
   verStream.write('t12');
   verStream.end('3');
-  verified = verStream.verify(certPem, s2, 'binary');
+  verified = verStream.verify(certPem, s2, 'latin1');
   assert.strictEqual(verified, true, 'sign and verify (stream)');
 }
 

--- a/test/parallel/test-file-read-noexist.js
+++ b/test/parallel/test-file-read-noexist.js
@@ -6,6 +6,6 @@ var fs = require('fs');
 
 var filename = path.join(common.fixturesDir, 'does_not_exist.txt');
 
-fs.readFile(filename, 'binary', common.mustCall(function(err, content) {
+fs.readFile(filename, 'latin1', common.mustCall(function(err, content) {
   assert.ok(err);
 }));

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
 const firstEncoding = 'base64';
-const secondEncoding = 'binary';
+const secondEncoding = 'latin1';
 
 const examplePath = path.join(common.fixturesDir, 'x.txt');
 const dummyPath = path.join(common.tmpDir, 'x.txt');

--- a/test/parallel/test-http-status-message.js
+++ b/test/parallel/test-http-status-message.js
@@ -22,7 +22,7 @@ function test() {
     bufs.push(chunk);
   });
   client.on('end', function() {
-    var head = Buffer.concat(bufs).toString('binary').split('\r\n')[0];
+    var head = Buffer.concat(bufs).toString('latin1').split('\r\n')[0];
     assert.equal('HTTP/1.1 200 Custom Message', head);
     console.log('ok');
     s.close();

--- a/test/parallel/test-net-binary.js
+++ b/test/parallel/test-net-binary.js
@@ -14,9 +14,9 @@ for (var i = 255; i >= 0; i--) {
 
 // safe constructor
 var echoServer = net.Server(function(connection) {
-  connection.setEncoding('binary');
+  connection.setEncoding('latin1');
   connection.on('data', function(chunk) {
-    connection.write(chunk, 'binary');
+    connection.write(chunk, 'latin1');
   });
   connection.on('end', function() {
     connection.end();
@@ -32,11 +32,11 @@ echoServer.on('listening', function() {
     port: this.address().port
   });
 
-  c.setEncoding('binary');
+  c.setEncoding('latin1');
   c.on('data', function(chunk) {
     var n = j + chunk.length;
     while (j < n && j < 256) {
-      c.write(String.fromCharCode(j), 'binary');
+      c.write(String.fromCharCode(j), 'latin1');
       j++;
     }
     if (j === 256) {

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -58,7 +58,7 @@ function test(decode, uncork, multi, next) {
     { encoding: 'ascii', chunk: 'hello, ' },
     { encoding: 'utf8', chunk: 'world' },
     { encoding: 'buffer', chunk: [33] },
-    { encoding: 'binary', chunk: '\nand then...' },
+    { encoding: 'latin1', chunk: '\nand then...' },
     { encoding: 'hex', chunk: 'facebea7deadbeefdecafbad' }
   ];
 
@@ -82,7 +82,7 @@ function test(decode, uncork, multi, next) {
     w.cork();
 
   w.write(Buffer.from('!'), 'buffer', cnt('!'));
-  w.write('\nand then...', 'binary', cnt('and then'));
+  w.write('\nand then...', 'latin1', cnt('and then'));
 
   if (multi)
     w.uncork();

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -140,6 +140,7 @@ test('write bufferize', function(t) {
         'utf8',
         'utf-8',
         'ascii',
+        'latin1',
         'binary',
         'base64',
         'ucs2',
@@ -177,6 +178,7 @@ test('write no bufferize', function(t) {
         'utf8',
         'utf-8',
         'ascii',
+        'latin1',
         'binary',
         'base64',
         'ucs2',
@@ -275,7 +277,7 @@ test('encoding should be ignored for buffers', function(t) {
     t.end();
   };
   var buf = Buffer.from(hex, 'hex');
-  tw.write(buf, 'binary');
+  tw.write(buf, 'latin1');
 });
 
 test('writables are not pipable', function(t) {

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -11,7 +11,13 @@ var write_str = 'a';
 
 // first do basic checks
 var b = Buffer.from(write_str, 'ucs2');
-var c = b.toString('binary');
+// first check latin1
+var c = b.toString('latin1');
+assert.equal(b[0], 0x61);
+assert.equal(b[1], 0);
+assert.equal(ucs2_control, c);
+// now check binary
+c = b.toString('binary');
 assert.equal(b[0], 0x61);
 assert.equal(b[1], 0);
 assert.equal(ucs2_control, c);
@@ -28,13 +34,20 @@ for (let i = 0; i < b.length; i += 2) {
   assert.equal(b[i], 0x61);
   assert.equal(b[i + 1], 0);
 }
+
 // create another string to create an external string
-var b_bin = b.toString('binary');
 var b_ucs = b.toString('ucs2');
+
 // check control against external binary string
+var l_bin = b.toString('latin1');
+assert.equal(ucs2_control, l_bin);
+
+// check control against external binary string
+var b_bin = b.toString('binary');
 assert.equal(ucs2_control, b_bin);
+
 // create buffer copy from external
-var c_bin = Buffer.from(b_bin, 'binary');
+var c_bin = Buffer.from(l_bin, 'latin1');
 var c_ucs = Buffer.from(b_ucs, 'ucs2');
 // make sure they're the same length
 assert.equal(c_bin.length, c_ucs.length);
@@ -44,8 +57,8 @@ for (let i = 0; i < c_bin.length; i++) {
 }
 // check resultant strings
 assert.equal(c_bin.toString('ucs2'), c_ucs.toString('ucs2'));
-assert.equal(c_bin.toString('binary'), ucs2_control);
-assert.equal(c_ucs.toString('binary'), ucs2_control);
+assert.equal(c_bin.toString('latin1'), ucs2_control);
+assert.equal(c_ucs.toString('latin1'), ucs2_control);
 
 
 // now let's test BASE64 and HEX ecoding/decoding


### PR DESCRIPTION
Backport of #7111, half of #7262 (the other half already landed) and #7284.

/cc @nodejs/buffer 

CI: https://ci.nodejs.org/job/node-test-commit/4461/