### PR TITLE
test: fix test-child-process-fork-regr-gh-2847

### DIFF
--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -49,14 +49,19 @@ var server = net.createServer(function(s) {
     server.close();
   }));
 
-  send();
-  send(function(err) {
-    // Ignore errors when sending the second handle because the worker
-    // may already have exited.
-    if (err) {
-      if (err.code !== 'ECONNREFUSED') {
-        throw err;
-      }
-    }
+  worker.on('online', function() {
+    send(function(err) {
+      assert.ifError(err);
+      send(function(err) {
+        // Ignore errors when sending the second handle because the worker
+        // may already have exited.
+        if (err) {
+          if ((err.message !== 'channel closed') &&
+             (err.code !== 'ECONNREFUSED')) {
+            throw err;
+          }
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

It's not guaranteed that the first socket that tries to connect is the
first that succeeds so the rest of assumptions made in the test are not
correct.
Fix it by making sure the second socket does not try to connect until
the first has succeeded.
The IPC channel can already be closed when sending the second socket. It
should be allowed.
Also, don't start sending messages until the worker is online.

Fixes: https://github.com/nodejs/node/issues/8950