### PR TITLE
test: revert changes to test/parallel/test-cluster-dgram-1.js

### DIFF
--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -1,11 +1,11 @@
 'use strict';
 const common = require('../common');
-const NUM_WORKERS = 4;
-const PACKETS_PER_WORKER = 10;
+var NUM_WORKERS = 4;
+var PACKETS_PER_WORKER = 10;
 
-const assert = require('assert');
-const cluster = require('cluster');
-const dgram = require('dgram');
+var assert = require('assert');
+var cluster = require('cluster');
+var dgram = require('dgram');
 
 
 if (common.isWindows) {
@@ -28,13 +28,13 @@ function master() {
     cluster.fork();
 
   // Wait until all workers are listening.
-  cluster.on('listening', common.mustCall(() => {
+  cluster.on('listening', function() {
     if (++listening < NUM_WORKERS)
       return;
 
     // Start sending messages.
-    const buf = Buffer.from('hello world');
-    const socket = dgram.createSocket('udp4');
+    var buf = Buffer.from('hello world');
+    var socket = dgram.createSocket('udp4');
     var sent = 0;
     doSend();
 
@@ -47,14 +47,15 @@ function master() {
       if (sent < NUM_WORKERS * PACKETS_PER_WORKER) {
         doSend();
       } else {
+        console.log('master sent %d packets', sent);
         socket.close();
       }
     }
-  }, NUM_WORKERS));
+  });
 
   // Set up event handlers for every worker. Each worker sends a message when
   // it has received the expected number of packets. After that it disconnects.
-  for (const key in cluster.workers) {
+  for (var key in cluster.workers) {
     if (cluster.workers.hasOwnProperty(key))
       setupWorker(cluster.workers[key]);
   }
@@ -62,13 +63,15 @@ function master() {
   function setupWorker(worker) {
     var received = 0;
 
-    worker.on('message', common.mustCall((msg) => {
+    worker.on('message', function(msg) {
       received = msg.received;
-    }));
+      console.log('worker %d received %d packets', worker.id, received);
+    });
 
-    worker.on('disconnect', common.mustCall(() => {
-      assert.strictEqual(received, PACKETS_PER_WORKER);
-    }));
+    worker.on('disconnect', function() {
+      assert(received === PACKETS_PER_WORKER);
+      console.log('worker %d disconnected', worker.id);
+    });
   }
 }
 
@@ -79,15 +82,15 @@ function worker() {
   // Create udp socket and start listening.
   var socket = dgram.createSocket('udp4');
 
-  socket.on('message', common.mustCall((data, info) => {
+  socket.on('message', function(data, info) {
     received++;
 
     // Every 10 messages, notify the master.
-    if (received === PACKETS_PER_WORKER) {
+    if (received == PACKETS_PER_WORKER) {
       process.send({received: received});
       process.disconnect();
     }
-  }, PACKETS_PER_WORKER));
+  });
 
   socket.bind(common.PORT);
 }


### PR DESCRIPTION


##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
cluster

##### Description of change
We've started to see frequent failures in
test/parallel/test-cluster-dgram-1.js on AIX since the refactoring
in https://github.com/nodejs/node/pull/8261.  Revert changes
until we have time to investigate properly.
