### PR TITLE
tls: add 'new' keyword for Array constructor call

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -29,7 +29,7 @@ exports.getCiphers = internalUtil.cachedResult(() => {
 // Convert protocols array into valid OpenSSL protocols list
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")
 function convertProtocols(protocols) {
-  const lens = Array(protocols.length);
+  const lens = new Array(protocols.length);
   const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
     var len = Buffer.byteLength(c);
     lens[i] = len;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

lib

##### Description of change
<!-- Provide a description of the change below this comment. -->

tls.js contains the only instance of Array() being called as a function rather than a constructor with the 'new' keyword.