### PR TITLE
doc: fix example in repl documentation about context properties

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -118,7 +118,7 @@ const repl = require('repl');
 var msg = 'message';
 
 const r = repl.start('> ');
-Object.defineProperty(r, 'm', {
+Object.defineProperty(r.context, 'm', {
   configurable: false,
   enumerable: true,
   value: msg


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fix an example in the repl documentation that explains how to set context properties.
We want to define the context property `repl.context.m`, not `repl.m`.