### PR TITLE
buffer: allow .write() offset to be at buffer end

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -714,7 +714,7 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   size_t max_length;
 
   CHECK_NOT_OOB(ParseArrayIndex(args[1], 0, &offset));
-  if (offset >= ts_obj_length)
+  if (offset > ts_obj_length)
     return env->ThrowRangeError("Offset is out of bounds");
 
   CHECK_NOT_OOB(ParseArrayIndex(args[2], ts_obj_length - offset, &max_length));

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -358,6 +358,9 @@ writeTest.write('e', 3, 'ascii');
 writeTest.write('j', 4, 'ascii');
 assert.equal(writeTest.toString(), 'nodejs');
 
+// Does not throw (see https://github.com/nodejs/node/issues/8127).
+Buffer.alloc(1).write('', 1, 0);
+
 // ASCII slice test
 {
   const asciiString = 'hello world';

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -358,8 +358,11 @@ writeTest.write('e', 3, 'ascii');
 writeTest.write('j', 4, 'ascii');
 assert.equal(writeTest.toString(), 'nodejs');
 
-// Does not throw (see https://github.com/nodejs/node/issues/8127).
-Buffer.alloc(1).write('', 1, 0);
+// Offset points to the end of the buffer
+// (see https://github.com/nodejs/node/issues/8127).
+assert.doesNotThrow(() => {
+  Buffer.alloc(1).write('', 1, 0);
+});
 
 // ASCII slice test
 {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Do not throw if the offset passed to `buf.write()` points to the end of the buffer.

Fixes: https://github.com/nodejs/node/issues/8127

CI: https://ci.nodejs.org/job/node-test-commit/4633/