### PR TITLE
src: remove VS 2013 compatibility hacks

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -99,29 +99,8 @@ void RegisterSignalHandler(int signal,
                            bool reset_handler = false);
 #endif
 
-#ifdef _WIN32
-// emulate snprintf() on windows, _snprintf() doesn't zero-terminate the buffer
-// on overflow...
-// VS 2015 added a standard conform snprintf
-#if defined( _MSC_VER ) && (_MSC_VER < 1900)
-#include <stdarg.h>
-inline static int snprintf(char *buffer, size_t n, const char *format, ...) {
-  va_list argp;
-  va_start(argp, format);
-  int ret = _vscprintf(format, argp);
-  vsnprintf_s(buffer, n, _TRUNCATE, format, argp);
-  va_end(argp);
-  return ret;
-}
-#endif
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define arraysize(a) (sizeof(a) / sizeof(*a))  // Workaround for VS 2013.
-#else
 template <typename T, size_t N>
 constexpr size_t arraysize(const T(&)[N]) { return N; }
-#endif
 
 #ifndef ROUND_UP
 # define ROUND_UP(a, b) ((a) % (b) ? ((a) + (b)) - ((a) % (b)) : (a))

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -28,33 +28,33 @@ bool ListNode<T>::IsEmpty() const {
   return prev_ == this;
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 ListHead<T, M>::Iterator::Iterator(ListNode<T>* node) : node_(node) {}
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 T* ListHead<T, M>::Iterator::operator*() const {
   return ContainerOf(M, node_);
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 const typename ListHead<T, M>::Iterator&
 ListHead<T, M>::Iterator::operator++() {
   node_ = node_->next_;
   return *this;
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 bool ListHead<T, M>::Iterator::operator!=(const Iterator& that) const {
   return node_ != that.node_;
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 ListHead<T, M>::~ListHead() {
   while (IsEmpty() == false)
     head_.next_->Remove();
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 void ListHead<T, M>::MoveBack(ListHead* that) {
   if (IsEmpty())
     return;
@@ -67,7 +67,7 @@ void ListHead<T, M>::MoveBack(ListHead* that) {
   head_.next_ = &head_;
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 void ListHead<T, M>::PushBack(T* element) {
   ListNode<T>* that = &(element->*M);
   head_.prev_->next_ = that;
@@ -76,7 +76,7 @@ void ListHead<T, M>::PushBack(T* element) {
   head_.prev_ = that;
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 void ListHead<T, M>::PushFront(T* element) {
   ListNode<T>* that = &(element->*M);
   head_.next_->prev_ = that;
@@ -85,12 +85,12 @@ void ListHead<T, M>::PushFront(T* element) {
   head_.next_ = that;
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 bool ListHead<T, M>::IsEmpty() const {
   return head_.IsEmpty();
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 T* ListHead<T, M>::PopFront() {
   if (IsEmpty())
     return nullptr;
@@ -99,12 +99,12 @@ T* ListHead<T, M>::PopFront() {
   return ContainerOf(M, node);
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 typename ListHead<T, M>::Iterator ListHead<T, M>::begin() const {
   return Iterator(head_.next_);
 }
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 typename ListHead<T, M>::Iterator ListHead<T, M>::end() const {
   return Iterator(const_cast<ListNode<T>*>(&head_));
 }

--- a/src/util.h
+++ b/src/util.h
@@ -122,18 +122,8 @@ template <typename T> using remove_reference = std::remove_reference<T>;
 template <typename T>
 class ListNode;
 
-template <typename T>
-using ListNodeMember = ListNode<T> T::*;
-
-// VS 2013 doesn't understand dependent templates.
-#ifdef _MSC_VER
-#define ListNodeMember(T) ListNodeMember
-#else
-#define ListNodeMember(T) ListNodeMember<T>
-#endif
-
 // TAILQ-style intrusive list head.
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 class ListHead;
 
 template <typename T>
@@ -145,13 +135,13 @@ class ListNode {
   inline bool IsEmpty() const;
 
  private:
-  template <typename U, ListNodeMember(U) M> friend class ListHead;
+  template <typename U, ListNode<U> (U::*M)> friend class ListHead;
   ListNode* prev_;
   ListNode* next_;
   DISALLOW_COPY_AND_ASSIGN(ListNode);
 };
 
-template <typename T, ListNodeMember(T) M>
+template <typename T, ListNode<T> (T::*M)>
 class ListHead {
  public:
   class Iterator {

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -47,7 +47,6 @@ if /i "%1"=="clean"         set target=Clean&goto arg-ok
 if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
-if /i "%1"=="vc2013"        set target_env=vc2013&goto arg-ok
 if /i "%1"=="vc2015"        set target_env=vc2015&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
@@ -133,51 +132,26 @@ if defined noprojgen if defined nobuild if defined nosign if not defined msi got
 
 @rem Set environment for msbuild
 
-if defined target_env if "%target_env%" NEQ "vc2015" goto vc-set-2013
 @rem Look for Visual Studio 2015
 echo Looking for Visual Studio 2015
-if not defined VS140COMNTOOLS goto vc-set-2013
-if not exist "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2013
+if not defined VS140COMNTOOLS goto msbuild-not-found
+if not exist "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" goto msbuild-not-found
 echo Found Visual Studio 2015
 if defined msi (
   echo Looking for WiX installation for Visual Studio 2015...
   if not exist "%WIX%\SDK\VS2015" (
     echo Failed to find WiX install for Visual Studio 2015
     echo VS2015 support for WiX is only present starting at version 3.10
-    goto vc-set-2013
+    goto wix-not-found
   )
 )
 if "%VCVARS_VER%" NEQ "140" (
   call "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat"
   SET VCVARS_VER=140
 )
-if not defined VCINSTALLDIR goto vc-set-2013
+if not defined VCINSTALLDIR goto msbuild-not-found
 set GYP_MSVS_VERSION=2015
 set PLATFORM_TOOLSET=v140
-goto msbuild-found
-
-:vc-set-2013
-if defined target_env if "%target_env%" NEQ "vc2013" goto msbuild-not-found
-@rem Look for Visual Studio 2013
-echo Looking for Visual Studio 2013
-if not defined VS120COMNTOOLS goto msbuild-not-found
-if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto msbuild-not-found
-echo Found Visual Studio 2013
-if defined msi (
-  echo Looking for WiX installation for Visual Studio 2013...
-  if not exist "%WIX%\SDK\VS2013" (
-    echo Failed to find WiX install for Visual Studio 2013
-    echo VS2013 support for WiX is only present starting at version 3.8
-    goto wix-not-found
-  )
-)
-if "%VCVARS_VER%" NEQ "120" (
-  call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
-  SET VCVARS_VER=120
-)
-if not defined VCINSTALLDIR goto msbuild-not-found
-set GYP_MSVS_VERSION=2013
-set PLATFORM_TOOLSET=v120
 goto msbuild-found
 
 :msbuild-not-found
@@ -388,7 +362,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [nosign] [x86/x64] [vc2013/vc2015] [download-all] [enable-vtune]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [nosign] [x86/x64] [vc2015] [download-all] [enable-vtune]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build


### PR DESCRIPTION
We can remove some Visual Studio 2013-specific workarounds now that
support for that compiler has officially been dropped.

Refs: #7484
Refs: #8049 

("has been dropped" == future tense.)

The last commit is something I can drop if people feel it's less readable.

CI: https://ci.nodejs.org/job/node-test-pull-request/3625/ (expected to fail on the vs2013 buildbots.)