### PR TITLE
src: rename handle__ to handle_ in HandleWrap

### DIFF
--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -56,7 +56,7 @@ void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
     return;
 
   CHECK_EQ(false, wrap->persistent().IsEmpty());
-  uv_close(wrap->handle__, OnClose);
+  uv_close(wrap->handle_, OnClose);
   wrap->state_ = kClosing;
 
   if (args[0]->IsFunction()) {
@@ -73,8 +73,8 @@ HandleWrap::HandleWrap(Environment* env,
                        AsyncWrap* parent)
     : AsyncWrap(env, object, provider, parent),
       state_(kInitialized),
-      handle__(handle) {
-  handle__->data = this;
+      handle_(handle) {
+  handle_->data = this;
   HandleScope scope(env->isolate());
   Wrap(object, this);
   env->handle_wrap_queue()->PushBack(this);

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -47,7 +47,7 @@ class HandleWrap : public AsyncWrap {
     return IsAlive(wrap) && uv_has_ref(wrap->GetHandle());
   }
 
-  inline uv_handle_t* GetHandle() const { return handle__; }
+  inline uv_handle_t* GetHandle() const { return handle_; }
 
  protected:
   HandleWrap(Environment* env,
@@ -63,9 +63,7 @@ class HandleWrap : public AsyncWrap {
   static void OnClose(uv_handle_t* handle);
   ListNode<HandleWrap> handle_wrap_queue_;
   enum { kInitialized, kClosing, kClosingWithCallback, kClosed } state_;
-  // Using double underscore due to handle_ member in tcp_wrap. Probably
-  // tcp_wrap should rename it's member to 'handle'.
-  uv_handle_t* const handle__;
+  uv_handle_t* const handle_;
 };
 
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change

Commit 46633934fed7dfce289298cf16ea0f4161b77bb7 (src: pull
OnConnection from pipe_wrap and tcp_wrap) removed the private handle_
member from TCPWrap which should allow us to rename the private
handle__ member in HandleWrap.