### PR TITLE
test: clean up test-timers-immediate

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -103,7 +103,7 @@ rules:
   no-dupe-class-members: 2
   no-new-symbol: 2
   no-this-before-super: 2
-  prefer-const: 2
+  prefer-const: [2, {ignoreReadBeforeAssign: true}]
   rest-spread-spacing: 2
   template-curly-spacing: 2
 

--- a/test/parallel/test-timers-immediate.js
+++ b/test/parallel/test-timers-immediate.js
@@ -1,25 +1,20 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-let immediateA = false;
-let immediateB = false;
-let immediateC = [];
-let immediateD = [];
+let immediateB;
+let immediateC;
+let immediateD;
 
-setImmediate(function() {
-  try {
-    immediateA = process.hrtime(before);
-  } catch (e) {
-    console.log('failed to get hrtime with offset');
-  }
+let mainFinished = false;
+
+setImmediate(common.mustCall(function() {
+  assert.strictEqual(mainFinished, true);
   clearImmediate(immediateB);
-});
-
-const before = process.hrtime();
+}));
 
 immediateB = setImmediate(function() {
-  immediateB = true;
+  common.fail('this immediate should not run');
 });
 
 setImmediate(function(x, y, z) {
@@ -31,8 +26,8 @@ setImmediate(function(x, y, z, a, b) {
 }, 1, 2, 3, 4, 5);
 
 process.on('exit', function() {
-  assert.ok(immediateA, 'Immediate should happen after normal execution');
-  assert.notStrictEqual(immediateB, true, 'immediateB should not fire');
   assert.deepStrictEqual(immediateC, [1, 2, 3], 'immediateC args should match');
   assert.deepStrictEqual(immediateD, [1, 2, 3, 4, 5], '5 args should match');
 });
+
+mainFinished = true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

Clean up test-timers-immediate. Use of `let` also requires a tweak to
ESLint rules (but it's one that we should do as timers is pretty much
the reason it exists).