### PR TITLE
Added required UIRef for localized strings

### DIFF
--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -357,6 +357,7 @@
     </UI>
 
     <UIRef Id="WixUI_Common"/>
+    <UIRef Id="WixUI_ErrorProgressText"/>
     <WixVariable Id="WixUIBannerBmp" Value="..\..\..\doc\thin-white-stripe.jpg"/>
     <WixVariable Id="WixUIDialogBmp" Value="..\..\..\doc\full-white-stripe.jpg"/>
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SourceDir)\LICENSE.rtf"/>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Description of change

Installing the latest builds on Windows, I noticed the installer was display incorrect strings for the status text on the progress page. Digging into this a little I found the root cause.

It appears localization work has started on the installer (even though still only for en-us at the moment). However a `UIRef` element required for localized errors and progress text is missing, causing the progress status messages (and others) in the installer to display the template string incorrectly.

This fix simply adds the required `UIRef` as outlined at the end of the doc page at http://wixtoolset.org/documentation/manual/v3/wixui/wixui_localization.html, or in the StackOverflow answer at http://stackoverflow.com/a/5986030/1674945 .

Below shows the progress dialog before and after the change.
### Before

![nodeinstaller](https://cloud.githubusercontent.com/assets/993909/19012568/8dfa10d4-876e-11e6-8e4f-5ed1dfec21dd.png)
### After

![nodeinstallerfixed](https://cloud.githubusercontent.com/assets/993909/19012570/94527034-876e-11e6-8732-6df3717711e2.png)
