### PR TITLE
tools: make argument alignment linting more strict

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -696,7 +696,7 @@ REPLServer.prototype.createContext = function() {
       return GLOBAL_OBJECT_PROPERTY_MAP[name] === undefined;
     }).forEach((name) => {
       Object.defineProperty(context, name,
-        Object.getOwnPropertyDescriptor(global, name));
+                            Object.getOwnPropertyDescriptor(global, name));
     });
   }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -28,7 +28,7 @@ assert.doesNotThrow(makeBlock(a.ok, true),
 assert.doesNotThrow(makeBlock(a.ok, 'test'), 'ok(\'test\')');
 
 assert.throws(makeBlock(a.equal, true, false),
-                a.AssertionError, 'equal(true, false)');
+              a.AssertionError, 'equal(true, false)');
 
 assert.doesNotThrow(makeBlock(a.equal, null, null),
                     'equal(null, null)');
@@ -71,10 +71,8 @@ assert.throws(makeBlock(a.deepEqual, new Date(), new Date(2000, 3, 14)),
               a.AssertionError,
               'deepEqual(new Date(), new Date(2000, 3, 14))');
 
-assert.throws(makeBlock(
-  a.notDeepEqual,
-  new Date(2000, 3, 14),
-  new Date(2000, 3, 14)),
+assert.throws(
+  makeBlock(a.notDeepEqual, new Date(2000, 3, 14), new Date(2000, 3, 14)),
   a.AssertionError,
   'notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
 );
@@ -465,7 +463,7 @@ function testAssertionMessage(actual, expected) {
     assert.equal(actual, '');
   } catch (e) {
     assert.equal(e.toString(),
-        ['AssertionError:', expected, '==', '\'\''].join(' '));
+                 ['AssertionError:', expected, '==', '\'\''].join(' '));
     assert.ok(e.generatedMessage, 'Message not marked as generated');
   }
 }

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -243,8 +243,9 @@ assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
   {
     // Length should be 12
     const f = Buffer.from('привет', encoding);
-    assert.deepStrictEqual(f,
-      Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4]));
+    assert.deepStrictEqual(
+      f, Buffer.from([63, 4, 64, 4, 56, 4, 50, 4, 53, 4, 66, 4])
+    );
     assert.strictEqual(f.toString(encoding), 'привет');
   }
 

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -74,8 +74,9 @@ assert.strictEqual(Buffer.byteLength('ßœ∑≈', 'unkn0wn enc0ding'), 10);
 assert.strictEqual(Buffer.byteLength('aGVsbG8gd29ybGQ=', 'base64'), 11);
 assert.strictEqual(Buffer.byteLength('bm9kZS5qcyByb2NrcyE=', 'base64'), 14);
 assert.strictEqual(Buffer.byteLength('aGkk', 'base64'), 3);
-assert.strictEqual(Buffer.byteLength('bHNrZGZsa3NqZmtsc2xrZmFqc2RsZmtqcw==',
-    'base64'), 25);
+assert.strictEqual(
+  Buffer.byteLength('bHNrZGZsa3NqZmtsc2xrZmFqc2RsZmtqcw==', 'base64'), 25
+);
 // special padding
 assert.strictEqual(Buffer.byteLength('aaa=', 'base64'), 2);
 assert.strictEqual(Buffer.byteLength('aaaa==', 'base64'), 3);

