### PR TITLE
tls: introduce `secureContext` for `tls.connect`

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -694,6 +694,10 @@ Creates a new client connection to the given `port` and `host` (old API) or
     SSL version 3. The possible values depend on your installation of
     OpenSSL and are defined in the constant [SSL_METHODS][].
 
+  - `secureContext`: An optional TLS context object from
+     `tls.createSecureContext( ... )`. Could it be used for caching client
+     certificates, key, and CA certificates.
+
   - `session`: A `Buffer` instance, containing TLS session.
 
 The `callback` parameter will be added as a listener for the

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -973,7 +973,7 @@ exports.connect = function(/* [port, host], options, cb */) {
                  (options.socket && options.socket._host) ||
                  'localhost';
   const NPN = {};
-  const context = tls.createSecureContext(options);
+  const context = options.secureContext || tls.createSecureContext(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);
 
   var socket = new TLSSocket(options.socket, {

--- a/test/parallel/test-tls-connect-secure-context.js
+++ b/test/parallel/test-tls-connect-secure-context.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+const tls = require('tls');
+
+const fs = require('fs');
+const path = require('path');
+
+const keysDir = path.join(common.fixturesDir, 'keys');
+
+const ca = fs.readFileSync(path.join(keysDir, 'ca1-cert.pem'));
+const cert = fs.readFileSync(path.join(keysDir, 'agent1-cert.pem'));
+const key = fs.readFileSync(path.join(keysDir, 'agent1-key.pem'));
+
+const server = tls.createServer({
+  cert: cert,
+  key: key
+}, function(c) {
+  c.end();
+}).listen(common.PORT, function() {
+  const secureContext = tls.createSecureContext({
+    ca: ca
+  });
+
+  const socket = tls.connect({
+    secureContext: secureContext,
+    servername: 'agent1',
+    port: common.PORT
+  }, common.mustCall(function() {
+    server.close();
+    socket.end();
+  }));
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add `secureContext` option to `tls.connect`. It is useful for caching
client certificates, key, and CA certificates.

PR-URL: https://github.com/nodejs/node/pull/4246
Reviewed-By: James M Snell <jasnell@gmail.com>

-------------

Backport of: https://github.com/nodejs/node/pull/4246#issuecomment-251229400