### PR TITLE
doc: document that readline write() is processed as input

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -315,6 +315,9 @@ rl.write('Delete this!');
 rl.write(null, {ctrl: true, name: 'u'});
 ```
 
+*Note*: The `rl.write()` method will write the data to the `readline`
+Interface's `input` *as if it were provided by the user*.
+
 ## readline.clearLine(stream, dir)
 <!-- YAML
 added: v0.7.7


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change
Document that data written using readline.write() is processed as input.

Fixes: https://github.com/nodejs/node/issues/4402