### PR TITLE
tools: enable rest-spread-spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -87,6 +87,7 @@ rules:
   no-new-symbol: 2
   no-this-before-super: 2
   prefer-const: 2
+  rest-spread-spacing: 2
   template-curly-spacing: 2
 
   # Custom rules in tools/eslint-rules


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

There are currently 17 instances of the spread operator and all of them
have no space between the operator and the subsequent argument. This
change enables a lint rule to enforce that same style on any future uses
of the spread operator.

Refs: https://github.com/nodejs/node/pull/6573/files/7a1b47f329f2e6481ef8f54951570197fd98378d#r74479351