### PR TITLE
dns: tweak regex for IPv6 addresses

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -292,7 +292,7 @@ exports.setServers = function(servers) {
     if (ipVersion !== 0)
       return [ipVersion, serv];
 
-    const match = serv.match(/\[(.*)\](:\d+)?/);
+    const match = serv.match(/\[(.*)\](?::\d+)?/);
     // we have an IPv6 in brackets
     if (match) {
       ipVersion = isIP(match[1]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dns

##### Description of change
<!-- Provide a description of the change below this comment. -->

The regex used in `dns.setServers()` to match IPv6 addresses in square brackets uses a capturing group for the port but this info is not needed.

This commit replaces the capturing group with a non capturing one.