### PR TITLE
test: favor `===` over `==` in test-timers.js

### DIFF
--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -39,7 +39,7 @@ setInterval(function() {
   assert.equal(true, t - WINDOW < diff && diff < t + WINDOW);
 
   assert.equal(true, interval_count <= 3);
-  if (interval_count == 3)
+  if (interval_count === 3)
     clearInterval(this);
 }, 1000);
 
@@ -54,7 +54,7 @@ setInterval(function(param) {
   ++interval_count2;
   assert.equal('test param', param);
 
-  if (interval_count2 == 3)
+  if (interval_count2 === 3)
     clearInterval(this);
 }, 1000, 'test param');
 
@@ -71,7 +71,7 @@ setInterval(function(param1, param2) {
   assert.equal('param1', param1);
   assert.equal('param2', param2);
 
-  if (interval_count3 == 3)
+  if (interval_count3 === 3)
     clearInterval(this);
 }, 1000, 'param1', 'param2');
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test timers

##### Description of change
<!-- Provide a description of the change below this comment. -->

Use `===` instead of `==` in pummel/test-timers.js