### PR TITLE
benchmark: add benches for fs.stat & fs.statSync

### DIFF
--- a/benchmark/fs/bench-readdir.js
+++ b/benchmark/fs/bench-readdir.js
@@ -14,7 +14,7 @@ function main(conf) {
 
   bench.start();
   (function r(cntr) {
-    if (--cntr <= 0)
+    if (cntr-- <= 0)
       return bench.end(n);
     fs.readdir(path.resolve(__dirname, '../../lib/'), function() {
       r(cntr);

--- a/benchmark/fs/bench-realpath.js
+++ b/benchmark/fs/bench-realpath.js
@@ -27,7 +27,7 @@ function main(conf) {
 
 function relativePath(n) {
   (function r(cntr) {
-    if (--cntr <= 0)
+    if (cntr-- <= 0)
       return bench.end(n);
     fs.realpath(relative_path, function() {
       r(cntr);
@@ -37,7 +37,7 @@ function relativePath(n) {
 
 function resolvedPath(n) {
   (function r(cntr) {
-    if (--cntr <= 0)
+    if (cntr-- <= 0)
       return bench.end(n);
     fs.realpath(resolved_path, function() {
       r(cntr);

--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+const bench = common.createBenchmark(main, {
+  n: [1e4],
+  kind: ['lstat', 'stat']
+});
+
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const fn = fs[conf.kind];
+
+  bench.start();
+  (function r(cntr) {
+    if (cntr-- <= 0)
+      return bench.end(n);
+    fn(__filename, function() {
+      r(cntr);
+    });
+  }(n));
+}

--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -11,7 +11,6 @@ const bench = common.createBenchmark(main, {
 
 function main(conf) {
   const n = conf.n >>> 0;
-  const fn = fs[conf.kind];
 
   bench.start();
   (function r(cntr, fn) {
@@ -20,5 +19,5 @@ function main(conf) {
     fn(__filename, function() {
       r(cntr, fn);
     });
-  }(n, fn));
+  }(n, fs[conf.kind]));
 }

--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -14,11 +14,11 @@ function main(conf) {
   const fn = fs[conf.kind];
 
   bench.start();
-  (function r(cntr) {
+  (function r(cntr, fn) {
     if (cntr-- <= 0)
       return bench.end(n);
     fn(__filename, function() {
-      r(cntr);
+      r(cntr, fn);
     });
-  }(n));
+  }(n, fn));
 }

--- a/benchmark/fs/bench-statSync.js
+++ b/benchmark/fs/bench-statSync.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+const bench = common.createBenchmark(main, {
+  n: [1e4],
+  kind: ['lstatSync', 'statSync']
+});
+
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const fn = fs[conf.kind];
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    fn(__filename);
+  }
+  bench.end(n);
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

benchmark

##### Description of change

Add very simple benchmarks for `fs.stat` and `fs.statSync` as well as `fs.lstat` and `fs.lstatSync` based on the `readdir` benchmarks.

Linter run: https://ci.nodejs.org/job/node-test-linter/4005/