### PR TITLE
child_process, win: fix shell spawn with AutoRun

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -124,7 +124,7 @@ added: v0.1.90
   * `encoding` {String} (Default: `'utf8'`)
   * `shell` {String} Shell to execute the command with
     (Default: `'/bin/sh'` on UNIX, `'cmd.exe'` on Windows, The shell should
-     understand the `-c` switch on UNIX or `/s /c` on Windows. On Windows,
+     understand the `-c` switch on UNIX or `/d /s /c` on Windows. On Windows,
      command line parsing should be compatible with `cmd.exe`.)
   * `timeout` {Number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
@@ -307,7 +307,7 @@ added: v0.1.90
   * `shell` {Boolean|String} If `true`, runs `command` inside of a shell. Uses
     `'/bin/sh'` on UNIX, and `'cmd.exe'` on Windows. A different shell can be
     specified as a string. The shell should understand the `-c` switch on UNIX,
-    or `/s /c` on Windows. Defaults to `false` (no shell).
+    or `/d /s /c` on Windows. Defaults to `false` (no shell).
 * return: {ChildProcess}
 
 The `child_process.spawn()` method spawns a new process using the given
@@ -609,7 +609,7 @@ added: v0.11.12
   * `env` {Object} Environment key-value pairs
   * `shell` {String} Shell to execute the command with
     (Default: `'/bin/sh'` on UNIX, `'cmd.exe'` on Windows, The shell should
-     understand the `-c` switch on UNIX or `/s /c` on Windows. On Windows,
+     understand the `-c` switch on UNIX or `/d /s /c` on Windows. On Windows,
      command line parsing should be compatible with `cmd.exe`.)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
@@ -662,7 +662,7 @@ added: v0.11.12
   * `shell` {Boolean|String} If `true`, runs `command` inside of a shell. Uses
     `'/bin/sh'` on UNIX, and `'cmd.exe'` on Windows. A different shell can be
     specified as a string. The shell should understand the `-c` switch on UNIX,
-    or `/s /c` on Windows. Defaults to `false` (no shell).
+    or `/d /s /c` on Windows. Defaults to `false` (no shell).
 * return: {Object}
   * `pid` {Number} Pid of the child process
   * `output` {Array} Array of results from stdio output

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -338,7 +338,7 @@ function normalizeSpawnArguments(file /*, args, options*/) {
     if (process.platform === 'win32') {
       file = typeof options.shell === 'string' ? options.shell :
               process.env.comspec || 'cmd.exe';
-      args = ['/s', '/c', '"' + command + '"'];
+      args = ['/d', '/s', '/c', '"' + command + '"'];
       options.windowsVerbatimArguments = true;
     } else {
       if (typeof options.shell === 'string')

--- a/test/common.js
+++ b/test/common.js
@@ -241,7 +241,7 @@ exports.spawnPwd = function(options) {
   var spawn = require('child_process').spawn;
 
   if (exports.isWindows) {
-    return spawn('cmd.exe', ['/c', 'cd'], options);
+    return spawn('cmd.exe', ['/d', '/c', 'cd'], options);
   } else {
     return spawn('pwd', [], options);
   }
@@ -252,7 +252,7 @@ exports.spawnSyncPwd = function(options) {
   const spawnSync = require('child_process').spawnSync;
 
   if (exports.isWindows) {
-    return spawnSync('cmd.exe', ['/c', 'cd'], options);
+    return spawnSync('cmd.exe', ['/d', '/c', 'cd'], options);
   } else {
     return spawnSync('pwd', [], options);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process, win

##### Description of change
<!-- Provide a description of the change below this comment. -->

Under Windows system can be configured to execute a specific command each time a shell is spawned. Under some conditions this breaks the way node handles shell scripts under windows. This commit adds `/d` switch to `spawn` and `spawnSync` which disables this AutoRun functionality.

Fixes: https://github.com/nodejs/node-v0.x-archive/issues/25458