### PR TITLE
Fixes an issue where Buffer.from was not supporting SharedArrayBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const binding = process.binding('buffer');
-const { isArrayBuffer } = process.binding('util');
+const { isArrayBuffer, isSharedArrayBuffer } = process.binding('util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -264,7 +264,8 @@ function fromObject(obj) {
   }
 
   if (obj) {
-    if (isArrayBuffer(obj.buffer) || 'length' in obj) {
+    if (isArrayBuffer(obj.buffer) || 'length' in obj ||
+        isSharedArrayBuffer(obj)) {
       if (typeof obj.length !== 'number' || obj.length !== obj.length) {
         return new FastBuffer();
       }
@@ -351,8 +352,10 @@ function base64ByteLength(str, bytes) {
 
 function byteLength(string, encoding) {
   if (typeof string !== 'string') {
-    if (ArrayBuffer.isView(string) || isArrayBuffer(string))
+    if (ArrayBuffer.isView(string) || isArrayBuffer(string) ||
+        isSharedArrayBuffer(string)) {
       return string.byteLength;
+    }
 
     string = '' + string;
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -103,7 +103,7 @@ Buffer.from = function(value, encodingOrOffset, length) {
   if (typeof value === 'number')
     throw new TypeError('"value" argument must not be a number');
 
-  if (isArrayBuffer(value))
+  if (isArrayBuffer(value) || isSharedArrayBuffer(value))
     return fromArrayBuffer(value, encodingOrOffset, length);
 
   if (typeof value === 'string')

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -20,6 +20,7 @@ using v8::Value;
 
 #define VALUE_METHOD_MAP(V)                                                   \
   V(isArrayBuffer, IsArrayBuffer)                                             \
+  V(isSharedArrayBuffer, IsSharedArrayBuffer)                                 \
   V(isDataView, IsDataView)                                                   \
   V(isDate, IsDate)                                                           \
   V(isMap, IsMap)                                                             \

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -23,3 +23,7 @@ arr1[1] = 6000;
 arr2[1] = 6000;
 
 assert.deepStrictEqual(arr_buf, ar_buf, 0);
+
+// Checks for calling Buffer.byteLength on a SharedArrayBuffer
+
+assert.strictEqual(Buffer.byteLength(sab), sab.byteLength, 0);

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -7,19 +7,19 @@ const assert = require('assert');
 const Buffer = require('buffer').Buffer;
 
 const sab = new SharedArrayBuffer(24);
-const arr = new Uint16Array(sab);
-const ar = new Uint16Array(12);
-ar[0] = 5000;
-arr[0] = 5000;
-arr[1] = 4000;
-ar[1] = 4000;
+const arr1 = new Uint16Array(sab);
+const arr2 = new Uint16Array(12);
+arr2[0] = 5000;
+arr1[0] = 5000;
+arr1[1] = 4000;
+arr2[1] = 4000;
 
-var arr_buf = Buffer.from(arr.buffer);
-var ar_buf = Buffer.from(ar.buffer);
+const arr_buf = Buffer.from(arr1.buffer);
+const ar_buf = Buffer.from(arr2.buffer);
 
 assert.deepStrictEqual(arr_buf, ar_buf, 0);
 
-arr[1] = 6000;
-ar[1] = 6000;
+arr1[1] = 6000;
+arr2[1] = 6000;
 
 assert.deepStrictEqual(arr_buf, ar_buf, 0);

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -1,0 +1,25 @@
+/*global SharedArrayBuffer*/
+'use strict';
+// Flags: --harmony-sharedarraybuffer
+
+require('../common');
+const assert = require('assert');
+const Buffer = require('buffer').Buffer;
+
+const sab = new SharedArrayBuffer(24);
+const arr = new Uint16Array(sab);
+const ar = new Uint16Array(12);
+ar[0] = 5000;
+arr[0] = 5000;
+arr[1] = 4000;
+ar[1] = 4000;
+
+var arr_buf = Buffer.from(arr.buffer);
+var ar_buf = Buffer.from(ar.buffer);
+
+assert.deepStrictEqual(arr_buf, ar_buf, 0);
+
+arr[1] = 6000;
+ar[1] = 6000;
+
+assert.deepStrictEqual(arr_buf, ar_buf, 0);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->
Exposes `isSharedArrayBuffer` to check for `SharedArrayBuffer` type object in JS. 
Buffer.from can now take a `SharedArrayBuffer` as an argument.
refer to issue #8440.