### PR TITLE
util: don't init Debug if it's not needed yet

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -301,10 +301,10 @@ function ensureDebugIsInitialized() {
 
 
 function inspectPromise(p) {
-  ensureDebugIsInitialized();
   // Only create a mirror if the object is a Promise.
   if (!binding.isPromise(p))
     return null;
+  ensureDebugIsInitialized();
   const mirror = Debug.MakeMirror(p, true);
   return {status: mirror.status(), value: mirror.promiseValue().value_};
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util

##### Description of change

Because any call to `util.inspect()` with an object results in
`inspectPromise()` being called, `Debug` was being initialized even when
it's not needed. Instead, the initialization is placed after the
`isPromise` check.