### PR TITLE
doc: remove outdated LTS info from ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ The most important consideration in every code change is the impact it will have
 
 Node.js does not remove stdlib JS API.
 
-Shipping with current and well supported dependencies is the best way to ensure long term stability of the platform. When those dependencies are no longer maintained Node.js will take on their continued maintenance as part of our [Long Term Support policy](#long-term-support).
+Shipping with current and well supported dependencies is the best way to ensure long term stability of the platform.
 
 Node.js will continue to adopt new V8 releases.
 * When V8 ships a breaking change to their C++ API that can be handled by [`nan`](https://github.com/nodejs/nan)
@@ -23,14 +23,6 @@ appropriate to increase the minor rather than major.
 No new API will be added in *patch* releases.
 
 Any API addition will cause an increase in the *minor* version.
-
-### Long Term Support
-
-Node.js supports old versions for as long as community members are fixing bugs in them.
-
-As long as there is a community back porting bug fixes we will push patch releases for those versions of Node.js.
-
-When old versions of dependencies like V8 are no longer supported by their project Node.js will take on the responsibility of maintenance to ensure continued long term support in Node.js patch releases.
 
 ## Channels
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

The ROADMAP.md doc has not been substantially updated since its creation
in February 2015. As such, the LTS information is incorrect. Removing it
for now. (If it is deemed critical to the roadmap, links to current
information can be added back in. I'm skeptical that the roadmap
document is of much utility at this point, though, given the lack of
updates. Less may be more here, as the cliché goes.)

@nodejs/tsc @nodejs/lts @nodejs/ctc 