### PR TITLE
doc: fix broken link in dgram doc

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -477,6 +477,7 @@ and `udp6` sockets). The bound address and port can be retrieved using
 [`Buffer`]: buffer.html
 [`'close'`]: #dgram_event_close
 [`close()`]: #dgram_socket_close_callback
+[`cluster`]: cluster.html
 [`dgram.createSocket()`]: #dgram_dgram_createsocket_options_callback
 [`dgram.Socket#bind()`]: #dgram_socket_bind_options_callback
 [`Error`]: errors.html#errors_class_error


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* doc


##### Description of change

Fixes a broken link in dgram doc

`cluster` is referenced in [`dgram.bind()`](https://github.com/nodejs/node/blob/379d9162a2d992f7ff8a20d00f088ede1bf2f0fe/doc/api/dgram.md#socketbindoptions-callback) but is missing in the list of references at the bottom of the doc markdown.