### PR TITLE
build: do not lint src dir for JS errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -671,11 +671,11 @@ bench: bench-net bench-http bench-fs bench-tls
 bench-ci: bench
 
 jslint:
-	$(NODE) tools/jslint.js -J benchmark lib src test tools
+	$(NODE) tools/jslint.js -J benchmark lib test tools
 
 jslint-ci:
 	$(NODE) tools/jslint.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
-		benchmark lib src test tools
+		benchmark lib test tools
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_root_certs.h

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -351,12 +351,12 @@ if defined jslint_ci goto jslint-ci
 if not defined jslint goto exit
 if not exist tools\eslint\lib\eslint.js goto no-lint
 echo running jslint
-%config%\node tools\jslint.js -J benchmark lib src test tools
+%config%\node tools\jslint.js -J benchmark lib test tools
 goto exit
 
 :jslint-ci
 echo running jslint-ci
-%config%\node tools\jslint.js -J -f tap -o test-eslint.tap benchmark lib src test tools
+%config%\node tools\jslint.js -J -f tap -o test-eslint.tap benchmark lib test tools
 goto exit
 
 :no-lint


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

There are no JavaScript files in the `src` directory. It can be
safely omitted from the JavaScript linting step.