### PR TITLE
test: accept expected AIX result test-stdio-closed

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -30,8 +30,5 @@ test-tick-processor-unknown     : PASS,FLAKY
 test-fs-watch-enoent                 : FAIL, PASS
 test-fs-watch-encoding               : FAIL, PASS
 
-#being worked under https://github.com/nodejs/node/issues/7973
-test-stdio-closed                        : PASS, FLAKY
-
 #covered by https://github.com/nodejs/node/issues/8271
 test-child-process-fork-dgram            : PASS, FLAKY

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var spawn = require('child_process').spawn;
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
 
 if (common.isWindows) {
   common.skip('platform not supported.');
@@ -9,18 +9,28 @@ if (common.isWindows) {
 }
 
 if (process.argv[2] === 'child') {
-  process.stdout.write('stdout', function() {
-    process.stderr.write('stderr', function() {
-      process.exit(42);
+  try {
+    process.stdout.write('stdout', function() {
+      try {
+        process.stderr.write('stderr', function() {
+          process.exit(42);
+        });
+      } catch (e) {
+        process.exit(84);
+      }
     });
-  });
+  } catch (e) {
+    assert.strictEqual(e.code, 'EBADF');
+    assert.strictEqual(e.message, 'EBADF: bad file descriptor, write');
+    process.exit(126);
+  }
   return;
 }
 
 // Run the script in a shell but close stdout and stderr.
-var cmd = `"${process.execPath}" "${__filename}" child 1>&- 2>&-`;
-var proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
+const cmd = `"${process.execPath}" "${__filename}" child 1>&- 2>&-`;
+const proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
 
 proc.on('exit', common.mustCall(function(exitCode) {
-  assert.equal(exitCode, 42);
+  assert.strictEqual(exitCode, common.isAix ? 126 : 42);
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

AIX handles closed stdio differently (but still compliant with spec as
far as I can tell) than other POSIX variants we test. Test results are
different than Linux and others because AIX takes measures to not re-use
the file descriptors for stdio if one of the stdio streams is closed.

Fixes: https://github.com/nodejs/node/issues/8375

/cc @mhdawson @gireeshpunathil @bnoordhuis 