### PR TITLE
node_main: use ERROR_EXE_MACHINE_TYPE_MISMATCH instead 1 as exit code

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -2,12 +2,13 @@
 
 #ifdef _WIN32
 #include <VersionHelpers.h>
+#include <WinError.h>
 
 int wmain(int argc, wchar_t *wargv[]) {
   if (!IsWindows7OrGreater()) {
     fprintf(stderr, "This application is only supported on Windows 7, "
                     "Windows Server 2008 R2, or higher.");
-    exit(1);
+    exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
   }
 
   // Convert argv to to UTF8


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
windows

##### Description of change
<!-- Provide a description of the change below this comment. -->

If `IsWindows7OrGreater()` returns `false`, the Node.js program should
exit with a more specific code ERROR_EXE_MACHINE_TYPE_MISMATCH instead
the code 0x1(ERROR_INVALID_FUNCTION).