### PR TITLE
src: remove unneeded ABORT after CHECK(0)

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1135,7 +1135,6 @@ static void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
     break;
   default:
     CHECK(0 && "bad address family");
-    ABORT();
   }
 
   GetAddrInfoReqWrap* req_wrap = new GetAddrInfoReqWrap(env, req_wrap_obj);
@@ -1261,7 +1260,6 @@ static void SetServers(const FunctionCallbackInfo<Value>& args) {
         break;
       default:
         CHECK(0 && "Bad address family.");
-        ABORT();
     }
 
     if (err)

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -155,7 +155,6 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
     event_string = env->change_string();
   } else {
     CHECK(0 && "bad fs events flag");
-    ABORT();
   }
 
   Local<Value> argv[] = {

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -189,7 +189,6 @@ long NodeBIO::Ctrl(BIO* bio, int cmd, long num,  // NOLINT(runtime/int)
       break;
     case BIO_C_SET_BUF_MEM:
       CHECK(0 && "Can't use SET_BUF_MEM_PTR with NodeBIO");
-      ABORT();
       break;
     case BIO_C_GET_BUF_MEM_PTR:
       CHECK(0 && "Can't use GET_BUF_MEM_PTR with NodeBIO");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change
<!-- Provide a description of the change below this comment. -->

`CHECK` includes `node::Abort()`, so that's unneeded to call `ABORT` after
`CHECK(0)`.

In src/util.h:

```cpp
#define ABORT() node::Abort()
#define CHECK(expr)                                                           \
  do {                                                                        \
    if (UNLIKELY(!(expr))) {                                                  \
      static const char* const args[] = { __FILE__, STRINGIFY(__LINE__),      \
                                          #expr, PRETTY_FUNCTION_NAME };      \
      node::Assert(&args);                                                    \
    }                                                                         \
  } while (0)
```

And in src/node.cc:

```cpp
NO_RETURN void Abort() {
  // ...
}
NO_RETURN void Assert(const char* const (*args)[4]) {
  // ...
  Abort();
}
```

Thus we could remove `ABORT()`s after `CHECK(0)` :)