### PR TITLE
Update release announcement instruction for Twitter

### DIFF
--- a/doc/releases.md
+++ b/doc/releases.md
@@ -299,9 +299,11 @@ Create a new blog post by running the [nodejs.org release-post.js script](https:
 
 ### 15. Announce
 
-The nodejs.org website will automatically rebuild and include the new version. You simply need to announce the build, preferably via Twitter with a message such as:
+The nodejs.org website will automatically rebuild and include the new version. To announce the build on Twitter through the official @nodejs account, email [pr@nodejs.org](pr@nodejs.org) with a message such as:
 
 > v5.8.0 of @nodejs is out: https://nodejs.org/en/blog/release/v5.8.0/ … something here about notable changes
+
+To ensure communication goes out with the timing of the blog post, please allow 24 hour prior notice. If known, please include the date and time the release will be shared with the community in the email to coordinate these announcements.
 
 ### 16. Cleanup
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
N/a

##### Description of change
This change updates the instructions for release announcements to allow for the official @nodejs account to tweet releases instead of retweeting. 

Future iterations of this can include automation upon blog post publishing, but this is to help in the short term so that we're coordinating communications manually with those who have access to the Twitter account, instead of not at all.

