### PR TITLE
test: skip pseudo-tty/no_dropped_stdio test

### DIFF
--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -1,3 +1,5 @@
+prefix pseudo-tty
+
 [$system==aix]
 # test issue only, covered under https://github.com/nodejs/node/issues/7973
-no_dropped_stdio           : PASS, FLAKY
+no_dropped_stdio           : SKIP

--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -152,7 +152,7 @@ class TTYTestConfiguration(test.TestConfiguration):
     return ['sample', 'sample=shell']
 
   def GetTestStatus(self, sections, defs):
-    status_file = join(self.root, 'message.status')
+    status_file = join(self.root, 'pseudo-tty.status')
     if exists(status_file):
       test.ReadConfigurationInto(status_file, sections, defs)
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test



We had marked pseudo-tty/no_dropped_stdio as flaky but
in some failures it hangs and does not seem to timeout,
and or is reported as an error.

Also add prefix to status file as it was missing.

Also fix name of status file in testcfg.py. It
was pointing to message.status instead of
pseudo-tty.status.