### PR TITLE
test: fix child-process-uid-gid on Windows

### DIFF
--- a/test/parallel/test-child-process-uid-gid.js
+++ b/test/parallel/test-child-process-uid-gid.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-if (process.getuid() === 0) {
+if (!common.isWindows && process.getuid() === 0) {
   common.skip('as this test should not be run as `root`');
   return;
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

##### Description of change
<!-- Provide a description of the change below this comment. -->

The process.getuid method does not exist on this platform.

Ref: https://github.com/nodejs/node/pull/8864
