### PR TITLE
src: Malloc/Calloc size 0 returns non-null pointer

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5368,7 +5368,7 @@ class RandomBytesRequest : public AsyncWrap {
         error_(0),
         size_(size),
         data_(static_cast<char*>(node::Malloc(size))) {
-    if (data() == nullptr && size > 0)
+    if (data() == nullptr)
       FatalError("node::RandomBytesRequest()", "Out of Memory");
     Wrap(object, this);
   }

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -246,11 +246,13 @@ void* Realloc(void* pointer, size_t size) {
 
 // As per spec realloc behaves like malloc if passed nullptr.
 void* Malloc(size_t size) {
+  if (size == 0) size = 1;
   return Realloc(nullptr, size);
 }
 
 void* Calloc(size_t n, size_t size) {
-  if ((n == 0) || (size == 0)) return nullptr;
+  if (n == 0) n = 1;
+  if (size == 0) size = 1;
   CHECK_GE(n * size, n);  // Overflow guard.
   return calloc(n, size);
 }

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -89,3 +89,17 @@ TEST(UtilTest, ToLower) {
   EXPECT_EQ('a', ToLower('a'));
   EXPECT_EQ('a', ToLower('A'));
 }
+
+TEST(UtilTest, Malloc) {
+  using node::Malloc;
+  EXPECT_NE(nullptr, Malloc(0));
+  EXPECT_NE(nullptr, Malloc(1));
+}
+
+TEST(UtilTest, Calloc) {
+  using node::Calloc;
+  EXPECT_NE(nullptr, Calloc(0, 0));
+  EXPECT_NE(nullptr, Calloc(1, 0));
+  EXPECT_NE(nullptr, Calloc(0, 1));
+  EXPECT_NE(nullptr, Calloc(1, 1));
+}

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -84,3 +84,11 @@ assert.throws(function() {
 assert.throws(function() {
   crypto.pbkdf2('password', 'salt', 1, 4073741824, 'sha256', common.fail);
 }, /Bad key length/);
+
+// Should not get FATAL ERROR with empty password and salt
+// https://github.com/nodejs/node/issues/8571
+assert.doesNotThrow(() => {
+  crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustCall((e) => {
+    assert.ifError(e);
+  }));
+});


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

crypto.pbkdf2() with empty password and/or salt causes a fatal error in
Node.js 6.6.0. It did not in 6.5.0. The problematic change is
a00ccb0fb9eb716925058b0a20fcec9251de3309. We still need to review other
changes in that change set, but this is a test and fix for the specific
issue reported in https://github.com/nodejs/node/issues/8571.

The problem is that `malloc(0)` may return NULL on some platforms. So
do not report out-of-memory error unless `malloc` was passed a number
greater than `0`.

Fixes: https://github.com/nodejs/node/issues/8571