### PR TITLE
timers: expose timer classes

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -447,6 +447,7 @@ exports.clearInterval = function(timer) {
 };
 
 
+exports.Timeout = Timeout;
 function Timeout(after) {
   this._called = false;
   this._idleTimeout = after;
@@ -585,6 +586,7 @@ function runCallback(timer) {
 }
 
 
+exports.Immediate = Immediate;
 function Immediate() {
   // assigning the callback here can cause optimize/deoptimize thrashing
   // so have caller annotate the object (node v6.0.0, v8 5.0.71.35)

--- a/test/parallel/test-timers-classes.js
+++ b/test/parallel/test-timers-classes.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const timers = require('timers');
+
+const immediate = setImmediate(() => {});
+const timeout = setTimeout(() => {}, 0);
+const interval = setInterval(() => {}, 0);
+
+assert(immediate instanceof timers.Immediate);
+assert(timeout instanceof timers.Timeout);
+assert(interval instanceof timers.Timeout);
+
+// Clean up
+clearImmediate(immediate);
+clearTimeout(timeout);
+clearInterval(interval);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

timers
##### Description of change

This allows for determining whether an arbitrary object is a timer object, using `instanceof`. For example, code intent on unreffing or clearing timers passed to it may want to check that the are, in fact, timers first.

Test included. Docs already covered timer classes.
