### PR TITLE
win,msi: mark INSTALLDIR property as secure

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -46,7 +46,7 @@
     <Property Id="ApplicationFolderName" Value="nodejs"/>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"/>
 
-    <Property Id="INSTALLDIR">
+    <Property Id="INSTALLDIR" Secure="yes">
       <RegistrySearch Id="InstallPathRegistry"
                       Type="raw"
                       Root="HKLM"


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Windows, MSI.

##### Description of change

When installing with `Always install with elevated privileges` policy set on Windows, MSIExec will spawn an installation process with elevated privileges, but will only be able to pass secure properties to it. Without this change, INSTALLDIR could not be passed and would revert to the default, effectively ignoring any change in the installation directory made by the user.

This marks INSTALLDIR as secure, allowing it to be passed to the server MSIExec process during installation.

Tested on Windows 7 with the policy set, with the MSI and INSTALLDIR in two different non-C hard drives (showing that other properties get their values corretly). Also tested upgrade from released Node 6.4 to this on Windows 10.

Fixes: https://github.com/nodejs/node/issues/6057

cc @nodejs/platform-windows 