### PR TITLE
test: confirm that assert truncates long values

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -528,4 +528,9 @@ testBlockTypeError(assert.doesNotThrow, undefined);
 assert.throws(() => { throw 'error'; }, (err) => err === 'error');
 assert.throws(() => { throw new Error(); }, (err) => err instanceof Error);
 
+// Long values should be truncated for display.
+assert.throws(() => {
+  assert.strictEqual('A'.repeat(1000), '');
+}, new RegExp(`'${'A'.repeat(127)} === ''`));
+
 console.log('All OK');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test assert

##### Description of change
<!-- Provide a description of the change below this comment. -->

`assert` has code to truncate values that take more than 128 characters
to display. Add a test for this functionality, as the code is not
currently exercised in the existing tests.