### PR TITLE
win,build: forward release_urlbase to configure

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -33,7 +33,6 @@ set noperfctr=
 set noperfctr_msi_arg=
 set i18n_arg=
 set download_arg=
-set release_urls_arg=
 set build_release=
 set enable_vtune_arg=
 set configure_flags=
@@ -107,7 +106,7 @@ if "%config%"=="Debug" set configure_flags=%configure_flags% --debug
 if defined nosnapshot set configure_flags=%configure_flags% --without-snapshot
 if defined noetw set configure_flags=%configure_flags% --without-etw& set noetw_msi_arg=/p:NoETW=1
 if defined noperfctr set configure_flags=%configure_flags% --without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
-if defined release_urlbase set release_urlbase_arg=--release-urlbase=%release_urlbase%
+if defined release_urlbase set configure_flags=%configure_flags% --release-urlbase=%release_urlbase%
 if defined download_arg set configure_flags=%configure_flags% %download_arg%
 if defined enable_vtune_arg set configure_flags=%configure_flags% --enable-vtune-profiling
 if defined dll set configure_flags=%configure_flags% --shared


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Windows, Build.

##### Description of change

The `RELEASE_URLBASE` environment variable is used in releases as a prefix for links in the `process.release` object (https://github.com/nodejs/node/pull/2154). The `Makefile` picks it and forwards it to `configure`, but `vcbuild.bat` did not. Hence, in Windows, Node releases have a correct `process.release` because it uses the default URL, but nightlies, RCs and so on do not, breaking node-gyp. This enables native modules to be built with such versions of Node.

cc @nodejs/platform-windows 