### PR TITLE
doc: enable first-heading-level remark-lint rule

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -13,7 +13,7 @@
       "file-extension": "md",
       "final-definition": true,
       "final-newline": true,
-      "first-heading-level": false,
+      "first-heading-level": 1,
       "hard-break-spaces": true,
       "heading-increment": false,
       "heading-style": "atx",

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,4 +1,4 @@
-## Building Node.js
+# Building Node.js
 
 Depending on what platform or features you require, the build process may
 differ slightly. After you've successfully built a binary, running the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-## Code of Conduct
+# Code of Conduct
 
-### Conduct
+## Conduct
 
 * We are committed to providing a friendly, safe and welcoming
   environment for all, regardless of level of experience, gender
@@ -38,17 +38,17 @@
   documentation. There is no need to address persons when explaining
   code (e.g. "When the developer").
 
-### Contact
+## Contact
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by:
 
 * Emailing [report@nodejs.org](mailto:report@nodejs.org) (this will email all TSC members)
 * Contacting [individual TSC members](https://nodejs.org/en/foundation/tsc/#current-members-of-the-technical-steering-committee).
 
-### Moderation
+## Moderation
 See the TSC's [moderation policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md) for details about moderation.
 
-### Attribution
+## Attribution
 
 This Code of Conduct is adapted from [Rust's wonderful
 CoC](http://www.rust-lang.org/conduct.html) as well as the

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -1,3 +1,5 @@
+# Additional Onboarding Information
+
 ## Who to CC in issues
 
 | subsystem | maintainers |


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc, tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

This makes sure that the first heading in all markdown files is `h1`.

Only three files needed to be changed to conform:
 1. `BUILDING.md`
 2. `CODE_OF_CONDUCT.md`
 3. `doc/onboarding-extras.md`

Also, `.remarkrc` is updated to include the `first-heading-level: 1` rule in order to catch similar issues in the future.

This change could be controversial, as it changes the actual look of the Code of Conduct document, so I made a stand-alone PR for it to be reviewed separately. I'm not sure if the new header levels are the best choice, and I'm open for any suggestions here.

/cc @nodejs/documentation, @nodejs/inclusivity, @Trott, @addaleax.