### PR TITLE
test: enable addons test to pass with debug build

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -138,8 +138,7 @@ Once built, the binary Addon can be used from within Node.js by pointing
 
 ```js
 // hello.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 console.log(addon.hello()); // 'world'
 ```
@@ -317,8 +316,7 @@ Once compiled, the example Addon can be required and used from within Node.js:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 console.log('This should be eight:', addon.add(3, 5));
 ```
@@ -371,8 +369,7 @@ To test it, run the following JavaScript:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 addon((msg) => {
   console.log(msg); // 'hello world'
@@ -422,8 +419,7 @@ To test it in JavaScript:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 var obj1 = addon('hello');
 var obj2 = addon('world');
@@ -481,8 +477,7 @@ To test:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 var fn = addon();
 console.log(fn()); // 'hello world'
@@ -644,8 +639,7 @@ Test it with:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 var obj = new addon.MyObject(10);
 console.log(obj.plusOne()); // 11
@@ -837,8 +831,7 @@ Test it with:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const createObject = require(`./build/${buildType}/addon`);
+const createObject = require('./build/Release/addon');
 
 var obj = createObject(10);
 console.log(obj.plusOne()); // 11
@@ -1014,8 +1007,7 @@ Test it with:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 
 var obj1 = addon.createObject(10);
 var obj2 = addon.createObject(20);
@@ -1099,8 +1091,7 @@ Test in JavaScript by running:
 
 ```js
 // test.js
-const buildType = process.config.target_defaults.default_configuration;
-const addon = require(`./build/${buildType}/addon`);
+const addon = require('./build/Release/addon');
 ```
 
 [bindings]: https://github.com/TooTallNate/node-bindings

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -138,7 +138,8 @@ Once built, the binary Addon can be used from within Node.js by pointing
 
 ```js
 // hello.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 console.log(addon.hello()); // 'world'
 ```
@@ -316,7 +317,8 @@ Once compiled, the example Addon can be required and used from within Node.js:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 console.log('This should be eight:', addon.add(3, 5));
 ```
