### PR TITLE
test: vars to const and let in child_process

### DIFF
--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -1,10 +1,10 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var spawn = require('child_process').spawn;
+const spawn = require('child_process').spawn;
 
-var cat = spawn(common.isWindows ? 'more' : 'cat');
+const cat = spawn(common.isWindows ? 'more' : 'cat');
 cat.stdin.write('hello');
 cat.stdin.write(' ');
 cat.stdin.write('world');
@@ -14,7 +14,7 @@ assert.ok(!cat.stdin.readable);
 
 cat.stdin.end();
 
-var response = '';
+let response = '';
 
 cat.stdout.setEncoding('utf8');
 cat.stdout.on('data', function(chunk) {

--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -1,7 +1,7 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var BUFSIZE = 1024;
+const assert = require('assert');
+const BUFSIZE = 1024;
 
 switch (process.argv[2]) {
   case undefined:
@@ -13,11 +13,11 @@ switch (process.argv[2]) {
 }
 
 function parent() {
-  var spawn = require('child_process').spawn;
-  var child = spawn(process.execPath, [__filename, 'child']);
-  var sent = 0;
+  const spawn = require('child_process').spawn;
+  const child = spawn(process.execPath, [__filename, 'child']);
+  let sent = 0;
 
-  var n = '';
+  let n = '';
   child.stdout.setEncoding('ascii');
   child.stdout.on('data', function(c) {
     n += c;
@@ -34,7 +34,7 @@ function parent() {
   } while (child.stdin.write(buf));
 
   // then write a bunch more times.
-  for (var i = 0; i < 100; i++) {
+  for (let i = 0; i < 100; i++) {
     const buf = Buffer.alloc(BUFSIZE, '.');
     sent += BUFSIZE;
     child.stdin.write(buf);
@@ -47,7 +47,7 @@ function parent() {
 }
 
 function child() {
-  var received = 0;
+  let received = 0;
   process.stdin.on('data', function(c) {
     received += c.length;
   });

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var options = {stdio: ['pipe']};
-var child = common.spawnPwd(options);
+let options = {stdio: ['pipe']};
+let child = common.spawnPwd(options);
 
 assert.notEqual(child.stdout, null);
 assert.notEqual(child.stderr, null);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
<!-- Provide a description of the change below this comment. -->

Replaced var keyword with const and let in some of the tests for child
process stdin and stdio.

As part of https://github.com/nodejs/code-and-learn/issues/56