### PR TITLE
test:replace indexOf, assert.equal, add mustCall

### DIFF
--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -12,7 +12,7 @@ if (common.isWindows) {
   // On Windows, creating symlinks requires admin privileges.
   // We'll only try to run symlink test if we have enough privileges.
   exec('whoami /priv', function(err, o) {
-    if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
+    if (err || !o.includes('SeCreateSymbolicLinkPrivilege')) {
       common.skip('insufficient privileges');
       return;
     }
@@ -25,7 +25,7 @@ common.refreshTmpDir();
 const linkData = path.join(common.fixturesDir, '/cycles/root.js');
 const linkPath = path.join(common.tmpDir, 'symlink1.js');
 
-fs.symlink(linkData, linkPath, function(err) {
+fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   if (err) throw err;
 
   fs.lstat(linkPath, common.mustCall(function(err, stats) {
@@ -40,9 +40,9 @@ fs.symlink(linkData, linkPath, function(err) {
 
   fs.readlink(linkPath, common.mustCall(function(err, destination) {
     if (err) throw err;
-    assert.equal(destination, linkData);
+    assert.strictEqual(destination, linkData);
   }));
-});
+}));
 
 
 process.on('exit', function() {

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -26,20 +26,20 @@ const linkData = path.join(common.fixturesDir, '/cycles/root.js');
 const linkPath = path.join(common.tmpDir, 'symlink1.js');
 
 fs.symlink(linkData, linkPath, common.mustCall(function(err) {
-  if (err) throw err;
+  assert.ifError(err);
 
   fs.lstat(linkPath, common.mustCall(function(err, stats) {
-    if (err) throw err;
+    assert.ifError(err);
     linkTime = stats.mtime.getTime();
   }));
 
   fs.stat(linkPath, common.mustCall(function(err, stats) {
-    if (err) throw err;
+    assert.ifError(err);
     fileTime = stats.mtime.getTime();
   }));
 
   fs.readlink(linkPath, common.mustCall(function(err, destination) {
-    if (err) throw err;
+    assert.ifError(err);
     assert.strictEqual(destination, linkData);
   }));
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
In test/parallel/test-fs-symlink.js:

Line 15: the use of o.indexOf() can be replaced with a usage of o.includes() which will make it more clear.
Line 43: the use of assert.equal() can be assert.strictEqual() instead
Line 28: the callback should be wrapped in common.mustCall() like in other instances of callbacks later in the file.
