### PR TITLE
test: change equal to strictEqual in path tests

### DIFF
--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -7,107 +7,111 @@ const f = __filename;
 const failures = [];
 
 // path.basename tests
-assert.equal(path.basename(f), 'test-path.js');
-assert.equal(path.basename(f, '.js'), 'test-path');
-assert.equal(path.basename(''), '');
-assert.equal(path.basename('/dir/basename.ext'), 'basename.ext');
-assert.equal(path.basename('/basename.ext'), 'basename.ext');
-assert.equal(path.basename('basename.ext'), 'basename.ext');
-assert.equal(path.basename('basename.ext/'), 'basename.ext');
-assert.equal(path.basename('basename.ext//'), 'basename.ext');
-assert.equal(path.basename('aaa/bbb', '/bbb'), 'bbb');
-assert.equal(path.basename('aaa/bbb', 'a/bbb'), 'bbb');
-assert.equal(path.basename('aaa/bbb', 'bbb'), 'bbb');
-assert.equal(path.basename('aaa/bbb//', 'bbb'), 'bbb');
-assert.equal(path.basename('aaa/bbb', 'bb'), 'b');
-assert.equal(path.basename('aaa/bbb', 'b'), 'bb');
-assert.equal(path.basename('/aaa/bbb', '/bbb'), 'bbb');
-assert.equal(path.basename('/aaa/bbb', 'a/bbb'), 'bbb');
-assert.equal(path.basename('/aaa/bbb', 'bbb'), 'bbb');
-assert.equal(path.basename('/aaa/bbb//', 'bbb'), 'bbb');
-assert.equal(path.basename('/aaa/bbb', 'bb'), 'b');
-assert.equal(path.basename('/aaa/bbb', 'b'), 'bb');
-assert.equal(path.basename('/aaa/bbb'), 'bbb');
-assert.equal(path.basename('/aaa/'), 'aaa');
-assert.equal(path.basename('/aaa/b'), 'b');
-assert.equal(path.basename('/a/b'), 'b');
-assert.equal(path.basename('//a'), 'a');
+assert.strictEqual(path.basename(f), 'test-path.js');
+assert.strictEqual(path.basename(f, '.js'), 'test-path');
+assert.strictEqual(path.basename(''), '');
+assert.strictEqual(path.basename('/dir/basename.ext'), 'basename.ext');
+assert.strictEqual(path.basename('/basename.ext'), 'basename.ext');
+assert.strictEqual(path.basename('basename.ext'), 'basename.ext');
+assert.strictEqual(path.basename('basename.ext/'), 'basename.ext');
+assert.strictEqual(path.basename('basename.ext//'), 'basename.ext');
+assert.strictEqual(path.basename('aaa/bbb', '/bbb'), 'bbb');
+assert.strictEqual(path.basename('aaa/bbb', 'a/bbb'), 'bbb');
+assert.strictEqual(path.basename('aaa/bbb', 'bbb'), 'bbb');
+assert.strictEqual(path.basename('aaa/bbb//', 'bbb'), 'bbb');
+assert.strictEqual(path.basename('aaa/bbb', 'bb'), 'b');
+assert.strictEqual(path.basename('aaa/bbb', 'b'), 'bb');
+assert.strictEqual(path.basename('/aaa/bbb', '/bbb'), 'bbb');
+assert.strictEqual(path.basename('/aaa/bbb', 'a/bbb'), 'bbb');
+assert.strictEqual(path.basename('/aaa/bbb', 'bbb'), 'bbb');
+assert.strictEqual(path.basename('/aaa/bbb//', 'bbb'), 'bbb');
+assert.strictEqual(path.basename('/aaa/bbb', 'bb'), 'b');
+assert.strictEqual(path.basename('/aaa/bbb', 'b'), 'bb');
+assert.strictEqual(path.basename('/aaa/bbb'), 'bbb');
+assert.strictEqual(path.basename('/aaa/'), 'aaa');
+assert.strictEqual(path.basename('/aaa/b'), 'b');
+assert.strictEqual(path.basename('/a/b'), 'b');
+assert.strictEqual(path.basename('//a'), 'a');
 
 // On Windows a backslash acts as a path separator.
