### PR TITLE
doc, zlib: clarify zlib server example

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -9,7 +9,7 @@ Deflate/Inflate. It can be accessed using:
 const zlib = require('zlib');
 ```
 
-Compressing or decompressing a stream (such as a file) can be accomplished by 
+Compressing or decompressing a stream (such as a file) can be accomplished by
 piping the source stream data through a `zlib` stream into a destination stream:
 
 ```js
@@ -46,12 +46,12 @@ zlib.unzip(buffer, (err, buffer) => {
 ## Compressing HTTP requests and responses
 
 The `zlib` module can be used to implement support for the `gzip` and `deflate`
-content-encoding mechanisms defined by 
+content-encoding mechanisms defined by
 [HTTP](https://tools.ietf.org/html/rfc7230#section-4.2).
 
 The HTTP [`Accept-Encoding`][] header is used within an http request to identify
-the compression encodings accepted by the client. The [`Content-Encoding`][] 
-header is used to identify the compression encodings actually applied to a 
+the compression encodings accepted by the client. The [`Content-Encoding`][]
+header is used to identify the compression encodings actually applied to a
 message.
 
 **Note: the examples given below are drastically simplified to show
@@ -86,31 +86,57 @@ request.on('response', (response) => {
 });
 
 // server example
-// Running a gzip operation on every request is quite expensive.
-// It would be much more efficient to cache the compressed buffer.
+// read file, compress to buffers, cache buffers, start server when ready
 const zlib = require('zlib');
 const http = require('http');
 const fs = require('fs');
-http.createServer((request, response) => {
-  var raw = fs.createReadStream('index.html');
-  var acceptEncoding = request.headers['accept-encoding'];
-  if (!acceptEncoding) {
-    acceptEncoding = '';
-  }
+const path = require('path');
+const EventEmitter = require('events');
+const ee = new EventEmitter();
 
-  // Note: this is not a conformant accept-encoding parser.
-  // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
-  if (acceptEncoding.match(/\bdeflate\b/)) {
-    response.writeHead(200, { 'Content-Encoding': 'deflate' });
-    raw.pipe(zlib.createDeflate()).pipe(response);
-  } else if (acceptEncoding.match(/\bgzip\b/)) {
-    response.writeHead(200, { 'Content-Encoding': 'gzip' });
-    raw.pipe(zlib.createGzip()).pipe(response);
-  } else {
-    response.writeHead(200, {});
-    raw.pipe(response);
-  }
-}).listen(1337);
+let deflated = null;
+let gzipped = null;
+let raw = null;
+
+fs.readFile(path.resolve(__dirname, './index.html'), (err, buf) => {
+  if (err) throw err;
+
+  raw = buf;
+
+  zlib.deflate(buf, (err, result) => {
+    if (err) throw err;
+    deflated = result
+
+    zlib.gzip(buf, (err, result) => {
+      if (err) throw err;
+      gzipped = result;
+
+      ee.emit('ready');
+    })
+  })
+});
+
+ee.on('ready', () => {
+  http.createServer((request, response) => {
+    var acceptEncoding = request.headers['accept-encoding'];
+    if (!acceptEncoding) {
+      acceptEncoding = '';
+    }
+    // Note: this is not a conformant accept-encoding parser.
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
+    if (acceptEncoding.match(/\bdeflate\b/)) {
+      response.writeHead(200, { 'Content-Encoding': 'deflate' });
+      response.write(deflated);
+    } else if (acceptEncoding.match(/\bgzip\b/)) {
+      response.writeHead(200, { 'Content-Encoding': 'gzip' });
+      response.write(gzipped);
+    } else {
+      response.writeHead(200, {});
+      response.write(raw);
+    }
+    return response.end();
+  }).listen(1337);
+});
 ```
 
 By default, the `zlib` methods with throw an error when decompressing
@@ -230,7 +256,7 @@ not surprising. This section is taken almost directly from the
 [zlib documentation][].  See <http://zlib.net/manual.html#Constants> for more
 details.
 
-*Note*: Previously, the constants were available directly from 
+*Note*: Previously, the constants were available directly from
 `require('zlib')`, for instance `zlib.Z_NO_FLUSH`. Accessing the constants
 directly from the module is currently still possible but should be considered
 deprecated.
@@ -444,8 +470,8 @@ Returns a new [Unzip][] object with an [options][].
 
 <!--type=misc-->
 
-All of these take a [Buffer][] or string as the first argument, an optional 
-second argument to supply options to the `zlib` classes and will call the 
+All of these take a [Buffer][] or string as the first argument, an optional
+second argument to supply options to the `zlib` classes and will call the
 supplied callback with `callback(error, result)`.
 
 Every method has a `*Sync` counterpart, which accept the same arguments, but


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines
##### Affected core subsystem(s)

`doc`, `zlib`
##### Description of change

<!-- Provide a description of the change below this comment. -->

The previous example shows how to nicely stream `zlib` data into a response,
while warning to do this on every request. A suggested caching strategy
with a `stream` seems to verbose, so this example leverages `zlib`s
convenience methods ahead of time.

PS: my editor removed tailing spaces automatically. If necessary I exclude that before landing.
