### PR TITLE
test: additional refactoring/cleanup of buffer tests

### DIFF
--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -22,18 +22,18 @@ assert.equal(buf.length, ab.byteLength);
 
 buf.fill(0xC);
 for (let i = 0; i < LENGTH; i++) {
-  assert.equal(ui[i], 0xC);
+  assert.strictEqual(ui[i], 0xC);
   ui[i] = 0xF;
-  assert.equal(buf[i], 0xF);
+  assert.strictEqual(buf[i], 0xF);
 }
 
 buf.writeUInt32LE(0xF00, 0);
 buf.writeUInt32BE(0xB47, 4);
 buf.writeDoubleLE(3.1415, 8);
 
-assert.equal(dv.getUint32(0, true), 0xF00);
-assert.equal(dv.getUint32(4), 0xB47);
-assert.equal(dv.getFloat64(8, true), 3.1415);
+assert.strictEqual(dv.getUint32(0, true), 0xF00);
+assert.strictEqual(dv.getUint32(4), 0xB47);
+assert.strictEqual(dv.getFloat64(8, true), 3.1415);
 
 
 // Now test protecting users from doing stupid things
@@ -61,12 +61,12 @@ b.writeDoubleBE(11.11, 0, true);
   ab[3] = 4;
   ab[4] = 5;
   const buf = Buffer.from(ab.buffer, 1, 3);
-  assert.equal(buf.length, 3);
-  assert.equal(buf[0], 2);
-  assert.equal(buf[1], 3);
-  assert.equal(buf[2], 4);
+  assert.strictEqual(buf.length, 3);
+  assert.strictEqual(buf[0], 2);
+  assert.strictEqual(buf[1], 3);
+  assert.strictEqual(buf[2], 4);
   buf[0] = 9;