-assert.equal(path.win32.basename('\\dir\\basename.ext'), 'basename.ext');
-assert.equal(path.win32.basename('\\basename.ext'), 'basename.ext');
-assert.equal(path.win32.basename('basename.ext'), 'basename.ext');
-assert.equal(path.win32.basename('basename.ext\\'), 'basename.ext');
-assert.equal(path.win32.basename('basename.ext\\\\'), 'basename.ext');
-assert.equal(path.win32.basename('foo'), 'foo');
-assert.equal(path.win32.basename('aaa\\bbb', '\\bbb'), 'bbb');
-assert.equal(path.win32.basename('aaa\\bbb', 'a\\bbb'), 'bbb');
-assert.equal(path.win32.basename('aaa\\bbb', 'bbb'), 'bbb');
-assert.equal(path.win32.basename('aaa\\bbb\\\\\\\\', 'bbb'), 'bbb');
-assert.equal(path.win32.basename('aaa\\bbb', 'bb'), 'b');
-assert.equal(path.win32.basename('aaa\\bbb', 'b'), 'bb');
+assert.strictEqual(path.win32.basename('\\dir\\basename.ext'), 'basename.ext');
+assert.strictEqual(path.win32.basename('\\basename.ext'), 'basename.ext');
+assert.strictEqual(path.win32.basename('basename.ext'), 'basename.ext');
+assert.strictEqual(path.win32.basename('basename.ext\\'), 'basename.ext');
+assert.strictEqual(path.win32.basename('basename.ext\\\\'), 'basename.ext');
+assert.strictEqual(path.win32.basename('foo'), 'foo');
+assert.strictEqual(path.win32.basename('aaa\\bbb', '\\bbb'), 'bbb');
+assert.strictEqual(path.win32.basename('aaa\\bbb', 'a\\bbb'), 'bbb');
+assert.strictEqual(path.win32.basename('aaa\\bbb', 'bbb'), 'bbb');
+assert.strictEqual(path.win32.basename('aaa\\bbb\\\\\\\\', 'bbb'), 'bbb');
+assert.strictEqual(path.win32.basename('aaa\\bbb', 'bb'), 'b');
+assert.strictEqual(path.win32.basename('aaa\\bbb', 'b'), 'bb');
 
 // On unix a backslash is just treated as any other character.
-assert.equal(path.posix.basename('\\dir\\basename.ext'), '\\dir\\basename.ext');
-assert.equal(path.posix.basename('\\basename.ext'), '\\basename.ext');
-assert.equal(path.posix.basename('basename.ext'), 'basename.ext');
-assert.equal(path.posix.basename('basename.ext\\'), 'basename.ext\\');
-assert.equal(path.posix.basename('basename.ext\\\\'), 'basename.ext\\\\');
-assert.equal(path.posix.basename('foo'), 'foo');
+assert.strictEqual(path.posix.basename('\\dir\\basename.ext'),
+                   '\\dir\\basename.ext');
+assert.strictEqual(path.posix.basename('\\basename.ext'), '\\basename.ext');
+assert.strictEqual(path.posix.basename('basename.ext'), 'basename.ext');
+assert.strictEqual(path.posix.basename('basename.ext\\'), 'basename.ext\\');
+assert.strictEqual(path.posix.basename('basename.ext\\\\'), 'basename.ext\\\\');
+assert.strictEqual(path.posix.basename('foo'), 'foo');
 
 // POSIX filenames may include control characters
 // c.f. http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html
 const controlCharFilename = 'Icon' + String.fromCharCode(13);
