### PR TITLE
url: fix off-by-one error in loop handling dots

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -852,7 +852,7 @@ Url.prototype.resolveObject = function(relative) {
   // strip single dots, resolve double dots to parent dir
   // if the path tries to go above the root, `up` ends up > 0
   var up = 0;
-  for (var i = srcPath.length; i >= 0; i--) {
+  for (var i = srcPath.length - 1; i >= 0; i--) {
     last = srcPath[i];
     if (last === '.') {
       spliceOne(srcPath, i);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes an error where a loop, used to traverse an array of length `n`, ran `n + 1` times instead of `n`.