### PR TITLE
crypto: fix ucs2/ucs-2/utf16le/utf-16le encoding check

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -100,7 +100,7 @@ Hmac.prototype._transform = Hash.prototype._transform;
 
 
 function getDecoder(decoder, encoding) {
-  if (encoding === 'utf-8') encoding = 'utf8';  // Normalize encoding.
+  encoding = internalUtil.normalizeEncoding(encoding);
   decoder = decoder || new StringDecoder(encoding);
   assert(decoder.encoding === encoding, 'Cannot change encoding');
   return decoder;

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -113,3 +113,29 @@ testCipher2(Buffer.from('0123456789abcdef'));
   c.update('update', 'utf-8');
   c.final('utf8');  // Should not throw.
 }
+
+// Regression tests for https://github.com/nodejs/node/issues/8236.
+{
+  const key = '0123456789abcdef';
+  const plaintext = 'Top secret!!!';
+  const c = crypto.createCipher('aes192', key);
+  var ciph = c.update(plaintext, 'utf16le', 'base64');
+  ciph += c.final('base64');
+
+  var decipher = crypto.createDecipher('aes192', key);
+
+  var txt;
+  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'ucs2'));
+  assert.doesNotThrow(() => txt += decipher.final('ucs2'));
+  assert.strictEqual(txt, plaintext, 'decrypted result in ucs2');
+
+  decipher = crypto.createDecipher('aes192', key);
+  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'ucs-2'));
+  assert.doesNotThrow(() => txt += decipher.final('ucs-2'));
+  assert.strictEqual(txt, plaintext, 'decrypted result in ucs-2');
+
+  decipher = crypto.createDecipher('aes192', key);
+  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'utf-16le'));
+  assert.doesNotThrow(() => txt += decipher.final('utf-16le'));
+  assert.strictEqual(txt, plaintext, 'decrypted result in utf-16le');
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
crypto


##### Description of change
Normalize the encoding in getDecoder() before using it. Fixes an
AssertionError: "Cannot change encoding" when encoding is "ucs2", "ucs-2"
or "utf-16le"

Fixes: https://github.com/nodejs/node/issues/8236