### PR TITLE
dns: lookupService() callback must be a function

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -191,8 +191,11 @@ exports.lookupService = function(host, port, callback) {
   if (isIP(host) === 0)
     throw new TypeError('"host" argument needs to be a valid IP address');
 
-  if (port == null || !isLegalPort(port))
+  if (!isLegalPort(port))
     throw new TypeError(`"port" should be >= 0 and < 65536, got "${port}"`);
+
+  if (typeof callback !== 'function')
+    throw new TypeError('"callback" argument must be a function');
 
   port = +port;
   callback = makeAsync(callback);

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -56,9 +56,6 @@ function errnoException(err, syscall, hostname) {
 //   callback.immediately = true;
 // }
 function makeAsync(callback) {
-  if (typeof callback !== 'function') {
-    return callback;
-  }
   return function asyncCallback() {
     if (asyncCallback.immediately) {
       // The API already returned, we can invoke the callback immediately.

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -177,3 +177,7 @@ assert.throws(function() {
 assert.throws(function() {
   dns.lookupService('0.0.0.0', 'test', noop);
 }, /"port" should be >= 0 and < 65536, got "test"/);
+
+assert.throws(() => {
+  dns.lookupService('0.0.0.0', 80, null);
+}, /^TypeError: "callback" argument must be a function$/);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
dns

##### Description of change
`lookupService()` requires a callback function. The first commit in this PR adds a check to verify that the callback is actually a function.

As a result of the first commit, the second commit drops a pointless check. `makeAsync()` is an internal method in the dns module. All of the functions that call `makeAsync()` have already validated that the callback is a function. The second commit removes a redundant `typeof` function check.

`lookupService()` already does not work unless a function is passed, but technically the change in error message makes this a semver major. It is worth noting that currently, if you pass an object as the callback, `lookupService()` does not throw immediately, and instead throws in an asynchronous callback. Perhaps that is enough to convince someone that this is a bug fix and not just a semver major error message change ;-)