### PR TITLE
test: expand test coverage for url.js

### DIFF
--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -999,7 +999,6 @@ for (const u in parseTestsWithQueryString) {
 
 // some extra formatting tests, just to verify
 // that it'll format slightly wonky content to a valid url.
-
 var formatTests = {
   'http://example.com?': {
     href: 'http://example.com/?',

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -999,6 +999,10 @@ for (const u in parseTestsWithQueryString) {
 
 // some extra formatting tests, just to verify
 // that it'll format slightly wonky content to a valid url.
+
+// Example of url which has more than 255 characters in hostname and excesses the limit.
+const excessHostnameUrl = 'http://' + 'a'.repeat(255) + '.com/node';
+
 var formatTests = {
   'http://example.com?': {
     href: 'http://example.com/?',
@@ -1198,6 +1202,17 @@ var formatTests = {
     search: '?foo=bar#1#2#3&abc=#4##5',
     query: {},
     pathname: '/'
+  },
+
+  // more than 255 characters in hostname which excesses the limit
+  [excessHostnameUrl]: {
+    href: 'http:///node',
+    protocol: 'http:',
+    slashes: true,
+    host: '',
+    hostname: '',
+    pathname: '/node',
+    path: '/node'
   },
 
   // https://github.com/nodejs/node/issues/3361

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1000,9 +1000,6 @@ for (const u in parseTestsWithQueryString) {
 // some extra formatting tests, just to verify
 // that it'll format slightly wonky content to a valid url.
 
-// Example of url which has more than 255 characters in hostname and excesses the limit.
-const excessHostnameUrl = 'http://' + 'a'.repeat(255) + '.com/node';
-
 var formatTests = {
   'http://example.com?': {
     href: 'http://example.com/?',
@@ -1204,8 +1201,8 @@ var formatTests = {
     pathname: '/'
   },
 
-  // more than 255 characters in hostname which excesses the limit
-  [excessHostnameUrl]: {
+  // more than 255 characters in hostname which exceeds the limit
+  [`http://${'a'.repeat(255)}.com/node`]: {
     href: 'http:///node',
     protocol: 'http:',
     slashes: true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test url



##### Description of change
<!-- Provide a description of the change below this comment. -->
Currently line 309 of lib/url.js is not reachable from test-url because there are no examples which have more than 255 characters in the hostname of the url.
I added one example which can reach that line.