### PR TITLE
repl: improve .help

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1257,12 +1257,13 @@ function defineDefaultCommands(repl) {
   });
 
   repl.defineCommand('help', {
-    help: 'Show repl options',
+    help: 'Print this help message',
     action: function() {
-      var self = this;
-      Object.keys(this.commands).sort().forEach(function(name) {
-        var cmd = self.commands[name];
-        self.outputStream.write(name + '\t' + (cmd.help || '') + '\n');
+      Object.keys(this.commands).sort().forEach((name) => {
+        const cmd = this.commands[name];
+        const spaces = ' '.repeat(Math.max(9 - name.length, 1));
+        const line = '.' + name + (cmd.help ? spaces + cmd.help : '') + '\n';
+        this.outputStream.write(line);
       });
       this.displayPrompt();
     }
@@ -1308,7 +1309,7 @@ function defineDefaultCommands(repl) {
   });
 
   repl.defineCommand('editor', {
-    help: 'Entering editor mode (^D to finish, ^C to cancel)',
+    help: 'Enter editor mode',
     action() {
       if (!this.terminal) return;
       this.editorMode = true;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1259,9 +1259,13 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('help', {
     help: 'Print this help message',
     action: function() {
-      Object.keys(this.commands).sort().forEach((name) => {
+      const names = Object.keys(this.commands).sort();
+      const longestNameLength = names.reduce((max, name) => {
+        return Math.max(max, name.length);
+      }, 1);
+      names.forEach((name) => {
         const cmd = this.commands[name];
-        const spaces = ' '.repeat(Math.max(9 - name.length, 1));
+        const spaces = ' '.repeat(longestNameLength - name.length + 3);
         const line = '.' + name + (cmd.help ? spaces + cmd.help : '') + '\n';
         this.outputStream.write(line);
       });

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1262,7 +1262,7 @@ function defineDefaultCommands(repl) {
       const names = Object.keys(this.commands).sort();
       const longestNameLength = names.reduce((max, name) => {
         return Math.max(max, name.length);
-      }, 1);
+      }, 0);
       names.forEach((name) => {
         const cmd = this.commands[name];
         const spaces = ' '.repeat(longestNameLength - name.length + 3);

--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -35,8 +35,8 @@ r.defineCommand('say2', function() {
 });
 
 inputStream.write('.help\n');
-assert(/\nsay1\thelp for say1\n/.test(output), 'help for say1 not present');
-assert(/\nsay2\t\n/.test(output), 'help for say2 not present');
+assert(/\n.say1     help for say1\n/.test(output), 'help for say1 not present');
+assert(/\n.say2\n/.test(output), 'help for say2 not present');
 inputStream.write('.say1 node developer\n');
 assert(/> hello node developer/.test(output), 'say1 outputted incorrectly');
 inputStream.write('.say2 node developer\n');


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
repl

##### Description of change
- Added dots to `.help` print
- Use spaces instead of tabs so there's no misalignment on terminals with a tab size other than 4
- Fixed the help text for `.editor`

Before:
```
> .help
break	Sometimes you get stuck, this gets you out
clear	Alias for .break
editor	Entering editor mode (^D to finish, ^C to cancel)
exit	Exit the repl
help	Show repl options
load	Load JS from a file into the REPL session
save	Save all evaluated commands in this REPL session to a file
```
After:
```
> .help
.break    Sometimes you get stuck, this gets you out
.clear    Alias for .break
.editor   Enter editor mode
.exit     Exit the repl
.help     Show repl options
.load     Load JS from a file into the REPL session
.save     Save all evaluated commands in this REPL session to a file
```