-assert.equal(path.posix.basename('/a/b/' + controlCharFilename),
+assert.strictEqual(path.posix.basename('/a/b/' + controlCharFilename),
              controlCharFilename);
 
 
 // path.dirname tests
-assert.equal(path.dirname(f).substr(-13),
+assert.strictEqual(path.dirname(f).substr(-13),
              common.isWindows ? 'test\\parallel' : 'test/parallel');
 
-assert.equal(path.posix.dirname('/a/b/'), '/a');
-assert.equal(path.posix.dirname('/a/b'), '/a');
-assert.equal(path.posix.dirname('/a'), '/');
-assert.equal(path.posix.dirname(''), '.');
-assert.equal(path.posix.dirname('/'), '/');
-assert.equal(path.posix.dirname('////'), '/');
-assert.equal(path.posix.dirname('foo'), '.');
+assert.strictEqual(path.posix.dirname('/a/b/'), '/a');
+assert.strictEqual(path.posix.dirname('/a/b'), '/a');
+assert.strictEqual(path.posix.dirname('/a'), '/');
+assert.strictEqual(path.posix.dirname(''), '.');
+assert.strictEqual(path.posix.dirname('/'), '/');
+assert.strictEqual(path.posix.dirname('////'), '/');
+assert.strictEqual(path.posix.dirname('foo'), '.');
 
-assert.equal(path.win32.dirname('c:\\'), 'c:\\');
-assert.equal(path.win32.dirname('c:\\foo'), 'c:\\');
-assert.equal(path.win32.dirname('c:\\foo\\'), 'c:\\');
-assert.equal(path.win32.dirname('c:\\foo\\bar'), 'c:\\foo');
-assert.equal(path.win32.dirname('c:\\foo\\bar\\'), 'c:\\foo');
-assert.equal(path.win32.dirname('c:\\foo\\bar\\baz'), 'c:\\foo\\bar');
-assert.equal(path.win32.dirname('\\'), '\\');
-assert.equal(path.win32.dirname('\\foo'), '\\');
-assert.equal(path.win32.dirname('\\foo\\'), '\\');
-assert.equal(path.win32.dirname('\\foo\\bar'), '\\foo');
-assert.equal(path.win32.dirname('\\foo\\bar\\'), '\\foo');
-assert.equal(path.win32.dirname('\\foo\\bar\\baz'), '\\foo\\bar');
-assert.equal(path.win32.dirname('c:'), 'c:');
-assert.equal(path.win32.dirname('c:foo'), 'c:');
-assert.equal(path.win32.dirname('c:foo\\'), 'c:');
-assert.equal(path.win32.dirname('c:foo\\bar'), 'c:foo');
-assert.equal(path.win32.dirname('c:foo\\bar\\'), 'c:foo');
-assert.equal(path.win32.dirname('c:foo\\bar\\baz'), 'c:foo\\bar');
-assert.equal(path.win32.dirname('\\\\unc\\share'), '\\\\unc\\share');
-assert.equal(path.win32.dirname('\\\\unc\\share\\foo'), '\\\\unc\\share\\');
-assert.equal(path.win32.dirname('\\\\unc\\share\\foo\\'), '\\\\unc\\share\\');
-assert.equal(path.win32.dirname('\\\\unc\\share\\foo\\bar'),
+assert.strictEqual(path.win32.dirname('c:\\'), 'c:\\');
+assert.strictEqual(path.win32.dirname('c:\\foo'), 'c:\\');
+assert.strictEqual(path.win32.dirname('c:\\foo\\'), 'c:\\');
+assert.strictEqual(path.win32.dirname('c:\\foo\\bar'), 'c:\\foo');
+assert.strictEqual(path.win32.dirname('c:\\foo\\bar\\'), 'c:\\foo');
+assert.strictEqual(path.win32.dirname('c:\\foo\\bar\\baz'), 'c:\\foo\\bar');
+assert.strictEqual(path.win32.dirname('\\'), '\\');
+assert.strictEqual(path.win32.dirname('\\foo'), '\\');
+assert.strictEqual(path.win32.dirname('\\foo\\'), '\\');
+assert.strictEqual(path.win32.dirname('\\foo\\bar'), '\\foo');
+assert.strictEqual(path.win32.dirname('\\foo\\bar\\'), '\\foo');
+assert.strictEqual(path.win32.dirname('\\foo\\bar\\baz'), '\\foo\\bar');
+assert.strictEqual(path.win32.dirname('c:'), 'c:');
+assert.strictEqual(path.win32.dirname('c:foo'), 'c:');
+assert.strictEqual(path.win32.dirname('c:foo\\'), 'c:');
+assert.strictEqual(path.win32.dirname('c:foo\\bar'), 'c:foo');
+assert.strictEqual(path.win32.dirname('c:foo\\bar\\'), 'c:foo');
+assert.strictEqual(path.win32.dirname('c:foo\\bar\\baz'), 'c:foo\\bar');
+assert.strictEqual(path.win32.dirname('\\\\unc\\share'),
+                   '\\\\unc\\share');
+assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo'),
+                   '\\\\unc\\share\\');
+assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\'),
+                   '\\\\unc\\share\\');
+assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\bar'),
              '\\\\unc\\share\\foo');
