### PR TITLE
doc: fix onReadable reentry after unshift called

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -963,10 +963,10 @@ function parseHeader(stream, callback) {
         header += split.shift();
         const remaining = split.join('\n\n');
         const buf = Buffer.from(remaining, 'utf8');
-        if (buf.length)
-          stream.unshift(buf);
         stream.removeListener('error', callback);
         stream.removeListener('readable', onReadable);
+        if (buf.length)
+          stream.unshift(buf);
         // now the body of the message can be read from the stream.
         callback(null, header, stream);
       } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc: stream

##### Description of change
<!-- Provide a description of the change below this comment. -->

In example parseHeader, stream listen **readable** event,
if call stream.unshift(buf) before stream.removeListener('readable',
onReadable), readable event will be emited before removeListener,
so callback will not been called correctlly.
After change to
```js
stream.removeListener('error', callback);
stream.removeListener('readable', onReadable);
if (buf.length)
stream.unshift(buf);
```
It solves this problem.