### PR TITLE
doc: drop 50-character limit for commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,11 @@ $ git config --global user.email "j.random.user@example.com"
 Writing good commit logs is important. A commit log should describe what
 changed and why. Follow these guidelines when writing one:
 
-1. The first line should be 50 characters or less and contain a short
+1. The first line should be kept short and contain a concise
    description of the change prefixed with the name of the changed
    subsystem (e.g. "net: add localAddress and localPort to Socket").
 2. Keep the second line blank.
-3. Wrap all other lines at 72 columns.
+3. Wrap all lines at 72 columns.
 
 A good commit log can look something like this:
 


### PR DESCRIPTION
Replace the current limit of 50 characters for the first line of the commit message with a more flexible formulation.

Copying the reasoning from https://github.com/nodejs/node/pull/8294#issuecomment-242902382:

50 characters is a pretty hard limit when you need to include something like `child_process: ` and/or are a non-native speaker with reduced vocabulary.