### PR TITLE
doc: fix typo

### DIFF
--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -58,7 +58,7 @@ For example, the query string `'foo=bar&abc=xyz&abc=123'` is parsed into:
 
 *Note*: The object returned by the `querystring.parse()` method _does not_
 prototypically extend from the JavaScript `Object`. This means that the
-typical `Object` methods such as `obj.toString()`, `obj.hashOwnProperty()`,
+typical `Object` methods such as `obj.toString()`, `obj.hasOwnProperty()`,
 and others are not defined and *will not work*.
 
 By default, percent-encoded characters within the query string will be assumed


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
None, just a tiny doc change

##### Description of change
Fix a typo in the `querystring` docs: `obj.hashOwnProperty()` → `obj.hasOwnProperty()`.
