### PR TITLE
timers: length == 0 is untouchable because type checking

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -333,7 +333,6 @@ exports.setTimeout = function(callback, after) {
   var ontimeout = callback;
   switch (length) {
     // fast cases
-    case 0:
     case 1:
     case 2:
       break;
@@ -392,7 +391,6 @@ exports.setInterval = function(callback, repeat) {
   var length = arguments.length;
   var ontimeout = callback;
   switch (length) {
-    case 0:
     case 1:
     case 2:
       break;
@@ -605,7 +603,6 @@ exports.setImmediate = function(callback, arg1, arg2, arg3) {
 
   switch (arguments.length) {
     // fast cases
-    case 0:
     case 1:
       break;
     case 2:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers

##### Description of change
<!-- Provide a description of the change below this comment. -->
In `setTimetout`, `setInterval` and `setImmediate` functions, the case 0 on `arguments.length` are untouchable because an `TypeError` would be threw and not able to run at that line.