### PR TITLE
doc:  ./node to node in debugger.md

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -120,7 +120,7 @@ It is also possible to set a breakpoint in a file (module) that
 isn't loaded yet:
 
 ```txt
-$ ./node debug test/fixtures/break-in-module/main.js
+$ node debug test/fixtures/break-in-module/main.js
 < debugger listening on port 5858
 connecting to port 5858... ok
 break in test/fixtures/break-in-module/main.js:1


### PR DESCRIPTION
doc: typo in line 123 of doc/api/debugger.md

example node calls use *node*, not *./node*

Fixes: Examples in debugger documentation should all use global node #8942