### PR TITLE
src: simplify memory management using `node::Malloc()` and friends

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -174,8 +174,7 @@ static void ares_poll_close_cb(uv_handle_t* watcher) {
 
 /* Allocates and returns a new node_ares_task */
 static node_ares_task* ares_task_create(Environment* env, ares_socket_t sock) {
-  node_ares_task* task =
-    static_cast<node_ares_task*>(node::Malloc(sizeof(*task)));
+  auto task = node::Malloc<node_ares_task>(1);
 
   if (task == nullptr) {
     /* Out of memory. */

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -174,7 +174,7 @@ static void ares_poll_close_cb(uv_handle_t* watcher) {
 
 /* Allocates and returns a new node_ares_task */
 static node_ares_task* ares_task_create(Environment* env, ares_socket_t sock) {
-  auto task = node::Malloc<node_ares_task>(1);
+  auto task = node::UncheckedMalloc<node_ares_task>(1);
 
   if (task == nullptr) {
     /* Out of memory. */

--- a/src/node.cc
+++ b/src/node.cc
@@ -979,9 +979,9 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
 void* ArrayBufferAllocator::Allocate(size_t size) {
   if (zero_fill_field_ || zero_fill_all_buffers)
-    return node::Calloc(size);
+    return node::UncheckedCalloc(size);
   else
-    return node::Malloc(size);
+    return node::UncheckedMalloc(size);
 }
 
 static bool DomainHasErrorHandler(const Environment* env,

--- a/src/node.cc
+++ b/src/node.cc
@@ -979,7 +979,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
 void* ArrayBufferAllocator::Allocate(size_t size) {
   if (zero_fill_field_ || zero_fill_all_buffers)
-    return node::Calloc(size, 1);
+    return node::Calloc(size);
   else
     return node::Malloc(size);
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -183,6 +183,8 @@ bool trace_warnings = false;
 // that is used by lib/module.js
 bool config_preserve_symlinks = false;
 
+bool v8_initialized = false;
+
 // process-relative uptime base, initialized at start-up
 static double prog_start_time;
 static bool debugger_running;
@@ -4490,6 +4492,7 @@ int Start(int argc, char** argv) {
 
   v8_platform.Initialize(v8_thread_pool_size);
   V8::Initialize();
+  v8_initialized = true;
 
   int exit_code = 1;
   {
@@ -4503,6 +4506,7 @@ int Start(int argc, char** argv) {
     StartNodeInstance(&instance_data);
     exit_code = instance_data.exit_code();
   }
+  v8_initialized = false;
   V8::Dispose();
 
   v8_platform.Dispose();

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -89,8 +89,8 @@ bool zero_fill_all_buffers = false;
 namespace {
 
 inline void* BufferMalloc(size_t length) {
-  return zero_fill_all_buffers ? node::Calloc(length) :
-                                 node::Malloc(length);
+  return zero_fill_all_buffers ? node::UncheckedCalloc(length) :
+                                 node::UncheckedMalloc(length);
 }
 
 }  // namespace
@@ -285,7 +285,6 @@ MaybeLocal<Object> New(Isolate* isolate,
       data = nullptr;
     } else if (actual < length) {
       data = node::Realloc(data, actual);
-      CHECK_NE(data, nullptr);
     }
   }
 
@@ -363,7 +362,7 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
   void* new_data;
   if (length > 0) {
     CHECK_NE(data, nullptr);
-    new_data = node::Malloc(length);
+    new_data = node::UncheckedMalloc(length);
     if (new_data == nullptr)
       return Local<Object>();
     memcpy(new_data, data, length);
@@ -1086,7 +1085,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
                           offset,
                           is_forward);
   } else if (enc == LATIN1) {
-    uint8_t* needle_data = node::Malloc<uint8_t>(needle_length);
+    uint8_t* needle_data = node::UncheckedMalloc<uint8_t>(needle_length);
     if (needle_data == nullptr) {
       return args.GetReturnValue().Set(-1);
     }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5592,11 +5592,10 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
   const size_t num_curves = EC_get_builtin_curves(nullptr, 0);
   Local<Array> arr = Array::New(env->isolate(), num_curves);
   EC_builtin_curve* curves;
-  size_t alloc_size;
 
   if (num_curves) {
-    alloc_size = sizeof(*curves) * num_curves;
-    curves = static_cast<EC_builtin_curve*>(node::Malloc(alloc_size));
+    curves = static_cast<EC_builtin_curve*>(node::Malloc(sizeof(*curves),
+                                                         num_curves));
 
     CHECK_NE(curves, nullptr);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2280,7 +2280,6 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
 
     // OpenSSL takes control of the pointer after accepting it
     char* data = node::Malloc(len);
-    CHECK_NE(data, nullptr);
     memcpy(data, resp, len);
 
     if (!SSL_set_tlsext_status_ocsp_resp(s, data, len))
@@ -3331,7 +3330,6 @@ bool CipherBase::GetAuthTag(char** out, unsigned int* out_len) const {
     return false;
   *out_len = auth_tag_len_;
   *out = node::Malloc(auth_tag_len_);
-  CHECK_NE(*out, nullptr);
   memcpy(*out, auth_tag_, auth_tag_len_);
   return true;
 }
@@ -4907,7 +4905,6 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   int field_size = EC_GROUP_get_degree(ecdh->group_);
   size_t out_len = (field_size + 7) / 8;
   char* out = node::Malloc(out_len);
-  CHECK_NE(out, nullptr);
 
   int r = ECDH_compute_key(out, out_len, pub, ecdh->key_, nullptr);
   EC_POINT_free(pub);
@@ -4943,7 +4940,6 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get public key length");
 
   unsigned char* out = node::Malloc<unsigned char>(size);
-  CHECK_NE(out, nullptr);
 
   int r = EC_POINT_point2oct(ecdh->group_, pub, form, out, size, nullptr);
   if (r != size) {
@@ -4969,7 +4965,6 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
   int size = BN_num_bytes(b);
   unsigned char* out = node::Malloc<unsigned char>(size);
-  CHECK_NE(out, nullptr);
 
   if (size != BN_bn2bin(b, out)) {
     free(out);
@@ -5101,8 +5096,6 @@ class PBKDF2Request : public AsyncWrap {
         keylen_(keylen),
         key_(node::Malloc(keylen)),
         iter_(iter) {
-    if (key() == nullptr)
-      FatalError("node::PBKDF2Request()", "Out of Memory");
     Wrap(object, this);
   }
 
@@ -5263,9 +5256,6 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_IF_NOT_BUFFER(args[1], "Salt");
 
   pass = node::Malloc(passlen);
-  if (pass == nullptr) {
-    FatalError("node::PBKDF2()", "Out of Memory");
-  }
   memcpy(pass, Buffer::Data(args[0]), passlen);
 
   saltlen = Buffer::Length(args[1]);
@@ -5275,9 +5265,6 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   }
 
   salt = node::Malloc(saltlen);
-  if (salt == nullptr) {
-    FatalError("node::PBKDF2()", "Out of Memory");
-  }
   memcpy(salt, Buffer::Data(args[1]), saltlen);
 
   if (!args[2]->IsNumber()) {
@@ -5368,8 +5355,6 @@ class RandomBytesRequest : public AsyncWrap {
         error_(0),
         size_(size),
         data_(node::Malloc(size)) {
-    if (data() == nullptr)
-      FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
   }
 
@@ -5595,8 +5580,6 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 
   if (num_curves) {
     curves = node::Malloc<EC_builtin_curve>(num_curves);
-
-    CHECK_NE(curves, nullptr);
 
     if (EC_get_builtin_curves(curves, num_curves)) {
       for (size_t i = 0; i < num_curves; i++) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2279,7 +2279,7 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     size_t len = Buffer::Length(obj);
 
     // OpenSSL takes control of the pointer after accepting it
-    char* data = reinterpret_cast<char*>(node::Malloc(len));
+    char* data = node::Malloc(len);
     CHECK_NE(data, nullptr);
     memcpy(data, resp, len);
 
@@ -3330,7 +3330,7 @@ bool CipherBase::GetAuthTag(char** out, unsigned int* out_len) const {
   if (initialised_ || kind_ != kCipher || !auth_tag_)
     return false;
   *out_len = auth_tag_len_;
-  *out = static_cast<char*>(node::Malloc(auth_tag_len_));
+  *out = node::Malloc(auth_tag_len_);
   CHECK_NE(*out, nullptr);
   memcpy(*out, auth_tag_, auth_tag_len_);
   return true;
@@ -4906,7 +4906,7 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // NOTE: field_size is in bits
   int field_size = EC_GROUP_get_degree(ecdh->group_);
   size_t out_len = (field_size + 7) / 8;
-  char* out = static_cast<char*>(node::Malloc(out_len));
+  char* out = node::Malloc(out_len);
   CHECK_NE(out, nullptr);
 
   int r = ECDH_compute_key(out, out_len, pub, ecdh->key_, nullptr);
@@ -4942,7 +4942,7 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (size == 0)
     return env->ThrowError("Failed to get public key length");
 
-  unsigned char* out = static_cast<unsigned char*>(node::Malloc(size));
+  unsigned char* out = node::Malloc<unsigned char>(size);
   CHECK_NE(out, nullptr);
 
   int r = EC_POINT_point2oct(ecdh->group_, pub, form, out, size, nullptr);
@@ -4968,7 +4968,7 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH private key");
 
   int size = BN_num_bytes(b);
-  unsigned char* out = static_cast<unsigned char*>(node::Malloc(size));
+  unsigned char* out = node::Malloc<unsigned char>(size);
   CHECK_NE(out, nullptr);
 
   if (size != BN_bn2bin(b, out)) {
@@ -5099,7 +5099,7 @@ class PBKDF2Request : public AsyncWrap {
         saltlen_(saltlen),
         salt_(salt),
         keylen_(keylen),
-        key_(static_cast<char*>(node::Malloc(keylen))),
+        key_(node::Malloc(keylen)),
         iter_(iter) {
     if (key() == nullptr)
       FatalError("node::PBKDF2Request()", "Out of Memory");
@@ -5262,7 +5262,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
 
   THROW_AND_RETURN_IF_NOT_BUFFER(args[1], "Salt");
 
-  pass = static_cast<char*>(node::Malloc(passlen));
+  pass = node::Malloc(passlen);
   if (pass == nullptr) {
     FatalError("node::PBKDF2()", "Out of Memory");
   }
@@ -5274,7 +5274,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
     goto err;
   }
 
-  salt = static_cast<char*>(node::Malloc(saltlen));
+  salt = node::Malloc(saltlen);
   if (salt == nullptr) {
     FatalError("node::PBKDF2()", "Out of Memory");
   }
@@ -5367,7 +5367,7 @@ class RandomBytesRequest : public AsyncWrap {
       : AsyncWrap(env, object, AsyncWrap::PROVIDER_CRYPTO),
         error_(0),
         size_(size),
-        data_(static_cast<char*>(node::Malloc(size))) {
+        data_(node::Malloc(size)) {
     if (data() == nullptr)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
@@ -5594,8 +5594,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
   EC_builtin_curve* curves;
 
   if (num_curves) {
-    curves = static_cast<EC_builtin_curve*>(node::Malloc(sizeof(*curves),
-                                                         num_curves));
+    curves = node::Malloc<EC_builtin_curve>(num_curves);
 
     CHECK_NE(curves, nullptr);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -160,7 +160,7 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
 
   virtual void* Allocate(size_t size);  // Defined in src/node.cc
   virtual void* AllocateUninitialized(size_t size)
-    { return node::Malloc(size); }
+    { return node::UncheckedMalloc(size); }
   virtual void Free(void* data, size_t) { free(data); }
 
  private:

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -37,6 +37,9 @@ namespace node {
 // that is used by lib/module.js
 extern bool config_preserve_symlinks;
 
+// Tells whether it is safe to call v8::Isolate::GetCurrent().
+extern bool v8_initialized;
+
 // Forward declaration
 class Environment;
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -150,12 +150,6 @@ void StreamWrap::OnAlloc(uv_handle_t* handle,
 void StreamWrap::OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx) {
   buf->base = node::Malloc(size);
   buf->len = size;
-
-  if (buf->base == nullptr && size > 0) {
-    FatalError(
-        "node::StreamWrap::DoAlloc(size_t, uv_buf_t*, void*)",
-        "Out Of Memory");
-  }
 }
 
 
@@ -204,8 +198,8 @@ void StreamWrap::OnReadImpl(ssize_t nread,
     return;
   }
 
-  char* base = node::Realloc(buf->base, nread);
   CHECK_LE(static_cast<size_t>(nread), buf->len);
+  char* base = node::Realloc(buf->base, nread);
 
   if (pending == UV_TCP) {
     pending_obj = AcceptHandle<TCPWrap, uv_tcp_t>(env, wrap);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -148,7 +148,7 @@ void StreamWrap::OnAlloc(uv_handle_t* handle,
 
 
 void StreamWrap::OnAllocImpl(size_t size, uv_buf_t* buf, void* ctx) {
-  buf->base = static_cast<char*>(node::Malloc(size));
+  buf->base = node::Malloc(size);
   buf->len = size;
 
   if (buf->base == nullptr && size > 0) {
@@ -204,7 +204,7 @@ void StreamWrap::OnReadImpl(ssize_t nread,
     return;
   }
 
-  char* base = static_cast<char*>(node::Realloc(buf->base, nread));
+  char* base = node::Realloc(buf->base, nread);
   CHECK_LE(static_cast<size_t>(nread), buf->len);
 
   if (pending == UV_TCP) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -54,7 +54,7 @@ class ExternString: public ResourceType {
       return scope.Escape(String::Empty(isolate));
 
     TypeName* new_data =
-        static_cast<TypeName*>(node::Malloc(length * sizeof(*new_data)));
+        static_cast<TypeName*>(node::Malloc(length, sizeof(*new_data)));
     if (new_data == nullptr) {
       return Local<String>();
     }

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -53,7 +53,7 @@ class ExternString: public ResourceType {
     if (length == 0)
       return scope.Escape(String::Empty(isolate));
 
-    TypeName* new_data = node::Malloc<TypeName>(length);
+    TypeName* new_data = node::UncheckedMalloc<TypeName>(length);
     if (new_data == nullptr) {
       return Local<String>();
     }
@@ -623,7 +623,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case ASCII:
       if (contains_non_ascii(buf, buflen)) {
-        char* out = node::Malloc(buflen);
+        char* out = node::UncheckedMalloc(buflen);
         if (out == nullptr) {
           return Local<String>();
         }
@@ -658,7 +658,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case BASE64: {
       size_t dlen = base64_encoded_size(buflen);
-      char* dst = node::Malloc(dlen);
+      char* dst = node::UncheckedMalloc(dlen);
       if (dst == nullptr) {
         return Local<String>();
       }
@@ -677,7 +677,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case HEX: {
       size_t dlen = buflen * 2;
-      char* dst = node::Malloc(dlen);
+      char* dst = node::UncheckedMalloc(dlen);
       if (dst == nullptr) {
         return Local<String>();
       }

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -53,8 +53,7 @@ class ExternString: public ResourceType {
     if (length == 0)
       return scope.Escape(String::Empty(isolate));
 
-    TypeName* new_data =
-        static_cast<TypeName*>(node::Malloc(length, sizeof(*new_data)));
+    TypeName* new_data = node::Malloc<TypeName>(length);
     if (new_data == nullptr) {
       return Local<String>();
     }
@@ -624,7 +623,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case ASCII:
       if (contains_non_ascii(buf, buflen)) {
-        char* out = static_cast<char*>(node::Malloc(buflen));
+        char* out = node::Malloc(buflen);
         if (out == nullptr) {
           return Local<String>();
         }
@@ -659,7 +658,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case BASE64: {
       size_t dlen = base64_encoded_size(buflen);
-      char* dst = static_cast<char*>(node::Malloc(dlen));
+      char* dst = node::Malloc(dlen);
       if (dst == nullptr) {
         return Local<String>();
       }
@@ -678,7 +677,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 
     case HEX: {
       size_t dlen = buflen * 2;
-      char* dst = static_cast<char*>(node::Malloc(dlen));
+      char* dst = node::Malloc(dlen);
       if (dst == nullptr) {
         return Local<String>();
       }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -662,7 +662,6 @@ void TLSWrap::OnReadImpl(ssize_t nread,
 
 void TLSWrap::OnAllocSelf(size_t suggested_size, uv_buf_t* buf, void* ctx) {
   buf->base = node::Malloc(suggested_size);
-  CHECK_NE(buf->base, nullptr);
   buf->len = suggested_size;
 }
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -661,7 +661,7 @@ void TLSWrap::OnReadImpl(ssize_t nread,
 
 
 void TLSWrap::OnAllocSelf(size_t suggested_size, uv_buf_t* buf, void* ctx) {
-  buf->base = static_cast<char*>(node::Malloc(suggested_size));
+  buf->base = node::Malloc(suggested_size);
   CHECK_NE(buf->base, nullptr);
   buf->len = suggested_size;
 }

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -374,7 +374,7 @@ void UDPWrap::OnSend(uv_udp_send_t* req, int status) {
 void UDPWrap::OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
-  buf->base = static_cast<char*>(node::Malloc(suggested_size));
+  buf->base = node::Malloc(suggested_size);
   buf->len = suggested_size;
 
   if (buf->base == nullptr && suggested_size > 0) {
@@ -416,7 +416,7 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
     return;
   }
 
-  char* base = static_cast<char*>(node::Realloc(buf->base, nread));
+  char* base = node::Realloc(buf->base, nread);
   argv[2] = Buffer::New(env, base, nread).ToLocalChecked();
   argv[3] = AddressToJS(env, addr);
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -376,11 +376,6 @@ void UDPWrap::OnAlloc(uv_handle_t* handle,
                       uv_buf_t* buf) {
   buf->base = node::Malloc(suggested_size);
   buf->len = suggested_size;
-
-  if (buf->base == nullptr && suggested_size > 0) {
-    FatalError("node::UDPWrap::OnAlloc(uv_handle_t*, size_t, uv_buf_t*)",
-               "Out Of Memory");
-  }
 }
 
 
@@ -416,7 +411,7 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
     return;
   }
 
-  char* base = node::Realloc(buf->base, nread);
+  char* base = node::UncheckedRealloc(buf->base, nread);
   argv[2] = Buffer::New(env, base, nread).ToLocalChecked();
   argv[3] = AddressToJS(env, addr);
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -244,29 +244,30 @@ inline size_t MultiplyWithOverflowCheck(size_t a, size_t b) {
 // that the standard allows them to either return a unique pointer or a
 // nullptr for zero-sized allocation requests.  Normalize by always using
 // a nullptr.
-void* Realloc(void* pointer, size_t n, size_t size) {
-  size_t full_size = MultiplyWithOverflowCheck(size, n);
+template <typename T>
+T* Realloc(T* pointer, size_t n) {
+  size_t full_size = MultiplyWithOverflowCheck(sizeof(T), n);
 
   if (full_size == 0) {
     free(pointer);
     return nullptr;
   }
 
-  return realloc(pointer, full_size);
+  return static_cast<T*>(realloc(pointer, full_size));
 }
 
 // As per spec realloc behaves like malloc if passed nullptr.
-void* Malloc(size_t n, size_t size) {
+template <typename T>
+T* Malloc(size_t n) {
   if (n == 0) n = 1;
-  if (size == 0) size = 1;
-  return Realloc(nullptr, n, size);
+  return Realloc<T>(nullptr, n);
 }
 
-void* Calloc(size_t n, size_t size) {
+template <typename T>
+T* Calloc(size_t n) {
   if (n == 0) n = 1;
-  if (size == 0) size = 1;
-  MultiplyWithOverflowCheck(size, n);
-  return calloc(n, size);
+  MultiplyWithOverflowCheck(sizeof(T), n);
+  return static_cast<T*>(calloc(n, sizeof(T)));
 }
 
 }  // namespace node

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -253,7 +253,15 @@ T* UncheckedRealloc(T* pointer, size_t n) {
     return nullptr;
   }
 
-  return static_cast<T*>(realloc(pointer, full_size));
+  void* allocated = realloc(pointer, full_size);
+
+  if (UNLIKELY(allocated == nullptr)) {
+    // Tell V8 that memory is low and retry.
+    LowMemoryNotification();
+    allocated = realloc(pointer, full_size);
+  }
+
+  return static_cast<T*>(allocated);
 }
 
 // As per spec realloc behaves like malloc if passed nullptr.

--- a/src/util.cc
+++ b/src/util.cc
@@ -77,4 +77,13 @@ BufferValue::BufferValue(Isolate* isolate, Local<Value> value) {
   }
 }
 
+void LowMemoryNotification() {
+  if (v8_initialized) {
+    auto isolate = v8::Isolate::GetCurrent();
+    if (isolate != nullptr) {
+      isolate->LowMemoryNotification();
+    }
+  }
+}
+
 }  // namespace node

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,6 +1,7 @@
 #include "util.h"
 #include "string_bytes.h"
 #include "node_buffer.h"
+#include "node_internals.h"
 #include <stdio.h>
 
 namespace node {

--- a/src/util.h
+++ b/src/util.h
@@ -22,9 +22,16 @@ namespace node {
 // that the standard allows them to either return a unique pointer or a
 // nullptr for zero-sized allocation requests.  Normalize by always using
 // a nullptr.
-inline void* Realloc(void* pointer, size_t n, size_t size = 1);
-inline void* Malloc(size_t n, size_t size = 1);
-inline void* Calloc(size_t n, size_t size = 1);
+template <typename T>
+inline T* Realloc(T* pointer, size_t n);
+template <typename T>
+inline T* Malloc(size_t n);
+template <typename T>
+inline T* Calloc(size_t n);
+
+// Shortcuts for char*.
+inline char* Malloc(size_t n) { return Malloc<char>(n); }
+inline char* Calloc(size_t n) { return Calloc<char>(n); }
 
 #ifdef __GNUC__
 #define NO_RETURN __attribute__((noreturn))
@@ -285,7 +292,7 @@ class MaybeStackBuffer {
     if (storage <= kStackStorageSize) {
       buf_ = buf_st_;
     } else {
-      buf_ = static_cast<T*>(Malloc(sizeof(T), storage));
+      buf_ = Malloc<T>(storage);
       CHECK_NE(buf_, nullptr);
     }
 

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,15 @@ namespace node {
 // nullptr for zero-sized allocation requests.  Normalize by always using
 // a nullptr.
 template <typename T>
+inline T* UncheckedRealloc(T* pointer, size_t n);
+template <typename T>
+inline T* UncheckedMalloc(size_t n);
+template <typename T>
+inline T* UncheckedCalloc(size_t n);
+
+// Same things, but aborts immediately instead of returning nullptr when
+// no memory is available.
+template <typename T>
 inline T* Realloc(T* pointer, size_t n);
 template <typename T>
 inline T* Malloc(size_t n);
@@ -32,6 +41,8 @@ inline T* Calloc(size_t n);
 // Shortcuts for char*.
 inline char* Malloc(size_t n) { return Malloc<char>(n); }
 inline char* Calloc(size_t n) { return Calloc<char>(n); }
+inline char* UncheckedMalloc(size_t n) { return UncheckedMalloc<char>(n); }
+inline char* UncheckedCalloc(size_t n) { return UncheckedCalloc<char>(n); }
 
 #ifdef __GNUC__
 #define NO_RETURN __attribute__((noreturn))
@@ -293,7 +304,6 @@ class MaybeStackBuffer {
       buf_ = buf_st_;
     } else {
       buf_ = Malloc<T>(storage);
-      CHECK_NE(buf_, nullptr);
     }
 
     // Remember how much was allocated to check against that in SetLength().

--- a/src/util.h
+++ b/src/util.h
@@ -44,6 +44,11 @@ inline char* Calloc(size_t n) { return Calloc<char>(n); }
 inline char* UncheckedMalloc(size_t n) { return UncheckedMalloc<char>(n); }
 inline char* UncheckedCalloc(size_t n) { return UncheckedCalloc<char>(n); }
 
+// Used by the allocation functions when allocation fails.
+// Thin wrapper around v8::Isolate::LowMemoryNotification() that checks
+// whether V8 is initialized.
+void LowMemoryNotification();
+
 #ifdef __GNUC__
 #define NO_RETURN __attribute__((noreturn))
 #else

--- a/src/util.h
+++ b/src/util.h
@@ -22,9 +22,9 @@ namespace node {
 // that the standard allows them to either return a unique pointer or a
 // nullptr for zero-sized allocation requests.  Normalize by always using
 // a nullptr.
-inline void* Realloc(void* pointer, size_t size);
-inline void* Malloc(size_t size);
-inline void* Calloc(size_t n, size_t size);
+inline void* Realloc(void* pointer, size_t n, size_t size = 1);
+inline void* Malloc(size_t n, size_t size = 1);
+inline void* Calloc(size_t n, size_t size = 1);
 
 #ifdef __GNUC__
 #define NO_RETURN __attribute__((noreturn))
@@ -285,10 +285,7 @@ class MaybeStackBuffer {
     if (storage <= kStackStorageSize) {
       buf_ = buf_st_;
     } else {
-      // Guard against overflow.
-      CHECK_LE(storage, sizeof(T) * storage);
-
-      buf_ = static_cast<T*>(Malloc(sizeof(T) * storage));
+      buf_ = static_cast<T*>(Malloc(sizeof(T), storage));
       CHECK_NE(buf_, nullptr);
     }
 

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -92,14 +92,16 @@ TEST(UtilTest, ToLower) {
 
 TEST(UtilTest, Malloc) {
   using node::Malloc;
+  EXPECT_NE(nullptr, Malloc<char>(0));
+  EXPECT_NE(nullptr, Malloc<char>(1));
   EXPECT_NE(nullptr, Malloc(0));
   EXPECT_NE(nullptr, Malloc(1));
 }
 
 TEST(UtilTest, Calloc) {
   using node::Calloc;
-  EXPECT_NE(nullptr, Calloc(0, 0));
-  EXPECT_NE(nullptr, Calloc(1, 0));
-  EXPECT_NE(nullptr, Calloc(0, 1));
-  EXPECT_NE(nullptr, Calloc(1, 1));
+  EXPECT_NE(nullptr, Calloc<char>(0));
+  EXPECT_NE(nullptr, Calloc<char>(1));
+  EXPECT_NE(nullptr, Calloc(0));
+  EXPECT_NE(nullptr, Calloc(1));
 }

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -105,3 +105,19 @@ TEST(UtilTest, Calloc) {
   EXPECT_NE(nullptr, Calloc(0));
   EXPECT_NE(nullptr, Calloc(1));
 }
+
+TEST(UtilTest, UncheckedMalloc) {
+  using node::UncheckedMalloc;
+  EXPECT_NE(nullptr, UncheckedMalloc<char>(0));
+  EXPECT_NE(nullptr, UncheckedMalloc<char>(1));
+  EXPECT_NE(nullptr, UncheckedMalloc(0));
+  EXPECT_NE(nullptr, UncheckedMalloc(1));
+}
+
+TEST(UtilTest, UncheckedCalloc) {
+  using node::UncheckedCalloc;
+  EXPECT_NE(nullptr, UncheckedCalloc<char>(0));
+  EXPECT_NE(nullptr, UncheckedCalloc<char>(1));
+  EXPECT_NE(nullptr, UncheckedCalloc(0));
+  EXPECT_NE(nullptr, UncheckedCalloc(1));
+}

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -90,6 +90,10 @@ TEST(UtilTest, ToLower) {
   EXPECT_EQ('a', ToLower('A'));
 }
 
+namespace node {
+  void LowMemoryNotification() {}
+}
+
 TEST(UtilTest, Malloc) {
   using node::Malloc;
   EXPECT_NE(nullptr, Malloc<char>(0));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

- Add an optional `size` param to `node::Malloc()` and `node::Realloc()` in `calloc(3)`-style and use proper overflow detection.
- Make the allocation methods templates so that they directly give the correct return type, removing a number of `static_cast`s to the desired pointer types.
- Add shortcuts for the `node::Malloc()` + `CHECK_NE(·, nullptr)` combinations that often occur together in the codebase.
- Call `v8::Isolate::GetCurrent()->LowMemoryNotification()` when an allocation fails to give V8 a chance to clean up and return memory before retrying (and possibly giving up).

Any of the changes here can be left out but I believe that they all pretty much make sense to have.

~~CI: https://ci.nodejs.org/job/node-test-commit/4994/~~
~~CI: https://ci.nodejs.org/job/node-test-commit/4995/~~
~~CI: https://ci.nodejs.org/job/node-test-commit/4996/~~
~~CI: https://ci.nodejs.org/job/node-test-commit/4997/~~
~~CI: https://ci.nodejs.org/job/node-test-commit/5008/~~
~~CI: https://ci.nodejs.org/job/node-test-commit/5013/~~
CI: https://ci.nodejs.org/job/node-test-commit/5025/