### PR TITLE
repl: Auto alignment for .editor mode

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -41,6 +41,7 @@ function Interface(input, output, completer, terminal) {
 
   this._sawReturn = false;
   this.isCompletionEnabled = true;
+  this.isKeyPressed = false;
   this._previousKey = null;
 
   EventEmitter.call(this);
@@ -246,6 +247,10 @@ Interface.prototype._addHistory = function() {
 
   // if the history is disabled then return the line
   if (this.historySize === 0) return this.line;
+
+  const line = this.line.replace(/^\s+|\s+$/, '');
+  // if the trimmed line is empty then return the line
+  if (line.length === 0) return this.line;
 
   if (this.history.length === 0 || this.history[0] !== this.line) {
     this.history.unshift(this.line);
@@ -946,6 +951,10 @@ function emitKeypressEvents(stream, iface) {
       var r = stream[KEYPRESS_DECODER].write(b);
       if (r) {
         clearTimeout(timeoutId);
+
+        if (iface) {
+          iface._sawKeyPress = r.length === 1;
+        }
 
         for (var i = 0; i < r.length; i++) {
           if (r[i] === '\t' && typeof r[i + 1] === 'string' && iface) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -248,9 +248,8 @@ Interface.prototype._addHistory = function() {
   // if the history is disabled then return the line
   if (this.historySize === 0) return this.line;
 
-  const line = this.line.replace(/^\s+|\s+$/, '');
   // if the trimmed line is empty then return the line
-  if (line.length === 0) return this.line;
+  if (this.line.trim().length === 0) return this.line;
 
   if (this.history.length === 0 || this.history[0] !== this.line) {
     this.history.unshift(this.line);

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -41,7 +41,7 @@ function Interface(input, output, completer, terminal) {
 
   this._sawReturn = false;
   this.isCompletionEnabled = true;
-  this.isKeyPressed = false;
+  this._sawKeyPress = false;
   this._previousKey = null;
 
   EventEmitter.call(this);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -471,6 +471,15 @@ function REPLServer(prompt,
 
     if (self.editorMode) {
       self.bufferedCommand += cmd + '\n';
+
+      // code alignment
+      const matches = self._sawKeyPress ? cmd.match(/^\s+/) : null;
+      if (matches) {
+        const prefix = matches[0];
+        self.inputStream.write(prefix);
+        self.line = prefix;
+        self.cursor = prefix.length;
+      }
       self.memory(cmd);
       return;
     }

--- a/test/parallel/test-repl-.editor.js
+++ b/test/parallel/test-repl-.editor.js
@@ -9,7 +9,7 @@ const repl = require('repl');
 // \u001b[3G - Moves the cursor to 3rd column
 const terminalCode = '\u001b[1G\u001b[0J> \u001b[3G';
 
-function run(input, output, event) {
+function run({input, output, event}) {
   const stream = new common.ArrayStream();
   let found = '';
 
@@ -57,7 +57,7 @@ const tests = [
   }
 ];
 
-tests.forEach(({input, output, event}) => run(input, output, event));
+tests.forEach(run);
 
 // Auto code alignment for .editor mode
 function testCodeAligment({input, cursor = 0, line = ''}) {
@@ -73,9 +73,14 @@ function testCodeAligment({input, cursor = 0, line = ''}) {
 
   stream.emit('data', '.editor\n');
   input.split('').forEach((ch) => stream.emit('data', ch));
-  replServer.close();
+  // Test the content of current line and the cursor position
   assert.strictEqual(line, replServer.line);
   assert.strictEqual(cursor, replServer.cursor);
+
+  replServer.write('', {ctrl: true, name: 'd'});
+  replServer.close();
+  // Ensure that empty lines are not saved in history
+  assert.notStrictEqual(replServer.history[0].trim(), '');
 }
 
 const codeAlignmentTests = [

--- a/test/parallel/test-repl-.editor.js
+++ b/test/parallel/test-repl-.editor.js
@@ -49,7 +49,54 @@ const tests = [
     input: 'var i = 1;\ni + 3',
     output: '\n4',
     event: {ctrl: true, name: 'd'}
+  },
+  {
+    input: '  var i = 1;\ni + 3',
+    output: '\n4',
+    event: {ctrl: true, name: 'd'}
   }
 ];
 
 tests.forEach(({input, output, event}) => run(input, output, event));
+
+// Auto code alignment for .editor mode
+function testCodeAligment({input, cursor = 0, line = ''}) {
+  const stream = new common.ArrayStream();
+
+  const replServer = repl.start({
+    prompt: '> ',
+    terminal: true,
+    input: stream,
+    output: stream,
+    useColors: false
+  });
+
+  stream.emit('data', '.editor\n');
+  input.split('').forEach((ch) => stream.emit('data', ch));
+  replServer.close();
+  assert.strictEqual(line, replServer.line);
+  assert.strictEqual(cursor, replServer.cursor);
+}
+
+const codeAlignmentTests = [
+  {
+    input: 'var i = 1;\n'
+  },
+  {
+    input: '  var i = 1;\n',
+    cursor: 2,
+    line: '  '
+  },
+  {
+    input: '     var i = 1;\n',
+    cursor: 5,
+    line: '     '
+  },
+  {
+    input: ' var i = 1;\n var j = 2\n',
+    cursor: 2,
+    line: '  '
+  }
+];
+
+codeAlignmentTests.forEach(testCodeAligment);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

When in `.editor` mode, current line whitespace prefixes
are preserved in the subsequent line.

```js
node 🙈 ₹ node
> .editor
// Entering editor mode (^D to finish, ^C to cancel)
function test() {
  console.log('tested!'); //On enter, cursor will be at 2nd position
  _
```