### PR TITLE
net: make holding the buffer in memory more robust

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -694,7 +694,6 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   } else {
     var enc;
     if (data instanceof Buffer) {
-      req.buffer = data;  // Keep reference alive.
       enc = 'buffer';
     } else {
       enc = encoding;

--- a/src/env.h
+++ b/src/env.h
@@ -69,6 +69,7 @@ namespace node {
   V(args_string, "args")                                                      \
   V(async, "async")                                                           \
   V(async_queue_string, "_asyncQueue")                                        \
+  V(buffer_string, "buffer")                                                  \
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
   V(bytes_read_string, "bytesRead")                                           \

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -227,6 +227,7 @@ int StreamBase::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
 
   err = DoWrite(req_wrap, bufs, count, nullptr);
   req_wrap_obj->Set(env->async(), True(env->isolate()));
+  req_wrap_obj->Set(env->buffer_string(), args[1]);
 
   if (err)
     req_wrap->Dispose();

--- a/test/parallel/test-net-write-fully-async-buffer.js
+++ b/test/parallel/test-net-write-fully-async-buffer.js
@@ -1,0 +1,34 @@
+'use strict';
+// Flags: --expose-gc
+
+// Note: This is a variant of test-net-write-fully-async-hex-string.js.
+// This always worked, but it seemed appropriate to add a test that checks the
+// behaviour for Buffers, too.
+const common = require('../common');
+const net = require('net');
+
+const data = Buffer.allocUnsafe(1000000);
+
+const server = net.createServer(common.mustCall(function(conn) {
+  conn.resume();
+})).listen(0, common.mustCall(function() {
+  const conn = net.createConnection(this.address().port, common.mustCall(() => {
+    let count = 0;
+
+    function write_loop() {
+      if (count++ === 200) {
+        conn.destroy();
+        server.close();
+        return;
+      }
+
+      while (conn.write(Buffer.from(data)));
+      global.gc(true);
+      // The buffer allocated above should still be alive.
+    }
+
+    conn.on('drain', write_loop);
+
+    write_loop();
+  }));
+}));

--- a/test/parallel/test-net-write-fully-async-buffer.js
+++ b/test/parallel/test-net-write-fully-async-buffer.js
@@ -7,7 +7,7 @@
 const common = require('../common');
 const net = require('net');
 
-const data = Buffer.allocUnsafe(1000000);
+const data = Buffer.alloc(1000000);
 
 const server = net.createServer(common.mustCall(function(conn) {
   conn.resume();
@@ -15,7 +15,7 @@ const server = net.createServer(common.mustCall(function(conn) {
   const conn = net.createConnection(this.address().port, common.mustCall(() => {
     let count = 0;
 
-    function write_loop() {
+    function writeLoop() {
       if (count++ === 200) {
         conn.destroy();
         server.close();
@@ -27,8 +27,8 @@ const server = net.createServer(common.mustCall(function(conn) {
       // The buffer allocated above should still be alive.
     }
 
-    conn.on('drain', write_loop);
+    conn.on('drain', writeLoop);
 
-    write_loop();
+    writeLoop();
   }));
 }));

--- a/test/parallel/test-net-write-fully-async-hex-string.js
+++ b/test/parallel/test-net-write-fully-async-hex-string.js
@@ -5,7 +5,7 @@
 const common = require('../common');
 const net = require('net');
 
-const data = Buffer.allocUnsafe(1000000).toString('hex');
+const data = Buffer.alloc(1000000).toString('hex');
 
 const server = net.createServer(common.mustCall(function(conn) {
   conn.resume();
@@ -13,7 +13,7 @@ const server = net.createServer(common.mustCall(function(conn) {
   const conn = net.createConnection(this.address().port, common.mustCall(() => {
     let count = 0;
 
-    function write_loop() {
+    function writeLoop() {
       if (count++ === 20) {
         conn.destroy();
         server.close();
@@ -25,8 +25,8 @@ const server = net.createServer(common.mustCall(function(conn) {
       // The buffer allocated inside the .write() call should still be alive.
     }
 
-    conn.on('drain', write_loop);
+    conn.on('drain', writeLoop);
 
-    write_loop();
+    writeLoop();
   }));
 }));

--- a/test/parallel/test-net-write-fully-async-hex-string.js
+++ b/test/parallel/test-net-write-fully-async-hex-string.js
@@ -1,0 +1,32 @@
+'use strict';
+// Flags: --expose-gc
+
+// Regression test for https://github.com/nodejs/node/issues/8251.
+const common = require('../common');
+const net = require('net');
+
+const data = Buffer.allocUnsafe(1000000).toString('hex');
+
+const server = net.createServer(common.mustCall(function(conn) {
+  conn.resume();
+})).listen(0, common.mustCall(function() {
+  const conn = net.createConnection(this.address().port, common.mustCall(() => {
+    let count = 0;
+
+    function write_loop() {
+      if (count++ === 20) {
+        conn.destroy();
+        server.close();
+        return;
+      }
+
+      while (conn.write(data, 'hex'));
+      global.gc(true);
+      // The buffer allocated inside the .write() call should still be alive.
+    }
+
+    conn.on('drain', write_loop);
+
+    write_loop();
+  }));
+}));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

net/src?

##### Description of change

Set the `req.buffer` property, which serves as a way of keeping a `Buffer` alive that is being written to a stream, on the C++ side instead of the JS side.

This closes a hole where buffers that were temporarily created in order to write strings with uncommon encodings (e.g. `hex`) were passed to the native side without being set as `req.buffer`.

Fixes: https://github.com/nodejs/node/issues/8251
CI: https://ci.nodejs.org/job/node-test-commit/4749/