### PR TITLE
net: make holding the buffer in memory more robust (v4.x backport)

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -685,7 +685,6 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   } else {
     var enc;
     if (data instanceof Buffer) {
-      req.buffer = data;  // Keep reference alive.
       enc = 'buffer';
     } else {
       enc = encoding;

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -225,6 +225,7 @@ int StreamBase::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
 
   err = DoWrite(req_wrap, bufs, count, nullptr);
   req_wrap_obj->Set(env->async(), True(env->isolate()));
+  req_wrap_obj->Set(env->buffer_string(), args[1]);
 
   if (err)
     req_wrap->Dispose();

--- a/test/parallel/test-net-write-fully-async-buffer.js
+++ b/test/parallel/test-net-write-fully-async-buffer.js
@@ -1,0 +1,34 @@
+'use strict';
+// Flags: --expose-gc
+
+// Note: This is a variant of test-net-write-fully-async-hex-string.js.
+// This always worked, but it seemed appropriate to add a test that checks the
+// behaviour for Buffers, too.
+const common = require('../common');
+const net = require('net');
+
+const data = Buffer.alloc(1000000);
+
+const server = net.createServer(common.mustCall(function(conn) {
+  conn.resume();
+})).listen(0, common.mustCall(function() {
+  const conn = net.createConnection(this.address().port, common.mustCall(() => {
+    let count = 0;
+
+    function writeLoop() {
+      if (count++ === 200) {
+        conn.destroy();
+        server.close();
+        return;
+      }
+
+      while (conn.write(Buffer.from(data)));
+      global.gc(true);
+      // The buffer allocated above should still be alive.
+    }
+
+    conn.on('drain', writeLoop);
+
+    writeLoop();
+  }));
+}));

--- a/test/parallel/test-net-write-fully-async-hex-string.js
+++ b/test/parallel/test-net-write-fully-async-hex-string.js
@@ -1,0 +1,32 @@
+'use strict';
+// Flags: --expose-gc
+
+// Regression test for https://github.com/nodejs/node/issues/8251.
+const common = require('../common');
+const net = require('net');
+
+const data = Buffer.alloc(1000000).toString('hex');
+
+const server = net.createServer(common.mustCall(function(conn) {
+  conn.resume();
+})).listen(0, common.mustCall(function() {
+  const conn = net.createConnection(this.address().port, common.mustCall(() => {
+    let count = 0;
+
+    function writeLoop() {
+      if (count++ === 20) {
+        conn.destroy();
+        server.close();
+        return;
+      }
+
+      while (conn.write(data, 'hex'));
+      global.gc(true);
+      // The buffer allocated inside the .write() call should still be alive.
+    }
+
+    conn.on('drain', writeLoop);
+
+    writeLoop();
+  }));
+}));


### PR DESCRIPTION
Set the `req.buffer` property, which serves as a way of keeping
a `Buffer` alive that is being written to a stream, on the C++
side instead of the JS side.

This closes a hole where buffers that were temporarily created
in order to write strings with uncommon encodings (e.g. `hex`)
were passed to the native side without being set as `req.buffer`.

Fixes: https://github.com/nodejs/node/issues/8251
PR-URL: https://github.com/nodejs/node/pull/8252

(@TheAlphaNerd my instinct has become to automatically assign v4.x backports to you, in part because that makes it very easy to discern them visually in PR lists… if you think that’s cool I’ll keep doing it?)