### PR TITLE
net: net.isIP() needs scope tests and a review of its type checking

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1077,14 +1077,14 @@ void AfterGetNameInfo(uv_getnameinfo_t* req,
 
 
 static void IsIP(const FunctionCallbackInfo<Value>& args) {
-  node::Utf8Value ip(args.GetIsolate(), args[0]);
   char address_buffer[sizeof(struct in6_addr)];
-
   int rc = 0;
+
   if (args.Length() < 1) {
     args.GetReturnValue().Set(rc);
     return;
   }
+  node::Utf8Value ip(args.GetIsolate(), args[0]);
   if (uv_inet_pton(AF_INET, *ip, &address_buffer) == 0)
     rc = 4;
   else if (uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0)
@@ -1094,25 +1094,25 @@ static void IsIP(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void IsIPv4(const FunctionCallbackInfo<Value>& args) {
-  node::Utf8Value ip(args.GetIsolate(), args[0]);
   char address_buffer[sizeof(struct in_addr)];
 
-  if (args.Length() && uv_inet_pton(AF_INET, *ip, &address_buffer) == 0) {
-    args.GetReturnValue().Set(true);
-  } else {
-    args.GetReturnValue().Set(false);
+  if (args.Length() > 0) {
+    node::Utf8Value ip(args.GetIsolate(), args[0]);
+    if (uv_inet_pton(AF_INET, *ip, &address_buffer) == 0)
+      return args.GetReturnValue().Set(true);
   }
+  args.GetReturnValue().Set(false);
 }
 
 static void IsIPv6(const FunctionCallbackInfo<Value>& args) {
-  node::Utf8Value ip(args.GetIsolate(), args[0]);
   char address_buffer[sizeof(struct in6_addr)];
 
-  if (args.Length() && uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0) {
-    args.GetReturnValue().Set(true);
-  } else {
-    args.GetReturnValue().Set(false);
+  if (args.Length() > 0) {
+    node::Utf8Value ip(args.GetIsolate(), args[0]);
+    if (uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0)
+      return args.GetReturnValue().Set(true);
   }
+  args.GetReturnValue().Set(false);
 }
 
 static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1081,6 +1081,10 @@ static void IsIP(const FunctionCallbackInfo<Value>& args) {
   char address_buffer[sizeof(struct in6_addr)];
 
   int rc = 0;
+  if (args.Length() < 1) {
+    args.GetReturnValue().Set(rc);
+    return;
+  }
   if (uv_inet_pton(AF_INET, *ip, &address_buffer) == 0)
     rc = 4;
   else if (uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0)
@@ -1093,7 +1097,7 @@ static void IsIPv4(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value ip(args.GetIsolate(), args[0]);
   char address_buffer[sizeof(struct in_addr)];
 
-  if (uv_inet_pton(AF_INET, *ip, &address_buffer) == 0) {
+  if (args.Length() && uv_inet_pton(AF_INET, *ip, &address_buffer) == 0) {
     args.GetReturnValue().Set(true);
   } else {
     args.GetReturnValue().Set(false);
@@ -1104,7 +1108,7 @@ static void IsIPv6(const FunctionCallbackInfo<Value>& args) {
   node::Utf8Value ip(args.GetIsolate(), args[0]);
   char address_buffer[sizeof(struct in6_addr)];
 
-  if (uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0) {
+  if (args.Length() && uv_inet_pton(AF_INET6, *ip, &address_buffer) == 0) {
     args.GetReturnValue().Set(true);
   } else {
     args.GetReturnValue().Set(false);

--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -27,9 +27,18 @@ assert.equal(net.isIP('::2001:252:1:255.255.255.255.76'), 0);
 assert.equal(net.isIP('::anything'), 0);
 assert.equal(net.isIP('::1'), 6);
 assert.equal(net.isIP('::'), 6);
+assert.equal(net.isIP('::%anything'), 6);
+assert.equal(net.isIP('0.0.0.0%anything'), 0);
+assert.equal(net.isIP('0.0.0.0%1'), 0);
+assert.equal(net.isIP('::1%anything'), 6);
+assert.equal(net.isIP('::1%1'), 6);
+assert.equal(net.isIP('::%0'), 6);
+
 assert.equal(net.isIP('0000:0000:0000:0000:0000:0000:12345:0000'), 0);
 assert.equal(net.isIP('0'), 0);
 assert.equal(net.isIP(), 0);
+assert.equal(net.isIP('1st arg', '2nd arg'), 0);
+assert.equal(net.isIP('::', '2nd arg'), 6);
 assert.equal(net.isIP(''), 0);
 assert.equal(net.isIP(null), 0);
 assert.equal(net.isIP(123), 0);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

net
##### Description of change

<!-- Provide a description of the change below this comment. -->

The IPv6 family and libuv support '%' notation for zoned scopes, so
 it should be tested. net.isIP() also has fewer checks before calling
 into libuv than other wrappers and could be more conservative without
 breaking castable Objects.
