### PR TITLE
doc: improve header styling for API docs

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -15,6 +15,31 @@ body {
   background: #fff;
 }
 
+h1, h2, h3, h4 {
+  margin: .8em 0 .5em;
+  line-height: 1.2;
+}
+
+h5, h6 {
+  margin: 1em 0 .8em;
+  line-height: 1.2;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 2.441em;
+}
+
+h2 {font-size: 1.953em;}
+
+h3 {font-size: 1.563em;}
+
+h4 {font-size: 1.25em;}
+
+h5 {font-size: 1em;}
+
+h6 {font-size: .8em;}
+
 pre, tt, code, .pre, span.type, a.type {
   font-family: Monaco, Consolas, "Lucida Console", monospace;
 }
@@ -127,7 +152,7 @@ abbr {
 p {
   position: relative;
   text-rendering: optimizeLegibility;
-  margin: 0 0 1em 0;
+  margin: 0 0 1.125em 0;
   line-height: 1.5em;
 }
 
@@ -180,10 +205,10 @@ h1, h2, h3, h4, h5, h6 {
   text-rendering: optimizeLegibility;
   font-weight: 700;
   position: relative;
-  margin-bottom: .5em;
 }
 
 header h1 {
+  font-size: 2em;
   line-height: 2em;
   margin: 0;
 }
@@ -198,30 +223,15 @@ header h1 {
   background-color: #ccc;
 }
 
-#toc + h1 {
-  margin-top: 1em;
-  padding-top: 0;
-}
-
-h2 {
-  font-size: 1.5em;
-  margin: 1em 0 .5em;
-}
-
 h2 + h2 {
   margin: 0 0 .5em;
-}
-
-h3 {
-  font-size: 1em;
-  margin: 1.5em 0 .5em;
 }
 
 h3 + h3 {
   margin: 0 0 .5em;
 }
 
-h2, h3, h4 {
+h2, h3, h4, h5 {
   position: relative;
   padding-right: 40px;
 }
@@ -242,16 +252,6 @@ h1 span a, h2 span a, h3 span a, h4 span a {
   color: #000;
   text-decoration: none;
   font-weight: bold;
-}
-
-h5 {
-  font-size: 1.125em;
-  line-height: 1.4em;
-}
-
-h6 {
-  font-size: 1em;
-  line-height: 1.4667em;
 }
 
 pre, tt, code {
@@ -353,7 +353,7 @@ hr {
   margin-bottom: 0;
 }
 
-p tt, p code, li code {
+tt, code {
   font-size: .9em;
   color: #040404;
   background-color: #f2f2f2;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Improved the header sizing. 
Previously I found it consistently hard to find which API I was looking at.

Sizes were mostly decided by using http://type-scale.com/
with the 1.250 "Major Third" scaling.

Live preview at https://fishrock123.github.io/api/

Screenshots available at: https://gist.github.com/Fishrock123/e2a4676535abed7c8ecb72b1ae081f60