### PR TITLE
module: NativeModule._cache turned to a Map

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -402,7 +402,7 @@
   }
 
   NativeModule._source = process.binding('natives');
-  NativeModule._cache = {};
+  NativeModule._cache = new Map();
 
   NativeModule.require = function(id) {
     if (id == 'native_module') {
@@ -429,7 +429,7 @@
   };
 
   NativeModule.getCached = function(id) {
-    return NativeModule._cache[id];
+    return NativeModule._cache.get(id);
   };
 
   NativeModule.exists = function(id) {
@@ -491,7 +491,7 @@
   };
 
   NativeModule.prototype.cache = function() {
-    NativeModule._cache[this.id] = this;
+    NativeModule._cache.set(this.id, this);
   };
 
   startup();


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Description of change

Changed `NativeModule._cache` in `lib/internal/bootstrap_node.js` to be a `Map`, in accordance to https://github.com/nodejs/code-and-learn/issues/56#issuecomment-247447165

<!-- Provide a description of the change below this comment. -->
