### PR TITLE
http: set socket timeout when socket connects

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -739,7 +739,9 @@ ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
   }
 
   this.once('socket', function(sock) {
-    sock.setTimeout(msecs, emitTimeout);
+    sock.once('connect', function() {
+      sock.setTimeout(msecs, emitTimeout);
+    });
   });
 
   return this;

--- a/test/parallel/test-http-client-timeout-on-connect.js
+++ b/test/parallel/test-http-client-timeout-on-connect.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  // This space is intentionally left blank.
+});
+
+server.listen(0, common.localhostIPv4, common.mustCall(() => {
+  const port = server.address().port;
+  const req = http.get(`http://${common.localhostIPv4}:${port}`);
+
+  req.setTimeout(1);
+  req.on('socket', common.mustCall((socket) => {
+    assert.strictEqual(socket._idleTimeout, undefined);
+    socket.on('connect', common.mustCall(() => {
+      assert.strictEqual(socket._idleTimeout, 1);
+    }));
+  }));
+  req.on('timeout', common.mustCall(() => req.abort()));
+  req.on('error', common.mustCall((err) => {
+    assert.strictEqual('socket hang up', err.message);
+    server.close();
+  }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http
##### Description of change

<!-- Provide a description of the change below this comment. -->

`request.setTimeout()` calls `socket.setTimeout()` as soon as a socket is assigned to the request. This makes the `timeout` event to be emitted on the request even if the underlying socket never connects.

This commit makes `socket.setTimeout()` to be called only when the underlying socket is connected.
