### PR TITLE
Edited BUILDING.md, removing broken workaround for case where `python`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -34,14 +34,7 @@ $ ./configure
 $ make
 ```
 
-If your Python binary is in a non-standard location or has a
-non-standard name, run the following instead:
-
-```console
-$ export PYTHON=/path/to/python
-$ $PYTHON ./configure
-$ make
-```
+Note that the above requires that `python` resolve to Python 2.6/2.7 and not a newer version.
 
 To run the tests:
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
##### Description of change
Updated BUILDING.md, removing workaround for Python conflicts that didn't work.