### PR TITLE
test: improve test-child-process-fork-dgram

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -32,6 +32,3 @@ test-fs-watch-encoding               : FAIL, PASS
 
 #being worked under https://github.com/nodejs/node/issues/7973
 test-stdio-closed                        : PASS, FLAKY
-
-#covered by https://github.com/nodejs/node/issues/8271
-test-child-process-fork-dgram            : PASS, FLAKY


### PR DESCRIPTION
##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
Previous implementation was subject to timing out as there
was no guarantee that the parent or child would ever
receive a message.  Modified test so that once parent or
child receives a message it stops receiving them so that
we are guaranteed the next message will be received by the
other end.

The test also left lingering processes when it timed out
so pulled the timeout into the test itself so that it
could properly cleanup in case of failure.