### PR TITLE
changed var to const, added strict equality checks

### DIFF
--- a/test/parallel/test-fs-read-stream-fd-leak.js
+++ b/test/parallel/test-fs-read-stream-fd-leak.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
-var path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 
 var openCount = 0;
-var _fsopen = fs.open;
-var _fsclose = fs.close;
+const _fsopen = fs.open;
+const _fsclose = fs.close;
 
-var loopCount = 50;
-var totalCheck = 50;
-var emptyTxt = path.join(common.fixturesDir, 'empty.txt');
+const loopCount = 50;
+const totalCheck = 50;
+const emptyTxt = path.join(common.fixturesDir, 'empty.txt');
 
 fs.open = function() {
   openCount++;
@@ -29,20 +29,25 @@ function testLeak(endFn, callback) {
   var i = 0;
   var check = 0;
 
-  var checkFunction = function() {
-    if (openCount != 0 && check < totalCheck) {
+  const checkFunction = function() {
+    if (openCount !== 0 && check < totalCheck) {
       check++;
       setTimeout(checkFunction, 100);
       return;
     }
-    assert.equal(0, openCount, 'no leaked file descriptors using ' +
-                 endFn + '() (got ' + openCount + ')');
+
+    assert.strictEqual(
+      0,
+      openCount,
+      `no leaked file descriptors using ${endFn}() (got ${openCount})`
+    );
+
     openCount = 0;
     callback && setTimeout(callback, 100);
   };
 
   setInterval(function() {
-    var s = fs.createReadStream(emptyTxt);
+    const s = fs.createReadStream(emptyTxt);
     s[endFn]();
 
     if (++i === loopCount) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test fs


##### Description of change
<!-- Provide a description of the change below this comment. -->

Changed var to const where appropriate. Substituted
assert.strictEqual for assert.equal for better type checks.