### PR TITLE
build: don't build icu with -fno-rtti

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -67,6 +67,7 @@
           [ 'os_posix == 1 and OS != "mac" and OS != "ios"', {
             'cflags': [ '-Wno-deprecated-declarations' ],
             'cflags_cc': [ '-frtti' ],
+            'cflags_cc!': [ '-fno-rtti' ],
           }],
           [ 'OS == "mac" or OS == "ios"', {
             'xcode_settings': {'GCC_ENABLE_CPP_RTTI': 'YES' },


### PR DESCRIPTION
ICU should be compiled with -frtti (and it sets that flag in its gyp
file) but it was also inheriting the -fno-rtti flag from common.gypi,
breaking the build on some systems.

Fixes: #8867