### PR TITLE
fs,module: add module-loader-only realpath cache

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1644,7 +1644,7 @@ fs.realpathSync = function realpathSync(p, options) {
       // dev/ino always return 0 on windows, so skip the check.
       var linkTarget = null;
       if (!isWindows) {
-        var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+        const id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
         if (seenLinks.hasOwnProperty(id)) {
           linkTarget = seenLinks[id];
         }
@@ -1761,7 +1761,7 @@ fs.realpath = function realpath(p, options, callback) {
     // call gotTarget as soon as the link target is known
     // dev/ino always return 0 on windows, so skip the check.
     if (!isWindows) {
-      var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+      const id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
       if (seenLinks.hasOwnProperty(id)) {
         return gotTarget(null, seenLinks[id], base);
       }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1560,6 +1560,10 @@ function encodeRealpathResult(result, options, err) {
   }
 }
 
+// This is removed from the fs exports in lib/module.js in order to make
+// sure that this stays internal.
+const realpathCacheKey = fs.realpathCacheKey = Symbol('realpathCacheKey');
+
 fs.realpathSync = function realpathSync(p, options) {
   if (!options)
     options = {};
@@ -1574,6 +1578,12 @@ fs.realpathSync = function realpathSync(p, options) {
 
   const seenLinks = {};
   const knownHard = {};
+  const cache = options[realpathCacheKey];
+  const original = p;
+
+  if (cache && cache.has(p)) {
+    return cache.get(p);
+  }
 
   // current character position in p
   var pos;
@@ -1614,39 +1624,45 @@ fs.realpathSync = function realpathSync(p, options) {
     pos = nextPartRe.lastIndex;
 
     // continue if not a symlink
-    if (knownHard[base]) {
+    if (knownHard[base] || (cache && cache.get(base) === base)) {
       continue;
     }
 
     var resolvedLink;
-    var stat = fs.lstatSync(base);
-    if (!stat.isSymbolicLink()) {
-      knownHard[base] = true;
-      continue;
-    }
-
-    // read the link if it wasn't read before
-    // dev/ino always return 0 on windows, so skip the check.
-    var linkTarget = null;
-    if (!isWindows) {
-      var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
-      if (seenLinks.hasOwnProperty(id)) {
-        linkTarget = seenLinks[id];
+    if (cache && cache.has(base)) {
+      resolvedLink = cache.get(base);
+    } else {
+      var stat = fs.lstatSync(base);
+      if (!stat.isSymbolicLink()) {
+        knownHard[base] = true;
+        continue;
       }
-    }
-    if (linkTarget === null) {
-      fs.statSync(base);
-      linkTarget = fs.readlinkSync(base);
-    }
-    resolvedLink = pathModule.resolve(previous, linkTarget);
 
-    if (!isWindows) seenLinks[id] = linkTarget;
+      // read the link if it wasn't read before
+      // dev/ino always return 0 on windows, so skip the check.
+      var linkTarget = null;
+      if (!isWindows) {
+        var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+        if (seenLinks.hasOwnProperty(id)) {
+          linkTarget = seenLinks[id];
+        }
+      }
+      if (linkTarget === null) {
+        fs.statSync(base);
+        linkTarget = fs.readlinkSync(base);
+      }
+      resolvedLink = pathModule.resolve(previous, linkTarget);
+
+      if (cache) cache.set(base, resolvedLink);
+      if (!isWindows) seenLinks[id] = linkTarget;
+    }
 
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
     start();
   }
 
+  if (cache) cache.set(original, p);
   return encodeRealpathResult(p, options);
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1581,8 +1581,9 @@ fs.realpathSync = function realpathSync(p, options) {
   const cache = options[realpathCacheKey];
   const original = p;
 
-  if (cache && cache.has(p)) {
-    return cache.get(p);
+  const maybeCachedResult = cache && cache.get(p);
+  if (maybeCachedResult) {
+    return maybeCachedResult;
   }
 
   // current character position in p
@@ -1629,8 +1630,9 @@ fs.realpathSync = function realpathSync(p, options) {
     }
 
     var resolvedLink;
-    if (cache && cache.has(base)) {
-      resolvedLink = cache.get(base);
+    const maybeCachedResolved = cache && cache.get(base);
+    if (maybeCachedResolved) {
+      resolvedLink = maybeCachedResolved;
     } else {
       var stat = fs.lstatSync(base);
       if (!stat.isSymbolicLink()) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1642,9 +1642,10 @@ fs.realpathSync = function realpathSync(p, options) {
 
       // read the link if it wasn't read before
       // dev/ino always return 0 on windows, so skip the check.
-      var linkTarget = null;
+      let linkTarget = null;
+      let id;
       if (!isWindows) {
-        const id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
+        id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
         if (seenLinks.hasOwnProperty(id)) {
           linkTarget = seenLinks[id];
         }
@@ -1760,8 +1761,9 @@ fs.realpath = function realpath(p, options, callback) {
     // stat & read the link if not read before
     // call gotTarget as soon as the link target is known
     // dev/ino always return 0 on windows, so skip the check.
+    let id;
     if (!isWindows) {
-      const id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
+      id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
       if (seenLinks.hasOwnProperty(id)) {
         return gotTarget(null, seenLinks[id], base);
       }

--- a/lib/module.js
+++ b/lib/module.js
@@ -112,7 +112,7 @@ function tryPackage(requestPath, exts, isMain) {
 // In order to minimize unnecessary lstat() calls,
 // this cache is a list of known-real paths.
 // Set to an empty object to reset.
-Module._realpathCache = new Map();
+const realpathCache = new Map();
 
 const realpathCacheKey = fs.realpathCacheKey;
 delete fs.realpathCacheKey;
@@ -131,7 +131,7 @@ function tryFile(requestPath, isMain) {
 
 function toRealPath(requestPath) {
   return fs.realpathSync(requestPath, {
-    [realpathCacheKey]: Module._realpathCache
+    [realpathCacheKey]: realpathCache
   });
 }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -109,6 +109,14 @@ function tryPackage(requestPath, exts, isMain) {
          tryExtensions(path.resolve(filename, 'index'), exts, isMain);
 }
 
+// In order to minimize unnecessary lstat() calls,
+// this cache is a list of known-real paths.
+// Set to an empty object to reset.
+Module._realpathCache = new Map();
+
+const realpathCacheKey = fs.realpathCacheKey;
+delete fs.realpathCacheKey;
+
 // check if the file exists and is not a directory
 // if using --preserve-symlinks and isMain is false,
 // keep symlinks intact, otherwise resolve to the
@@ -118,7 +126,13 @@ function tryFile(requestPath, isMain) {
   if (preserveSymlinks && !isMain) {
     return rc === 0 && path.resolve(requestPath);
   }
-  return rc === 0 && fs.realpathSync(requestPath);
+  return rc === 0 && toRealPath(requestPath);
+}
+
+function toRealPath(requestPath) {
+  return fs.realpathSync(requestPath, {
+    [realpathCacheKey]: Module._realpathCache
+  });
 }
 
 // given a path check a the file exists with any of the set extensions
@@ -164,7 +178,7 @@ Module._findPath = function(request, paths, isMain) {
         if (preserveSymlinks && !isMain) {
           filename = path.resolve(basePath);
         } else {
-          filename = fs.realpathSync(basePath);
+          filename = toRealPath(basePath);
         }
       } else if (rc === 1) {  // Directory.
         if (exts === undefined)

--- a/lib/module.js
+++ b/lib/module.js
@@ -111,7 +111,7 @@ function tryPackage(requestPath, exts, isMain) {
 
 // In order to minimize unnecessary lstat() calls,
 // this cache is a list of known-real paths.
-// Set to an empty object to reset.
+// Set to an empty Map to reset.
 const realpathCache = new Map();
 
 const realpathCacheKey = fs.realpathCacheKey;


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

fs, module

##### Description of change

Reintroduce a realpath cache with the same mechanisms which existed before b488b19eaf2b2e7a3ca5eccd2445e245847a5f76 (`fs: optimize realpath using uv_fs_realpath()`), but only for the synchronous version and with the cache being passed as a hidden option to make sure it is only used internally.

The cache is hidden from userland applications because it has been decided that fully reintroducing as part of the public API might stand in the way of future optimizations.

/cc @nodejs/fs @bzoz