### PR TITLE
doc: link onboarding to contributing guide

### DIFF
--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -165,15 +165,13 @@ Update your `master` branch (or whichever branch you are landing on, almost alwa
 
 Landing a PR
 
-* if it all looks good, `curl -L 'url-of-pr.patch' | git am`
+* If it all looks good, `curl -L 'url-of-pr.patch' | git am`
   * If `git am` fails, see [the relevant section of the Onboarding Extras doc](./onboarding-extras.md#if-git-am-fails).
 * `git rebase -i upstream/master`
-* squash into logical commits if necessary
+* Squash into logical commits if necessary.
 * `./configure && make -j8 test` (`-j8` builds node in parallel with 8 threads. adjust to the number of cores (or processor-level threads) your processor has (or slightly more) for best results.)
 * Amend the commit description.
-  * Commits should be of the form `subsystem[,subsystem]: small description\n\nbig description\n\n<metadata>`
-  * The first line should not exceed 50 characters.
-  * The remaining lines (except for metadata lines) should wrap at 72 characters.
+  * The commit message text must conform to the [guidelines for contributing](../CONTRIBUTING.md#step-3-commit).
   * Add required metadata:
     * `PR-URL: <full-pr-url>`
     * `Reviewed-By: <collaborator name> <collaborator email>`

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -171,7 +171,7 @@ Landing a PR
 * Squash into logical commits if necessary.
 * `./configure && make -j8 test` (`-j8` builds node in parallel with 8 threads. adjust to the number of cores (or processor-level threads) your processor has (or slightly more) for best results.)
 * Amend the commit description.
-  * The commit message text must conform to the [guidelines for contributing](../CONTRIBUTING.md#step-3-commit).
+  * The commit message text must conform to the [commit message guidelines](../CONTRIBUTING.md#step-3-commit).
   * Add required metadata:
     * `PR-URL: <full-pr-url>`
     * `Reviewed-By: <collaborator name> <collaborator email>`


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Replace the description of the commit message requirements in
onboarding.md with a link to the commit message requirements as they
appear in the CONTRIBUTING.md.

Advantages include:

* Only one place to keep the commit message requirements up to date
* Most collaborators being onboarded will already have several commits
  in their name and already be familiar with the requirements. So
  repeating information here makes finding the new information (about
  metadata, for example) harder to find.

/cc @lpinca 