### PR TITLE
util: Add format for SharedArrayBuffer

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -447,9 +447,10 @@ function formatValue(ctx, value, recurseTimes) {
       formatted = formatPrimitiveNoColor(ctx, raw);
       return ctx.stylize('[Boolean: ' + formatted + ']', 'boolean');
     }
-    // Fast path for ArrayBuffer.  Can't do the same for DataView because it
-    // has a non-primitive .buffer property that we need to recurse for.
-    if (binding.isArrayBuffer(value)) {
+    // Fast path for ArrayBuffer and SharedArrayBuffer.
+    // Can't do the same for DataView because it has a non-primitive
+    // .buffer property that we need to recurse for.
+    if (binding.isArrayBuffer(value) || binding.isSharedArrayBuffer(value)) {
       return `${getConstructorOf(value).name}` +
              ` { byteLength: ${formatNumber(ctx, value.byteLength)} }`;
     }
@@ -487,7 +488,8 @@ function formatValue(ctx, value, recurseTimes) {
       keys.unshift('size');
     empty = value.size === 0;
     formatter = formatMap;
-  } else if (binding.isArrayBuffer(value)) {
+  } else if (binding.isArrayBuffer(value) ||
+             binding.isSharedArrayBuffer(value)) {
     braces = ['{', '}'];
     keys.unshift('byteLength');
     visibleKeys.byteLength = true;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -20,7 +20,6 @@ using v8::Value;
 
 #define VALUE_METHOD_MAP(V)                                                   \
   V(isArrayBuffer, IsArrayBuffer)                                             \
-  V(isSharedArrayBuffer, IsSharedArrayBuffer)                                 \
   V(isDataView, IsDataView)                                                   \
   V(isDate, IsDate)                                                           \
   V(isMap, IsMap)                                                             \
@@ -29,6 +28,7 @@ using v8::Value;
   V(isRegExp, IsRegExp)                                                       \
   V(isSet, IsSet)                                                             \
   V(isSetIterator, IsSetIterator)                                             \
+  V(isSharedArrayBuffer, IsSharedArrayBuffer)                                 \
   V(isTypedArray, IsTypedArray)
 
 

--- a/test/parallel/test-util-format-shared-arraybuffer.js
+++ b/test/parallel/test-util-format-shared-arraybuffer.js
@@ -1,0 +1,10 @@
+// Flags: --harmony_sharedarraybuffer
+
+'use strict';
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+/* global SharedArrayBuffer */
+const sab = new SharedArrayBuffer(4);
+assert.strictEqual(util.format(sab), 'SharedArrayBuffer { byteLength: 4 }');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util

##### Description of change
<!-- Provide a description of the change below this comment. -->

[SharedArrayBuffer](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) is a new global object to share memories between workers.
Currently workers does not work in node, but future v8 has those new global objects.
This change supports a format for SharedArrayBuffer.

Note: this PR is from code-and-learn 
https://github.com/nodejs/code-and-learn/issues/56#issuecomment-247447165