### PR TITLE
intl: add deprecation warning for v8BreakIterator

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -118,16 +118,17 @@ function setupConfig(_source) {
     return value;
   });
   const processConfig = process.binding('config');
-  // Intl.v8BreakIterator() would crash w/ fatal error, so throw instead.
-  if (processConfig.hasIntl &&
-      processConfig.hasSmallICU &&
-      Intl.hasOwnProperty('v8BreakIterator') &&
-      !process.icu_data_dir) {
+  if (typeof Intl !== 'undefined' && Intl.hasOwnProperty('v8BreakIterator')) {
+    const oldV8BreakIterator = Intl.v8BreakIterator;
     const des = Object.getOwnPropertyDescriptor(Intl, 'v8BreakIterator');
-    des.value = function v8BreakIterator() {
-      throw new Error('v8BreakIterator: full ICU data not installed. ' +
-                      'See https://github.com/nodejs/node/wiki/Intl');
-    };
+    des.value = require('internal/util').deprecate(function v8BreakIterator() {
+      if (processConfig.hasSmallICU && !process.icu_data_dir) {
+        // Intl.v8BreakIterator() would crash w/ fatal error, so throw instead.
+        throw new Error('v8BreakIterator: full ICU data not installed. ' +
+                        'See https://github.com/nodejs/node/wiki/Intl');
+      }
+      return Reflect.construct(oldV8BreakIterator, arguments);
+    }, 'Intl.v8BreakIterator is deprecated and will be removed soon.');
     Object.defineProperty(Intl, 'v8BreakIterator', des);
   }
   // Don’t let icu_data_dir leak through.

--- a/test/parallel/test-intl-v8BreakIterator.js
+++ b/test/parallel/test-intl-v8BreakIterator.js
@@ -6,6 +6,9 @@ if (global.Intl === undefined || Intl.v8BreakIterator === undefined) {
   return common.skip('no Intl');
 }
 
+const warning = 'Intl.v8BreakIterator is deprecated and will be removed soon.';
+common.expectWarning('DeprecationWarning', warning);
+
 try {
   new Intl.v8BreakIterator();
   // May succeed if data is available - OK


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

intl, V8

##### Description of change
<!-- Provide a description of the change below this comment. -->

Ref: https://github.com/nodejs/node/issues/8865