### PR TITLE
deps: cherry-pick de5aaad from V8's upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 80
+#define V8_PATCH_LEVEL 81
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/debug/debug.cc
+++ b/deps/v8/src/debug/debug.cc
@@ -962,6 +962,14 @@ void Debug::PrepareStepOnThrow() {
     it.Advance();
   }
 
+  if (last_step_action() == StepNext) {
+    while (!it.done()) {
+      Address current_fp = it.frame()->UnpaddedFP();
+      if (current_fp >= thread_local_.target_fp_) break;
+      it.Advance();
+    }
+  }
+
   // Find the closest Javascript frame we can flood with one-shots.
   while (!it.done() &&
          !it.frame()->function()->shared()->IsSubjectToDebugging()) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

V8

##### Description of change
<!-- Provide a description of the change below this comment. -->

Original commit message:

    [Debugger] Fix StepNext over function with caught exception

    Without CL debugger on StepNext adds breakpoint to function where
    throw instruction is located. In case of StepNext we will skip pause
    in this function because StepNext shouldn't break in a deeper frame.

    BUG=chromium:604495
    R=yangguo@chromium.org
    LOG=N

    Review URL: https://codereview.chromium.org/1894263002

    Cr-Commit-Position: refs/heads/master@{#35627}

Fixes: https://github.com/nodejs/node/issues/7219

cc @nodejs/v8 