### PR TITLE
Benchmark: add destructuring object

### DIFF
--- a/benchmark/es/destructuring-object-bench.js
+++ b/benchmark/es/destructuring-object-bench.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  method: ['normal', 'destructureObject'],
+  millions: [100]
+});
+
+function runNormal(n) {
+  var i = 0;
+  var o = { x: 0, y: 1 };
+  bench.start();
+  for (; i < n; i++) {
+    /* eslint-disable no-unused-vars */
+    var x = o.x;
+    var y = o.y;
+    var r = o.r || 2;
+    /* eslint-enable no-unused-vars */
+  }
+  bench.end(n / 1e6);
+}
+
+function runDestructured(n) {
+  var i = 0;
+  var o = { x: 0, y: 1 };
+  bench.start();
+  for (; i < n; i++) {
+    /* eslint-disable no-unused-vars */
+    var { x, y, r = 2 } = o;
+    /* eslint-enable no-unused-vars */
+  }
+  bench.end(n / 1e6);
+}
+
+function main(conf) {
+  const n = +conf.millions * 1e6;
+
+  switch (conf.method) {
+    case 'normal':
+      runNormal(n);
+      break;
+    case 'destructureObject':
+      runDestructured(n);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

~~Maybe throse codes should be changed:~~

###### FROM

https://github.com/nodejs/node/blob/master/lib/fs.js#L1-L40


###### TO
```js
// Maintainers, keep in mind that ES1-style octal literals (`0666`) are not
// allowed in strict mode. Use ES6-style octal literals instead (`0o666`).

'use strict';

const { fs: constants } = process.binding('constants');
const util = require('util');
const pathModule = require('path');

const binding = process.binding('fs');
const fs = exports;
const { Buffer } = require('buffer');
const { Stream } = require('stream');
const EventEmitter = require('events');
const { FSReqWrap } = binding;
const { FSEvent } = process.binding('fs_event_wrap');
const { assertEncoding, SyncWriteStream } = require('internal/fs');

Object.defineProperty(exports, 'constants', {
  configurable: false,
  enumerable: true,
  value: constants
});

const { Readable, Writable } = Stream;

const kMinPoolSpace = 128;
const { kMaxLength } = require('buffer');

const {
  O_APPEND = 0,
  O_CREAT = 0,
  O_EXCL = 0,
  O_RDONLY = 0,
  O_RDWR = 0,
  O_SYNC = 0,
  O_TRUNC = 0,
  O_WRONLY = 0
} = constants;
```

#### Benchmark Results: ~~~23% improvement~~ **higher is better**

```
 λ ~/D/o/node git:(master) 1≡ > ./node benchmark/es/destructuring-object-bench.js
es/destructuring-object-bench.js millions=100 method="normal": 392.4462171885431
es/destructuring-object-bench.js millions=100 method="destructureObject": 300.60502352237313
 λ ~/D/o/node git:(master) 1≡ > ./node benchmark/es/destructuring-object-bench.js
es/destructuring-object-bench.js millions=100 method="normal": 378.884718277464
es/destructuring-object-bench.js millions=100 method="destructureObject": 306.7606096492869
 λ ~/D/o/node git:(master) 1≡ > ./node benchmark/es/destructuring-object-bench.js
es/destructuring-object-bench.js millions=100 method="normal": 385.192791572974
es/destructuring-object-bench.js millions=100 method="destructureObject": 296.1235505392568
```