### PR TITLE
readline docs: adding events link

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -126,7 +126,7 @@ The `'SIGCONT'` event is emitted when a Node.js process previously moved into
 the background using `<ctrl>-Z` (i.e. `SIGTSTP`) is then brought back to the
 foreground using `fg(1)`.
 
-If the `input` stream was paused *before* the `SIGSTP` request, this event will
+If the `input` stream was paused *before* the `SIGTSTP` request, this event will
 not be emitted.
 
 The listener function is invoked without passing any arguments.
@@ -169,7 +169,7 @@ rl.on('SIGINT', () => {
 added: v0.7.5
 -->
 
-The `'SIGTSPT'` event is emitted when the `input` stream receives a `<ctrl>-Z`
+The `'SIGTSTP'` event is emitted when the `input` stream receives a `<ctrl>-Z`
 input, typically known as `SIGTSTP`. If there are no `SIGTSTP` event listeners
 registered when the `input` stream receives a `SIGTSTP`, the Node.js process
 will be sent to the background.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -90,7 +90,7 @@ The `'pause'` event is emitted when one of the following occur:
 
 * The `input` stream is paused.
 * The `input` stream is not paused and receives the `SIGCONT` event. (See
-  events `SIGTSTP` and `SIGCONT`)
+  events [`SIGTSTP`][] and [`SIGCONT`][])
 
 The listener function is called without passing any arguments.
 
@@ -523,3 +523,5 @@ rl.on('line', (line) => {
 [Writable]: stream.html
 [Readable]: stream.html
 [TTY]: tty.html
+[`SIGTSTP`]: readline.html#readline_event_sigtstp
+[`SIGCONT`]: readline.html#readline_event_sigcont


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- doc

##### Description of change
I add two missing links to the `readline` documentation

