### PR TITLE
benchmark: add benchmarks for `Buffer.from()`

### DIFF
--- a/benchmark/buffers/buffer-from.js
+++ b/benchmark/buffers/buffer-from.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+const bench = common.createBenchmark(main, {
+  source: [
+    'array',
+    'arraybuffer',
+    'arraybuffer-middle',
+    'buffer',
+    'uint8array',
+    'string',
+    'string-base64'
+  ],
+  len: [10, 2048],
+  n: [1024]
+});
+
+function main(conf) {
+  const len = +conf.len;
+  const n = +conf.n;
+
+  const array = new Array(len).fill(42);
+  const arrayBuf = new ArrayBuffer(len);
+  const str = 'a'.repeat(len);
+  const buffer = Buffer.allocUnsafe(len);
+  const uint8array = new Uint8Array(len);
+
+  var i;
+
+  switch (conf.source) {
+    case 'array':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(array);
+      }
+      bench.end(n);
+      break;
+    case 'arraybuffer':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(arrayBuf);
+      }
+      bench.end(n);
+      break;
+    case 'arraybuffer-middle':
+      const offset = ~~(len / 4);
+      const length = ~~(len / 2);
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(arrayBuf, offset, length);
+      }
+      bench.end(n);
+      break;
+    case 'buffer':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(buffer);
+      }
+      bench.end(n);
+      break;
+    case 'uint8array':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(uint8array);
+      }
+      bench.end(n);
+      break;
+    case 'string':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(str);
+      }
+      bench.end(n);
+      break;
+    case 'string-base64':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(str, 'base64');
+      }
+      bench.end(n);
+      break;
+    default:
+      assert.fail(null, null, 'Should not get here');
+  }
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

benchmarks

##### Description of change

Adds benchmarks for `Buffer.from()` and its various argument combinations.

Ref: #8733

It also looks like there’s a performance regression on the current `master` that isn’t on v6 and which exceeds the one described in #8733 notably:

```
$ nvm use 6.6
Now using node v6.6.0
$ node benchmark/buffers/buffer-from.js
buffers/buffer-from.js n=1024 len=10 source="array": 1352.177972206885
buffers/buffer-from.js n=1024 len=2048 source="array": 108.78659817646022
buffers/buffer-from.js n=1024 len=10 source="arraybuffer": 2849.9419428697133
buffers/buffer-from.js n=1024 len=2048 source="arraybuffer": 3303.4248644402187
buffers/buffer-from.js n=1024 len=10 source="arraybuffer-middle": 3115.8790362447385
buffers/buffer-from.js n=1024 len=2048 source="arraybuffer-middle": 3143.4771954881257
buffers/buffer-from.js n=1024 len=10 source="buffer": 1362.2701961428957
buffers/buffer-from.js n=1024 len=2048 source="buffer": 367.766503317392
buffers/buffer-from.js n=1024 len=10 source="uint8array": 1480.231221483884
buffers/buffer-from.js n=1024 len=2048 source="uint8array": 139.1829921904438
buffers/buffer-from.js n=1024 len=10 source="string": 685.3303955985581
buffers/buffer-from.js n=1024 len=2048 source="string": 163.58717416397928
buffers/buffer-from.js n=1024 len=10 source="string-base64": 504.0783343717544
buffers/buffer-from.js n=1024 len=2048 source="string-base64": 110.29233159776292
$ ./node benchmark/buffers/buffer-from.js 
buffers/buffer-from.js n=1024 len=10 source="array": 522.2764604853
buffers/buffer-from.js n=1024 len=2048 source="array": 97.72530491842134
buffers/buffer-from.js n=1024 len=10 source="arraybuffer": 776.7268797100915
buffers/buffer-from.js n=1024 len=2048 source="arraybuffer": 658.5854603318716
buffers/buffer-from.js n=1024 len=10 source="arraybuffer-middle": 690.3042490225982
buffers/buffer-from.js n=1024 len=2048 source="arraybuffer-middle": 742.2573140765411
buffers/buffer-from.js n=1024 len=10 source="buffer": 496.9498820166972
buffers/buffer-from.js n=1024 len=2048 source="buffer": 296.6712882896401
buffers/buffer-from.js n=1024 len=10 source="uint8array": 561.3881977090617
buffers/buffer-from.js n=1024 len=2048 source="uint8array": 124.81186442783465
buffers/buffer-from.js n=1024 len=10 source="string": 386.8836136075654
buffers/buffer-from.js n=1024 len=2048 source="string": 173.50450305089902
buffers/buffer-from.js n=1024 len=10 source="string-base64": 370.7046939007373
buffers/buffer-from.js n=1024 len=2048 source="string-base64": 120.02970526090957
```

:(