### PR TITLE
test: remove `&socket` from test_inspector_socket

### DIFF
--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -504,7 +504,6 @@ TEST_F(InspectorSocketTest, ExtraTextBeforeRequest) {
   SPIN_WHILE(last_event != kInspectorHandshakeFailed);
   expect_handshake_failure();
   EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)), 0);
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&socket)), 0);
 }
 
 TEST_F(InspectorSocketTest, ExtraLettersBeforeRequest) {
@@ -516,7 +515,6 @@ TEST_F(InspectorSocketTest, ExtraLettersBeforeRequest) {
   SPIN_WHILE(last_event != kInspectorHandshakeFailed);
   expect_handshake_failure();
   EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)), 0);
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&socket)), 0);
 }
 
 TEST_F(InspectorSocketTest, RequestWithoutKey) {
@@ -531,7 +529,6 @@ TEST_F(InspectorSocketTest, RequestWithoutKey) {
   SPIN_WHILE(last_event != kInspectorHandshakeFailed);
   expect_handshake_failure();
   EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&client_socket)), 0);
-  EXPECT_EQ(uv_is_active(reinterpret_cast<uv_handle_t*>(&socket)), 0);
 }
 
 TEST_F(InspectorSocketTest, KillsConnectionOnProtocolViolation) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test 

##### Description of change
<!-- Provide a description of the change below this comment. -->

What is `socket`, where did it came from? We don't know.

On a more serious note: `socket` is function from `sys/socket.h`. There
is no way casting it to structure could yield any useful results.

R= @nodejs/v8 