### PR TITLE
doc: Recommend using port 0 instead of common.PORT

### DIFF
--- a/doc/guides/writing_tests.md
+++ b/doc/guides/writing_tests.md
@@ -78,9 +78,11 @@ This is the body of the test. This test is quite simple, it just tests that an
 HTTP server accepts `non-ASCII` characters in the headers of an incoming
 request. Interesting things to notice:
 
-- The use of 0 as the listening port. Always use 0 instead of using an
-  arbitrary value, as it allows to run tests in parallel safely, as the
-  operating system will assign a random port.
+- If the test doesn't depend on a specific port number then always use 0 instead
+  of an arbitrary value, as it allows to run tests in parallel safely, as the
+  operating system will assign a random port. If the test requires a specific
+  port, for example if the test checks that assigning a specific port works as
+  expected, then it is ok to assign a specific port number.
 - The use of `common.mustCall` to check that some callbacks/listeners are
   called.
 - The HTTP server is closed once all the checks have run. This way, the test can

--- a/doc/guides/writing_tests.md
+++ b/doc/guides/writing_tests.md
@@ -31,9 +31,9 @@ Let's analyze this very basic test from the Node.js test suite:
 6  const server = http.createServer(common.mustCall((req, res) => {
 7    res.end('ok');
 8  }));
-9  server.listen(common.PORT, () => {
+9  server.listen(0, () => {
 10   http.get({
-11     port: common.PORT,
+11     port: server.address().port,
 12     headers: {'Test': 'Düsseldorf'}
 13   }, common.mustCall((res) => {
 14     assert.equal(res.statusCode, 200);
@@ -78,10 +78,9 @@ This is the body of the test. This test is quite simple, it just tests that an
 HTTP server accepts `non-ASCII` characters in the headers of an incoming
 request. Interesting things to notice:
 
-- The use of `common.PORT` as the listening port. Always use `common.PORT`
-  instead of using an arbitrary value, as it allows to run tests in parallel
-  safely, as they are not trying to reuse the same port another test is already
-  using.
+- The use of 0 as the listening port. Always use 0 instead of using an
+  arbitrary value, as it allows to run tests in parallel safely, as the
+  operating system will assign a random port.
 - The use of `common.mustCall` to check that some callbacks/listeners are
   called.
 - The HTTP server is closed once all the checks have run. This way, the test can
@@ -131,7 +130,7 @@ process.on('exit', function() {
 var server = http.createServer(function(req, res) {
   request++;
   res.end();
-}).listen(common.PORT, function() {
+}).listen(0, function() {
   var options = {
     agent: null,
     port: this.address().port
@@ -154,7 +153,7 @@ var http = require('http');
 
 var server = http.createServer(common.mustCall(function(req, res) {
   res.end();
-})).listen(common.PORT, function() {
+})).listen(0, function() {
   var options = {
     agent: null,
     port: this.address().port

--- a/doc/guides/writing_tests.md
+++ b/doc/guides/writing_tests.md
@@ -79,7 +79,7 @@ HTTP server accepts `non-ASCII` characters in the headers of an incoming
 request. Interesting things to notice:
 
 - If the test doesn't depend on a specific port number then always use 0 instead
-  of an arbitrary value, as it allows to run tests in parallel safely, as the
+  of an arbitrary value, as it allows tests to be run in parallel safely, as the
   operating system will assign a random port. If the test requires a specific
   port, for example if the test checks that assigning a specific port works as
   expected, then it is ok to assign a specific port number.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->
In the [writing_tests](https://github.com/nodejs/node/blob/master/doc/guides/writing_tests.md) guide it is recommended to use common.PORT
instead of an arbitrary value, but the recommendation is to use
port 0 instead and the docs should reflect that.