### PR TITLE
doc: remove "feature branch" jargon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,10 @@ does not align with the project team. Node.js has two IRC channels,
 
 ### Step 2: Branch
 
-Create a feature branch and start hacking:
+Create a branch and start hacking:
 
 ```text
-$ git checkout -b my-feature-branch -t origin/master
+$ git checkout -b my-branch -t origin/master
 ```
 
 ### Step 3: Commit
@@ -184,15 +184,15 @@ core modules.
 ### Step 6: Push
 
 ```text
-$ git push origin my-feature-branch
+$ git push origin my-branch
 ```
 
-Go to https://github.com/yourusername/node and select your feature branch.
+Go to https://github.com/yourusername/node and select your branch.
 Click the 'Pull Request' button and fill out the form.
 
 Pull requests are usually reviewed within a few days. If there are comments
 to address, apply your changes in a separate commit and push that to your
-feature branch. Post a comment in the pull request afterwards; GitHub does
+branch. Post a comment in the pull request afterwards; GitHub does
 not send out notifications when you add commits.
 
 <a id="developers-certificate-of-origin"></a>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

In the context of the CONTRIBUTING.md document, there is no advantage to
describing the branch as a "feature branch" and the term may be
confusing. Just refer to it as a branch.

Context for the curious: The phrase "feature branch" in CONTIRUBTING.md
confused someone I was assisting today. It occured to me that the word
"feature" doesn't add anything and can be confusing. ("I'm doing a bug
fix so I don't need to create a feature branch, right?")

/cc @thecoolestguy