### PR TITLE
test: mark pseudo-tty/no_dropped_stdio as flaky

### DIFF
--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -1,0 +1,3 @@
+[$system==aix]
+# test issue only, covered under https://github.com/nodejs/node/issues/7973
+no_dropped_stdio           : PASS, FLAKY


### PR DESCRIPTION
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
pseudo-tty

##### Description of change

We've determined there is a test issue related to python as
opposed to node, mark as flaky until we an resolve