### PR TITLE
Fix path.relative UNC path result

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -619,12 +619,8 @@ const win32 = {
 
     // We found a mismatch before the first common path separator was seen, so
     // return the original `to`.
-    // TODO: do this just for device roots (and not UNC paths)?
     if (i !== length && lastCommonSep === -1) {
-      if (toStart > 0)
-        return toOrig.slice(toStart);
-      else
-        return toOrig;
+      return toOrig;
     }
 
     var out = '';

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -492,7 +492,9 @@ const relativeTests = [
      ['C:\\baz-quux', 'C:\\baz', '..\\baz'],
      ['C:\\baz', 'C:\\baz-quux', '..\\baz-quux'],
      ['\\\\foo\\baz-quux', '\\\\foo\\baz', '..\\baz'],
-     ['\\\\foo\\baz', '\\\\foo\\baz-quux', '..\\baz-quux']
+     ['\\\\foo\\baz', '\\\\foo\\baz-quux', '..\\baz-quux'],
+     ['C:\\baz', '\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz'],
+     ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz']
     ]
   ],
   [ path.posix.relative,


### PR DESCRIPTION
##### Checklist
- [x] `vcbuild test nosign` (Windows) passes
  (Some tests failed, but they're unrelated: the failures repro without this change.)
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
path

##### Description of change
When the result of a path.relative() is an absolute UNC path, it should
include the leading backslashes.

Fixes: https://github.com/nodejs/node/issues/8444