### PR TITLE
test: replace var with const and add mustCall cb

### DIFF
--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -1,8 +1,8 @@
 'use strict';
 const common = require('../common');
-var http = require('http');
+const http = require('http');
 
-var server = http.Server(function(req, res) {
+const server = http.Server(function(req, res) {
   console.log('Server accepted request.');
   res.writeHead(200);
   res.write('Part of my res.');
@@ -20,24 +20,25 @@ server.listen(0, common.mustCall(function() {
     console.log('Got res: ' + res.statusCode);
     console.dir(res.headers);
 
-    res.on('data', function(chunk) {
+    res.on('data', common.mustCall((chunk) => {
       console.log('Read ' + chunk.length + ' bytes');
       console.log(' chunk=%j', chunk.toString());
-    });
+    }));
 
-    res.on('end', function() {
+    res.on('end', common.mustCall(() => {
       console.log('Response ended.');
-    });
+    }));
 
-    res.on('aborted', function() {
+    res.on('aborted', common.mustCall(() => {
       console.log('Response aborted.');
-    });
+    }));
 
-    res.socket.on('close', function() {
+    res.socket.on('close', common.mustCall(() => {
       console.log('socket closed, but not res');
-    });
+    }));
 
-    // it would be nice if this worked:
-    res.on('close', common.mustCall(function() {}));
+    res.on('close', common.mustCall(() => {
+      console.log('Response closed.');
+    }));
   }));
 }));


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

test
##### Description of change

Replaced all `var` usage with `const`.
Replaced all provided callbacks with the `common.mustCall` helper
method.
Removed the funny comment because, thanks to mustCall, it actually
runs.
