### PR TITLE
lib,fs: use process.emitWarning instead of internal print dep warning

### DIFF
--- a/lib/_linklist.js
+++ b/lib/_linklist.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const msg = require('internal/util').printDeprecationMessage;
-
 module.exports = require('internal/linkedlist');
-msg('_linklist module is deprecated. Please use a userland alternative.');
+process.emitWarning(
+  '_linklist module is deprecated. Please use a userland alternative.',
+  'DeprecationWarning');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -43,7 +43,6 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
-const printDeprecation = require('internal/util').printDeprecationMessage;
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +
@@ -613,10 +612,14 @@ var readWarned = false;
 fs.read = function(fd, buffer, offset, length, position, callback) {
   if (!(buffer instanceof Buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
-    readWarned = printDeprecation('fs.read\'s legacy String interface ' +
-                                  'is deprecated. Use the Buffer API as ' +
-                                  'mentioned in the documentation instead.',
-                                  readWarned);
+    if (!readWarned) {
+      readWarned = true;
+      process.emitWarning(
+        'fs.read\'s legacy String interface is deprecated. Use the Buffer ' +
+        'API as mentioned in the documentation instead.',
+        'DeprecationWarning');
+    }
+
     const cb = arguments[4];
     const encoding = arguments[3];
 
@@ -673,10 +676,13 @@ fs.readSync = function(fd, buffer, offset, length, position) {
 
   if (!(buffer instanceof Buffer)) {
     // legacy string interface (fd, length, position, encoding, callback)
-    readSyncWarned = printDeprecation('fs.readSync\'s legacy String interface' +
-                                      'is deprecated. Use the Buffer API as ' +
-                                      'mentioned in the documentation instead.',
-                                      readSyncWarned);
+    if (!readSyncWarned) {
+      readSyncWarned = true;
+      process.emitWarning(
+        'fs.readSync\'s legacy String interface is deprecated. Use the ' +
+        'Buffer API as mentioned in the documentation instead.',
+        'DeprecationWarning');
+    }
     legacy = true;
     encoding = arguments[3];
 

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const traceWarnings = process.traceProcessWarnings;
-const noDeprecation = process.noDeprecation;
-const traceDeprecation = process.traceDeprecation;
-const throwDeprecation = process.throwDeprecation;
 const prefix = `(${process.release.name}:${process.pid}) `;
 
 exports.setup = setupProcessWarnings;
@@ -13,8 +9,9 @@ function setupProcessWarnings() {
     process.on('warning', (warning) => {
       if (!(warning instanceof Error)) return;
       const isDeprecation = warning.name === 'DeprecationWarning';
-      if (isDeprecation && noDeprecation) return;
-      const trace = traceWarnings || (isDeprecation && traceDeprecation);
+      if (isDeprecation && process.noDeprecation) return;
+      const trace = process.traceProcessWarnings ||
+                    (isDeprecation && process.traceDeprecation);
       if (trace && warning.stack) {
         console.error(`${prefix}${warning.stack}`);
       } else {
@@ -41,9 +38,12 @@ function setupProcessWarnings() {
     if (!(warning instanceof Error)) {
       throw new TypeError('\'warning\' must be an Error object or string.');
     }
-    if (throwDeprecation && warning.name === 'DeprecationWarning')
-      throw warning;
-    else
-      process.nextTick(() => process.emit('warning', warning));
+    if (warning.name === 'DeprecationWarning') {
+      if (process.noDeprecation)
+        return;
+      if (process.throwDeprecation)
+        throw warning;
+    }
+    process.nextTick(() => process.emit('warning', warning));
   };
 }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -19,16 +19,6 @@ exports.deprecate = function(fn, msg) {
   return exports._deprecate(fn, msg);
 };
 
-// All the internal deprecations have to use this function only, as this will
-// prepend the prefix to the actual message.
-exports.printDeprecationMessage = function(msg, warned, ctor) {
-  if (warned || process.noDeprecation)
-    return true;
-  process.emitWarning(msg, 'DeprecationWarning',
-                      ctor || exports.printDeprecationMessage);
-  return true;
-};
-
 exports.error = function(msg) {
   const fmt = `${prefix}${msg}`;
   if (arguments.length > 1) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -63,7 +63,10 @@ exports._deprecate = function(fn, msg) {
 
   var warned = false;
   function deprecated() {
-    warned = exports.printDeprecationMessage(msg, warned, deprecated);
+    if (!warned) {
+      warned = true;
+      process.emitWarning(msg, 'DeprecationWarning', deprecated);
+    }
     if (new.target) {
       return Reflect.construct(fn, arguments, new.target);
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -196,10 +196,14 @@ Module._findPath = function(request, paths, isMain) {
     if (filename) {
       // Warn once if '.' resolved outside the module dir
       if (request === '.' && i > 0) {
-        warned = internalUtil.printDeprecationMessage(
-          'warning: require(\'.\') resolved outside the package ' +
-          'directory. This functionality is deprecated and will be removed ' +
-          'soon.', warned);
+        if (!warned) {
+          warned = true;
+          process.emitWarning(
+            'warning: require(\'.\') resolved outside the package ' +
+            'directory. This functionality is deprecated and will be removed ' +
+            'soon.',
+            'DeprecationWarning');
+        }
       }
 
       Module._pathCache[cacheKey] = filename;

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -1,10 +1,9 @@
 'use strict';
 
-const util = require('internal/util');
-
 // the sys module was renamed to 'util'.
 // this shim remains to keep old programs working.
 // sys is deprecated and shouldn't be used
 
 module.exports = require('util');
-util.printDeprecationMessage('sys is deprecated. Use util instead.');
+process.emitWarning('sys is deprecated. Use util instead.',
+                    'DeprecationWarning');

--- a/test/parallel/test-process-no-deprecation.js
+++ b/test/parallel/test-process-no-deprecation.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_internals --no-warnings
+// Flags: --no-warnings
 
 // The --no-warnings flag only supresses writing the warning to stderr, not the
 // emission of the corresponding event. This test file can be run without it.
@@ -15,8 +15,7 @@ function listener() {
 
 process.addListener('warning', listener);
 
-const internalUtil = require('internal/util');
-internalUtil.printDeprecationMessage('Something is deprecated.');
+process.emitWarning('Something is deprecated.', 'DeprecationWarning');
 
 // The warning would be emitted in the next tick, so continue after that.
 process.nextTick(common.mustCall(() => {
@@ -29,5 +28,5 @@ process.nextTick(common.mustCall(() => {
     assert.strictEqual(warning.message, 'Something else is deprecated.');
   }));
 
-  internalUtil.printDeprecationMessage('Something else is deprecated.');
+  process.emitWarning('Something else is deprecated.', 'DeprecationWarning');
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

lib, fs

##### Description of change

This removes uses of the the internal/util `printDeprecationMessage()` API in favor of
using `process.emitWarning(msg, 'DeprecationWarning')`. This allows us to remove the
graceful-fs warning in `fs` providing at least a temporary relief of the logjam that is
occurring there.

The PR also adds a new lint rule that flags uses of `printDeprecationMessage()`

/cc @ChALkeR @TheAlphaNerd @nodejs/ctc 

This is an alternative to https://github.com/nodejs/node/pull/6413. If this lands, We do not have to do the revert.