### PR TITLE
https: fix memory leak with https.request()

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -123,6 +123,14 @@ Agent.prototype.addRequest = function(req, options) {
   options = util._extend({}, options);
   options = util._extend(options, this.options);
 
+  if (!options.servername) {
+    options.servername = options.host;
+    const hostHeader = req.getHeader('host');
+    if (hostHeader) {
+      options.servername = hostHeader.replace(/:.*$/, '');
+    }
+  }
+
   var name = this.getName(options);
   if (!this.sockets[name]) {
     this.sockets[name] = [];

--- a/test/parallel/test-https-agent-sockets-leak.js
+++ b/test/parallel/test-https-agent-sockets-leak.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const fs = require('fs');
+const https = require('https');
+const assert = require('assert');
+
+const options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+};
+
+const server = https.Server(options, common.mustCall((req, res) => {
+  res.writeHead(200);
+  res.end('https\n');
+}));
+
+const agent = new https.Agent({
+  keepAlive: false
+});
+
+server.listen(0, common.mustCall(() => {
+  https.get({
+    host: server.address().host,
+    port: server.address().port,
+    headers: {host: 'agent1'},
+    rejectUnauthorized: true,
+    ca: options.ca,
+    agent: agent
+  }, common.mustCall((res) => {
+    res.resume();
+    server.close();
+
+    // Only one entry should exist in agent.sockets pool
+    // If there are more entries in agent.sockets,
+    // removeSocket will not delete them resulting in a resource leak
+    assert.strictEqual(Object.keys(agent.sockets).length, 1);
+
+    res.req.on('close', common.mustCall(() => {
+      // To verify that no leaks occur, check that no entries
+      // exist in agent.sockets pool after both request and socket
+      // has been closed.
+      assert.strictEqual(Object.keys(agent.sockets).length, 0);
+    }));
+  }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

https

##### Description of change
<!-- Provide a description of the change below this comment. -->

If calling `https.request()` with `options.headers.host` defined and `options.servername` undefined, `https.Agent.createSocket` mutates connection `options` **after** `https.Agent.addRequest` has created empty socket pool array with mismatching connection name. 

This results in two socket pool arrays being created and only the last one gets eventually deleted by `removeSocket` - effectively causing a memory leak.

This commit fixes the leak by making sure that `addRequest` does the same modifications to `options` object as the `createSocket`. 

`createSocket` is intentionally left unmodified to prevent userland regressions.

Test case included.

Fixes: https://github.com/nodejs/node/issues/6687

/cc @nodejs/http @nodejs/crypto