### PR TITLE
build: don't require processing docs for nightlies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,8 @@ PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacO
 PKGDIR=out/dist-osx
 
 release-only:
-	@if `grep -q REPLACEME doc/api/*.md`; then \
+	@if [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
+		`grep -q REPLACEME doc/api/*.md`; then \
 		echo 'Please update Added: tags in the documentation first.' ; \
 		exit 1 ; \
 	fi


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build

##### Description of change

Our nightlies were experiencing issues since we didn't properly replace version info in documentation (#6864). Skip that check unless we're actually doing release builds.

/cc @mhdawson, @williamkapke (reporter), @bnoordhuis, @addaleax 
