### PR TITLE
src: updating references to the old node.js file

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3374,9 +3374,8 @@ void LoadEnvironment(Environment* env) {
   // assigning things to their places.
 
   // We start the process this way in order to be more modular. Developers
-  // who do not like how 'lib/internal/bootstrap_node.js' setups the module
-  // system but do like Node's I/O bindings may want to replace 'f' with
-  // their own function.
+  // who do not like how bootstrap_node.js setups the module system but do
+  // like Node's I/O bindings may want to replace 'f' with their own function.
 
   // Add a reference to the global object
   Local<Object> global = env->context()->Global();

--- a/src/node.cc
+++ b/src/node.cc
@@ -3346,7 +3346,6 @@ void LoadEnvironment(Environment* env) {
   env->isolate()->SetFatalErrorHandler(node::OnFatalError);
   env->isolate()->AddMessageListener(OnMessage);
 
-  // The node.js file returns a function 'f'
   atexit(AtExit);
 
   TryCatch try_catch(env->isolate());
@@ -3366,16 +3365,18 @@ void LoadEnvironment(Environment* env) {
     ReportException(env, try_catch);
     exit(10);
   }
+  // The bootstrap_node.js file returns a function 'f'
   CHECK(f_value->IsFunction());
   Local<Function> f = Local<Function>::Cast(f_value);
 
   // Now we call 'f' with the 'process' variable that we've built up with
-  // all our bindings. Inside node.js we'll take care of assigning things to
-  // their places.
+  // all our bindings. Inside bootstrap_node.js we'll take care of
+  // assigning things to their places.
 
   // We start the process this way in order to be more modular. Developers
-  // who do not like how 'src/node.js' setups the module system but do like
-  // Node's I/O bindings may want to replace 'f' with their own function.
+  // who do not like how 'lib/internal/bootstrap_node.js' setups the module
+  // system but do like Node's I/O bindings may want to replace 'f' with
+  // their own function.
 
   // Add a reference to the global object
   Local<Object> global = env->context()->Global();


### PR DESCRIPTION

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change

The node.js script was renamed to bootstrap_node.js as part of
81b6882e519fcfbb07c85815dccdcc663204e6e6. When I did this I missed
several comments in src/node.cc that referred to the old file name.

This commit updates the comments to refer to bootstrap_node.js and
correct the path to this file where used.
It also moves a comment that seems to have drifted in the file.