### PR TITLE
deps: revert default gtest reporter change

### DIFF
--- a/deps/gtest/src/gtest.cc
+++ b/deps/gtest/src/gtest.cc
@@ -4433,7 +4433,7 @@ UnitTestImpl::UnitTestImpl(UnitTest* parent)
 #endif
       // Will be overridden by the flag before first use.
       catch_exceptions_(false) {
-  listeners()->SetDefaultResultPrinter(new TapUnitTestResultPrinter);
+  listeners()->SetDefaultResultPrinter(new PrettyUnitTestResultPrinter);
 }
 
 UnitTestImpl::~UnitTestImpl() {


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* gtest


##### Description of change

The default gtest reporter changed in c56ae16db24688819b from a pretty printing reporter to TAP. This caused TAP output to be displayed when running `make test` locally (outside of CI). This commit reverts that particular change.

/cc @bnoordhuis @jasnell 

CI: https://ci.nodejs.org/job/node-test-pull-request/4405/