### PR TITLE
test: cleanup/update test-os.js

### DIFF
--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -101,7 +101,7 @@ console.error(interfaces);
 switch (platform) {
   case 'linux':
     {
-      const filter = function(e) { return e.address == '127.0.0.1'; };
+      const filter = function(e) { return e.address === '127.0.0.1'; };
       const actual = interfaces.lo.filter(filter);
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                         mac: '00:00:00:00:00:00', family: 'IPv4',
@@ -111,7 +111,7 @@ switch (platform) {
     }
   case 'win32':
     {
-      const filter = function(e) { return e.address == '127.0.0.1'; };
+      const filter = function(e) { return e.address === '127.0.0.1'; };
       const actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                         mac: '00:00:00:00:00:00', family: 'IPv4',
@@ -129,17 +129,17 @@ const home = os.homedir();
 
 console.log('homedir = ' + home);
 is.string(home);
-assert.ok(home.indexOf(path.sep) !== -1);
+assert.ok(home.includes(path.sep));
 
 if (common.isWindows && process.env.USERPROFILE) {
   assert.strictEqual(home, process.env.USERPROFILE);
   delete process.env.USERPROFILE;
-  assert.ok(os.homedir().indexOf(path.sep) !== -1);
+  assert.ok(os.homedir().includes(path.sep));
   process.env.USERPROFILE = home;
 } else if (!common.isWindows && process.env.HOME) {
   assert.strictEqual(home, process.env.HOME);
   delete process.env.HOME;
-  assert.ok(os.homedir().indexOf(path.sep) !== -1);
+  assert.ok(os.homedir().includes(path.sep));
   process.env.HOME = home;
 }
 
@@ -157,13 +157,13 @@ if (common.isWindows) {
 } else {
   is.number(pwd.uid);
   is.number(pwd.gid);
-  assert.notStrictEqual(pwd.shell.indexOf(path.sep), -1);
+  assert.ok(pwd.shell.includes(path.sep));
   assert.strictEqual(pwd.uid, pwdBuf.uid);
   assert.strictEqual(pwd.gid, pwdBuf.gid);
   assert.strictEqual(pwd.shell, pwdBuf.shell.toString('utf8'));
 }
 
 is.string(pwd.username);
-assert.notStrictEqual(pwd.homedir.indexOf(path.sep), -1);
+assert.ok(pwd.homedir.includes(path.sep));
 assert.strictEqual(pwd.username, pwdBuf.username.toString('utf8'));
 assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Replaced `==` with `===
Replaced `indexOf(...) !== -1` with `includes()`