### PR TITLE
test: add an zlib binding addon test

### DIFF
--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -1,0 +1,55 @@
+#include <node.h>
+#include <node_buffer.h>
+#include <assert.h>
+#include <zlib.h>
+
+namespace {
+
+inline void CompressBytes(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  assert(info[0]->IsArrayBufferView());
+  auto view = info[0].As<v8::ArrayBufferView>();
+  auto byte_offset = view->ByteOffset();
+  auto byte_length = view->ByteLength();
+  assert(view->HasBuffer());
+  auto buffer = view->Buffer();
+  auto contents = buffer->GetContents();
+  auto data = static_cast<unsigned char*>(contents.Data()) + byte_offset;
+
+  Bytef buf[1024];
+
+  z_stream stream;
+  stream.zalloc = nullptr;
+  stream.zfree = nullptr;
+
+  int err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+                         -15, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+  assert(err == Z_OK);
+
+  stream.avail_in = byte_length;
+  stream.next_in = data;
+  stream.avail_out = sizeof(buf);
+  stream.next_out = buf;
+  err = deflate(&stream, Z_FINISH);
+  assert(err == Z_STREAM_END);
+
+  auto result = node::Buffer::Copy(info.GetIsolate(),
+                                   reinterpret_cast<const char*>(buf),
+                                   sizeof(buf) - stream.avail_out);
+
+  deflateEnd(&stream);
+
+  info.GetReturnValue().Set(result.ToLocalChecked());
+}
+
+inline void Initialize(v8::Local<v8::Object> exports,
+                       v8::Local<v8::Value> module,
+                       v8::Local<v8::Context> context) {
+  auto isolate = context->GetIsolate();
+  auto key = v8::String::NewFromUtf8(isolate, "compressBytes");
+  auto value = v8::FunctionTemplate::New(isolate, CompressBytes)->GetFunction();
+  assert(exports->Set(context, key, value).IsJust());
+}
+
+}  // anonymous namespace
+
+NODE_MODULE_CONTEXT_AWARE(binding, Initialize)

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': ['binding.cc'],
+      'include_dirs': ['../../../deps/zlib'],
+    },
+  ]
+}

--- a/test/addons/zlib-binding/test.js
+++ b/test/addons/zlib-binding/test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const binding = require('./build/Release/binding');
+
+const input = Buffer.from('Hello, World!');
+
+const output = zlib.inflateRawSync(binding.compressBytes(input));
+assert.deepStrictEqual(input, output);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test/zlib

##### Description of change

Add a test addon that makes use of the zlib implementation bundled with node, checking that a compression/decompression round-trip works.

This is largely based on the already-existing OpenSSL addon.

Fixes: https://github.com/nodejs/node/issues/7535

Initial CI: https://ci.nodejs.org/job/node-test-commit/4488/