### PR TITLE
process: add `startTime` property

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1445,6 +1445,15 @@ if (process.getuid && process.setuid) {
 Android)
 
 
+## process.startTime
+<!-- YAML
+added: REPLACEME
+-->
+
+The `process.startTime` property returns the number of milliseconds since epoch the current Node.js
+process was started.
+
+
 ## process.stderr
 
 The `process.stderr` property returns a [Writable][] stream equivalent to or

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -32,6 +32,12 @@
       setupGlobalConsole();
     }
 
+    Object.defineProperty(process, 'startTime', {
+      enumerable: true,
+      configurable: false,
+      value: Date.now()
+    });
+
     const _process = NativeModule.require('internal/process');
 
     _process.setup_hrtime();

--- a/test/parallel/test-process-startTime.js
+++ b/test/parallel/test-process-startTime.js
@@ -1,0 +1,10 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const now = Date.now();
+const diffFromNow = now - process.startTime;
+
+// Make it a bit flexible
+assert.ok(diffFromNow > 0);
+assert.ok(diffFromNow < common.platformTimeout(100));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
process


##### Description of change
<!-- Provide a description of the change below this comment. -->

This property allows us to check the starting time of the application,
instead of just the uptime currently exposed by `process.uptime()`.

This started as me thinking I'd just have to expose whatever was used for `uptime`, but as per [libuv docs](http://docs.libuv.org/en/v1.x/loop.html#c.uv_now):
> Don’t make assumptions about the starting point, you will only get disappointed.

So then I went down the path of getting the real timestamp. I have no idea if it's a bad idea to import `ctime`, but that's what googling led me to.

Warning: this is the first time in my life I've written C++, so, even in just 5 lines of code, I might have messed up.