### PR TITLE
test: clean tls-connect-given-socket

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -279,7 +279,7 @@ added: v0.1.16
 
 * `...paths` {String} A sequence of path segments
 
-The `path.join()` method join all given `path` segments together using the
+The `path.join()` method joins all given `path` segments together using the
 platform specific separator as a delimiter, then normalizes the resulting path.
 
 Zero-length `path` segments are ignored. If the joined path string is a

--- a/test/parallel/test-tls-connect-given-socket.js
+++ b/test/parallel/test-tls-connect-given-socket.js
@@ -1,42 +1,42 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
-var net = require('net');
-var fs = require('fs');
-var path = require('path');
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
 
-var serverConnected = 0;
-var clientConnected = 0;
+let serverConnected = 0;
+let clientConnected = 0;
 
-var options = {
+const options = {
   key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem')),
   cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
 };
 
-var server = tls.createServer(options, function(socket) {
+const server = tls.createServer(options, function(socket) {
   serverConnected++;
   socket.end('Hello');
 }).listen(0, function() {
-  var waiting = 2;
+  let waiting = 2;
   function establish(socket) {
-    var client = tls.connect({
+    const client = tls.connect({
       rejectUnauthorized: false,
       socket: socket
     }, function() {
       clientConnected++;
-      var data = '';
+      let data = '';
       client.on('data', function(chunk) {
         data += chunk.toString();
       });
       client.on('end', function() {
-        assert.equal(data, 'Hello');
+        assert.strictEqual(data, 'Hello');
         if (--waiting === 0)
           server.close();
       });
@@ -48,31 +48,30 @@ var server = tls.createServer(options, function(socket) {
   }
 
   // Immediate death socket
-  var immediateDeath = net.connect(this.address().port);
+  const immediateDeath = net.connect(this.address().port);
   establish(immediateDeath).destroy();
 
   // Outliving
-  var outlivingTCP = net.connect(this.address().port);
-  outlivingTCP.on('connect', function() {
+  const outlivingTCP = net.connect(this.address().port);
+  outlivingTCP.on('connect', common.mustCall(function() {
     outlivingTLS.destroy();
     next();
-  });
-  var outlivingTLS = establish(outlivingTCP);
+  }));
+  const outlivingTLS = establish(outlivingTCP);
 
   function next() {
     // Already connected socket
-    var connected = net.connect(server.address().port, function() {
+    const connected = net.connect(server.address().port, function() {
       establish(connected);
     });
 
     // Connecting socket
-    var connecting = net.connect(server.address().port);
+    const connecting = net.connect(server.address().port);
     establish(connecting);
-
   }
 });
 
 process.on('exit', function() {
-  assert.equal(serverConnected, 2);
-  assert.equal(clientConnected, 2);
+  assert.strictEqual(serverConnected, 2);
+  assert.strictEqual(clientConnected, 2);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes

##### Description of change
<!-- Provide a description of the change below this comment. -->

Changed vars to consts and lets, assert.equals to assert.strictEquals and added
common.mustCall around a connect callback