### PR TITLE
src: fix unused-result warning

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -132,7 +132,7 @@ void Initialize(Local<Object> target,
 #define V(name, _)                                                            \
   target->Set(context,                                                        \
               FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Integer::NewFromUnsigned(env->isolate(), index++));
+              Integer::NewFromUnsigned(env->isolate(), index++)).FromJust();
   {
     uint32_t index = 0;
     PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
c++

##### Description of change
<!-- Provide a description of the change below this comment. -->
I was getting these warnings on `OS X` locally:

```
../src/node_util.cc:138:43: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
    PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
                                          ^~
../src/env.h:56:3: note: expanded from macro 'PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES'
  V(alpn_buffer_private_symbol, "node:alpnBuffer")                            \
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/node_util.cc:133:3: note: expanded from macro 'V'
  target->Set(context,                                                        \
  ^~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/node_util.cc:138:43: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
    PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
                                          ^~
../src/env.h:57:3: note: expanded from macro 'PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES'
  V(arrow_message_private_symbol, "node:arrowMessage")                        \
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/node_util.cc:133:3: note: expanded from macro 'V'
  target->Set(context,                                                        \
```