-assert.equal(path.win32.dirname('\\\\unc\\share\\foo\\bar\\'),
+assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\bar\\'),
              '\\\\unc\\share\\foo');
-assert.equal(path.win32.dirname('\\\\unc\\share\\foo\\bar\\baz'),
+assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\bar\\baz'),
              '\\\\unc\\share\\foo\\bar');
-assert.equal(path.win32.dirname('/a/b/'), '/a');
-assert.equal(path.win32.dirname('/a/b'), '/a');
-assert.equal(path.win32.dirname('/a'), '/');
-assert.equal(path.win32.dirname(''), '.');
-assert.equal(path.win32.dirname('/'), '/');
-assert.equal(path.win32.dirname('////'), '/');
-assert.equal(path.win32.dirname('foo'), '.');
+assert.strictEqual(path.win32.dirname('/a/b/'), '/a');
+assert.strictEqual(path.win32.dirname('/a/b'), '/a');
+assert.strictEqual(path.win32.dirname('/a'), '/');
+assert.strictEqual(path.win32.dirname(''), '.');
+assert.strictEqual(path.win32.dirname('/'), '/');
+assert.strictEqual(path.win32.dirname('////'), '/');
+assert.strictEqual(path.win32.dirname('foo'), '.');
 
 
 // path.extname tests
@@ -175,27 +179,27 @@ assert.equal(path.win32.dirname('foo'), '.');
       failures.push('\n' + message);
   });
 });
-assert.equal(failures.length, 0, failures.join(''));
+assert.strictEqual(failures.length, 0, failures.join(''));
 
 // On Windows, backslash is a path separator.
-assert.equal(path.win32.extname('.\\'), '');
-assert.equal(path.win32.extname('..\\'), '');
-assert.equal(path.win32.extname('file.ext\\'), '.ext');
-assert.equal(path.win32.extname('file.ext\\\\'), '.ext');
-assert.equal(path.win32.extname('file\\'), '');
-assert.equal(path.win32.extname('file\\\\'), '');
-assert.equal(path.win32.extname('file.\\'), '.');
-assert.equal(path.win32.extname('file.\\\\'), '.');
+assert.strictEqual(path.win32.extname('.\\'), '');
+assert.strictEqual(path.win32.extname('..\\'), '');
+assert.strictEqual(path.win32.extname('file.ext\\'), '.ext');
+assert.strictEqual(path.win32.extname('file.ext\\\\'), '.ext');
+assert.strictEqual(path.win32.extname('file\\'), '');
+assert.strictEqual(path.win32.extname('file\\\\'), '');
+assert.strictEqual(path.win32.extname('file.\\'), '.');
+assert.strictEqual(path.win32.extname('file.\\\\'), '.');
 
 // On *nix, backslash is a valid name component like any other character.
