### PR TITLE
test: exercise EE function type checking paths

### DIFF
--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -1,68 +1,72 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-var events = require('events');
+const common = require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
 
-var e = new events.EventEmitter();
+{
+  const ee = new EventEmitter();
+  const events_new_listener_emited = [];
+  const listeners_new_listener_emited = [];
 
-var events_new_listener_emited = [];
-var listeners_new_listener_emited = [];
-var times_hello_emited = 0;
+  // Sanity check
+  assert.strictEqual(ee.addListener, ee.on);
 
-// sanity check
-assert.equal(e.addListener, e.on);
+  ee.on('newListener', function(event, listener) {
+    // Don't track newListener listeners.
+    if (event === 'newListener')
+      return;
 
-e.on('newListener', function(event, listener) {
-  if (event === 'newListener')
-    return; // Don't track our adding of newListener listeners.
-  console.log('newListener: ' + event);
-  events_new_listener_emited.push(event);
-  listeners_new_listener_emited.push(listener);
-});
+    events_new_listener_emited.push(event);
+    listeners_new_listener_emited.push(listener);
+  });
 
-function hello(a, b) {
-  console.log('hello');
-  times_hello_emited += 1;
-  assert.equal('a', a);
-  assert.equal('b', b);
+  const hello = common.mustCall(function(a, b) {
+    assert.strictEqual('a', a);
+    assert.strictEqual('b', b);
+  });
+
+  ee.once('newListener', function(name, listener) {
+    assert.strictEqual(name, 'hello');
+    assert.strictEqual(listener, hello);
+    assert.deepStrictEqual(this.listeners('hello'), []);
+  });
+
+  ee.on('hello', hello);
+  ee.once('foo', common.fail);
+  assert.deepStrictEqual(['hello', 'foo'], events_new_listener_emited);
+  assert.deepStrictEqual([hello, common.fail], listeners_new_listener_emited);
+
+  ee.emit('hello', 'a', 'b');
 }
-e.once('newListener', function(name, listener) {
-  assert.equal(name, 'hello');
-  assert.equal(listener, hello);
-  assert.deepStrictEqual(this.listeners('hello'), []);
-});
-e.on('hello', hello);
-
-var foo = function() {};
-e.once('foo', foo);
-
-console.log('start');
-
-e.emit('hello', 'a', 'b');
-
 
 // just make sure that this doesn't throw:
-var f = new events.EventEmitter();
-f.setMaxListeners(0);
+{
+  const f = new EventEmitter();
 
+  f.setMaxListeners(0);
+}
 
-process.on('exit', function() {
-  assert.deepStrictEqual(['hello', 'foo'], events_new_listener_emited);
-  assert.deepStrictEqual([hello, foo], listeners_new_listener_emited);
-  assert.equal(1, times_hello_emited);
-});
+{
+  const listen1 = function listen1() {};
+  const listen2 = function listen2() {};
+  const ee = new EventEmitter();
 
-var listen1 = function listen1() {};
-var listen2 = function listen2() {};
-var e1 = new events.EventEmitter();
-e1.once('newListener', function() {
-  assert.deepStrictEqual(e1.listeners('hello'), []);
-  e1.once('newListener', function() {
-    assert.deepStrictEqual(e1.listeners('hello'), []);
+  ee.once('newListener', function() {
+    assert.deepStrictEqual(ee.listeners('hello'), []);
+    ee.once('newListener', function() {
+      assert.deepStrictEqual(ee.listeners('hello'), []);
+    });
+    ee.on('hello', listen2);
   });
-  e1.on('hello', listen2);
-});
-e1.on('hello', listen1);
-// The order of listeners on an event is not always the order in which the
-// listeners were added.
-assert.deepStrictEqual(e1.listeners('hello'), [listen2, listen1]);
+  ee.on('hello', listen1);
+  // The order of listeners on an event is not always the order in which the
+  // listeners were added.
+  assert.deepStrictEqual(ee.listeners('hello'), [listen2, listen1]);
+}
+
+// Verify that the listener must be a function
+assert.throws(() => {
+  const ee = new EventEmitter();
+
+  ee.on('foo', null);
+}, /^TypeError: "listener" argument must be a function$/);

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -1,8 +1,9 @@
 'use strict';
 const common = require('../common');
-var events = require('events');
+const assert = require('assert');
+const EventEmitter = require('events');
 
-var e = new events.EventEmitter();
+const e = new EventEmitter();
 
 e.once('hello', common.mustCall(function(a, b) {}));
 
@@ -26,3 +27,10 @@ e.once('e', common.mustCall(function() {
 e.once('e', common.mustCall(function() {}));
 
 e.emit('e');
+
+// Verify that the listener must be a function
+assert.throws(() => {
+  const ee = new EventEmitter();
+
+  ee.once('foo', null);
+}, /^TypeError: "listener" argument must be a function$/);

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -17,6 +17,12 @@ myEE.prependOnceListener('foo', common.mustCall(() => assert.equal(m++, 0)));
 
 myEE.emit('foo');
 
+// Verify that the listener must be a function
+assert.throws(() => {
+  const ee = new EventEmitter();
+
+  ee.prependOnceListener('foo', null);
+}, /^TypeError: "listener" argument must be a function$/);
 
 // Test fallback if prependListener is undefined.
 const stream = require('stream');

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -1,13 +1,13 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const events = require('events');
+const EventEmitter = require('events');
 
 function listener1() {}
 function listener2() {}
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
   ee.on('hello', listener1);
   ee.on('removeListener', common.mustCall((name, cb) => {
     assert.strictEqual(name, 'hello');
@@ -18,7 +18,7 @@ function listener2() {}
 }
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
   ee.on('hello', listener1);
   ee.on('removeListener', common.fail);
   ee.removeListener('hello', listener2);
@@ -26,7 +26,7 @@ function listener2() {}
 }
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
   ee.on('hello', listener1);
   ee.on('hello', listener2);
   ee.once('removeListener', common.mustCall((name, cb) => {
@@ -46,7 +46,7 @@ function listener2() {}
 }
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
 
   function remove1() {
     common.fail('remove1 should not have been called');
@@ -67,7 +67,7 @@ function listener2() {}
 }
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
   ee.on('hello', listener1);
   ee.on('hello', listener2);
   ee.once('removeListener', common.mustCall((name, cb) => {
@@ -87,7 +87,7 @@ function listener2() {}
 }
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
   const listener3 = common.mustCall(() => {
     ee.removeListener('hello', listener4);
   }, 2);
@@ -106,7 +106,7 @@ function listener2() {}
 }
 
 {
-  const ee = new events.EventEmitter();
+  const ee = new EventEmitter();
 
   ee.once('hello', listener1);
   ee.on('removeListener', common.mustCall((eventName, listener) => {
@@ -115,3 +115,10 @@ function listener2() {}
   }));
   ee.emit('hello');
 }
+
+// Verify that the removed listener must be a function
+assert.throws(() => {
+  const ee = new EventEmitter();
+
+  ee.removeListener('foo', null);
+}, /^TypeError: "listener" argument must be a function$/);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This commit adds tests for `on()`, `once()`, `removeListener()`, and `prependOnceListener()`, which all throw a `TypeError` if the listener argument is not a function.