### PR TITLE
process: improve stack trace on async(libuv) error

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -62,23 +62,32 @@ function setupNextTick() {
       scheduleMicrotasks();
   }
 
-  function _combinedTickCallback(args, callback) {
-    if (args === undefined) {
-      callback();
-    } else {
-      switch (args.length) {
-        case 1:
-          callback(args[0]);
-          break;
-        case 2:
-          callback(args[0], args[1]);
-          break;
-        case 3:
-          callback(args[0], args[1], args[2]);
-          break;
-        default:
-          callback.apply(null, args);
+  function _combinedTickCallback(args, callback, stack) {
+    try {
+      if (args === undefined) {
+        callback();
+      } else {
+        switch (args.length) {
+          case 1:
+            callback(args[0]);
+            break;
+          case 2:
+            callback(args[0], args[1]);
+            break;
+          case 3:
+            callback(args[0], args[1], args[2]);
+            break;
+          default:
+            callback.apply(null, args);
+        }
       }
+    } catch (err) {
+      if (err instanceof Error) {
+        const stackIdx = stack.indexOf('\n');
+        if (stackIdx !== -1)
+          err.stack = `${err.stack}\n${stack.slice(stackIdx + 1)}`;
+      }
+      throw err;
     }
   }
 
@@ -95,7 +104,7 @@ function setupNextTick() {
         // Using separate callback execution functions allows direct
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
-        _combinedTickCallback(args, callback);
+        _combinedTickCallback(args, callback, tock.stack);
         if (1e4 < tickInfo[kIndex])
           tickDone();
       }
@@ -119,7 +128,7 @@ function setupNextTick() {
         // Using separate callback execution functions allows direct
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
-        _combinedTickCallback(args, callback);
+        _combinedTickCallback(args, callback, tock.stack);
         if (1e4 < tickInfo[kIndex])
           tickDone();
         if (domain)
@@ -135,6 +144,7 @@ function setupNextTick() {
     this.callback = c;
     this.domain = process.domain || null;
     this.args = args;
+    Error.captureStackTrace(this, TickObject);
   }
 
   function nextTick(callback) {

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
-var N = 2;
+const assert = require('assert');
+const N = 2;
 
 function cb() {
   throw new Error();
@@ -10,7 +11,10 @@ for (var i = 0; i < N; ++i) {
   process.nextTick(common.mustCall(cb));
 }
 
-process.on('uncaughtException', common.mustCall(function() {}, N));
+process.on('uncaughtException', common.mustCall(function(err) {
+  // assert the async error should have this file line
+  assert(/test\/parallel\/test-aprocess-next-tick.js/.test(err.stack));
+}, N));
 
 process.on('exit', function() {
   process.removeAllListeners('uncaughtException');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

process
##### Description of change

<!-- Provide a description of the change below this comment. -->

This patch saves the stack into `TickObject` by calling `Error.captureStackTrace()`, and will append those stacks if something went wrong.

For example:

``` js
require('child_process').spawn('error factory');
```

will throw:

```
Error: spawn error factory ENOENT
    at exports._errnoException (util.js:1026:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:182:32)
    at onErrorNT (internal/child_process.js:348:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

but with this change, we will see the following:

```
internal/process/next_tick.js:102
          throw err;
          ^

Error: spawn error factory ENOENT
    at exports._errnoException (util.js:1026:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:99:11)
    at Module.runMain (module.js:592:11)
    at run (bootstrap_node.js:382:7)
    at startup (bootstrap_node.js:137:9)
    at bootstrap_node.js:497:3
    at process.nextTick (internal/process/next_tick.js:160:24)
    at ChildProcess.spawn (internal/child_process.js:296:13)
    at Object.exports.spawn (child_process.js:385:9)
    at Object.<anonymous> (/Users/yorkieliu/workspace/test-process-next-tick.js:2:26)
    .......<more stack>
```

This would help developer to track what happened when some async callbacks are thrown, mostly are syscall error.

_But to be noted that, this adds a possible unneeded `.stack` field to every `TickObject` and `catch` every call to `callback`. Both are hurting the perf in huge I guess. I'm not sure if we could land this, but I think the feature really saves time when debugging Node.js programs, perhaps an (CLI/API) option from user-land could be the way to go_
