### PR TITLE
deps: cherry-pick 8ed65b97 from V8's upstream

### DIFF
--- a/deps/v8/src/field-type.cc
+++ b/deps/v8/src/field-type.cc
@@ -13,7 +13,9 @@ namespace internal {
 
 // static
 FieldType* FieldType::None() {
-  return reinterpret_cast<FieldType*>(Smi::FromInt(0));
+  // Do not Smi::FromInt(0) here or for Any(), as that may translate
+  // as `nullptr` which is not a valid value for `this`.
+  return reinterpret_cast<FieldType*>(Smi::FromInt(2));
 }
 
 // static

--- a/deps/v8/test/cctest/test-field-type-tracking.cc
+++ b/deps/v8/test/cctest/test-field-type-tracking.cc
@@ -2481,7 +2481,7 @@ TEST(FieldTypeConvertSimple) {
 
   Zone zone(isolate->allocator());
 
-  CHECK_EQ(FieldType::Any()->Convert(&zone), Type::NonInternal());
+  CHECK_EQ(FieldType::Any()->Convert(&zone), Type::Any());
   CHECK_EQ(FieldType::None()->Convert(&zone), Type::None());
 }
 

--- a/deps/v8/test/cctest/test-field-type-tracking.cc
+++ b/deps/v8/test/cctest/test-field-type-tracking.cc
@@ -16,6 +16,7 @@
 #include "src/global-handles.h"
 #include "src/ic/stub-cache.h"
 #include "src/macro-assembler.h"
+#include "src/types.h"
 
 using namespace v8::internal;
 
@@ -2473,6 +2474,16 @@ TEST(TransitionAccessorConstantToSameAccessorConstant) {
   TestTransitionTo(transition_op, transition_op, checker);
 }
 
+TEST(FieldTypeConvertSimple) {
+  CcTest::InitializeVM();
+  v8::HandleScope scope(CcTest::isolate());
+  Isolate* isolate = CcTest::i_isolate();
+
+  Zone zone(isolate->allocator());
+
+  CHECK_EQ(FieldType::Any()->Convert(&zone), Type::NonInternal());
+  CHECK_EQ(FieldType::None()->Convert(&zone), Type::None());
+}
 
 // TODO(ishell): add this test once IS_ACCESSOR_FIELD_SUPPORTED is supported.
 // TEST(TransitionAccessorConstantToAnotherAccessorConstant)


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
deps/v8

##### Description of change

Um, hope I’m doing this right by backporting v8/v8@8ed65b97 to v6.x – in master that should not be necessary as this will come with a regular V8 5.4 update before v7.x is cut?

The test needed a little fixup to work with V8 5.1.

------
Original commit message:

    Make FieldType::None() non-nullptr value to avoid undefined behaviour

    When FieldType::None() returns a cast Smi::FromInt(0), which translates
    as nullptr, the FieldType::IsNone() check becomes equivalent to
    `this == nullptr` which is not allowed by the standard and
    therefore optimized away as a false constant by GCC 6.

    This has lead to crashes when invoking methods on FieldType::None().

    Using a different Smi constant for FieldType::None() makes the compiler
    always include a comparison against that value. The choice of these
    constants has no effect as they are effectively arbitrary.

    BUG=https://github.com/nodejs/node/issues/8310

    Review-Url: https://codereview.chromium.org/2292953002
    Cr-Commit-Position: refs/heads/master@{#39023}

Fixes: #8310

CI:
https://ci.nodejs.org/job/node-test-commit/4923/
https://ci.nodejs.org/job/node-test-commit-v8-linux/305/