### PR TITLE
test: modernized JS and tighten equality checking in test-eval.js

### DIFF
--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -1,13 +1,13 @@
 'use strict';
 const common = require('../common');
-var util = require('util');
-var assert = require('assert');
-var exec = require('child_process').exec;
+const util = require('util');
+const assert = require('assert');
+const exec = require('child_process').exec;
 
-var cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
+const cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
            'foo', 'bar'].join(' ');
-var expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
+const expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
 exec(cmd, common.mustCall(function(err, stdout, stderr) {
   assert.ifError(err);
-  assert.equal(stderr, expected);
+  assert.strictEqual(stderr, expected);
 }));

--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -4,8 +4,8 @@ const util = require('util');
 const assert = require('assert');
 const exec = require('child_process').exec;
 
-const cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
-           'foo', 'bar'].join(' ');
+const cmd = ['"' + process.execPath + '"', '-e',
+             '"console.error(process.argv)"', 'foo', 'bar'].join(' ');
 const expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
 exec(cmd, common.mustCall(function(err, stdout, stderr) {
   assert.ifError(err);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Changed var -> const and assert.equal -> assert.strictEqual
Cleanup according to nodejs/code-and-learn#56