-assert.equal(path.posix.extname('.\\'), '');
-assert.equal(path.posix.extname('..\\'), '.\\');
-assert.equal(path.posix.extname('file.ext\\'), '.ext\\');
-assert.equal(path.posix.extname('file.ext\\\\'), '.ext\\\\');
-assert.equal(path.posix.extname('file\\'), '');
-assert.equal(path.posix.extname('file\\\\'), '');
-assert.equal(path.posix.extname('file.\\'), '.\\');
-assert.equal(path.posix.extname('file.\\\\'), '.\\\\');
+assert.strictEqual(path.posix.extname('.\\'), '');
+assert.strictEqual(path.posix.extname('..\\'), '.\\');
+assert.strictEqual(path.posix.extname('file.ext\\'), '.ext\\');
+assert.strictEqual(path.posix.extname('file.ext\\\\'), '.ext\\\\');
+assert.strictEqual(path.posix.extname('file\\'), '');
+assert.strictEqual(path.posix.extname('file\\\\'), '');
+assert.strictEqual(path.posix.extname('file.\\'), '.\\');
+assert.strictEqual(path.posix.extname('file.\\\\'), '.\\\\');
 
 
 // path.join tests
@@ -332,7 +336,7 @@ joinTests.forEach(function(test) {
     });
   });
 });
-assert.equal(failures.length, 0, failures.join(''));
+assert.strictEqual(failures.length, 0, failures.join(''));
 
 
 // Test thrown TypeErrors
