### PR TITLE
internal: fix TypeError in v8-polyfill

### DIFF
--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -76,7 +76,7 @@ function readline() {
     const bytes = fs.readSync(fd, buf, 0, buf.length);
     line += dec.write(buf.slice(0, bytes));
     if (line.length === 0) {
-      return false;
+      return '';
     }
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
v8 profile processor


##### Description of change
`readline()` can return a boolean, in which case, line 90 will throw an exception. This change addresses the issue by defaulting to a string in `readline()` instead of returning false.