### PR TITLE
test: use strict equality in regression test

### DIFF
--- a/test/sequential/test-regress-GH-877.js
+++ b/test/sequential/test-regress-GH-877.js
@@ -25,7 +25,7 @@ server.listen(common.PORT, '127.0.0.1', function() {
     };
 
     var req = http.get(options, function(res) {
-      if (++responses == N) {
+      if (++responses === N) {
         server.close();
       }
       res.resume();
@@ -47,6 +47,6 @@ server.listen(common.PORT, '127.0.0.1', function() {
 });
 
 process.on('exit', function() {
-  assert.ok(responses == N);
+  assert.strictEqual(responses, N);
   assert.ok(maxQueued <= 10);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Replace `==` with `===` and `assert.strictEqual()` in
test-regress-GH-877.js.