### PR TITLE
inspector: wait for both sides closing

### DIFF
--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -306,6 +306,11 @@ static void manual_inspector_socket_cleanup() {
   inspector.buffer.clear();
 }
 
+static void assert_both_sockets_closed() {
+  SPIN_WHILE(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)));
+  SPIN_WHILE(uv_is_active(reinterpret_cast<uv_handle_t*>(&inspector.client)));
+}
+
 static void on_connection(uv_connect_t* connect, int status) {
   GTEST_ASSERT_EQ(0, status);
   connect->data = connect;
@@ -481,8 +486,7 @@ TEST_F(InspectorSocketTest, ExtraTextBeforeRequest) {
   do_write(const_cast<char*>(HANDSHAKE_REQ), sizeof(HANDSHAKE_REQ) - 1);
   SPIN_WHILE(last_event != kInspectorHandshakeFailed);
   expect_handshake_failure();
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)), 0);
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&socket)), 0);
+  assert_both_sockets_closed();
 }
 
 TEST_F(InspectorSocketTest, ExtraLettersBeforeRequest) {
@@ -493,8 +497,7 @@ TEST_F(InspectorSocketTest, ExtraLettersBeforeRequest) {
   do_write(const_cast<char*>(HANDSHAKE_REQ), sizeof(HANDSHAKE_REQ) - 1);
   SPIN_WHILE(last_event != kInspectorHandshakeFailed);
   expect_handshake_failure();
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)), 0);
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&socket)), 0);
+  assert_both_sockets_closed();
 }
 
 TEST_F(InspectorSocketTest, RequestWithoutKey) {
@@ -508,8 +511,7 @@ TEST_F(InspectorSocketTest, RequestWithoutKey) {
   do_write(const_cast<char*>(BROKEN_REQUEST), sizeof(BROKEN_REQUEST) - 1);
   SPIN_WHILE(last_event != kInspectorHandshakeFailed);
   expect_handshake_failure();
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)), 0);
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&socket)), 0);
+  assert_both_sockets_closed();
 }
 
 TEST_F(InspectorSocketTest, KillsConnectionOnProtocolViolation) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Inspector test, no run-time changes.


##### Description of change
Removes race condition when test relied on both sides of the socket
to be closed on the same UV event loop iteration.

Fixes: nodejs/node#8498