### PR TITLE
repl,util: insert carriage returns in output

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -242,7 +242,7 @@ function REPLServer(prompt,
     var err, result, retry = false, input = code, wrappedErr;
     // first, create the Script object to check the syntax
 
-    if (code === '\n')
+    if (code === '\n' || code === '\r\n')
       return cb(null);
 
     while (true) {
@@ -251,7 +251,7 @@ function REPLServer(prompt,
             (self.replMode === exports.REPL_MODE_STRICT || retry)) {
           // "void 0" keeps the repl from returning "use strict" as the
           // result value for let/const statements.
-          code = `'use strict'; void 0;\n${code}`;
+          code = `'use strict'; void 0;\r\n${code}`;
         }
         var script = vm.createScript(code, {
           filename: file,
@@ -265,7 +265,7 @@ function REPLServer(prompt,
           if (self.wrappedCmd) {
             self.wrappedCmd = false;
             // unwrap and try again
-            code = `${input.substring(1, input.length - 2)}\n`;
+            code = `${input.substring(1, input.length - 2)}\r\n`;
             wrappedErr = e;
           } else {
             retry = true;
@@ -367,7 +367,7 @@ function REPLServer(prompt,
       e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
                                 (_, pre, line) => pre + (line - 1));
     }
-    top.outputStream.write((e.stack || e) + '\n');
+    top.outputStream.write((e.stack || e) + '\r\n');
     top.lineParser.reset();
     top.bufferedCommand = '';
     top.lines.level = [];
@@ -453,7 +453,7 @@ function REPLServer(prompt,
         sawSIGINT = false;
         return;
       }
-      self.output.write('(To exit, press ^C again or type .exit)\n');
+      self.output.write('(To exit, press ^C again or type .exit)\r\n');
       sawSIGINT = true;
     } else {
       sawSIGINT = false;
@@ -470,7 +470,7 @@ function REPLServer(prompt,
     sawSIGINT = false;
 
     if (self.editorMode) {
-      self.bufferedCommand += cmd + '\n';
+      self.bufferedCommand += cmd + '\r\n';
       return;
     }
 
@@ -490,7 +490,7 @@ function REPLServer(prompt,
       if (self.parseREPLKeyword(keyword, rest) === true) {
         return;
       } else if (!self.bufferedCommand) {
-        self.outputStream.write('Invalid REPL keyword\n');
+        self.outputStream.write('Invalid REPL keyword\r\n');
         finish(null);
         return;
       }
@@ -509,8 +509,8 @@ function REPLServer(prompt,
       self.wrappedCmd = false;
       if (e && !self.bufferedCommand && cmd.trim().startsWith('npm ')) {
         self.outputStream.write('npm should be run outside of the ' +
-                                'node repl, in your normal shell.\n' +
-                                '(Press Control-D to exit.)\n');
+                                'node repl, in your normal shell.\r\n' +
+                                '(Press Control-D to exit.)\r\n');
         self.lineParser.reset();
         self.bufferedCommand = '';
         self.displayPrompt();
@@ -525,7 +525,7 @@ function REPLServer(prompt,
           // {
           // ...  x: 1
           // ... }
-          self.bufferedCommand += cmd + '\n';
+          self.bufferedCommand += cmd + '\r\n';
           self.displayPrompt();
           return;
         } else {
@@ -548,7 +548,7 @@ function REPLServer(prompt,
         if (!self.underscoreAssigned) {
           self.last = ret;
         }
-        self.outputStream.write(self.writer(ret) + '\n');
+        self.outputStream.write(self.writer(ret) + '\r\n');
       }
 
       // Display prompt again
@@ -578,10 +578,10 @@ function REPLServer(prompt,
 
   self.on('SIGCONT', function() {
     if (self.editorMode) {
-      self.outputStream.write(`${self._initialPrompt}.editor\n`);
+      self.outputStream.write(`${self._initialPrompt}.editor\r\n`);
       self.outputStream.write(
-        '// Entering editor mode (^D to finish, ^C to cancel)\n');
-      self.outputStream.write(`${self.bufferedCommand}\n`);
+        '// Entering editor mode (^D to finish, ^C to cancel)\r\n');
+      self.outputStream.write(`${self.bufferedCommand}\r\n`);
       self.prompt(true);
     } else {
       self.displayPrompt(true);
@@ -713,7 +713,7 @@ REPLServer.prototype.createContext = function() {
       this.last = value;
       if (!this.underscoreAssigned) {
         this.underscoreAssigned = true;
-        this.outputStream.write('Expression assignment to _ now disabled.\n');
+        this.outputStream.write('Expression assignment to _ now disabled.\r\n');
       }
     }
   });
@@ -762,7 +762,7 @@ function ArrayStream() {
   this.run = function(data) {
     var self = this;
     data.forEach(function(line) {
-      self.emit('data', line + '\n');
+      self.emit('data', line + '\r\n');
     });
   };
 }
@@ -1232,7 +1232,7 @@ function defineDefaultCommands(repl) {
       this.lineParser.reset();
       this.bufferedCommand = '';
       if (!this.useGlobal) {
-        this.outputStream.write('Clearing context...\n');
+        this.outputStream.write('Clearing context...\r\n');
         this.resetContext();
       }
       this.displayPrompt();
@@ -1252,7 +1252,7 @@ function defineDefaultCommands(repl) {
       var self = this;
       Object.keys(this.commands).sort().forEach(function(name) {
         var cmd = self.commands[name];
-        self.outputStream.write(name + '\t' + (cmd.help || '') + '\n');
+        self.outputStream.write(name + '\t' + (cmd.help || '') + '\r\n');
       });
       this.displayPrompt();
     }
@@ -1262,10 +1262,10 @@ function defineDefaultCommands(repl) {
     help: 'Save all evaluated commands in this REPL session to a file',
     action: function(file) {
       try {
-        fs.writeFileSync(file, this.lines.join('\n') + '\n');
-        this.outputStream.write('Session saved to:' + file + '\n');
+        fs.writeFileSync(file, this.lines.join('\r\n') + '\r\n');
+        this.outputStream.write('Session saved to:' + file + '\r\n');
       } catch (e) {
-        this.outputStream.write('Failed to save:' + file + '\n');
+        this.outputStream.write('Failed to save:' + file + '\r\n');
       }
       this.displayPrompt();
     }
@@ -1279,19 +1279,21 @@ function defineDefaultCommands(repl) {
         if (stats && stats.isFile()) {
           var self = this;
           var data = fs.readFileSync(file, 'utf8');
-          var lines = data.split('\n');
+          // \r\n, \n, or \r followed by something other than \n
+          const lineEnding = /\r?\n|\r(?!\n)/;
+          var lines = data.split(lineEnding);
           this.displayPrompt();
           lines.forEach(function(line) {
             if (line) {
-              self.write(line + '\n');
+              self.write(line + '\r\n');
             }
           });
         } else {
           this.outputStream.write('Failed to load:' + file +
-                                  ' is not a valid file\n');
+                                  ' is not a valid file\r\n');
         }
       } catch (e) {
-        this.outputStream.write('Failed to load:' + file + '\n');
+        this.outputStream.write('Failed to load:' + file + '\r\n');
       }
       this.displayPrompt();
     }
@@ -1304,7 +1306,7 @@ function defineDefaultCommands(repl) {
       this.editorMode = true;
       REPLServer.super_.prototype.setPrompt.call(this, '');
       this.outputStream.write(
-        '// Entering editor mode (^D to finish, ^C to cancel)\n');
+        '// Entering editor mode (^D to finish, ^C to cancel)\r\n');
     }
   });
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -836,9 +836,9 @@ function reduceToSingleString(output, base, braces, breakLength) {
            // If the opening "brace" is too large, like in the case of "Set {",
            // we need to force the first item to be on the next line or the
            // items will not line up correctly.
-           (base === '' && braces[0].length === 1 ? '' : base + '\n ') +
+           (base === '' && braces[0].length === 1 ? '' : base + '\r\n ') +
            ' ' +
-           output.join(',\n  ') +
+           output.join(',\r\n  ') +
            ' ' +
            braces[1];
   }
@@ -1001,19 +1001,19 @@ exports.print = internalUtil.deprecate(function() {
 
 exports.puts = internalUtil.deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
-    process.stdout.write(arguments[i] + '\n');
+    process.stdout.write(arguments[i] + '\r\n');
   }
 }, 'util.puts is deprecated. Use console.log instead.');
 
 
 exports.debug = internalUtil.deprecate(function(x) {
-  process.stderr.write('DEBUG: ' + x + '\n');
+  process.stderr.write('DEBUG: ' + x + '\r\n');
 }, 'util.debug is deprecated. Use console.error instead.');
 
 
 exports.error = internalUtil.deprecate(function(x) {
   for (var i = 0, len = arguments.length; i < len; ++i) {
-    process.stderr.write(arguments[i] + '\n');
+    process.stderr.write(arguments[i] + '\r\n');
   }
 }, 'util.error is deprecated. Use console.error instead.');
 

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -123,7 +123,7 @@ const interactive = childProcess.exec(nodeBinary + ' '
   + '-i',
   common.mustCall(function(err, stdout, stderr) {
     assert.ifError(err);
-    assert.strictEqual(stdout, `> 'test'\n> `);
+    assert.strictEqual(stdout, `> 'test'\r\n> `);
   }));
 
 interactive.stdin.write('a\n');

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -27,7 +27,8 @@ putIn.run(testFile);
 putIn.run(['.save ' + saveFileName]);
 
 // the file should have what I wrote
-assert.equal(fs.readFileSync(saveFileName, 'utf8'), testFile.join('\n') + '\n');
+assert.equal(fs.readFileSync(saveFileName, 'utf8'), testFile.join('\r\n')
+             + '\r\n');
 
 // make sure that the REPL data is "correct"
 // so when I load it back I know I'm good
@@ -54,7 +55,7 @@ var loadFile = join(common.tmpDir, 'file.does.not.exist');
 // should not break
 putIn.write = function(data) {
   // make sure I get a failed to load message and not some crazy error
-  assert.equal(data, 'Failed to load:' + loadFile + '\n');
+  assert.equal(data, 'Failed to load:' + loadFile + '\r\n');
   // eat me to avoid work
   putIn.write = function() {};
 };
@@ -63,7 +64,7 @@ putIn.run(['.load ' + loadFile]);
 // throw error on loading directory
 loadFile = common.tmpDir;
 putIn.write = function(data) {
-  assert.equal(data, 'Failed to load:' + loadFile + ' is not a valid file\n');
+  assert.equal(data, 'Failed to load:' + loadFile + ' is not a valid file\r\n');
   putIn.write = function() {};
 };
 putIn.run(['.load ' + loadFile]);
@@ -78,7 +79,7 @@ const invalidFileName = join(common.tmpDir, '\0\0\0\0\0');
 // should not break
 putIn.write = function(data) {
   // make sure I get a failed to save message and not some other error
-  assert.equal(data, 'Failed to save:' + invalidFileName + '\n');
+  assert.equal(data, 'Failed to save:' + invalidFileName + '\r\n');
   // reset to no-op
   putIn.write = function() {};
 };

--- a/test/parallel/test-repl-autolibs.js
+++ b/test/parallel/test-repl-autolibs.js
@@ -19,7 +19,7 @@ function test1() {
     if (data.length) {
 
       // inspect output matches repl output
-      assert.equal(data, util.inspect(require('fs'), null, 2, false) + '\n');
+      assert.equal(data, util.inspect(require('fs'), null, 2, false) + '\r\n');
       // globally added lib matches required lib
       assert.equal(global.fs, require('fs'));
       test2();
@@ -36,7 +36,7 @@ function test2() {
     gotWrite = true;
     if (data.length) {
       // repl response error message
-      assert.equal(data, '{}\n');
+      assert.equal(data, '{}\r\n');
       // original value wasn't overwritten
       assert.equal(val, global.url);
     }

--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -34,10 +34,10 @@ r.defineCommand('say2', function() {
   this.displayPrompt();
 });
 
-inputStream.write('.help\n');
-assert(/\nsay1\thelp for say1\n/.test(output), 'help for say1 not present');
-assert(/\nsay2\t\n/.test(output), 'help for say2 not present');
-inputStream.write('.say1 node developer\n');
+inputStream.write('.help\r\n');
+assert(/\r\nsay1\thelp for say1\r\n/.test(output), 'help for say1 not present');
+assert(/\r\nsay2\t\r\n/.test(output), 'help for say2 not present');
+inputStream.write('.say1 node developer\r\n');
 assert(/> hello node developer/.test(output), 'say1 outputted incorrectly');
-inputStream.write('.say2 node developer\n');
+inputStream.write('.say2 node developer\r\n');
 assert(/> hello from say2/.test(output), 'say2 outputted incorrectly');

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -21,14 +21,14 @@ function testSloppyMode() {
 
   cli.input.emit('data', `
     x = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), '> 3\n> ');
+  `.trim() + '\r\n');
+  assert.equal(cli.output.accumulator.join(''), '> 3\r\n> ');
   cli.output.accumulator.length = 0;
 
   cli.input.emit('data', `
     let y = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), 'undefined\n> ');
+  `.trim() + '\r\n');
+  assert.equal(cli.output.accumulator.join(''), 'undefined\r\n> ');
 }
 
 function testStrictMode() {
@@ -36,15 +36,15 @@ function testStrictMode() {
 
   cli.input.emit('data', `
     x = 3
-  `.trim() + '\n');
+  `.trim() + '\r\n');
   assert.ok(/ReferenceError: x is not defined/.test(
       cli.output.accumulator.join('')));
   cli.output.accumulator.length = 0;
 
   cli.input.emit('data', `
     let y = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), 'undefined\n> ');
+  `.trim() + '\r\n');
+  assert.equal(cli.output.accumulator.join(''), 'undefined\r\n> ');
 }
 
 function testAutoMode() {
@@ -52,14 +52,14 @@ function testAutoMode() {
 
   cli.input.emit('data', `
     x = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), '> 3\n> ');
+  `.trim() + '\r\n');
+  assert.equal(cli.output.accumulator.join(''), '> 3\r\n> ');
   cli.output.accumulator.length = 0;
 
   cli.input.emit('data', `
     let y = 3
-  `.trim() + '\n');
-  assert.equal(cli.output.accumulator.join(''), 'undefined\n> ');
+  `.trim() + '\r\n');
+  assert.equal(cli.output.accumulator.join(''), 'undefined\r\n> ');
 }
 
 function initRepl(mode) {

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -37,7 +37,7 @@ class ActionStream extends stream.Stream {
       if (typeof action === 'object') {
         self.emit('keypress', '', action);
       } else {
-        self.emit('data', action + '\n');
+        self.emit('data', action + '\r\n');
       }
       setImmediate(doAction);
     }
@@ -138,7 +138,7 @@ const tests = [
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath },
     test: [UP, CLEAR, '\'42\'', ENTER],
     expected: [prompt, convertMsg, prompt, prompt + '\'=^.^=\'', prompt, '\'',
-               '4', '2', '\'', '\'42\'\n', prompt, prompt],
+               '4', '2', '\'', '\'42\'\r\n', prompt, prompt],
     after: function ensureHistoryFixture() {
       // XXX(Fishrock123) Make sure nothing weird happened to our fixture
       //  or it's temporary copy.
@@ -154,7 +154,7 @@ const tests = [
   { // Requires the above testcase
     env: {},
     test: [UP, UP, ENTER],
-    expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\n',
+    expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\r\n',
                prompt]
   },
   {

--- a/test/parallel/test-repl-recoverable.js
+++ b/test/parallel/test-repl-recoverable.js
@@ -21,7 +21,7 @@ putIn.write = function(msg) {
     recovered = true;
   }
 
-  if (msg === 'true\n') {
+  if (msg === 'true\r\n') {
     rendered = true;
   }
 };
@@ -30,8 +30,8 @@ repl.start('', putIn, customEval);
 
 // https://github.com/nodejs/node/issues/2939
 // Expose recoverable errors to the consumer.
-putIn.emit('data', '1\n');
-putIn.emit('data', '2\n');
+putIn.emit('data', '1\r\n');
+putIn.emit('data', '2\r\n');
 
 process.on('exit', function() {
   assert(recovered, 'REPL never recovered');

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -24,11 +24,11 @@ server.listen(options, function() {
   const conn = net.connect(options);
   conn.setEncoding('utf8');
   conn.on('data', (data) => answer += data);
-  conn.write('require("baz")\nrequire("./baz")\n.exit\n');
+  conn.write('require("baz")\r\nrequire("./baz")\r\n.exit\r\n');
 });
 
 process.on('exit', function() {
   assert.strictEqual(false, /Cannot find module/.test(answer));
   assert.strictEqual(false, /Error/.test(answer));
-  assert.strictEqual(answer, '\'eye catcher\'\n\'perhaps I work\'\n');
+  assert.strictEqual(answer, '\'eye catcher\'\r\n\'perhaps I work\'\r\n');
 });

--- a/test/parallel/test-repl-sigint.js
+++ b/test/parallel/test-repl-sigint.js
@@ -34,17 +34,18 @@ child.stdout.once('data', common.mustCall(() => {
     process.kill(child.pid, 'SIGINT');
     child.stdout.once('data', common.mustCall(() => {
       // Make sure state from before the interruption is still available.
-      child.stdin.end('a*2*3*7\n');
+      child.stdin.end('a*2*3*7\r\n');
     }));
   }));
 
   child.stdin.write('a = 1001;' +
                     'process.kill(+process.env.REPL_TEST_PPID, "SIGUSR2");' +
-                    'while(true){}\n');
+                    'while(true){}\r\n');
 }));
 
 child.on('close', function(code) {
   assert.strictEqual(code, 0);
-  assert.notStrictEqual(stdout.indexOf('Script execution interrupted.\n'), -1);
-  assert.notStrictEqual(stdout.indexOf('42042\n'), -1);
+  assert.notStrictEqual(stdout.indexOf('Script execution interrupted.' +
+                                       '\r\n'), -1);
+  assert.notStrictEqual(stdout.indexOf('42042\r\n'), -1);
 });

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -151,6 +151,6 @@ function initRepl(mode) {
 }
 
 function assertOutput(output, expected) {
-  const lines = output.accum.trim().split('\n');
+  const lines = output.accum.trim().split('\r\n');
   assert.deepStrictEqual(lines, expected);
 }

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -10,9 +10,9 @@ var spawn = require('child_process').spawn;
 var args = [ '-i' ];
 var child = spawn(process.execPath, args);
 
-var input = 'var foo = "bar\\\nbaz"';
+var input = 'var foo = "bar\\\r\nbaz"';
 // Match '...' as well since it marks a multi-line statement
-var expectOut = /^> ... undefined\n/;
+var expectOut = /^> ... undefined\r\n/;
 
 child.stderr.setEncoding('utf8');
 child.stderr.on('data', function(c) {

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -24,7 +24,7 @@ const globalTest = (useGlobal, cb, output) => (err, repl) => {
   let str = '';
   output.on('data', (data) => (str += data));
   global.lunch = 'tacos';
-  repl.write('global.lunch;\n');
+  repl.write('global.lunch;\r\n');
   repl.close();
   delete global.lunch;
   cb(null, str.trim());
@@ -54,8 +54,8 @@ const processTest = (useGlobal, cb, output) => (err, repl) => {
   output.on('data', (data) => (str += data));
 
   // if useGlobal is false, then `let process` should work
-  repl.write('let process;\n');
-  repl.write('21 * 2;\n');
+  repl.write('let process;\r\n');
+  repl.write('21 * 2;\r\n');
   repl.close();
   cb(null, str.trim());
 };
@@ -63,7 +63,7 @@ const processTest = (useGlobal, cb, output) => (err, repl) => {
 for (const option of processTestCases) {
   runRepl(option, processTest, common.mustCall((err, output) => {
     assert.ifError(err);
-    assert.strictEqual(output, 'undefined\n42');
+    assert.strictEqual(output, 'undefined\r\n42');
   }));
 }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -12,8 +12,8 @@ const prompt_unix = 'node via Unix socket> ';
 const prompt_tcp = 'node via TCP socket> ';
 const prompt_multiline = '... ';
 const prompt_npm = 'npm should be run outside of the ' +
-                   'node repl, in your normal shell.\n' +
-                   '(Press Control-D to exit.)\n';
+                   'node repl, in your normal shell.\r\n' +
+                   '(Press Control-D to exit.)\r\n';
 const expect_npm = prompt_npm + prompt_unix;
 var server_tcp, server_unix, client_tcp, client_unix, replServer;
 
@@ -37,7 +37,7 @@ function send_expect(list) {
     cur.client.expect = cur.expect;
     cur.client.list = list;
     if (cur.send.length > 0) {
-      cur.client.write(cur.send + '\n');
+      cur.client.write(cur.send + '\r\n');
     }
   }
 }
@@ -99,7 +99,7 @@ function error_test() {
         run_strict_test = false;
         strict_mode_error_test();
       } else {
-        console.error('End of Error test, running TCP test.\n');
+        console.error('End of Error test, running TCP test.\r\n');
         tcp_test();
       }
 
@@ -109,6 +109,11 @@ function error_test() {
   });
 
   send_expect([
+    // Can handle carriage returns
+    { client: client_unix, send: '(function(){return "JungMinu";})()',
+      expect: "'JungMinu'\r\n" + prompt_unix },
+    { client: client_unix, send: 'const JungMinu="\\r\\nMinwooJung";JungMinu',
+      expect: 'MinwooJung' },
     // Uncaught error throws and prints out
     { client: client_unix, send: 'throw new Error(\'test error\');',
       expect: /^Error: test error/ },
@@ -131,12 +136,12 @@ function error_test() {
     { client: client_unix, send: '`io.js ${"1.0"',
       expect: prompt_multiline },
     { client: client_unix, send: '+ ".2"}`',
-      expect: `'io.js 1.0.2'\n${prompt_unix}` },
+      expect: `'io.js 1.0.2'\r\n${prompt_unix}` },
     // Dot prefix in multiline commands aren't treated as commands
     { client: client_unix, send: '("a"',
       expect: prompt_multiline },
     { client: client_unix, send: '.charAt(0))',
-      expect: `'a'\n${prompt_unix}` },
+      expect: `'a'\r\n${prompt_unix}` },
     // Floating point numbers are not interpreted as REPL commands.
     { client: client_unix, send: '.1234',
       expect: '0.1234' },
@@ -182,7 +187,7 @@ function error_test() {
     { client: client_unix, send: 'function blah() { return 1; }',
       expect: prompt_unix },
     { client: client_unix, send: 'blah()',
-      expect: '1\n' + prompt_unix },
+      expect: '1\r\n' + prompt_unix },
     // Functions should not evaluate twice (#2773)
     { client: client_unix, send: 'var I = [1,2,3,function() {}]; I.pop()',
       expect: '[Function]' },
@@ -206,13 +211,13 @@ function error_test() {
     { client: client_unix, send: '2)',
       expect: prompt_multiline },
     { client: client_unix, send: ')',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\r\n' + prompt_unix },
     // npm prompt error message
     { client: client_unix, send: 'npm install foobar',
       expect: expect_npm },
-    { client: client_unix, send: '(function() {\n\nreturn 1;\n})()',
+    { client: client_unix, send: '(function() {\r\n\r\nreturn 1;\r\n})()',
       expect: '1' },
-    { client: client_unix, send: '{\n\na: 1\n}',
+    { client: client_unix, send: '{\r\n\r\na: 1\r\n}',
       expect: '{ a: 1 }' },
     { client: client_unix, send: 'url.format("http://google.com")',
       expect: 'http://google.com/' },
@@ -221,18 +226,18 @@ function error_test() {
     // this makes sure that we don't print `undefined` when we actually print
     // the error message
     { client: client_unix, send: '.invalid_repl_command',
-      expect: 'Invalid REPL keyword\n' + prompt_unix },
+      expect: 'Invalid REPL keyword\r\n' + prompt_unix },
     // this makes sure that we don't crash when we use an inherited property as
     // a REPL command
     { client: client_unix, send: '.toString',
-      expect: 'Invalid REPL keyword\n' + prompt_unix },
+      expect: 'Invalid REPL keyword\r\n' + prompt_unix },
     // fail when we are not inside a String and a line continuation is used
     { client: client_unix, send: '[] \\',
       expect: /\bSyntaxError: Invalid or unexpected token/ },
     // do not fail when a String is created with line continuation
-    { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
+    { client: client_unix, send: '\'the\\\r\nfourth\\\r\neye\'',
       expect: prompt_multiline + prompt_multiline +
-              '\'thefourtheye\'\n' + prompt_unix },
+              '\'thefourtheye\'\r\n' + prompt_unix },
     // Don't fail when a partial String is created and line continuation is used
     // with whitespace characters at the end of the string. We are to ignore it.
     // This test is to make sure that we properly remove the whitespace
@@ -240,99 +245,99 @@ function error_test() {
     { client: client_unix, send: '  \t    .break  \t  ',
       expect: prompt_unix },
     // multiline strings preserve whitespace characters in them
-    { client: client_unix, send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
+    { client: client_unix, send: '\'the \\\r\n   fourth\t\t\\\r\n  eye  \'',
       expect: prompt_multiline + prompt_multiline +
-              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix },
+              '\'the    fourth\\t\\t  eye  \'\r\n' + prompt_unix },
     // more than one multiline strings also should preserve whitespace chars
-    { client: client_unix, send: '\'the \\\n   fourth\' +  \'\t\t\\\n  eye  \'',
+    { client: client_unix, send: '\'the \\\r\n   fourth\' +  \'\t\t\\\r\n  eye  \'',
       expect: prompt_multiline + prompt_multiline +
-              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix },
+              '\'the    fourth\\t\\t  eye  \'\r\n' + prompt_unix },
     // using REPL commands within a string literal should still work
-    { client: client_unix, send: '\'\\\n.break',
+    { client: client_unix, send: '\'\\\r\n.break',
       expect: prompt_unix },
     // using REPL command "help" within a string literal should still work
-    { client: client_unix, send: '\'thefourth\\\n.help\neye\'',
+    { client: client_unix, send: '\'thefourth\\\r\n.help\r\neye\'',
       expect: /'thefourtheye'/ },
     // empty lines in the REPL should be allowed
-    { client: client_unix, send: '\n\r\n\r\n',
+    { client: client_unix, send: '\r\n\r\r\n\r\r\n',
       expect: prompt_unix + prompt_unix + prompt_unix },
     // empty lines in the string literals should not affect the string
-    { client: client_unix, send: '\'the\\\n\\\nfourtheye\'\n',
+    { client: client_unix, send: '\'the\\\r\n\\\r\nfourtheye\'\r\n',
       expect: prompt_multiline + prompt_multiline +
-              '\'thefourtheye\'\n' + prompt_unix },
+              '\'thefourtheye\'\r\n' + prompt_unix },
     // Regression test for https://github.com/nodejs/node/issues/597
     { client: client_unix,
-      send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
-      expect: `true\n${prompt_unix}` },
+      send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\r\n',
+      expect: `true\r\n${prompt_unix}` },
     // the following test's result depends on the RegEx's match from the above
     { client: client_unix,
-      send: 'RegExp.$1\nRegExp.$2\nRegExp.$3\nRegExp.$4\nRegExp.$5\n' +
-            'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
-      expect: ['\'1\'\n', '\'2\'\n', '\'3\'\n', '\'4\'\n', '\'5\'\n', '\'6\'\n',
-               '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
+      send: 'RegExp.$1\r\nRegExp.$2\r\nRegExp.$3\r\nRegExp.$4\r\nRegExp.$5\r\n' +
+            'RegExp.$6\r\nRegExp.$7\r\nRegExp.$8\r\nRegExp.$9\r\n',
+      expect: ['\'1\'\r\n', '\'2\'\r\n', '\'3\'\r\n', '\'4\'\r\n', '\'5\'\r\n', '\'6\'\r\n',
+               '\'7\'\r\n', '\'8\'\r\n', '\'9\'\r\n'].join(`${prompt_unix}`) },
     // regression tests for https://github.com/nodejs/node/issues/2749
-    { client: client_unix, send: 'function x() {\nreturn \'\\n\';\n }',
+    { client: client_unix, send: 'function x() {\r\nreturn \'\\r\\n\';\r\n }',
       expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x() {\nreturn \'\\\\\';\n }',
+              'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x() {\r\nreturn \'\\\\\';\r\n }',
       expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+              'undefined\r\n' + prompt_unix },
     // regression tests for https://github.com/nodejs/node/issues/3421
-    { client: client_unix, send: 'function x() {\n//\'\n }',
+    { client: client_unix, send: 'function x() {\r\n//\'\r\n }',
       expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x() {\n//"\n }',
+              'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x() {\r\n//"\r\n }',
       expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x() {//\'\n }',
-      expect: prompt_multiline + 'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x() {//"\n }',
-      expect: prompt_multiline + 'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x() {\nvar i = "\'";\n }',
+              'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x() {//\'\r\n }',
+      expect: prompt_multiline + 'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x() {//"\r\n }',
+      expect: prompt_multiline + 'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x() {\r\nvar i = "\'";\r\n }',
       expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+              'undefined\r\n' + prompt_unix },
     { client: client_unix, send: 'function x(/*optional*/) {}',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\r\n' + prompt_unix },
     { client: client_unix, send: 'function x(/* // 5 */) {}',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\r\n' + prompt_unix },
     { client: client_unix, send: '// /* 5 */',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\r\n' + prompt_unix },
     { client: client_unix, send: '"//"',
-      expect: '\'//\'\n' + prompt_unix },
+      expect: '\'//\'\r\n' + prompt_unix },
     { client: client_unix, send: '"data /*with*/ comment"',
-      expect: '\'data /*with*/ comment\'\n' + prompt_unix },
+      expect: '\'data /*with*/ comment\'\r\n' + prompt_unix },
     { client: client_unix, send: 'function x(/*fn\'s optional params*/) {}',
-      expect: 'undefined\n' + prompt_unix },
-    { client: client_unix, send: '/* \'\n"\n\'"\'\n*/',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: '/* \'\r\n"\r\n\'"\'\r\n*/',
+      expect: 'undefined\r\n' + prompt_unix },
     // REPL should get a normal require() function, not one that allows
     // access to internal modules without the --expose_internals flag.
     { client: client_unix, send: 'require("internal/repl")',
       expect: /^Error: Cannot find module 'internal\/repl'/ },
     // REPL should handle quotes within regexp literal in multiline mode
-    { client: client_unix, send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
+    { client: client_unix, send: "function x(s) {\r\nreturn s.replace(/'/,'');\r\n}",
       expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
-    { client: client_unix, send: "function x(s) {\nreturn s.replace(/\'/,'');\n}",
+            'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: "function x(s) {\r\nreturn s.replace(/\'/,'');\r\n}",
       expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x(s) {\nreturn s.replace(/"/,"");\n}',
+            'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x(s) {\r\nreturn s.replace(/"/,"");\r\n}',
       expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
-    { client: client_unix, send: 'function x(s) {\nreturn s.replace(/.*/,"");\n}',
+            'undefined\r\n' + prompt_unix },
+    { client: client_unix, send: 'function x(s) {\r\nreturn s.replace(/.*/,"");\r\n}',
       expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
+            'undefined\r\n' + prompt_unix },
     { client: client_unix, send: '{ var x = 4; }',
-      expect: 'undefined\n' + prompt_unix },
+      expect: 'undefined\r\n' + prompt_unix },
     // Illegal token is not recoverable outside string literal, RegExp literal,
     // or block comment. https://github.com/nodejs/node/issues/3611
     { client: client_unix, send: 'a = 3.5e',
       expect: /\bSyntaxError: Invalid or unexpected token/ },
     // Mitigate https://github.com/nodejs/node/issues/548
     { client: client_unix, send: 'function name(){ return "node"; };name()',
-      expect: "'node'\n" + prompt_unix },
+      expect: "'node'\r\n" + prompt_unix },
     { client: client_unix, send: 'function name(){ return "nodejs"; };name()',
-      expect: "'nodejs'\n" + prompt_unix },
+      expect: "'nodejs'\r\n" + prompt_unix },
     // Avoid emitting repl:line-number for SyntaxError
     { client: client_unix, send: 'a = 3.5e',
       expect: /^(?!repl)/ },
@@ -366,12 +371,12 @@ function tcp_test() {
         { client: client_tcp, send: '',
           expect: prompt_tcp },
         { client: client_tcp, send: 'invoke_me(333)',
-          expect: ('\'' + 'invoked 333' + '\'\n' + prompt_tcp) },
+          expect: ('\'' + 'invoked 333' + '\'\r\n' + prompt_tcp) },
         { client: client_tcp, send: 'a += 1',
-          expect: ('12346' + '\n' + prompt_tcp) },
+          expect: ('12346' + '\r\n' + prompt_tcp) },
         { client: client_tcp,
           send: 'require(' + JSON.stringify(moduleFilename) + ').number',
-          expect: ('42' + '\n' + prompt_tcp) }
+          expect: ('42' + '\r\n' + prompt_tcp) }
       ]);
     });
 
@@ -386,7 +391,7 @@ function tcp_test() {
         if (client_tcp.list && client_tcp.list.length > 0) {
           send_expect(client_tcp.list);
         } else {
-          console.error('End of TCP test.\n');
+          console.error('End of TCP test.\r\n');
           clean_up();
         }
       } else {
@@ -435,13 +440,13 @@ function unix_test() {
         { client: client_unix, send: '',
           expect: prompt_unix },
         { client: client_unix, send: 'message',
-          expect: ('\'' + message + '\'\n' + prompt_unix) },
+          expect: ('\'' + message + '\'\r\n' + prompt_unix) },
         { client: client_unix, send: 'invoke_me(987)',
-          expect: ('\'' + 'invoked 987' + '\'\n' + prompt_unix) },
+          expect: ('\'' + 'invoked 987' + '\'\r\n' + prompt_unix) },
         { client: client_unix, send: 'a = 12345',
-          expect: ('12345' + '\n' + prompt_unix) },
+          expect: ('12345' + '\r\n' + prompt_unix) },
         { client: client_unix, send: '{a:1}',
-          expect: ('{ a: 1 }' + '\n' + prompt_unix) }
+          expect: ('{ a: 1 }' + '\r\n' + prompt_unix) }
       ]);
     });
 
@@ -456,7 +461,7 @@ function unix_test() {
         if (client_unix.list && client_unix.list.length > 0) {
           send_expect(client_unix.list);
         } else {
-          console.error('End of Unix test, running Error test.\n');
+          console.error('End of Unix test, running Error test.\r\n');
           process.nextTick(error_test);
         }
       } else {

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -48,11 +48,11 @@ const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
 const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Object], {} ],' +
-                  ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
+                  ' Proxy [ {}, {} ] ],\r\n  Proxy [ Proxy [ {}, {} ]' +
                   ', Proxy [ Proxy [Object], {} ] ] ]';
 const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Object], Proxy [Object]' +
-                  ' ],\n    Proxy [ Proxy [Object], Proxy [Object] ] ],\n' +
-                  '  Proxy [ Proxy [ Proxy [Object], Proxy [Object] ],\n' +
+                  ' ],\r\n    Proxy [ Proxy [Object], Proxy [Object] ] ],\r\n' +
+                  '  Proxy [ Proxy [ Proxy [Object], Proxy [Object] ],\r\n' +
                   '    Proxy [ Proxy [Object], Proxy [Object] ] ] ]';
 assert.strictEqual(util.inspect(proxy1, opts), expected1);
 assert.strictEqual(util.inspect(proxy2, opts), expected2);

--- a/test/parallel/test-util-inspect-simd.js
+++ b/test/parallel/test-util-inspect-simd.js
@@ -17,9 +17,10 @@ assert.strictEqual(
 
 assert.strictEqual(
     inspect(SIMD.Bool8x16()),
-    'Bool8x16 [\n  false,\n  false,\n  false,\n  false,\n  false,\n' +
-    '  false,\n  false,\n  false,\n  false,\n  false,\n  false,\n' +
-    '  false,\n  false,\n  false,\n  false,\n  false ]');
+    'Bool8x16 [\r\n  false,\r\n  false,\r\n  false,\r\n  false,\r\n' +
+    '  false,\r\n  false,\r\n  false,\r\n  false,\r\n  false,\r\n' +
+    '  false,\r\n  false,\r\n  false,\r\n  false,\r\n  false,\r\n' +
+    '  false,\r\n  false ]');
 
 assert.strictEqual(
     inspect(SIMD.Bool32x4()),

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -11,12 +11,12 @@ assert.equal(util.inspect('hello'), "'hello'");
 assert.equal(util.inspect(function() {}), '[Function]');
 assert.equal(util.inspect(undefined), 'undefined');
 assert.equal(util.inspect(null), 'null');
-assert.equal(util.inspect(/foo(bar\n)?/gi), '/foo(bar\\n)?/gi');
+assert.equal(util.inspect(/foo(bar\r\n)?/gi), '/foo(bar\\r\\n)?/gi');
 assert.strictEqual(util.inspect(new Date('Sun, 14 Feb 2010 11:48:40 GMT')),
   new Date('2010-02-14T12:48:40+01:00').toISOString());
 assert.strictEqual(util.inspect(new Date('')), (new Date('')).toString());
 
-assert.equal(util.inspect('\n\u0001'), "'\\n\\u0001'");
+assert.equal(util.inspect('\r\n\u0001'), "'\\r\\n\\u0001'");
 
 assert.equal(util.inspect([]), '[]');
 assert.equal(util.inspect(Object.create([])), 'Array {}');
@@ -55,25 +55,25 @@ for (const showHidden of [true, false]) {
   const dv = new DataView(ab, 1, 2);
   assert.equal(util.inspect(ab, showHidden), 'ArrayBuffer { byteLength: 4 }');
   assert.equal(util.inspect(new DataView(ab, 1, 2), showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
+               'DataView {\r\n' +
+               '  byteLength: 2,\r\n' +
+               '  byteOffset: 1,\r\n' +
                '  buffer: ArrayBuffer { byteLength: 4 } }');
   assert.equal(util.inspect(ab, showHidden), 'ArrayBuffer { byteLength: 4 }');
   assert.equal(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
+               'DataView {\r\n' +
+               '  byteLength: 2,\r\n' +
+               '  byteOffset: 1,\r\n' +
                '  buffer: ArrayBuffer { byteLength: 4 } }');
   ab.x = 42;
   dv.y = 1337;
   assert.equal(util.inspect(ab, showHidden),
                'ArrayBuffer { byteLength: 4, x: 42 }');
   assert.equal(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
+               'DataView {\r\n' +
+               '  byteLength: 2,\r\n' +
+               '  byteOffset: 1,\r\n' +
+               '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\r\n' +
                '  y: 1337 }');
 }
 
@@ -83,25 +83,25 @@ for (const showHidden of [true, false]) {
   const dv = vm.runInNewContext('new DataView(ab, 1, 2)', { ab: ab });
   assert.equal(util.inspect(ab, showHidden), 'ArrayBuffer { byteLength: 4 }');
   assert.equal(util.inspect(new DataView(ab, 1, 2), showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
+               'DataView {\r\n' +
+               '  byteLength: 2,\r\n' +
+               '  byteOffset: 1,\r\n' +
                '  buffer: ArrayBuffer { byteLength: 4 } }');
   assert.equal(util.inspect(ab, showHidden), 'ArrayBuffer { byteLength: 4 }');
   assert.equal(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
+               'DataView {\r\n' +
+               '  byteLength: 2,\r\n' +
+               '  byteOffset: 1,\r\n' +
                '  buffer: ArrayBuffer { byteLength: 4 } }');
   ab.x = 42;
   dv.y = 1337;
   assert.equal(util.inspect(ab, showHidden),
                'ArrayBuffer { byteLength: 4, x: 42 }');
   assert.equal(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
+               'DataView {\r\n' +
+               '  byteLength: 2,\r\n' +
+               '  byteOffset: 1,\r\n' +
+               '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\r\n' +
                '  y: 1337 }');
 }
 
@@ -121,13 +121,13 @@ for (const showHidden of [true, false]) {
     array[0] = 65;
     array[1] = 97;
     assert.equal(util.inspect(array, true),
-                 `${constructor.name} [\n` +
-                 `  65,\n` +
-                 `  97,\n` +
-                 `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
-                 `  [length]: ${length},\n` +
-                 `  [byteLength]: ${byteLength},\n` +
-                 `  [byteOffset]: 0,\n` +
+                 `${constructor.name} [\r\n` +
+                 `  65,\r\n` +
+                 `  97,\r\n` +
+                 `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT}` +
+                 `,\r\n  [length]: ${length},\r\n` +
+                 `  [byteLength]: ${byteLength},\r\n` +
+                 `  [byteOffset]: 0,\r\n` +
                  `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
     assert.equal(util.inspect(array, false), `${constructor.name} [ 65, 97 ]`);
   });
@@ -153,13 +153,13 @@ for (const showHidden of [true, false]) {
     array[0] = 65;
     array[1] = 97;
     assert.equal(util.inspect(array, true),
-                 `${constructor.name} [\n` +
-                 `  65,\n` +
-                 `  97,\n` +
-                 `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
-                 `  [length]: ${length},\n` +
-                 `  [byteLength]: ${byteLength},\n` +
-                 `  [byteOffset]: 0,\n` +
+                 `${constructor.name} [\r\n` +
+                 `  65,\r\n` +
+                 `  97,\r\n` +
+                 `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT}` +
+                 `,\r\n  [length]: ${length},\r\n` +
+                 `  [byteLength]: ${byteLength},\r\n` +
+                 `  [byteOffset]: 0,\r\n` +
                  `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
     assert.equal(util.inspect(array, false), `${constructor.name} [ 65, 97 ]`);
   });
@@ -454,7 +454,7 @@ assert.doesNotThrow(function() {
 // util.inspect with "colors" option should produce as many lines as without it
 function test_lines(input) {
   var count_lines = function(str) {
-    return (str.match(/\n/g) || []).length;
+    return (str.match(/\r\n/g) || []).length;
   };
 
   var without_color = util.inspect(input);
@@ -585,7 +585,7 @@ assert.strictEqual(util.inspect(keys), 'SetIterator { 1, 3 }');
 // Assumes that the first numeric character is the start of an item.
 
 function checkAlignment(container) {
-  var lines = util.inspect(container).split('\n');
+  var lines = util.inspect(container).split('\r\n');
   var pos;
   lines.forEach(function(line) {
     var npos = line.search(/\d/);
@@ -728,7 +728,7 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
 
   assert.strictEqual(oneLine, '{ foo: \'abc\', bar: \'xyz\' }');
   assert.strictEqual(oneLine, util.inspect(obj, {breakLength: breakpoint + 1}));
-  assert.strictEqual(twoLines, '{ foo: \'abc\',\n  bar: \'xyz\' }');
+  assert.strictEqual(twoLines, '{ foo: \'abc\',\r\n  bar: \'xyz\' }');
 }
 
 // util.inspect.defaultOptions tests

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -30,7 +30,7 @@ execFile(node, noDep, function(er, stdout, stderr) {
   console.error('--no-deprecation: silence deprecations');
   assert.equal(er, null);
   assert.equal(stdout, '');
-  assert.equal(stderr, 'DEBUG: This is deprecated\n');
+  assert.equal(stderr, 'DEBUG: This is deprecated\r\n');
   console.log('silent ok');
 });
 
@@ -38,7 +38,7 @@ execFile(node, traceDep, function(er, stdout, stderr) {
   console.error('--trace-deprecation: show stack');
   assert.equal(er, null);
   assert.equal(stdout, '');
-  var stack = stderr.trim().split('\n');
+  var stack = stderr.trim().split('\r\n');
   // just check the top and bottom.
   assert(/util.debug is deprecated. Use console.error instead./.test(stack[1]));
   assert(/DEBUG: This is deprecated/.test(stack[0]));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl, util

##### Description of change
<!-- Provide a description of the change below this comment. -->

`\n` is not enough for Linux with some custom stream
add carriage returns to ensure that the output is displayed correctly
using `\r\n` should not be a problem, even on non-Windows platforms.

Fixes: https://github.com/nodejs/node/issues/7954