### PR TITLE
doc: remove extra comma in cluster docs

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -43,7 +43,7 @@ $ NODE_DEBUG=cluster node server.js
 23521,Master Worker 23528 online
 ```
 
-Please note that, on Windows, it is not yet possible to set up a named pipe
+Please note that on Windows, it is not yet possible to set up a named pipe
 server in a worker.
 
 ## How It Works


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Removes an extraneous comma.