### PR TITLE
test: fix test-debug-signal-cluster.js flakyness

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -19,7 +19,6 @@ test-tick-processor-cpp-core    : PASS,FLAKY
 test-tick-processor-unknown     : PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
-test-debug-signal-cluster         : PASS,FLAKY
 
 [$system==freebsd]
 
@@ -33,10 +32,6 @@ test-fs-watch-encoding               : FAIL, PASS
 
 #being worked under https://github.com/nodejs/node/issues/7973
 test-stdio-closed                        : PASS, FLAKY
-
-#covered by  https://github.com/nodejs/node/issues/3796
-# but more frequent on AIX ?
-test-debug-signal-cluster                : PASS, FLAKY
 
 #covered by https://github.com/nodejs/node/issues/8271
 test-child-process-fork-dgram            : PASS, FLAKY

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -82,7 +82,7 @@ function assertDebuggerAgentsOutput() {
   // output may be interleaved arbitrarily. Moreover, child processes' output
   // may be written using an arbitrary number of system calls, and no assumption
   // on buffering or atomicity of output should be made. Thus, we process the
-  // output of all chid processes' debugger agents character by character, and
+  // output of all child processes' debugger agents character by character, and
   // remove each character from the set of expected characters. Once all the
   // output from all debugger agents has been processed, we consider that we got
   // the content we expected if there's no character left in the initial
@@ -91,5 +91,5 @@ function assertDebuggerAgentsOutput() {
     expectedContent = expectedContent.replace(char, '');
   });
 
-  assert.equal(expectedContent, '');
+  assert.strictEqual(expectedContent, '');
 }

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const os = require('os');
 const path = require('path');
 
 const port = common.PORT;
@@ -11,13 +12,24 @@ const args = [`--debug-port=${port}`, serverPath];
 const options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };
 const child = spawn(process.execPath, args, options);
 
-const outputLines = [];
-var waitingForDebuggers = false;
+var expectedContent = [
+  'Starting debugger agent.',
+  'Debugger listening on 127.0.0.1:' + (port + 0),
+  'Starting debugger agent.',
+  'Debugger listening on 127.0.0.1:' + (port + 1),
+  'Starting debugger agent.',
+  'Debugger listening on 127.0.0.1:' + (port + 2),
+].join(os.EOL);
+expectedContent += os.EOL; // the last line also contains an EOL character
+
+var debuggerAgentsOutput = '';
+var debuggerAgentsStarted = false;
 
 var pids;
 
 child.stderr.on('data', function(data) {
-  const lines = data.toString().replace(/\r/g, '').trim().split('\n');
+  const childStderrOutputString = data.toString();
+  const lines = childStderrOutputString.replace(/\r/g, '').trim().split('\n');
 
   lines.forEach(function(line) {
     console.log('> ' + line);
@@ -30,24 +42,26 @@ child.stderr.on('data', function(data) {
         pids = msg.pids;
         console.error('got pids %j', pids);
 
-        waitingForDebuggers = true;
         process._debugProcess(child.pid);
+        debuggerAgentsStarted = true;
       });
 
       child.send({
         type: 'getpids'
       });
-    } else if (waitingForDebuggers) {
-      outputLines.push(line);
     }
-
   });
-  if (outputLines.length === expectedLines.length)
-    onNoMoreLines();
+
+  if (debuggerAgentsStarted) {
+    debuggerAgentsOutput += childStderrOutputString;
+    if (debuggerAgentsOutput.length === expectedContent.length) {
+      onNoMoreDebuggerAgentsOutput();
+    }
+  }
 });
 
-function onNoMoreLines() {
-  assertOutputLines();
+function onNoMoreDebuggerAgentsOutput() {
+  assertDebuggerAgentsOutput();
   process.exit();
 }
 
@@ -63,21 +77,19 @@ process.on('exit', function onExit() {
   });
 });
 
-const expectedLines = [
-  'Starting debugger agent.',
-  'Debugger listening on 127.0.0.1:' + (port + 0),
-  'Starting debugger agent.',
-  'Debugger listening on 127.0.0.1:' + (port + 1),
-  'Starting debugger agent.',
-  'Debugger listening on 127.0.0.1:' + (port + 2),
-];
+function assertDebuggerAgentsOutput() {
+  // Workers can take different amout of time to start up, and child processes'
+  // output may be interleaved arbitrarily. Moreover, child processes' output
+  // may be written using an arbitrary number of system calls, and no assumption
+  // on buffering or atomicity of output should be made. Thus, we process the
+  // output of all chid processes' debugger agents character by character, and
+  // remove each character from the set of expected characters. Once all the
+  // output from all debugger agents has been processed, we consider that we got
+  // the content we expected if there's no character left in the initial
+  // expected content.
+  debuggerAgentsOutput.split('').forEach(function gotChar(char) {
+    expectedContent = expectedContent.replace(char, '');
+  });
 
-function assertOutputLines() {
-  // Do not assume any particular order of output messages,
-  // since workers can take different amout of time to
-  // start up
-  outputLines.sort();
-  expectedLines.sort();
-
-  assert.deepStrictEqual(outputLines, expectedLines);
+  assert.equal(expectedContent, '');
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Tests.

##### Description of change

Do not assume any order and buffering/atomicity of output from child
processes' debugger agents.

Fixes #3796.