### PR TITLE
doc: make node(1) more consistent with tradition

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -202,8 +202,26 @@ Setting this will void any guarantee that stdio will not be interleaved or
 dropped at program exit. \fBAvoid use.\fR
 
 
-.SH RESOURCES AND DOCUMENTATION
+.SH BUGS
+Bugs are tracked in GitHub Issues:
+.ur https://github.com/nodejs/node/issues
 
+
+.SH AUTHORS
+Written and maintained by 1000+ contributors:
+.ur https://github.com/nodejs/node/blob/master/AUTHORS
+
+
+.SH COPYRIGHT
+Copyright Node.js contributors. Node.js is available under the MIT license.
+
+Node.js also includes external libraries that are available under a variety
+of licenses. See
+.ur https://github.com/nodejs/node/blob/master/LICENSE
+for the full license text.
+
+
+.SH RESOURCES AND DOCUMENTATION
 Website:
 .ur https://nodejs.org/
 
@@ -218,6 +236,7 @@ Mailing list:
 
 IRC (general questions):
 .ur "chat.freenode.net #node.js"
+(unofficial)
 
-IRC (node core development):
+IRC (Node.js core development):
 .ur "chat.freenode.net #node-dev"


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

* Removed loads of whitespace
* Added traditional BUGS and AUTHORS sections
* Renamed ENVIRONMENT VARIABLES to ENVIRONMENT, as is traditional

In particular I'm not sure if everyone will be cool with the BUGS text - I personally think it's good but if anyone disagrees I'm not super attached to it. Also, I put `.\"`s instead of outright removing the newlines because I think it's (slightly) more readable, but I can also get rid of those.