### PR TITLE
build: make addons build  dep. on node_version.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ test/addons/.buildstamp: config.gypi \
 	deps/npm/node_modules/node-gyp/package.json \
 	$(ADDONS_BINDING_GYPS) $(ADDONS_BINDING_SOURCES) \
 	deps/uv/include/*.h deps/v8/include/*.h \
-	src/node.h src/node_buffer.h src/node_object_wrap.h \
+	src/node.h src/node_buffer.h src/node_object_wrap.h src/node_version.h \
 	test/addons/.docbuildstamp
 	# Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 	# embedded addons have been generated from the documentation.


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

addon tests

##### Description of change

Make the `test/addons/.buildstamp` file dependent on `src/node_version.h` since addons need to be re-compiled after `NODE_MODULE_VERSION` bumps, e.g. as it happened recently in b5bdff876ba62ed58664eb011a863d0960f4089b.