### PR TITLE
Make it build using openssl 1.1.0

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -143,7 +143,6 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // Do not keep read/write buffers in free list
   if (options.singleUse) {
     c.singleUse = true;
-    c.context.setFreeListLength(0);
   }
 
   return c;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -91,8 +91,6 @@ class SecureContext : public BaseObject {
   static const int kTicketKeyIVIndex = 4;
 
  protected:
-  static const int64_t kExternalSize = sizeof(SSL_CTX);
-
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Init(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetKey(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -112,8 +110,6 @@ class SecureContext : public BaseObject {
   static void LoadPKCS12(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetTicketKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetTicketKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetFreeListLength(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EnableTicketKeyCallback(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CtxGetter(v8::Local<v8::String> property,
@@ -136,18 +132,17 @@ class SecureContext : public BaseObject {
         cert_(nullptr),
         issuer_(nullptr) {
     MakeWeak<SecureContext>(this);
-    env->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
   }
 
   void FreeCTXMem() {
     if (ctx_) {
-      env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
-      if (ctx_->cert_store == root_cert_store) {
+      if (SSL_CTX_get_cert_store(ctx_) == root_cert_store) {
         // SSL_CTX_free() will attempt to free the cert_store as well.
         // Since we want our root_cert_store to stay around forever
         // we just clear the field. Hopefully OpenSSL will not modify this
         // struct in future versions.
-        ctx_->cert_store = nullptr;
+        // XXX: Maybe we should just call X509_STORE_up_ref() instead?
+        SSL_CTX_set_cert_store(ctx_, nullptr);
       }
       SSL_CTX_free(ctx_);
       if (cert_ != nullptr)
@@ -184,7 +179,6 @@ class SSLWrap {
         cert_cb_arg_(nullptr),
         cert_cb_running_(false) {
     ssl_ = SSL_new(sc->ctx_);
-    env_->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
     CHECK_NE(ssl_, nullptr);
   }
 
@@ -214,19 +208,20 @@ class SSLWrap {
  protected:
   typedef void (*CertCb)(void* arg);
 
-  // Size allocated by OpenSSL: one for SSL structure, one for SSL3_STATE and
-  // some for buffers.
-  // NOTE: Actually it is much more than this
-  static const int64_t kExternalSize =
-      sizeof(SSL) + sizeof(SSL3_STATE) + 42 * 1024;
-
   static void InitNPN(SecureContext* sc);
   static void AddMethods(Environment* env, v8::Local<v8::FunctionTemplate> t);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   static SSL_SESSION* GetSessionCallback(SSL* s,
                                          unsigned char* key,
                                          int len,
                                          int* copy);
+#else
+  static SSL_SESSION* GetSessionCallback(SSL* s,
+                                         const unsigned char* key,
+                                         int len,
+                                         int* copy);
+#endif
   static int NewSessionCallback(SSL* s, SSL_SESSION* sess);
   static void OnClientHello(void* arg,
                             const ClientHelloParser::ClientHello& hello);
@@ -420,7 +415,7 @@ class CipherBase : public BaseObject {
     if (!initialised_)
       return;
     delete[] auth_tag_;
-    EVP_CIPHER_CTX_cleanup(&ctx_);
+    EVP_CIPHER_CTX_free(ctx_);
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
@@ -467,10 +462,11 @@ class CipherBase : public BaseObject {
         auth_tag_(nullptr),
         auth_tag_len_(0) {
     MakeWeak<CipherBase>(this);
+    ctx_ = EVP_CIPHER_CTX_new();
   }
 
  private:
-  EVP_CIPHER_CTX ctx_; /* coverity[member_decl] */
+  EVP_CIPHER_CTX* ctx_; /* coverity[member_decl] */
   const EVP_CIPHER* cipher_; /* coverity[member_decl] */
   bool initialised_;
   CipherKind kind_;
@@ -483,7 +479,11 @@ class Hmac : public BaseObject {
   ~Hmac() override {
     if (!initialised_)
       return;
-    HMAC_CTX_cleanup(&ctx_);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    free(ctx_);
+#else
+    HMAC_CTX_free(ctx_);
+#endif
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
@@ -502,10 +502,15 @@ class Hmac : public BaseObject {
       : BaseObject(env, wrap),
         initialised_(false) {
     MakeWeak<Hmac>(this);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    ctx_ = reinterpret_cast<HMAC_CTX *>(malloc(sizeof(HMAC_CTX)));
+#else
+    ctx_ = HMAC_CTX_new();
+#endif
   }
 
  private:
-  HMAC_CTX ctx_; /* coverity[member_decl] */
+  HMAC_CTX *ctx_; /* coverity[member_decl] */
   bool initialised_;
 };
 
@@ -514,7 +519,11 @@ class Hash : public BaseObject {
   ~Hash() override {
     if (!initialised_)
       return;
-    EVP_MD_CTX_cleanup(&mdctx_);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    free(mdctx_);
+#else
+    EVP_MD_CTX_free(mdctx_);
+#endif
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
@@ -531,10 +540,15 @@ class Hash : public BaseObject {
       : BaseObject(env, wrap),
         initialised_(false) {
     MakeWeak<Hash>(this);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    mdctx_ = reinterpret_cast<EVP_MD_CTX *>(malloc(sizeof(EVP_MD_CTX)));
+#else
+    mdctx_ = EVP_MD_CTX_new();
+#endif
   }
 
  private:
-  EVP_MD_CTX mdctx_; /* coverity[member_decl] */
+  EVP_MD_CTX *mdctx_; /* coverity[member_decl] */
   bool initialised_;
   bool finalized_;
 };
@@ -554,18 +568,27 @@ class SignBase : public BaseObject {
   SignBase(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),
         initialised_(false) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    mdctx_ = reinterpret_cast<EVP_MD_CTX *>(malloc(sizeof(EVP_MD_CTX)));
+#else
+    mdctx_ = EVP_MD_CTX_new();
+#endif
   }
 
   ~SignBase() override {
     if (!initialised_)
       return;
-    EVP_MD_CTX_cleanup(&mdctx_);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    free(mdctx_);
+#else
+    EVP_MD_CTX_free(mdctx_);
+#endif
   }
 
  protected:
   void CheckThrow(Error error);
 
-  EVP_MD_CTX mdctx_; /* coverity[member_decl] */
+  EVP_MD_CTX *mdctx_; /* coverity[member_decl] */
   bool initialised_;
 };
 

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -7,24 +7,64 @@
 
 namespace node {
 
-const BIO_METHOD NodeBIO::method = {
-  BIO_TYPE_MEM,
-  "node.js SSL buffer",
-  NodeBIO::Write,
-  NodeBIO::Read,
-  NodeBIO::Puts,
-  NodeBIO::Gets,
-  NodeBIO::Ctrl,
-  NodeBIO::New,
-  NodeBIO::Free,
-  nullptr
-};
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define BIO_set_data(bio, data) bio->ptr = data
+#define BIO_get_data(bio) bio->ptr
+#define BIO_set_shutdown(bio, shutdown_) bio->shutdown = shutdown_
+#define BIO_get_shutdown(bio) bio->shutdown
+#define BIO_set_init(bio, init_) bio->init = init_
+#define BIO_get_init(bio) bio->init
+#endif
 
+static int New(BIO* bio);
+static int Free(BIO* bio);
+static int Read(BIO* bio, char* out, int len);
+static int Write(BIO* bio, const char* data, int len);
+static int Puts(BIO* bio, const char* str);
+static int Gets(BIO* bio, char* out, int size);
+static long Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
+                 void* ptr);
+
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+const BIO_METHOD *GetNodeBioMethod()
+{
+static const BIO_METHOD method = {
+    BIO_TYPE_MEM,
+    "node.js SSL buffer",
+    Write,
+    Read,
+    Puts,
+    Gets,
+    Ctrl,
+    New,
+    Free,
+    nullptr
+  };
+  return &method;
+}
+
+#else
+BIO_METHOD *GetNodeBioMethod()
+{
+  BIO_METHOD *method = BIO_meth_new(BIO_TYPE_MEM, "node.js SSL buffer");
+  BIO_meth_set_write(method, Write);
+  BIO_meth_set_read(method, Read);
+  BIO_meth_set_puts(method, Puts);
+  BIO_meth_set_gets(method, Gets);
+  BIO_meth_set_ctrl(method, Ctrl);
+  BIO_meth_set_create(method, New);
+  BIO_meth_set_destroy(method, Free);
+  return method;
+}
+#endif
+
+const BIO_METHOD *method = GetNodeBioMethod();
 
 BIO* NodeBIO::New() {
   // The const_cast doesn't violate const correctness.  OpenSSL's usage of
   // BIO_METHOD is effectively const but BIO_new() takes a non-const argument.
-  return BIO_new(const_cast<BIO_METHOD*>(&method));
+  return BIO_new(const_cast<BIO_METHOD*>(method));
 }
 
 
@@ -48,26 +88,25 @@ void NodeBIO::AssignEnvironment(Environment* env) {
 }
 
 
-int NodeBIO::New(BIO* bio) {
-  bio->ptr = new NodeBIO();
+static int New(BIO* bio) {
+  BIO_set_data(bio, new NodeBIO());
 
   // XXX Why am I doing it?!
-  bio->shutdown = 1;
-  bio->init = 1;
-  bio->num = -1;
+  BIO_set_shutdown(bio, 1);
+  BIO_set_init(bio, 1);
 
   return 1;
 }
 
 
-int NodeBIO::Free(BIO* bio) {
+static int Free(BIO* bio) {
   if (bio == nullptr)
     return 0;
 
-  if (bio->shutdown) {
-    if (bio->init && bio->ptr != nullptr) {
-      delete FromBIO(bio);
-      bio->ptr = nullptr;
+  if (BIO_get_shutdown(bio)) {
+    if (BIO_get_init(bio) && BIO_get_data(bio) != nullptr) {
+      delete NodeBIO::FromBIO(bio);
+      BIO_set_data(bio, nullptr);
     }
   }
 
@@ -75,14 +114,16 @@ int NodeBIO::Free(BIO* bio) {
 }
 
 
-int NodeBIO::Read(BIO* bio, char* out, int len) {
+static int Read(BIO* bio, char* out, int len) {
   int bytes;
+  NodeBIO* nbio = NodeBIO::FromBIO(bio);
+
   BIO_clear_retry_flags(bio);
 
-  bytes = FromBIO(bio)->Read(out, len);
+  bytes = nbio->Read(out, len);
 
   if (bytes == 0) {
-    bytes = bio->num;
+    bytes = nbio->eof_return();
     if (bytes != 0) {
       BIO_set_retry_read(bio);
     }
@@ -125,22 +166,22 @@ size_t NodeBIO::PeekMultiple(char** out, size_t* size, size_t* count) {
 }
 
 
-int NodeBIO::Write(BIO* bio, const char* data, int len) {
+static int Write(BIO* bio, const char* data, int len) {
   BIO_clear_retry_flags(bio);
 
-  FromBIO(bio)->Write(data, len);
+  NodeBIO::FromBIO(bio)->Write(data, len);
 
   return len;
 }
 
 
-int NodeBIO::Puts(BIO* bio, const char* str) {
+static int Puts(BIO* bio, const char* str) {
   return Write(bio, str, strlen(str));
 }
 
 
-int NodeBIO::Gets(BIO* bio, char* out, int size) {
-  NodeBIO* nbio =  FromBIO(bio);
+static int Gets(BIO* bio, char* out, int size) {
+  NodeBIO* nbio = NodeBIO::FromBIO(bio);
 
   if (nbio->Length() == 0)
     return 0;
@@ -164,12 +205,12 @@ int NodeBIO::Gets(BIO* bio, char* out, int size) {
 }
 
 
-long NodeBIO::Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
+static long Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
                    void* ptr) {
   NodeBIO* nbio;
   long ret;  // NOLINT(runtime/int)
 
-  nbio = FromBIO(bio);
+  nbio = NodeBIO::FromBIO(bio);
   ret = 1;
 
   switch (cmd) {
@@ -180,7 +221,7 @@ long NodeBIO::Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
       ret = nbio->Length() == 0;
       break;
     case BIO_C_SET_BUF_MEM_EOF_RETURN:
-      bio->num = num;
+      nbio->set_eof_return(num);
       break;
     case BIO_CTRL_INFO:
       ret = nbio->Length();
@@ -196,10 +237,10 @@ long NodeBIO::Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
       ret = 0;
       break;
     case BIO_CTRL_GET_CLOSE:
-      ret = bio->shutdown;
+      ret = BIO_get_shutdown(bio);
       break;
     case BIO_CTRL_SET_CLOSE:
-      bio->shutdown = num;
+      BIO_set_shutdown(bio, num);
       break;
     case BIO_CTRL_WPENDING:
       ret = 0;

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -17,6 +17,7 @@ class NodeBIO {
   NodeBIO() : env_(nullptr),
               initial_(kInitialBufferLength),
               length_(0),
+              eof_return_(-1),
               read_head_(nullptr),
               write_head_(nullptr) {
   }
@@ -75,30 +76,31 @@ class NodeBIO {
     return length_;
   }
 
+  inline void set_eof_return(int num) {
+    eof_return_ = num;
+  }
+
+  inline int eof_return() {
+    return eof_return_;
+  }
+
   inline void set_initial(size_t initial) {
     initial_ = initial;
   }
 
   static inline NodeBIO* FromBIO(BIO* bio) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     CHECK_NE(bio->ptr, nullptr);
     return static_cast<NodeBIO*>(bio->ptr);
+#else
+    CHECK_NE(BIO_get_data(bio), nullptr);
+    return static_cast<NodeBIO*>(BIO_get_data(bio));
+#endif
   }
-
- private:
-  static int New(BIO* bio);
-  static int Free(BIO* bio);
-  static int Read(BIO* bio, char* out, int len);
-  static int Write(BIO* bio, const char* data, int len);
-  static int Puts(BIO* bio, const char* str);
-  static int Gets(BIO* bio, char* out, int size);
-  static long Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
-                   void* ptr);
 
   // Enough to handle the most of the client hellos
   static const size_t kInitialBufferLength = 1024;
   static const size_t kThroughputBufferLength = 16384;
-
-  static const BIO_METHOD method;
 
   class Buffer {
    public:
@@ -131,6 +133,7 @@ class NodeBIO {
   Environment* env_;
   size_t initial_;
   size_t length_;
+  int eof_return_;
   Buffer* read_head_;
   Buffer* write_head_;
 };

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -627,11 +627,11 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('sha1');
   sign.update(input);
   const signature = sign.sign(privateKey, 'hex');
 
-  const verify = crypto.createVerify('DSS1');
+  const verify = crypto.createVerify('sha1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(publicKey, signature, 'hex'), true);

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -213,11 +213,11 @@ assert.throws(function() {
 
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('sha1');
   sign.update(input);
   const signature = sign.sign(dsaKeyPem, 'hex');
 
-  const verify = crypto.createVerify('DSS1');
+  const verify = crypto.createVerify('sha1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(dsaPubPem, signature, 'hex'), true);
@@ -230,7 +230,7 @@ assert.throws(function() {
 const input = 'I AM THE WALRUS';
 
 {
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('sha1');
   sign.update(input);
   assert.throws(function() {
     sign.sign({ key: dsaKeyPemEncrypted, passphrase: 'wrong' }, 'hex');
@@ -240,7 +240,7 @@ const input = 'I AM THE WALRUS';
 {
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('sha1');
   sign.update(input);
 
   let signature;
@@ -249,7 +249,7 @@ const input = 'I AM THE WALRUS';
     signature = sign.sign(signOptions, 'hex');
   });
 
-  const verify = crypto.createVerify('DSS1');
+  const verify = crypto.createVerify('sha1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(dsaPubPem, signature, 'hex'), true);

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -72,12 +72,10 @@ assert.notEqual(-1, tls.getCiphers().indexOf('aes256-sha'));
 assert.equal(-1, tls.getCiphers().indexOf('AES256-SHA'));
 assertSorted(tls.getCiphers());
 
-// Assert that we have sha and sha1 but not SHA and SHA1.
+// Assert that we have sha1 but not SHA1.
 assert.notEqual(0, crypto.getHashes().length);
 assert.notEqual(-1, crypto.getHashes().indexOf('sha1'));
-assert.notEqual(-1, crypto.getHashes().indexOf('sha'));
 assert.equal(-1, crypto.getHashes().indexOf('SHA1'));
-assert.equal(-1, crypto.getHashes().indexOf('SHA'));
 assert.notEqual(-1, crypto.getHashes().indexOf('RSA-SHA1'));
 assert.equal(-1, crypto.getHashes().indexOf('rsa-sha1'));
 assertSorted(crypto.getHashes());
@@ -137,7 +135,7 @@ assert.throws(function() {
                                         '/test_bad_rsa_privkey.pem', 'ascii');
   // this would inject errors onto OpenSSL's error stack
   crypto.createSign('sha1').sign(sha1_privateKey);
-}, /asn1 encoding routines:ASN1_CHECK_TLEN:wrong tag/);
+}, /asn1 encoding routines:asn1_check_tlen:wrong tag/);
 
 // Make sure memory isn't released before being returned
 console.log(crypto.randomBytes(16));

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -34,7 +34,7 @@ assert.throws(() => tls.createServer({ticketKeys: 'abcd'}),
               /TypeError: Ticket keys must be a buffer/);
 
 assert.throws(() => tls.createServer({ticketKeys: new Buffer(0)}),
-              /TypeError: Ticket keys length must be 48 bytes/);
+              /TypeError: Ticket keys length incorrect/);
 
 assert.throws(() => tls.createSecurePair({}),
               /Error: First argument must be a tls module SecureContext/);

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -14,7 +14,7 @@ var fs = require('fs');
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
-  ciphers: 'ECDHE-RSA-RC4-SHA',
+  ciphers: 'ECDHE-RSA-AES128-SHA',
   ecdhCurve: false
 };
 

--- a/test/parallel/test-tls-junk-server.js
+++ b/test/parallel/test-tls-junk-server.js
@@ -23,7 +23,7 @@ server.listen(0, function() {
   req.end();
 
   req.once('error', common.mustCall(function(err) {
-    assert(/unknown protocol/.test(err.message));
+    assert(/wrong version number/.test(err.message));
     server.close();
   }));
 });

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -25,11 +25,7 @@ var stderr = '';
 server.listen(0, '127.0.0.1', function() {
   var address = this.address().address + ':' + this.address().port;
   var args = ['s_client',
-              '-no_ssl2',
               '-ssl3',
-              '-no_tls1',
-              '-no_tls1_1',
-              '-no_tls1_2',
               '-connect', address];
 
   // for the performance and stability issue in s_client on Windows

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -19,7 +19,7 @@ var fs = require('fs');
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
-  ciphers: 'DES-CBC3-SHA'
+  ciphers: 'AES256-SHA'
 };
 
 var reply = 'I AM THE WALRUS'; // something recognizable


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

crypto
##### Description of change

<!-- Provide a description of the change below this comment. -->

This is to make it possible to build against OpenSSL 1.1.0 (#4270)

It currently has 2 new test failures when build against 1.0.2, because OpenSSL generates a different error message in 1.0.2 and 1.1.0.  I'm not sure how to deal with that.

In test/parallel/test-crypto.js the message is changed from "asn1 encoding routines:ASN1_CHECK_TLEN:wrong tag" to "asn1 encoding routines:asn1_check_tlen:wrong tag".  (The function name in openssl got renamed from all capital letters to small letters.)

In test/parallel/test-tls-junk-server.js, the error message changed from "/unknown protocol/" to "/wrong version number/".

It also fixes 3 current issues with the test suite against the 1.0.2 version.

When building against the 1.1.0 version there are various tests that fail.  There are a total of 11 test failures.

Some tests assumes the TLS ticket is 48 bytes.  This was always just an implementation details and you could already ask OpenSSL what the size was.  The encryption got changed from AES128 to AES256 in 1.1.0 and so the size changed. I have no idea how to get that size to the right places in the test suite.

Some of the other failures are related to ciphers that are disabled by default.  For instance anonymous ciphers like AECDH are disabled and you need to enable them by selecting a different security level, which can for instance be done by adding `@SECLEVEL=0` to the cipher list, but that's not compatible with the 1.0.x version.  Ciphers like 3DES and RC4 are disabled by default.

Other tests fails because the key size that's used is too small.

I'm not sure yet why some of the other tests fail.

There are also a bunch of warnings about deprecated functions.  I left them like they are.  The proper way to deal with it will probably break compatibility.

PS: During make test I'm getting invalid opcode traps, this seems unrelated to my changes and doesn't seem to cause test suite failures.
