### PR TITLE
async_wrap: add a missing case to test-async-wrap-throw-no-init

### DIFF
--- a/test/parallel/test-async-wrap-throw-no-init.js
+++ b/test/parallel/test-async-wrap-throw-no-init.js
@@ -4,10 +4,13 @@ require('../common');
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
 
-
 assert.throws(function() {
   async_wrap.setupHooks(null);
 }, /first argument must be an object/);
+
+assert.throws(function() {
+  async_wrap.setupHooks({});
+}, /init callback must be a function/);
 
 assert.throws(function() {
   async_wrap.enable();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_wrap, test

##### Description of change
<!-- Provide a description of the change below this comment. -->
This covers [this line](https://github.com/nodejs/node/blob/master/src/async-wrap.cc#L145) in "src/async-wrap.cc". /R= @trevnorris 