### PR TITLE
test: fix flaky test-force-repl

### DIFF
--- a/test/parallel/test-force-repl.js
+++ b/test/parallel/test-force-repl.js
@@ -6,13 +6,13 @@ const spawn = require('child_process').spawn;
 // spawn a node child process in "interactive" mode (force the repl)
 const cp = spawn(process.execPath, ['-i']);
 var timeoutId = setTimeout(function() {
-  throw new Error('timeout!');
+  common.fail('timeout!');
 }, common.platformTimeout(5000)); // give node + the repl 5 seconds to start
 
 cp.stdout.setEncoding('utf8');
 
 cp.stdout.once('data', common.mustCall(function(b) {
   clearTimeout(timeoutId);
-  assert.equal(b, '> ');
+  assert.strictEqual(b, '> ');
   cp.kill();
 }));

--- a/test/parallel/test-force-repl.js
+++ b/test/parallel/test-force-repl.js
@@ -1,24 +1,18 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var spawn = require('child_process').spawn;
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
 
 // spawn a node child process in "interactive" mode (force the repl)
-var cp = spawn(process.execPath, ['-i']);
-var gotToEnd = false;
+const cp = spawn(process.execPath, ['-i']);
 var timeoutId = setTimeout(function() {
   throw new Error('timeout!');
-}, common.platformTimeout(1000)); // give node + the repl 1 second to boot up
+}, common.platformTimeout(5000)); // give node + the repl 5 seconds to start
 
 cp.stdout.setEncoding('utf8');
 
-cp.stdout.once('data', function(b) {
+cp.stdout.once('dasta', common.mustCall(function(b) {
   clearTimeout(timeoutId);
   assert.equal(b, '> ');
-  gotToEnd = true;
   cp.kill();
-});
-
-process.on('exit', function() {
-  assert(gotToEnd);
-});
+}));

--- a/test/parallel/test-force-repl.js
+++ b/test/parallel/test-force-repl.js
@@ -11,7 +11,7 @@ var timeoutId = setTimeout(function() {
 
 cp.stdout.setEncoding('utf8');
 
-cp.stdout.once('dasta', common.mustCall(function(b) {
+cp.stdout.once('data', common.mustCall(function(b) {
   clearTimeout(timeoutId);
   assert.equal(b, '> ');
   cp.kill();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

Increase time allowed for startup from 1 second to 5 seconds to avoid
occasional flakiness. While at it, refactor a few minor things such as
var->const and using common.mustCall().

Fixes: https://github.com/nodejs/node/issues/8483