### PR TITLE
lib: runtime deprecation of the constants module

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// This module is soft-deprecated. Users should be directed towards using
+// This module is deprecated. Users should be directed towards using
 // the specific constants exposed by the individual modules on which they
 // are most relevant.
 const constants = process.binding('constants');
@@ -9,3 +9,8 @@ Object.assign(exports,
               constants.os.signals,
               constants.fs,
               constants.crypto);
+
+process.emitWarning(
+  'The \'constants\' module is deprecated and will be removed soon. ' +
+  'Module-specific constants can be accessed via the relevant module.',
+  'DeprecationWarning');


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

constants

##### Description of change

`require('constants')` was previously doc-only deprecated in v6. This bumps it up to a runtime deprecation for either v7 or v8.