### PR TITLE
src: make debugger listen on 127.0.0.1 by default

### DIFF
--- a/src/debug-agent.cc
+++ b/src/debug-agent.cc
@@ -69,7 +69,7 @@ Agent::~Agent() {
 }
 
 
-bool Agent::Start(const std::string& host, int port, bool wait) {
+bool Agent::Start(const char* host, int port, bool wait) {
   int err;
 
   if (state_ == kRunning)

--- a/src/debug-agent.h
+++ b/src/debug-agent.h
@@ -76,7 +76,7 @@ class Agent {
   typedef void (*DispatchHandler)(node::Environment* env);
 
   // Start the debugger agent thread
-  bool Start(const std::string& host, int port, bool wait);
+  bool Start(const char* host, int port, bool wait);
   // Listen for debug events
   void Enable();
   // Stop the debugger agent

--- a/test/parallel/test-debug-port-cluster.js
+++ b/test/parallel/test-debug-port-cluster.js
@@ -16,8 +16,7 @@ child.stderr.setEncoding('utf8');
 
 const checkMessages = common.mustCall(() => {
   for (let port = PORT_MIN; port <= PORT_MAX; port += 1) {
-    const re = RegExp(`Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):${port}`);
-    assert(re.test(stderr));
+    assert(stderr.includes(`Debugger listening on 127.0.0.1:${port}`));
   }
 });
 

--- a/test/parallel/test-debug-port-from-cmdline.js
+++ b/test/parallel/test-debug-port-from-cmdline.js
@@ -39,10 +39,10 @@ function processStderrLine(line) {
 function assertOutputLines() {
   var expectedLines = [
     'Starting debugger agent.',
-    'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + debugPort,
+    'Debugger listening on 127.0.0.1:' + debugPort,
   ];
 
   assert.equal(outputLines.length, expectedLines.length);
   for (var i = 0; i < expectedLines.length; i++)
-    assert(RegExp(expectedLines[i]).test(outputLines[i]));
+    assert(expectedLines[i].includes(outputLines[i]));
 }

--- a/test/parallel/test-debug-port-numbers.js
+++ b/test/parallel/test-debug-port-numbers.js
@@ -52,10 +52,8 @@ function kill(child) {
 
 process.on('exit', function() {
   for (const child of children) {
-    const port = child.test.port;
-    const one = RegExp(`Debugger listening on (\\[::\\]|0\.0\.0\.0):${port}`);
-    const two = RegExp(`connecting to 127.0.0.1:${port}`);
-    assert(one.test(child.test.stdout));
-    assert(two.test(child.test.stdout));
+    const { port, stdout } = child.test;
+    assert(stdout.includes(`Debugger listening on 127.0.0.1:${port}`));
+    assert(stdout.includes(`connecting to 127.0.0.1:${port}`));
   }
 });

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -63,11 +63,11 @@ process.on('exit', function onExit() {
 
 var expectedLines = [
   'Starting debugger agent.',
-  'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + (port + 0),
+  'Debugger listening on 127.0.0.1:' + (port + 0),
   'Starting debugger agent.',
-  'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + (port + 1),
+  'Debugger listening on 127.0.0.1:' + (port + 1),
   'Starting debugger agent.',
-  'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + (port + 2),
+  'Debugger listening on 127.0.0.1:' + (port + 2),
 ];
 
 function assertOutputLines() {
@@ -79,5 +79,5 @@ function assertOutputLines() {
 
   assert.equal(outputLines.length, expectedLines.length);
   for (var i = 0; i < expectedLines.length; i++)
-    assert(RegExp(expectedLines[i]).test(outputLines[i]));
+    assert(expectedLines[i].includes(outputLines[i]));
 }

--- a/test/sequential/test-debug-host-port.js
+++ b/test/sequential/test-debug-host-port.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 let run = () => {};
-function test(args, re) {
+function test(args, needle) {
   const next = run;
   run = () => {
     const options = {encoding: 'utf8'};
@@ -14,34 +14,32 @@ function test(args, re) {
     proc.stderr.setEncoding('utf8');
     proc.stderr.on('data', (data) => {
       stderr += data;
-      if (re.test(stderr)) proc.kill();
+      if (stderr.includes(needle)) proc.kill();
     });
     proc.on('exit', common.mustCall(() => {
-      assert(re.test(stderr));
+      assert(stderr.includes(needle));
       next();
     }));
   };
 }
 
-test(['--debug-brk'], /Debugger listening on (\[::\]|0\.0\.0\.0):5858/);
-test(['--debug-brk=1234'], /Debugger listening on (\[::\]|0\.0\.0\.0):1234/);
-test(['--debug-brk=127.0.0.1'], /Debugger listening on 127\.0\.0\.1:5858/);
-test(['--debug-brk=127.0.0.1:1234'], /Debugger listening on 127\.0\.0\.1:1234/);
-test(['--debug-brk=localhost'],
-     /Debugger listening on (\[::\]|127\.0\.0\.1):5858/);
-test(['--debug-brk=localhost:1234'],
-     /Debugger listening on (\[::\]|127\.0\.0\.1):1234/);
+test(['--debug-brk'], 'Debugger listening on 127.0.0.1:5858');
+test(['--debug-brk=1234'], 'Debugger listening on 127.0.0.1:1234');
+test(['--debug-brk=0.0.0.0'], 'Debugger listening on 0.0.0.0:5858');
+test(['--debug-brk=0.0.0.0:1234'], 'Debugger listening on 0.0.0.0:1234');
+test(['--debug-brk=localhost'], 'Debugger listening on 127.0.0.1:5858');
+test(['--debug-brk=localhost:1234'], 'Debugger listening on 127.0.0.1:1234');
 
 if (common.hasIPv6) {
-  test(['--debug-brk=::'], /Debug port must be in range 1024 to 65535/);
-  test(['--debug-brk=::0'], /Debug port must be in range 1024 to 65535/);
-  test(['--debug-brk=::1'], /Debug port must be in range 1024 to 65535/);
-  test(['--debug-brk=[::]'], /Debugger listening on \[::\]:5858/);
-  test(['--debug-brk=[::0]'], /Debugger listening on \[::\]:5858/);
-  test(['--debug-brk=[::]:1234'], /Debugger listening on \[::\]:1234/);
-  test(['--debug-brk=[::0]:1234'], /Debugger listening on \[::\]:1234/);
+  test(['--debug-brk=::'], 'Debug port must be in range 1024 to 65535');
+  test(['--debug-brk=::0'], 'Debug port must be in range 1024 to 65535');
+  test(['--debug-brk=::1'], 'Debug port must be in range 1024 to 65535');
+  test(['--debug-brk=[::]'], 'Debugger listening on [::]:5858');
+  test(['--debug-brk=[::0]'], 'Debugger listening on [::]:5858');
+  test(['--debug-brk=[::]:1234'], 'Debugger listening on [::]:1234');
+  test(['--debug-brk=[::0]:1234'], 'Debugger listening on [::]:1234');
   test(['--debug-brk=[::ffff:127.0.0.1]:1234'],
-       /Debugger listening on \[::ffff:127\.0\.0\.1\]:1234/);
+       'Debugger listening on [::ffff:127.0.0.1]:1234');
 }
 
 run();  // Runs tests in reverse order.


### PR DESCRIPTION
Commit 2272052 ("net: bind to `::` TCP address by default") from
April 2014 seems to have accidentally changed the default listen
address from 127.0.0.1 to 0.0.0.0, a.k.a. the "any" address.

From a security viewpoint it's undesirable to accept debug agent
connections from anywhere so let's change that back.  Users can
override the default with the `--debug=<host>:<port>` switch.

Fixes: #8081

CI: https://ci.nodejs.org/job/node-test-pull-request/3670/