### PR TITLE
test: update var to const, use arrow functions

### DIFF
--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var cluster = require('cluster');
-var fork = cluster.fork;
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const fork = cluster.fork;
 
 if (cluster.isMaster) {
   fork(); // it is intentionally called `fork` instead of
   fork(); // `cluster.fork` to test that `this` is not used
-  cluster.disconnect(common.mustCall(function() {
+  cluster.disconnect(common.mustCall(() => {
     assert.deepStrictEqual(Object.keys(cluster.workers), []);
   }));
 }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes

##### Affected core subsystem(s)
test

##### Description of change
- Replaced `var` with `const`.
- Replaced anonymous function with arrow function.