### PR TITLE
doc: standardize rest parameters

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -100,7 +100,7 @@ The global `console` is a special `Console` whose output is sent to
 new Console(process.stdout, process.stderr);
 ```
 
-### console.assert(value[, message][, ...])
+### console.assert(value[, message][, ...args])
 <!-- YAML
 added: v0.1.101
 -->
@@ -177,7 +177,7 @@ Defaults to `2`. To make it recurse indefinitely, pass `null`.
 Defaults to `false`. Colors are customizable; see
 [customizing `util.inspect()` colors][].
 
-### console.error([data][, ...])
+### console.error([data][, ...args])
 <!-- YAML
 added: v0.1.100
 -->
@@ -199,14 +199,14 @@ If formatting elements (e.g. `%d`) are not found in the first string then
 [`util.inspect()`][] is called on each argument and the resulting string
 values are concatenated. See [`util.format()`][] for more information.
 
-### console.info([data][, ...])
+### console.info([data][, ...args])
 <!-- YAML
 added: v0.1.100
 -->
 
 The `console.info()` function is an alias for [`console.log()`][].
 
-### console.log([data][, ...])
+### console.log([data][, ...args])
 <!-- YAML
 added: v0.1.100
 -->
@@ -260,7 +260,7 @@ leaking it. On older versions, the timer persisted. This allowed
 `console.timeEnd()` to be called multiple times for the same label. This
 functionality was unintended and is no longer supported.*
 
-### console.trace(message[, ...])
+### console.trace(message[, ...args])
 <!-- YAML
 added: v0.1.104
 -->
@@ -284,20 +284,20 @@ console.trace('Show me');
   //    at REPLServer.Interface._ttyWrite (readline.js:826:14)
 ```
 
-### console.warn([data][, ...])
+### console.warn([data][, ...args])
 <!-- YAML
 added: v0.1.100
 -->
 
 The `console.warn()` function is an alias for [`console.error()`][].
 
-[`console.error()`]: #console_console_error_data
-[`console.log()`]: #console_console_log_data
+[`console.error()`]: #console_console_error_data_args
+[`console.log()`]: #console_console_log_data_args
 [`console.time()`]: #console_console_time_label
 [`console.timeEnd()`]: #console_console_timeend_label
 [`process.stderr`]: process.html#process_process_stderr
 [`process.stdout`]: process.html#process_process_stdout
-[`util.format()`]: util.html#util_util_format_format
+[`util.format()`]: util.html#util_util_format_format_args
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [customizing `util.inspect()` colors]: util.html#util_customizing_util_inspect_colors
 [web-api-assert]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -269,9 +269,10 @@ uncaught exceptions to the active Domain object.
 Domain is a child class of [`EventEmitter`][].  To handle the errors that it
 catches, listen to its `'error'` event.
 
-### domain.run(fn[, arg][, ...])
+### domain.run(fn[, ...args])
 
 * `fn` {Function}
+* `...args` {any}
 
 Run the supplied function in the context of the domain, implicitly
 binding all event emitters, timers, and lowlevel requests that are
@@ -449,6 +450,6 @@ is emitted.
 [`domain.exit()`]: #domain_domain_exit
 [`Error`]: errors.html#errors_class_error
 [`EventEmitter`]: events.html#events_class_eventemitter
