### PR TITLE
test: add assert.notDeepStrictEqual() tests

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -166,14 +166,27 @@ assert.doesNotThrow(makeBlock(a.deepEqual, new Boolean(true), {}),
                     a.AssertionError);
 
 //deepStrictEqual
-assert.doesNotThrow(makeBlock(a.deepStrictEqual, new Date(2000, 3, 14),
-                    new Date(2000, 3, 14)),
-                    'deepStrictEqual(new Date(2000, 3, 14),\
-                    new Date(2000, 3, 14))');
+assert.doesNotThrow(
+  makeBlock(a.deepStrictEqual, new Date(2000, 3, 14), new Date(2000, 3, 14)),
+  'deepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
+);
 
-assert.throws(makeBlock(a.deepStrictEqual, new Date(), new Date(2000, 3, 14)),
-              a.AssertionError,
-              'deepStrictEqual(new Date(), new Date(2000, 3, 14))');
+assert.throws(
+  makeBlock(a.deepStrictEqual, new Date(), new Date(2000, 3, 14)),
+  a.AssertionError,
+  'deepStrictEqual(new Date(), new Date(2000, 3, 14))'
+);
+
+assert.throws(
+  makeBlock(a.notDeepStrictEqual, new Date(2000, 3, 14), new Date(2000, 3, 14)),
+  a.AssertionError,
+  'notDeepStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
+);
+
+assert.doesNotThrow(
+  makeBlock(a.notDeepStrictEqual, new Date(), new Date(2000, 3, 14)),
+  'notDeepStrictEqual(new Date(), new Date(2000, 3, 14))'
+);
 
 // 7.3 - strict
 assert.doesNotThrow(makeBlock(a.deepStrictEqual, /a/, /a/));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test assert

##### Description of change
<!-- Provide a description of the change below this comment. -->

There is no test coverage for `assert.notDeepStrictEqual()`. Add some
minimal tests.