### PR TITLE
doc: clarify that path.isAbsolute on windows accepts / and \

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -270,9 +270,6 @@ path.isAbsolute('bar/baz')     // false
 path.isAbsolute('.')           // false
 ```
 
-*Note*: On Windows, the `path.isAbsolute()` method will accept both forward
-slash (`/`) and backwards slash (`\`) characters as path delimiters.
-
 A [`TypeError`][] is thrown if `path` is not a string.
 
 ## path.join([path[, ...]])
@@ -514,6 +511,10 @@ added: v0.11.15
 
 The `path.win32` property provides access to Windows-specific implementations
 of the `path` methods.
+
+*Note*: On Windows, both the forward slash (`/`) and backward slash (`\`)
+characters are accepted as path delimiters; however, only the backward slash
+(`\`) will be used in return values.
 
 [`path.posix`]: #path_path_posix
 [`path.win32`]: #path_path_win32

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -261,11 +261,17 @@ path.isAbsolute('.')        // false
 On Windows:
 
 ```js
-path.isAbsolute('//server')  // true
-path.isAbsolute('C:/foo/..') // true
-path.isAbsolute('bar\\baz')  // false
-path.isAbsolute('.')         // false
+path.isAbsolute('//server')    // true
+path.isAbsolute('\\\\server')  // true
+path.isAbsolute('C:/foo/..')   // true
+path.isAbsolute('C:\\foo\\..') // true
+path.isAbsolute('bar\\baz')    // false
+path.isAbsolute('bar/baz')     // false
+path.isAbsolute('.')           // false
 ```
+
+*Note*: On Windows, the `path.isAbsolute()` method will accept both forward
+slash (`/`) and backwards slash (`\`) characters as path delimiters.
 
 A [`TypeError`][] is thrown if `path` is not a string.
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change
Clarify that path.isAbsolute() on windows accepts / and \ as path delims

Fixes: https://github.com/nodejs/node/issues/6520