### PR TITLE
test: cleanup vars to const and '==' to '==='

### DIFF
--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -26,8 +26,8 @@ var srv = net.createServer(function(c) {
 });
 
 srv.listen(0, '127.0.0.1', common.mustCall(function() {
-  var port = this.address().port;
-  var headers = [
+  const port = this.address().port;
+  const headers = [
     {
       connection: 'upgrade',
       upgrade: 'websocket'
@@ -54,11 +54,11 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
       });
 
       socket.on('close', common.mustCall(function() {
-        assert.equal(recvData, 'nurtzo');
+        assert.strictEqual(recvData.toString(), 'nurtzo');
       }));
 
       console.log(res.headers);
-      var expectedHeaders = {
+      const expectedHeaders = {
         hello: 'world',
         connection: 'upgrade',
         upgrade: 'websocket'
@@ -66,7 +66,7 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
       assert.deepStrictEqual(expectedHeaders, res.headers);
 
       socket.end();
-      if (--left == 0)
+      if (--left === 0)
         srv.close();
     }));
     req.on('close', common.mustCall(function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test/parallel

##### Description of change
<!-- Provide a description of the change below this comment. -->

Modified test-http-upgrade-client.js to clean up var usage and
equality comparisons to strict equality comparisons.

Line 29: Changed var port to const port
Line 30: Changed var headers to const headers
Line 57: Changed assert.equal to assert.strictEqual
Line 61: Changed var expectedHeaders to const
Line 69: Changed '==' to '===' comparison