--- a/test/parallel/test-buffer-inheritance.js
+++ b/test/parallel/test-buffer-inheritance.js
@@ -26,7 +26,7 @@ vals.forEach(function(t) {
   assert.strictEqual(t.constructor, T);
   assert.strictEqual(Object.getPrototypeOf(t), T.prototype);
   assert.strictEqual(Object.getPrototypeOf(Object.getPrototypeOf(t)),
-    Buffer.prototype);
+                     Buffer.prototype);
 
   t.fill(5);
   let cntr = 0;

--- a/test/parallel/test-debugger-util-regression.js
+++ b/test/parallel/test-debugger-util-regression.js
@@ -62,6 +62,6 @@ proc.stdin.on('error', (err) => {
 process.on('exit', (code) => {
   assert.equal(code, 0, 'the program should exit cleanly');
   assert.equal(stdout.includes('{ a: \'b\' }'), true,
-      'the debugger should print the result of util.inspect');
+               'the debugger should print the result of util.inspect');
   assert.equal(stderr, '', 'stderr should be empty');
 });

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -56,8 +56,8 @@ function runTestWithoutAbortOnUncaughtException() {
         // message must include only the message of the error thrown from the
         // process' uncaughtException handler.
         assert(stderr.includes(uncaughtExceptionHandlerErrMsg),
-            'stderr output must include proper uncaughtException handler\'s ' +
-            'error\'s message');
+               'stderr output must include proper uncaughtException ' +
+               'handler\'s error\'s message');
         assert(!stderr.includes(domainErrMsg), 'stderr output must not ' +
           'include domain\'s error\'s message');
 
@@ -75,7 +75,7 @@ function runTestWithAbortOnUncaughtException() {
                     'child process should not have run its uncaughtException ' +
                     'event handler');
     assert(common.nodeProcessAborted(err.code, err.signal),
-        'process should have aborted, but did not');
+           'process should have aborted, but did not');
   });
 }
 

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -121,7 +121,7 @@ if (process.argv[2] === 'child') {
         if (!options.useTryCatch && options.throwInDomainErrHandler) {
           if (cmdLineOption === '--abort_on_uncaught_exception') {
             assert(common.nodeProcessAborted(exitCode, signal),
-              'process should have aborted, but did not');
+                   'process should have aborted, but did not');
           } else {
             // By default, uncaught exceptions make node exit with an exit
             // code of 7.

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -32,21 +32,21 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
 
 
 fs.open(fn2, constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC, 0o644,
-    common.mustCall(function(err, fd) {
-      if (err) throw err;
-      console.log('open done');
-      fs.write(fd, '', 0, 'utf8', function(err, written) {
-        assert.equal(0, written);
-      });
-      fs.write(fd, expected, 0, 'utf8', common.mustCall(function(err, written) {
-        console.log('write done');
-        if (err) throw err;
-        assert.equal(Buffer.byteLength(expected), written);
-        fs.closeSync(fd);
-        const found = fs.readFileSync(fn2, 'utf8');
-        console.log('expected: "%s"', expected);
-        console.log('found: "%s"', found);
-        fs.unlinkSync(fn2);
-        assert.strictEqual(expected, found);
-      }));
-    }));
+        common.mustCall((err, fd) => {
+          if (err) throw err;
+          console.log('open done');
+          fs.write(fd, '', 0, 'utf8', (err, written) => {
+            assert.equal(0, written);
+          });
+          fs.write(fd, expected, 0, 'utf8', common.mustCall((err, written) => {
+            console.log('write done');
+            if (err) throw err;
+            assert.equal(Buffer.byteLength(expected), written);
+            fs.closeSync(fd);
+            const found = fs.readFileSync(fn2, 'utf8');
+            console.log('expected: "%s"', expected);
+            console.log('found: "%s"', found);
+            fs.unlinkSync(fn2);
+            assert.strictEqual(expected, found);
+          }));
+        }));

--- a/test/parallel/test-http-invalidheaderfield2.js
+++ b/test/parallel/test-http-invalidheaderfield2.js
@@ -90,8 +90,8 @@ const checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
   'Ding!\x07'
 ].forEach(function(str) {
   assert.strictEqual(checkInvalidHeaderChar(str),
-                    true,
-                    'checkInvalidHeaderChar(' +
-                      inspect(str) +
-                      ') unexpectedly succeeded');
+                     true,
+                     'checkInvalidHeaderChar(' +
+                       inspect(str) +
+                       ') unexpectedly succeeded');
 });

