### PR TITLE
doc: script with space  spawn example for windows

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -82,7 +82,8 @@ be launched using [`child_process.execFile()`][]. When running on Windows, `.bat
 and `.cmd` files can be invoked using [`child_process.spawn()`][] with the `shell`
 option set, with [`child_process.exec()`][], or by spawning `cmd.exe` and passing
 the `.bat` or `.cmd` file as an argument (which is what the `shell` option and
-[`child_process.exec()`][] do).
+[`child_process.exec()`][] do). In any case, if the script filename contains
+spaces it needs to be quoted.
 
 ```js
 // On Windows Only ...
@@ -109,6 +110,13 @@ exec('my.bat', (err, stdout, stderr) => {
     return;
   }
   console.log(stdout);
+});
+
+// Script with spaces in the filename:
+const bat = spawn('"my script.cmd"', ['a', 'b'], { shell:true });
+// or:
+exec('"my script.cmd" a b', (err, stdout, stderr) => {
+  // ...
 });
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change
Adds an example of how to spawn a shell script under Windows with spaces in its filename.

Ref: https://github.com/nodejs/node/issues/7367

cc @nodejs/documentation 