### PR TITLE
test: add test for assert.notStrictEqual()

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -56,6 +56,9 @@ assert.throws(makeBlock(a.strictEqual, 2, '2'),
 assert.throws(makeBlock(a.strictEqual, null, undefined),
               a.AssertionError, 'strictEqual(null, undefined)');
 
+assert.throws(makeBlock(a.notStrictEqual, 2, 2),
+              a.AssertionError, 'notStrictEqual(2, 2)');
+
 assert.doesNotThrow(makeBlock(a.notStrictEqual, 2, '2'),
                     'notStrictEqual(2, \'2\')');
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test assert

##### Description of change
<!-- Provide a description of the change below this comment. -->

There is currently no test for `assert.notStrictEqual()` throwing an
`AssertionError` when passed identical values. This change adds such a
test.