### PR TITLE
Add NODE_PRESERVE_SYMLINKS environment variable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -277,6 +277,13 @@ added: v0.11.15
 Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small-icu support.
 
+### `NODE_PRESERVE_SYMLINKS=1`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set to `1`, instructs the module loader to preserve symbolic links when
+resolving and caching modules.
 
 ### `NODE_REPL_HISTORY=file`
 <!-- YAML

--- a/src/node.cc
+++ b/src/node.cc
@@ -4188,6 +4188,11 @@ void Init(int* argc,
   V8::SetFlagsFromString(NODE_V8_OPTIONS, sizeof(NODE_V8_OPTIONS) - 1);
 #endif
 
+  // Allow for environment set preserving symlinks.
+  if (auto preserve_symlinks = secure_getenv("NODE_PRESERVE_SYMLINKS")) {
+    config_preserve_symlinks = (*preserve_symlinks == '1');
+  }
+
   // Parse a few arguments which are specific to Node.
   int v8_argc;
   const char** v8_argv;

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -6,6 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const exec = require('child_process').exec;
 const spawn = require('child_process').spawn;
+const util = require('util');
 
 common.refreshTmpDir();
 
@@ -53,7 +54,16 @@ function test() {
   const node = process.execPath;
   const child = spawn(node, ['--preserve-symlinks', linkScript]);
   child.on('close', function(code, signal) {
-    assert(!code);
+    assert.strictEqual(code, 0);
+    assert(!signal);
+  });
+
+  // Also verify that symlinks works for setting preserve via env variables
+  const childEnv = spawn(node, [linkScript], {
+    env: util._extend(process.env, {NODE_PRESERVE_SYMLINKS: '1'})
+  });
+  childEnv.on('close', function(code, signal) {
+    assert.strictEqual(code, 0);
     assert(!signal);
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
cli

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add a way through environment variables to set the --preserve-symlinks
flag. Any non-null value of NODE_PRESERVE_SYMLINKS will enable symlinks.

Fixes: https://github.com/nodejs/node/issues/8509