### PR TITLE
crypto: make malloc failure check cross-platform

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5368,7 +5368,7 @@ class RandomBytesRequest : public AsyncWrap {
         error_(0),
         size_(size),
         data_(static_cast<char*>(malloc(size))) {
-    if (data() == nullptr)
+    if (data() == nullptr && size > 0)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
   }

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -27,11 +27,6 @@ test-debug-signal-cluster         : PASS,FLAKY
 test-fs-watch-enoent                 : FAIL, PASS
 test-fs-watch-encoding               : FAIL, PASS
 
-# being worked under https://github.com/nodejs/node/pull/7564
-test-async-wrap-post-did-throw           : PASS, FLAKY
-test-async-wrap-throw-from-callback      : PASS, FLAKY
-test-crypto-random                       : PASS, FLAKY
-
 #being worked under https://github.com/nodejs/node/issues/7973
 test-stdio-closed                        : PASS, FLAKY
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

`malloc(0)` may return NULL on some platforms. Do not report
out-of-memory error unless `malloc` was passed a number greater than
`0`.

Marking as `in progress` for the moment. This is an attempt to fix some of the perma-flaky tests on AIX.