### PR TITLE
test: fix localhost error in test-dns-ipv6

### DIFF
--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -179,7 +179,12 @@ TEST(function test_lookup_all_ipv6(done) {
 
 TEST(function test_lookupservice_ip_ipv6(done) {
   var req = dns.lookupService('::1', 80, function(err, host, service) {
-    if (err) throw err;
+    if (err) {
+      // Not skipping the test, rather checking an alternative result,
+      // i.e. that ::1 may not be configured (e.g. in /etc/hosts)
+      assert.strictEqual(err.code, 'ENOTFOUND');
+      return done();
+    }
     assert.equal(typeof host, 'string');
     assert(host);
     assert(['http', 'www', '80'].includes(service));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change

If localhost doesn't resolve to ::1 in IPv6, we should skip the test.

This is the same fix as https://github.com/nodejs/node/commit/814b8c3cf796efa710ec1874ec4a30f7d50222cb (#7766)

cc: @Trott 