### PR TITLE
readline: key interval delay for \r & \n

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -359,8 +359,9 @@ added: v0.1.98
     check, otherwise the history caching mechanism is not initialized at all.
   * `prompt` - the prompt string to use. Default: `'> '`
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
-    `crlfDelay`, both `\r` and `\n` will be treated as separate end-of-line
-    input. Default to `100` milliseconds.
+    `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
+    end-of-line input. Default to `100` milliseconds.
+    `crlfDelay` will be coerced to `[100, 2000]` range.
 
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -358,8 +358,8 @@ added: v0.1.98
     only if `terminal` is set to `true` by the user or by an internal `output`
     check, otherwise the history caching mechanism is not initialized at all.
   * `prompt` - the prompt string to use. Default: `'> '`
-  * `crLfDelay` {number} If the delay between `\r` and `\n` exceeds
-    `crLfDelay`, both `\r` and `\n` will be treated as separate end-of-line
+  * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
+    `crlfDelay`, both `\r` and `\n` will be treated as separate end-of-line
     input. Default to `100` milliseconds.
 
 The `readline.createInterface()` method creates a new `readline.Interface`

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -358,6 +358,9 @@ added: v0.1.98
     only if `terminal` is set to `true` by the user or by an internal `output`
     check, otherwise the history caching mechanism is not initialized at all.
   * `prompt` - the prompt string to use. Default: `'> '`
+  * `crLfDelay` {number} If the delay between `\r` and `\n` exceeds
+    `crLfDelay`, both `\r` and `\n` will be treated as separate end-of-line
+    input. Default to `100` milliseconds.
 
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const kHistorySize = 30;
-const kCRLFDelayInMillis = 100;
+const kcrlfDelayInMillis = 100;
 
 const util = require('util');
 const debug = util.debuglog('readline');
@@ -22,19 +22,19 @@ const stripVTControlCharacters = internalReadline.stripVTControlCharacters;
 
 
 exports.createInterface = function(input, output, completer, terminal,
-    crLfDelay = kCRLFDelayInMillis) {
+                                   crlfDelay = kcrlfDelayInMillis) {
   var rl;
   if (arguments.length === 1) {
     rl = new Interface(input);
   } else {
-    rl = new Interface(input, output, completer, terminal, crLfDelay);
+    rl = new Interface(input, output, completer, terminal, crlfDelay);
   }
   return rl;
 };
 
 
 function Interface(input, output, completer, terminal,
-    crLfDelay = kCRLFDelayInMillis) {
+                   crlfDelay = kcrlfDelayInMillis) {
   if (!(this instanceof Interface)) {
     // call the constructor preserving original number of arguments
     const self = Object.create(Interface.prototype);
@@ -59,8 +59,8 @@ function Interface(input, output, completer, terminal,
     if (input.prompt !== undefined) {
       prompt = input.prompt;
     }
-    if (input.crLfDelay !== undefined) {
-      crLfDelay = input.crLfDelay;
+    if (input.crlfDelay !== undefined) {
+      crlfDelay = input.crlfDelay;
     }
     input = input.input;
   }
@@ -79,10 +79,10 @@ function Interface(input, output, completer, terminal,
     throw new TypeError('Argument "historySize" must be a positive number');
   }
 
-  if (typeof crLfDelay !== 'number' ||
-      isNaN(crLfDelay) ||
-      crLfDelay <= 0) {
-    throw new TypeError('Argument "crLfDelay" must be a positive number > 0');
+  if (typeof crlfDelay !== 'number' ||
+      isNaN(crlfDelay) ||
+      crlfDelay <= 0) {
+    throw new TypeError('Argument "crlfDelay" must be a positive number > 0');
   }
 
   // backwards compat; check the isTTY prop of the output stream
@@ -96,7 +96,7 @@ function Interface(input, output, completer, terminal,
   this.output = output;
   this.input = input;
   this.historySize = historySize;
-  this.crLfDelay = crLfDelay;
+  this.crlfDelay = crlfDelay;
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {
@@ -355,7 +355,7 @@ Interface.prototype._normalWrite = function(b) {
   }
   var string = this._decoder.write(b);
   if (this._sawReturnAt &&
-      Date.now() - this._sawReturnAt <= this.crLfDelay) {
+      Date.now() - this._sawReturnAt <= this.crlfDelay) {
     string = string.replace(/^\n/, '');
     this._sawReturnAt = 0;
   }
@@ -866,9 +866,9 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'enter':
-        // When key interval > crLfDelay
+        // When key interval > crlfDelay
         if (this._sawReturnAt === 0 ||
-            Date.now() - this._sawReturnAt > this.crLfDelay) {
+            Date.now() - this._sawReturnAt > this.crlfDelay) {
           this._line();
         }
         this._sawReturnAt = 0;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -7,7 +7,8 @@
 'use strict';
 
 const kHistorySize = 30;
-const kcrlfDelayInMillis = 100;
+const kMincrlfDelay = 100;
+const kMaxcrlfDelay = 2000;
 
 const util = require('util');
 const debug = util.debuglog('readline');
@@ -21,20 +22,18 @@ const isFullWidthCodePoint = internalReadline.isFullWidthCodePoint;
 const stripVTControlCharacters = internalReadline.stripVTControlCharacters;
 
 
-exports.createInterface = function(input, output, completer, terminal,
-                                   crlfDelay = kcrlfDelayInMillis) {
+exports.createInterface = function(input, output, completer, terminal) {
   var rl;
   if (arguments.length === 1) {
     rl = new Interface(input);
   } else {
-    rl = new Interface(input, output, completer, terminal, crlfDelay);
+    rl = new Interface(input, output, completer, terminal);
   }
   return rl;
 };
 
 
-function Interface(input, output, completer, terminal,
-                   crlfDelay = kcrlfDelayInMillis) {
+function Interface(input, output, completer, terminal) {
   if (!(this instanceof Interface)) {
     // call the constructor preserving original number of arguments
     const self = Object.create(Interface.prototype);
@@ -48,6 +47,7 @@ function Interface(input, output, completer, terminal,
 
   EventEmitter.call(this);
   var historySize;
+  let crlfDelay;
   let prompt = '> ';
 
   if (arguments.length === 1) {
@@ -59,9 +59,7 @@ function Interface(input, output, completer, terminal,
     if (input.prompt !== undefined) {
       prompt = input.prompt;
     }
-    if (input.crlfDelay !== undefined) {
-      crlfDelay = input.crlfDelay;
-    }
+    crlfDelay = input.crlfDelay;
     input = input.input;
   }
 
@@ -79,12 +77,6 @@ function Interface(input, output, completer, terminal,
     throw new TypeError('Argument "historySize" must be a positive number');
   }
 
-  if (typeof crlfDelay !== 'number' ||
-      isNaN(crlfDelay) ||
-      crlfDelay <= 0) {
-    throw new TypeError('Argument "crlfDelay" must be a positive number > 0');
-  }
-
   // backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
   if (terminal === undefined && !(output === null || output === undefined)) {
@@ -96,7 +88,8 @@ function Interface(input, output, completer, terminal,
   this.output = output;
   this.input = input;
   this.historySize = historySize;
-  this.crlfDelay = crlfDelay;
+  this.crlfDelay = Math.max(kMincrlfDelay,
+                            Math.min(kMaxcrlfDelay, crlfDelay >>> 0));
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const kHistorySize = 30;
+const kCRLFDelayInMillis = 100;
 
 const util = require('util');
 const debug = util.debuglog('readline');
@@ -39,7 +40,7 @@ function Interface(input, output, completer, terminal) {
     return self;
   }
 
-  this._sawReturn = false;
+  this._sawReturnAt = 0;
   this.isCompletionEnabled = true;
   this._previousKey = null;
 
@@ -341,9 +342,10 @@ Interface.prototype._normalWrite = function(b) {
     return;
   }
   var string = this._decoder.write(b);
-  if (this._sawReturn) {
+  if (this._sawReturnAt &&
+      Date.now() - this._sawReturnAt <= kCRLFDelayInMillis) {
     string = string.replace(/^\n/, '');
-    this._sawReturn = false;
+    this._sawReturnAt = 0;
   }
 
   // Run test() on the new string chunk, not on the entire line buffer.
@@ -354,7 +356,7 @@ Interface.prototype._normalWrite = function(b) {
     this._line_buffer = null;
   }
   if (newPartContainsEnding) {
-    this._sawReturn = string.endsWith('\r');
+    this._sawReturnAt = string.endsWith('\r') ? Date.now() : 0;
 
     // got one or more newlines; process into "line" events
     var lines = string.split(lineEnding);
@@ -842,20 +844,22 @@ Interface.prototype._ttyWrite = function(s, key) {
     /* No modifier keys used */
 
     // \r bookkeeping is only relevant if a \n comes right after.
-    if (this._sawReturn && key.name !== 'enter')
-      this._sawReturn = false;
+    if (this._sawReturnAt && key.name !== 'enter')
+      this._sawReturnAt = 0;
 
     switch (key.name) {
       case 'return':  // carriage return, i.e. \r
-        this._sawReturn = true;
+        this._sawReturnAt = Date.now();
         this._line();
         break;
 
       case 'enter':
-        if (this._sawReturn)
-          this._sawReturn = false;
-        else
+        // When key interval > kCRLFDelayInMillis
+        if (this._sawReturnAt === 0 ||
+            Date.now() - this._sawReturnAt > kCRLFDelayInMillis) {
           this._line();
+        }
+        this._sawReturnAt = 0;
         break;
 
       case 'backspace':

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -21,18 +21,20 @@ const isFullWidthCodePoint = internalReadline.isFullWidthCodePoint;
 const stripVTControlCharacters = internalReadline.stripVTControlCharacters;
 
 
-exports.createInterface = function(input, output, completer, terminal) {
+exports.createInterface = function(input, output, completer, terminal,
+    crLfDelay = kCRLFDelayInMillis) {
   var rl;
   if (arguments.length === 1) {
     rl = new Interface(input);
   } else {
-    rl = new Interface(input, output, completer, terminal);
+    rl = new Interface(input, output, completer, terminal, crLfDelay);
   }
   return rl;
 };
 
 
-function Interface(input, output, completer, terminal) {
+function Interface(input, output, completer, terminal,
+    crLfDelay = kCRLFDelayInMillis) {
   if (!(this instanceof Interface)) {
     // call the constructor preserving original number of arguments
     const self = Object.create(Interface.prototype);
@@ -57,6 +59,9 @@ function Interface(input, output, completer, terminal) {
     if (input.prompt !== undefined) {
       prompt = input.prompt;
     }
+    if (input.crLfDelay !== undefined) {
+      crLfDelay = input.crLfDelay;
+    }
     input = input.input;
   }
 
@@ -74,6 +79,12 @@ function Interface(input, output, completer, terminal) {
     throw new TypeError('Argument "historySize" must be a positive number');
   }
 
+  if (typeof crLfDelay !== 'number' ||
+      isNaN(crLfDelay) ||
+      crLfDelay <= 0) {
+    throw new TypeError('Argument "crLfDelay" must be a positive number > 0');
+  }
+
   // backwards compat; check the isTTY prop of the output stream
   //  when `terminal` was not specified
   if (terminal === undefined && !(output === null || output === undefined)) {
@@ -85,6 +96,7 @@ function Interface(input, output, completer, terminal) {
   this.output = output;
   this.input = input;
   this.historySize = historySize;
+  this.crLfDelay = crLfDelay;
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {
@@ -343,7 +355,7 @@ Interface.prototype._normalWrite = function(b) {
   }
   var string = this._decoder.write(b);
   if (this._sawReturnAt &&
-      Date.now() - this._sawReturnAt <= kCRLFDelayInMillis) {
+      Date.now() - this._sawReturnAt <= this.crLfDelay) {
     string = string.replace(/^\n/, '');
     this._sawReturnAt = 0;
   }
@@ -854,9 +866,9 @@ Interface.prototype._ttyWrite = function(s, key) {
         break;
 
       case 'enter':
-        // When key interval > kCRLFDelayInMillis
+        // When key interval > crLfDelay
         if (this._sawReturnAt === 0 ||
-            Date.now() - this._sawReturnAt > kCRLFDelayInMillis) {
+            Date.now() - this._sawReturnAt > this.crLfDelay) {
           this._line();
         }
         this._sawReturnAt = 0;

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -46,6 +46,11 @@ function isWarned(emitter) {
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
   assert.strictEqual(rli.historySize, 30);
 
+  // default crLfDelay is 100ms
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
+  assert.strictEqual(rli.crLfDelay, 100);
+
   fi.emit('data', 'asdf\n');
   assert.deepStrictEqual(rli.history, terminal ? ['asdf'] : undefined);
   rli.close();
@@ -199,14 +204,16 @@ function isWarned(emitter) {
   assert.equal(callCount, expectedLines.length);
   rli.close();
 
-  // Emit two line events where there is a delay
-  //   between \r and \n
+  // Emit two line events when the delay
+  //   between \r and \n exceeds crLFDelay
   {
     const fi = new FakeInput();
+    const delay = 200;
     const rli = new readline.Interface({
       input: fi,
       output: fi,
-      terminal: terminal
+      terminal: terminal,
+      crLfDelay: delay
     });
     let callCount = 0;
     rli.on('line', function(line) {
@@ -217,7 +224,7 @@ function isWarned(emitter) {
       fi.emit('data', '\n');
       assert.equal(callCount, 2);
       rli.close();
-    }, 200);
+    }, delay * 2);
   }
 
   // \t when there is no completer function should behave like an ordinary

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -201,7 +201,7 @@ function isWarned(emitter) {
 
   // Emit two line events where there is a delay
   //   between \r and \n
-  (() => {
+  {
     const fi = new FakeInput();
     const rli = new readline.Interface({
       input: fi,
@@ -218,7 +218,7 @@ function isWarned(emitter) {
       assert.equal(callCount, 2);
       rli.close();
     }, 200);
-  })();
+  }
 
   // \t when there is no completer function should behave like an ordinary
   //   character

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -26,6 +26,24 @@ function isWarned(emitter) {
   return false;
 }
 
+{
+  // Default crlfDelay is 100ms
+  const fi = new FakeInput();
+  let rli = new readline.Interface({ input: fi, output: fi });
+  assert.strictEqual(rli.crlfDelay, 100);
+  rli.close();
+
+  // Minimum crlfDelay is 100ms
+  rli = new readline.Interface({ input: fi, output: fi, crlfDelay: 0});
+  assert.strictEqual(rli.crlfDelay, 100);
+  rli.close();
+
+  // Maximum crlfDelay is 2000ms
+  rli = new readline.Interface({ input: fi, output: fi, crlfDelay: 1 << 30});
+  assert.strictEqual(rli.crlfDelay, 2000);
+  rli.close();
+}
+
 [ true, false ].forEach(function(terminal) {
   var fi;
   var rli;
@@ -45,11 +63,6 @@ function isWarned(emitter) {
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
   assert.strictEqual(rli.historySize, 30);
-
-  // default crlfDelay is 100ms
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
-  assert.strictEqual(rli.crlfDelay, 100);
 
   fi.emit('data', 'asdf\n');
   assert.deepStrictEqual(rli.history, terminal ? ['asdf'] : undefined);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -46,10 +46,10 @@ function isWarned(emitter) {
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
   assert.strictEqual(rli.historySize, 30);
 
-  // default crLfDelay is 100ms
+  // default crlfDelay is 100ms
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal});
-  assert.strictEqual(rli.crLfDelay, 100);
+  assert.strictEqual(rli.crlfDelay, 100);
 
   fi.emit('data', 'asdf\n');
   assert.deepStrictEqual(rli.history, terminal ? ['asdf'] : undefined);
@@ -205,7 +205,7 @@ function isWarned(emitter) {
   rli.close();
 
   // Emit two line events when the delay
-  //   between \r and \n exceeds crLFDelay
+  //   between \r and \n exceeds crlfDelay
   {
     const fi = new FakeInput();
     const delay = 200;
@@ -213,7 +213,7 @@ function isWarned(emitter) {
       input: fi,
       output: fi,
       terminal: terminal,
-      crLfDelay: delay
+      crlfDelay: delay
     });
     let callCount = 0;
     rli.on('line', function(line) {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -199,6 +199,27 @@ function isWarned(emitter) {
   assert.equal(callCount, expectedLines.length);
   rli.close();
 
+  // Emit two line events where there is a delay
+  //   between \r and \n
+  (() => {
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal
+    });
+    let callCount = 0;
+    rli.on('line', function(line) {
+      callCount++;
+    });
+    fi.emit('data', '\r');
+    setTimeout(() => {
+      fi.emit('data', '\n');
+      assert.equal(callCount, 2);
+      rli.close();
+    }, 200);
+  })();
+
   // \t when there is no completer function should behave like an ordinary
   //   character
   fi = new FakeInput();

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -29,17 +29,27 @@ function isWarned(emitter) {
 {
   // Default crlfDelay is 100ms
   const fi = new FakeInput();
-  let rli = new readline.Interface({ input: fi, output: fi });
+  const rli = new readline.Interface({ input: fi, output: fi });
   assert.strictEqual(rli.crlfDelay, 100);
   rli.close();
+}
 
+{
   // Minimum crlfDelay is 100ms
-  rli = new readline.Interface({ input: fi, output: fi, crlfDelay: 0});
+  const fi = new FakeInput();
+  const rli = new readline.Interface({ input: fi, output: fi, crlfDelay: 0});
   assert.strictEqual(rli.crlfDelay, 100);
   rli.close();
+}
 
+{
   // Maximum crlfDelay is 2000ms
-  rli = new readline.Interface({ input: fi, output: fi, crlfDelay: 1 << 30});
+  const fi = new FakeInput();
+  const rli = new readline.Interface({
+    input: fi,
+    output: fi,
+    crlfDelay: 1 << 30
+  });
   assert.strictEqual(rli.crlfDelay, 2000);
   rli.close();
 }

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -243,11 +243,11 @@ function isWarned(emitter) {
       callCount++;
     });
     fi.emit('data', '\r');
-    setTimeout(() => {
+    setTimeout(common.mustCall(() => {
       fi.emit('data', '\n');
       assert.equal(callCount, 2);
       rli.close();
-    }, delay * 2);
+    }), delay * 2);
   }
 
   // \t when there is no completer function should behave like an ordinary


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline

##### Description of change
<!-- Provide a description of the change below this comment. -->

Emit two line events when there is a delay between
CR('\r') and LF('\n')