### PR TITLE
build: fix dependencies on AIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ uninstall:
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
 
 clean:
-	-rm -rf out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE) out/$(BUIDLTYPE)/node.exp
+	-rm -rf out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE) \
+                out/$(BUILDTYPE)/node.exp
 	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' -o -name '*.d' | xargs rm -rf; fi
 	-rm -rf node_modules
 	@if [ -d deps/icu ]; then echo deleting deps/icu; rm -rf deps/icu; fi
@@ -134,17 +135,16 @@ test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
 		--nodedir="$(shell pwd)"
 
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
+DOCBUILDSTAMP_PREREQS = tools/doc/addon-verify.js doc/api/addons.md
+
 ifeq ($(OSTYPE),aix)
-  test/addons/.docbuildstamp: tools/doc/addon-verify.js doc/api/addons.md out/Release/node.exp
-	$(RM) -r test/addons/??_*/
-	$(NODE) $<
-	touch $@
-else
-  test/addons/.docbuildstamp: tools/doc/addon-verify.js doc/api/addons.md
-	$(RM) -r test/addons/??_*/
-	$(NODE) $<
-	touch $@
+DOCBUILDSTAMP_PREREQS = $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
 endif
+
+test/addons/.docbuildstamp: $(DOCBUILDSTAMP_PREREQS)
+	$(RM) -r test/addons/??_*/
+	$(NODE) $<
+	touch $@
 
 ADDONS_BINDING_GYPS := \
 	$(filter-out test/addons/??_*/binding.gyp, \

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ uninstall:
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'
 
 clean:
-	-rm -rf out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE)
+	-rm -rf out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE) out/$(BUIDLTYPE)/node.exp
 	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' -o -name '*.d' | xargs rm -rf; fi
 	-rm -rf node_modules
 	@if [ -d deps/icu ]; then echo deleting deps/icu; rm -rf deps/icu; fi
@@ -134,10 +134,17 @@ test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
 		--nodedir="$(shell pwd)"
 
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
-test/addons/.docbuildstamp: tools/doc/addon-verify.js doc/api/addons.md
+ifeq ($(OSTYPE),aix)
+  test/addons/.docbuildstamp: tools/doc/addon-verify.js doc/api/addons.md out/Release/node.exp
 	$(RM) -r test/addons/??_*/
 	$(NODE) $<
 	touch $@
+else
+  test/addons/.docbuildstamp: tools/doc/addon-verify.js doc/api/addons.md
+	$(RM) -r test/addons/??_*/
+	$(NODE) $<
+	touch $@
+endif
 
 ADDONS_BINDING_GYPS := \
 	$(filter-out test/addons/??_*/binding.gyp, \

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
 DOCBUILDSTAMP_PREREQS = tools/doc/addon-verify.js doc/api/addons.md
 
 ifeq ($(OSTYPE),aix)
-DOCBUILDSTAMP_PREREQS = $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
+DOCBUILDSTAMP_PREREQS := $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
 endif
 
 test/addons/.docbuildstamp: $(DOCBUILDSTAMP_PREREQS)

--- a/node.gyp
+++ b/node.gyp
@@ -906,7 +906,6 @@
         },
         {
           'target_name': 'node_exp',
-          'process_outputs_as_sources': 1,
           'type': 'none',
           'dependencies': [
             '<(node_core_target_name)',

--- a/tools/create_expfile.sh
+++ b/tools/create_expfile.sh
@@ -36,7 +36,7 @@
 echo "Searching $1 to write out expfile to $2"
 
 # this special sequence must be at the start of the exp file
-echo "#!." > $2
+echo "#!." > $2.tmp
 
 # pull the symbols from the .a files
 find $1 -name "*.a" | grep -v gtest \
@@ -45,4 +45,6 @@ find $1 -name "*.a" | grep -v gtest \
       if ((($2 == "T") || ($2 == "D") || ($2 == "B")) &&
           (substr($3,1,1) != ".")) { print $3 }
     }' \
-  | sort -u >> $2
+  | sort -u >> $2.tmp
+
+mv -f $2.tmp $2


### PR DESCRIPTION
#### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
addons test


##### Description of change
addon tests were still starting to run before the node exp file
creation was complete.

- remove process_outputs_as_sources as it did not fix the
  problem
- update create_expfile.sh so that exp file is created in a
  temporary file and then renamed to final name so that
  file is only visible once it is complete
- update target used in building addons so that for
  AIX it depends on the exp file being available

Fixes: https://github.com/nodejs/node/pull/8285