### PR TITLE
udp: remove ancient check

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -53,9 +53,6 @@ function newHandle(type) {
     return handle;
   }
 
-  if (type == 'unix_dgram')
-    throw new Error('"unix_dgram" type sockets are not supported any more');
-
   throw new Error('Bad socket type specified. Valid types are: udp4, udp6');
 }
 


### PR DESCRIPTION
Unix datagram support was removed 5 years ago.