### PR TITLE
test: add test for attempted multiple IPC channels

### DIFF
--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -17,3 +17,7 @@ assert.equal(child.stderr, null);
 options = {stdio: 'ignore'};
 child = common.spawnSyncCat(options);
 assert.deepStrictEqual(options, {stdio: 'ignore'});
+
+assert.throws(() => {
+  common.spawnPwd({stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'ipc']});
+}, /^Error: Child process can have only one IPC pipe$/);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This error was previously not covered. This commit adds coverage.