### PR TITLE
inspector: zero out structure members

### DIFF
--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -9,6 +9,9 @@
 #include <string>
 #include <vector>
 
+namespace node {
+namespace inspector {
+
 enum inspector_handshake_event {
   kInspectorHandshakeUpgrading,
   kInspectorHandshakeUpgraded,
@@ -16,13 +19,13 @@ enum inspector_handshake_event {
   kInspectorHandshakeFailed
 };
 
-struct inspector_socket_s;
+class InspectorSocket;
 
-typedef void (*inspector_cb)(struct inspector_socket_s*, int);
+typedef void (*inspector_cb)(InspectorSocket*, int);
 // Notifies as handshake is progressing. Returning false as a response to
 // kInspectorHandshakeUpgrading or kInspectorHandshakeHttpGet event will abort
 // the connection. inspector_write can be used from the callback.
-typedef bool (*handshake_cb)(struct inspector_socket_s*,
+typedef bool (*handshake_cb)(InspectorSocket*,
                              enum inspector_handshake_event state,
                              const std::string& path);
 
@@ -45,7 +48,12 @@ struct ws_state_s {
   bool received_close;
 };
 
-struct inspector_socket_s {
+class InspectorSocket {
+ public:
+  InspectorSocket() : data(nullptr), http_parsing_state(nullptr),
+                      ws_state(nullptr), buffer(0), ws_mode(false),
+                      shutting_down(false), connection_eof(false) { }
+  void reinit();
   void* data;
   struct http_parsing_state_s* http_parsing_state;
   struct ws_state_s* ws_state;
@@ -54,35 +62,39 @@ struct inspector_socket_s {
   bool ws_mode;
   bool shutting_down;
   bool connection_eof;
+ private:
+  DISALLOW_COPY_AND_ASSIGN(InspectorSocket);
 };
 
-typedef struct inspector_socket_s inspector_socket_t;
-
-int inspector_accept(uv_stream_t* server, struct inspector_socket_s* inspector,
+int inspector_accept(uv_stream_t* server, InspectorSocket* inspector,
                      handshake_cb callback);
 
-void inspector_close(struct inspector_socket_s* inspector,
+void inspector_close(InspectorSocket* inspector,
                      inspector_cb callback);
 
 // Callbacks will receive stream handles. Use inspector_from_stream to get
-// inspector_socket_t* from the stream handle.
-int inspector_read_start(struct inspector_socket_s* inspector, uv_alloc_cb,
+// InspectorSocket* from the stream handle.
+int inspector_read_start(InspectorSocket* inspector, uv_alloc_cb,
                           uv_read_cb);
-void inspector_read_stop(struct inspector_socket_s* inspector);
-void inspector_write(struct inspector_socket_s* inspector,
+void inspector_read_stop(InspectorSocket* inspector);
+void inspector_write(InspectorSocket* inspector,
     const char* data, size_t len);
-bool inspector_is_active(const struct inspector_socket_s* inspector);
+bool inspector_is_active(const InspectorSocket* inspector);
 
-inline inspector_socket_t* inspector_from_stream(uv_tcp_t* stream) {
-  return node::ContainerOf(&inspector_socket_t::client, stream);
+inline InspectorSocket* inspector_from_stream(uv_tcp_t* stream) {
+  return node::ContainerOf(&InspectorSocket::client, stream);
 }
 
-inline inspector_socket_t* inspector_from_stream(uv_stream_t* stream) {
+inline InspectorSocket* inspector_from_stream(uv_stream_t* stream) {
   return inspector_from_stream(reinterpret_cast<uv_tcp_t*>(stream));
 }
 
-inline inspector_socket_t* inspector_from_stream(uv_handle_t* stream) {
+inline InspectorSocket* inspector_from_stream(uv_handle_t* stream) {
   return inspector_from_stream(reinterpret_cast<uv_tcp_t*>(stream));
 }
+
+}  // namespace inspector
+}  // namespace node
+
 
 #endif  // SRC_INSPECTOR_SOCKET_H_


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Change is internal to inspector.


##### Description of change
Ctor has to be added as memset to 0 is no longer an option, since
the structure now has std::vector member.

This is an attempt at guessing a fix for nodejs/node#8155 - so far I was not able to repro it.