### PR TITLE
crypto: fix default encoding of LazyTransform

### DIFF
--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -5,6 +5,7 @@
 
 const stream = require('stream');
 const util = require('util');
+const crypto = require('crypto');
 
 module.exports = LazyTransform;
 
@@ -22,7 +23,11 @@ util.inherits(LazyTransform, stream.Transform);
     get: function() {
       stream.Transform.call(this, this._options);
       this._writableState.decodeStrings = false;
-      this._writableState.defaultEncoding = 'latin1';
+
+      if (!this._options || !this._options.defaultEncoding) {
+        this._writableState.defaultEncoding = crypto.DEFAULT_ENCODING;
+      }
+
       return this[prop];
     },
     set: function(val) {

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -181,9 +181,9 @@ function testEncoding(options, assertionHash) {
     hashValue += data.toString('hex');
   });
 
-  hash.on('end', () => {
-    assert.equal(hashValue, assertionHash);
-  });
+  hash.on('end', common.mustCall(() => {
+    assert.strictEqual(hashValue, assertionHash);
+  }));
 
   hash.write('öäü');
   hash.end();
@@ -193,8 +193,8 @@ function testEncoding(options, assertionHash) {
 const assertionHashUtf8 =
   '4f53d15bee524f082380e6d7247cc541e7cb0d10c64efdcc935ceeb1e7ea345c';
 
-// Hash of "öäü" in ascii format
-const assertionHashAscii =
+// Hash of "öäü" in latin1 format
+const assertionHashLatin1 =
   'cd37bccd5786e2e76d9b18c871e919e6eb11cc12d868f5ae41c40ccff8e44830';
 
 testEncoding(undefined, assertionHashUtf8);
@@ -205,5 +205,5 @@ testEncoding({
 }, assertionHashUtf8);
 
 testEncoding({
-  defaultEncoding: 'ascii'
-}, assertionHashAscii);
+  defaultEncoding: 'latin1'
+}, assertionHashLatin1);

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -168,3 +168,42 @@ console.log(crypto.randomBytes(16));
 assert.throws(function() {
   tls.createSecureContext({ crl: 'not a CRL' });
 }, /^Error: Failed to parse CRL$/);
+
+/**
+ * Check if the stream function uses utf8 as a default encoding.
+ **/
+
+function testEncoding(options, assertionHash) {
+  const hash = crypto.createHash('sha256', options);
+  let hashValue = '';
+
+  hash.on('data', (data) => {
+    hashValue += data.toString('hex');
+  });
+
+  hash.on('end', () => {
+    assert.equal(hashValue, assertionHash);
+  });
+
+  hash.write('öäü');
+  hash.end();
+}
+
+// Hash of "öäü" in utf8 format
+const assertionHashUtf8 =
+  '4f53d15bee524f082380e6d7247cc541e7cb0d10c64efdcc935ceeb1e7ea345c';
+
+// Hash of "öäü" in ascii format
+const assertionHashAscii =
+  'cd37bccd5786e2e76d9b18c871e919e6eb11cc12d868f5ae41c40ccff8e44830';
+
+testEncoding(undefined, assertionHashUtf8);
+testEncoding({}, assertionHashUtf8);
+
+testEncoding({
+  defaultEncoding: 'utf8'
+}, assertionHashUtf8);
+
+testEncoding({
+  defaultEncoding: 'ascii'
+}, assertionHashAscii);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

crypto
##### Description of change

<!-- Provide a description of the change below this comment. -->

Change the default encoding from latin1 to utf8
and extend the test-crypto tests.
