### PR TITLE
tools: fix release script on macOS 10.12

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -69,15 +69,8 @@ function sign {
 
   local version=$1
 
-  gpgtagkey=$(git tag -v $version 2>&1 | grep 'key ID' | awk '{print $NF}')
-
-  if [ "X${gpgtagkey}" == "X" ]; then
-    echo "Could not find signed tag for \"${version}\""
-    exit 1
-  fi
-
-  if [ "${gpgtagkey}" != "${gpgkey}" ]; then
-    echo "GPG key for \"${version}\" tag is not yours, cannot sign"
+  if ! git tag -v $version 2>&1 | grep "${gpgkey}" | grep key > /dev/null; then
+    echo "Could not find signed tag for \"${version}\" or GPG key is not yours"
     exit 1
   fi
 


### PR DESCRIPTION

##### Checklist

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tools


##### Description of change

Previously, we were relying on the output of gpg from git tag -v to
verify that the key selected by the releaser is the key that was used
to sign the tag. This output can change depending on the version of git
being used. Now, we just check that the output of git tag -v contains
the key selected.

Fixes: https://github.com/nodejs/node/issues/8822

/cc @nodejs/release 