-  assert.equal(ab[1], 9);
+  assert.strictEqual(ab[1], 9);
 
   assert.throws(() => Buffer.from(ab.buffer, 6), (err) => {
     assert(err instanceof RangeError);
@@ -89,12 +89,12 @@ b.writeDoubleBE(11.11, 0, true);
   ab[3] = 4;
   ab[4] = 5;
   const buf = Buffer(ab.buffer, 1, 3);
-  assert.equal(buf.length, 3);
-  assert.equal(buf[0], 2);
-  assert.equal(buf[1], 3);
-  assert.equal(buf[2], 4);
+  assert.strictEqual(buf.length, 3);
+  assert.strictEqual(buf[0], 2);
+  assert.strictEqual(buf[1], 3);
+  assert.strictEqual(buf[2], 4);
   buf[0] = 9;
-  assert.equal(ab[1], 9);
+  assert.strictEqual(ab[1], 9);
 
   assert.throws(() => Buffer(ab.buffer, 6), (err) => {
     assert(err instanceof RangeError);

--- a/test/parallel/test-buffer-ascii.js
+++ b/test/parallel/test-buffer-ascii.js
@@ -1,23 +1,23 @@
 'use strict';
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
 // ASCII conversion in node.js simply masks off the high bits,
 // it doesn't do transliteration.
-assert.equal(Buffer.from('hérité').toString('ascii'), 'hC)ritC)');
+assert.strictEqual(Buffer.from('hérité').toString('ascii'), 'hC)ritC)');
 
 // 71 characters, 78 bytes. The ’ character is a triple-byte sequence.
-var input = 'C’est, graphiquement, la réunion d’un accent aigu ' +
-            'et d’un accent grave.';
+const input = 'C’est, graphiquement, la réunion d’un accent aigu ' +
+              'et d’un accent grave.';
 
-var expected = 'Cb\u0000\u0019est, graphiquement, la rC)union ' +
-               'db\u0000\u0019un accent aigu et db\u0000\u0019un ' +
-               'accent grave.';
+const expected = 'Cb\u0000\u0019est, graphiquement, la rC)union ' +
+                 'db\u0000\u0019un accent aigu et db\u0000\u0019un ' +
+                 'accent grave.';
 
-var buf = Buffer.from(input);
+const buf = Buffer.from(input);
 
 for (var i = 0; i < expected.length; ++i) {
-  assert.equal(buf.slice(i).toString('ascii'), expected.slice(i));
+  assert.strictEqual(buf.slice(i).toString('ascii'), expected.slice(i));
 
   // Skip remainder of multi-byte sequence.
   if (input.charCodeAt(i) > 65535) ++i;

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -1,26 +1,28 @@
 'use strict';
 
 require('../common');
-var assert = require('assert');
-var Buffer = require('buffer').Buffer;
-var SlowBuffer = require('buffer').SlowBuffer;
+const assert = require('assert');
+const Buffer = require('buffer').Buffer;
+const SlowBuffer = require('buffer').SlowBuffer;
 
 // coerce values to string
-assert.equal(Buffer.byteLength(32, 'latin1'), 2);
-assert.equal(Buffer.byteLength(NaN, 'utf8'), 3);
-assert.equal(Buffer.byteLength({}, 'latin1'), 15);
-assert.equal(Buffer.byteLength(), 9);
+assert.strictEqual(Buffer.byteLength(32, 'latin1'), 2);
+assert.strictEqual(Buffer.byteLength(NaN, 'utf8'), 3);
+assert.strictEqual(Buffer.byteLength({}, 'latin1'), 15);
+assert.strictEqual(Buffer.byteLength(), 9);
 
-var buff = new Buffer(10);
-assert(ArrayBuffer.isView(buff));
-var slowbuff = new SlowBuffer(10);
-assert(ArrayBuffer.isView(slowbuff));
+assert(ArrayBuffer.isView(new Buffer(10)));
+assert(ArrayBuffer.isView(new SlowBuffer(10)));
+assert(ArrayBuffer.isView(Buffer.alloc(10)));
+assert(ArrayBuffer.isView(Buffer.allocUnsafe(10)));
+assert(ArrayBuffer.isView(Buffer.allocUnsafeSlow(10)));
+assert(ArrayBuffer.isView(Buffer.from('')));
 
 // buffer
 var incomplete = Buffer.from([0xe4, 0xb8, 0xad, 0xe6, 0x96]);
-assert.equal(Buffer.byteLength(incomplete), 5);
+assert.strictEqual(Buffer.byteLength(incomplete), 5);
 var ascii = Buffer.from('abc');
-assert.equal(Buffer.byteLength(ascii), 3);
+assert.strictEqual(Buffer.byteLength(ascii), 3);
 
 // ArrayBuffer
 var buffer = new ArrayBuffer(8);
@@ -28,60 +30,60 @@ assert.equal(Buffer.byteLength(buffer), 8);
 
 // TypedArray
 var int8 = new Int8Array(8);
-assert.equal(Buffer.byteLength(int8), 8);
+assert.strictEqual(Buffer.byteLength(int8), 8);
 var uint8 = new Uint8Array(8);
-assert.equal(Buffer.byteLength(uint8), 8);
+assert.strictEqual(Buffer.byteLength(uint8), 8);
 var uintc8 = new Uint8ClampedArray(2);
-assert.equal(Buffer.byteLength(uintc8), 2);
+assert.strictEqual(Buffer.byteLength(uintc8), 2);
 var int16 = new Int16Array(8);
-assert.equal(Buffer.byteLength(int16), 16);
+assert.strictEqual(Buffer.byteLength(int16), 16);
 var uint16 = new Uint16Array(8);
-assert.equal(Buffer.byteLength(uint16), 16);
+assert.strictEqual(Buffer.byteLength(uint16), 16);
 var int32 = new Int32Array(8);
-assert.equal(Buffer.byteLength(int32), 32);
+assert.strictEqual(Buffer.byteLength(int32), 32);
 var uint32 = new Uint32Array(8);
-assert.equal(Buffer.byteLength(uint32), 32);
+assert.strictEqual(Buffer.byteLength(uint32), 32);
 var float32 = new Float32Array(8);
-assert.equal(Buffer.byteLength(float32), 32);
+assert.strictEqual(Buffer.byteLength(float32), 32);
 var float64 = new Float64Array(8);
-assert.equal(Buffer.byteLength(float64), 64);
+assert.strictEqual(Buffer.byteLength(float64), 64);
 
 // DataView
 var dv = new DataView(new ArrayBuffer(2));
-assert.equal(Buffer.byteLength(dv), 2);
+assert.strictEqual(Buffer.byteLength(dv), 2);
 
 // special case: zero length string
-assert.equal(Buffer.byteLength('', 'ascii'), 0);
-assert.equal(Buffer.byteLength('', 'HeX'), 0);
+assert.strictEqual(Buffer.byteLength('', 'ascii'), 0);
+assert.strictEqual(Buffer.byteLength('', 'HeX'), 0);
 
 // utf8
-assert.equal(Buffer.byteLength('∑éllö wørl∂!', 'utf-8'), 19);
-assert.equal(Buffer.byteLength('κλμνξο', 'utf8'), 12);
-assert.equal(Buffer.byteLength('挵挶挷挸挹', 'utf-8'), 15);
-assert.equal(Buffer.byteLength('𠝹𠱓𠱸', 'UTF8'), 12);
+assert.strictEqual(Buffer.byteLength('∑éllö wørl∂!', 'utf-8'), 19);
+assert.strictEqual(Buffer.byteLength('κλμνξο', 'utf8'), 12);
+assert.strictEqual(Buffer.byteLength('挵挶挷挸挹', 'utf-8'), 15);
+assert.strictEqual(Buffer.byteLength('𠝹𠱓𠱸', 'UTF8'), 12);
 // without an encoding, utf8 should be assumed
-assert.equal(Buffer.byteLength('hey there'), 9);
-assert.equal(Buffer.byteLength('𠱸挶νξ#xx :)'), 17);
-assert.equal(Buffer.byteLength('hello world', ''), 11);
+assert.strictEqual(Buffer.byteLength('hey there'), 9);
+assert.strictEqual(Buffer.byteLength('𠱸挶νξ#xx :)'), 17);
+assert.strictEqual(Buffer.byteLength('hello world', ''), 11);
 // it should also be assumed with unrecognized encoding
-assert.equal(Buffer.byteLength('hello world', 'abc'), 11);
-assert.equal(Buffer.byteLength('ßœ∑≈', 'unkn0wn enc0ding'), 10);
+assert.strictEqual(Buffer.byteLength('hello world', 'abc'), 11);
+assert.strictEqual(Buffer.byteLength('ßœ∑≈', 'unkn0wn enc0ding'), 10);
 
 // base64
-assert.equal(Buffer.byteLength('aGVsbG8gd29ybGQ=', 'base64'), 11);
-assert.equal(Buffer.byteLength('bm9kZS5qcyByb2NrcyE=', 'base64'), 14);
-assert.equal(Buffer.byteLength('aGkk', 'base64'), 3);
-assert.equal(Buffer.byteLength('bHNrZGZsa3NqZmtsc2xrZmFqc2RsZmtqcw==',
+assert.strictEqual(Buffer.byteLength('aGVsbG8gd29ybGQ=', 'base64'), 11);
+assert.strictEqual(Buffer.byteLength('bm9kZS5qcyByb2NrcyE=', 'base64'), 14);
+assert.strictEqual(Buffer.byteLength('aGkk', 'base64'), 3);
+assert.strictEqual(Buffer.byteLength('bHNrZGZsa3NqZmtsc2xrZmFqc2RsZmtqcw==',
     'base64'), 25);
 // special padding
-assert.equal(Buffer.byteLength('aaa=', 'base64'), 2);
-assert.equal(Buffer.byteLength('aaaa==', 'base64'), 3);
+assert.strictEqual(Buffer.byteLength('aaa=', 'base64'), 2);
+assert.strictEqual(Buffer.byteLength('aaaa==', 'base64'), 3);
 
-assert.equal(Buffer.byteLength('Il était tué'), 14);
-assert.equal(Buffer.byteLength('Il était tué', 'utf8'), 14);
-assert.equal(Buffer.byteLength('Il était tué', 'ascii'), 12);
-assert.equal(Buffer.byteLength('Il était tué', 'latin1'), 12);
-assert.equal(Buffer.byteLength('Il était tué', 'binary'), 12);
+assert.strictEqual(Buffer.byteLength('Il était tué'), 14);
+assert.strictEqual(Buffer.byteLength('Il était tué', 'utf8'), 14);
+assert.strictEqual(Buffer.byteLength('Il était tué', 'ascii'), 12);
+assert.strictEqual(Buffer.byteLength('Il était tué', 'latin1'), 12);
+assert.strictEqual(Buffer.byteLength('Il était tué', 'binary'), 12);
 ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].forEach(function(encoding) {
-  assert.equal(24, Buffer.byteLength('Il était tué', encoding));
+  assert.strictEqual(24, Buffer.byteLength('Il était tué', encoding));
 });

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -6,51 +6,51 @@ const assert = require('assert');
 const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 const b = Buffer.from([5, 6, 7, 8, 9, 0, 1, 2, 3, 4]);
 
-assert.equal(-1, a.compare(b));
+assert.strictEqual(-1, a.compare(b));
 
 // Equivalent to a.compare(b).
-assert.equal(-1, a.compare(b, 0));
-assert.equal(-1, a.compare(b, '0'));
+assert.strictEqual(-1, a.compare(b, 0));
+assert.strictEqual(-1, a.compare(b, '0'));
 
 // Equivalent to a.compare(b).
-assert.equal(-1, a.compare(b, 0, undefined, 0));
+assert.strictEqual(-1, a.compare(b, 0, undefined, 0));
 
 // Zero-length targer, return 1
-assert.equal(1, a.compare(b, 0, 0, 0));
-assert.equal(1, a.compare(b, '0', '0', '0'));
+assert.strictEqual(1, a.compare(b, 0, 0, 0));
+assert.strictEqual(1, a.compare(b, '0', '0', '0'));
 
 // Equivalent to Buffer.compare(a, b.slice(6, 10))
-assert.equal(1, a.compare(b, 6, 10));
+assert.strictEqual(1, a.compare(b, 6, 10));
 
 // Zero-length source, return -1
-assert.equal(-1, a.compare(b, 6, 10, 0, 0));
+assert.strictEqual(-1, a.compare(b, 6, 10, 0, 0));
 
 // Equivalent to Buffer.compare(a.slice(4), b.slice(0, 5))
-assert.equal(1, a.compare(b, 0, 5, 4));
+assert.strictEqual(1, a.compare(b, 0, 5, 4));
 
 // Equivalent to Buffer.compare(a.slice(1), b.slice(5))
-assert.equal(1, a.compare(b, 5, undefined, 1));
+assert.strictEqual(1, a.compare(b, 5, undefined, 1));
 
 // Equivalent to Buffer.compare(a.slice(2), b.slice(2, 4))
-assert.equal(-1, a.compare(b, 2, 4, 2));
+assert.strictEqual(-1, a.compare(b, 2, 4, 2));
 
 // Equivalent to Buffer.compare(a.slice(4), b.slice(0, 7))
-assert.equal(-1, a.compare(b, 0, 7, 4));
+assert.strictEqual(-1, a.compare(b, 0, 7, 4));
 
 // Equivalent to Buffer.compare(a.slice(4, 6), b.slice(0, 7));
-assert.equal(-1, a.compare(b, 0, 7, 4, 6));
+assert.strictEqual(-1, a.compare(b, 0, 7, 4, 6));
 
 // zero length target
-assert.equal(1, a.compare(b, 0, null));
+assert.strictEqual(1, a.compare(b, 0, null));
 
 // coerces to targetEnd == 5
-assert.equal(-1, a.compare(b, 0, {valueOf: () => 5}));
+assert.strictEqual(-1, a.compare(b, 0, {valueOf: () => 5}));
 
 // zero length target
-assert.equal(1, a.compare(b, Infinity, -Infinity));
+assert.strictEqual(1, a.compare(b, Infinity, -Infinity));
 
 // zero length target because default for targetEnd <= targetSource
-assert.equal(1, a.compare(b, '0xff'));
+assert.strictEqual(1, a.compare(b, '0xff'));
 
 const oor = /out of range index/;
 

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -1,24 +1,27 @@
 'use strict';
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var zero = [];
-var one = [ Buffer.from('asdf') ];
-var long = [];
+const zero = [];
+const one = [ Buffer.from('asdf') ];
+const long = [];
 for (var i = 0; i < 10; i++) long.push(Buffer.from('asdf'));
 
-var flatZero = Buffer.concat(zero);
-var flatOne = Buffer.concat(one);
-var flatLong = Buffer.concat(long);
-var flatLongLen = Buffer.concat(long, 40);
+const flatZero = Buffer.concat(zero);
+const flatOne = Buffer.concat(one);
+const flatLong = Buffer.concat(long);
+const flatLongLen = Buffer.concat(long, 40);
 
-assert(flatZero.length === 0);
-assert(flatOne.toString() === 'asdf');
+assert.strictEqual(flatZero.length, 0);
+assert.strictEqual(flatOne.toString(), 'asdf');
+
+const check = new Array(10 + 1).join('asdf');
+
 // A special case where concat used to return the first item,
 // if the length is one. This check is to make sure that we don't do that.
-assert(flatOne !== one[0]);
-assert(flatLong.toString() === (new Array(10 + 1).join('asdf')));
-assert(flatLongLen.toString() === (new Array(10 + 1).join('asdf')));
+assert.notStrictEqual(flatOne, one[0]);
+assert.strictEqual(flatLong.toString(), check);
+assert.strictEqual(flatLongLen.toString(), check);
 
 assertWrongList();
 assertWrongList(null);
@@ -28,7 +31,7 @@ assertWrongList(['hello', 'world']);
 assertWrongList(['hello', Buffer.from('world')]);
 
 function assertWrongList(value) {
-  assert.throws(function() {
+  assert.throws(() => {
     Buffer.concat(value);
   }, function(err) {
     return err instanceof TypeError &&

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -3,8 +3,8 @@
 require('../common');
 const assert = require('assert');
 
-var b = Buffer.allocUnsafe(1024);
-var c = Buffer.allocUnsafe(512);
+const b = Buffer.allocUnsafe(1024);
+const c = Buffer.allocUnsafe(512);
 var cntr = 0;
 
 {
@@ -88,7 +88,7 @@ var cntr = 0;
 }
 
 // copy string longer than buffer length (failure will segfault)
-var bb = Buffer.allocUnsafe(10);
+const bb = Buffer.allocUnsafe(10);
 bb.fill('hello crazy world');
 
 

--- a/test/parallel/test-buffer-inheritance.js
+++ b/test/parallel/test-buffer-inheritance.js
@@ -23,16 +23,16 @@ T.prototype.sum = function sum() {
 const vals = [new T(4), T(4)];
 
 vals.forEach(function(t) {
-  assert.equal(t.constructor, T);
-  assert.equal(Object.getPrototypeOf(t), T.prototype);
-  assert.equal(Object.getPrototypeOf(Object.getPrototypeOf(t)),
+  assert.strictEqual(t.constructor, T);
+  assert.strictEqual(Object.getPrototypeOf(t), T.prototype);
+  assert.strictEqual(Object.getPrototypeOf(Object.getPrototypeOf(t)),
     Buffer.prototype);
 
   t.fill(5);
   let cntr = 0;
   for (let i = 0; i < t.length; i++)
     cntr += t[i];
-  assert.equal(t.length * 5, cntr);
+  assert.strictEqual(t.length * 5, cntr);
 
   // Check this does not throw
   t.toString();

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -1,10 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-
-var util = require('util');
-
-var buffer = require('buffer');
+const assert = require('assert');
+const util = require('util');
+const buffer = require('buffer');
 
 buffer.INSPECT_MAX_BYTES = 2;
 

--- a/test/parallel/test-buffer-iterator.js
+++ b/test/parallel/test-buffer-iterator.js
@@ -1,8 +1,8 @@
 'use strict';
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var buffer = Buffer.from([1, 2, 3, 4, 5]);
+const buffer = Buffer.from([1, 2, 3, 4, 5]);
 var arr;
 var b;
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test (buffer)

##### Description of change
Another round of cleanups for Buffer tests

* Favor use of strictEqual where possible
* Use const as appropriate
* Other miscellaneous cleanups