### PR TITLE
assert: remove code that is never reached

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -61,11 +61,7 @@ assert.AssertionError = function AssertionError(options) {
 util.inherits(assert.AssertionError, Error);
 
 function truncate(s, n) {
-  if (typeof s === 'string') {
-    return s.length < n ? s : s.slice(0, n);
-  } else {
-    return s;
-  }
+  return s.length < n ? s : s.slice(0, n);
 }
 
 function getMessage(self) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -61,7 +61,7 @@ assert.AssertionError = function AssertionError(options) {
 util.inherits(assert.AssertionError, Error);
 
 function truncate(s, n) {
-  return s.length < n ? s : s.slice(0, n);
+  return s.slice(0, n);
 }
 
 function getMessage(self) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert

##### Description of change
<!-- Provide a description of the change below this comment. -->

The internal function `truncate()` is only called with the first
argument being the output of `util.inspect()`. `util.inspect()` calls
its own internal `formatValue()` which is guaranteed to return a string.

Therefore, we can remove the check in `truncate()` that the first
argument is a string as well as code to handle the case where it is not
a string.