### PR TITLE
tls: hard deprecate tls.createSecurePair

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -235,4 +235,6 @@ exports.TLSSocket = require('_tls_wrap').TLSSocket;
 exports.Server = require('_tls_wrap').Server;
 exports.createServer = require('_tls_wrap').createServer;
 exports.connect = require('_tls_wrap').connect;
-exports.createSecurePair = require('_tls_legacy').createSecurePair;
+exports.createSecurePair = internalUtil.deprecate(function() {
+  return require('_tls_legacy').createSecurePair.apply(null, arguments);
+}, 'tls.createSecurePair is deprecated. Use tls.TLSSocket instead.');

--- a/test/parallel/test-tls-deprecated.js
+++ b/test/parallel/test-tls-deprecated.js
@@ -1,0 +1,11 @@
+'use strict';
+const common = require('../common');
+const tls = require('tls');
+
+common.expectWarning('DeprecationWarning', [
+  'tls.createSecurePair is deprecated. Use tls.TLSSocket instead.'
+]);
+
+try {
+  tls.createSecurePair();
+} catch (err) {}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tls
##### Description of change

<!-- Provide a description of the change below this comment. -->

We should use `util.deprecated` to wrap the deprecated `createSecurePair` in tls module.
