### PR TITLE
test: expand test coverage for url.js

### DIFF
--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -158,6 +158,17 @@ var parseTests = {
     path: '/Y'
   },
 
+  // whitespace in the front
+  ' http://www.example.com/': {
+    href: 'http://www.example.com/',
+    protocol: 'http:',
+    slashes: true,
+    host: 'www.example.com',
+    hostname: 'www.example.com',
+    pathname: '/',
+    path: '/'
+  },
+
   // + not an invalid host character
   // per https://url.spec.whatwg.org/#host-parsing
   'http://x.y.com+a/b/c': {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test url
lib/url


##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently Line 156 of lib/url.js is not reachable from test-url because there are no example URL which has white space in the front of url.
I added one example which can reach that line.