### PR TITLE
http: reject control characters in http.request()

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -43,13 +43,12 @@ function ClientRequest(options, cb) {
   if (self.agent && self.agent.protocol)
     expectedProtocol = self.agent.protocol;
 
-  if (options.path && / /.test(options.path)) {
+  if (options.path && /[\u0000-\u0020]/.test(options.path)) {
     // The actual regex is more like /[^A-Za-z0-9\-._~!$&'()*+,;=/:@]/
     // with an additional rule for ignoring percentage-escaped characters
     // but that's a) hard to capture in a regular expression that performs
-    // well, and b) possibly too restrictive for real-world usage. That's
-    // why it only scans for spaces because those are guaranteed to create
-    // an invalid request.
+    // well, and b) possibly too restrictive for real-world usage.
+    // Restrict the filter to control characters and spaces.
     throw new TypeError('Request path contains unescaped characters');
   } else if (protocol !== expectedProtocol) {
     throw new Error('Protocol "' + protocol + '" not supported. ' +

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -1,9 +1,14 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
 
-assert.throws(function() {
-  // Path with spaces in it should throw.
-  http.get({ path: 'bad path' }, common.fail);
-}, /contains unescaped characters/);
+function* bad() {
+  for (let i = 0; i <= 32; i += 1)
+    yield 'bad' + String.fromCharCode(i) + 'path';
+}
+
+for (const path of bad()) {
+  assert.throws(() => http.get({ path }, common.fail),
+                /contains unescaped characters/);
+}


### PR DESCRIPTION
First commit:

Unsanitized paths containing line feed characters can be used for header injection and request splitting so reject them with an exception.

Second commit:

The first commit is the result of nodejs-security@ discussion but I had a change of heart.  I can't see any reasonable use case for allowing control characters (characters <= 31) but I can think of several scenarios where they can be used to exploit software bugs so let's ban them altogether.

There is a a potential compatibility issue in that tabs in paths have been observed in the wild, but, to the best of my knowledge, only in requests from buggy HTTP clients.  Here too I don't see a reason to allow them in requests that node.js initiates.

@nodejs/http @nodejs/security