### PR TITLE
src: moving f function call comment

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3388,14 +3388,6 @@ void LoadEnvironment(Environment* env) {
   CHECK(f_value->IsFunction());
   Local<Function> f = Local<Function>::Cast(f_value);
 
-  // Now we call 'f' with the 'process' variable that we've built up with
-  // all our bindings. Inside bootstrap_node.js we'll take care of
-  // assigning things to their places.
-
-  // We start the process this way in order to be more modular. Developers
-  // who do not like how bootstrap_node.js setups the module system but do
-  // like Node's I/O bindings may want to replace 'f' with their own function.
-
   // Add a reference to the global object
   Local<Object> global = env->context()->Global();
 
@@ -3425,6 +3417,13 @@ void LoadEnvironment(Environment* env) {
   // (Allows you to set stuff on `global` from anywhere in JavaScript.)
   global->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global);
 
+  // Now we call 'f' with the 'process' variable that we've built up with
+  // all our bindings. Inside bootstrap_node.js we'll take care of
+  // assigning things to their places.
+
+  // We start the process this way in order to be more modular. Developers
+  // who do not like how bootstrap_node.js setups the module system but do
+  // like Node's I/O bindings may want to replace 'f' with their own function.
   Local<Value> arg = env->process_object();
   f->Call(Null(env->isolate()), 1, &arg);
 }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change

The comment about calling the f function seems to have drifted
a little. Moving it to be closer to the actual call.