### PR TITLE
doc/json: make sure links are correctly passed to marked

### DIFF
--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -109,6 +109,7 @@ function doJSON(input, filename, cb) {
           current.shortDesc = current.desc;
           current.desc = [];
         }
+        current.desc.links = lexed.links;
         current.desc.push(tok);
         state = 'DESC';
       }
@@ -144,6 +145,7 @@ function doJSON(input, filename, cb) {
     }
 
     current.desc = current.desc || [];
+    current.desc.links = lexed.links;
     current.desc.push(tok);
 
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools, doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously, an attempt was made to make sure the links state is inherited in the JSON documentation output. Unfortunately, this support was not complete, which results in various unresolved links in the JSON output. As an example, [buffer.json][1] contains

```html
initialized by calling [<code>buf.fill(fill, encoding)</code>][<code>buf.fill()</code>]
```

where it should be the converted HTML.

This commit completes that attempt. After this commit, individual instances of the parser (for descriptions) inherit the links state from the root lexer, so that individual Markdown links in descriptions could be resolved. That same example is now substituted with

```html
initialized by calling <a href="#buffer_buf_fill_value_offset_end_encoding"><code>buf.fill(fill, encoding)</code></a>
```

[1]: https://nodejs.org/api/buffer.json