### PR TITLE
vm: change ContextifyScript to Script in comment

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -5,7 +5,7 @@ const Script = binding.ContextifyScript;
 
 // The binding provides a few useful primitives:
 // - Script(code, { filename = "evalmachine.anonymous",
-//                            displayErrors = true } = {})
+//                  displayErrors = true } = {})
 //   with methods:
 //   - runInThisContext({ displayErrors = true } = {})
 //   - runInContext(sandbox, { displayErrors = true, timeout = undefined } = {})

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -4,7 +4,7 @@ const binding = process.binding('contextify');
 const Script = binding.ContextifyScript;
 
 // The binding provides a few useful primitives:
-// - ContextifyScript(code, { filename = "evalmachine.anonymous",
+// - Script(code, { filename = "evalmachine.anonymous",
 //                            displayErrors = true } = {})
 //   with methods:
 //   - runInThisContext({ displayErrors = true } = {})


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
vm

##### Description of change
Reading the comment at the top of the vm.js, I think that
`ContextifyScript` should perhaps just be `Script`.