### PR TITLE
tools: add additional ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@ rules:
 
   # Best Practices
   # http://eslint.org/docs/rules/#best-practices
+  dot-location: [2, property]
   no-fallthrough: 2
   no-global-assign: 2
   no-multi-spaces: 2
@@ -37,6 +38,10 @@ rules:
   no-redeclare: 2
   no-self-assign: 2
   no-unused-labels: 2
+  no-useless-call: 2
+  no-useless-escape: 2
+  no-void: 2
+  no-with: 2
 
   # Strict Mode
   # http://eslint.org/docs/rules/#strict-mode
@@ -64,6 +69,8 @@ rules:
   # http://eslint.org/docs/rules/#stylistic-issues
   brace-style: [2, 1tbs, {allowSingleLine: true}]
   comma-spacing: 2
+  comma-style: 2
+  computed-property-spacing: 2
   eol-last: 2
   func-call-spacing: 2
   indent: [2, 2, {SwitchCase: 1, MemberExpression: 1}]
@@ -74,9 +81,11 @@ rules:
   new-parens: 2
   no-mixed-spaces-and-tabs: 2
   no-multiple-empty-lines: [2, {max: 2}]
+  no-tabs: 2
   no-trailing-spaces: 2
   quotes: [2, single, avoid-escape]
   semi: 2
