### PR TITLE
doc: Added missing e to "timeout"

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -50,9 +50,9 @@ added: v0.9.1
 When called, the active `Timeout` object will not require the Node.js event loop
 to remain active. If there is no other activity keeping the event loop running,
 the process may exit before the `Timeout` object's callback is invoked. Calling
-`timout.unref()` multiple times will have no effect.
+`timeout.unref()` multiple times will have no effect.
 
-*Note*: Calling `timout.unref()` creates an internal timer that will wake the
+*Note*: Calling `timeout.unref()` creates an internal timer that will wake the
 Node.js event loop. Creating too many of these can adversely impact performance
 of the Node.js application.
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

- doc

##### Description of change
The `timers` documentation (specifically in `timeout.unref()`) spelled "timeout" as "timout" twice, so I edited the document to correct the spelling.