### PR TITLE
events: make memory leak warning name more verbose

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -285,6 +285,7 @@ The emitted warning can be inspected with [`process.on('warning')`][] and will
 have the additional `emitter`, `type` and `count` properties, referring to
 the event emitter instance, the event’s name and the number of attached
 listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
 
 ### emitter.addListener(eventName, listener)
 <!-- YAML

--- a/lib/events.js
+++ b/lib/events.js
@@ -259,7 +259,7 @@ function _addListener(target, type, listener, prepend) {
         const w = new Error('Possible EventEmitter memory leak detected. ' +
                             `${existing.length} ${type} listeners added. ` +
                             'Use emitter.setMaxListeners() to increase limit');
-        w.name = 'Warning';
+        w.name = 'MaxListenersExceededWarning';
         w.emitter = target;
         w.type = type;
         w.count = existing.length;

--- a/test/parallel/test-event-emitter-max-listeners-warning.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning.js
@@ -11,7 +11,7 @@ e.setMaxListeners(1);
 
 process.on('warning', common.mustCall((warning) => {
   assert.ok(warning instanceof Error);
-  assert.strictEqual(warning.name, 'Warning');
+  assert.strictEqual(warning.name, 'MaxListenersExceededWarning');
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
   assert.strictEqual(warning.type, 'event-type');


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

events

##### Description of change

Switch from a generic `Warning` to the more specific `MaxListenersExceededWarning`, as suggested in #8298 (separate PR for this because this is a semver-major change).

CI: https://ci.nodejs.org/job/node-test-commit/4842/