### PR TITLE
test: add coverage for spawnSync() killSignal

### DIFF
--- a/test/parallel/test-child-process-spawnsync-kill-signal.js
+++ b/test/parallel/test-child-process-spawnsync-kill-signal.js
@@ -1,0 +1,51 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  setInterval(() => {}, 1000);
+} else {
+  const exitCode = common.isWindows ? 1 : 0;
+  const { SIGKILL } = process.binding('constants').os.signals;
+
+  function spawn(killSignal) {
+    const child = cp.spawnSync(process.execPath,
+                               [__filename, 'child'],
+                               {killSignal, timeout: 100});
+
+    assert.strictEqual(child.status, exitCode);
+    assert.strictEqual(child.error.code, 'ETIMEDOUT');
+    return child;
+  }
+
+  // Verify that an error is thrown for unknown signals.
+  assert.throws(() => {
+    spawn('SIG_NOT_A_REAL_SIGNAL');
+  }, /Error: Unknown signal: SIG_NOT_A_REAL_SIGNAL/);
+
+  // Verify that the default kill signal is SIGTERM.
+  {
+    const child = spawn();
+
+    assert.strictEqual(child.signal, 'SIGTERM');
+    assert.strictEqual(child.options.killSignal, undefined);
+  }
+
+  // Verify that a string signal name is handled properly.
+  {
+    const child = spawn('SIGKILL');
+
+    assert.strictEqual(child.signal, 'SIGKILL');
+    assert.strictEqual(child.options.killSignal, SIGKILL);
+  }
+
+  // Verify that a numeric signal is handled properly.
+  {
+    const child = spawn(SIGKILL);
+
+    assert.strictEqual(typeof SIGKILL, 'number');
+    assert.strictEqual(child.signal, 'SIGKILL');
+    assert.strictEqual(child.options.killSignal, SIGKILL);
+  }
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This commit adds a test for the `killSignal` option to `spawnSync()`, and the other sync child process functions by extension.

This was previously untested according to https://node-core-coverage.addaleax.net/