### PR TITLE
doc: add example for running with v8-inspector

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -193,4 +193,12 @@ e.g. `--inspect=9222` will accept DevTools connections on port 9222.
 To break on the first line of the application code, provide the `--debug-brk`
 flag in addition to `--inspect`.
 
+```txt
+$ node --inspect index.js
+Debugger listening on port 9229.
+Warning: This is an experimental feature and could change at any time.
+To start debugging, open the following URL in Chrome:
+    chrome-devtools://devtools/remote/serve_file/@60cd6e859b9f557d2312f5bf532f6aec5f284980/inspector.html?experiments=true&v8only=true&ws=localhost:9229/node
+```
+
 [TCP-based protocol]: https://github.com/v8/v8/wiki/Debugging-Protocol


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc debugger

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add example to show what running Node.js with `--inspect`
should look like.

Some IDEs do not show the link when running with `--inspect`.
This example hints to what the full output looks like.