### PR TITLE
doc: fix variable scoping bug in Stream HTTP server example code

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -130,15 +130,14 @@ const server = http.createServer( (req, res) => {
   req.on('end', () => {
     try {
       const data = JSON.parse(body);
+      // write back something interesting to the user:
+      res.write(typeof data);
+      res.end();
     } catch (er) {
       // uh oh!  bad json!
       res.statusCode = 400;
       return res.end(`error: ${er.message}`);
     }
-
-    // write back something interesting to the user:
-    res.write(typeof data);
-    res.end();
   });
 });
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

Const is block-scoped.
Stream HTTP server example code is broken since `const` was introduced inside a try block.