### PR TITLE
buffer: fix performance regression

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -6,7 +6,11 @@ const { isArrayBuffer, isSharedArrayBuffer } = process.binding('util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
-class FastBuffer extends Uint8Array {}
+class FastBuffer extends Uint8Array {
+  constructor(arg1, arg2, arg3) {
+    super(arg1, arg2, arg3);
+  }
+}
 
 FastBuffer.prototype.constructor = Buffer;
 Buffer.prototype = FastBuffer.prototype;


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

V8 5.4 changed the way that the default constructor of derived classes
is called. It introduced a significant performance regression in the
buffer module for the creation of pooled buffers. This commit forces the
definition back to how it was.

Ref: https://bugs.chromium.org/p/v8/issues/detail?id=4890

Benchmark results using the script from https://github.com/nodejs/node/pull/8738:
```
6.6.0:
m.js n=1024 len=10 source="array": 2940.0523751381074
m.js n=1024 len=2048 source="array": 243.34844074199046
m.js n=1024 len=10 source="arraybuffer": 5469.801373510926
m.js n=1024 len=2048 source="arraybuffer": 5897.122441515577
m.js n=1024 len=10 source="arraybuffer-middle": 5715.82551047164
m.js n=1024 len=2048 source="arraybuffer-middle": 5651.568910575927
m.js n=1024 len=10 source="buffer": 2627.6210998395145
m.js n=1024 len=2048 source="buffer": 659.2472687131358
m.js n=1024 len=10 source="uint8array": 2598.5564648340537
m.js n=1024 len=2048 source="uint8array": 270.0350801781541
m.js n=1024 len=10 source="string": 1847.099925407467
m.js n=1024 len=2048 source="string": 335.8807107007938
m.js n=1024 len=10 source="string-base64": 1628.3220387388276
m.js n=1024 len=2048 source="string-base64": 293.5605053750516

Current master:
m.js n=1024 len=10 source="array": 1105.7778268274712
m.js n=1024 len=2048 source="array": 262.61636308568154
m.js n=1024 len=10 source="arraybuffer": 1463.1770393435074
m.js n=1024 len=2048 source="arraybuffer": 1438.3519347799318
m.js n=1024 len=10 source="arraybuffer-middle": 1289.6443262079608
m.js n=1024 len=2048 source="arraybuffer-middle": 1465.8917985524079
m.js n=1024 len=10 source="buffer": 1154.3281747402962
m.js n=1024 len=2048 source="buffer": 714.9198271277221
m.js n=1024 len=10 source="uint8array": 1188.4816701911184
m.js n=1024 len=2048 source="uint8array": 312.9837225134168
m.js n=1024 len=10 source="string": 1021.2184715065113
m.js n=1024 len=2048 source="string": 415.72725788425214
m.js n=1024 len=10 source="string-base64": 746.3019883767605
m.js n=1024 len=2048 source="string-base64": 272.66673662077363

This PR:
m.js n=1024 len=10 source="array": 4360.13359704818
m.js n=1024 len=2048 source="array": 210.9601264473078
m.js n=1024 len=10 source="arraybuffer": 6096.237297560867
m.js n=1024 len=2048 source="arraybuffer": 6204.587073036097
m.js n=1024 len=10 source="arraybuffer-middle": 6931.443006081272
m.js n=1024 len=2048 source="arraybuffer-middle": 5500.454679186303
m.js n=1024 len=10 source="buffer": 3741.9594463683297
m.js n=1024 len=2048 source="buffer": 782.6012936368813
m.js n=1024 len=10 source="uint8array": 4495.957363782579
m.js n=1024 len=2048 source="uint8array": 188.2792093087443
m.js n=1024 len=10 source="string": 2287.6058600223178
m.js n=1024 len=2048 source="string": 461.90557855442626
m.js n=1024 len=10 source="string-base64": 2026.5954755341668
m.js n=1024 len=2048 source="string-base64": 298.25954061659525
```