### PR TITLE
test: refactor test-net-server-max-connections

### DIFF
--- a/test/parallel/test-net-server-max-connections.js
+++ b/test/parallel/test-net-server-max-connections.js
@@ -9,23 +9,19 @@ const net = require('net');
 // and the last 10 connections are rejected.
 
 const N = 20;
-var count = 0;
 var closes = 0;
 const waits = [];
 
-const server = net.createServer(function(connection) {
-  console.error('connect %d', count++);
+const server = net.createServer(common.mustCall(function(connection) {
   connection.write('hello');
   waits.push(function() { connection.end(); });
-});
+}, N / 2));
 
 server.listen(0, function() {
   makeConnection(0);
 });
 
 server.maxConnections = N / 2;
-
-console.error('server.maxConnections = %d', server.maxConnections);
 
 
 function makeConnection(index) {

--- a/test/parallel/test-net-server-max-connections.js
+++ b/test/parallel/test-net-server-max-connections.js
@@ -1,19 +1,19 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var net = require('net');
+const net = require('net');
 
-// This test creates 200 connections to a server and sets the server's
-// maxConnections property to 100. The first 100 connections make it through
-// and the last 100 connections are rejected.
+// This test creates 20 connections to a server and sets the server's
+// maxConnections property to 10. The first 10 connections make it through
+// and the last 10 connections are rejected.
 
-var N = 200;
+const N = 20;
 var count = 0;
 var closes = 0;
-var waits = [];
+const waits = [];
 
-var server = net.createServer(function(connection) {
+const server = net.createServer(function(connection) {
   console.error('connect %d', count++);
   connection.write('hello');
   waits.push(function() { connection.end(); });
@@ -29,7 +29,7 @@ console.error('server.maxConnections = %d', server.maxConnections);
 
 
 function makeConnection(index) {
-  var c = net.createConnection(server.address().port);
+  const c = net.createConnection(server.address().port);
   var gotData = false;
 
   c.on('connect', function() {
@@ -42,10 +42,10 @@ function makeConnection(index) {
       closes++;
 
       if (closes < N / 2) {
-        assert.ok(server.maxConnections <= index,
-                  index +
-                  ' was one of the first closed connections ' +
-                  'but shouldnt have been');
+        assert.ok(
+          server.maxConnections <= index,
+          `${index} should not have been one of the first closed connections`
+        );
       }
 
       if (closes === N / 2) {
@@ -58,11 +58,11 @@ function makeConnection(index) {
       }
 
       if (index < server.maxConnections) {
-        assert.equal(true, gotData,
-                     index + ' didn\'t get data, but should have');
+        assert.strictEqual(true, gotData,
+                           `${index} didn't get data, but should have`);
       } else {
-        assert.equal(false, gotData,
-                     index + ' got data, but shouldn\'t have');
+        assert.strictEqual(false, gotData,
+                           `${index} got data, but shouldn't have`);
       }
     });
   });
@@ -86,5 +86,5 @@ function makeConnection(index) {
 
 
 process.on('exit', function() {
-  assert.equal(N, closes);
+  assert.strictEqual(N, closes);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test timed out on Windows in CI. Made the following changes:

* reduced total connections from 200 to 20
* var -> const
* string concatenation -> templates
* assert.equal -> assert.strictEqual

/cc @nodejs/testing