### PR TITLE
doc: fix "timout" typo in timeout

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -50,9 +50,9 @@ added: v0.9.1
 When called, the active `Timeout` object will not require the Node.js event loop
 to remain active. If there is no other activity keeping the event loop running,
 the process may exit before the `Timeout` object's callback is invoked. Calling
-`timout.unref()` multiple times will have no effect.
+`timeout.unref()` multiple times will have no effect.
 
-*Note*: Calling `timout.unref()` creates an internal timer that will wake the
+*Note*: Calling `timeout.unref()` creates an internal timer that will wake the
 Node.js event loop. Creating too many of these can adversely impact performance
 of the Node.js application.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
None

##### Description of change
<!-- Provide a description of the change below this comment. -->

Corrected doc typo to `timeout`