### PR TITLE
test: remove FIXME pummel/test-tls-securepair-client

### DIFF
--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -39,12 +39,6 @@ function test2() {
 }
 
 function test(keyfn, certfn, check, next) {
-  // FIXME: Avoid the common PORT as this test currently hits a C-level
-  // assertion error with node_g. The program aborts without HUPing
-  // the openssl s_server thus causing many tests to fail with
-  // EADDRINUSE.
-  var PORT = common.PORT + 5;
-
   keyfn = join(common.fixturesDir, keyfn);
   var key = fs.readFileSync(keyfn).toString();
 
@@ -52,7 +46,7 @@ function test(keyfn, certfn, check, next) {
   var cert = fs.readFileSync(certfn).toString();
 
   var server = spawn(common.opensslCli, ['s_server',
-                                         '-accept', PORT,
+                                         '-accept', common.PORT,
                                          '-cert', certfn,
                                          '-key', keyfn]);
   server.stdout.pipe(process.stdout);
@@ -121,7 +115,7 @@ function test(keyfn, certfn, check, next) {
     pair.encrypted.pipe(s);
     s.pipe(pair.encrypted);
 
-    s.connect(PORT);
+    s.connect(common.PORT);
 
     s.on('connect', function() {
       console.log('client connected');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Reverts: 85827bd
Refs: #4640
Using `common.PORT` no longer causes other tests to fail

~~Currently running `make -j4 test`  returns errors for parallel/test-internal-modules and parallel/test-repl but that seems to be unrelated to this pull request.~~ 
It seems that there's something unusual going on with the VM I use to build