### PR TITLE
test: fix fork-dgram on AIX

### DIFF
--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -32,10 +32,10 @@ if (process.argv[2] === 'child') {
 
       server.on('message', function() {
         process.send('gotMessage');
+        server.close();
       });
 
     } else if (msg === 'stop') {
-      server.close();
       process.removeListener('message', removeMe);
     }
   });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Closes the server as soon as the child receives a message

I'm not sure that this is the correct fix, but I've tried this with some debugging information (see [this gist](https://gist.github.com/gibfahn/6050bc4562080f159caf7470f6ffa8fe/)) and both parent and child do seem to be receiving a message on AIX.

Fixes: #8271 

**Refs:**
Previous PR (to fix on SmartOS): https://github.com/nodejs/node-v0.x-archive/pull/8045
Previous Issue (ditto): https://github.com/nodejs/node-v0.x-archive/issues/8046
Original Commit: https://github.com/nodejs/node/commit/bdf7ac2c5dcdbb59d9a4db7e8eaa66462b1bed26
Original PR: https://github.com/nodejs/node-v0.x-archive/pull/4864