### PR TITLE
url: fix inconsistent port in url.resolveObject

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -781,6 +781,7 @@ Url.prototype.resolveObject = function(relative) {
     // it's absolute.
     if (relative.host || relative.host === '') {
       result.host = relative.host;
+      result.port = relative.port;
       result.auth = null;
     }
     if (relative.hostname || relative.hostname === '') {

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1570,6 +1570,11 @@ var relativeTests2 = [
    'http://asdf:qwer@www.example.com',
    'http://diff:auth@www.example.com/'],
 
+  // changing port
+  ['https://example.com:81/',
+   'https://example.com:82/',
+   'https://example.com:81/'],
+
   // https://github.com/nodejs/node/issues/1435
   ['https://another.host.com/',
    'https://user:password@example.org/',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

url

##### Description of change
<!-- Provide a description of the change below this comment. -->

This commit fixes a bug where url.resolveObject returns conflicting host and port values.

```
$ node
> url.resolveObject('http://example.com:81', 'http://example.com:82');
Url {
  protocol: 'http:',
  slashes: true,
  auth: null,
  host: 'example.com:82',
  port: '81',
  hostname: 'example.com',
  hash: null,
  search: null,
  query: null,
  pathname: '/',
  path: '/',
  href: 'http://example.com:82/' }
> 
```

Fixes: https://github.com/nodejs/node/issues/8213