### PR TITLE
crypto: use system CAs instead of bundled ones

### DIFF
--- a/configure
+++ b/configure
@@ -133,6 +133,11 @@ parser.add_option('--openssl-fips',
     dest='openssl_fips',
     help='Build OpenSSL using FIPS canister .o file in supplied folder')
 
+parser.add_option('--openssl-use-def-ca-store',
+    action='store_true',
+    dest='use_openssl_ca_store',
+    help='Use OpenSSL supplied CA store instead of compiled-in Mozilla CA copy.')
+
 shared_optgroup.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -927,6 +932,8 @@ def configure_openssl(o):
   o['variables']['node_use_openssl'] = b(not options.without_ssl)
   o['variables']['node_shared_openssl'] = b(options.shared_openssl)
   o['variables']['openssl_no_asm'] = 1 if options.openssl_no_asm else 0
+  if options.use_openssl_ca_store:
+    o['defines'] += ['NODE_OPENSSL_CERT_STORE']
   if options.openssl_fips:
     o['variables']['openssl_fips'] = options.openssl_fips
     fips_dir = os.path.join(root_dir, 'deps', 'openssl', 'fips')

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -257,6 +257,24 @@ Load an OpenSSL configuration file on startup. Among other uses, this can be
 used to enable FIPS-compliant crypto if Node.js is built with
 `./configure --openssl-fips`.
 
+### `--use-openssl-ca`, `--use-bundled-ca`
+<!-- YAML
+added: REPLACEME
+-->
+
+Use OpenSSL's default CA store or use bundled Mozilla CA store as supplied by
+current NodeJS version. The default store is selectable at build-time.
+
+Using OpenSSL store allows for external modifications of the store. For most
+Linux and BSD distributions, this store is maintained by the distribution
+maintainers and system administrators. OpenSSL CA store location is dependent on
+configuration of the OpenSSL library but this can be altered at runtime using
+environmental variables.
+
+The bundled CA store, as supplied by NodeJS, is a snapshot of Mozilla CA store
+that is fixed at release time. It is identical on all supported platforms.
+
+See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
 ### `--icu-data-dir=file`
 <!-- YAML
@@ -339,6 +357,16 @@ misformatted, but any errors are otherwise ignored.
 
 Note that neither the well known nor extra certificates are used when the `ca`
 options property is explicitly specified for a TLS or HTTPS client or server.
+
+### `SSL_CERT_DIR=dir`
+
+If `--use-openssl-ca` is enabled, this overrides and sets OpenSSL's directory
+containing trusted certificates.
+
+### `SSL_CERT_FILE=file`
+
+If `--use-openssl-ca` is enabled, this overrides and sets OpenSSL's file
+containing trusted certificates.
 
 [emit_warning]: process.html#process_process_emitwarning_warning_name_ctor
 [Buffer]: buffer.html#buffer_buffer

--- a/doc/node.1
+++ b/doc/node.1
@@ -172,6 +172,22 @@ used to enable FIPS-compliant crypto if Node.js is built with
 \fB./configure \-\-openssl\-fips\fR.
 
 .TP
+.BR \-\-use\-openssl\-ca,\-\-use\-bundled\-ca
+Use OpenSSL's default CA store or use bundled Mozilla CA store as supplied by
+current NodeJS version. The default store is selectable at build-time.
+
+Using OpenSSL store allows for external modifications of the store. For most
+Linux and BSD distributions, this store is maintained by the distribution
+maintainers and system administrators. OpenSSL CA store location is dependent on
+configuration of the OpenSSL library but this can be altered at runtime using
+environmental variables.
+
+The bundled CA store, as supplied by NodeJS, is a snapshot of Mozilla CA store
+that is fixed at release time. It is identical on all supported platforms.
+
+See \fBSSL_CERT_DIR\fR and \fBSSL_CERT_FILE\fR.
+
+.TP
 .BR \-\-icu\-data\-dir =\fIfile\fR
 Specify ICU data load path. (overrides \fBNODE_ICU_DATA\fR)
 
@@ -207,6 +223,15 @@ when outputting to a TTY on platforms which support async stdio.
 Setting this will void any guarantee that stdio will not be interleaved or
 dropped at program exit. \fBAvoid use.\fR
 
+.TP
+.BR SSL_CERT_DIR = \fIdir\fR
+If \fB\-\-use\-openssl\-ca\fR is enabled, this overrides and sets OpenSSL's directory
+containing trusted certificates.
+
+.TP
+.BR SSL_CERT_FILE = \fIfile\fR
+If \fB\-\-use\-openssl\-ca\fR is enabled, this overrides and sets OpenSSL's
+file containing trusted certificates.
 
 .SH BUGS
 Bugs are tracked in GitHub Issues:

--- a/src/node.cc
+++ b/src/node.cc
@@ -163,6 +163,14 @@ static const char* icu_data_dir = nullptr;
 bool no_deprecation = false;
 
 #if HAVE_OPENSSL
