### PR TITLE
crypto: expose ECDH class

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -79,10 +79,6 @@ const {
 } = require('internal/crypto/util');
 const Certificate = require('internal/crypto/certificate');
 
-function createECDH(curve) {
-  return new ECDH(curve);
-}
-
 module.exports = exports = {
   // Methods
   _toBuf: toBuf,
@@ -92,7 +88,7 @@ module.exports = exports = {
   createDecipheriv: Decipheriv,
   createDiffieHellman: DiffieHellman,
   createDiffieHellmanGroup: DiffieHellmanGroup,
-  createECDH,
+  createECDH: ECDH,
   createHash: Hash,
   createHmac: Hmac,
   createSign: Sign,
@@ -124,6 +120,7 @@ module.exports = exports = {
   Decipheriv,
   DiffieHellman,
   DiffieHellmanGroup,
+  ECDH,
   Hash,
   Hmac,
   Sign,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -168,6 +168,9 @@ DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
 
 
 function ECDH(curve) {
+  if (!(this instanceof ECDH))
+    return new ECDH(curve);
+
   if (typeof curve !== 'string')
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve', 'string');
 

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -18,6 +18,7 @@ const TEST_CASES = {
   'Verify': ['RSA-SHA1'],
   'DiffieHellman': [1024],
   'DiffieHellmanGroup': ['modp5'],
+  'ECDH': ['prime256v1'],
   'Credentials': []
 };
 

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const crypto = require('crypto');
+
+// 'ClassName' : ['args', 'for', 'constructor']
+const TEST_CASES = {
+  'Hash': ['sha1'],
+  'Hmac': ['sha1', 'Node'],
+  'Cipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
+  'Decipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
+  'Sign': ['RSA-SHA1'],
+  'Verify': ['RSA-SHA1'],
+  'DiffieHellman': [1024],
+  'DiffieHellmanGroup': ['modp5'],
+  'Credentials': []
+};
+
+if (!common.hasFipsCrypto) {
+  TEST_CASES.Cipher = ['aes192', 'secret'];
+  TEST_CASES.Decipher = ['aes192', 'secret'];
+}
+
+for (const [clazz, args] of Object.entries(TEST_CASES)) {
+  assert(crypto[`create${clazz}`](...args) instanceof crypto[clazz]);
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

crypto
##### Description of change

ECDH class was not previously exposed, which was inconsistent with the rest of the classes in that module.

Docs already document the class, and no tests current exist (that I could fine) to test the presence of any of the other classes, so didn't change tests. Shall I add another set of tests that checks the presence of both the classes and the `create` functions for them? Separate PR?
