### PR TITLE
test: refactor test-crypto test files

### DIFF
--- a/test/parallel/test-crypto-domain.js
+++ b/test/parallel/test-crypto-domain.js
@@ -25,8 +25,8 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const domain = require('domain');
 const crypto = require('crypto');
+const domain = require('domain');
 
 function test(fn) {
   const ex = new Error('BAM');

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -4,8 +4,9 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const crypto = require('crypto');
+const fs = require('fs');
+
 const fixtures = require('../common/fixtures');
 
 // Test hashing
@@ -80,11 +81,11 @@ const fileStream = fs.createReadStream(fn);
 fileStream.on('data', function(data) {
   sha1Hash.update(data);
 });
-fileStream.on('close', function() {
+fileStream.on('close', common.mustCall(function() {
   assert.strictEqual(sha1Hash.digest('hex'),
                      '22723e553129a336ad96e10f6aecdf0f45e4149e',
                      'Test SHA1 of sample.png');
-});
+}));
 
 // Issue #2227: unknown digest method should throw an error.
 assert.throws(function() {


### PR DESCRIPTION
##### Checklist
- [x] `make lint`
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Description of change

Updated ./test/parallel/test-crypto*
- `var` to `const`
- `assert.equal` to `assert.StrictEqual`, same with `notEqual`
- wrap callback with `common.mustCall()`
