### PR TITLE
test: add test for invalid cert string

### DIFF
--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -8,27 +8,33 @@ if (!common.hasCrypto) {
 const assert = require('assert');
 const tls = require('tls');
 
-const singles = 'C=US\nST=CA\nL=SF\nO=Node.js Foundation\nOU=Node.js\n' +
-                'CN=ca1\nemailAddress=ry@clouds.org';
-const singlesOut = tls.parseCertString(singles);
-assert.deepStrictEqual(singlesOut, {
-  C: 'US',
-  ST: 'CA',
-  L: 'SF',
-  O: 'Node.js Foundation',
-  OU: 'Node.js',
-  CN: 'ca1',
-  emailAddress: 'ry@clouds.org'
-});
+{
+  const singles = 'C=US\nST=CA\nL=SF\nO=Node.js Foundation\nOU=Node.js\n' +
+                  'CN=ca1\nemailAddress=ry@clouds.org';
+  const singlesOut = tls.parseCertString(singles);
+  assert.deepStrictEqual(singlesOut, {
+    C: 'US',
+    ST: 'CA',
+    L: 'SF',
+    O: 'Node.js Foundation',
+    OU: 'Node.js',
+    CN: 'ca1',
+    emailAddress: 'ry@clouds.org'
+  });
+}
 
-const doubles = 'OU=Domain Control Validated\nOU=PositiveSSL Wildcard\n' +
-                'CN=*.nodejs.org';
-const doublesOut = tls.parseCertString(doubles);
-assert.deepStrictEqual(doublesOut, {
-  OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
-  CN: '*.nodejs.org'
-});
+{
+  const doubles = 'OU=Domain Control Validated\nOU=PositiveSSL Wildcard\n' +
+                  'CN=*.nodejs.org';
+  const doublesOut = tls.parseCertString(doubles);
+  assert.deepStrictEqual(doublesOut, {
+    OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
+    CN: '*.nodejs.org'
+  });
+}
 
-const invalid = 'fhqwhgads';
-const invalidOut = tls.parseCertString(invalid);
-assert.deepStrictEqual(invalidOut, {});
+{
+  const invalid = 'fhqwhgads';
+  const invalidOut = tls.parseCertString(invalid);
+  assert.deepStrictEqual(invalidOut, {});
+}

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -28,3 +28,7 @@ assert.deepStrictEqual(doublesOut, {
   OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
   CN: '*.nodejs.org'
 });
+
+const invalid = 'fhqwhgads';
+const invalidOut = tls.parseCertString(invalid);
+assert.deepStrictEqual(invalidOut, {});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

`tls.parseCertString()` should return an empty object if passed an
invalid cert string. This behavior is not currently tested. Add minimal
test.