### PR TITLE
fs: export `realpathCacheKey` from `internal/fs`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1455,10 +1455,6 @@ function encodeRealpathResult(result, options, err) {
   }
 }
 
-// This is removed from the fs exports in lib/module.js in order to make
-// sure that this stays internal.
-const realpathCacheKey = fs.realpathCacheKey = Symbol('realpathCacheKey');
-
 fs.realpathSync = function realpathSync(p, options) {
   options = getOptions(options, {});
   nullCheck(p);
@@ -1468,7 +1464,7 @@ fs.realpathSync = function realpathSync(p, options) {
 
   const seenLinks = {};
   const knownHard = {};
-  const cache = options[realpathCacheKey];
+  const cache = options[internalFS.realpathCacheKey];
   const original = p;
 
   const maybeCachedResult = cache && cache.get(p);

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -96,3 +96,5 @@ SyncWriteStream.prototype.destroy = function() {
 };
 
 exports.SyncWriteStream = SyncWriteStream;
+
+exports.realpathCacheKey = Symbol('realpathCacheKey');

--- a/lib/module.js
+++ b/lib/module.js
@@ -6,6 +6,7 @@ const internalModule = require('internal/module');
 const vm = require('vm');
 const assert = require('assert').ok;
 const fs = require('fs');
+const internalFS = require('internal/fs');
 const path = require('path');
 const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
@@ -113,9 +114,6 @@ function tryPackage(requestPath, exts, isMain) {
 // Set to an empty Map to reset.
 const realpathCache = new Map();
 
-const realpathCacheKey = fs.realpathCacheKey;
-delete fs.realpathCacheKey;
-
 // check if the file exists and is not a directory
 // if using --preserve-symlinks and isMain is false,
 // keep symlinks intact, otherwise resolve to the
@@ -130,7 +128,7 @@ function tryFile(requestPath, isMain) {
 
 function toRealPath(requestPath) {
   return fs.realpathSync(requestPath, {
-    [realpathCacheKey]: realpathCache
+    [internalFS.realpathCacheKey]: realpathCache
   });
 }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

fs
##### Description of change

Move the internally defined symbol `fs.realpathCacheKey` to the internal fs module, where it’s more appropriate.

The symbol was recently added in c084287a608ef, but since `internal/fs` is only available in the v7.x branch, this needs to be a separate follow-up change.
