### PR TITLE
Default context

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -329,7 +329,7 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
   V8NodeInspector(AgentImpl* agent, node::Environment* env,
                   v8::Platform* platform)
                   : agent_(agent),
-                    isolate_(env->isolate()),
+                    env_(env),
                     platform_(platform),
                     terminated_(false),
                     running_nested_loop_(false),
@@ -349,7 +349,7 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
         Mutex::ScopedLock scoped_lock(agent_->pause_lock_);
         agent_->pause_cond_.Wait(scoped_lock);
       }
-      while (v8::platform::PumpMessageLoop(platform_, isolate_))
+      while (v8::platform::PumpMessageLoop(platform_, env_->isolate()))
         {}
     } while (!terminated_);
     terminated_ = false;
@@ -377,13 +377,18 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
     session_->dispatchProtocolMessage(message);
   }
 
+  v8::Local<v8::Context> ensureDefaultContextInGroup(int contextGroupId)
+      override {
+    return env_->context();
+  }
+
   V8Inspector* inspector() {
     return inspector_.get();
   }
 
  private:
   AgentImpl* agent_;
-  v8::Isolate* isolate_;
+  node::Environment* env_;
   v8::Platform* platform_;
   bool terminated_;
   bool running_nested_loop_;

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -141,6 +141,13 @@ function testInspectScope(session) {
         }
       }, setupExpectValue(1002)
     ],
+    [
+      {
+        'method': 'Runtime.evaluate', 'params': {
+          'expression': '5 * 5'
+        }
+      }, (message) => assert.strictEqual(25, message['result']['value'])
+    ],
   ]);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
This change touches only the inspector integration.


##### Description of change
Inspector now returns a proper context when the default context is requested. This makes it possible to omit context ID from some requests.

Note that this PR is built on top of another PR (nodejs/node#8429) and adds a new test. I will roll the test change into that PR if this one is greenlighted first.

CC: @ofrobots 
