### PR TITLE
test: increase _debugger coverage

### DIFF
--- a/test/fixtures/debug-uncaught-async.js
+++ b/test/fixtures/debug-uncaught-async.js
@@ -13,4 +13,4 @@ assert.doesNotThrow(emit);
 
 debug.start(['sterrance']);
 
-setTimeout(emit, 100);
+setImmediate(emit);

--- a/test/fixtures/debug-uncaught-async.js
+++ b/test/fixtures/debug-uncaught-async.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const debug = require('_debugger');
+
+function emit() {
+  const error = new Error('fhqwhgads');
+  process.emit('uncaughtException', error);
+}
+
+assert.doesNotThrow(emit);
+
+debug.start(['sterrance']);
+
+setTimeout(emit, 100);

--- a/test/parallel/test-debug-uncaught-exception-async.js
+++ b/test/parallel/test-debug-uncaught-exception-async.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+const emitUncaught = path.join(common.fixturesDir, 'debug-uncaught-async.js');
+const result = spawn(process.execPath, [emitUncaught], {encoding: 'utf8'});
+
+var stderr = '';
+result.stderr.on('data', (data) => {
+  stderr += data;
+});
+
+result.on('close', (code) => {
+  const expectedMessage =
+    "There was an internal error in Node's debugger. Please report this bug.";
+
+  assert.strictEqual(code, 1);
+  assert(stderr.includes(expectedMessage));
+  assert(stderr.includes('Error: fhqwhgads'));
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test debugger

##### Description of change
<!-- Provide a description of the change below this comment. -->

The uncaught exception test for `_debugger.js` was not exercising some
code (particularly concerning `interface_.child`) because of the
synchronous nature of the test. This adds an asynchronous version to
increase test coverage.