### PR TITLE
test: fix running child-process-uid-gid as root

### DIFF
--- a/test/parallel/test-child-process-uid-gid.js
+++ b/test/parallel/test-child-process-uid-gid.js
@@ -3,6 +3,11 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
+if (process.getuid() === 0) {
+  common.skip('as this test should not be run as `root`');
+  return;
+}
+
 const expectedError = common.isWindows ? /\bENOTSUP\b/ : /\bEPERM\b/;
 
 assert.throws(() => {


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
test-child-process-uid-gid fails when run as root. Seeing that other tests are skipped when running as root, adding the same behavior to this test as well.

Replaces #8794
