### PR TITLE
src: Add does_zap_garbage to v8 HeapStatistics

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -22,6 +22,15 @@ Returns an object with the following properties:
 * `total_available_size` {number}
 * `used_heap_size` {number}
 * `heap_size_limit` {number}
+* `malloced_memory` {number}
+* `peak_malloced_memory` {number}
+* `does_zap_garbage` {number}
+
+`does_zap_garbage` is a 0/1 boolean, which signifies whether the `--zap_code_space`
+option is enabled or not. This makes V8 overwrite heap garbage with a bit
+pattern. The RSS footprint (resident memory set) gets bigger because it 
+continuously touches all heap pages and that makes them less likely to get 
+swapped out by the operating system.
 
 For example:
 
@@ -32,7 +41,10 @@ For example:
   total_physical_size: 7326976,
   total_available_size: 1152656,
   used_heap_size: 3476208,
-  heap_size_limit: 1535115264
+  heap_size_limit: 1535115264,
+  malloced_memory: 16384,
+  peak_malloced_memory: 1127496,
+  does_zap_garbage: 0
 }
 ```
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -25,6 +25,9 @@ const kTotalPhysicalSizeIndex = v8binding.kTotalPhysicalSizeIndex;
 const kTotalAvailableSize = v8binding.kTotalAvailableSize;
 const kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
 const kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
+const kDoesZapGarbageIndex = v8binding.kDoesZapGarbageIndex;
+const kMallocedMemoryIndex = v8binding.kMallocedMemoryIndex;
+const kPeakMallocedMemoryIndex = v8binding.kPeakMallocedMemoryIndex;
 
 // Properties for heap space statistics buffer extraction.
 const heapSpaceStatisticsBuffer =
@@ -49,7 +52,10 @@ exports.getHeapStatistics = function() {
     'total_physical_size': buffer[kTotalPhysicalSizeIndex],
     'total_available_size': buffer[kTotalAvailableSize],
     'used_heap_size': buffer[kUsedHeapSizeIndex],
-    'heap_size_limit': buffer[kHeapSizeLimitIndex]
+    'heap_size_limit': buffer[kHeapSizeLimitIndex],
+    'malloced_memory': buffer[kMallocedMemoryIndex],
+    'peak_malloced_memory': buffer[kPeakMallocedMemoryIndex],
+    'does_zap_garbage': buffer[kDoesZapGarbageIndex]
   };
 };
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -28,7 +28,10 @@ using v8::Value;
   V(2, total_physical_size, kTotalPhysicalSizeIndex)                          \
   V(3, total_available_size, kTotalAvailableSize)                             \
   V(4, used_heap_size, kUsedHeapSizeIndex)                                    \
-  V(5, heap_size_limit, kHeapSizeLimitIndex)
+  V(5, heap_size_limit, kHeapSizeLimitIndex)                                  \
+  V(6, malloced_memory, kMallocedMemoryIndex)                                 \
+  V(7, peak_malloced_memory, kPeakMallocedMemoryIndex)                        \
+  V(8, does_zap_garbage, kDoesZapGarbageIndex)
 
 #define V(a, b, c) +1
 static const size_t kHeapStatisticsPropertiesCount =

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -5,7 +5,10 @@ var v8 = require('v8');
 
 var s = v8.getHeapStatistics();
 var keys = [
+  'does_zap_garbage',
   'heap_size_limit',
+  'malloced_memory',
+  'peak_malloced_memory',
   'total_available_size',
   'total_heap_size',
   'total_heap_size_executable',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s) src, doc

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
##### Description of change

<!-- Provide a description of the change below this comment. -->

Following https://github.com/nodejs/code-and-learn/issues/56 I have exposed does_zap_garbage to HeapStatistics.
The other fields, malloced_memory and peak_malloced_memory don't seem to be in the current version of v8 in master.

I have also updated the docs and test so that it matches the 
