### PR TITLE
Raise a warning when listening for usafe signals

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -191,6 +191,14 @@ function setupSignalHandlers() {
   process.on('newListener', function(type, listener) {
     if (isSignal(type) &&
         !signalWraps.hasOwnProperty(type)) {
+
+      if (['SIGBUS', 'SIGFPE', 'SIGSEGV', 'SIGILL'].indexOf(type) > -1) {
+        process.emitWarning(
+          'Listening to SIGBUS, SIGFPE, SIGSEGV, SIGILL signals ' +
+          'is not safe and the listener may be called in an ' +
+          'infinite loop');
+      }
+
       const Signal = process.binding('signal_wrap').Signal;
       const wrap = new Signal();
 

--- a/test/parallel/test-process-safe-signals.js
+++ b/test/parallel/test-process-safe-signals.js
@@ -1,0 +1,5 @@
+'use strict';
+const common = require('../common');
+
+process.on('warning', common.fail);
+process.on('SIGINT', () => {});

--- a/test/parallel/test-process-unsafe-signals.js
+++ b/test/parallel/test-process-unsafe-signals.js
@@ -1,0 +1,13 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+process.on('warning', common.mustCall((warning) => {
+  assert.strictEqual(warning.name, 'Warning');
+  assert.strictEqual(warning.message,
+                     'Listening to SIGBUS, SIGFPE, SIGSEGV, SIGILL signals ' +
+                     'is not safe and the listener may be called in an ' +
+                     'infinite loop');
+}));
+
+process.on('SIGBUS', () => {});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] `make -j4 test` (UNIX)
- [x ] tests and/or benchmarks are included
- [nodejs/node#8410] documentation is changed or added 
- [ x] commit message follows commit guidelines
##### Description of change

<!-- Provide a description of the change below this comment. -->

We might want to emit a warning for signals that users shouldn’t listen on (as listed in the docs warning in nodejs/node#8410)
