### PR TITLE
test: fix test-cluster-dgram-1 flakiness

### DIFF
--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -66,7 +66,7 @@ function master() {
       received = msg.received;
     }));
 
-    worker.on('disconnect', common.mustCall(() => {
+    worker.on('exit', common.mustCall(() => {
       assert.strictEqual(received, PACKETS_PER_WORKER);
     }));
   }

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -64,6 +64,7 @@ function master() {
 
     worker.on('message', common.mustCall((msg) => {
       received = msg.received;
+      worker.disconnect();
     }));
 
     worker.on('exit', common.mustCall(() => {
@@ -85,7 +86,7 @@ function worker() {
     // Every 10 messages, notify the master.
     if (received === PACKETS_PER_WORKER) {
       process.send({received: received});
-      process.disconnect();
+      socket.close();
     }
   }, PACKETS_PER_WORKER));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Check for the number of messages received in the `exit` event listener
instead of the `disconnect` listener.

Fixes: https://github.com/nodejs/node/issues/8380