### PR TITLE
child_process: reuse existing no-op function

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -87,7 +87,7 @@ const handleConversion = {
       // remove handle from socket object, it will be closed when the socket
       // will be sent
       if (!options.keepOpen) {
-        handle.onread = function() {};
+        handle.onread = nop;
         socket._handle = null;
       }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process

##### Description of change
The `internal/child_process` module has an existing no-op function. This commit utilizes that function, instead of creating extraneous closures.