### PR TITLE
debugger: check -e flag in debug break setup

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -549,7 +549,7 @@ Module.prototype._compile = function(content, filename) {
     displayErrors: true
   });
 
-  if (process._debugWaitConnect) {
+  if (process._debugWaitConnect && process._eval == null) {
     if (!resolvedArgv) {
       // we enter the repl if we're not given a filename argument.
       if (process.argv[1]) {

--- a/test/parallel/test-debug-brk.js
+++ b/test/parallel/test-debug-brk.js
@@ -3,33 +3,48 @@
 const common = require('../common');
 const spawn = require('child_process').spawn;
 
-var procStderr = '';
-var agentStdout = '';
-var needToSpawnAgent = true;
-var needToExit = true;
+let run = () => {};
+function test(extraArgs) {
+  const next = run;
+  run = () => {
+    var procStderr = '';
+    var agentStdout = '';
+    var needToSpawnAgent = true;
+    var needToExit = true;
 
-const procArgs = [`--debug-brk=${common.PORT}`, '-e', '0'];
-const proc = spawn(process.execPath, procArgs);
-proc.stderr.setEncoding('utf8');
+    const procArgs = [`--debug-brk=${common.PORT}`].concat(extraArgs);
+    const proc = spawn(process.execPath, procArgs);
+    proc.stderr.setEncoding('utf8');
 
-const exitAll = common.mustCall((processes) => {
-  processes.forEach((myProcess) => { myProcess.kill(); });
-});
+    const exitAll = common.mustCall((processes) => {
+      processes.forEach((myProcess) => { myProcess.kill(); });
+    });
 
-proc.stderr.on('data', (chunk) => {
-  procStderr += chunk;
-  if (/Debugger listening on/.test(procStderr) && needToSpawnAgent) {
-    needToSpawnAgent = false;
-    const agentArgs = ['debug', `localhost:${common.PORT}`];
-    const agent = spawn(process.execPath, agentArgs);
-    agent.stdout.setEncoding('utf8');
+    proc.stderr.on('data', (chunk) => {
+      procStderr += chunk;
+      if (/Debugger listening on/.test(procStderr) && needToSpawnAgent) {
+        needToSpawnAgent = false;
+        const agentArgs = ['debug', `localhost:${common.PORT}`];
+        const agent = spawn(process.execPath, agentArgs);
+        agent.stdout.setEncoding('utf8');
 
-    agent.stdout.on('data', (chunk) => {
-      agentStdout += chunk;
-      if (/connecting to .+ ok/.test(agentStdout) && needToExit) {
-        needToExit = false;
-        exitAll([proc, agent]);
+        agent.stdout.on('data', (chunk) => {
+          agentStdout += chunk;
+          if (/connecting to .+ ok/.test(agentStdout) && needToExit) {
+            needToExit = false;
+            exitAll([proc, agent]);
+          }
+        });
       }
     });
-  }
-});
+
+    proc.on('exit', () => {
+      next();
+    });
+  };
+}
+
+test(['-e', '0']);
+test(['-e', '0', 'foo']);
+
+run();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

module
##### Description of change

<!-- Provide a description of the change below this comment. -->

When both --debug-brk and --eval are set, and a filename is
specified, its full path is not set correctly, causing an error
for relative filenames with './' omitted.

For example, 'node --debug-brk -e 0 hello.js' throws an error.

Since the script referenced by the filename is never run anyway,
this change skips resolving its full path if both --debug-brk and
--eval are set.
