### PR TITLE
process: fix handling of process.noDeprecation in emitWarning

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const traceWarnings = process.traceProcessWarnings;
-const noDeprecation = process.noDeprecation;
-const traceDeprecation = process.traceDeprecation;
-const throwDeprecation = process.throwDeprecation;
 const prefix = `(${process.release.name}:${process.pid}) `;
 
 exports.setup = setupProcessWarnings;
@@ -13,8 +9,9 @@ function setupProcessWarnings() {
     process.on('warning', (warning) => {
       if (!(warning instanceof Error)) return;
       const isDeprecation = warning.name === 'DeprecationWarning';
-      if (isDeprecation && noDeprecation) return;
-      const trace = traceWarnings || (isDeprecation && traceDeprecation);
+      if (isDeprecation && process.noDeprecation) return;
+      const trace = process.traceProcessWarnings ||
+                    (isDeprecation && process.traceDeprecation);
       if (trace && warning.stack) {
         console.error(`${prefix}${warning.stack}`);
       } else {
@@ -41,9 +38,12 @@ function setupProcessWarnings() {
     if (!(warning instanceof Error)) {
       throw new TypeError('\'warning\' must be an Error object or string.');
     }
-    if (throwDeprecation && warning.name === 'DeprecationWarning')
-      throw warning;
-    else
-      process.nextTick(() => process.emit('warning', warning));
+    if (warning.name === 'DeprecationWarning') {
+      if (process.noDeprecation)
+        return;
+      if (process.throwDeprecation)
+        throw warning;
+    }
+    process.nextTick(() => process.emit('warning', warning));
   };
 }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

process

##### Description of change
Cherry-pick of process: fix handling of process.noDeprecation in emitWarning from:

  PR-URL: https://github.com/nodejs/node/pull/8166
  Reviewed-By: Сковорода Никита Андреевич <chalkerx@gmail.com>
  Reviewed-By: Myles Borins <myles.borins@gmail.com>