### PR TITLE
inspector: Simplify buffer management

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -244,7 +244,7 @@ void InterruptCallback(v8::Isolate*, void* agent) {
 }
 
 void DataCallback(uv_stream_t* stream, ssize_t read, const uv_buf_t* buf) {
-  inspector_socket_t* socket = static_cast<inspector_socket_t*>(stream->data);
+  inspector_socket_t* socket = inspector_from_stream(stream);
   static_cast<AgentImpl*>(socket->data)->OnRemoteDataIO(socket, read, buf);
 }
 

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -178,7 +178,7 @@ struct expectations {
 
 static void grow_expects_buffer(uv_handle_t* stream, size_t size, uv_buf_t* b) {
   expectations* expects = static_cast<expectations*>(
-      (static_cast<inspector_socket_t*>(stream->data))->data);
+      inspector_from_stream(stream)->data);
   size_t end = expects->actual_end;
   // Grow the buffer in chunks of 64k.
   size_t new_length = (end + size + 65535) & ~((size_t) 0xFFFF);
@@ -213,7 +213,7 @@ static void grow_expects_buffer(uv_handle_t* stream, size_t size, uv_buf_t* b) {
 static void save_read_data(uv_stream_t* stream, ssize_t nread,
                            const uv_buf_t* buf) {
   expectations* expects =static_cast<expectations*>(
-      (static_cast<inspector_socket_t*>(stream->data))->data);
+      inspector_from_stream(stream)->data);
   expects->err_code = nread < 0 ? nread : 0;
   if (nread > 0) {
     expects->actual_end += nread;
@@ -254,8 +254,7 @@ static void expect_on_server(const char* data, size_t len) {
 
 static void inspector_record_error_code(uv_stream_t* stream, ssize_t nread,
                                         const uv_buf_t* buf) {
-  inspector_socket_t *inspector =
-      reinterpret_cast<inspector_socket_t*>(stream->data);
+  inspector_socket_t *inspector = inspector_from_stream(stream);
   // Increment instead of assign is to ensure the function is only called once
   *(static_cast<int *>(inspector->data)) += nread;
 }
@@ -760,8 +759,7 @@ static void CleanupSocketAfterEOF_close_cb(inspector_socket_t* inspector,
 static void CleanupSocketAfterEOF_read_cb(uv_stream_t* stream, ssize_t nread,
                                           const uv_buf_t* buf) {
   EXPECT_EQ(UV_EOF, nread);
-  inspector_socket_t* insp =
-      reinterpret_cast<inspector_socket_t*>(stream->data);
+  inspector_socket_t* insp = inspector_from_stream(stream);
   inspector_close(insp, CleanupSocketAfterEOF_close_cb);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
This only touches the protocol implementation for the V8 inspector.

##### Description of change
<!-- Provide a description of the change below this comment. -->

This change simplifies buffer management to address a number of issues
that original implementation had.

Original implementation was trying to reduce the number of allocations
by providing regions of the internal buffer to libuv IO code. This
introduced some potential use after free issues if the buffer grows
(or shrinks) while there's a pending read. It also had some confusing
math that resulted in issues on Windows version of the libuv.

Fixes: https://github.com/nodejs/node/issues/8155
CC: @ofrobots 