### PR TITLE
lib: fix beforeExit not working with -e

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -341,7 +341,7 @@
     // Defer evaluation for a tick.  This is a workaround for deferred
     // events not firing when evaluating scripts from the command line,
     // see https://github.com/nodejs/node/issues/1600.
-    process.nextTick(function() {
+    setImmediate(function() {
       const result = module._compile(script, `${name}-wrapper`);
       if (process._print_eval) console.log(result);
     });

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -6,9 +6,10 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 42
 42
 [eval]:1
@@ -20,9 +21,10 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 [eval]:1
 throw new Error("hello")
 ^
@@ -32,9 +34,10 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 100
 [eval]:1
 var x = 100; y = x;
@@ -45,9 +48,10 @@ ReferenceError: y is not defined
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 [eval]:1
 var ______________________________________________; throw 10
                                                     ^

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -7,9 +7,10 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 42
 42
 
@@ -22,9 +23,10 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 
 [stdin]:1
 throw new Error("hello")
@@ -35,9 +37,10 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 100
 
 [stdin]:1
@@ -49,9 +52,10 @@ ReferenceError: y is not defined
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at bootstrap_node.js:*:*
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
-    at process._tickCallback (internal/process/next_tick.js:*:*)
+    at Immediate.<anonymous> (bootstrap_node.js:*:*)
+    at runCallback (timers.js:*:*)
+    at tryOnImmediate (timers.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 
 [stdin]:1
 var ______________________________________________; throw 10


### PR DESCRIPTION
Commit 93a44d5 ("src: fix deferred events not working with -e") defers
evaluation of the script to the next tick.

A side effect of that change is that 'beforeExit' listeners run before
the actual script.  'beforeExit' is emitted when the event loop is
empty but process.nextTick() does not ref the event loop.

Fix that by using setImmediate().  Because it is implemented in terms
of a uv_check_t handle, it interacts with the event loop properly.

Fixes: #8534 

R=@fishrock123