### PR TITLE
test: in test/parallel/test-fs-realpath.js:

### DIFF
--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -1,28 +1,29 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
-var path = require('path');
-var exec = require('child_process').exec;
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').exec;
 var async_completed = 0, async_expected = 0, unlink = [];
 var skipSymlinks = false;
 
 common.refreshTmpDir();
 
 var root = '/';
-var assertEqualPath = assert.equal;
+var assertEqualPath = assert.strictEqual;
 if (common.isWindows) {
   // something like "C:\\"
   root = process.cwd().substr(0, 3);
   assertEqualPath = function(path_left, path_right, message) {
-    assert.equal(path_left.toLowerCase(), path_right.toLowerCase(), message);
+    assert
+      .strictEqual(path_left.toLowerCase(), path_right.toLowerCase(), message);
   };
 
   // On Windows, creating symlinks requires admin privileges.
   // We'll only try to run symlink test if we have enough privileges.
   try {
     exec('whoami /priv', function(err, o) {
-      if (err || o.indexOf('SeCreateSymbolicLinkPrivilege') == -1) {
+      if (err || !o.includes('SeCreateSymbolicLinkPrivilege')) {
         skipSymlinks = true;
       }
       runTest();
@@ -41,8 +42,8 @@ function tmp(p) {
   return path.join(common.tmpDir, p);
 }
 
-var targetsAbsDir = path.join(common.tmpDir, 'targets');
-var tmpAbsDir = common.tmpDir;
+const targetsAbsDir = path.join(common.tmpDir, 'targets');
+const tmpAbsDir = common.tmpDir;
 
 // Set up targetsAbsDir and expected subdirectories
 fs.mkdirSync(targetsAbsDir);
@@ -91,7 +92,7 @@ function test_simple_relative_symlink(callback) {
     fs.symlinkSync(t[1], t[0], 'file');
     unlink.push(t[0]);
   });
-  var result = fs.realpathSync(entry);
+  const result = fs.realpathSync(entry);
   assertEqualPath(result, path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assertEqualPath(result, path.resolve(expected));
@@ -103,7 +104,7 @@ function test_simple_absolute_symlink(callback) {
 
   // this one should still run, even if skipSymlinks is set,
   // because it uses a junction.
-  var type = skipSymlinks ? 'junction' : 'dir';
+  const type = skipSymlinks ? 'junction' : 'dir';
 
   console.log('using type=%s', type);
 
@@ -117,7 +118,7 @@ function test_simple_absolute_symlink(callback) {
     fs.symlinkSync(t[1], t[0], type);
     unlink.push(t[0]);
   });
-  var result = fs.realpathSync(entry);
+  const result = fs.realpathSync(entry);
   assertEqualPath(result, path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assertEqualPath(result, path.resolve(expected));
@@ -131,16 +132,17 @@ function test_deep_relative_file_symlink(callback) {
     return runNextTest();
   }
 
-  var expected = path.join(common.fixturesDir, 'cycles', 'root.js');
-  var linkData1 = path.relative(path.join(targetsAbsDir, 'nested-index', 'one'),
-    expected);
-  var linkPath1 = path.join(targetsAbsDir,
+  const expected = path.join(common.fixturesDir, 'cycles', 'root.js');
+  const linkData1 = path
+                      .relative(path.join(targetsAbsDir, 'nested-index', 'one'),
+                                expected);
+  const linkPath1 = path.join(targetsAbsDir,
                             'nested-index', 'one', 'symlink1.js');
   try {fs.unlinkSync(linkPath1);} catch (e) {}
   fs.symlinkSync(linkData1, linkPath1, 'file');
 
-  var linkData2 = '../one/symlink1.js';
-  var entry = path.join(targetsAbsDir,
+  const linkData2 = '../one/symlink1.js';
+  const entry = path.join(targetsAbsDir,
                         'nested-index', 'two', 'symlink1-b.js');
   try {fs.unlinkSync(entry);} catch (e) {}
   fs.symlinkSync(linkData2, entry, 'file');
@@ -159,15 +161,15 @@ function test_deep_relative_dir_symlink(callback) {
     common.skip('symlink test (no privs)');
     return runNextTest();
   }
-  var expected = path.join(common.fixturesDir, 'cycles', 'folder');
-  var path1b = path.join(targetsAbsDir, 'nested-index', 'one');
-  var linkPath1b = path.join(path1b, 'symlink1-dir');
-  var linkData1b = path.relative(path1b, expected);
+  const expected = path.join(common.fixturesDir, 'cycles', 'folder');
+  const path1b = path.join(targetsAbsDir, 'nested-index', 'one');
+  const linkPath1b = path.join(path1b, 'symlink1-dir');
+  const linkData1b = path.relative(path1b, expected);
   try {fs.unlinkSync(linkPath1b);} catch (e) {}
   fs.symlinkSync(linkData1b, linkPath1b, 'dir');
 
-  var linkData2b = '../one/symlink1-dir';
-  var entry = path.join(targetsAbsDir,
+  const linkData2b = '../one/symlink1-dir';
+  const entry = path.join(targetsAbsDir,
                         'nested-index', 'two', 'symlink12-dir');
   try {fs.unlinkSync(entry);} catch (e) {}
   fs.symlinkSync(linkData2b, entry, 'dir');
@@ -187,7 +189,7 @@ function test_cyclic_link_protection(callback) {
     common.skip('symlink test (no privs)');
     return runNextTest();
   }
-  var entry = common.tmpDir + '/cycles/realpath-3a';
+  const entry = common.tmpDir + '/cycles/realpath-3a';
   [
     [entry, '../cycles/realpath-3b'],
     [common.tmpDir + '/cycles/realpath-3b', '../cycles/realpath-3c'],
@@ -210,10 +212,10 @@ function test_cyclic_link_overprotection(callback) {
     common.skip('symlink test (no privs)');
     return runNextTest();
   }
-  var cycles = common.tmpDir + '/cycles';
-  var expected = fs.realpathSync(cycles);
-  var folder = cycles + '/folder';
-  var link = folder + '/cycles';
+  const cycles = common.tmpDir + '/cycles';
+  const expected = fs.realpathSync(cycles);
+  const folder = cycles + '/folder';
+  const link = folder + '/cycles';
   var testPath = cycles;
   testPath += '/folder/cycles'.repeat(10);
   try {fs.unlinkSync(link);} catch (ex) {}
@@ -233,26 +235,26 @@ function test_relative_input_cwd(callback) {
   }
 
   // we need to calculate the relative path to the tmp dir from cwd
-  var entrydir = process.cwd();
-  var entry = path.relative(entrydir,
+  const entrydir = process.cwd();
+  const entry = path.relative(entrydir,
       path.join(common.tmpDir + '/cycles/realpath-3a'));
-  var expected = common.tmpDir + '/cycles/root.js';
+  const expected = common.tmpDir + '/cycles/root.js';
   [
     [entry, '../cycles/realpath-3b'],
     [common.tmpDir + '/cycles/realpath-3b', '../cycles/realpath-3c'],
     [common.tmpDir + '/cycles/realpath-3c', 'root.js']
   ].forEach(function(t) {
-    var fn = t[0];
+    const fn = t[0];
     console.error('fn=%j', fn);
     try {fs.unlinkSync(fn);} catch (e) {}
-    var b = path.basename(t[1]);
-    var type = (b === 'root.js' ? 'file' : 'dir');
+    const b = path.basename(t[1]);
+    const type = (b === 'root.js' ? 'file' : 'dir');
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], fn, type);
     fs.symlinkSync(t[1], fn, 'file');
     unlink.push(fn);
   });
 
-  var origcwd = process.cwd();
+  const origcwd = process.cwd();
   process.chdir(entrydir);
   assertEqualPath(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
@@ -282,7 +284,7 @@ function test_deep_symlink_mix(callback) {
   $tmpDir/targets/nested-index/two/realpath-c -> $tmpDir/cycles/root.js
   $tmpDir/targets/cycles/root.js (hard)
   */
-  var entry = tmp('node-test-realpath-f1');
+  const entry = tmp('node-test-realpath-f1');
   try { fs.unlinkSync(tmp('node-test-realpath-d2/foo')); } catch (e) {}
   try { fs.rmdirSync(tmp('node-test-realpath-d2')); } catch (e) {}
   fs.mkdirSync(tmp('node-test-realpath-d2'), 0o700);
@@ -306,7 +308,7 @@ function test_deep_symlink_mix(callback) {
   } finally {
     unlink.push(tmp('node-test-realpath-d2'));
   }
-  var expected = tmpAbsDir + '/cycles/root.js';
+  const expected = tmpAbsDir + '/cycles/root.js';
   assertEqualPath(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assertEqualPath(result, path.resolve(expected));
@@ -316,10 +318,10 @@ function test_deep_symlink_mix(callback) {
 
 function test_non_symlinks(callback) {
   console.log('test_non_symlinks');
-  var entrydir = path.dirname(tmpAbsDir);
-  var entry = tmpAbsDir.substr(entrydir.length + 1) + '/cycles/root.js';
-  var expected = tmpAbsDir + '/cycles/root.js';
-  var origcwd = process.cwd();
+  const entrydir = path.dirname(tmpAbsDir);
+  const entry = tmpAbsDir.substr(entrydir.length + 1) + '/cycles/root.js';
+  const expected = tmpAbsDir + '/cycles/root.js';
+  const origcwd = process.cwd();
   process.chdir(entrydir);
   assertEqualPath(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
@@ -329,7 +331,7 @@ function test_non_symlinks(callback) {
   });
 }
 
-var upone = path.join(process.cwd(), '..');
+const upone = path.join(process.cwd(), '..');
 function test_escape_cwd(cb) {
   console.log('test_escape_cwd');
   asynctest(fs.realpath, ['..'], cb, function(er, uponeActual) {
@@ -338,7 +340,7 @@ function test_escape_cwd(cb) {
                     ' actual:' + uponeActual);
   });
 }
-var uponeActual = fs.realpathSync('..');
+const uponeActual = fs.realpathSync('..');
 assertEqualPath(upone, uponeActual,
                 'realpathSync("..") expected: ' + path.resolve(upone) +
                 ' actual:' + uponeActual);
@@ -375,11 +377,11 @@ function test_up_multiple(cb) {
   fs.symlinkSync('..', tmp('a/b/e'), 'dir');
   unlink.push(tmp('a/b/e'));
 
-  var abedabed = tmp('abedabed'.split('').join('/'));
-  var abedabed_real = tmp('');
+  const abedabed = tmp('abedabed'.split('').join('/'));
+  const abedabed_real = tmp('');
 
-  var abedabeda = tmp('abedabeda'.split('').join('/'));
-  var abedabeda_real = tmp('a');
+  const abedabeda = tmp('abedabeda'.split('').join('/'));
+  const abedabeda_real = tmp('a');
 
   assertEqualPath(fs.realpathSync(abedabeda), abedabeda_real);
   assertEqualPath(fs.realpathSync(abedabed), abedabed_real);
@@ -409,11 +411,11 @@ function test_abs_with_kids(cb) {
 
   // this one should still run, even if skipSymlinks is set,
   // because it uses a junction.
-  var type = skipSymlinks ? 'junction' : 'dir';
+  const type = skipSymlinks ? 'junction' : 'dir';
 
   console.log('using type=%s', type);
 
-  var root = tmpAbsDir + '/node-test-realpath-abs-kids';
+  const root = tmpAbsDir + '/node-test-realpath-abs-kids';
   function cleanup() {
     ['/a/b/c/x.txt',
       '/a/link'
@@ -442,9 +444,9 @@ function test_abs_with_kids(cb) {
     fs.symlinkSync(root + '/a/b', root + '/a/link', type);
   }
   setup();
-  var linkPath = root + '/a/link/c/x.txt';
-  var expectPath = root + '/a/b/c/x.txt';
-  var actual = fs.realpathSync(linkPath);
+  const linkPath = root + '/a/link/c/x.txt';
+  const expectPath = root + '/a/b/c/x.txt';
+  const actual = fs.realpathSync(linkPath);
   // console.log({link:linkPath,expect:expectPath,actual:actual},'sync');
   assertEqualPath(actual, path.resolve(expectPath));
   asynctest(fs.realpath, [linkPath], cb, function(er, actual) {
@@ -456,7 +458,7 @@ function test_abs_with_kids(cb) {
 
 // ----------------------------------------------------------------------------
 
-var tests = [
+const tests = [
   test_simple_error_callback,
   test_simple_relative_symlink,
   test_simple_absolute_symlink,
@@ -471,11 +473,11 @@ var tests = [
   test_abs_with_kids,
   test_up_multiple
 ];
-var numtests = tests.length;
+const numtests = tests.length;
 var testsRun = 0;
 function runNextTest(err) {
   if (err) throw err;
-  var test = tests.shift();
+  const test = tests.shift();
   if (!test) {
     return console.log(numtests +
                        ' subtests completed OK for fs.realpath');
@@ -487,13 +489,13 @@ function runNextTest(err) {
 
 assertEqualPath(root, fs.realpathSync('/'));
 fs.realpath('/', function(err, result) {
-  assert.equal(null, err);
+  assert.ifError(err);
   assertEqualPath(root, result);
 });
 
 
 function runTest() {
-  var tmpDirs = ['cycles', 'cycles/folder'];
+  const tmpDirs = ['cycles', 'cycles/folder'];
   tmpDirs.forEach(function(t) {
     t = tmp(t);
     fs.mkdirSync(t, 0o700);
@@ -506,6 +508,5 @@ function runTest() {
 
 process.on('exit', function() {
   assert.equal(numtests, testsRun);
-  unlink.forEach(function(path) { try {fs.unlinkSync(path);} catch (e) {} });
   assert.equal(async_completed, async_expected);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

 test: in test/parallel/test-fs-realpath.js:

Replaced .indexOf() with .includes() for more clarity as to
what it is doing.

Many of the instances of var changed to const.

Instances of assert.equal() refactored to assert.strictEqual() or
assert.ifError()

Removed the unlinkSync() call in the exit event handler because it
probably only handles files in the testing tmp directory so there is
no need to unlink them.