### PR TITLE
doc: note that listening on SIGSEGV & co is unsafe

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -422,6 +422,9 @@ It is important to take note of the following:
 * `SIGKILL` cannot have a listener installed, it will unconditionally terminate
   Node.js on all platforms.
 * `SIGSTOP` cannot have a listener installed.
+* `SIGBUS`, `SIGFPE`, `SIGSEGV` and `SIGILL`, when not raised artificially,
+   inherently leave the process in a state from which it is not safe to
+   attempt to call JS listeners.
 
 *Note*: Windows does not support sending signals, but Node.js offers some
 emulation with [`process.kill()`][], and [`ChildProcess.kill()`][]. Sending

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -422,9 +422,9 @@ It is important to take note of the following:
 * `SIGKILL` cannot have a listener installed, it will unconditionally terminate
   Node.js on all platforms.
 * `SIGSTOP` cannot have a listener installed.
-* `SIGBUS`, `SIGFPE`, `SIGSEGV` and `SIGILL`, when not raised artificially,
-   inherently leave the process in a state from which it is not safe to
-   attempt to call JS listeners.
+* `SIGBUS`, `SIGFPE`, `SIGSEGV` and `SIGILL`, when not raised artificially
+   using kill(2), inherently leave the process in a state from which it is not
+   safe to attempt to call JS listeners.
 
 *Note*: Windows does not support sending signals, but Node.js offers some
 emulation with [`process.kill()`][], and [`ChildProcess.kill()`][]. Sending

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -424,7 +424,9 @@ It is important to take note of the following:
 * `SIGSTOP` cannot have a listener installed.
 * `SIGBUS`, `SIGFPE`, `SIGSEGV` and `SIGILL`, when not raised artificially
    using kill(2), inherently leave the process in a state from which it is not
-   safe to attempt to call JS listeners.
+   safe to attempt to call JS listeners. Doing so might lead to the process
+   hanging in an endless loop, since listeners attached using `process.on()` are
+   called asynchronously and therefore unable to correct the underlying problem.
 
 *Note*: Windows does not support sending signals, but Node.js offers some
 emulation with [`process.kill()`][], and [`ChildProcess.kill()`][]. Sending


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

Note that trying to listen for some signals using `process.on()` is unsafe in the `process` docs.