### PR TITLE
buffer: expose underlying buffer object always

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -402,10 +402,6 @@ Object.defineProperty(Buffer.prototype, 'parent', {
   get: function() {
     if (!(this instanceof Buffer))
       return undefined;
-    if (this.byteLength === 0 ||
-        this.byteLength === this.buffer.byteLength) {
-      return undefined;
-    }
     return this.buffer;
   }
 });

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -994,7 +994,7 @@ if (common.hasCrypto) {
 
 const ps = Buffer.poolSize;
 Buffer.poolSize = 0;
-assert.strictEqual(Buffer.allocUnsafe(1).parent, undefined);
+assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);
 Buffer.poolSize = ps;
 
 // Test Buffer.copy() segfault

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -13,9 +13,7 @@ const buf = Buffer.from(ab);
 
 
 assert.ok(buf instanceof Buffer);
-// For backwards compatibility of old .parent property test that if buf is not
-// a slice then .parent should be undefined.
-assert.equal(buf.parent, undefined);
+assert.equal(buf.parent, buf.buffer);
 assert.equal(buf.buffer, ab);
 assert.equal(buf.length, ab.byteLength);
 

--- a/test/parallel/test-buffer-parent-property.js
+++ b/test/parallel/test-buffer-parent-property.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/*
+ * Fix for https://github.com/nodejs/node/issues/8266
+ *
+ * Zero length Buffer objects should expose the `buffer` property of the
+ * TypedArrays, via the `parent` property.
+ */
+require('../common');
+const assert = require('assert');
+
+// If the length of the buffer object is zero
+assert((new Buffer(0)).parent instanceof ArrayBuffer);
+
+// If the length of the buffer object is equal to the underlying ArrayBuffer
+assert((new Buffer(Buffer.poolSize)).parent instanceof ArrayBuffer);
+
+// Same as the previous test, but with user created buffer
+const arrayBuffer = new ArrayBuffer(0);
+assert.strictEqual(new Buffer(arrayBuffer).parent, arrayBuffer);
+assert.strictEqual(new Buffer(arrayBuffer).buffer, arrayBuffer);
+assert.strictEqual(Buffer.from(arrayBuffer).parent, arrayBuffer);
+assert.strictEqual(Buffer.from(arrayBuffer).buffer, arrayBuffer);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

If the Buffer object's length is zero, or equal to the underlying
buffer object's length, `parent` property returns `undefined`.

    > new Buffer(0).parent
    undefined
    > new Buffer(Buffer.poolSize).parent
    undefined

This patch makes the buffer objects to consistently expose the buffer
object via the `parent` property, always.

Fixes: https://github.com/nodejs/node/issues/8266

---

cc @nodejs/buffer 