### PR TITLE
dgram: use Buffer.alloc(0) for zero-size buffers

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -350,7 +350,7 @@ Socket.prototype.send = function(buffer,
     self.bind({port: 0, exclusive: true}, null);
 
   if (list.length === 0)
-    list.push(Buffer.allocUnsafe(0));
+    list.push(Buffer.alloc(0));
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.


### PR DESCRIPTION
##### Checklist

- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
dgram


##### Description of change

There is no difference between `Buffer.alloc(0)` and `Buffer.allocUnsafe(0)`, so there is no reason to confuse anyone reading the code with an additional call to `allocUnsafe`.

/cc @jasnell @addaleax 

*Upd:* ow, I created a branch on this repo, will delete it after this merges.