### PR TITLE
test: Removes FIXME parallel/test-setproctitle

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -2,7 +2,6 @@
 // Original test written by Jakub Lekstan <kuebzky@gmail.com>
 const common = require('../common');
 
-require('../common');
 if (!(common.isFreeBSD || common.isOSX || common.isLinux || common.isSunOS)) {
   common.skip(`Unsupported platform [${process.platform}]`);
   return;

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -4,7 +4,7 @@ const common = require('../common');
 
 require('../common');
 // FIXME add sunos support
-if (!(common.isFreeBSD || common.isOSX || common.isLinux)) {
+if (!(common.isFreeBSD || common.isOSX || common.isLinux || common.isSunOS)) {
   console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
   return;
 }

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -3,9 +3,8 @@
 const common = require('../common');
 
 require('../common');
-// FIXME add sunos support
 if (!(common.isFreeBSD || common.isOSX || common.isLinux || common.isSunOS)) {
-  console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
+  common.skip(`Unsupported platform [${process.platform}]`);
   return;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
##### Description of change

<!-- Provide a description of the change below this comment. -->

Refs:#4640
Adds check for `SunOS` support

~~Currently running make -j4 test returns errors for 'parallel/test-internal-modules' and 'parallel/test-repl' but that seems to be unrelated to this pull request.~~
It seems that there's something unusual going on with the VM I use to build
