### PR TITLE
src: guard against overflow in ParseArrayIndex() (v4.x)

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -187,6 +187,7 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
 
   // Check that the result fits in a size_t.
   const uint64_t kSizeMax = static_cast<uint64_t>(static_cast<size_t>(-1));
+  // coverity[pointless_expression]
   if (static_cast<uint64_t>(tmp_i) > kSizeMax)
     return false;
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -171,6 +171,25 @@ void CallbackInfo::WeakCallback(Isolate* isolate, Local<Object> object) {
 }
 
 
+// Parse index for external array data.
+inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
+                                            size_t def,
+                                            size_t* ret) {
+  if (arg->IsUndefined()) {
+    *ret = def;
+    return true;
+  }
+
+  int64_t tmp_i = arg->IntegerValue();
+
+  if (tmp_i < 0)
+    return false;
+
+  *ret = static_cast<size_t>(tmp_i);
+  return true;
+}
+
+
 // Buffer methods
 
 bool HasInstance(Local<Value> val) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -185,6 +185,11 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
   if (tmp_i < 0)
     return false;
 
+  // Check that the result fits in a size_t.
+  const uint64_t kSizeMax = static_cast<uint64_t>(static_cast<size_t>(-1));
+  if (static_cast<uint64_t>(tmp_i) > kSizeMax)
+    return false;
+
   *ret = static_cast<size_t>(tmp_i);
   return true;
 }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -160,24 +160,6 @@ inline bool IsBigEndian() {
   return GetEndianness() == kBigEndian;
 }
 
-// parse index for external array data
-inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
-                                            size_t def,
-                                            size_t* ret) {
-  if (arg->IsUndefined()) {
-    *ret = def;
-    return true;
-  }
-
-  int32_t tmp_i = arg->Int32Value();
-
-  if (tmp_i < 0)
-    return false;
-
-  *ret = static_cast<size_t>(tmp_i);
-  return true;
-}
-
 void ThrowError(v8::Isolate* isolate, const char* errmsg);
 void ThrowTypeError(v8::Isolate* isolate, const char* errmsg);
 void ThrowRangeError(v8::Isolate* isolate, const char* errmsg);

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1444,6 +1444,13 @@ assert.equal(Buffer.prototype.offset, undefined);
 assert.equal(SlowBuffer.prototype.parent, undefined);
 assert.equal(SlowBuffer.prototype.offset, undefined);
 
+// ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
+assert.throws(() => {
+  const a = Buffer(1).fill(0);
+  const b = Buffer(1).fill(0);
+  a.copy(b, 0, 0x100000000, 0x100000001);
+}), /out of range index/;
+
 // Unpooled buffer (replaces SlowBuffer)
 const ubuf = Buffer.allocUnsafeSlow(10);
 assert(ubuf);


### PR DESCRIPTION
Back-port of https://github.com/nodejs/node/pull/7497 and https://github.com/nodejs/node/pull/7587.

R=@TheAlphaNerd

CI: https://ci.nodejs.org/job/node-test-pull-request/3941/