### PR TITLE
Removes call to `net.Socket.resume`

### DIFF
--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -109,10 +109,6 @@ if (process.argv[2] === 'child') {
         console.error('[m] CLIENT: close event');
         disconnected += 1;
       });
-      // XXX This resume() should be unnecessary.
-      // a stream high water mark should be enough to keep
-      // consuming the input.
-      client.resume();
     }
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

`resume` is not necessary since `pause` is never called
Ref: #4640