### PR TITLE
doc: fix url markdown formatting

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -31,7 +31,7 @@ illustrate each.
 "  http:   // user:pass @ host.com : 8080   /p/a/t/h  ?  query=string   #hash "
 │          ││           │          │      │          │ │              │       │
 └──────────┴┴───────────┴──────────┴──────┴──────────┴─┴──────────────┴───────┘
-(all spaces in the "" line should be ignored -- they're purely for formatting)
+(all spaces in the "" line should be ignored -- they are purely for formatting)
 ```
 
 ### urlObject.href


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Documentation for the URL module

##### Description of change
<!-- Provide a description of the change below this comment. -->
This is very similar to #7817. The single quote throws off the syntax highlighting in the diagram describing the URL Object when the documentation is viewed on the [Node.js web site](https://nodejs.org/api/url.html#url_url_strings_and_url_objects). I've implemented a similar fix for the affected section.
