### PR TITLE
win,build: improvements to vcbuild.bat

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -82,7 +82,8 @@ if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&got
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
 if /i "%1"=="dll"           set dll=1&goto arg-ok
 
-echo Warning: ignoring invalid command line option `%1`.
+echo Error: invalid command line option `%1`.
+exit /b 1
 
 :arg-ok
 :arg-ok

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -343,12 +343,16 @@ for /d %%F in (test\addons\??_*) do (
 )
 :: generate
 "%node_exe%" tools\doc\addon-verify.js
+if %errorlevel% neq 0 exit /b %errorlevel%
 :: building addons
+SetLocal EnableDelayedExpansion
 for /d %%F in (test\addons\*) do (
   "%node_exe%" deps\npm\node_modules\node-gyp\bin\node-gyp rebuild ^
     --directory="%%F" ^
     --nodedir="%cd%"
+  if !errorlevel! neq 0 exit /b !errorlevel!
 )
+EndLocal
 goto run-tests
 
 :run-tests

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -129,6 +129,8 @@ call :getnodeversion || exit /b 1
 
 if "%target%"=="Clean" rmdir /Q /S "%~dp0%config%\node-v%FULLVERSION%-win-%target_arch%" > nul 2> nul
 
+if defined noprojgen if defined nobuild if defined nosign if not defined msi goto licensertf
+
 @rem Set environment for msbuild
 
 if defined target_env if "%target_env%" NEQ "vc2015" goto vc-set-2013


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Windows, Build.

##### Description of change

This PR includes 3 changes to `vcbuild.bat`:
- https://github.com/nodejs/node/commit/76427246f4044586b35a94f20af6ea2cc223318d : Fail and exit immediately when an invalid option is passed to `vcbuild.bat`. Before there was only a warning, and since the output is quite verbose it was very easy to miss it and vcbuild would run without the options that the user probably wanted.
- https://github.com/nodejs/node/commit/f26497cbb0106d0125f5ae98e9275e32227b3e34 : When `msbuild` and other Visual Studio tools are not needed, do not search for Visual Studio. This allows for running the tests in a machine with an unsupported version of VS, or no VS at all. This unblocks https://github.com/nodejs/node/pull/8067 , since for v6 onwards we want to build node only with VS2015 but still want to run the tests in machines with VS2013 (node-gyp will detect it independently).
- https://github.com/nodejs/node/commit/f2f2aa4c52ebabf05d22052e7b007b39fe0530f2 : When addons fail to build with node-gyp, fail immediately. Before, the build would only fail because the tests would fail later. This makes the output easier to read, since the run ends immediately after the failed node-gyp invocation.

I think the commits should not be squashed because they address different concerns, but I can squash if this is not consensual.

cc @nodejs/platform-windows 