### PR TITLE
win,tools: ignore linting for line breaks

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -344,7 +344,7 @@ if defined jslint_ci goto jslint-ci
 if not defined jslint goto exit
 if not exist tools\eslint\lib\eslint.js goto no-lint
 echo running jslint
-%config%\node tools\eslint\bin\eslint.js --cache --rulesdir=tools\eslint-rules benchmark lib test tools
+%config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules benchmark lib test tools
 goto exit
 
 :jslint-ci


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Windows, tools.

##### Description of change

Replaces: https://github.com/nodejs/node/pull/7019

Line breaks on Windows should be CRLF, but Node also supports LF. Hence, do not check line breaks on Windows, when running `vcbuild jslint`.

Credit to @Trott, this is a direct implementation of [his suggestion](https://github.com/nodejs/node/pull/7019#issuecomment-248159172).

Fixes: https://github.com/nodejs/node/issues/6912

cc @nodejs/platform-windows @bnoordhuis 