### PR TITLE
buffer: make byteLength throw on invalid input

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -631,8 +631,6 @@ console.log(`${str}: ${str.length} characters, ` +
 When `string` is a `Buffer`/[`DataView`]/[`TypedArray`]/[`ArrayBuffer`], the
 actual byte length is returned.
 
-Otherwise, converts to `String` and returns the byte length of string.
-
 ### Class Method: Buffer.compare(buf1, buf2)
 <!-- YAML
 added: v0.11.13

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -369,7 +369,7 @@ function byteLength(string, encoding) {
       return string.byteLength;
     }
 
-    string = '' + string;
+    throw new TypeError('"string" must be a string, Buffer, or ArrayBuffer');
   }
 
   var len = string.length;

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -7,10 +7,14 @@ const SlowBuffer = require('buffer').SlowBuffer;
 const vm = require('vm');
 
 // coerce values to string
-assert.strictEqual(Buffer.byteLength(32, 'latin1'), 2);
-assert.strictEqual(Buffer.byteLength(NaN, 'utf8'), 3);
-assert.strictEqual(Buffer.byteLength({}, 'latin1'), 15);
-assert.strictEqual(Buffer.byteLength(), 9);
+assert.throws(() => { Buffer.byteLength(32, 'latin1'); },
+              '"string" must be a string, Buffer, or ArrayBuffer');
+assert.throws(() => { Buffer.byteLength(NaN, 'utf8'); },
+              '"string" must be a string, Buffer, or ArrayBuffer');
+assert.throws(() => { Buffer.byteLength({}, 'latin1'); },
+              '"string" must be a string, Buffer, or ArrayBuffer');
+assert.throws(() => { Buffer.byteLength(); },
+              '"string" must be a string, Buffer, or ArrayBuffer');
 
 assert(ArrayBuffer.isView(new Buffer(10)));
 assert(ArrayBuffer.isView(new SlowBuffer(10)));


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* buffer


##### Description of change

This makes `buffer.byteLength()` throw if the first argument passed to it is not a Buffer/TypedArray/etc. or string, instead of converting the value to string and calculating the length of *that* string.

If other values are being passed, IMHO that could signal a programming error. For example, if an `undefined` value is passed in, I would not expect to get `'undefined'.length` returned. If `undefined` is passed in, it probably means I have a bug in my code somewhere where a variable isn't being set (properly).

CI: https://ci.nodejs.org/job/node-test-pull-request/4404/
CITGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/403/