--- a/test/parallel/test-timers-throw-when-cb-not-function.js
+++ b/test/parallel/test-timers-throw-when-cb-not-function.js
@@ -9,17 +9,17 @@ function doSetTimeout(callback, after) {
 }
 
 assert.throws(doSetTimeout('foo'),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetTimeout({foo: 'bar'}),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetTimeout(),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetTimeout(undefined, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetTimeout(null, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetTimeout(false, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 
 
 function doSetInterval(callback, after) {
@@ -29,17 +29,17 @@ function doSetInterval(callback, after) {
 }
 
 assert.throws(doSetInterval('foo'),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetInterval({foo: 'bar'}),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetInterval(),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetInterval(undefined, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetInterval(null, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetInterval(false, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 
 
 function doSetImmediate(callback, after) {
@@ -49,14 +49,14 @@ function doSetImmediate(callback, after) {
 }
 
 assert.throws(doSetImmediate('foo'),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetImmediate({foo: 'bar'}),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetImmediate(),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetImmediate(undefined, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetImmediate(null, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);
 assert.throws(doSetImmediate(false, 0),
-  /"callback" argument must be a function/);
+              /"callback" argument must be a function/);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -12,8 +12,10 @@ assert.strictEqual(util.inspect(function() {}), '[Function]');
 assert.strictEqual(util.inspect(undefined), 'undefined');
 assert.strictEqual(util.inspect(null), 'null');
 assert.strictEqual(util.inspect(/foo(bar\n)?/gi), '/foo(bar\\n)?/gi');
-assert.strictEqual(util.inspect(new Date('Sun, 14 Feb 2010 11:48:40 GMT')),
-  new Date('2010-02-14T12:48:40+01:00').toISOString());
+assert.strictEqual(
+  util.inspect(new Date('Sun, 14 Feb 2010 11:48:40 GMT')),
+  new Date('2010-02-14T12:48:40+01:00').toISOString()
+);
 assert.strictEqual(util.inspect(new Date('')), (new Date('')).toString());
 
 assert.strictEqual(util.inspect('\n\u0001'), "'\\n\\u0001'");
@@ -30,14 +32,14 @@ assert.strictEqual(util.inspect({a: 1, b: 2}), '{ a: 1, b: 2 }');
 assert.strictEqual(util.inspect({'a': {}}), '{ a: {} }');
 assert.strictEqual(util.inspect({'a': {'b': 2}}), '{ a: { b: 2 } }');
 assert.strictEqual(util.inspect({'a': {'b': { 'c': { 'd': 2 }}}}),
-  '{ a: { b: { c: [Object] } } }');
+                   '{ a: { b: { c: [Object] } } }');
 assert.strictEqual(util.inspect({'a': {'b': { 'c': { 'd': 2 }}}}, false, null),
-  '{ a: { b: { c: { d: 2 } } } }');
+                   '{ a: { b: { c: { d: 2 } } } }');
 assert.strictEqual(util.inspect([1, 2, 3], true), '[ 1, 2, 3, [length]: 3 ]');
 assert.strictEqual(util.inspect({'a': {'b': { 'c': 2}}}, false, 0),
-  '{ a: [Object] }');
+                   '{ a: [Object] }');
 assert.strictEqual(util.inspect({'a': {'b': { 'c': 2}}}, false, 1),
-  '{ a: { b: [Object] } }');
+                   '{ a: { b: [Object] } }');
 assert.strictEqual(util.inspect(Object.create({},
   {visible: {value: 1, enumerable: true}, hidden: {value: 2}})),
   '{ visible: 1 }'
@@ -64,29 +66,29 @@ for (const showHidden of [true, false]) {
     'ArrayBuffer { byteLength: 4 }'
   );
   assert.strictEqual(util.inspect(new DataView(ab, 1, 2), showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4 } }');
+                     'DataView {\n' +
+                     '  byteLength: 2,\n' +
+                     '  byteOffset: 1,\n' +
+                     '  buffer: ArrayBuffer { byteLength: 4 } }');
   assert.strictEqual(
     util.inspect(ab, showHidden),
     'ArrayBuffer { byteLength: 4 }'
   );
   assert.strictEqual(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4 } }');
+                     'DataView {\n' +
+                     '  byteLength: 2,\n' +
+                     '  byteOffset: 1,\n' +
+                     '  buffer: ArrayBuffer { byteLength: 4 } }');
   ab.x = 42;
   dv.y = 1337;
   assert.strictEqual(util.inspect(ab, showHidden),
-               'ArrayBuffer { byteLength: 4, x: 42 }');
+                     'ArrayBuffer { byteLength: 4, x: 42 }');
   assert.strictEqual(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
-               '  y: 1337 }');
+                     'DataView {\n' +
+                     '  byteLength: 2,\n' +
+                     '  byteOffset: 1,\n' +
+                     '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
+                     '  y: 1337 }');
 }
 
 // Now do the same checks but from a different context
@@ -98,29 +100,29 @@ for (const showHidden of [true, false]) {
     'ArrayBuffer { byteLength: 4 }'
   );
   assert.strictEqual(util.inspect(new DataView(ab, 1, 2), showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4 } }');
+                     'DataView {\n' +
+                     '  byteLength: 2,\n' +
+                     '  byteOffset: 1,\n' +
+                     '  buffer: ArrayBuffer { byteLength: 4 } }');
   assert.strictEqual(
     util.inspect(ab, showHidden),
     'ArrayBuffer { byteLength: 4 }'
   );
   assert.strictEqual(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4 } }');
