### PR TITLE
buffer: alias toLocaleString to toString

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1332,3 +1332,5 @@ Buffer.prototype.swap64 = function swap64() {
   }
   return swap64n(this);
 };
+
+Buffer.prototype.toLocaleString = Buffer.prototype.toString;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1496,3 +1496,9 @@ assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be a number/);
 assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
               /"size" argument must be a number/);
+
+assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);
+{
+  const buf = Buffer.from('test');
+  assert.strictEqual(buf.toLocaleString(), buf.toString());
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Buffer

##### Description of change
Make Buffer.prototype.toLocaleString an alias of Buffer.prototype.toString so that the output is actually useful.

Fixes: https://github.com/nodejs/node/issues/8147

/cc @nodejs/buffer