### PR TITLE
doc: update windows prerequisites

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -101,8 +101,8 @@ Prerequisites:
 * [Python 2.6 or 2.7](https://www.python.org/downloads/)
 * One of:
   * [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools)
-  * [Visual Studio](https://www.visualstudio.com/) 2013 / 2015, all editions including the Community edition
-  * [Visual Studio](https://www.visualstudio.com/) Express 2013 / 2015 for Desktop
+  * [Visual Studio 2015 Update 3](https://www.visualstudio.com/), all editions
+    including the Community edition.
 * Basic Unix tools required for some tests,
   [Git for Windows](http://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.


### PR DESCRIPTION
Visual Studio 2013 is no longer supported.  Update the Windows build
prerequisites.

Refs: #7484