### PR TITLE
src: add no-op for --harmony-proxies flag

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3801,6 +3801,12 @@ static void ParseArgs(int* argc,
     } else if (strncmp(arg, "--icu-data-dir=", 15) == 0) {
       icu_data_dir = arg + 15;
 #endif
+    } else if (strcmp(arg, "--harmony-proxies") == 0 ||
+               strcmp(arg, "--harmony_proxies") == 0 ||
+               strcmp(arg, "-harmony-proxies") == 0 ||
+               strcmp(arg, "-harmony_proxies") == 0) {
+      // Keep V8 flags to make 5.0 -> 5.1 not breaking.
+      // This is only needed in v6.x.
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js

--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -1,8 +1,9 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-var v8 = require('v8');
-var vm = require('vm');
+const common = require('../common');
+const assert = require('assert');
+const exec = require('child_process').execSync;
+const v8 = require('v8');
+const vm = require('vm');
 
 // Note: changing V8 flags after an isolate started is not guaranteed to work.
 // Specifically here, V8 may cache compiled scripts between the flip of the
@@ -14,3 +15,15 @@ assert(vm.runInThisContext('%_IsSmi(43)'));
 v8.setFlagsFromString('--noallow_natives_syntax');
 assert.throws(function() { eval('%_IsSmi(44)'); }, SyntaxError);
 assert.throws(function() { vm.runInThisContext('%_IsSmi(45)'); }, SyntaxError);
+
+// Verify that the --harmony-proxies flag doesn't error
+const flags = ['--harmony-proxies',
+               '--harmony_proxies',
+               '-harmony-proxies',
+               '-harmony_proxies'];
+
+for (const flag of flags) {
+  assert.doesNotThrow(common.mustCall(() => {
+    exec(`${process.execPath} ${flag}`)
+  }));
+}


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change
<!-- Provide a description of the change below this comment. -->

The upgrade from V8 5.0 to V8 5.1 removed the --harmony-proxies flag.
This restores them as no-ops to prevent breakage.

Fixes: https://github.com/nodejs/node/issues/8388