### PR TITLE
Fallback to process cwd when resolving drive cwd

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -169,10 +169,12 @@ const win32 = {
       } else {
         // Windows has the concept of drive-specific current working
         // directories. If we've resolved a drive letter but not yet an
-        // absolute path, get cwd for that drive. We're sure the device is not
+        // absolute path, get cwd for that drive, or the process cwd if
+        // the drive cwd is not available. We're sure the device is not
         // a UNC path at this points, because UNC paths are always absolute.
-        path = process.env['=' + resolvedDevice];
-        // Verify that a drive-local cwd was found and that it actually points
+        path = process.env['=' + resolvedDevice] || process.cwd();
+
+        // Verify that a cwd was found and that it actually points
         // to our drive. If not, default to the drive's root.
         if (path === undefined ||
             path.slice(0, 3).toLowerCase() !==

--- a/test/fixtures/path-resolve.js
+++ b/test/fixtures/path-resolve.js
@@ -1,0 +1,4 @@
+// Tests resolving a path in the context of a spawned process.
+// See https://github.com/nodejs/node/issues/7215
+var path = require('path');
+console.log(path.resolve(process.argv[2]));

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const child = require('child_process');
 const path = require('path');
 
 const f = __filename;
@@ -439,6 +440,17 @@ resolveTests.forEach(function(test) {
   });
 });
 assert.equal(failures.length, 0, failures.join(''));
+
+if (common.isWindows) {
+  // Test resolving the current Windows drive letter from a spawned process.
+  // See https://github.com/nodejs/node/issues/7215
+  const currentDriveLetter = path.parse(process.cwd()).root.substring(0, 2);
+  const resolveFixture = path.join(common.fixturesDir, 'path-resolve.js');
+  var spawnResult = child.spawnSync(
+    process.argv[0], [resolveFixture, currentDriveLetter]);
+  var resolvedPath = spawnResult.stdout.toString().trim();
+  assert.equal(resolvedPath.toLowerCase(), process.cwd().toLowerCase());
+}
 
 
 // path.isAbsolute tests


### PR DESCRIPTION
##### Checklist
- [x] `vcbuild test nosign` (Windows) passes (Some tests failed, but they're unrelated: the failures repro without this change.)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added (N/A - path.resolve's Windows drive-letter-specific behavior is not documented. Should it be?)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
path

##### Description of change
The `path.resolve()` function when given just a drive letter such as "C:" tries to get a drive-specific CWD, but that isn't available in cases when the process is not launched via cmd.exe and the process CWD has not been explicitly set on that drive.

This change adds a fallback to the process CWD, if the process CWD happens to be on the resolved drive letter. If the process CWD is on another drive, then a drive-specific CWD cannot be resolved and defaults to the drive's root as before.

Based on experimentation, the fixed behavior matches that of other similar path resolution implementations on Windows I checked: [.NET's System.IO.Path.GetFullPath()](https://msdn.microsoft.com/en-us/library/system.io.path.getfullpath.aspx) and [Python's os.path.abspath()](https://docs.python.org/3.3/library/os.path.html#os.path.abspath).

Fixes: https://github.com/nodejs/node/issues/7215