@@ -368,24 +372,24 @@ typeErrorTests.forEach(function(test) {
 
 
 // path.normalize tests
-assert.equal(path.win32.normalize('./fixtures///b/../b/c.js'),
+assert.strictEqual(path.win32.normalize('./fixtures///b/../b/c.js'),
              'fixtures\\b\\c.js');
-assert.equal(path.win32.normalize('/foo/../../../bar'), '\\bar');
-assert.equal(path.win32.normalize('a//b//../b'), 'a\\b');
-assert.equal(path.win32.normalize('a//b//./c'), 'a\\b\\c');
-assert.equal(path.win32.normalize('a//b//.'), 'a\\b');
-assert.equal(path.win32.normalize('//server/share/dir/file.ext'),
+assert.strictEqual(path.win32.normalize('/foo/../../../bar'), '\\bar');
+assert.strictEqual(path.win32.normalize('a//b//../b'), 'a\\b');
+assert.strictEqual(path.win32.normalize('a//b//./c'), 'a\\b\\c');
+assert.strictEqual(path.win32.normalize('a//b//.'), 'a\\b');
+assert.strictEqual(path.win32.normalize('//server/share/dir/file.ext'),
              '\\\\server\\share\\dir\\file.ext');
-assert.equal(path.win32.normalize('/a/b/c/../../../x/y/z'), '\\x\\y\\z');
+assert.strictEqual(path.win32.normalize('/a/b/c/../../../x/y/z'), '\\x\\y\\z');
 
-assert.equal(path.posix.normalize('./fixtures///b/../b/c.js'),
+assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
              'fixtures/b/c.js');
-assert.equal(path.posix.normalize('/foo/../../../bar'), '/bar');
-assert.equal(path.posix.normalize('a//b//../b'), 'a/b');
-assert.equal(path.posix.normalize('a//b//./c'), 'a/b/c');
-assert.equal(path.posix.normalize('a//b//.'), 'a/b');
-assert.equal(path.posix.normalize('/a/b/c/../../../x/y/z'), '/x/y/z');
-assert.equal(path.posix.normalize('///..//./foo/.//bar'), '/foo/bar');
+assert.strictEqual(path.posix.normalize('/foo/../../../bar'), '/bar');
+assert.strictEqual(path.posix.normalize('a//b//../b'), 'a/b');
+assert.strictEqual(path.posix.normalize('a//b//./c'), 'a/b/c');
+assert.strictEqual(path.posix.normalize('a//b//.'), 'a/b');
+assert.strictEqual(path.posix.normalize('/a/b/c/../../../x/y/z'), '/x/y/z');
+assert.strictEqual(path.posix.normalize('///..//./foo/.//bar'), '/foo/bar');
 
 
 // path.resolve tests
@@ -438,33 +442,33 @@ resolveTests.forEach(function(test) {
       failures.push('\n' + message);
   });
 });
-assert.equal(failures.length, 0, failures.join(''));
+assert.strictEqual(failures.length, 0, failures.join(''));
 
 
 // path.isAbsolute tests
-assert.equal(path.win32.isAbsolute('/'), true);
-assert.equal(path.win32.isAbsolute('//'), true);
-assert.equal(path.win32.isAbsolute('//server'), true);
-assert.equal(path.win32.isAbsolute('//server/file'), true);
-assert.equal(path.win32.isAbsolute('\\\\server\\file'), true);
-assert.equal(path.win32.isAbsolute('\\\\server'), true);
-assert.equal(path.win32.isAbsolute('\\\\'), true);
-assert.equal(path.win32.isAbsolute('c'), false);
-assert.equal(path.win32.isAbsolute('c:'), false);
-assert.equal(path.win32.isAbsolute('c:\\'), true);
-assert.equal(path.win32.isAbsolute('c:/'), true);
-assert.equal(path.win32.isAbsolute('c://'), true);
-assert.equal(path.win32.isAbsolute('C:/Users/'), true);
-assert.equal(path.win32.isAbsolute('C:\\Users\\'), true);
-assert.equal(path.win32.isAbsolute('C:cwd/another'), false);
-assert.equal(path.win32.isAbsolute('C:cwd\\another'), false);
-assert.equal(path.win32.isAbsolute('directory/directory'), false);
-assert.equal(path.win32.isAbsolute('directory\\directory'), false);
+assert.strictEqual(path.win32.isAbsolute('/'), true);
+assert.strictEqual(path.win32.isAbsolute('//'), true);
+assert.strictEqual(path.win32.isAbsolute('//server'), true);
+assert.strictEqual(path.win32.isAbsolute('//server/file'), true);
+assert.strictEqual(path.win32.isAbsolute('\\\\server\\file'), true);
+assert.strictEqual(path.win32.isAbsolute('\\\\server'), true);
+assert.strictEqual(path.win32.isAbsolute('\\\\'), true);
+assert.strictEqual(path.win32.isAbsolute('c'), false);
+assert.strictEqual(path.win32.isAbsolute('c:'), false);
+assert.strictEqual(path.win32.isAbsolute('c:\\'), true);
+assert.strictEqual(path.win32.isAbsolute('c:/'), true);
+assert.strictEqual(path.win32.isAbsolute('c://'), true);
+assert.strictEqual(path.win32.isAbsolute('C:/Users/'), true);
+assert.strictEqual(path.win32.isAbsolute('C:\\Users\\'), true);
+assert.strictEqual(path.win32.isAbsolute('C:cwd/another'), false);
+assert.strictEqual(path.win32.isAbsolute('C:cwd\\another'), false);
+assert.strictEqual(path.win32.isAbsolute('directory/directory'), false);
+assert.strictEqual(path.win32.isAbsolute('directory\\directory'), false);
 
-assert.equal(path.posix.isAbsolute('/home/foo'), true);
-assert.equal(path.posix.isAbsolute('/home/foo/..'), true);
-assert.equal(path.posix.isAbsolute('bar/'), false);
-assert.equal(path.posix.isAbsolute('./baz'), false);
+assert.strictEqual(path.posix.isAbsolute('/home/foo'), true);
+assert.strictEqual(path.posix.isAbsolute('/home/foo/..'), true);
+assert.strictEqual(path.posix.isAbsolute('bar/'), false);
+assert.strictEqual(path.posix.isAbsolute('./baz'), false);
 
 
 // path.relative tests
@@ -528,54 +532,56 @@ relativeTests.forEach(function(test) {
       failures.push('\n' + message);
   });
 });
-assert.equal(failures.length, 0, failures.join(''));
+assert.strictEqual(failures.length, 0, failures.join(''));
 
 
 // path.sep tests
 // windows
-assert.equal(path.win32.sep, '\\');
+assert.strictEqual(path.win32.sep, '\\');
 // posix
-assert.equal(path.posix.sep, '/');
+assert.strictEqual(path.posix.sep, '/');
 
 // path.delimiter tests
 // windows
-assert.equal(path.win32.delimiter, ';');
+assert.strictEqual(path.win32.delimiter, ';');
 // posix
-assert.equal(path.posix.delimiter, ':');
+assert.strictEqual(path.posix.delimiter, ':');
 
 
 // path._makeLong tests
 const emptyObj = {};
