### PR TITLE
test: exclude tests for AIX

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -31,3 +31,14 @@ test-tls-connect-address-family : PASS,FLAKY
 # regressions until this work is complete
 [$system==aix]
 test-fs-watch-enoent                 : FAIL, PASS
+# Disable so we don't get failures now that AIX has been
+# added to regular CI runs
+test-regress-GH-1899                 : FAIL, PASS
+test-stdio-closed                    : FAIL, PASS
+
+# Flaky until https://github.com/nodejs/build/issues/415 is resolved.
+# On some of the buildbots, AAAA queries for localhost don't resolve
+# to an address and neither do any of the alternatives from the
+# localIPv6Hosts list from test/common.js.
+test-https-connect-address-family : PASS,FLAKY
+test-tls-connect-address-family : PASS,FLAKY


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
exclude tests for AIX in 4.x stream now that
its been added to regular regression runs.  This
will avoid known failures from making the build
look RED while also being able to catch any
new regressions if they are introduced.