### PR TITLE
module: make require.cache reassignable

### DIFF
--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -34,7 +34,14 @@ function makeRequireFunction() {
   // Enable support to add extra extension types.
   require.extensions = Module._extensions;
 
-  require.cache = Module._cache;
+  Object.defineProperty(require, 'cache', {
+    get() {
+      return Module._cache;
+    },
+    set(newCache) {
+      Module._cache = newCache;
+    }
+  });
 
   return require;
 }

--- a/test/parallel/test-require-cache.js
+++ b/test/parallel/test-require-cache.js
@@ -30,5 +30,5 @@ var assert = require('assert');
 
   assert.strictEqual(require(relativePath).extraProperty, mod.extraProperty);
   require.cache = {};
-  assert.equal(typeof require(relativePath).extraProperty, 'undefined');
+  assert.strictEqual(require(relativePath).extraProperty, undefined);
 }

--- a/test/parallel/test-require-cache.js
+++ b/test/parallel/test-require-cache.js
@@ -21,3 +21,14 @@ var assert = require('assert');
 
   assert.strictEqual(require(relativePath), fakeModule);
 }
+
+
+{
+  const relativePath = '../fixtures/semicolon';
+  const mod = require(relativePath);
+  mod.extraProperty = {};
+
+  assert.strictEqual(require(relativePath).extraProperty, mod.extraProperty);
+  require.cache = {};
+  assert.equal(typeof require(relativePath).extraProperty, 'undefined');
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

module
##### Description of change

Previously, when wanting to clear require.cache completely, the only
options were to manually delete each property or to reassign the
underlying cache object at `require('module')._cache`.

By making require.cache a passthrough to `require('module')._cache`, the
require cache can now be cleared by just setting `require.cache` to a new
empty object.
