### PR TITLE
inspector: add --inspect-brk flag

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3480,6 +3480,12 @@ static void PrintHelp() {
          "                           does not appear to be a terminal\n"
          "  -r, --require            module to preload (option can be "
          "repeated)\n"
+#if HAVE_INSPECTOR
+         "  --inspect[=host:port] activate inspector on host:port\n"
+         "                        (default: 127.0.0.1:9229)\n"
+         "  --inspect-brk[=host:port]  activate inspector on host:port\n"
+         "                             and break at start of user script\n"
+#endif
          "  --no-deprecation         silence deprecation warnings\n"
          "  --trace-deprecation      show stack traces on deprecations\n"
          "  --throw-deprecation      throw an exception on deprecations\n"

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -428,7 +428,7 @@ Harness.prototype.expectShutDown = function(errorCode) {
 
 exports.startNodeForInspectorTest = function(callback) {
   const child = spawn(process.execPath,
-      [ '--inspect', '--debug-brk', mainScript ]);
+      [ '--inspect-brk', mainScript ]);
 
   const timeoutId = timeout('Child process did not start properly', 4);
 

--- a/test/sequential/test-debugger-debug-brk.js
+++ b/test/sequential/test-debugger-debug-brk.js
@@ -26,3 +26,5 @@ function test(arg) {
 
 test('--debug-brk');
 test('--debug-brk=5959');
+test('--inspect-brk');
+test('--inspect-brk=9230');


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

inspector
##### Description of change

<!-- Provide a description of the change below this comment. -->

add `--inspect-brk` flag to provide same behavior as `--debug-brk` flag but for inspector. This allows complete separation of inspector and debugger (old debugger) flags.
