### PR TITLE
benchmark: use 'yes' instead of echo in a loop

### DIFF
--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -20,8 +20,7 @@ function main(conf) {
   const msg = `"${'.'.repeat(len)}"`;
   msg.match(/./);
   const options = {'stdio': ['ignore', 'pipe', 'ignore']};
-  // NOTE: Command below assumes bash shell.
-  const child = exec(`while\n  echo ${msg}\ndo :; done\n`, options);
+  const child = exec(`yes ${msg}`, options);
 
   var bytes = 0;
   child.stdout.on('data', function(msg) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark


##### Description of change
This changes `child-process-exec-stdout` benchmark to use `yes` instead of `echo` in a while loop. This makes this benchmark consistent with`child-process-read` which already uses `yes` and allows this benchmark to be executed on Windows.

/cc @nodejs/benchmarking