### PR TITLE
src: unbreak build when compiling against uclibc

### DIFF
--- a/src/backtrace_posix.cc
+++ b/src/backtrace_posix.cc
@@ -4,7 +4,9 @@
 #include <features.h>
 #endif
 
-#if defined(__linux__) && !defined(__GLIBC__) || defined(_AIX)
+#if defined(__linux__) && !defined(__GLIBC__) || \
+    defined(__UCLIBC__) || \
+    defined(_AIX)
 #define HAVE_EXECINFO_H 0
 #else
 #define HAVE_EXECINFO_H 1


### PR DESCRIPTION
It seems that it is possible with some toolchains for both `__GLIBC__`
and `__UCLIBC__` to be defined, confusing our "do we have execinfo.h?"
logic.

Assume that when `__UCLIBC__` is defined, we are dealing with a libc
that does not have execinfo.h.

Fixes: #8233