### PR TITLE
benchmark: make v8-bench.js output consistent

### DIFF
--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -23,6 +23,7 @@ load('regexp.js');
 load('splay.js');
 load('navier-stokes.js');
 
+const benchmark_name = path.join('misc', 'v8-bench.js');
 const times = {};
 global.BenchmarkSuite.RunSuites({
   NotifyStart: function(name) {
@@ -31,8 +32,10 @@ global.BenchmarkSuite.RunSuites({
   NotifyResult: function(name, result) {
     const elapsed = process.hrtime(times[name]);
     common.sendResult({
-      name: name,
-      conf: {},
+      name: benchmark_name,
+      conf: {
+        benchmark: name
+      },
       rate: result,
       time: elapsed[0] + elapsed[1] / 1e9
     });
@@ -42,8 +45,10 @@ global.BenchmarkSuite.RunSuites({
   },
   NotifyScore: function(score) {
     common.sendResult({
-      name: 'Score (version ' + global.BenchmarkSuite.version + ')',
-      conf: {},
+      name: benchmark_name,
+      conf: {
+        benchmark: 'Score (version ' + global.BenchmarkSuite.version + ')'
+      },
       rate: score,
       time: 0
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark

##### Description of change
<!-- Provide a description of the change below this comment. -->

This changes the way v8-bench.js reports its performance to be consistent
with other benchmarks.

cc @nodejs/benchmarking 