### PR TITLE
test: add and assert readable/writable arguments

### DIFF
--- a/test/parallel/test-tcp-wrap-connect.js
+++ b/test/parallel/test-tcp-wrap-connect.js
@@ -10,25 +10,25 @@ function makeConnection() {
 
   var req = new TCPConnectWrap();
   var err = client.connect(req, '127.0.0.1', this.address().port);
-  assert.equal(err, 0);
+  assert.strictEqual(err, 0);
 
   req.oncomplete = function(status, client_, req_, readable, writable) {
-    assert.equal(0, status);
-    assert.equal(client, client_);
-    assert.equal(req, req_);
-    assert.equal(true, readable);
-    assert.equal(true, writable);
+    assert.strictEqual(0, status);
+    assert.strictEqual(client, client_);
+    assert.strictEqual(req, req_);
+    assert.strictEqual(true, readable);
+    assert.strictEqual(true, writable);
 
     console.log('connected');
     var shutdownReq = new ShutdownWrap();
     var err = client.shutdown(shutdownReq);
-    assert.equal(err, 0);
+    assert.strictEqual(err, 0);
 
     shutdownReq.oncomplete = function(status, client_, req_) {
       console.log('shutdown complete');
-      assert.equal(0, status);
-      assert.equal(client, client_);
-      assert.equal(shutdownReq, req_);
+      assert.strictEqual(0, status);
+      assert.strictEqual(client, client_);
+      assert.strictEqual(shutdownReq, req_);
       shutdownCount++;
       client.close();
     };
@@ -56,7 +56,7 @@ var server = require('net').Server(function(s) {
 server.listen(0, makeConnection);
 
 process.on('exit', function() {
-  assert.equal(1, shutdownCount);
-  assert.equal(1, connectCount);
-  assert.equal(1, endCount);
+  assert.strictEqual(1, shutdownCount);
+  assert.strictEqual(1, connectCount);
+  assert.strictEqual(1, endCount);
 });

--- a/test/parallel/test-tcp-wrap-connect.js
+++ b/test/parallel/test-tcp-wrap-connect.js
@@ -19,13 +19,11 @@ function makeConnection() {
     assert.strictEqual(true, readable);
     assert.strictEqual(true, writable);
 
-    console.log('connected');
     var shutdownReq = new ShutdownWrap();
     var err = client.shutdown(shutdownReq);
     assert.strictEqual(err, 0);
 
     shutdownReq.oncomplete = function(status, client_, req_) {
-      console.log('shutdown complete');
       assert.strictEqual(0, status);
       assert.strictEqual(client, client_);
       assert.strictEqual(shutdownReq, req_);
@@ -42,11 +40,9 @@ var endCount = 0;
 var shutdownCount = 0;
 
 var server = require('net').Server(function(s) {
-  console.log('got connection');
   connectCount++;
   s.resume();
   s.on('end', function() {
-    console.log('got eof');
     endCount++;
     s.destroy();
     server.close();

--- a/test/parallel/test-tcp-wrap-connect.js
+++ b/test/parallel/test-tcp-wrap-connect.js
@@ -12,10 +12,12 @@ function makeConnection() {
   var err = client.connect(req, '127.0.0.1', this.address().port);
   assert.equal(err, 0);
 
-  req.oncomplete = function(status, client_, req_) {
+  req.oncomplete = function(status, client_, req_, readable, writable) {
     assert.equal(0, status);
     assert.equal(client, client_);
     assert.equal(req, req_);
+    assert.equal(true, readable);
+    assert.equal(true, writable);
 
     console.log('connected');
     var shutdownReq = new ShutdownWrap();


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently the readable and writable arguments are not specified in the
req.oncomplete method. Adding and asserting that they are always true
(which is always the case for TCP). This might seem unnecessary but it
can't hurt to have them to pickup any breaking modifications made to
ConnectionWrap::AfterConnect in the future.