### PR TITLE
readline: Emit 'line' event with line number

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -76,8 +76,8 @@ received input.
 For example:
 
 ```js
-rl.on('line', (input) => {
-  console.log(`Received: ${input}`);
+rl.on('line', (input, lineNumber) => {
+  console.log(`Received: ${input}, line #: ${lineNumber}`);
 });
 ```
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -43,6 +43,7 @@ function Interface(input, output, completer, terminal) {
   this.isCompletionEnabled = true;
   this._sawKeyPress = false;
   this._previousKey = null;
+  this._linesEmitted = 0;
 
   EventEmitter.call(this);
   var historySize;
@@ -104,14 +105,14 @@ function Interface(input, output, completer, terminal) {
   function onend() {
     if (typeof self._line_buffer === 'string' &&
         self._line_buffer.length > 0) {
-      self.emit('line', self._line_buffer);
+      self.emit('line', self._line_buffer, ++self._linesEmitted);
     }
     self.close();
   }
 
   function ontermend() {
     if (typeof self.line === 'string' && self.line.length > 0) {
-      self.emit('line', self.line);
+      self.emit('line', self.line, ++self._linesEmitted);
     }
     self.close();
   }
@@ -230,7 +231,7 @@ Interface.prototype._onLine = function(line) {
     this.setPrompt(this._oldPrompt);
     cb(line);
   } else {
-    this.emit('line', line);
+    this.emit('line', line, ++this._linesEmitted);
   }
 };
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -97,107 +97,133 @@ function isWarned(emitter) {
   assert.ok(called);
   rli.close();
 
-  // sending multiple newlines at once
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  var expectedLines = ['foo', 'bar', 'baz'];
-  var callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  fi.emit('data', expectedLines.join('\n') + '\n');
-  assert.equal(callCount, expectedLines.length);
-  rli.close();
+  {
+    // sending multiple newlines at once
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal
+    });
+    const expectedLines = ['foo', 'bar', 'baz'];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    fi.emit('data', expectedLines.join('\n') + '\n');
+    assert.equal(rli._linesEmitted, expectedLines.length);
+    rli.close();
+  }
 
-  // sending multiple newlines at once that does not end with a new line
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  expectedLines = ['foo', 'bar', 'baz', 'bat'];
-  callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  fi.emit('data', expectedLines.join('\n'));
-  assert.equal(callCount, expectedLines.length - 1);
-  rli.close();
+  {
+    // sending multiple newlines at once that does not end with a new line
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal
+    });
+    const expectedLines = ['foo', 'bar', 'baz', 'bat'];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    fi.emit('data', expectedLines.join('\n'));
+    assert.equal(rli._linesEmitted, expectedLines.length - 1);
+    rli.close();
+  }
 
-  // sending multiple newlines at once that does not end with a new(empty)
-  // line and a `end` event
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  expectedLines = ['foo', 'bar', 'baz', ''];
-  callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  rli.on('close', function() {
-    callCount++;
-  });
-  fi.emit('data', expectedLines.join('\n'));
-  fi.emit('end');
-  assert.equal(callCount, expectedLines.length);
-  rli.close();
+  {
+    // sending multiple newlines at once that does not end with a new(empty)
+    // line and a `end` event
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal
+    });
+    const expectedLines = ['foo', 'bar', 'baz', ''];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    rli.on('close', common.mustCall(() => {}));
+    fi.emit('data', expectedLines.join('\n'));
+    fi.emit('end');
+    assert.equal(rli._linesEmitted, expectedLines.length - 1);
+    rli.close();
+  }
 
   // sending multiple newlines at once that does not end with a new line
   // and a `end` event(last line is)
 
-  // \r\n should emit one line event, not two
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  expectedLines = ['foo', 'bar', 'baz', 'bat'];
-  callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  fi.emit('data', expectedLines.join('\r\n'));
-  assert.equal(callCount, expectedLines.length - 1);
-  rli.close();
+  {
+    // \r\n should emit one line event, not two
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal
+    });
+    const expectedLines = ['foo', 'bar', 'baz', 'bat'];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    fi.emit('data', expectedLines.join('\r\n'));
+    assert.equal(rli._linesEmitted, expectedLines.length - 1);
+    rli.close();
+  }
 
-  // \r\n should emit one line event when split across multiple writes.
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  expectedLines = ['foo', 'bar', 'baz', 'bat'];
-  callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  expectedLines.forEach(function(line) {
-    fi.emit('data', line + '\r');
-    fi.emit('data', '\n');
-  });
-  assert.equal(callCount, expectedLines.length);
-  rli.close();
+  {
+    // \r\n should emit one line event when split across multiple writes.
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal
+    });
+    const expectedLines = ['foo', 'bar', 'baz', 'bat'];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    expectedLines.forEach((line) => {
+      fi.emit('data', line + '\r');
+      fi.emit('data', '\n');
+    });
+    assert.equal(rli._linesEmitted, expectedLines.length);
+    rli.close();
+  }
 
-  // \r should behave like \n when alone
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: true });
-  expectedLines = ['foo', 'bar', 'baz', 'bat'];
-  callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  fi.emit('data', expectedLines.join('\r'));
-  assert.equal(callCount, expectedLines.length - 1);
-  rli.close();
+  {
+    // \r should behave like \n when alone
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: true
+    });
+    const expectedLines = ['foo', 'bar', 'baz', 'bat'];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    fi.emit('data', expectedLines.join('\r'));
+    assert.equal(rli._linesEmitted, expectedLines.length - 1);
+    rli.close();
+  }
 
-  // \r at start of input should output blank line
-  fi = new FakeInput();
-  rli = new readline.Interface({ input: fi, output: fi, terminal: true });
-  expectedLines = ['', 'foo' ];
-  callCount = 0;
-  rli.on('line', function(line) {
-    assert.equal(line, expectedLines[callCount]);
-    callCount++;
-  });
-  fi.emit('data', '\rfoo\r');
-  assert.equal(callCount, expectedLines.length);
-  rli.close();
+  {
+    // \r at start of input should output blank line
+    const fi = new FakeInput();
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: true
+    });
+    const expectedLines = ['', 'foo' ];
+    rli.on('line', (line, lineNumber) => {
+      assert.equal(line, expectedLines[lineNumber - 1]);
+    });
+    fi.emit('data', '\rfoo\r');
+    assert.equal(rli._linesEmitted, expectedLines.length);
+    rli.close();
+  }
 
   // \t when there is no completer function should behave like an ordinary
   //   character
@@ -258,17 +284,15 @@ function isWarned(emitter) {
   var buf = Buffer.from('☮', 'utf8');
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-  callCount = 0;
   rli.on('line', function(line) {
-    callCount++;
     assert.equal(line, buf.toString('utf8'));
   });
   [].forEach.call(buf, function(i) {
     fi.emit('data', Buffer.from([i]));
   });
-  assert.equal(callCount, 0);
+  assert.equal(rli._linesEmitted, 0);
   fi.emit('data', '\n');
-  assert.equal(callCount, 1);
+  assert.equal(rli._linesEmitted, 1);
   rli.close();
 
   // Regression test for repl freeze, #1968:
@@ -305,7 +329,7 @@ function isWarned(emitter) {
     // question
     fi = new FakeInput();
     rli = new readline.Interface({ input: fi, output: fi, terminal: terminal });
-    expectedLines = ['foo'];
+    let expectedLines = ['foo'];
     rli.question(expectedLines[0], function() {
       rli.close();
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline

##### Description of change
<!-- Provide a description of the change below this comment. -->

While emitting 'line' event, line number will be emitted as second parameter.

```js
rl.on('line', (input, lineNumber) => {
  console.log(`Received: ${input}, line #: ${lineNumber}`);
});
```

Refs: https://github.com/nodejs/node/issues/8393