### PR TITLE
inspector,test: zero out expectations

### DIFF
--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -248,7 +248,7 @@ static void setup_inspector_expecting() {
   if (inspector.data) {
     return;
   }
-  expectations* expects = new expectations();
+  expectations* expects = new expectations({});
   inspector.data = expects;
   inspector_read_start(&inspector, grow_expects_buffer, save_read_data);
 }

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -248,6 +248,7 @@ static void setup_inspector_expecting() {
   if (inspector.data) {
     return;
   }
+  // ({}) is needed because VS2013 does not zero the struct with ()
   expectations* expects = new expectations({});
   inspector.data = expects;
   inspector_read_start(&inspector, grow_expects_buffer, save_read_data);


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

Inspector (test)

##### Description of change

VS2013 was not running in CI for v6 when https://github.com/nodejs/node/pull/8832 landed. When compiling with VS2013 and running on Windows 2008, `cctest.exe` hangs consuming 100% CPU. This happens because Visual Studio 2013 does not zero out the `expectations` structure when allocating.

@nodejs/release this only needs to land if https://github.com/nodejs/node/issues/7989 is not approved before the next v6 release.

CI: https://ci.nodejs.org/view/All/job/node-test-commit/5512/

cc @nodejs/v8-inspector 
