### PR TITLE
zlib: fix raw inflate with custom dictionary

### DIFF
--- a/test/parallel/test-zlib-dictionary-fail.js
+++ b/test/parallel/test-zlib-dictionary-fail.js
@@ -3,7 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-// Should raise an error, not trigger an assertion in src/node_zlib.cc
+// String "test" encoded with dictionary "dict".
+const input = Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]);
+
 {
   const stream = zlib.createInflate();
 
@@ -11,11 +13,9 @@ const zlib = require('zlib');
     assert(/Missing dictionary/.test(err.message));
   }));
 
-  // String "test" encoded with dictionary "dict".
-  stream.write(Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
+  stream.write(input);
 }
 
-// Should raise an error, not trigger an assertion in src/node_zlib.cc
 {
   const stream = zlib.createInflate({ dictionary: Buffer.from('fail') });
 
@@ -23,11 +23,9 @@ const zlib = require('zlib');
     assert(/Bad dictionary/.test(err.message));
   }));
 
-  // String "test" encoded with dictionary "dict".
-  stream.write(Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
+  stream.write(input);
 }
 
-// Should raise an error, not trigger an assertion in src/node_zlib.cc
 {
   const stream = zlib.createInflateRaw({ dictionary: Buffer.from('fail') });
 
@@ -37,6 +35,5 @@ const zlib = require('zlib');
     assert(/invalid/.test(err.message));
   }));
 
-  // String "test" encoded with dictionary "dict".
-  stream.write(Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
+  stream.write(input);
 }

--- a/test/parallel/test-zlib-dictionary-fail.js
+++ b/test/parallel/test-zlib-dictionary-fail.js
@@ -26,3 +26,17 @@ const zlib = require('zlib');
   // String "test" encoded with dictionary "dict".
   stream.write(Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
 }
+
+// Should raise an error, not trigger an assertion in src/node_zlib.cc
+{
+  const stream = zlib.createInflateRaw({ dictionary: Buffer.from('fail') });
+
+  stream.on('error', common.mustCall(function(err) {
+    // It's not possible to separate invalid dict and invalid data when using
+    // the raw format
+    assert(/invalid/.test(err.message));
+  }));
+
+  // String "test" encoded with dictionary "dict".
+  stream.write(Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
+}

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -1,7 +1,7 @@
 'use strict';
 // test compression/decompression with dictionary
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
@@ -32,6 +32,7 @@ function basicDictionaryTest() {
   let output = '';
   const deflate = zlib.createDeflate({ dictionary: spdyDict });
   const inflate = zlib.createInflate({ dictionary: spdyDict });
+  inflate.setEncoding('utf-8');
 
   deflate.on('data', function(chunk) {
     inflate.write(chunk);
@@ -45,9 +46,9 @@ function basicDictionaryTest() {
     inflate.end();
   });
 
-  inflate.on('end', function() {
-    assert.equal(input, output);
-  });
+  inflate.on('end', common.mustCall(function() {
+    assert.strictEqual(input, output);
+  }));
 
   deflate.write(input);
   deflate.end();
@@ -58,6 +59,7 @@ function deflateResetDictionaryTest() {
   let output = '';
   const deflate = zlib.createDeflate({ dictionary: spdyDict });
   const inflate = zlib.createInflate({ dictionary: spdyDict });
+  inflate.setEncoding('utf-8');
 
   deflate.on('data', function(chunk) {
     if (doneReset)
@@ -72,9 +74,9 @@ function deflateResetDictionaryTest() {
     inflate.end();
   });
 
-  inflate.on('end', function() {
-    assert.equal(input, output);
-  });
+  inflate.on('end', common.mustCall(function() {
+    assert.strictEqual(input, output);
+  }));
 
   deflate.write(input);
   deflate.flush(function() {
@@ -89,6 +91,7 @@ function rawDictionaryTest() {
   let output = '';
   const deflate = zlib.createDeflateRaw({ dictionary: spdyDict });
   const inflate = zlib.createInflateRaw({ dictionary: spdyDict });
+  inflate.setEncoding('utf-8');
 
   deflate.on('data', function(chunk) {
     inflate.write(chunk);
@@ -102,9 +105,9 @@ function rawDictionaryTest() {
     inflate.end();
   });
 
-  inflate.on('end', function() {
-    assert.equal(input, output);
-  });
+  inflate.on('end', common.mustCall(function() {
+    assert.strictEqual(input, output);
+  }));
 
   deflate.write(input);
   deflate.end();
@@ -115,6 +118,7 @@ function deflateRawResetDictionaryTest() {
   let output = '';
   const deflate = zlib.createDeflateRaw({ dictionary: spdyDict });
   const inflate = zlib.createInflateRaw({ dictionary: spdyDict });
+  inflate.setEncoding('utf-8');
 
   deflate.on('data', function(chunk) {
     if (doneReset)
@@ -129,9 +133,9 @@ function deflateRawResetDictionaryTest() {
     inflate.end();
   });
 
-  inflate.on('end', function() {
-    assert.equal(input, output);
-  });
+  inflate.on('end', common.mustCall(function() {
+    assert.strictEqual(input, output);
+  }));
 
   deflate.write(input);
   deflate.flush(function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib


##### Description of change
<!-- Provide a description of the change below this comment. -->

Moves inflateSetDictionary right after inflateInit2 when mode is
INFLATERAW, since without the wrapper in appears zlib won't return
Z_NEED_DICT as it would otherwise, and will thus attempt inflating
without the dictionary, leading to an error.

Closes #8507.