### PR TITLE
module: correct comment text "read-only" to "shallow"

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -636,7 +636,7 @@ Module._initPaths = function() {
 
   modulePaths = paths;
 
-  // clone as a read-only copy, for introspection.
+  // clone as a shallow copy, for introspection.
   Module.globalPaths = modulePaths.slice(0);
 };
 


### PR DESCRIPTION
##### Checklist
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
module

##### Description of change

The comment here was misleading, implying that the property was being
copied as a read-only, when in fact it's just a shallow copy. This
serves the purpose of providing the array for introspection, but it
isn't read-only.