### PR TITLE
test: add test for zlib.create*Raw()

### DIFF
--- a/test/parallel/test-zlib-create-raw.js
+++ b/test/parallel/test-zlib-create-raw.js
@@ -1,0 +1,15 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+{
+  const inflateRaw = zlib.createInflateRaw();
+  assert(inflateRaw instanceof zlib.InflateRaw);
+}
+
+{
+  const deflateRaw = zlib.createDeflateRaw();
+  assert(deflateRaw instanceof zlib.DeflateRaw);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test zlib

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently, there are no tests that exercise `zlib.createInflateRaw()` or
`zlib.createDeflateRaw()`.

This adds minimal tests that invoke the functions and confirm that they
return `zlib.InflateRaw`/`zlib.DeflateRaw` objects.