### PR TITLE
build: add config.gypi to test/addons/.buildstamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ ADDONS_BINDING_GYPS := \
 # Implicitly depends on $(NODE_EXE), see the build-addons rule for rationale.
 # Depends on node-gyp package.json so that build-addons is (re)executed when
 # node-gyp is updated as part of an npm update.
-test/addons/.buildstamp: deps/npm/node_modules/node-gyp/package.json \
+test/addons/.buildstamp: config.gypi \
+	deps/npm/node_modules/node-gyp/package.json \
 	$(ADDONS_BINDING_GYPS) test/addons/.docbuildstamp
 	# Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 	# embedded addons have been generated from the documentation.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change


This motivation for this commit is to enable a reconfiguration of the
build type (Debug/Release) to be reflected by the addons tests.

Currently, when using configure --debug, and then running the tests, the
addons build configurations (build/config.gypi) will not be updated.
Adding config.gypi to the test/addons/.buildstamp target's
prerequisites will cause the addons configurations to be updated when
config.gypi has been updated.

Also, build-addons has been added as a prerequisite to the test target
to have the addons rebuilt if the build type configuration has changed.

This is a backport of https://github.com/nodejs/node/pull/7893.