### PR TITLE
test: assert was never checked

### DIFF
--- a/test/parallel/test-http-abort-before-end.js
+++ b/test/parallel/test-http-abort-before-end.js
@@ -1,25 +1,29 @@
 'use strict';
 const common = require('../common');
-var http = require('http');
-var assert = require('assert');
+const http = require('http');
+const assert = require('assert');
 
-var server = http.createServer(common.fail);
+const server = http.createServer(common.skip);
 
-server.listen(0, function() {
-  var req = http.request({
+server.listen(0, common.mustCall(function() {
+  const req = http.request({
     method: 'GET',
     host: '127.0.0.1',
     port: this.address().port
   });
 
-  req.on('error', function(ex) {
+  req.write('foo=bar');
+
+  req.on('error', common.mustCall((ex) => {
     // https://github.com/joyent/node/issues/1399#issuecomment-2597359
     // abort() should emit an Error, not the net.Socket object
     assert(ex instanceof Error);
+  }));
+
+  server.once('request', () => {
+    req.abort();
+    req.end();
+
+    server.close();
   });
-
-  req.abort();
-  req.end();
-
-  server.close();
-});
+}));


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test
##### Description of change

<!-- Provide a description of the change below this comment. -->

Since there was no request being made, the socket was clean closed.
Adding `common.mustCall` helped figuring out that the `error` event was
never fired.
Also, the helper callback supplied upon `createServer` would throw an
error when there was one so i replaced with `common.skip` so the error
can be debugged.
Thanks @mikeal for the tip!
