### PR TITLE
Revert "repl: disable Ctrl+C support on win32 for now"

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -289,13 +289,7 @@ function REPLServer(prompt,
     if (!err) {
       // Unset raw mode during evaluation so that Ctrl+C raises a signal.
       let previouslyInRawMode;
-
-      // Temporarily disabled on Windows due to output problems that likely
-      // result from the raw mode switches here, see
-      // https://github.com/nodejs/node/issues/7837
-      // Setting NODE_REPL_CTRLC is meant as a temporary opt-in for debugging.
-      if (self.breakEvalOnSigint &&
-          (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
+      if (self.breakEvalOnSigint) {
         // Start the SIGINT watchdog before entering raw mode so that a very
         // quick Ctrl+C doesn’t lead to aborting the process completely.
         utilBinding.startSigintWatchdog();
@@ -315,8 +309,7 @@ function REPLServer(prompt,
             result = script.runInContext(context, scriptOptions);
           }
         } finally {
-          if (self.breakEvalOnSigint &&
-              (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
+          if (self.breakEvalOnSigint) {
             // Reset terminal mode to its previous value.
             self._setRawMode(previouslyInRawMode);
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

repl
##### Description of change

This reverts commit f59b8888f12b491c69cc5be6f812414d50b1ec36, since apparently https://github.com/libuv/libuv/pull/1054 fixed the underlying problem that led to temporary disabling. I’d really like Windows users (@seishun? @bzoz?) to check that everything works as expected.

Ref: https://github.com/libuv/libuv/pull/1054
Ref: https://github.com/nodejs/node/issues/7837
