### PR TITLE
test: test non-buffer/string with zlib

### DIFF
--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -7,5 +7,13 @@ require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-// Passing nothing (undefined) instead of string/buffer to `zlib.deflateSync()`
-assert.throws(zlib.deflateSync, /^TypeError: Not a string or buffer$/);
+const expected = /^TypeError: Not a string or buffer$/;
+
+assert.throws(() => { zlib.deflateSync(undefined); }, expected);
+assert.throws(() => { zlib.deflateSync(null); }, expected);
+assert.throws(() => { zlib.deflateSync(true); }, expected);
+assert.throws(() => { zlib.deflateSync(false); }, expected);
+assert.throws(() => { zlib.deflateSync(0); }, expected);
+assert.throws(() => { zlib.deflateSync(1); }, expected);
+assert.throws(() => { zlib.deflateSync([1, 2, 3]); }, expected);
+assert.throws(() => { zlib.deflateSync({foo: 'bar'}); }, expected);

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Check the error condition testing for passing something other than a string
+// or buffer.
+
+require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+// Passing nothing (undefined) instead of string/buffer to `zlib.deflateSync()`
+assert.throws(zlib.deflateSync, /^TypeError: Not a string or buffer$/);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test zlib

##### Description of change
<!-- Provide a description of the change below this comment. -->

Check the error condition testing for passing something other than a
string or buffer. Currently, there are no tests for this error condition.
