### PR TITLE
TLS/SSL: tls.TLSSocket emits error event on handshake failure

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -426,7 +426,13 @@ TLSSocket.prototype._init = function(socket, wrap) {
 
     // Destroy socket if error happened before handshake's finish
     if (!self._secureEstablished) {
-      self.destroy(self._tlsError(err));
+      if (!self._controlReleased) {
+        // When handshake fails control is not yet released,
+        // so self._tlsError will return null instead of actual error
+        self.destroy(err);
+      } else {
+        self.destroy(self._tlsError(err));
+      }
     } else if (options.isServer &&
                rejectUnauthorized &&
                /peer did not return a certificate/.test(err.message)) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -426,13 +426,9 @@ TLSSocket.prototype._init = function(socket, wrap) {
 
     // Destroy socket if error happened before handshake's finish
     if (!self._secureEstablished) {
-      if (!self._controlReleased) {
-        // When handshake fails control is not yet released,
-        // so self._tlsError will return null instead of actual error
-        self.destroy(err);
-      } else {
-        self.destroy(self._tlsError(err));
-      }
+      // When handshake fails control is not yet released,
+      // so self._tlsError will return null instead of actual error
+      self.destroy(err);
     } else if (options.isServer &&
                rejectUnauthorized &&
                /peer did not return a certificate/.test(err.message)) {

--- a/test/parallel/test-tls-failed-handshake-emits-error.js
+++ b/test/parallel/test-tls-failed-handshake-emits-error.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const tls = require('tls');
+const net = require('net');
+const assert = require('assert');
+
+const bonkers = Buffer.alloc(1024, 42);
+
+const server = net.createServer(function(c) {
+  setTimeout(function() {
+    const s = new tls.TLSSocket(c, {
+      isServer: true,
+      server: server
+    });
+
+    s.on('error', common.mustCall(function(e) {
+      assert.ok(e instanceof Error,
+        'Instance of Error should be passed to error handler');
+      assert.ok(e.message.match(
+        /SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol/),
+        'Expecting SSL unknown protocol');
+    }));
+
+    s.on('close', function() {
+      server.close();
+      s.destroy();
+    });
+  }, common.platformTimeout(200));
+}).listen(0, function() {
+  const c = net.connect({port: this.address().port}, function() {
+    c.write(bonkers);
+  });
+});

--- a/test/parallel/test-tls-server-failed-handshake-emits-clienterror.js
+++ b/test/parallel/test-tls-server-failed-handshake-emits-clienterror.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const tls = require('tls');
+const net = require('net');
+const assert = require('assert');
+
+const bonkers = Buffer.alloc(1024, 42);
+
+let tlsClientErrorEmited = false;
+
+const server = tls.createServer({})
+  .listen(0, function() {
+    const c = net.connect({ port: this.address().port }, function() {
+      c.write(bonkers);
+    });
+
+  }).on('tlsClientError', function(e) {
+    tlsClientErrorEmited = true;
+    assert.ok(e instanceof Error,
+              'Instance of Error should be passed to error handler');
+    assert.ok(e.message.match(
+      /SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol/),
+      'Expecting SSL unknown protocol');
+  });
+
+setTimeout(function() {
+  server.close();
+
+  assert.ok(tlsClientErrorEmited,
+            'tlsClientError should be emited');
+
+}, common.platformTimeout(200));

--- a/test/parallel/test-tls-socket-failed-handshake-emits-error.js
+++ b/test/parallel/test-tls-socket-failed-handshake-emits-error.js
@@ -20,7 +20,7 @@ const server = net.createServer(function(c) {
 
     s.on('error', common.mustCall(function(e) {
       assert.ok(e instanceof Error,
-        'Instance of Error should be passed to error handler');
+                'Instance of Error should be passed to error handler');
       assert.ok(e.message.match(
         /SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol/),
         'Expecting SSL unknown protocol');


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes *
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`tls/ssl`

##### Description of change
`tls.TLSSocket` emits now `error` event on handshake failure.

Fixes https://github.com/nodejs/node/issues/8803

##### Notes
* `upstream/master` does not pass `make -j8 test` on time of this contribution - with unrelated errors. Tests related to `tls/ssl` and new test to highlight referenced issue pass.