### PR TITLE
test: fix flaky fs-watch tests

### DIFF
--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -13,14 +13,12 @@ const fs = require('fs');
 
 const testDir = common.tmpDir;
 const filenameOne = 'watch.txt';
-const testsubdirName = 'testsubdir';
-const testsubdir = path.join(testDir, testsubdirName);
-const relativePathOne = path.join('testsubdir', filenameOne);
-const filepathOne = path.join(testsubdir, filenameOne);
 
 common.refreshTmpDir();
 
-fs.mkdirSync(testsubdir, 0o700);
+const testsubdir = fs.mkdtempSync(testDir + path.sep);
+const relativePathOne = path.join(path.basename(testsubdir), filenameOne);
+const filepathOne = path.join(testsubdir, filenameOne);
 
 const watcher = fs.watch(testDir, {recursive: true});
 

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -73,9 +73,9 @@ setImmediate(function() {
   fs.writeFileSync(filepathTwoAbs, 'pardner');
 });
 
-var filenameThree = 'newfile.txt';
-var testsubdir = fs.mkdtempSync(testDir + path.sep);
-var filepathThree = path.join(testsubdir, filenameThree);
+const filenameThree = 'newfile.txt';
+const testsubdir = fs.mkdtempSync(testDir + path.sep);
+const filepathThree = path.join(testsubdir, filenameThree);
 
 assert.doesNotThrow(
     function() {

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -21,11 +21,6 @@ var filenameTwo = 'hasOwnProperty';
 var filepathTwo = filenameTwo;
 var filepathTwoAbs = path.join(testDir, filenameTwo);
 
-var filenameThree = 'newfile.txt';
-var testsubdir = fs.mkdtempSync(testDir + path.sep);
-var filepathThree = path.join(testsubdir, filenameThree);
-
-
 process.on('exit', function() {
   assert.ok(watchSeenOne > 0);
   assert.ok(watchSeenTwo > 0);
@@ -78,7 +73,9 @@ setImmediate(function() {
   fs.writeFileSync(filepathTwoAbs, 'pardner');
 });
 
-fs.mkdirSync(testsubdir, 0o700);
+var filenameThree = 'newfile.txt';
+var testsubdir = fs.mkdtempSync(testDir + path.sep);
+var filepathThree = path.join(testsubdir, filenameThree);
 
 assert.doesNotThrow(
     function() {

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -22,7 +22,7 @@ var filepathTwo = filenameTwo;
 var filepathTwoAbs = path.join(testDir, filenameTwo);
 
 var filenameThree = 'newfile.txt';
-var testsubdir = path.join(testDir, 'testsubdir');
+var testsubdir = fs.mkdtempSync(testDir + path.sep);
 var filepathThree = path.join(testsubdir, filenameThree);
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

`test-fs-watch-recursive` and `test-fs-watch` were both watching the
same folder: `tmp/testsubdir` so running them sequentially on `OS X`
could make `test-fs-watch` to fail due to events generated in the other
test. Make them watch a random directory to fix the issue.

Fixes: https://github.com/nodejs/node/issues/8045