+  semi-spacing: 2
   space-before-blocks: [2, always]
   space-before-function-paren: [2, never]
   space-in-parens: [2, never]

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -4,8 +4,8 @@ const util = require('util');
 const common = require('../common');
 const v8 = require('v8');
 const bench = common.createBenchmark(main, {
-  n: [1e6]
-, type: ['string',
+  n: [1e6],
+  type: ['string',
          'number',
          'object',
          'unknown',

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -918,7 +918,7 @@ Server.prototype.addContext = function(servername, context) {
 
   var re = new RegExp('^' +
                       servername.replace(/([\.^$+?\-\\[\]{}])/g, '\\$1')
-                                .replace(/\*/g, '[^\.]*') +
+                                .replace(/\*/g, '[^.]*') +
                       '$');
   this._contexts.push([re, tls.createSecureContext(context).context]);
 };

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -125,7 +125,7 @@
           const filename = Module._resolveFilename(process.argv[1]);
           var source = fs.readFileSync(filename, 'utf-8');
           // remove shebang and BOM
-          source = internalModule.stripBOM(source.replace(/^\#\!.*/, ''));
+          source = internalModule.stripBOM(source.replace(/^#!.*/, ''));
           // wrap it
           source = Module.wrap(source);
           // compile the script, this will throw if it fails

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -77,9 +77,9 @@ function checkHttpResponse(port, path, callback) {
   http.get({port, path}, function(res) {
     let response = '';
     res.setEncoding('utf8');
-    res.
-      on('data', (data) => response += data.toString()).
-      on('end', () => callback(JSON.parse(response)));
+    res
+      .on('data', (data) => response += data.toString())
+      .on('end', () => callback(JSON.parse(response)));
   });
 }
 

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -85,9 +85,9 @@ function testBreakpointOnStart(session) {
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ];
 
-  session.
-    sendInspectorCommands(commands).
-    expectMessages(setupExpectBreakOnLine(0, session.mainScriptPath, session));
+  session
+    .sendInspectorCommands(commands)
+    .expectMessages(setupExpectBreakOnLine(0, session.mainScriptPath, session));
 }
 
 function testSetBreakpointAndResume(session) {
@@ -105,9 +105,9 @@ function testSetBreakpointAndResume(session) {
           'params': { 'scriptId': session.mainScriptId } },
         expectMainScriptSource ],
   ];
-  session.
-    sendInspectorCommands(commands).
-    expectMessages([
+  session
+    .sendInspectorCommands(commands)
+    .expectMessages([
       setupExpectConsoleOutput('log', ['A message', 5]),
       setupExpectBreakOnLine(5, session.mainScriptPath,
                              session, (id) => scopeId = id),
@@ -131,7 +131,7 @@ function testInspectScope(session) {
     [
       {
         'method': 'Debugger.evaluateOnCallFrame', 'params': {
-          'callFrameId': '{\"ordinal\":0,\"injectedScriptId\":1}',
+          'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
           'expression': 'k + t',
           'objectGroup': 'console',
           'includeCommandLineAPI': true,
@@ -153,9 +153,9 @@ function testInspectScope(session) {
 
 function testWaitsForFrontendDisconnect(session, harness) {
   console.log('[test]', 'Verify node waits for the frontend to disconnect');
-  session.sendInspectorCommands({ 'method': 'Debugger.resume'}).
-    expectStderrOutput('Waiting for the debugger to disconnect...').
-    disconnect(true);
+  session.sendInspectorCommands({ 'method': 'Debugger.resume'})
+    .expectStderrOutput('Waiting for the debugger to disconnect...')
+    .disconnect(true);
 }
 
 function runTests(harness) {

--- a/test/message/throw_in_line_with_tabs.js
+++ b/test/message/throw_in_line_with_tabs.js
@@ -1,4 +1,4 @@
-/* eslint-disable indent */
+/* eslint-disable indent, no-tabs */
 'use strict';
 require('../common');
 

--- a/test/parallel/test-debug-protocol-execute.js
+++ b/test/parallel/test-debug-protocol-execute.js
@@ -15,6 +15,6 @@ assert.strictEqual(protocol.res.body, undefined);
 
 protocol.state = 'sterrance';
 assert.throws(
-	() => { protocol.execute('grumblecakes'); },
-	/^Error: Unknown state$/
+  () => { protocol.execute('grumblecakes'); },
+  /^Error: Unknown state$/
 );

--- a/test/parallel/test-http-multi-line-headers.js
+++ b/test/parallel/test-http-multi-line-headers.js
@@ -14,7 +14,7 @@ var server = net.createServer(function(conn) {
       'Content-Length: ' + body.length + '\r\n' +
       'Content-Type: text/plain;\r\n' +
       ' x-unix-mode=0600;\r\n' +
-      ' name=\"hello.txt\"\r\n' +
+      ' name="hello.txt"\r\n' +
       '\r\n' +
       body;
 

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -27,7 +27,7 @@ const server = http.createServer((req, res) => {
 var count = 0;
 
 server.listen(0, common.mustCall(() => {
-  for (let n = 1; n <= MAX_COUNT ; n++) {
+  for (let n = 1; n <= MAX_COUNT; n++) {
     // This runs twice, the first time, the server will use
     // setHeader, the second time it uses writeHead. In either
     // case, the error handler must be called because the client

--- a/test/parallel/test-http-response-multiheaders.js
+++ b/test/parallel/test-http-response-multiheaders.js
@@ -48,7 +48,7 @@ const server = http.createServer(function(req, res) {
 
 server.listen(0, common.mustCall(function() {
   var count = 0;
-  for (let n = 1; n <= 2 ; n++) {
+  for (let n = 1; n <= 2; n++) {
     // this runs twice, the first time, the server will use
     // setHeader, the second time it uses writeHead. The
     // result on the client side should be the same in

--- a/test/parallel/test-regress-GH-5727.js
+++ b/test/parallel/test-regress-GH-5727.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const net = require('net');
 
 const invalidPort = -1 >>> 0;
-const errorMessage = /"port" argument must be \>= 0 and \< 65536/;
+const errorMessage = /"port" argument must be >= 0 and < 65536/;
 
 net.Server().listen(common.PORT, function() {
   const address = this.address();

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -160,7 +160,7 @@ function error_test() {
     // invalid RegExps are a special case of syntax error,
     // should throw
     { client: client_unix, send: '/(/;',
-      expect: /\bSyntaxError: Invalid regular expression\:/ },
+      expect: /\bSyntaxError: Invalid regular expression:/ },
     // invalid RegExp modifiers are a special case of syntax error,
     // should throw (GH-4012)
     { client: client_unix, send: 'new RegExp("foo", "wrong modifier");',
@@ -313,7 +313,7 @@ function error_test() {
     { client: client_unix, send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
       expect: prompt_multiline + prompt_multiline +
             'undefined\n' + prompt_unix },
-    { client: client_unix, send: "function x(s) {\nreturn s.replace(/\'/,'');\n}",
+    { client: client_unix, send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
       expect: prompt_multiline + prompt_multiline +
             'undefined\n' + prompt_unix },
     { client: client_unix, send: 'function x(s) {\nreturn s.replace(/"/,"");\n}',

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -154,7 +154,7 @@ test('write bufferize', function(t) {
   });
 
   chunks.forEach(function(chunk, i) {
-    var enc = encodings[ i % encodings.length ];
+    var enc = encodings[i % encodings.length];
     chunk = Buffer.from(chunk);
     tw.write(chunk.toString(enc), enc);
   });
@@ -192,7 +192,7 @@ test('write no bufferize', function(t) {
   });
 
   chunks.forEach(function(chunk, i) {
-    var enc = encodings[ i % encodings.length ];
+    var enc = encodings[i % encodings.length];
     chunk = Buffer.from(chunk);
     tw.write(chunk.toString(enc), enc);
   });

--- a/test/parallel/test-tls-cipher-list.js
+++ b/test/parallel/test-tls-cipher-list.js
@@ -16,9 +16,9 @@ function doCheck(arg, check) {
     '-pe',
     'require("crypto").constants.defaultCipherList'
   ]);
-  spawn(process.execPath, arg, {}).
-    on('error', common.fail).
-    stdout.on('data', function(chunk) {
+  spawn(process.execPath, arg, {})
+    .on('error', common.fail)
+    .stdout.on('data', function(chunk) {
       out += chunk;
     }).on('end', function() {
       assert.equal(out.trim(), check);

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -10,7 +10,7 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var hosterr = /Hostname\/IP doesn\'t match certificate\'s altnames/g;
+var hosterr = /Hostname\/IP doesn't match certificate's altnames/g;
 var testCases =
     [{ ca: ['ca1-cert'],
        key: 'agent2-key',

--- a/test/sequential/test-process-warnings.js
+++ b/test/sequential/test-process-warnings.js
@@ -29,5 +29,5 @@ execFile(node, traceWarn, function(er, stdout, stderr) {
   assert.equal(er, null);
   assert.equal(stdout, '');
   assert(/^\(.+\)\sWarning: a bad practice warning/.test(stderr));
-  assert(/at Object\.\<anonymous\>\s\(.+warnings.js:3:9\)/.test(stderr));
+  assert(/at Object\.<anonymous>\s\(.+warnings.js:3:9\)/.test(stderr));
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

This enables the following ESLint rules, all of which are already followed in the vast majority of the codebase:

* [`dot-location`](http://eslint.org/docs/rules/dot-location): On multiline property access, require the dot to be placed next to the property name rather than the object name. (1 existing violation)
* [`no-useless-call`](http://eslint.org/docs/rules/no-useless-call): Disallow unnecessary `Function.prototype.call` expressions, e.g. `foo.bar.call(foo)`. (0 existing violations)
* [`no-useless-escape`](http://eslint.org/docs/rules/no-useless-escape): Disallows characters in strings/regexes from being escaped with a backslash unless the backslash is actually doing something. (8 existing violations)
* [`no-void`](http://eslint.org/docs/rules/no-void): Disallows `void` expressions. (0 existing violations)
* [`no-with`](http://eslint.org/docs/rules/no-with): Disallows `with` statements. (0 existing violations)
* [`comma-style`](http://eslint.org/docs/rules/comma-style): Require commas to be placed at the end of a line, rather than the beginning. (1 existing violation)
* [`computed-property-spacing`](http://eslint.org/docs/rules/computed-property-spacing): When accessing a computed property (e.g. `foo[bar]`), disallow spaces inside the square brackets. (2 existing violations)
* [`no-tabs`](http://eslint.org/docs/rules/comma-style): Disallow tab characters. (1 existing violation)
* [`semi-spacing`](http://eslint.org/docs/rules/comma-style): Disallow spaces before semicolons, and require spaces after semicolons. (2 existing violations)