### PR TITLE
doc: fix buf.readUIntBE, buf.readUIntLE examples

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1644,10 +1644,10 @@ Examples:
 const buf = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
 
 // Prints: 1234567890ab
-console.log(buf.readUIntLE(0, 6).toString(16));
+console.log(buf.readUIntBE(0, 6).toString(16));
 
 // Prints: ab9078563412
-console.log(buf.readUIntBE(0, 6).toString(16));
+console.log(buf.readUIntLE(0, 6).toString(16));
 
 // Throws an exception: RangeError: Index out of range
 console.log(buf.readUIntBE(1, 6).toString(16));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

The documentation describing the output from the examples for
buf.readUIntBE and buf.readUIntLE were switched in terms of what the
code would actually output. This patch addresses this by switching the
two lines of example code to be in the same order as the functions are
listed earlier in the documentation.