-assert.equal(path.posix._makeLong('/foo/bar'), '/foo/bar');
-assert.equal(path.posix._makeLong('foo/bar'), 'foo/bar');
-assert.equal(path.posix._makeLong(null), null);
-assert.equal(path.posix._makeLong(true), true);
-assert.equal(path.posix._makeLong(1), 1);
-assert.equal(path.posix._makeLong(), undefined);
-assert.equal(path.posix._makeLong(emptyObj), emptyObj);
+assert.strictEqual(path.posix._makeLong('/foo/bar'), '/foo/bar');
+assert.strictEqual(path.posix._makeLong('foo/bar'), 'foo/bar');
+assert.strictEqual(path.posix._makeLong(null), null);
+assert.strictEqual(path.posix._makeLong(true), true);
+assert.strictEqual(path.posix._makeLong(1), 1);
+assert.strictEqual(path.posix._makeLong(), undefined);
+assert.strictEqual(path.posix._makeLong(emptyObj), emptyObj);
 if (common.isWindows) {
   // These tests cause resolve() to insert the cwd, so we cannot test them from
   // non-Windows platforms (easily)
-  assert.equal(path.win32._makeLong('foo\\bar').toLowerCase(),
+  assert.strictEqual(path.win32._makeLong('foo\\bar').toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
-  assert.equal(path.win32._makeLong('foo/bar').toLowerCase(),
+  assert.strictEqual(path.win32._makeLong('foo/bar').toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
   const currentDeviceLetter = path.parse(process.cwd()).root.substring(0, 2);
-  assert.equal(path.win32._makeLong(currentDeviceLetter).toLowerCase(),
+  assert.strictEqual(path.win32._makeLong(currentDeviceLetter).toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase());
-  assert.equal(path.win32._makeLong('C').toLowerCase(),
+  assert.strictEqual(path.win32._makeLong('C').toLowerCase(),
                '\\\\?\\' + process.cwd().toLowerCase() + '\\c');
 }
-assert.equal(path.win32._makeLong('C:\\foo'), '\\\\?\\C:\\foo');
-assert.equal(path.win32._makeLong('C:/foo'), '\\\\?\\C:\\foo');
-assert.equal(path.win32._makeLong('\\\\foo\\bar'), '\\\\?\\UNC\\foo\\bar\\');
-assert.equal(path.win32._makeLong('//foo//bar'), '\\\\?\\UNC\\foo\\bar\\');
-assert.equal(path.win32._makeLong('\\\\?\\foo'), '\\\\?\\foo');
-assert.equal(path.win32._makeLong(null), null);
-assert.equal(path.win32._makeLong(true), true);
-assert.equal(path.win32._makeLong(1), 1);
-assert.equal(path.win32._makeLong(), undefined);
-assert.equal(path.win32._makeLong(emptyObj), emptyObj);
+assert.strictEqual(path.win32._makeLong('C:\\foo'), '\\\\?\\C:\\foo');
+assert.strictEqual(path.win32._makeLong('C:/foo'), '\\\\?\\C:\\foo');
+assert.strictEqual(path.win32._makeLong('\\\\foo\\bar'),
+                   '\\\\?\\UNC\\foo\\bar\\');
+assert.strictEqual(path.win32._makeLong('//foo//bar'),
+                   '\\\\?\\UNC\\foo\\bar\\');
+assert.strictEqual(path.win32._makeLong('\\\\?\\foo'), '\\\\?\\foo');
+assert.strictEqual(path.win32._makeLong(null), null);
+assert.strictEqual(path.win32._makeLong(true), true);
+assert.strictEqual(path.win32._makeLong(1), 1);
+assert.strictEqual(path.win32._makeLong(), undefined);
+assert.strictEqual(path.win32._makeLong(emptyObj), emptyObj);
 
 
 if (common.isWindows)

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -60,12 +60,12 @@ assert.strictEqual(path.posix.basename('foo'), 'foo');
 // c.f. http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html
 const controlCharFilename = 'Icon' + String.fromCharCode(13);
 assert.strictEqual(path.posix.basename('/a/b/' + controlCharFilename),
-             controlCharFilename);
+                   controlCharFilename);
 
 
 // path.dirname tests
 assert.strictEqual(path.dirname(f).substr(-13),
-             common.isWindows ? 'test\\parallel' : 'test/parallel');
+                   common.isWindows ? 'test\\parallel' : 'test/parallel');
 
 assert.strictEqual(path.posix.dirname('/a/b/'), '/a');
 assert.strictEqual(path.posix.dirname('/a/b'), '/a');
@@ -100,11 +100,11 @@ assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo'),
 assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\'),
                    '\\\\unc\\share\\');
 assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\bar'),
-             '\\\\unc\\share\\foo');
+                   '\\\\unc\\share\\foo');
 assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\bar\\'),
-             '\\\\unc\\share\\foo');
+                   '\\\\unc\\share\\foo');
 assert.strictEqual(path.win32.dirname('\\\\unc\\share\\foo\\bar\\baz'),
-             '\\\\unc\\share\\foo\\bar');
+                   '\\\\unc\\share\\foo\\bar');
 assert.strictEqual(path.win32.dirname('/a/b/'), '/a');
 assert.strictEqual(path.win32.dirname('/a/b'), '/a');
 assert.strictEqual(path.win32.dirname('/a'), '/');
