### PR TITLE
v4.x backport: dns: tweak regex for IPv6 addresses

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -292,7 +292,7 @@ exports.setServers = function(servers) {
     if (ver)
       return newSet.push([ver, serv]);
 
-    var match = serv.match(/\[(.*)\](:\d+)?/);
+    var match = serv.match(/\[(.*)\](?::\d+)?/);
 
     // we have an IPv6 in brackets
     if (match) {


### PR DESCRIPTION
v4.x backport of https://github.com/nodejs/node/pull/8665

cc: @TheAlphaNerd