### PR TITLE
test: mark test-child-process-fork-dgram as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -38,3 +38,6 @@ test-stdio-closed                        : PASS, FLAKY
 #covered by  https://github.com/nodejs/node/issues/3796
 # but more frequent on AIX ?
 test-debug-signal-cluster                : PASS, FLAKY
+
+#covered by https://github.com/nodejs/node/issues/8271
+test-child-process-fork-dgram            : PASS, FLAKY


### PR DESCRIPTION
#### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
mark test-child-process-fork-dgram as flaky until we investigate/resolve 
https://github.com/nodejs/node/issues/8271