### PR TITLE
test: refactor test-tick-processor

### DIFF
--- a/test/parallel/test-tick-processor.js
+++ b/test/parallel/test-tick-processor.js
@@ -45,12 +45,10 @@ runTest(/RunInDebugContext/,
 
 function runTest(pattern, code) {
   cp.execFileSync(process.execPath, ['-prof', '-pe', code]);
-  var matches = fs.readdirSync(common.tmpDir).filter(function(file) {
-    return /^isolate-/.test(file);
-  });
-  if (matches.length != 1) {
-    common.fail('There should be a single log file.');
-  }
+  var matches = fs.readdirSync(common.tmpDir);
+
+  assert.strictEqual(matches.length, 1, 'There should be a single log file.');
+
   var log = matches[0];
   var out = cp.execSync(process.execPath +
                         ' --prof-process --call-graph-size=10 ' + log,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test does some extra work that isn't necessary because of the way
temp directories are handled. The test removes all files from the temp
directory with `common.refreshTmpDir()` but still filters the results
even though only its files will be in the directory.

Refactor to remove that unneeded logic.