### PR TITLE
doc,tool: add tls.TLSSocket to typeMap

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -24,6 +24,7 @@ const typeMap = {
   'cluster.Worker': 'cluster.html#cluster_class_worker',
   'dgram.Socket': 'dgram.html#dgram_class_dgram_socket',
   'net.Socket': 'net.html#net_class_net_socket',
+  'tls.TLSSocket': 'tls.html#tls_class_tls_tlssocket',
   'EventEmitter': 'events.html#events_class_eventemitter',
   'Timer': 'timers.html#timers_timers'
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

We use tls.TLSSocket type in [tls.md](https://nodejs.org/dist/latest-v6.x/docs/api/tls.html#tls_event_tlsclienterror), so that needs to be added to doctool's typeMap.