### PR TITLE
test: split test-crypto-timing-safe-equal

### DIFF
--- a/test/parallel/test-crypto-timing-safe-equal.js
+++ b/test/parallel/test-crypto-timing-safe-equal.js
@@ -1,4 +1,3 @@
-// Flags: --allow_natives_syntax
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-crypto-timing-safe-equal.js
+++ b/test/parallel/test-crypto-timing-safe-equal.js
@@ -1,0 +1,35 @@
+// Flags: --allow_natives_syntax
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const crypto = require('crypto');
+
+assert.strictEqual(
+  crypto.timingSafeEqual(Buffer.from('foo'), Buffer.from('foo')),
+  true,
+  'should consider equal strings to be equal'
+);
+
+assert.strictEqual(
+  crypto.timingSafeEqual(Buffer.from('foo'), Buffer.from('bar')),
+  false,
+  'should consider unequal strings to be unequal'
+);
+
+assert.throws(function() {
+  crypto.timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2]));
+}, 'should throw when given buffers with different lengths');
+
+assert.throws(function() {
+  crypto.timingSafeEqual('not a buffer', Buffer.from([1, 2]));
+}, 'should throw if the first argument is not a buffer');
+
+assert.throws(function() {
+  crypto.timingSafeEqual(Buffer.from([1, 2]), 'not a buffer');
+}, 'should throw if the second argument is not a buffer');

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -10,30 +10,6 @@ if (!common.hasCrypto) {
 
 const crypto = require('crypto');
 
-assert.strictEqual(
-  crypto.timingSafeEqual(Buffer.from('foo'), Buffer.from('foo')),
-  true,
-  'should consider equal strings to be equal'
-);
-
-assert.strictEqual(
-  crypto.timingSafeEqual(Buffer.from('foo'), Buffer.from('bar')),
-  false,
-  'should consider unequal strings to be unequal'
-);
-
-assert.throws(function() {
-  crypto.timingSafeEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2]));
-}, 'should throw when given buffers with different lengths');
-
-assert.throws(function() {
-  crypto.timingSafeEqual('not a buffer', Buffer.from([1, 2]));
-}, 'should throw if the first argument is not a buffer');
-
-assert.throws(function() {
-  crypto.timingSafeEqual(Buffer.from([1, 2]), 'not a buffer');
-}, 'should throw if the second argument is not a buffer');
-
 function runBenchmark(compareFunc, bufferA, bufferB, expectedResult) {
   const startTime = process.hrtime();
   const result = compareFunc(bufferA, bufferB);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

Move non-intensive parts of test-crypto-timing-safe-equal from
sequential to parallel.

The test in sequential is marked as flaky due to the intensive part of
the test. This will allow the non-intensive part to register as a
genuine failure if something breaks it.