### PR TITLE
module: allow but deprecate loading internals (in case it’s necessary)

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -441,16 +441,10 @@
   });
 
   if (EXPOSE_INTERNALS) {
-    NativeModule.nonInternalExists = NativeModule.exists;
-
     NativeModule.isInternal = function(id) {
       return false;
     };
   } else {
-    NativeModule.nonInternalExists = function(id) {
-      return NativeModule.exists(id) && !NativeModule.isInternal(id);
-    };
-
     NativeModule.isInternal = function(id) {
       return id.startsWith('internal/');
     };

--- a/lib/module.js
+++ b/lib/module.js
@@ -316,7 +316,7 @@ if (process.platform === 'win32') {
 var indexChars = [ 105, 110, 100, 101, 120, 46 ];
 var indexLen = indexChars.length;
 Module._resolveLookupPaths = function(request, parent) {
-  if (NativeModule.nonInternalExists(request)) {
+  if (NativeModule.exists(request)) {
     return [request, []];
   }
 
@@ -405,6 +405,7 @@ Module._resolveLookupPaths = function(request, parent) {
   return [id, [path.dirname(parent.filename)]];
 };
 
+var requireInternalWarned = false;
 
 // Check the cache for the requested file.
 // 1. If a module already exists in the cache: return its exports object.
@@ -425,8 +426,21 @@ Module._load = function(request, parent, isMain) {
     return cachedModule.exports;
   }
 
-  if (NativeModule.nonInternalExists(filename)) {
+  if (NativeModule.exists(filename)) {
     debug('load native module %s', request);
+
+    // TODO(addaleax): Revert to throwing an error when require()ing
+    // internal modules.
+    if (NativeModule.isInternal(filename) && !requireInternalWarned) {
+      requireInternalWarned = true;
+      process.emitWarning(
+        'Accessing internal modules of Node using `require()` is strongly ' +
+        'discouraged and will be disabled in the future. Please make sure ' +
+        'that your dependencies are up to date.',
+        'DeprecationWarning'
+      );
+    }
+
     return NativeModule.require(filename);
   }
 
@@ -457,7 +471,7 @@ function tryModuleLoad(module, filename) {
 }
 
 Module._resolveFilename = function(request, parent, isMain) {
-  if (NativeModule.nonInternalExists(request)) {
+  if (NativeModule.exists(request)) {
     return request;
   }
 

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -1,5 +1,6 @@
 'use strict';
 var common = require('../common');
+/*
 var path = require('path');
 var assert = require('assert');
 
@@ -11,3 +12,12 @@ assert.strictEqual(
   require(path.join(common.fixturesDir, 'internal-modules')),
   42
 );
+*/
+
+common.expectWarning('DeprecationWarning', [
+  'Accessing internal modules of Node using `require()` is strongly ' +
+  'discouraged and will be disabled in the future. ' +
+  'Please make sure that your dependencies are up to date.'
+]);
+
+require('internal/freelist');

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -307,8 +307,8 @@ function error_test() {
       expect: 'undefined\n' + prompt_unix },
     // REPL should get a normal require() function, not one that allows
     // access to internal modules without the --expose_internals flag.
-    { client: client_unix, send: 'require("internal/repl")',
-      expect: /^Error: Cannot find module 'internal\/repl'/ },
+    /*{ client: client_unix, send: 'require("internal/repl")',
+      expect: /^Error: Cannot find module 'internal\/repl'/ },*/
     // REPL should handle quotes within regexp literal in multiline mode
     { client: client_unix, send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
       expect: prompt_multiline + prompt_multiline +


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

module

##### Description of change

I am not a fan of this myself, but I’d want to have it prepared in case we need it in v7.x, e.g. because at the time of writing this gulp still uses `graceful-fs@1.x.x` for file watching.

----

Allow `require('internal/…')` as a stop-gap measure for supporting old versions of `graceful-fs` in Node v7.x, but print a deprecation warning for that.

CI: https://ci.nodejs.org/job/node-test-commit/5520/
CITGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/407/