### PR TITLE
http: fix legacy http.Client instanceof

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -95,5 +95,8 @@ Client.prototype.request = function(method, path, headers) {
 exports.Client = internalUtil.deprecate(Client, 'http.Client is deprecated.');
 
 exports.createClient = internalUtil.deprecate(function(port, host) {
-  return new Client(port, host);
+  const client = new Client(port, host);
+  // Need to set the prototype of the deprecated class to fix `instanceof`.
+  Object.setPrototypeOf(client, exports.Client.prototype);
+  return client;
 }, 'http.createClient is deprecated. Use http.request instead.');

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -38,6 +38,7 @@ var server = http.createServer(function(req, res) {
 
 server.listen(0, common.mustCall(function() {
   var client = http.createClient(this.address().port);
+  assert(client instanceof http.Client);
   var req = client.request('/hello', {'Accept': '*/*', 'Foo': 'bar'});
   setTimeout(function() {
     req.end();


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http

##### Description of change

Ensures that objects created with `http.createClient()` have `http.Client.prototype` as their prototype.

The new `internalUtil.deprecate()` fixes instantiation of deprecated classes, but in this case, since the unwrapped deprecated class is instantiated and returned, the prototype on the created object is not the same as the exposed class.

Setting the prototype on the new object to be prototype of the *wrapped*/exposed class fixes this, so now the following works fine:

```js
http.createClient() instanceof http.Client
```

##### Alternatives

* _Instantiate the wrapped class._ This would work fine, but you'd double up the deprecation messages, which is undesirable.
* _Use `Object.create(http.Client.prototype)` and then call the unwrapped constructor on the result (e.g. with `Client.call(client, port, host)`)._ I think this is pretty much equivalent to what I did, so I'm happy to change it to this if people think it's cleaner.
* _Ignore this since it's deprecated._ I'd rather not, since this is something intuitive and previously working (the `instanceof` relationship) that was **broken** by deprecating.