+                     'DataView {\n' +
+                     '  byteLength: 2,\n' +
+                     '  byteOffset: 1,\n' +
+                     '  buffer: ArrayBuffer { byteLength: 4 } }');
   ab.x = 42;
   dv.y = 1337;
   assert.strictEqual(util.inspect(ab, showHidden),
-               'ArrayBuffer { byteLength: 4, x: 42 }');
+                     'ArrayBuffer { byteLength: 4, x: 42 }');
   assert.strictEqual(util.inspect(dv, showHidden),
-               'DataView {\n' +
-               '  byteLength: 2,\n' +
-               '  byteOffset: 1,\n' +
-               '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
-               '  y: 1337 }');
+                     'DataView {\n' +
+                     '  byteLength: 2,\n' +
+                     '  byteOffset: 1,\n' +
+                     '  buffer: ArrayBuffer { byteLength: 4, x: 42 },\n' +
+                     '  y: 1337 }');
 }
 
 
@@ -138,15 +140,16 @@ for (const showHidden of [true, false]) {
     const array = new constructor(new ArrayBuffer(byteLength), 0, length);
     array[0] = 65;
     array[1] = 97;
-    assert.strictEqual(util.inspect(array, true),
-                 `${constructor.name} [\n` +
-                 `  65,\n` +
-                 `  97,\n` +
-                 `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
-                 `  [length]: ${length},\n` +
-                 `  [byteLength]: ${byteLength},\n` +
-                 `  [byteOffset]: 0,\n` +
-                 `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
+    assert.strictEqual(
+      util.inspect(array, true),
+      `${constructor.name} [\n` +
+      `  65,\n` +
+      `  97,\n` +
+      `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
+      `  [length]: ${length},\n` +
+      `  [byteLength]: ${byteLength},\n` +
+      `  [byteOffset]: 0,\n` +
+      `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
     assert.strictEqual(
       util.inspect(array, false),
       `${constructor.name} [ 65, 97 ]`
@@ -173,15 +176,16 @@ for (const showHidden of [true, false]) {
                                      });
     array[0] = 65;
     array[1] = 97;
-    assert.strictEqual(util.inspect(array, true),
-                 `${constructor.name} [\n` +
-                 `  65,\n` +
-                 `  97,\n` +
-                 `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
-                 `  [length]: ${length},\n` +
-                 `  [byteLength]: ${byteLength},\n` +
-                 `  [byteOffset]: 0,\n` +
-                 `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
+    assert.strictEqual(
+      util.inspect(array, true),
+      `${constructor.name} [\n` +
+      `  65,\n` +
+      `  97,\n` +
+      `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
+      `  [length]: ${length},\n` +
+      `  [byteLength]: ${byteLength},\n` +
+      `  [byteOffset]: 0,\n` +
+      `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
     assert.strictEqual(
       util.inspect(array, false),
       `${constructor.name} [ 65, 97 ]`
@@ -222,13 +226,13 @@ assert.strictEqual(
 
 // Dynamic properties
 assert.strictEqual(util.inspect({get readonly() {}}),
-  '{ readonly: [Getter] }');
+                   '{ readonly: [Getter] }');
 
 assert.strictEqual(util.inspect({get readwrite() {}, set readwrite(val) {}}),
-  '{ readwrite: [Getter/Setter] }');
+                   '{ readwrite: [Getter/Setter] }');
 
 assert.strictEqual(util.inspect({set writeonly(val) {}}),
-  '{ writeonly: [Setter] }');
+                   '{ writeonly: [Setter] }');
 
 var value = {};
 value['a'] = value;
@@ -666,7 +670,7 @@ if (typeof Symbol !== 'undefined') {
 
   assert.strictEqual(util.inspect(subject), '[ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(subject, options),
-      '[ 1, 2, 3, [length]: 3, [Symbol(symbol)]: 42 ]');
+                     '[ 1, 2, 3, [length]: 3, [Symbol(symbol)]: 42 ]');
 }
 
 // test Set
@@ -683,11 +687,11 @@ assert.strictEqual(
 {
   assert.strictEqual(util.inspect(new Map()), 'Map {}');
   assert.strictEqual(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])),
-               'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }');
+                     'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }');
   const map = new Map([['foo', null]]);
   map.bar = 42;
   assert.strictEqual(util.inspect(map, true),
-               'Map { \'foo\' => null, [size]: 1, bar: 42 }');
+                     'Map { \'foo\' => null, [size]: 1, bar: 42 }');
 }
 
 // test Promise
@@ -774,15 +778,15 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
   const x = new ObjectSubclass();
   x.foo = 42;
   assert.strictEqual(util.inspect(x),
-               'ObjectSubclass { foo: 42 }');
+                     'ObjectSubclass { foo: 42 }');
   assert.strictEqual(util.inspect(new ArraySubclass(1, 2, 3)),
-               'ArraySubclass [ 1, 2, 3 ]');
+                     'ArraySubclass [ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(new SetSubclass([1, 2, 3])),
-               'SetSubclass { 1, 2, 3 }');
+                     'SetSubclass { 1, 2, 3 }');
   assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
