### PR TITLE
src: handle thrown errors in CopyProperties()

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -125,7 +125,14 @@ class ContextifyContext {
     int length = names->Length();
     for (int i = 0; i < length; i++) {
       Local<String> key = names->Get(i)->ToString(env()->isolate());
-      bool has = sandbox_obj->HasOwnProperty(context, key).FromJust();
+      auto maybe_has = sandbox_obj->HasOwnProperty(context, key);
+
+      // Check for pending exceptions
+      if (!maybe_has.IsJust())
+        break;
+
+      bool has = maybe_has.FromJust();
+
       if (!has) {
         // Could also do this like so:
         //

--- a/test/parallel/test-vm-proxies.js
+++ b/test/parallel/test-vm-proxies.js
@@ -16,3 +16,16 @@ sandbox = { Proxy: Proxy };
 vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert.strictEqual(typeof sandbox.Proxy, 'function');
 assert.strictEqual(sandbox.Proxy, Proxy);
+
+// Handle a sandbox that throws while copying properties
+assert.throws(() => {
+  const handler = {
+    getOwnPropertyDescriptor: (target, prop) => {
+      throw new Error('whoops');
+    }
+  };
+  const sandbox = new Proxy({foo: 'bar'}, handler);
+  const context = vm.createContext(sandbox);
+
+  vm.runInContext('', context);
+}, /whoops/);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change
This commit prevents thrown JavaScript exceptions from crashing the process in `node_contextify`'s `CopyProperties()` function.

Closes #8537