### PR TITLE
util: support SharedArrayBuffer in inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -447,9 +447,10 @@ function formatValue(ctx, value, recurseTimes) {
       formatted = formatPrimitiveNoColor(ctx, raw);
       return ctx.stylize('[Boolean: ' + formatted + ']', 'boolean');
     }
-    // Fast path for ArrayBuffer.  Can't do the same for DataView because it
-    // has a non-primitive .buffer property that we need to recurse for.
-    if (binding.isArrayBuffer(value)) {
+    // Fast path for ArrayBuffer and SharedArrayBuffer.
+    // Can't do the same for DataView because it has a non-primitive .buffer
+    // property that we need to recurse for.
+    if (binding.isArrayBuffer(value) || binding.isSharedArrayBuffer(value)) {
       return `${getConstructorOf(value).name}` +
              ` { byteLength: ${formatNumber(ctx, value.byteLength)} }`;
     }
@@ -487,7 +488,8 @@ function formatValue(ctx, value, recurseTimes) {
       keys.unshift('size');
     empty = value.size === 0;
     formatter = formatMap;
-  } else if (binding.isArrayBuffer(value)) {
+  } else if (binding.isArrayBuffer(value) ||
+             binding.isSharedArrayBuffer(value)) {
     braces = ['{', '}'];
     keys.unshift('byteLength');
     visibleKeys.byteLength = true;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -20,6 +20,7 @@ using v8::Value;
 
 #define VALUE_METHOD_MAP(V)                                                   \
   V(isArrayBuffer, IsArrayBuffer)                                             \
+  V(isSharedArrayBuffer, IsSharedArrayBuffer)                                 \
   V(isDataView, IsDataView)                                                   \
   V(isDate, IsDate)                                                           \
   V(isMap, IsMap)                                                             \

--- a/test/parallel/test-util-inspect-sharedarraybuffer.js
+++ b/test/parallel/test-util-inspect-sharedarraybuffer.js
@@ -1,0 +1,10 @@
+// Flags: --harmony_sharedarraybuffer
+/* global SharedArrayBuffer */
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const inspect = require('util').inspect;
+
+assert.strictEqual(inspect(new SharedArrayBuffer(4)),
+  'SharedArrayBuffer { byteLength: 4 }');

--- a/test/parallel/test-util-inspect-simd.js
+++ b/test/parallel/test-util-inspect-simd.js
@@ -60,7 +60,7 @@ if (typeof SIMD.Uint8x16 === 'function') {
       'Uint8x16 [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]');
 }
 
-// Tests from test-inspect.js that should not fail with --harmony_simd.
+// Tests from test-util-inspect.js that should not fail with --harmony_simd.
 assert.strictEqual(inspect([]), '[]');
 assert.strictEqual(inspect([0]), '[ 0 ]');
 assert.strictEqual(inspect({}), '{}');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
@@ -42,6 +43,8 @@ assert.strictEqual(util.inspect(Object.create({},
   {visible: {value: 1, enumerable: true}, hidden: {value: 2}})),
   '{ visible: 1 }'
 );
+assert.strictEqual(util.inspect(new ArrayBuffer(4)),
+  'ArrayBuffer { byteLength: 4 }');
 
 assert(/Object/.test(
   util.inspect({a: {a: {a: {a: {}}}}}, undefined, undefined, true)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util
##### Description of change

<!-- Provide a description of the change below this comment. -->

Update inspect utility to support readable output of `SharedArrayBuffer` object. `SharedArrayBuffer` is available behind the `harmony_sharedarraybuffer` v8 flag. [See the MDN docs for more details on what a `SharedArrayBuffer` is](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer).
