### PR TITLE
buffer: hard-deprecate calling Buffer without new

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -3,7 +3,6 @@
 
 const binding = process.binding('buffer');
 const { isArrayBuffer } = process.binding('util');
-const { deprecate } = require('internal/util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
@@ -55,11 +54,6 @@ function alignPool() {
   }
 }
 
-const bufferDeprecationWarning =
-    deprecate(() => {}, 'Using Buffer without `new` will soon stop working. ' +
-      'Use `new Buffer`, or preferably ' +
-      'Buffer.from, Buffer.allocUnsafe or Buffer.alloc instead.');
-
 /**
  * The Buffer() construtor is "soft deprecated" ... that is, it is deprecated
  * in the documentation and should not be used moving forward. Rather,
@@ -70,9 +64,16 @@ const bufferDeprecationWarning =
  * much breakage at this time. It's not likely that the Buffer constructors
  * would ever actually be removed.
  **/
+var newBufferWarned = false;
 function Buffer(arg, encodingOrOffset, length) {
-  if (!new.target) {
-    bufferDeprecationWarning();
+  if (!new.target && !newBufferWarned) {
+    newBufferWarned = true;
+    process.emitWarning(
+      'Using Buffer without `new` will soon stop working. ' +
+      'Use `new Buffer`, or preferably ' +
+      'Buffer.from, Buffer.allocUnsafe or Buffer.alloc instead.',
+      'DeprecationWarning'
+    );
   }
   // Common case.
   if (typeof arg === 'number') {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -3,6 +3,7 @@
 
 const binding = process.binding('buffer');
 const { isArrayBuffer } = process.binding('util');
+const { deprecate } = require('internal/util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
@@ -54,6 +55,11 @@ function alignPool() {
   }
 }
 
+const bufferDeprecationWarning =
+    deprecate(() => {}, 'Using Buffer without `new` will soon stop working. ' +
+      'Use `new Buffer`, or preferably ' +
+      'Buffer.from, Buffer.allocUnsafe or Buffer.alloc instead.');
+
 /**
  * The Buffer() construtor is "soft deprecated" ... that is, it is deprecated
  * in the documentation and should not be used moving forward. Rather,
@@ -65,6 +71,9 @@ function alignPool() {
  * would ever actually be removed.
  **/
 function Buffer(arg, encodingOrOffset, length) {
+  if (!(this instanceof Buffer)) {
+    bufferDeprecationWarning();
+  }
   // Common case.
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -71,7 +71,7 @@ const bufferDeprecationWarning =
  * would ever actually be removed.
  **/
 function Buffer(arg, encodingOrOffset, length) {
-  if (!(this instanceof Buffer)) {
+  if (!new.target) {
     bufferDeprecationWarning();
   }
   // Common case.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -70,8 +70,8 @@ function Buffer(arg, encodingOrOffset, length) {
     newBufferWarned = true;
     process.emitWarning(
       'Using Buffer without `new` will soon stop working. ' +
-      'Use `new Buffer`, or preferably ' +
-      'Buffer.from, Buffer.allocUnsafe or Buffer.alloc instead.',
+      'Use `new Buffer()`, or preferably ' +
+      '`Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.',
       'DeprecationWarning'
     );
   }

--- a/test/parallel/test-buffer-deprecated.js
+++ b/test/parallel/test-buffer-deprecated.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const expected =
+  'Using Buffer without `new` will soon stop working. ' +
+  'Use `new Buffer()`, or preferably ' +
+  '`Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.';
+
+process.on('warning', common.mustCall((warning) => {
+  assert.strictEqual(warning.name, 'DeprecationWarning');
+  assert.strictEqual(warning.message, expected,
+                     `unexpected error message: "${warning.message}"`);
+}, 1));
+
+Buffer(1);
+Buffer(1);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

Light version of #7152.

We want to make `Buffer` a `class` so that it can be subclassed. However, instantiating a `class` requires `new`. This hard-deprecates calling `Buffer` without `new`.