### PR TITLE
tls: handle `error` events with `_tlsError`

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -272,7 +272,7 @@ function TLSSocket(socket, options) {
   // Proxy for API compatibility
   this.ssl = this._handle;
 
-  this.on('error', this._emitTLSError);
+  this.on('error', this._tlsError);
 
   this._init(socket, wrap);
 
@@ -554,7 +554,7 @@ TLSSocket.prototype._releaseControl = function() {
   if (this._controlReleased)
     return false;
   this._controlReleased = true;
-  this.removeListener('error', this._emitTLSError);
+  this.removeListener('error', this._tlsError);
   return true;
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously `TLSSocket#_emitTLSError` was used as an `error` event
handler. However that function can emit `error` event itself, so it is
not suitable for such use. Luckily the event can be emitted only when
the control is released, so this looping-error can't happen.

Replace the error handler for clarity and correctness.

cc @nodejs/crypto 