### PR TITLE
test: add cluster inspector debug port test

### DIFF
--- a/test/parallel/test-cluster-inspector-debug-port.js
+++ b/test/parallel/test-cluster-inspector-debug-port.js
@@ -1,0 +1,38 @@
+'use strict';
+// Flags: --inspect={PORT}
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const debuggerPort = common.PORT;
+
+if (cluster.isMaster) {
+  function checkExitCode(code, signal) {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }
+
+  function fork(offset, execArgv) {
+    if (execArgv)
+      cluster.setupMaster({execArgv});
+
+    const check = common.mustCall(checkExitCode);
+    cluster.fork({portSet: debuggerPort + offset}).on('exit', check);
+  }
+
+  assert.strictEqual(process.debugPort, debuggerPort);
+
+  fork(1);
+  fork(2, ['--inspect']);
+  fork(3, [`--inspect=${debuggerPort}`]);
+  fork(4, ['--inspect', '--debug']);
+  fork(5, [`--debug=${debuggerPort}`, '--inspect']);
+  fork(6, ['--inspect', `--debug-port=${debuggerPort}`]);
+} else {
+  const hasDebugArg = process.execArgv.some(function(arg) {
+    return /inspect/.test(arg);
+  });
+
+  assert.strictEqual(hasDebugArg, true);
+  assert.strictEqual(process.debugPort, +process.env.portSet);
+  process.exit();
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This commit adds a test for the debug port value in cluster workers using the inspector debugger.

Refs: https://github.com/nodejs/node/issues/8201
Refs: https://github.com/nodejs/node/pull/8386
Refs: https://github.com/nodejs/node/pull/8550