### PR TITLE
doc: errno is a number, not a string

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -449,13 +449,15 @@ added properties.
 ### Class: System Error
 
 #### error.code
-#### error.errno
 
 Returns a string representing the error code, which is always `E` followed by
 a sequence of capital letters, and may be referenced in `man 2 intro`.
 
-The properties `error.code` and `error.errno` are aliases of one another and
-return the same value.
+#### error.errno
+
+Returns a number corresponding to the **negated** error code, which may be
+referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
+`-2` because the error code for `ENOENT` is `2`.
 
 #### error.syscall
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

The documentation erroneously described the errno property as an alias for the
code property, but that is not the case in the implementation. errno is the
error code of the error as a number, and code is the error code of the error
as a string.

As proof, here's some code:

```javascript
fs.readFile("nonexistantdjkfald", function(e) {
  console.log(e.errno); 
  console.log(typeof(e.errno));
  console.log(e.code);
  console.log(typeof(e.code));
});
```

Output:

```
-2
number
ENOENT
string
```