### PR TITLE
test: var variables to const in zlib

### DIFF
--- a/test/parallel/test-zlib-close-after-write.js
+++ b/test/parallel/test-zlib-close-after-write.js
@@ -1,9 +1,9 @@
 'use strict';
 const common = require('../common');
-var zlib = require('zlib');
+const zlib = require('zlib');
 
 zlib.gzip('hello', common.mustCall(function(err, out) {
-  var unzip = zlib.createGunzip();
+  const unzip = zlib.createGunzip();
   unzip.write(out);
   unzip.close(common.mustCall(function() {}));
 }));

--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -1,8 +1,8 @@
 /* eslint-disable strict */
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var zlib = require('zlib');
+const zlib = require('zlib');
 
 assert.equal(zlib.constants.Z_OK, 0, 'Z_OK should be 0');
 zlib.constants.Z_OK = 1;

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -2,13 +2,13 @@
 // test convenience methods with and without options supplied
 
 require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
+const assert = require('assert');
+const zlib = require('zlib');
 
 var hadRun = 0;
 
-var expect = 'blahblahblahblahblahblah';
-var opts = {
+const expect = 'blahblahblahblahblahblah';
+const opts = {
   level: 9,
   chunkSize: 1024,
 };

--- a/test/parallel/test-zlib-dictionary-fail.js
+++ b/test/parallel/test-zlib-dictionary-fail.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
 
 // Should raise an error, not trigger an assertion in src/node_zlib.cc
 {

--- a/test/parallel/test-zlib-flush.js
+++ b/test/parallel/test-zlib-flush.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
-var path = require('path');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const path = require('path');
+const fs = require('fs');
 
 const file = fs.readFileSync(path.resolve(common.fixturesDir, 'person.jpg'));
 const chunkSize = 16;

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -2,27 +2,27 @@
 // test unzipping a file that was created with a non-node gzip lib,
 // piped in as fast as possible.
 
-var common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
-var path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const path = require('path');
 
 common.refreshTmpDir();
 
-var gunzip = zlib.createGunzip();
+const gunzip = zlib.createGunzip();
 
-var fs = require('fs');
+const fs = require('fs');
 
-var fixture = path.resolve(common.fixturesDir, 'person.jpg.gz');
-var unzippedFixture = path.resolve(common.fixturesDir, 'person.jpg');
-var outputFile = path.resolve(common.tmpDir, 'person.jpg');
-var expect = fs.readFileSync(unzippedFixture);
-var inp = fs.createReadStream(fixture);
-var out = fs.createWriteStream(outputFile);
+const fixture = path.resolve(common.fixturesDir, 'person.jpg.gz');
+const unzippedFixture = path.resolve(common.fixturesDir, 'person.jpg');
+const outputFile = path.resolve(common.tmpDir, 'person.jpg');
+const expect = fs.readFileSync(unzippedFixture);
+const inp = fs.createReadStream(fixture);
+const out = fs.createWriteStream(outputFile);
 
 inp.pipe(gunzip).pipe(out);
 out.on('close', function() {
-  var actual = fs.readFileSync(outputFile);
+  const actual = fs.readFileSync(outputFile);
   assert.equal(actual.length, expect.length, 'length should match');
   for (var i = 0, l = actual.length; i < l; i++) {
     assert.equal(actual[i], expect[i], 'byte[' + i + ']');

--- a/test/parallel/test-zlib-from-string.js
+++ b/test/parallel/test-zlib-from-string.js
@@ -2,35 +2,36 @@
 // test compressing and uncompressing a string with zlib
 
 require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
+const assert = require('assert');
+const zlib = require('zlib');
 
-var inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing elit.' +
-                  ' Morbi faucibus, purus at gravida dictum, libero arcu conv' +
-                  'allis lacus, in commodo libero metus eu nisi. Nullam commo' +
-                  'do, neque nec porta placerat, nisi est fermentum augue, vi' +
-                  'tae gravida tellus sapien sit amet tellus. Aenean non diam' +
-                  ' orci. Proin quis elit turpis. Suspendisse non diam ipsum.' +
-                  ' Suspendisse nec ullamcorper odio. Vestibulum arcu mi, sod' +
-                  'ales non suscipit id, ultrices ut massa. Sed ac sem sit am' +
-                  'et arcu malesuada fermentum. Nunc sed. ';
-var expectedBase64Deflate = 'eJxdUUtOQzEMvMoc4OndgT0gJCT2buJWlpI4jePeqZfpmXAK' +
-                            'LRKbLOzx/HK73q6vOrhCunlF1qIDJhNUeW5I2ozT5OkDlKWL' +
-                            'JWkncJG5403HQXAkT3Jw29B9uIEmToMukglZ0vS6ociBh4JG' +
-                            '8sV4oVLEUCitK2kxq1WzPnChHDzsaGKy491LofoAbWh8do43' +
-                            'oeuYhB5EPCjcLjzYJo48KrfQBvnJecNFJvHT1+RSQsGoC7dn' +
-                            '2t/xjhduTA1NWyQIZR0pbHwMDatnD+crPqKSqGPHp1vnlsWM' +
-                            '/07ubf7bheF7kqSj84Bm0R1fYTfaK8vqqqfKBtNMhe3OZh6N' +
-                            '95CTvMX5HJJi4xOVzCgUOIMSLH7wmeOHaFE4RdpnGavKtrB5' +
-                            'xzfO/Ll9';
-var expectedBase64Gzip = 'H4sIAAAAAAAAA11RS05DMQy8yhzg6d2BPSAkJPZu4laWkjiN496' +
-                         'pl+mZcAotEpss7PH8crverq86uEK6eUXWogMmE1R5bkjajNPk6Q' +
-                         'OUpYslaSdwkbnjTcdBcCRPcnDb0H24gSZOgy6SCVnS9LqhyIGHg' +
-                         'kbyxXihUsRQKK0raTGrVbM+cKEcPOxoYrLj3Uuh+gBtaHx2jjeh' +
-                         '65iEHkQ8KNwuPNgmjjwqt9AG+cl5w0Um8dPX5FJCwagLt2fa3/G' +
-                         'OF25MDU1bJAhlHSlsfAwNq2cP5ys+opKoY8enW+eWxYz/Tu5t/t' +
-                         'uF4XuSpKPzgGbRHV9hN9ory+qqp8oG00yF7c5mHo33kJO8xfkck' +
-                         'mLjE5XMKBQ4gxIsfvCZ44doUThF2mcZq8q2sHnHNzRtagj5AQAA';
+const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli' +
+                    't. Morbi faucibus, purus at gravida dictum, libero arcu ' +
+                    'convallis lacus, in commodo libero metus eu nisi. Nullam' +
+                    ' commodo, neque nec porta placerat, nisi est fermentum a' +
+                    'ugue, vitae gravida tellus sapien sit amet tellus. Aenea' +
+                    'n non diam orci. Proin quis elit turpis. Suspendisse non' +
+                    ' diam ipsum. Suspendisse nec ullamcorper odio. Vestibulu' +
+                    'm arcu mi, sodales non suscipit id, ultrices ut massa. S' +
+                    'ed ac sem sit amet arcu malesuada fermentum. Nunc sed. ';
+const expectedBase64Deflate = 'eJxdUUtOQzEMvMoc4OndgT0gJCT2buJWlpI4jePeqZfpmX' +
+                              'AKLRKbLOzx/HK73q6vOrhCunlF1qIDJhNUeW5I2ozT5OkD' +
+                              'lKWLJWkncJG5403HQXAkT3Jw29B9uIEmToMukglZ0vS6oc' +
+                              'iBh4JG8sV4oVLEUCitK2kxq1WzPnChHDzsaGKy491LofoA' +
+                              'bWh8do43oeuYhB5EPCjcLjzYJo48KrfQBvnJecNFJvHT1+' +
+                              'RSQsGoC7dn2t/xjhduTA1NWyQIZR0pbHwMDatnD+crPqKS' +
+                              'qGPHp1vnlsWM/07ubf7bheF7kqSj84Bm0R1fYTfaK8vqqq' +
+                              'fKBtNMhe3OZh6N95CTvMX5HJJi4xOVzCgUOIMSLH7wmeOH' +
+                              'aFE4RdpnGavKtrB5xzfO/Ll9';
+const expectedBase64Gzip = 'H4sIAAAAAAAAA11RS05DMQy8yhzg6d2BPSAkJPZu4laWkjiN4' +
+                           '96pl+mZcAotEpss7PH8crverq86uEK6eUXWogMmE1R5bkjajN' +
+                           'Pk6QOUpYslaSdwkbnjTcdBcCRPcnDb0H24gSZOgy6SCVnS9Lq' +
+                           'hyIGHgkbyxXihUsRQKK0raTGrVbM+cKEcPOxoYrLj3Uuh+gBt' +
+                           'aHx2jjeh65iEHkQ8KNwuPNgmjjwqt9AG+cl5w0Um8dPX5FJCw' +
+                           'agLt2fa3/GOF25MDU1bJAhlHSlsfAwNq2cP5ys+opKoY8enW+' +
+                           'eWxYz/Tu5t/tuF4XuSpKPzgGbRHV9hN9ory+qqp8oG00yF7c5' +
+                           'mHo33kJO8xfkckmLjE5XMKBQ4gxIsfvCZ44doUThF2mcZq8q2' +
+                           'sHnHNzRtagj5AQAA';
 
 zlib.deflate(inputString, function(err, buffer) {
   assert.equal(buffer.toString('base64'), expectedBase64Deflate,

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -5,7 +5,7 @@ require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-var nonStringInputs = [1, true, {a: 1}, ['a']];
+const nonStringInputs = [1, true, {a: 1}, ['a']];
 
 console.error('Doing the non-strings');
 nonStringInputs.forEach(function(input) {
@@ -20,7 +20,7 @@ nonStringInputs.forEach(function(input) {
 
 console.error('Doing the unzips');
 // zlib.Unzip classes need to get valid data, or else they'll throw.
-var unzips = [ zlib.Unzip(),
+const unzips = [ zlib.Unzip(),
                zlib.Gunzip(),
                zlib.Inflate(),
                zlib.InflateRaw() ];

--- a/test/parallel/test-zlib-params.js
+++ b/test/parallel/test-zlib-params.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
-var path = require('path');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const path = require('path');
+const fs = require('fs');
 
 const file = fs.readFileSync(path.resolve(common.fixturesDir, 'person.jpg'));
 const chunkSize = 12 * 1024;
@@ -20,7 +20,8 @@ deflater.write(chunk1, function() {
   deflater.params(0, zlib.constants.Z_DEFAULT_STRATEGY, function() {
     while (deflater.read());
     deflater.end(chunk2, function() {
-      var bufs = [], buf;
+      const bufs = [];
+      var buf;
       while (buf = deflater.read())
         bufs.push(buf);
       actual = Buffer.concat(bufs);

--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var crypto = require('crypto');
+const crypto = require('crypto');
 
-var stream = require('stream');
-var Stream = stream.Stream;
-var util = require('util');
-var zlib = require('zlib');
+const stream = require('stream');
+const Stream = stream.Stream;
+const util = require('util');
+const zlib = require('zlib');
 
 
 // emit random bytes, and keep a shasum
@@ -73,12 +73,12 @@ RandomReadStream.prototype._process = function() {
   // figure out how many bytes to output
   // if finished, then just emit end.
   var block = this._opt.block;
-  var jitter = this._opt.jitter;
+  const jitter = this._opt.jitter;
   if (jitter) {
     block += Math.ceil(Math.random() * jitter - (jitter / 2));
   }
   block = Math.min(block, this._remaining);
-  var buf = Buffer.allocUnsafe(block);
+  const buf = Buffer.allocUnsafe(block);
   for (var i = 0; i < block; i++) {
     buf[i] = Math.random() * 256;
   }

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
+const assert = require('assert');
+const zlib = require('zlib');
 
 zlib.gzip('hello', common.mustCall(function(err, out) {
-  var unzip = zlib.createGunzip();
+  const unzip = zlib.createGunzip();
   unzip.close(common.mustCall(function() {}));
   assert.throws(function() {
     unzip.write(out);

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -1,15 +1,15 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
+const assert = require('assert');
+const zlib = require('zlib');
 
-var gzip = zlib.createGzip();
-var gunz = zlib.createUnzip();
+const gzip = zlib.createGzip();
+const gunz = zlib.createUnzip();
 
 gzip.pipe(gunz);
 
 var output = '';
-var input = 'A line of data\n';
+const input = 'A line of data\n';
 gunz.setEncoding('utf8');
 gunz.on('data', function(c) {
   output += c;

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var zlib = require('zlib');
-var gz = zlib.Gzip();
-var emptyBuffer = Buffer.alloc(0);
+const zlib = require('zlib');
+const gz = zlib.Gzip();
+const emptyBuffer = Buffer.alloc(0);
 var received = 0;
 gz.on('data', function(c) {
   received += c.length;

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var zlib = require('zlib');
-var path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+const path = require('path');
 
 var zlibPairs =
     [[zlib.Deflate, zlib.Inflate],


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Changed var variables to const in test-zlib-(etc):
Changes in test-zlib-from-string is because var->const
pushed us over the max char limit per line.