### PR TITLE
buffer: fix check of buffer and rearrange conditional

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -264,8 +264,8 @@ function fromObject(obj) {
   }
 
   if (obj) {
-    if (isArrayBuffer(obj.buffer) || 'length' in obj ||
-        isSharedArrayBuffer(obj)) {
+    if ('length' in obj || isArrayBuffer(obj.buffer) ||
+        isSharedArrayBuffer(obj.buffer)) {
       if (typeof obj.length !== 'number' || obj.length !== obj.length) {
         return new FastBuffer();
       }

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -27,3 +27,5 @@ assert.deepStrictEqual(arr_buf, ar_buf, 0);
 // Checks for calling Buffer.byteLength on a SharedArrayBuffer
 
 assert.strictEqual(Buffer.byteLength(sab), sab.byteLength, 0);
+
+assert.doesNotThrow(() => Buffer.from({buffer: sab}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

refer to #8510 for more information.
isSharedArrayBuffer in fromObject was missing obj.buffer
moved the 'length' in obj check so that it is checked first making
the code slightly more performant and able to handle SharedArrayBuffer
without relying on an explicit check.

@addaleax please take a look.