@@ -373,17 +373,17 @@ typeErrorTests.forEach(function(test) {
 
 // path.normalize tests
 assert.strictEqual(path.win32.normalize('./fixtures///b/../b/c.js'),
-             'fixtures\\b\\c.js');
+                   'fixtures\\b\\c.js');
 assert.strictEqual(path.win32.normalize('/foo/../../../bar'), '\\bar');
 assert.strictEqual(path.win32.normalize('a//b//../b'), 'a\\b');
 assert.strictEqual(path.win32.normalize('a//b//./c'), 'a\\b\\c');
 assert.strictEqual(path.win32.normalize('a//b//.'), 'a\\b');
 assert.strictEqual(path.win32.normalize('//server/share/dir/file.ext'),
-             '\\\\server\\share\\dir\\file.ext');
+                   '\\\\server\\share\\dir\\file.ext');
 assert.strictEqual(path.win32.normalize('/a/b/c/../../../x/y/z'), '\\x\\y\\z');
 
 assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
-             'fixtures/b/c.js');
+                   'fixtures/b/c.js');
 assert.strictEqual(path.posix.normalize('/foo/../../../bar'), '/bar');
 assert.strictEqual(path.posix.normalize('a//b//../b'), 'a/b');
 assert.strictEqual(path.posix.normalize('a//b//./c'), 'a/b/c');
@@ -561,14 +561,14 @@ if (common.isWindows) {
   // These tests cause resolve() to insert the cwd, so we cannot test them from
   // non-Windows platforms (easily)
   assert.strictEqual(path.win32._makeLong('foo\\bar').toLowerCase(),
-               '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
+                     '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
   assert.strictEqual(path.win32._makeLong('foo/bar').toLowerCase(),
-               '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
+                     '\\\\?\\' + process.cwd().toLowerCase() + '\\foo\\bar');
   const currentDeviceLetter = path.parse(process.cwd()).root.substring(0, 2);
   assert.strictEqual(path.win32._makeLong(currentDeviceLetter).toLowerCase(),
-               '\\\\?\\' + process.cwd().toLowerCase());
+                     '\\\\?\\' + process.cwd().toLowerCase());
   assert.strictEqual(path.win32._makeLong('C').toLowerCase(),
-               '\\\\?\\' + process.cwd().toLowerCase() + '\\c');
+                     '\\\\?\\' + process.cwd().toLowerCase() + '\\c');
 }
 assert.strictEqual(path.win32._makeLong('C:\\foo'), '\\\\?\\C:\\foo');
 assert.strictEqual(path.win32._makeLong('C:/foo'), '\\\\?\\C:\\foo');


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tests

##### Description of change

Use strict equality in `test-path` set of unit tests.
