### PR TITLE
test: change equals comparison operator to be strict

### DIFF
--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -23,7 +23,7 @@ const assert = require('assert');
     assert.strictEqual(a, 'foo');
     assert.strictEqual(b, 'bar');
     assert.strictEqual(c, 'baz');
-    if (++ncalled == 3) clearTimeout(iv);
+    if (++ncalled === 3) clearTimeout(iv);
   }
 
   process.on('exit', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

The 'equals' comparison operator was '==' instead of the more strict '===', so it has been changed to be more strict.