+// use OpenSSL's cert store instead of bundled certs
+bool ssl_openssl_cert_store =
+#if defined(NODE_OPENSSL_CERT_STORE)
+        true;
+#else
+        false;
+#endif
+
 # if NODE_FIPS_MODE
 // used by crypto module
 bool enable_fips_crypto = false;
@@ -3502,6 +3510,16 @@ static void PrintHelp() {
 #if HAVE_OPENSSL
          "  --tls-cipher-list=val    use an alternative default TLS cipher "
          "list\n"
+         "  --use-bundled-ca         use bundled CA store"
+#if !defined(NODE_OPENSSL_CERT_STORE)
+         " (default)"
+#endif
+         "\n"
+         "  --use-openssl-ca         use OpenSSL's default CA store"
+#if defined(NODE_OPENSSL_CERT_STORE)
+         " (default)"
+#endif
+         "\n"
 #if NODE_FIPS_MODE
          "  --enable-fips            enable FIPS crypto at startup\n"
          "  --force-fips             force FIPS crypto (cannot be disabled)\n"
@@ -3672,6 +3690,10 @@ static void ParseArgs(int* argc,
 #if HAVE_OPENSSL
     } else if (strncmp(arg, "--tls-cipher-list=", 18) == 0) {
       default_cipher_list = arg + 18;
+    } else if (strncmp(arg, "--use-openssl-ca", 16) == 0) {
+      ssl_openssl_cert_store = true;
+    } else if (strncmp(arg, "--use-bundled-ca", 16) == 0) {
+      ssl_openssl_cert_store = false;
 #if NODE_FIPS_MODE
     } else if (strcmp(arg, "--enable-fips") == 0) {
       enable_fips_crypto = true;

--- a/src/node.h
+++ b/src/node.h
@@ -180,9 +180,12 @@ typedef intptr_t ssize_t;
 namespace node {
 
 NODE_EXTERN extern bool no_deprecation;
-#if HAVE_OPENSSL && NODE_FIPS_MODE
+#if HAVE_OPENSSL
+NODE_EXTERN extern bool ssl_openssl_cert_store;
+# if NODE_FIPS_MODE
 NODE_EXTERN extern bool enable_fips_crypto;
 NODE_EXTERN extern bool force_fips_crypto;
+# endif
 #endif
 
 NODE_EXTERN int Start(int argc, char *argv[]);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -710,14 +710,14 @@ static X509_STORE* NewRootCertStore() {
   }
 
   X509_STORE* store = X509_STORE_new();
-#if defined(NODE_OPENSSL_CERT_STORE)
-  X509_STORE_set_default_paths(store);
-#else
-  for (X509 *cert : root_certs_vector) {
-    X509_up_ref(cert);
-    X509_STORE_add_cert(store, cert);
+  if (ssl_openssl_cert_store) {
+    X509_STORE_set_default_paths(store);
+  } else {
+    for (X509 *cert : root_certs_vector) {
+      X509_up_ref(cert);
+      X509_STORE_add_cert(store, cert);
+    }
   }
-#endif
 
   return store;
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -123,7 +123,7 @@ const char* const root_certs[] = {
 std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
 X509_STORE* root_cert_store;
-std::vector<X509*>* root_certs_vector;
+std::vector<X509*> root_certs_vector;
 
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;
@@ -693,9 +693,7 @@ static int X509_up_ref(X509* cert) {
 
 
 static X509_STORE* NewRootCertStore() {
-  if (!root_certs_vector) {
-    root_certs_vector = new std::vector<X509*>;
-
+  if (root_certs_vector.empty()) {
     for (size_t i = 0; i < arraysize(root_certs); i++) {
       BIO* bp = NodeBIO::NewFixed(root_certs[i], strlen(root_certs[i]));
       X509 *x509 = PEM_read_bio_X509(bp, nullptr, CryptoPemCallback, nullptr);
@@ -707,12 +705,12 @@ static X509_STORE* NewRootCertStore() {
         return nullptr;
       }
 
-      root_certs_vector->push_back(x509);
+      root_certs_vector.push_back(x509);
     }
   }
 
   X509_STORE* store = X509_STORE_new();
-  for (auto& cert : *root_certs_vector) {
+  for (X509 *cert : root_certs_vector) {
     X509_up_ref(cert);
     X509_STORE_add_cert(store, cert);
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -710,10 +710,14 @@ static X509_STORE* NewRootCertStore() {
   }
 
   X509_STORE* store = X509_STORE_new();
+#if defined(NODE_OPENSSL_CERT_STORE)
+  X509_STORE_set_default_paths(store);
+#else
   for (X509 *cert : root_certs_vector) {
     X509_up_ref(cert);
     X509_STORE_add_cert(store, cert);
   }
+#endif
 
   return store;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

crypto
##### Description of change

<!-- Provide a description of the change below this comment. -->

Use system supplied CAs instead of using Node's bundled version.
This is a compile time option with default reverting back to 
using bundled certificates.

~~Also simplify cert_store lifetime by using reference count instead
of pulling it from under the SSL_CTX right before deletion.~~ (merged)
