### PR TITLE
fs: do not emit 'stop' watch event synchronously

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1443,6 +1443,10 @@ fs.watch = function(filename, options, listener) {
 
 // Stat Change Watchers
 
+function emitStop(self) {
+  self.emit('stop');
+}
+
 function StatWatcher() {
   EventEmitter.call(this);
 
@@ -1463,7 +1467,7 @@ function StatWatcher() {
   };
 
   this._handle.onstop = function() {
-    self.emit('stop');
+    process.nextTick(emitStop, self);
   };
 }
 util.inherits(StatWatcher, EventEmitter);

--- a/test/parallel/test-fs-watch-stop-async.js
+++ b/test/parallel/test-fs-watch-stop-async.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+const watch = fs.watchFile(__filename, () => {});
+let triggered;
+const listener = common.mustCall(() => {
+  triggered = true;
+});
+
+triggered = false;
+watch.once('stop', listener);  // Should trigger.
+watch.stop();
+assert.equal(triggered, false);
+setImmediate(() => {
+  assert.equal(triggered, true);
+  watch.removeListener('stop', listener);
+});

--- a/test/parallel/test-fs-watch-stop-sync.js
+++ b/test/parallel/test-fs-watch-stop-sync.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+const watch = fs.watchFile(__filename, () => {});
+watch.once('stop', assert.fail);  // Should not trigger.
+watch.stop();
+watch.removeListener('stop', assert.fail);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Emits 'stop' event for fs.watchFile on process.nextTick
to fix 'maximum call stack size exceeded' error when
`stop` is called synchronously after listener is attached.

Fixes: https://github.com/nodejs/node/issues/8421