### PR TITLE
test: stricter comparisons for equal and require var to const

### DIFF
--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var net = require('net');
+const net = require('net');
 
 var conns_closed = 0;
 
@@ -18,7 +18,7 @@ var server = net.createServer(common.mustCall(function(socket) {
   assert.ok(socket.remotePort);
   assert.notEqual(socket.remotePort, this.address().port);
   socket.on('end', function() {
-    if (++conns_closed == 2) server.close();
+    if (++conns_closed === 2) server.close();
   });
   socket.on('close', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));
@@ -33,7 +33,7 @@ server.listen(0, 'localhost', function() {
   client.on('connect', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(client.remoteAddress));
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(client.remoteFamily));
-    assert.equal(client.remotePort, server.address().port);
+    assert.strictEqual(client.remotePort, server.address().port);
     client.end();
   });
   client.on('close', function() {
@@ -43,7 +43,7 @@ server.listen(0, 'localhost', function() {
   client2.on('connect', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
-    assert.equal(client2.remotePort, server.address().port);
+    assert.strictEqual(client2.remotePort, server.address().port);
     client2.end();
   });
   client2.on('close', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net

##### Description of change
<!-- Provide a description of the change below this comment. -->

Line 21 used '==' for a Number comparison, changed to '===''.
Lines 36 and 46 used 'assert.equal', changed to 'assert.strictEqual'.
Lines 2, 3 and 4 require statements used var, changed to const.