### PR TITLE
buffer: deprecate parent property

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1327,6 +1327,12 @@ buf = buf.slice(0, 5);
 console.log(buf.length);
 ```
 
+### buf.parent
+
+> Stability: 0 - Deprecated: Use [`buf.buffer`] instead.
+
+The `buf.parent` property is a deprecated alias for `buf.buffer`.
+
 ### buf.readDoubleBE(offset[, noAssert])
 ### buf.readDoubleLE(offset[, noAssert])
 <!-- YAML
@@ -2427,6 +2433,7 @@ console.log(buf);
 ```
 
 [`buf.compare()`]: #buffer_buf_compare_target_targetstart_targetend_sourcestart_sourceend
+[`buf.buffer`]: #buffer_buf_buffer
 [`buf.entries()`]: #buffer_buf_entries
 [`buf.indexOf()`]: #buffer_buf_indexof_value_byteoffset_encoding
 [`buf.fill()`]: #buffer_buf_fill_value_offset_end_encoding

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -877,6 +877,19 @@ for (let i = 0; i < str.length ; i++) {
 console.log(buf.toString('ascii'));
 ```
 
+### buf.buffer
+
+The `buffer` property references the underlying `ArrayBuffer` object based on
+which this Buffer object is created.
+
+```js
+const arrayBuffer = new ArrayBuffer(16);
+const buffer = Buffer.from(arrayBuffer);
+
+console.log(buffer.buffer === arrayBuffer);
+// Prints: true
+```
+
 ### buf.compare(target[, targetStart[, targetEnd[, sourceStart[, sourceEnd]]]])
 <!-- YAML
 added: v0.11.13


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

buffer
##### Description of change

The `buffer` property already exposes the underlying buffer object. So
this property is being deprecated.

Refer: https://github.com/nodejs/node/issues/8266
Refer: https://github.com/nodejs/node/pull/8311

---

cc @nodejs/buffer 
