### PR TITLE
test: skip cpu-intensive tests on slow hosts

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -31,6 +31,10 @@ exports.isLinux = process.platform === 'linux';
 exports.isOSX = process.platform === 'darwin';
 
 exports.enoughTestMem = os.totalmem() > 0x40000000; /* 1 Gb */
+
+const cpus = os.cpus();
+exports.enoughTestCpu = cpus.length > 1 || cpus[0].speed > 999;
+
 exports.rootDir = exports.isWindows ? 'c:\\' : '/';
 
 function rimrafSync(p) {

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -9,14 +9,10 @@ prefix parallel
 [$system==win32]
 
 [$system==linux]
-test-tick-processor           : PASS,FLAKY
 
 [$system==macos]
 
 [$arch==arm || $arch==arm64]
-test-tick-processor-builtin     : PASS,FLAKY
-test-tick-processor-cpp-core    : PASS,FLAKY
-test-tick-processor-unknown     : PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 

--- a/test/parallel/test-tick-processor-builtin.js
+++ b/test/parallel/test-tick-processor-builtin.js
@@ -2,18 +2,6 @@
 const common = require('../common');
 const path = require('path');
 
-// TODO(mhdawson) Currently the test-tick-processor functionality in V8
-// depends on addresses being smaller than a full 64 bits.  Aix supports
-// the full 64 bits and the result is that it does not process the
-// addresses correctly and runs out of memory
-// Disabling until we get a fix upstreamed into V8
-if (common.isAix) {
-  common.skip('Aix address range too big for scripts.');
-  return;
-}
-
-const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
-
 if (common.isWindows ||
     common.isSunOS ||
     common.isAix ||
@@ -22,6 +10,13 @@ if (common.isWindows ||
   common.skip('C++ symbols are not mapped for this os.');
   return;
 }
+
+if (!common.enoughTestCpu) {
+  common.skip('test is CPU-intensive');
+  return;
+}
+
+const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
 
 base.runTest({
   pattern: /Builtin_DateNow/,

--- a/test/parallel/test-tick-processor-cpp-core.js
+++ b/test/parallel/test-tick-processor-cpp-core.js
@@ -2,18 +2,6 @@
 const common = require('../common');
 const path = require('path');
 
-// TODO(mhdawson) Currently the test-tick-processor functionality in V8
-// depends on addresses being smaller than a full 64 bits.  Aix supports
-// the full 64 bits and the result is that it does not process the
-// addresses correctly and runs out of memory
-// Disabling until we get a fix upstreamed into V8
-if (common.isAix) {
-  common.skip('Aix address range too big for scripts.');
-  return;
-}
-
-const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
-
 if (common.isWindows ||
     common.isSunOS ||
     common.isAix ||
@@ -22,6 +10,13 @@ if (common.isWindows ||
   common.skip('C++ symbols are not mapped for this os.');
   return;
 }
+
+if (!common.enoughTestCpu) {
+  common.skip('test is CPU-intensive');
+  return;
+}
+
+const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
 
 base.runTest({
   pattern: /RunInDebugContext/,

--- a/test/parallel/test-tick-processor-unknown.js
+++ b/test/parallel/test-tick-processor-unknown.js
@@ -12,6 +12,11 @@ if (common.isAix) {
   return;
 }
 
+if (!common.enoughTestCpu) {
+  common.skip('test is CPU-intensive');
+  return;
+}
+
 const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
 
 // Unknown checked for to prevent flakiness, if pattern is not found,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test arm V8

##### Description of change
<!-- Provide a description of the change below this comment. -->

The `test-tick-processor-*` tests are now passing everywhere except for
the single-processor 700MHz Raspberry Pi 1 devices.

The tests are CPU-intensive. Skip the tests if there is only one CPU and
it runs at a speed not more than 700 MHz.