### PR TITLE
buffer: hard-deprecate SlowBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -156,7 +156,16 @@ Buffer.allocUnsafeSlow = function(size) {
 
 // If --zero-fill-buffers command line argument is set, a zero-filled
 // buffer is returned.
+var slowBufferWarned = false;
 function SlowBuffer(length) {
+  if (!slowBufferWarned) {
+    slowBufferWarned = true;
+    process.emitWarning(
+      'SlowBuffer is deprecated. ' +
+      'Use `Buffer.alloc()` or `Buffer.allocUnsafeSlow()` instead.'
+    );
+  }
+
   if (+length != length)
     length = 0;
   return createUnsafeBuffer(+length);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

buffer
##### Description of change

<!-- Provide a description of the change below this comment. -->

This emits a warning first time `SlowBuffer` instance is created and instructs the users to switch to `Buffer.alloc()` or `Buffer.allocUnsafeSlow()`, both of which are not pooled.

Refs: https://github.com/nodejs/node/pull/8169
Refs: https://github.com/nodejs/node/pull/7152

Not sure if we should do this in v7 or v8. It looks like SlowBuffer is used only by a small number of modules (I found 416, only 330 of which — outside of tests, and some of those are false positives). Module authors could use [safe-buffer](https://github.com/feross/safe-buffer) to polyfill for older Node.js versions, though.

Labelling as `in progress` because this lacks tests.

/cc @nodejs/ctc, @seishun 
