### PR TITLE
inspector: Allow require in Runtime.evaluate

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -282,6 +282,7 @@
         return console;
       }
     });
+    setupInspectorCommandLineAPI();
   }
 
   function installInspectorConsole(globalConsole) {
@@ -308,6 +309,24 @@
       wrappedConsole[key] = globalConsole[key];
     }
     return wrappedConsole;
+  }
+
+  function setupInspectorCommandLineAPI() {
+    const inspector = process.binding('inspector');
+    const addCommandLineAPIMethod = inspector.addCommandLineAPIMethod;
+    if (!addCommandLineAPIMethod) return;
+
+    const Module = NativeModule.require('module');
+    const path = NativeModule.require('path');
+    const cwd = tryGetCwd(path);
+
+    const consoleAPIModule = new Module('[consoleAPI]');
+    consoleAPIModule.filename = path.join(cwd, consoleAPIModule.id);
+    consoleAPIModule.paths = Module._nodeModulePaths(cwd);
+
+    addCommandLineAPIMethod('require', function require(request) {
+      return consoleAPIModule.require(request);
+    });
   }
 
   function setupProcessFatal() {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -312,21 +312,19 @@
   }
 
   function setupInspectorCommandLineAPI() {
-    const inspector = process.binding('inspector');
-    const addCommandLineAPIMethod = inspector.addCommandLineAPIMethod;
-    if (!addCommandLineAPIMethod) return;
+    const { addCommandLineAPI } = process.binding('inspector');
+    if (!addCommandLineAPI) return;
 
     const Module = NativeModule.require('module');
+    const { makeRequireFunction } = NativeModule.require('internal/module');
     const path = NativeModule.require('path');
     const cwd = tryGetCwd(path);
 
-    const consoleAPIModule = new Module('[consoleAPI]');
-    consoleAPIModule.filename = path.join(cwd, consoleAPIModule.id);
-    consoleAPIModule.paths = Module._nodeModulePaths(cwd);
+    const consoleAPIModule = new Module('<inspector console>');
+    consoleAPIModule.paths =
+      Module._nodeModulePaths(cwd).concat(Module.globalPaths);
 
-    addCommandLineAPIMethod('require', function require(request) {
-      return consoleAPIModule.require(request);
-    });
+    addCommandLineAPI('require', makeRequireFunction(consoleAPIModule));
   }
 
   function setupProcessFatal() {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -322,7 +322,7 @@
 
     const consoleAPIModule = new Module('<inspector console>');
     consoleAPIModule.paths =
-      Module._nodeModulePaths(cwd).concat(Module.globalPaths);
+        Module._nodeModulePaths(cwd).concat(Module.globalPaths);
 
     addCommandLineAPI('require', makeRequireFunction(consoleAPIModule));
   }

--- a/src/env.h
+++ b/src/env.h
@@ -292,6 +292,7 @@ namespace node {
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(domains_stack_array, v8::Array)                                           \
+  V(inspector_console_api_object, v8::Object)                                 \
   V(jsstream_constructor_template, v8::FunctionTemplate)                      \
   V(module_load_list_array, v8::Array)                                        \
   V(pbkdf2_constructor_template, v8::ObjectTemplate)                          \

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -22,6 +22,7 @@
 namespace node {
 namespace inspector {
 namespace {
+using v8::Array;
 using v8::Context;
 using v8::External;
 using v8::Function;
@@ -554,6 +555,20 @@ class NodeInspectorClient : public V8InspectorClient {
     return env_->context();
   }
 
+  void installAdditionalCommandLineAPI(Local<Context> context,
+                                       Local<Object> target) override {
+    Local<Object> console_api = env_->inspector_console_api_object();
+
+    Local<Array> properties =
+        console_api->GetOwnPropertyNames(context).ToLocalChecked();
+    for (uint32_t i = 0; i < properties->Length(); ++i) {
+      Local<Value> key = properties->Get(context, i).ToLocalChecked();
+      target->Set(context,
+                  key,
+                  console_api->Get(context, key).ToLocalChecked()).FromJust();
+    }
+  }
+
   void FatalException(Local<Value> error, Local<v8::Message> message) {
     Local<Context> context = env_->context();
 
@@ -585,20 +600,6 @@ class NodeInspectorClient : public V8InspectorClient {
 
   ChannelImpl* channel() {
     return channel_.get();
-  }
-
-  void installAdditionalCommandLineAPI(v8::Local<v8::Context> context,
-                                       v8::Local<v8::Object> target) {
-    v8::Local<v8::Object> console_api = env_->inspector_console_api_object();
-
-    v8::Local<v8::Array> properties =
-        console_api->GetOwnPropertyNames(context).ToLocalChecked();
-    for (uint32_t i = 0; i < properties->Length(); ++i) {
-      v8::Local<v8::Value> key = properties->Get(context, i).ToLocalChecked();
-      target->Set(context,
-                  key,
-                  console_api->Get(context, key).ToLocalChecked()).FromJust();
-    }
   }
 
   void startRepeatingTimer(double interval_s,
@@ -696,17 +697,17 @@ bool Agent::StartIoThread(bool wait_for_connect) {
   return true;
 }
 
-static void AddCommandLineAPIMethod(
-    const v8::FunctionCallbackInfo<v8::Value>& info) {
+static void AddCommandLineAPI(
+    const FunctionCallbackInfo<Value>& info) {
   auto env = Environment::GetCurrent(info);
-  v8::Local<v8::Context> context = env->context();
+  Local<Context> context = env->context();
 
-  if (info.Length() != 2 || !info[0]->IsString() || !info[1]->IsFunction()) {
-    return env->ThrowTypeError("inspector.addCommandLineAPIMethod takes "
-        "exactly 2 arguments: a string and a function.");
+  if (info.Length() != 2 || !info[0]->IsString()) {
+    return env->ThrowTypeError("inspector.addCommandLineAPI takes "
+        "exactly 2 arguments: a string and a value.");
   }
 
-  v8::Local<v8::Object> console_api = env->inspector_console_api_object();
+  Local<Object> console_api = env->inspector_console_api_object();
   console_api->Set(context, info[0], info[1]).FromJust();
 }
 
@@ -812,11 +813,16 @@ void Url(const FunctionCallbackInfo<Value>& args) {
 void Agent::InitInspector(Local<Object> target, Local<Value> unused,
                           Local<Context> context, void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  env->set_inspector_console_api_object(Object::New(env->isolate()));
+  {
+    auto obj = Object::New(env->isolate());
+    auto null = Null(env->isolate());
+    CHECK(obj->SetPrototype(context, null).FromJust());
+    env->set_inspector_console_api_object(obj);
+  }
 
   Agent* agent = env->inspector_agent();
   env->SetMethod(target, "consoleCall", InspectorConsoleCall);
-  env->SetMethod(target, "addCommandLineAPIMethod", AddCommandLineAPIMethod);
+  env->SetMethod(target, "addCommandLineAPI", AddCommandLineAPI);
   if (agent->debug_options_.wait_for_connect())
     env->SetMethod(target, "callAndPauseOnStart", CallAndPauseOnStart);
   env->SetMethod(target, "connect", ConnectJSBindingsSession);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

inspector
##### Description of change

<!-- Provide a description of the change below this comment. -->

Being able to require modules from the console can be very handy while debugging issues. This allows to do it even when require is no longer in scope or the process isn't currently paused. It also creates the foundation for adding other command line API methods in the future (if more use cases come up).
