### PR TITLE
build: add node_module_version to config.gypi

### DIFF
--- a/configure
+++ b/configure
@@ -769,6 +769,8 @@ def configure_node(o):
   if options.enable_static:
     o['variables']['node_target_type'] = 'static_library'
 
+  o['variables']['node_module_version'] = 46
+
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module
 

--- a/node.gyp
+++ b/node.gyp
@@ -15,6 +15,7 @@
     'node_enable_v8_vtunejit%': 'false',
     'node_target_type%': 'executable',
     'node_core_target_name%': 'node',
+    'node_module_version%': '',
     'library_files': [
       'src/node.js',
       'lib/_debug_agent.js',

--- a/test/parallel/test-module-version.js
+++ b/test/parallel/test-module-version.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// Check for existence
+assert(process.config.variables.hasOwnProperty('node_module_version'));
+
+// Ensure that `node_module_version` is an Integer
+assert(!Number.isNaN(parseInt(process.config.variables.node_module_version)));
+assert.strictEqual(process.config.variables.node_module_version, 46);


### PR DESCRIPTION
Enable targetting of a different node version than
the currently running one when building binary modules.

Based on nodejs/node@410296c37

Ref: https://github.com/nodejs/node/pull/8027
Ref: https://github.com/nodejs/node/pull/7808
Ref: https://github.com/nodejs/node-gyp/pull/855