### PR TITLE
test: test sending over a closed IPC channel

### DIFF
--- a/test/parallel/test-child-process-send-after-close.js
+++ b/test/parallel/test-child-process-send-after-close.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const path = require('path');
+const fixture = path.join(common.fixturesDir, 'empty.js');
+const child = cp.fork(fixture);
+
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+
+  function testError(err) {
+    assert.strictEqual(err.message, 'channel closed');
+  }
+
+  child.on('error', common.mustCall(testError));
+
+  {
+    const result = child.send('ping');
+    assert.strictEqual(result, false);
+  }
+
+  {
+    const result = child.send('pong', common.mustCall(testError));
+    assert.strictEqual(result, false);
+  }
+}));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This commit adds a test that attempts to send data over an IPC channel once it has been closed.