### PR TITLE
src: fix build break for !NODE_USE_V8_PLATFORM

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -220,8 +220,9 @@ static struct {
   void Initialize(int thread_pool_size) {}
   void PumpMessageLoop(Isolate* isolate) {}
   void Dispose() {}
-  void StartInspector(Environment *env, int port, bool wait) {
+  bool StartInspector(Environment *env, int port, bool wait) {
     env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
+    return false;  // make compiler happy
   }
 #endif  // !NODE_USE_V8_PLATFORM
 } v8_platform;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
core

##### Description of change
<!-- Provide a description of the change below this comment. -->

`StartInspector` should return `bool` but there was signature
mismatch if not building for v8 platform i.e.
`!NODE_USE_V8_PLATFORM`