### PR TITLE
src: avoid duplicate AtExit functions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3326,7 +3326,7 @@ void SetupProcessObject(Environment* env,
 #undef READONLY_PROPERTY
 
 
-static void AtExit() {
+static void AtProcessExit() {
   uv_tty_reset_mode();
 }
 
@@ -3363,7 +3363,7 @@ void LoadEnvironment(Environment* env) {
   env->isolate()->SetFatalErrorHandler(node::OnFatalError);
   env->isolate()->AddMessageListener(OnMessage);
 
-  atexit(AtExit);
+  atexit(AtProcessExit);
 
   TryCatch try_catch(env->isolate());
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change
<!-- Provide a description of the change below this comment. -->

`node.cc` had two functions with the name `AtExit` with entirely different
purposes:

* `node::AtExit()`: file static; used to register the `atexit(3)` handler
  for the Node process.
* `node::AtExit(void (*)(void*), void*)`: publicly exported symbol that
  addons can use to request callbacks upon exit.

For code readability it is better to avoid the unintentional overload.

R=@addaleax, @bnoordhuis 
EDIT: CI: https://ci.nodejs.org/job/node-test-pull-request/3835/

