### PR TITLE
dns: handle array holes in setServers()

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -286,25 +286,26 @@ exports.setServers = function(servers) {
   // cache the original servers because in the event of an error setting the
   // servers cares won't have any servers available for resolution
   const orig = cares.getServers();
+  const newSet = [];
 
-  const newSet = servers.map((serv) => {
+  servers.forEach((serv) => {
     var ipVersion = isIP(serv);
     if (ipVersion !== 0)
-      return [ipVersion, serv];
+      return newSet.push([ipVersion, serv]);
 
     const match = serv.match(/\[(.*)\](:\d+)?/);
     // we have an IPv6 in brackets
     if (match) {
       ipVersion = isIP(match[1]);
       if (ipVersion !== 0)
-        return [ipVersion, match[1]];
+        return newSet.push([ipVersion, match[1]]);
     }
 
     const s = serv.split(/:\d+$/)[0];
     ipVersion = isIP(s);
 
     if (ipVersion !== 0)
-      return [ipVersion, s];
+      return newSet.push([ipVersion, s]);
 
     throw new Error(`IP address is not properly formatted: ${serv}`);
   });

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -7,6 +7,33 @@ const dns = require('dns');
 var existing = dns.getServers();
 assert(existing.length);
 
+// Verify that setServers() handles arrays with holes and other oddities
+assert.doesNotThrow(() => {
+  const servers = [];
+
+  servers[0] = '127.0.0.1';
+  servers[2] = '0.0.0.0';
+  dns.setServers(servers);
+});
+
+assert.doesNotThrow(() => {
+  const servers = ['127.0.0.1', '192.168.1.1'];
+
+  servers[3] = '127.1.0.1';
+  servers[4] = '127.1.0.1';
+  servers[5] = '127.1.1.1';
+
+  Object.defineProperty(servers, 2, {
+    enumerable: true,
+    get: () => {
+      servers.length = 3;
+      return '0.0.0.0';
+    }
+  });
+
+  dns.setServers(servers);
+});
+
 function noop() {}
 
 var goog = [


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
dns

##### Description of change
This commit adds better handling of exceptional array formats passed to `dns.setServers()`. Prior to this commit, the input array was validated using `map()`, which preserves holes, allowing them to be passed to c-ares, crashing Node. This commit replaces `map()` with `forEach()`, which skips holes.

Tests taken from #8538. Fixes #8538