### PR TITLE
doc,tool: refactor checking jsPrimitives

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -4,11 +4,16 @@ const jsDocUrl = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/' +
                  'Reference/Global_Objects/';
 const jsPrimitiveUrl = 'https://developer.mozilla.org/en-US/docs/Web/' +
                        'JavaScript/Data_structures';
-const jsPrimitives = [
-  'Number', 'String', 'Boolean', 'Null', 'Symbol'
-];
+const jsPrimitives = {
+  'Integer': 'Number',  // this is for extending
+  'Number': 'Number',
+  'String': 'String',
+  'Boolean': 'Boolean',
+  'Null': 'Null',
+  'Symbol': 'Symbol'
+};
 const jsGlobalTypes = [
-  'Error', 'Object', 'Function', 'Array', 'Uint8Array',
+  'Error', 'Object', 'Function', 'Array', 'TypedArray', 'Uint8Array',
   'Uint16Array', 'Uint32Array', 'Int8Array', 'Int16Array', 'Int32Array',
   'Uint8ClampedArray', 'Float32Array', 'Float64Array', 'Date', 'RegExp',
   'ArrayBuffer', 'DataView', 'Promise', 'EvalError', 'RangeError',
@@ -38,8 +43,9 @@ module.exports = {
       typeText = typeText.trim();
       if (typeText) {
         let typeUrl = null;
-        if (jsPrimitives.indexOf(typeText) !== -1) {
-          typeUrl = jsPrimitiveUrl + '#' + typeText + '_type';
+        const primitive = jsPrimitives[typeText];
+        if (primitive !== undefined) {
+          typeUrl = `${jsPrimitiveUrl}#${primitive}_type`;
         } else if (jsGlobalTypes.indexOf(typeText) !== -1) {
           typeUrl = jsDocUrl + typeText;
         } else if (typeMap[typeText]) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, tool

##### Description of change
<!-- Provide a description of the change below this comment. -->
There are most types like `Integer` and `TypedArray` in our documentations, but we don't have a good reference to them like others, so fix them in our doctool, but I'm not sure if we should map `Integer` as a `Number` type, actually even the `Integer` is not a real type in v8, by the way, the `Int32` might be more proper as v8 has the type `Int32Array` :)

