### PR TITLE
intl: (v4.x) Don't crash if v8BreakIterator not available

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2855,6 +2855,13 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(versions,
                     "icu",
                     OneByteString(env->isolate(), U_ICU_VERSION));
+
+  if (icu_data_dir != nullptr) {
+    // Did the user attempt (via env var or parameter) to set an ICU path?
+    READONLY_PROPERTY(process,
+                      "icu_data_dir",
+                      OneByteString(env->isolate(), icu_data_dir));
+  }
 #endif
 
   const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);

--- a/test/parallel/test-intl-v8BreakIterator.js
+++ b/test/parallel/test-intl-v8BreakIterator.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+if (global.Intl === undefined || Intl.v8BreakIterator === undefined) {
+  return console.log('1..0 # Skipped: no Intl');
+}
+
+try {
+  new Intl.v8BreakIterator();
+  // May succeed if data is available - OK
+} catch (e) {
+  // May throw this error if ICU data is not available - OK
+  assert.throws(() => new Intl.v8BreakIterator(), /ICU data/);
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines _(think so?)_

##### Affected core subsystem(s)
deps

##### Description of change

If the undocumented v8BreakIterator does not have data available,
monkeypatch it to throw an error instead of crashing.

Backport of #3111 c99f231c953f73babaa40e5350c4630a1f27f2c8