-[`setInterval()`]: timers.html#timers_setinterval_callback_delay_arg
-[`setTimeout()`]: timers.html#timers_settimeout_callback_delay_arg
+[`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
+[`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
 [`throw`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -294,7 +294,7 @@ added: v0.1.26
 
 Alias for `emitter.on(eventName, listener)`.
 
-### emitter.emit(eventName[, arg1][, arg2][, ...])
+### emitter.emit(eventName[, ...args])
 <!-- YAML
 added: v0.1.26
 -->

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -182,19 +182,19 @@ left untouched.
 Use the internal `require()` machinery to look up the location of a module,
 but rather than loading the module, just return the resolved filename.
 
-## setImmediate(callback[, arg][, ...])
+## setImmediate(callback[, ...args])
 
 <!-- type=global -->
 
 [`setImmediate`] is described in the [timers][] section.
 
-## setInterval(callback, delay[, arg][, ...])
+## setInterval(callback, delay[, ...args])
 
 <!-- type=global -->
 
 [`setInterval`] is described in the [timers][] section.
 
-## setTimeout(callback, delay[, arg][, ...])
+## setTimeout(callback, delay[, ...args])
 
 <!-- type=global -->
 
@@ -210,7 +210,7 @@ but rather than loading the module, just return the resolved filename.
 [`clearImmediate`]: timers.html#timers_clearimmediate_immediate
 [`clearInterval`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout`]: timers.html#timers_cleartimeout_timeout
-[`setImmediate`]: timers.html#timers_setimmediate_callback_arg
-[`setInterval`]: timers.html#timers_setinterval_callback_delay_arg
-[`setTimeout`]: timers.html#timers_settimeout_callback_delay_arg
+[`setImmediate`]: timers.html#timers_setimmediate_callback_args
+[`setInterval`]: timers.html#timers_setinterval_callback_delay_args
+[`setTimeout`]: timers.html#timers_settimeout_callback_delay_args
 [built-in objects]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -272,12 +272,12 @@ path.isAbsolute('.')           // false
 
 A [`TypeError`][] is thrown if `path` is not a string.
 
-## path.join([path[, ...]])
+## path.join([...paths])
 <!-- YAML
 added: v0.1.16
 -->
 
-* `[path[, ...]]` {String} A sequence of path segments
+* `...paths` {String} A sequence of path segments
 
 The `path.join()` method join all given `path` segments together using the
 platform specific separator as a delimiter, then normalizes the resulting path.
@@ -438,12 +438,12 @@ path.relative('C:\\orandea\\test\\aaa', 'C:\\orandea\\impl\\bbb')
 
 A [`TypeError`][] is thrown if neither `from` nor `to` is a string.
 
-## path.resolve([path[, ...]])
+## path.resolve([...paths])
 <!-- YAML
 added: v0.3.4
 -->
 
-* `[path[, ...]]` {String} A sequence of paths or path segments
+* `...paths` {String} A sequence of paths or path segments
 
 The `path.resolve()` method resolves a sequence of paths or path segments into
 an absolute path.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1138,14 +1138,13 @@ Will generate:
 
 `heapTotal` and `heapUsed` refer to V8's memory usage.
 
-## process.nextTick(callback[, arg][, ...])
+## process.nextTick(callback[, ...args])
 <!-- YAML
 added: v0.1.26
 -->
 
 * `callback` {Function}
-* `[, arg][, ...]` {any} Additional arguments to pass when invoking the
-  `callback`
+* `...args` {any} Additional arguments to pass when invoking the `callback`
 
 The `process.nextTick()` method adds the `callback` to the "next tick queue".
 Once the current turn of the event loop turn runs to completion, all callbacks
@@ -1700,7 +1699,7 @@ cases:
 [`process.execPath`]: #process_process_execpath
 [`promise.catch()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
 [`require.main`]: modules.html#modules_accessing_the_main_module
-[`setTimeout(fn, 0)`]: timers.html#timers_settimeout_callback_delay_arg
+[`setTimeout(fn, 0)`]: timers.html#timers_settimeout_callback_delay_args
 [process_emit_warning]: #process_process_emitwarning_warning_name_ctor
 [process_warning]: #process_event_warning
 [Signal Events]: #process_signal_events

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -65,14 +65,14 @@ a certain period of time. When a timer's function is called varies depending on
 which method was used to create the timer and what other work the Node.js
 event loop is doing.
 
-### setImmediate(callback[, ...arg])
+### setImmediate(callback[, ...args])
 <!-- YAML
 added: v0.9.1
 -->
 
 * `callback` {Function} The function to call at the end of this turn of
   [the Node.js Event Loop]
-* `[, ...arg]` Optional arguments to pass when the `callback` is called.
+* `...args` {any} Optional arguments to pass when the `callback` is called.
 
 Schedules the "immediate" execution of the `callback` after I/O events'
 callbacks and before timers created using [`setTimeout()`][] and
@@ -87,7 +87,7 @@ next event loop iteration.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
-### setInterval(callback, delay[, ...arg])
+### setInterval(callback, delay[, ...args])
 <!-- YAML
 added: v0.0.1
 -->
@@ -95,7 +95,7 @@ added: v0.0.1
 * `callback` {Function} The function to call when the timer elapses.
 * `delay` {number} The number of milliseconds to wait before calling the
   `callback`.
-* `[, ...arg]` Optional arguments to pass when the `callback` is called.
+* `...args` {any} Optional arguments to pass when the `callback` is called.
 
 Schedules repeated execution of `callback` every `delay` milliseconds.
 Returns a `Timeout` for use with [`clearInterval()`][].
@@ -105,7 +105,7 @@ set to `1`.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
-### setTimeout(callback, delay[, ...arg])
+### setTimeout(callback, delay[, ...args])
 <!-- YAML
 added: v0.0.1
 -->
@@ -113,7 +113,7 @@ added: v0.0.1
 * `callback` {Function} The function to call when the timer elapses.
 * `delay` {number} The number of milliseconds to wait before calling the
   `callback`.
-* `[, ...arg]` Optional arguments to pass when the `callback` is called.
+* `...args` {any} Optional arguments to pass when the `callback` is called.
 
 Schedules execution of a one-time `callback` after `delay` milliseconds.
 Returns a `Timeout` for use with [`clearTimeout()`][].
@@ -168,6 +168,6 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 [`clearImmediate()`]: timers.html#timers_clearimmediate_immediate
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout()`]: timers.html#timers_cleartimeout_timeout
-[`setImmediate()`]: timers.html#timers_setimmediate_callback_arg
-[`setInterval()`]: timers.html#timers_setinterval_callback_delay_arg
-[`setTimeout()`]: timers.html#timers_settimeout_callback_delay_arg
+[`setImmediate()`]: timers.html#timers_setimmediate_callback_args
+[`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
+[`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -88,12 +88,12 @@ The `--throw-deprecation` command line flag and `process.throwDeprecation`
 property take precedence over `--trace-deprecation` and
 `process.traceDeprecation`.
 
-## util.format(format[, ...])
+## util.format(format[, ...args])
 <!-- YAML
 added: v0.5.3
 -->
 
-* `format` {string} A `printf`-like format string.
+* `format` {String} A `printf`-like format string.
 
 The `util.format()` method returns a formatted string using the first argument
 as a `printf`-like format.
@@ -367,11 +367,11 @@ deprecated: v0.11.3
 
 > Stability: 0 - Deprecated: Use [`console.error()`][] instead.
 
-* `string` {string} The message to print to `stderr`
+* `string` {String} The message to print to `stderr`
 
 Deprecated predecessor of `console.error`.
 
-### util.error([...])
+### util.error([...strings])
 <!-- YAML
 added: v0.3.0
 deprecated: v0.11.3
@@ -379,7 +379,7 @@ deprecated: v0.11.3
 
 > Stability: 0 - Deprecated: Use [`console.error()`][] instead.
 
-* `string` {string} The message to print to `stderr`
+* `...strings` {String} The message to print to `stderr`
 
 Deprecated predecessor of `console.error`.
 
@@ -781,7 +781,7 @@ deprecated: v6.0.0
 
 > Stability: 0 - Deprecated: Use a third party module instead.
 
-* `string` {string}
+* `string` {String}
 
 The `util.log()` method prints the given `string` to `stdout` with an included
 timestamp.
@@ -792,7 +792,7 @@ const util = require('util');
 util.log('Timestamped message.');
 ```
 
-### util.print([...])
+### util.print([...strings])
 <!-- YAML
 added: v0.3.0
 deprecated: v0.11.3
@@ -802,7 +802,7 @@ deprecated: v0.11.3
 
 Deprecated predecessor of `console.log`.
 
-### util.puts([...])
+### util.puts([...strings])
 <!-- YAML
 added: v0.3.0
 deprecated: v0.11.3
@@ -833,7 +833,7 @@ similar built-in functionality through [`Object.assign()`].
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
 [Custom inspection functions on Objects]: #util_custom_inspection_functions_on_objects
 [`Error`]: errors.html#errors_class_error
-[`console.log()`]: console.html#console_console_log_data
-[`console.error()`]: console.html#console_console_error_data
+[`console.log()`]: console.html#console_console_log_data_args
+[`console.error()`]: console.html#console_console_error_data_args
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
 [`Object.assign()`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Current, rest parameters in API documentation take a variety of inconsistent forms, many of which cause the JSON documentation generator to emit a warning such as the following:

```
Warning: invalid param "..."
 > {"textRaw":"`string` {string} The message to print to `stderr` ","name":"string","type":"string","desc":"The message to print to `stderr`"}
 > util.error([...])
```

This pull request adopts a consistent form of documenting rest parameters, that fits the ES2015 syntax and is digestible for the documentation generator.

One caveat is that this PR changes the anchors of numerous functions, which may break links on the Internet. I could manually add `<a id>` to mitigate that, so let me know if that is preferred.