### PR TITLE
Adds assertions to zero length buffer slice test

### DIFF
--- a/test/parallel/test-buffer-slice.js
+++ b/test/parallel/test-buffer-slice.js
@@ -52,7 +52,8 @@ assert.equal(buf.slice('0', '-111'), '');
 
 // try to slice a zero length Buffer
 // see https://github.com/joyent/node/issues/5881
-Buffer.alloc(0).slice(0, 1);
+assert.doesNotThrow(() => Buffer.alloc(0).slice(0, 1));
+assert.strictEqual(Buffer.alloc(0).slice(0, 1).length, 0);
 
 {
   // Single argument slice


### PR DESCRIPTION

##### Checklist

- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer

##### Description of change
Existing test to show that slicing a 0 length buffer does not throw was missing the actual doesNotThrow assertion.

1) Adds missing assertion that slicing a 0 length buffer does not throw.
2) Adds assertion that slicing a 0 length buffer has a length of 0.