### PR TITLE
Document crypto.timingSafeEqual() added in v6.6.0

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1418,6 +1418,9 @@ keys:
 All paddings are defined in `crypto.constants`.
 
 ### crypto.timingSafeEqual(a, b)
+<!-- YAML
+added: v6.6.0
+-->
 
 Returns true if `a` is equal to `b`, without leaking timing information that
 would allow an attacker to guess one of the values. This is suitable for


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change

Document that the method `crypto.timingSafeEqual()` has been added in v6.6.0
cf. #8304