### PR TITLE
tls: copy the Buffer object before using

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -53,7 +53,8 @@ exports.convertNPNProtocols = function(protocols, out) {
   }
   // If it's already a Buffer - store it
   if (protocols instanceof Buffer) {
-    out.NPNProtocols = protocols;
+    // copy new buffer not to be modified by user
+    out.NPNProtocols = Buffer.from(protocols);
   }
 };
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -49,11 +49,9 @@ function convertProtocols(protocols) {
 exports.convertNPNProtocols = function(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
-    protocols = convertProtocols(protocols);
-  }
-  // If it's already a Buffer - store it
-  if (protocols instanceof Buffer) {
-    // copy new buffer not to be modified by user
+    out.NPNProtocols = convertProtocols(protocols);
+  } else if (protocols instanceof Buffer) {
+    // Copy new buffer not to be modified by user.
     out.NPNProtocols = Buffer.from(protocols);
   }
 };
@@ -61,11 +59,9 @@ exports.convertNPNProtocols = function(protocols, out) {
 exports.convertALPNProtocols = function(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
-    protocols = convertProtocols(protocols);
-  }
-  // If it's already a Buffer - store it
-  if (protocols instanceof Buffer) {
-    // copy new buffer not to be modified by user
+    out.ALPNProtocols = convertProtocols(protocols);
+  } else if (protocols instanceof Buffer) {
+    // Copy new buffer not to be modified by user.
     out.ALPNProtocols = Buffer.from(protocols);
   }
 };

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -38,3 +38,21 @@ assert.throws(() => tls.createServer({ticketKeys: new Buffer(0)}),
 
 assert.throws(() => tls.createSecurePair({}),
               /Error: First argument must be a tls module SecureContext/);
+
+{
+  const buffer = Buffer.from('abcd');
+  const out = {};
+  tls.convertALPNProtocols(buffer, out);
+  out.ALPNProtocols.write('efgh');
+  assert(buffer.equals(Buffer.from('abcd')));
+  assert(out.ALPNProtocols.equals(Buffer.from('efgh')));
+}
+
+{
+  const buffer = Buffer.from('abcd');
+  const out = {};
+  tls.convertNPNProtocols(buffer, out);
+  out.NPNProtocols.write('efgh');
+  assert(buffer.equals(Buffer.from('abcd')));
+  assert(out.NPNProtocols.equals(Buffer.from('efgh')));
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tls

##### Description of change

`convertNPNProtocols` uses the `protocols` buffer object as it is, and
if it is modified outside of core, it might have an impact. This patch
makes a copy of the buffer object, before using it.

---

cc @nodejs/crypto 