### PR TITLE
test: add missing assert.deepEqual() test case

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -165,6 +165,9 @@ assert.doesNotThrow(makeBlock(a.deepEqual, new Number(1), {}),
 assert.doesNotThrow(makeBlock(a.deepEqual, new Boolean(true), {}),
                     a.AssertionError);
 
+// same number of keys but different key names
+assert.throws(makeBlock(a.deepEqual, {a: 1}, {b: 1}), a.AssertionError);
+
 //deepStrictEqual
 assert.doesNotThrow(makeBlock(a.deepStrictEqual, new Date(2000, 3, 14),
                     new Date(2000, 3, 14)),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test assert

##### Description of change
<!-- Provide a description of the change below this comment. -->

None of the existing tests checked for the situation where
`assert.deepEqual()` receives two objects that have the same number of
keys but different key names. Therefore, [line 242 of `lib/assert.js`](https://github.com/nodejs/node/blob/3177b99737a4cfd46277f9408f7cbd2033901c7f/lib/assert.js#L242) was
not being exercised by any tests.

This change adds the missing test case.

Refs: https://node-core-coverage.addaleax.net/coverage-05b566a5ef7c41f6/root/assert.js.html