### PR TITLE
test: fix assertion in test-watch-file.js

### DIFF
--- a/test/pummel/test-watch-file.js
+++ b/test/pummel/test-watch-file.js
@@ -14,7 +14,7 @@ function watchFile() {
   fs.watchFile(f, function(curr, prev) {
     console.log(f + ' change');
     changes++;
-    assert.ok(curr.mtime != prev.mtime);
+    assert.notDeepStrictEqual(curr.mtime, prev.mtime);
     fs.unwatchFile(f);
     watchFile();
     fs.unwatchFile(f);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

Because it is comparing two Date objects, an assertion in
test/pummel/test-watch-file.js would never fire even if the two objects
represented the same time. Use `assert.notDeepStringEqual()` so that the
assertion fires if different Date objects represent the same time.