### PR TITLE
benchmark: add info about required Unix tools

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -34,6 +34,10 @@ benchmarker to be used by providing it as an argument, e. g.:
 
 `node benchmark/http/simple.js benchmarker=autocannon`
 
+Basic Unix tools are required for some benchmarks.
+[Git for Windows][git-for-windows] includes Git Bash and tools which can be
+included in the global `PATH`.
+
 To analyze the results `R` should be installed. Check you package manager or
 download it from https://www.r-project.org/.
 
@@ -348,3 +352,4 @@ Supported options keys are:
 [autocannon]: https://github.com/mcollina/autocannon
 [wrk]: https://github.com/wg/wrk
 [t-test]: https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes.2C_unequal_variances
+[git-for-windows]: http://git-scm.com/download/win

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -35,8 +35,8 @@ benchmarker to be used by providing it as an argument, e. g.:
 `node benchmark/http/simple.js benchmarker=autocannon`
 
 Basic Unix tools are required for some benchmarks.
-[Git for Windows][git-for-windows] includes Git Bash and tools which can be
-included in the global `PATH`.
+[Git for Windows][git-for-windows] includes Git Bash and the necessary tools,
+which need to be included in the global Windows `PATH`.
 
 To analyze the results `R` should be installed. Check you package manager or
 download it from https://www.r-project.org/.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark

##### Description of change
This adds note to `README.md` about Unix tools being required by some benchmarks as requested in https://github.com/nodejs/node/pull/8721 discussion.

/cc @nodejs/benchmarking 