### PR TITLE
test: add expectDeprecationWarning to common

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -508,3 +508,16 @@ exports.isAlive = function isAlive(pid) {
     return false;
   }
 };
+
+exports.expectWarning = function(name, expected) {
+  if (typeof expected === 'string')
+    expected = [expected];
+  process.on('warning', exports.mustCall((warning) => {
+    assert.strictEqual(warning.name, name);
+    assert.ok(expected.includes(warning.message),
+              `unexpected error message: "${warning.message}"`);
+    // Remove a warning message after it is seen so that we guarantee that we
+    // get each message only once.
+    expected.splice(expected.indexOf(warning.message), 1);
+  }, expected.length));
+};

--- a/test/parallel/test-buffer-deprecated.js
+++ b/test/parallel/test-buffer-deprecated.js
@@ -1,17 +1,11 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 const expected =
   'Using Buffer without `new` will soon stop working. ' +
   'Use `new Buffer()`, or preferably ' +
   '`Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.';
-
-process.on('warning', common.mustCall((warning) => {
-  assert.strictEqual(warning.name, 'DeprecationWarning');
-  assert.strictEqual(warning.message, expected,
-                     `unexpected error message: "${warning.message}"`);
-}, 1));
+common.expectWarning('DeprecationWarning', expected);
 
 Buffer(1);
 Buffer(1);

--- a/test/parallel/test-crypto-deprecated.js
+++ b/test/parallel/test-crypto-deprecated.js
@@ -9,19 +9,10 @@ if (!common.hasCrypto) {
 const crypto = require('crypto');
 const tls = require('tls');
 
-const expected = [
+common.expectWarning('DeprecationWarning', [
   'crypto.Credentials is deprecated. Use tls.SecureContext instead.',
   'crypto.createCredentials is deprecated. Use tls.createSecureContext instead.'
-];
-
-process.on('warning', common.mustCall((warning) => {
-  assert.strictEqual(warning.name, 'DeprecationWarning');
-  assert.notStrictEqual(expected.indexOf(warning.message), -1,
-                        `unexpected error message: "${warning.message}"`);
-  // Remove a warning message after it is seen so that we guarantee that we get
-  // each message only once.
-  expected.splice(expected.indexOf(warning.message), 1);
-}, expected.length));
+]);
 
 // Accessing the deprecated function is enough to trigger the warning event.
 // It does not need to be called. So the assert serves the purpose of both

--- a/test/parallel/test-repl-deprecated.js
+++ b/test/parallel/test-repl-deprecated.js
@@ -3,18 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const repl = require('repl');
 
-const expected = [
-  'replServer.convertToContext() is deprecated'
-];
-
-process.on('warning', common.mustCall((warning) => {
-  assert.strictEqual(warning.name, 'DeprecationWarning');
-  assert.notStrictEqual(expected.indexOf(warning.message), -1,
-                        `unexpected error message: "${warning.message}"`);
-  // Remove a warning message after it is seen so that we guarantee that we get
-  // each message only once.
-  expected.splice(expected.indexOf(warning.message), 1);
-}, expected.length));
+common.expectWarning('DeprecationWarning',
+                     'replServer.convertToContext() is deprecated');
 
 // Create a dummy stream that does nothing
 const stream = new common.ArrayStream();

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -121,21 +121,12 @@ assert.strictEqual(util.isFunction(function() {}), true);
 assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
-const expected = [
+common.expectWarning('DeprecationWarning', [
   'util.print is deprecated. Use console.log instead.',
   'util.puts is deprecated. Use console.log instead.',
   'util.debug is deprecated. Use console.error instead.',
   'util.error is deprecated. Use console.error instead.'
-];
-
-process.on('warning', common.mustCall((warning) => {
-  assert.strictEqual(warning.name, 'DeprecationWarning');
-  assert.notStrictEqual(expected.indexOf(warning.message), -1,
-                        `unexpected error message: "${warning.message}"`);
-  // Remove a warning message after it is seen so that we guarantee that we get
-  // each message only once.
-  expected.splice(expected.indexOf(warning.message), 1);
-}, expected.length));
+]);
 
 util.print('test');
 util.puts('test');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

##### Description of change
<!-- Provide a description of the change below this comment. -->

There are multiple tests that use the same boilerplate to test that
deprecation warnings are correctly emmited. This adds a new common
function to do that and changes the tests to use it.

/cc @nodejs/testing @addaleax 