### PR TITLE
src: pull AfterConnect from pipe_wrap and tcp_wrap

### DIFF
--- a/src/connection_wrap.h
+++ b/src/connection_wrap.h
@@ -17,6 +17,7 @@ class ConnectionWrap : public StreamWrap {
   }
 
   static void OnConnection(uv_stream_t* handle, int status);
+  static void AfterConnect(uv_connect_t* req, int status);
 
  protected:
   ConnectionWrap(Environment* env,

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -34,8 +34,6 @@ class PipeWrap : public ConnectionWrap<PipeWrap, uv_pipe_t> {
   static void SetPendingInstances(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif
-
-  static void AfterConnect(uv_connect_t* req, int status);
 };
 
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -235,34 +235,6 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void TCPWrap::AfterConnect(uv_connect_t* req, int status) {
-  ConnectWrap* req_wrap = static_cast<ConnectWrap*>(req->data);
-  TCPWrap* wrap = static_cast<TCPWrap*>(req->handle->data);
-  CHECK_EQ(req_wrap->env(), wrap->env());
-  Environment* env = wrap->env();
-
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-
-  // The wrap and request objects should still be there.
-  CHECK_EQ(req_wrap->persistent().IsEmpty(), false);
-  CHECK_EQ(wrap->persistent().IsEmpty(), false);
-
-  Local<Object> req_wrap_obj = req_wrap->object();
-  Local<Value> argv[5] = {
-    Integer::New(env->isolate(), status),
-    wrap->object(),
-    req_wrap_obj,
-    v8::True(env->isolate()),
-    v8::True(env->isolate())
-  };
-
-  req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
-
-  delete req_wrap;
-}
-
-
 void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -42,8 +42,6 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
   static void SetSimultaneousAccepts(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif
-
-  static void AfterConnect(uv_connect_t* req, int status);
 };
 
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src


##### Description of change

This commit attempts to address one of the items in
https://github.com/nodejs/node/issues/4641 which is related to
src/pipe_wrap.cc and src/tcp_wrap.cc.

Currently both pipe_wrap.cc and tcp_wrap.cc contain an AfterConnect
function that are almost identical. This commit extracts this function
into ConnectionWrap so that that both can share it.