### PR TITLE
test: use common.skip for tap skip output and test cleanup

### DIFF
--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
 
 // simulate `cat readfile.js | node readfile.js`
 
@@ -10,7 +10,7 @@ if (common.isWindows || common.isAix) {
   return;
 }
 
-var fs = require('fs');
+const fs = require('fs');
 
 if (process.argv[2] === 'child') {
   fs.readFile('/dev/stdin', function(er, data) {
@@ -20,15 +20,15 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-var filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
-var dataExpected = new Array(1000000).join('a');
+const filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
+const dataExpected = new Array(1000000).join('a');
 common.refreshTmpDir();
 fs.writeFileSync(filename, dataExpected);
 
-var exec = require('child_process').exec;
-var f = JSON.stringify(__filename);
-var node = JSON.stringify(process.execPath);
-var cmd = 'cat ' + filename + ' | ' + node + ' ' + f + ' child';
+const exec = require('child_process').exec;
+const f = JSON.stringify(__filename);
+const node = JSON.stringify(process.execPath);
+const cmd = `cat ${filename} | ${node} ${f} child`;
 exec(cmd, { maxBuffer: 1000000 }, function(err, stdout, stderr) {
   if (err) console.error(err);
   assert(!err, 'it exits normally');

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -6,7 +6,7 @@ var path = require('path');
 // simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAix) {
-  console.log(`1..0 # Skipped: No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /dev/stdin on ${process.platform}.`);
   return;
 }
 

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 // simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAix) {
-  console.log(`1..0 # Skipped: No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /dev/stdin on ${process.platform}.`);
   return;
 }
 

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 // simulate `cat readfile.js | node readfile.js`
 
@@ -9,9 +9,9 @@ if (common.isWindows || common.isAix) {
   return;
 }
 
-var fs = require('fs');
+const fs = require('fs');
 
-var dataExpected = fs.readFileSync(__filename, 'utf8');
+const dataExpected = fs.readFileSync(__filename, 'utf8');
 
 if (process.argv[2] === 'child') {
   fs.readFile('/dev/stdin', function(er, data) {
@@ -21,10 +21,10 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-var exec = require('child_process').exec;
-var f = JSON.stringify(__filename);
-var node = JSON.stringify(process.execPath);
-var cmd = 'cat ' + f + ' | ' + node + ' ' + f + ' child';
+const exec = require('child_process').exec;
+const f = JSON.stringify(__filename);
+const node = JSON.stringify(process.execPath);
+const cmd = `cat ${f} | ${node} ${f} child`;
 exec(cmd, function(err, stdout, stderr) {
   if (err) console.error(err);
   assert(!err, 'it exits normally');

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
 
 // simulate `cat readfile.js | node readfile.js`
 
@@ -10,22 +10,22 @@ if (common.isWindows || common.isAix) {
   return;
 }
 
-var fs = require('fs');
+const fs = require('fs');
 
 if (process.argv[2] === 'child') {
   process.stdout.write(fs.readFileSync('/dev/stdin', 'utf8'));
   return;
 }
 
-var filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
-var dataExpected = new Array(1000000).join('a');
+const filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
+const dataExpected = new Array(1000000).join('a');
 common.refreshTmpDir();
 fs.writeFileSync(filename, dataExpected);
 
-var exec = require('child_process').exec;
-var f = JSON.stringify(__filename);
-var node = JSON.stringify(process.execPath);
-var cmd = 'cat ' + filename + ' | ' + node + ' ' + f + ' child';
+const exec = require('child_process').exec;
+const f = JSON.stringify(__filename);
+const node = JSON.stringify(process.execPath);
+const cmd = `cat ${filename} | ${node} ${f} child`;
 exec(cmd, { maxBuffer: 1000000 }, function(err, stdout, stderr) {
   if (err) console.error(err);
   assert(!err, 'it exits normally');

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -6,7 +6,7 @@ var path = require('path');
 // simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAix) {
-  console.log(`1..0 # Skipped: No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /dev/stdin on ${process.platform}.`);
   return;
 }
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
Using `common.skip` instead of `console.log` for test output. Updated JS syntax to ES6 `const` and template strings where appropriate.
