### PR TITLE
test: removes FIXME parallel/test-repl-persistent-history

### DIFF
--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -139,17 +139,7 @@ const tests = [
     test: [UP, CLEAR, '\'42\'', ENTER],
     expected: [prompt, convertMsg, prompt, prompt + '\'=^.^=\'', prompt, '\'',
                '4', '2', '\'', '\'42\'\n', prompt, prompt],
-    after: function ensureHistoryFixture() {
-      // XXX(Fishrock123) Make sure nothing weird happened to our fixture
-      //  or it's temporary copy.
-      // Sometimes this test used to erase the fixture and I'm not sure why.
-      const history = fs.readFileSync(historyFixturePath, 'utf8');
-      assert.strictEqual(history,
-                         '\'you look fabulous today\'\n\'Stay Fresh~\'\n');
-      const historyCopy = fs.readFileSync(historyPath, 'utf8');
-      assert.strictEqual(historyCopy, '\'you look fabulous today\'' + os.EOL +
-                                      '\'Stay Fresh~\'' + os.EOL);
-    }
+    clean: false
   },
   { // Requires the above testcase
     env: {},
@@ -229,7 +219,7 @@ function runTest(assertCleaned) {
   const env = opts.env;
   const test = opts.test;
   const expected = opts.expected;
-  const after = opts.after;
+  const clean = opts.clean;
   const before = opts.before;
 
   if (before) before();
@@ -275,7 +265,7 @@ function runTest(assertCleaned) {
     });
 
     function onClose() {
-      const cleaned = after ? after() : cleanupTmpFile();
+      const cleaned = clean === false ? false : cleanupTmpFile();
 
       try {
         // Ensure everything that we expected was output


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

When NODE_REPL_HISTORY isn't defined `repl` defaults to temporary file
This prevents the temporary file from being cleared and removes check on fixture
Refs: #4640

/cc @Fishrock123