### PR TITLE
util: fix deprecated class prototype

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -69,7 +69,10 @@ exports._deprecate = function(fn, msg) {
   // The wrapper will keep the same prototype as fn to maintain prototype chain
   Object.setPrototypeOf(deprecated, fn);
   if (fn.prototype) {
-    Object.setPrototypeOf(deprecated.prototype, fn.prototype);
+    // Setting this (rather than using Object.setPrototype, as above) ensures
+    // that calling the unwrapped constructor gives an instanceof the wrapped
+    // constructor.
+    deprecated.prototype = fn.prototype;
   }
 
   return deprecated;

--- a/test/fixtures/deprecated-userland-class.js
+++ b/test/fixtures/deprecated-userland-class.js
@@ -7,6 +7,9 @@ class deprecatedClass {
 const deprecated = util.deprecate(deprecatedClass, 'deprecatedClass is deprecated.');
 
 const instance = new deprecated();
+const deprecatedInstance = new deprecatedClass();
 
 assert(instance instanceof deprecated);
 assert(instance instanceof deprecatedClass);
+assert(deprecatedInstance instanceof deprecated);
+assert(deprecatedInstance instanceof deprecatedClass);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util

##### Description of change

Ensure the wrapped class prototype is exactly the unwrapped class
prototype, rather than an object whose prototype is the unwrapped
class prototype.

This ensures that instances of the unwrapped class are instances
of the wrapped class. This is useful when both a wrapped class and
a factory for the unwrapped class are both exposed.

Ref: https://github.com/nodejs/node/pull/8103