### PR TITLE
internal: changed var to const in bootstrap_node.js

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -10,7 +10,7 @@
 (function(process) {
 
   function startup() {
-    var EventEmitter = NativeModule.require('events');
+    const EventEmitter = NativeModule.require('events');
     process._eventsCount = 0;
 
     Object.setPrototypeOf(process, Object.create(EventEmitter.prototype, {
@@ -92,7 +92,7 @@
       // channel. This needs to be done before any user code gets executed
       // (including preload modules).
       if (process.argv[1] && process.env.NODE_UNIQUE_ID) {
-        var cluster = NativeModule.require('cluster');
+        const cluster = NativeModule.require('cluster');
         cluster._setupWorker();
 
         // Make sure it's not accidentally inherited by child processes.
@@ -111,18 +111,18 @@
         });
       } else if (process.argv[1]) {
         // make process.argv[1] into a full path
-        var path = NativeModule.require('path');
+        const path = NativeModule.require('path');
         process.argv[1] = path.resolve(process.argv[1]);
 
-        var Module = NativeModule.require('module');
+        const Module = NativeModule.require('module');
 
         // check if user passed `-c` or `--check` arguments to Node.
         if (process._syntax_check_only != null) {
-          var vm = NativeModule.require('vm');
-          var fs = NativeModule.require('fs');
-          var internalModule = NativeModule.require('internal/module');
+          const vm = NativeModule.require('vm');
+          const fs = NativeModule.require('fs');
+          const internalModule = NativeModule.require('internal/module');
           // read the source
-          var filename = Module._resolveFilename(process.argv[1]);
+          const filename = Module._resolveFilename(process.argv[1]);
           var source = fs.readFileSync(filename, 'utf-8');
           // remove shebang and BOM
           source = internalModule.stripBOM(source.replace(/^\#\!.*/, ''));
@@ -140,7 +140,7 @@
         // If -i or --interactive were passed, or stdin is a TTY.
         if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
           // REPL
-          var cliRepl = NativeModule.require('internal/repl');
+          const cliRepl = NativeModule.require('internal/repl');
           cliRepl.createInternalRepl(process.env, function(err, repl) {
             if (err) {
               throw err;
@@ -254,7 +254,7 @@
                                            wrapConsoleCall) {
     if (!inspectorConsole)
       return;
-    var config = {};
+    const config = {};
     for (const key of Object.keys(console)) {
       if (!inspectorConsole.hasOwnProperty(key))
         continue;
@@ -374,7 +374,7 @@
       // V8 debug object about a connection, and runMain when
       // that occurs.  --isaacs
 
-      var debugTimeout = +process.env.NODE_DEBUG_TIMEOUT || 50;
+      const debugTimeout = +process.env.NODE_DEBUG_TIMEOUT || 50;
       setTimeout(entryFunction, debugTimeout);
 
     } else {
@@ -387,9 +387,9 @@
   // core modules found in lib/*.js. All core modules are compiled into the
   // node binary, so they can be loaded faster.
 
-  var ContextifyScript = process.binding('contextify').ContextifyScript;
+  const ContextifyScript = process.binding('contextify').ContextifyScript;
   function runInThisContext(code, options) {
-    var script = new ContextifyScript(code, options);
+    const script = new ContextifyScript(code, options);
     return script.runInThisContext();
   }
 
@@ -409,7 +409,7 @@
       return NativeModule;
     }
 
-    var cached = NativeModule.getCached(id);
+    const cached = NativeModule.getCached(id);
     if (cached && (cached.loaded || cached.loading)) {
       return cached.exports;
     }
@@ -420,7 +420,7 @@
 
     process.moduleLoadList.push(`NativeModule ${id}`);
 
-    var nativeModule = new NativeModule(id);
+    const nativeModule = new NativeModule(id);
 
     nativeModule.cache();
     nativeModule.compile();
@@ -477,7 +477,7 @@
     this.loading = true;
 
     try {
-      var fn = runInThisContext(source, {
+      const fn = runInThisContext(source, {
         filename: this.filename,
         lineOffset: 0,
         displayErrors: true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
`internals`


##### Description of change
<!-- Provide a description of the change below this comment. -->
Changed `var` to `const` where needed. Left the ones that can be `let`. @TheAlphaNerd pointed out that it is not used in "core" code.
Part of https://github.com/nodejs/code-and-learn/issues/56

