### PR TITLE
url: make `url.format()` encode all occurrences of `#` in `search`

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -624,7 +624,7 @@ Url.prototype.format = function() {
     }
   }
 
-  search = search.replace('#', '%23');
+  search = search.replace(/#/g, '%23');
 
   if (hash && hash.charCodeAt(0) !== 35/*#*/) hash = '#' + hash;
   if (search && search.charCodeAt(0) !== 63/*?*/) search = '?' + search;

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1176,6 +1176,19 @@ var formatTests = {
     pathname: '/fooA100%mBr',
   },
 
+  // multiple `#` in search
+  'http://example.com/?foo=bar%231%232%233&abc=%234%23%235#frag': {
+    href: 'http://example.com/?foo=bar%231%232%233&abc=%234%23%235#frag',
+    protocol: 'http:',
+    slashes: true,
+    host: 'example.com',
+    hostname: 'example.com',
+    hash: '#frag',
+    search: '?foo=bar#1#2#3&abc=#4##5',
+    query: {},
+    pathname: '/'
+  },
+
   // https://github.com/nodejs/node/issues/3361
   'file:///home/user': {
     href: 'file:///home/user',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url

##### Description of change
<!-- Provide a description of the change below this comment. -->

This fixes an error where the first occurrence of `#` in `search` parameter is URL encoded, and subsequent occurrences are not.

Also added a test for the case.

Fixes: #8064 