### PR TITLE
build: fix depenencies on AIX

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -906,6 +906,7 @@
         },
         {
           'target_name': 'node_exp',
+          'process_outputs_as_sources': 1,
           'type': 'none',
           'dependencies': [
             '<(node_core_target_name)',


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
build

##### Description of change

addon tests were starting to run before the node exp file
creation was complete. Add process_outputs_as_sources to
node_exp target to avoid this.
this.

Fixes: https://github.com/nodejs/node/issues/8239