### PR TITLE
udp/stream: use MaybeStackBuffers to manage buffer memory management

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -102,8 +102,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   size_t count = chunks->Length() >> 1;
 
-  uv_buf_t bufs_[16];
-  uv_buf_t* bufs = bufs_;
+  MaybeStackBuffer<uv_buf_t> bufs(count);
 
   // Determine storage size first
   size_t storage_size = 0;
@@ -131,9 +130,6 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   if (storage_size > INT_MAX)
     return UV_ENOBUFS;
-
-  if (arraysize(bufs_) < count)
-    bufs = new uv_buf_t[count];
 
   WriteWrap* req_wrap = WriteWrap::New(env,
                                        req_wrap_obj,
@@ -174,11 +170,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
     bytes += str_size;
   }
 
-  int err = DoWrite(req_wrap, bufs, count, nullptr);
-
-  // Deallocate space
-  if (bufs != bufs_)
-    delete[] bufs;
+  int err = DoWrite(req_wrap, *bufs, count, nullptr);
 
   req_wrap->object()->Set(env->async(), True(env->isolate()));
   req_wrap->object()->Set(env->bytes_string(),

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -102,7 +102,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   size_t count = chunks->Length() >> 1;
 
-  MaybeStackBuffer<uv_buf_t> bufs(count);
+  MaybeStackBuffer<uv_buf_t, 16> bufs(count);
 
   // Determine storage size first
   size_t storage_size = 0;

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -275,13 +275,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   SendWrap* req_wrap = new SendWrap(env, req_wrap_obj, have_callback);
   size_t msg_size = 0;
 
-  // allocate uv_buf_t of the correct size
-  // if bigger than 16 elements
-  uv_buf_t bufs_[16];
-  uv_buf_t* bufs = bufs_;
-
-  if (arraysize(bufs_) < count)
-    bufs = new uv_buf_t[count];
+  MaybeStackBuffer<uv_buf_t> bufs(count);
 
   // construct uv_buf_t array
   for (size_t i = 0; i < count; i++) {
@@ -313,15 +307,11 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   if (err == 0) {
     err = uv_udp_send(&req_wrap->req_,
                       &wrap->handle_,
-                      bufs,
+                      *bufs,
                       count,
                       reinterpret_cast<const sockaddr*>(&addr),
                       OnSend);
   }
-
-  // Deallocate space
-  if (bufs != bufs_)
-    delete[] bufs;
 
   req_wrap->Dispatched();
   if (err)

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -275,7 +275,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   SendWrap* req_wrap = new SendWrap(env, req_wrap_obj, have_callback);
   size_t msg_size = 0;
 
-  MaybeStackBuffer<uv_buf_t> bufs(count);
+  MaybeStackBuffer<uv_buf_t, 16> bufs(count);
 
   // construct uv_buf_t array
   for (size_t i = 0; i < count; i++) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`udp`
`stream`

##### Description of change
<!-- Provide a description of the change below this comment. -->
The `uv_buf_t bufs_[16]` lines could be `MaybeStackBuffer`s; as https://github.com/nodejs/code-and-learn/issues/56