### PR TITLE
readline docs: removing unnecessary section on rl.close() method 

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -202,8 +202,6 @@ added: v0.1.98
 The `rl.close()` method closes the `readline.Interface` instance and
 relinquishes control over the `input` and `output` streams. When called,
 the `'close'` event will be emitted.
-Closes the `Interface` instance, relinquishing control on the `input` and
-`output` streams. The `'close'` event will also be emitted.
 
 ### rl.pause()
 <!-- YAML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
- doc


##### Description of change
Reading the documentation I notice that we have in the `readline docs` a repeated section in the `rl.close() method`
