### PR TITLE
dns: improve makeAsync internally by removing unneeded vaiable.

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -63,8 +63,8 @@ function makeAsync(callback) {
     } else {
       var args = new Array(arguments.length + 1);
       args[0] = callback;
-      for (var i = 1, a = 0; a < arguments.length; ++i, ++a)
-        args[i] = arguments[a];
+      for (var i = 0; i < arguments.length; ++i)
+        args[i + 1] = arguments[i];
       process.nextTick.apply(null, args);
     }
   };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dns

##### Description of change
<!-- Provide a description of the change below this comment. -->
This removes the unneeded variable inside the MakeCallback's loop. And I have made a benchmark by myself, with 100,000,000 calls and 5 arguments per call, the optimized gets decreased about 500ms.