@@ -369,7 +371,8 @@ To test it, run the following JavaScript:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 addon((msg) => {
   console.log(msg); // 'hello world'
@@ -419,7 +422,8 @@ To test it in JavaScript:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 var obj1 = addon('hello');
 var obj2 = addon('world');
@@ -477,7 +481,8 @@ To test:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 var fn = addon();
 console.log(fn()); // 'hello world'
@@ -639,7 +644,8 @@ Test it with:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 var obj = new addon.MyObject(10);
 console.log(obj.plusOne()); // 11
@@ -831,7 +837,8 @@ Test it with:
 
 ```js
 // test.js
-const createObject = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const createObject = require(`./build/${buildType}/addon`);
 
 var obj = createObject(10);
 console.log(obj.plusOne()); // 11
@@ -1007,7 +1014,8 @@ Test it with:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 
 var obj1 = addon.createObject(10);
 var obj2 = addon.createObject(20);
@@ -1091,7 +1099,8 @@ Test in JavaScript by running:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+const buildType = process.config.target_defaults.default_configuration;
+const addon = require(`./build/${buildType}/addon`);
 ```
 
 [bindings]: https://github.com/TooTallNate/node-bindings

--- a/test/addons/async-hello-world/test.js
+++ b/test/addons/async-hello-world/test.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../../common');
 var assert = require('assert');
-var binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 
 binding(5, common.mustCall(function(err, val) {
   assert.equal(null, err);

--- a/test/addons/at-exit/test.js
+++ b/test/addons/at-exit/test.js
@@ -1,3 +1,3 @@
 'use strict';
-require('../../common');
-require('./build/Release/binding');
+const common = require('../../common');
+require(`./build/${common.buildType}/binding`);

--- a/test/addons/buffer-free-callback/test.js
+++ b/test/addons/buffer-free-callback/test.js
@@ -1,8 +1,8 @@
 'use strict';
 // Flags: --expose-gc
 
-require('../../common');
-var binding = require('./build/Release/binding');
+const common = require('../../common');
+const binding = require(`./build/${common.buildType}/binding`);
 
 function check(size, alignment, offset) {
   var buf = binding.alloc(size, alignment, offset);

--- a/test/addons/heap-profiler/test.js
+++ b/test/addons/heap-profiler/test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-require('../../common');
+const common = require('../../common');
 
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 
 // Create an AsyncWrap object.
 const timer = setTimeout(function() {}, 1);

--- a/test/addons/hello-world-function-export/test.js
+++ b/test/addons/hello-world-function-export/test.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../../common');
+const common = require('../../common');
 var assert = require('assert');
-var binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 assert.equal('world', binding());
 console.log('binding.hello() =', binding());

--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../../common');
+const common = require('../../common');
 var assert = require('assert');
-var binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 assert.equal('world', binding.hello());
 console.log('binding.hello() =', binding.hello());

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -21,7 +21,10 @@ for (var i = 0; i < 10; i++) {
   fs.mkdirSync(addonDestinationDir);
 }
 
-const addonPath = path.join(__dirname, 'build', 'Release', 'binding.node');
+const addonPath = path.join(__dirname,
+                            'build',
+                            common.buildType,
+                            'binding.node');
 const addonDestinationPath = path.join(addonDestinationDir, 'binding.node');
 
 // Copy binary to long path destination

--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -3,7 +3,7 @@
 const common = require('../../common');
 const assert = require('assert');
 const domain = require('domain');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const makeCallback = binding.makeCallback;
 
 // Make sure this is run in the future.

--- a/test/addons/make-callback/test.js
+++ b/test/addons/make-callback/test.js
@@ -3,7 +3,7 @@
 const common = require('../../common');
 const assert = require('assert');
 const vm = require('vm');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const makeCallback = binding.makeCallback;
 
 assert.strictEqual(42, makeCallback(process, common.mustCall(function() {

--- a/test/addons/null-buffer-neuter/test.js
+++ b/test/addons/null-buffer-neuter/test.js
@@ -1,7 +1,7 @@
 'use strict';
 // Flags: --expose-gc
 
-require('../../common');
-var binding = require('./build/Release/binding');
+const common = require('../../common');
+const binding = require(`./build/${common.buildType}/binding`);
 
 binding.run();

--- a/test/addons/openssl-binding/test.js
+++ b/test/addons/openssl-binding/test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-require('../../common');
+const common = require('../../common');
 const assert = require('assert');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const bytes = new Uint8Array(1024);
 assert(binding.randomBytes(bytes));
 assert(bytes.reduce((v, a) => v + a) > 0);

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-require('../../common');
+const common = require('../../common');
 const assert = require('assert');
-const { parseEncoding } = require('./build/Release/binding');
+const { parseEncoding } = require(`./build/${common.buildType}/binding`);
 
 assert.strictEqual(parseEncoding(''), 'UNKNOWN');
 

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 // v8 fails silently if string length > v8::String::kMaxLength

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 const assert = require('assert');
 
 const skipMessage = 'intensive toString tests due to memory confinements';

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -14,7 +14,7 @@ const assert = require('assert');
 
 common.refreshTmpDir();
 
-const addonPath = path.join(__dirname, 'build', 'Release');
+const addonPath = path.join(__dirname, 'build', common.buildType);
 const addonLink = path.join(common.tmpDir, 'addon');
 
 try {

--- a/test/addons/zlib-binding/test.js
+++ b/test/addons/zlib-binding/test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-require('../../common');
+const common = require('../../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const binding = require('./build/Release/binding');
+const binding = require(`./build/${common.buildType}/binding`);
 
 const input = Buffer.from('Hello, World!');
 

--- a/test/common.js
+++ b/test/common.js
@@ -36,6 +36,7 @@ const cpus = os.cpus();
 exports.enoughTestCpu = cpus.length > 1 || cpus[0].speed > 999;
 
 exports.rootDir = exports.isWindows ? 'c:\\' : '/';
+exports.buildType = process.config.target_defaults.default_configuration;
 
 function rimrafSync(p) {
   try {

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -65,8 +65,8 @@ function verifyFiles(files, blockName, onprogress, ondone) {
   files = Object.keys(files).map(function(name) {
     if (name === 'test.js') {
       files[name] = `'use strict';
-require('../../common');
-${files[name]}
+const common = require('../../common');
+${files[name].replace('Release', "' + common.buildType + '")}
 `;
     }
     return {


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently when running configure with the --debug option in combination
with the tests (./configure --debug && make -j8 test) there are a few
addon tests that fail with error messages similar to this:

=== release test ===
Path: addons/load-long-path/test
fs.js:558
  return binding.open(pathModule._makeLong(path), stringToFlags(flags),
mode);
                 ^

Error: ENOENT: no such file or directory, open
'/nodejs/node/test/addons/load-long-path/build/Release/binding.node'
    at Object.fs.openSync (fs.js:558:18)
    at Object.fs.readFileSync (fs.js:468:33)
    at Object.<anonymous>
(/nodejs/node/test/addons/load-long-path/test.js:28:19)
    at Module._compile (module.js:560:32)
    at Object.Module._extensions..js (module.js:569:10)
    at Module.load (module.js:477:32)
    at tryModuleLoad (module.js:436:12)
    at Function.Module._load (module.js:428:3)
    at Module.runMain (module.js:594:10)
    at run (bootstrap_node.js:382:7)
Command: out/Release/node
/nodejs/node/test/addons/load-long-path/test.js

This commit allows for the tests to pass even if the configured build
type is of type debug.