### PR TITLE
src: remove out-of-date TODO comment

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -354,7 +354,6 @@ void UDPWrap::RecvStop(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-// TODO(bnoordhuis) share with StreamWrap::AfterWrite() in stream_wrap.cc
 void UDPWrap::OnSend(uv_udp_send_t* req, int status) {
   SendWrap* req_wrap = static_cast<SendWrap*>(req->data);
   if (req_wrap->have_callback()) {


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change
This commit attempts to fix one of the items in
https://github.com/nodejs/node/issues/4641, which was to remove a
TODO the UDPWrap::OnSend function and share the code in that method with
StreamWrap::AfterWrite.

While looking into this addaleax pointed out that the implementations
for these two functions have diverged since the original comment
was added:

$ git log --pretty=short -u -L 357,357:src/udp_wrap.cc

$ git show cbd4033619cc45abdf878285c412bac9c3f36e4e:src/udp_wrap.cc |
grep -1 -A26 'UDPWrap::OnSend'

git show cbd4033619cc45abdf878285c412bac9c3f36e4e:src/stream_wrap.cc |
grep -A27 'void StreamWrap::AfterWrite'

Removing the TODO comment seems appropriate in this case.