### PR TITLE
test: fix test-cluster-worker-init.js flakyness

### DIFF
--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -3,30 +3,25 @@
 // verifies that, when a child process is forked, the cluster.worker
 // object can receive messages as expected
 
-require('../common');
-var assert = require('assert');
-var cluster = require('cluster');
-var msg = 'foo';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const msg = 'foo';
 
 if (cluster.isMaster) {
-  var worker = cluster.fork();
-  var timer = setTimeout(function() {
-    assert(false, 'message not received');
-  }, 5000);
+  const worker = cluster.fork();
 
-  timer.unref();
-
-  worker.on('message', function(message) {
-    assert(message, 'did not receive expected message');
+  worker.on('message', common.mustCall((message) => {
+    assert.strictEqual(message, true, 'did not receive expected message');
     worker.disconnect();
-  });
+  }));
 
-  worker.on('online', function() {
+  worker.on('online', () => {
     worker.send(msg);
   });
 } else {
   // GH #7998
-  cluster.worker.on('message', function(message) {
+  cluster.worker.on('message', (message) => {
     process.send(message === msg);
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, cluster

##### Description of change
<!-- Provide a description of the change below this comment. -->

Update test to match current test guidelines and use common.mustCall
instead of unref'd timer.

Fixes: https://github.com/nodejs/node/issues/8700