### PR TITLE
cluster: remove unused backlog argument

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -75,7 +75,7 @@ Worker.prototype.isConnected = function isConnected() {
 
 // Master/worker specific methods are defined in the *Init() functions.
 
-function SharedHandle(key, address, port, addressType, backlog, fd, flags) {
+function SharedHandle(key, address, port, addressType, fd, flags) {
   this.key = key;
   this.workers = [];
   this.handle = null;
@@ -113,7 +113,7 @@ SharedHandle.prototype.remove = function(worker) {
 
 // Start a round-robin server. Master accepts connections and distributes
 // them over the workers.
-function RoundRobinHandle(key, address, port, addressType, backlog, fd) {
+function RoundRobinHandle(key, address, port, addressType, fd) {
   this.key = key;
   this.all = {};
   this.free = [];
@@ -493,7 +493,6 @@ function masterInit() {
                                               message.address,
                                               message.port,
                                               message.addressType,
-                                              message.backlog,
                                               message.fd,
                                               message.flags);
     }


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* cluster


##### Description of change

Removes an unused backlog argument.

CI: https://ci.nodejs.org/job/node-test-pull-request/4345/

EDIT: CI is green except for a flaky test.