### PR TITLE
net, http: allow setting socket connection timeout for http request

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1419,6 +1419,8 @@ Options:
   request when the `agent` option is not used. This can be used to avoid
   creating a custom Agent class just to override the default `createConnection`
   function. See [`agent.createConnection()`][] for more details.
+- `timeout`: A number specifying the socket timeout in milliseconds. 
+  This will set the timeout before the socket is connected.
 
 The optional `callback` parameter will be added as a one time listener for
 the [`'response'`][] event.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -754,7 +754,9 @@ A factory function, which returns a new [`net.Socket`][] and automatically
 connects with the supplied `options`.
 
 The options are passed to both the [`net.Socket`][] constructor and the
-[`socket.connect`][] method.
+[`socket.connect`][] method. 
+
+Passing `timeout` as an option will call [`socket.setTimeout()`][] after the socket is created, but before it is connecting.
 
 The `connectListener` parameter will be added as a listener for the
 [`'connect'`][] event once.

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -67,6 +67,7 @@ function ClientRequest(options, cb) {
   }
 
   self.socketPath = options.socketPath;
+  self.timeout = options.timeout;
 
   var method = self.method = (options.method || 'GET').toUpperCase();
   if (!common._checkIsHttpToken(method)) {
@@ -134,7 +135,8 @@ function ClientRequest(options, cb) {
     self._last = true;
     self.shouldKeepAlive = false;
     const optionsPath = {
-      path: self.socketPath
+      path: self.socketPath,
+      timeout: self.timeout
     };
     const newSocket = self.agent.createConnection(optionsPath, oncreate);
     if (newSocket && !called) {
@@ -559,6 +561,10 @@ function tickOnSocket(req, socket) {
   socket.on('data', socketOnData);
   socket.on('end', socketOnEnd);
   socket.on('close', socketCloseListener);
+
+  if (req.timeout) {
+    socket.once('timeout', () => req.emit('timeout'));
+  }
   req.emit('socket', socket);
 }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -67,6 +67,11 @@ exports.connect = exports.createConnection = function() {
   args = normalizeConnectArgs(args);
   debug('createConnection', args);
   var s = new Socket(args[0]);
+
+  if (args[0].timeout) {
+    s.setTimeout(args[0].timeout);
+  }
+
   return Socket.prototype.connect.apply(s, args);
 };
 

--- a/test/parallel/test-http-client-timeout-option.js
+++ b/test/parallel/test-http-client-timeout-option.js
@@ -7,7 +7,8 @@ var options = {
   method: 'GET',
   port: undefined,
   host: '127.0.0.1',
-  path: '/'
+  path: '/',
+  timeout: 1
 };
 
 var server = http.createServer();
@@ -21,7 +22,6 @@ server.listen(0, options.host, function() {
   req.on('close', common.mustCall(() => server.close()));
 
   var timeout_events = 0;
-  req.setTimeout(1);
   req.on('timeout', common.mustCall(() => timeout_events += 1));
   setTimeout(function() {
     req.destroy();
@@ -29,5 +29,5 @@ server.listen(0, options.host, function() {
   }, common.platformTimeout(100));
   setTimeout(function() {
     req.end();
-  }, common.platformTimeout(50));
+  }, common.platformTimeout(10));
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http, net


##### Description of change

This allows passing the socket connection timeout to http#request
such that it will be set before the socket is connecting

Fixes #7580