### PR TITLE
benchmark: add --expose_internals switch

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -137,7 +137,8 @@ Benchmark.prototype._run = function() {
     }
 
     const child = child_process.fork(require.main.filename, childArgs, {
-      env: childEnv
+      env: childEnv,
+      execArgv: ['--expose_internals'].concat(process.execArgv)
     });
     child.on('message', sendResult);
     child.on('close', function(code) {

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var common = require('../common.js');
-var FreeList = require('internal/freelist').FreeList;
 
 var bench = common.createBenchmark(main, {
   n: [100000]
 });
 
 function main(conf) {
+  const FreeList = require('internal/freelist').FreeList;
   var n = conf.n;
   var poolSize = 1000;
   var list = new FreeList('test', poolSize, Object);

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -7,6 +7,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
+  // Using internal/freelist requires node to be run with --expose_internals
+  // switch. common.js will do that when calling main(), so we require
+  // this module here
   const FreeList = require('internal/freelist').FreeList;
   var n = conf.n;
   var poolSize = 1000;


### PR DESCRIPTION
##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark


##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds `--expose_insternals` switch to benchmark runner. This makes `misc/freelist.js` and any other benchmark requiring access to internal modules run properly on Windows.

cc @nodejs/benchmarking 