### PR TITLE
tools: increase armv6 timeout

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -816,7 +816,7 @@ FLAGS = {
     'debug'   : ['--enable-slow-asserts', '--debug-code', '--verify-heap'],
     'release' : []}
 TIMEOUT_SCALEFACTOR = {
-    'armv6' : { 'debug' : 12, 'release' : 3 },  # The ARM buildbots are slow.
+    'armv6' : { 'debug' : 12, 'release' : 5 },  # The ARM buildbots are slow.
     'arm'   : { 'debug' :  8, 'release' : 2 },
     'ia32'  : { 'debug' :  4, 'release' : 1 },
     'ppc'   : { 'debug' :  4, 'release' : 1 },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

Instead of skipping tests on Raspberry Pi in CI, this will allow a bit
more time for them to finish. We will likely still have to skip some,
but hopefully not nearly as many. This is especially targeted at the
various test-tick-processor-* tests.