### PR TITLE
deps: add back no-op harmony shipping flags

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 82
+#define V8_PATCH_LEVEL 83
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -235,6 +235,20 @@ DEFINE_IMPLICATION(es_staging, move_object_start)
 // and associated tests are moved from the harmony directory to the appropriate
 // esN directory.
 
+// no-op flags added back for V8 5.0 compatibility for Node.js v6.x.
+#define NODE_NOP_HARMONY_FEATURES(V)                                      \
+  V(harmony_default_parameters, "harmony default parameters")             \
+  V(harmony_destructuring_assignment, "harmony destructuring assignment") \
+  V(harmony_destructuring_bind, "harmony destructuring bind")             \
+  V(harmony_regexps, "harmony regular expression extensions")             \
+  V(harmony_proxies, "harmony proxies")                                   \
+  V(harmony_reflect, "harmony Reflect API")                               \
+  V(harmony_tostring, "harmony toString")
+
+#define FLAG_NODE_NOP_HARMONY_FEATURES(id, description) \
+  DEFINE_BOOL(id, true, "nop flag for " #description)
+NODE_NOP_HARMONY_FEATURES(FLAG_NODE_NOP_HARMONY_FEATURES)
+#undef FLAG_NODE_NOP_HARMONY_FEATURES
 
 #define FLAG_INPROGRESS_FEATURES(id, description) \
   DEFINE_BOOL(id, false, "enable " #description " (in progress)")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps:v8

##### Description of change
<!-- Provide a description of the change below this comment. -->

This PR adds back the shipping harmony flags (i.e. no-ops) that were removed in V8 5.1. While uses of V8 flags is generally not supported by Node, in this case a trivial change reduces minor hardship in the ecosystem by adding back these flags (and making them do nothing).

Fixes: https://github.com/nodejs/node/issues/8388
Ref: https://github.com/nodejs/node/pull/8395
R=@nodejs/v8
EDIT: ~~CI: https://ci.nodejs.org/job/node-test-pull-request/3967/~~
CI: https://ci.nodejs.org/job/node-test-pull-request/4033/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/310/
