### PR TITLE
timers: do not expose .unref()._handle._list

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -538,7 +538,9 @@ Timeout.prototype.unref = function() {
     }
 
     var handle = reuse(this);
-    if (handle) handle._list = null;
+    if (handle) {
+      handle._list = undefined;
+    }
 
     this._handle = handle || new TimerWrap();
     this._handle.owner = this;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -538,6 +538,7 @@ Timeout.prototype.unref = function() {
     }
 
     var handle = reuse(this);
+    if (handle) handle._list = null;
 
     this._handle = handle || new TimerWrap();
     this._handle.owner = this;

--- a/test/parallel/test-timers-unref-reuse-no-exposed-list.js
+++ b/test/parallel/test-timers-unref-reuse-no-exposed-list.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// In a case of handle re-use, _list should be null rather than undefined.
+const timer1 = setTimeout(() => {}, 1).unref();
+assert.strictEqual(timer1._handle._list, null,
+                   'timer1._handle._list should be nulled.');
+
+// Check that everything works even if the handle was not re-used.
+setTimeout(() => {}, 1);
+const timer2 = setTimeout(() => {}, 1).unref();
+// Note: It is unlikely that this assertion will be hit in a failure.
+// Instead, timers.js will likely throw a TypeError internally.
+assert.strictEqual(timer2._handle._list, undefined,
+                   'timer2._handle._list should not exist');

--- a/test/parallel/test-timers-unref-reuse-no-exposed-list.js
+++ b/test/parallel/test-timers-unref-reuse-no-exposed-list.js
@@ -10,7 +10,5 @@ assert.strictEqual(timer1._handle._list, undefined,
 // Check that everything works even if the handle was not re-used.
 setTimeout(() => {}, 1);
 const timer2 = setTimeout(() => {}, 1).unref();
-// Note: It is unlikely that this assertion will be hit in a failure.
-// Instead, timers.js will likely throw a TypeError internally.
 assert.strictEqual(timer2._handle._list, undefined,
                    'timer2._handle._list should be undefined');

--- a/test/parallel/test-timers-unref-reuse-no-exposed-list.js
+++ b/test/parallel/test-timers-unref-reuse-no-exposed-list.js
@@ -3,10 +3,9 @@
 require('../common');
 const assert = require('assert');
 
-// In a case of handle re-use, _list should be null rather than undefined.
 const timer1 = setTimeout(() => {}, 1).unref();
-assert.strictEqual(timer1._handle._list, null,
-                   'timer1._handle._list should be nulled.');
+assert.strictEqual(timer1._handle._list, undefined,
+                   'timer1._handle._list should be undefined');
 
 // Check that everything works even if the handle was not re-used.
 setTimeout(() => {}, 1);
@@ -14,4 +13,4 @@ const timer2 = setTimeout(() => {}, 1).unref();
 // Note: It is unlikely that this assertion will be hit in a failure.
 // Instead, timers.js will likely throw a TypeError internally.
 assert.strictEqual(timer2._handle._list, undefined,
-                   'timer2._handle._list should not exist');
+                   'timer2._handle._list should be undefined');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

timers
##### Description of change

<!-- Provide a description of the change below this comment. -->

The list is defunct at this point.
I believe this to be in effect a minor defect/oversight from
3eecdf9f1422640c7439507cb39ffb3dff57b3e4

Tangentially effects/related to https://github.com/nodejs/node/pull/8372

Edit: cc @indutny?
