### PR TITLE
meta: update NODE_MODULE_VERSION to 51

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -49,6 +49,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 48 /* Node.js v6.0.0 */
+#define NODE_MODULE_VERSION 51 /* Node.js v7.0.0 */
 
 #endif  // SRC_NODE_VERSION_H_


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change
<!-- Provide a description of the change below this comment. -->

    src: update NODE_MODULE_VERSION to 51

    When V8 was updated on master to 5.4 there were ABI breaking changes.
    In the past we have not landed these types of changes before a release,
    and as such have only bumped the NODE_MODULE_VERSION number in the
    release commit.

    Since we are going to be keeping the V8 5.4 beta on master and in the
    v7 betas I think it makes sense for us to bump the module number prior
    to a release commit being made. It is possible that this commit should
    be reverted prior to v7.0.0 being cut. Alternatively we may want to
    modify our release process for V8 to include a NODE_MODULE_VERSION
    bump before landing on master when applicable.

    NODE_MODULE_VERSION is being bumped to 51 instead of 49 to avoid
    conflicts with NODE_MODULE_VERSIONs being used in electron.

    Ref: https://github.com/electron/electron/issues/5851#issuecomment-246920775
    Ref: https://github.com/nodejs/node/pull/8317

/cc @nodejs/v8 @nodejs/ctc 