### PR TITLE
doc: fix example in stream doc

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1643,8 +1643,8 @@ class MyDuplex extends Duplex {
   _write(chunk, encoding, callback) {
     // The underlying source only deals with strings
     if (Buffer.isBuffer(chunk))
-      chunk = chunk.toString(encoding);
-    this[kSource].writeSomeData(chunk, encoding);
+      chunk = chunk.toString();
+    this[kSource].writeSomeData(chunk);
     callback();
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

If `chunk` is a buffer `chunk.toString(encoding)` throws an error as `'buffer'` is not a valid encoding. This fixes the documentation bug by not using the `encoding` argument.

Fixes: https://github.com/nodejs/node/issues/8085