-              'MapSubclass { \'foo\' => 42 }');
+                     'MapSubclass { \'foo\' => 42 }');
   assert.strictEqual(util.inspect(new PromiseSubclass(function() {})),
-               'PromiseSubclass { <pending> }');
+                     'PromiseSubclass { <pending> }');
 }
 
 // Corner cases.

--- a/test/parallel/test-vm-symbols.js
+++ b/test/parallel/test-vm-symbols.js
@@ -19,7 +19,7 @@ var context = new Document();
 vm.createContext(context);
 
 assert.equal(context.getSymbolValue(), 'foo',
-    'should return symbol-keyed value from the outside');
+             'should return symbol-keyed value from the outside');
 
 assert.equal(vm.runInContext('this.getSymbolValue()', context), 'foo',
-    'should return symbol-keyed value from the inside');
+             'should return symbol-keyed value from the inside');

--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -53,7 +53,7 @@ fs.createReadStream(pmmFileGz)
   .on('data', (data) => pmmResultBuffers.push(data))
   .on('finish', common.mustCall(() => {
     assert.deepStrictEqual(Buffer.concat(pmmResultBuffers), pmmExpected,
-      'result should match original random garbage');
+                           'result should match original random garbage');
   }));
 
 // test that the next gzip member can wrap around the input buffer boundary
@@ -61,14 +61,17 @@ fs.createReadStream(pmmFileGz)
   const resultBuffers = [];
 
   const unzip = zlib.createGunzip()
-   .on('error', (err) => {
-     assert.ifError(err);
-   })
-   .on('data', (data) => resultBuffers.push(data))
-   .on('finish', common.mustCall(() => {
-     assert.strictEqual(Buffer.concat(resultBuffers).toString(), 'abcdef',
-      `result should match original input (offset = ${offset})`);
-   }));
+    .on('error', (err) => {
+      assert.ifError(err);
+    })
+    .on('data', (data) => resultBuffers.push(data))
+    .on('finish', common.mustCall(() => {
+      assert.strictEqual(
+        Buffer.concat(resultBuffers).toString(),
+        'abcdef',
+        `result should match original input (offset = ${offset})`
+      );
+    }));
 
   // first write: write "abc" + the first bytes of "def"
   unzip.write(Buffer.concat([

--- a/test/parallel/test-zlib-unzip-one-byte-chunks.js
+++ b/test/parallel/test-zlib-unzip-one-byte-chunks.js
@@ -17,7 +17,7 @@ const unzip = zlib.createUnzip()
   .on('data', (data) => resultBuffers.push(data))
   .on('finish', common.mustCall(() => {
     assert.deepStrictEqual(Buffer.concat(resultBuffers).toString(), 'abcdef',
-      'result should match original string');
+                           'result should match original string');
   }));
 
 for (let i = 0; i < data.length; i++) {

--- a/tools/eslint-rules/align-function-arguments.js
+++ b/tools/eslint-rules/align-function-arguments.js
@@ -30,7 +30,6 @@ function checkArgumentAlignment(context, node) {
 
   const ignoreTypes = [
     'ArrowFunctionExpression',
-    'CallExpression',
     'FunctionExpression',
     'ObjectExpression',
   ];
@@ -48,18 +47,26 @@ function checkArgumentAlignment(context, node) {
     return;
   }
 
+  var misaligned;
+
   args.slice(1).forEach((argument) => {
-    if (argument.loc.start.line === currentLine + 1) {
-      if (argument.loc.start.column !== firstColumn) {
-        msg = 'Function called with argument in column ' +
-              `${argument.loc.start.column}, expected in ${firstColumn}`;
+    if (!misaligned) {
+      if (argument.loc.start.line === currentLine + 1) {
+        if (argument.loc.start.column !== firstColumn) {
+          if (isNodeFirstInLine(argument)) {
+            msg = 'Function argument in column ' +
+                  `${argument.loc.start.column + 1}, ` +
+                  `expected in ${firstColumn + 1}`;
+            misaligned = argument;
+          }
+        }
       }
     }
     currentLine = argument.loc.start.line;
   });
 
   if (msg)
-    context.report(node, msg);
+    context.report(misaligned, msg);
 }
 
 module.exports = function(context) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test lib

##### Description of change
<!-- Provide a description of the change below this comment. -->

A few nits in recent PR comments suggest that we can have slightly more
strict linting for argument alignment in multiline function calls. This
enables the existing linting requirements to apply when one or more of
the arguments themselves are function calls. Previously, that situation
had been excluded from linting.