### PR TITLE
V4.x backport for `tools: increase lint coverage` (https://github.com/nodejs/node/pull/7647)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,7 @@ lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*/
 test/fixtures
-test/**/node_modules
 test/disabled
 test/tmp*/
-tools/doc/node_modules
+tools/eslint
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -644,8 +644,8 @@ bench-idle:
 	$(NODE) benchmark/idle_clients.js &
 
 jslint:
-	$(NODE) tools/eslint/bin/eslint.js benchmark lib src test tools/doc \
-	  tools/eslint-rules --rulesdir tools/eslint-rules
+	$(NODE) tools/eslint/bin/eslint.js benchmark lib src test tools \
+	  --rulesdir tools/eslint-rules
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_root_certs.h

--- a/tools/license2rtf.js
+++ b/tools/license2rtf.js
@@ -1,15 +1,16 @@
+'use strict';
 
-var assert = require('assert'),
-    Stream = require('stream'),
-    inherits = require('util').inherits;
+const assert = require('assert');
+const Stream = require('stream');
+const inherits = require('util').inherits;
 
 
 /*
  * This filter consumes a stream of characters and emits one string per line.
  */
 function LineSplitter() {
-  var self = this,
-      buffer = "";
+  const self = this;
+  var buffer = '';
 
   Stream.call(this);
   this.writable = true;
@@ -38,33 +39,31 @@ inherits(LineSplitter, Stream);
  * This filter consumes lines and emits paragraph objects.
  */
 function ParagraphParser() {
-  var self = this,
-      block_is_license_block = false,
-      block_has_c_style_comment,
-      is_first_line_in_paragraph,
-      paragraph_line_indent,
-      paragraph;
+  const self = this;
+  var block_is_license_block = false;
+  var block_has_c_style_comment;
+  var paragraph_line_indent;
+  var paragraph;
 
-   Stream.call(this);
-   this.writable = true;
+  Stream.call(this);
+  this.writable = true;
 
-   resetBlock(false);
+  resetBlock(false);
 
-   this.write = function(data) {
-     parseLine(data + '');
-     return true;
-   };
+  this.write = function(data) {
+    parseLine(data + '');
+    return true;
+  };
 
-   this.end = function(data) {
-     if (data) {
-       parseLine(data + '');
-     }
-     flushParagraph();
-     self.emit('end');
-   };
+  this.end = function(data) {
+    if (data) {
+      parseLine(data + '');
+    }
+    flushParagraph();
+    self.emit('end');
+  };
 
   function resetParagraph() {
-    is_first_line_in_paragraph = true;
     paragraph_line_indent = -1;
 
     paragraph = {
@@ -165,8 +164,6 @@ function ParagraphParser() {
 
     if (line)
       paragraph.lines.push(line);
-
-    is_first_line_in_paragraph = false;
   }
 }
 inherits(ParagraphParser, Stream);
@@ -184,16 +181,16 @@ function Unwrapper() {
   this.writable = true;
 
   this.write = function(paragraph) {
-    var lines = paragraph.lines,
-        break_after = [],
-        i;
+    var lines = paragraph.lines;
+    var break_after = [];
+    var i;
 
     for (i = 0; i < lines.length - 1; i++) {
       var line = lines[i];
 
       // When a line is really short, the line was probably kept separate for a
       // reason.
-      if (line.length < 50)  {
+      if (line.length < 50) {
         // If the first word on the next line really didn't fit after the line,
         // it probably was just ordinary wrapping after all.
         var next_first_word_length = lines[i + 1].replace(/\s.*$/, '').length;
@@ -203,7 +200,7 @@ function Unwrapper() {
       }
     }
 
-    for (i = 0; i < lines.length - 1; ) {
+    for (i = 0; i < lines.length - 1;) {
       if (!break_after[i]) {
         lines[i] += ' ' + lines.splice(i + 1, 1)[0];
       } else {
@@ -233,8 +230,8 @@ inherits(Unwrapper, Stream);
  * This filter generates an rtf document from a stream of paragraph objects.
  */
 function RtfGenerator() {
-  var self = this,
-      did_write_anything = false;
+  const self = this;
+  var did_write_anything = false;
 
   Stream.call(this);
   this.writable = true;
@@ -245,11 +242,11 @@ function RtfGenerator() {
       did_write_anything = true;
     }
 
-    var li = paragraph.li,
-        level = paragraph.level + (li ? 1 : 0),
-        lic = paragraph.in_license_block;
+    var li = paragraph.li;
+    var level = paragraph.level + (li ? 1 : 0);
+    var lic = paragraph.in_license_block;
 
-    var rtf = "\\pard";
+    var rtf = '\\pard';
     rtf += '\\sa150\\sl300\\slmult1';
     if (level > 0)
       rtf += '\\li' + (level * 240);
@@ -290,18 +287,19 @@ function RtfGenerator() {
   function rtfEscape(string) {
     return string
       .replace(/[\\\{\}]/g, function(m) {
-       return '\\' + m;
+        return '\\' + m;
       })
       .replace(/\t/g, function() {
         return '\\tab ';
       })
+      // eslint-disable-next-line no-control-regex
       .replace(/[\x00-\x1f\x7f-\xff]/g, function(m) {
         return '\\\'' + toHex(m.charCodeAt(0), 2);
       })
       .replace(/\ufeff/g, '')
       .replace(/[\u0100-\uffff]/g, function(m) {
         return '\\u' + toHex(m.charCodeAt(0), 4) + '?';
-     });
+      });
   }
 
   function emitHeader() {
@@ -317,12 +315,12 @@ function RtfGenerator() {
 inherits(RtfGenerator, Stream);
 
 
-var stdin = process.stdin,
-    stdout = process.stdout,
-    line_splitter = new LineSplitter(),
-    paragraph_parser = new ParagraphParser(),
-    unwrapper = new Unwrapper(),
-    rtf_generator = new RtfGenerator();
+const stdin = process.stdin;
+const stdout = process.stdout;
+const line_splitter = new LineSplitter();
+const paragraph_parser = new ParagraphParser();
+const unwrapper = new Unwrapper();
+const rtf_generator = new RtfGenerator();
 
 stdin.setEncoding('utf-8');
 stdin.resume();

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -342,7 +342,8 @@ goto jslint
 :jslint
 if not defined jslint goto exit
 echo running jslint
-%config%\node tools\eslint\bin\eslint.js benchmark lib src test tools\doc tools\eslint-rules --rulesdir tools\eslint-rules
+<<<<<<< d1e2db2a13ddc9fb2f8cd1400b52656910d7374f
+%config%\node tools\eslint\bin\eslint.js benchmark lib src test tools --rulesdir tools\eslint-rules
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION
V4.x backport for https://github.com/nodejs/node/pull/7647:

> Extend linting to tools/license2rtf.js and any other JS that gets added
to the tools directory by default.

> This incidentally simplifies lint invocation and .eslintignore file.