### PR TITLE
Add platform specific teams to onboarding-extras

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -77,7 +77,7 @@ Please use these when possible / appropriate
 ### Other Labels
 
 * Operating system labels
-  * `os x`, `windows`, `smartos`, `aix`
+  * `macos`, `windows`, `smartos`, `aix`
   * No linux, linux is the implied default
 * Architecture labels
   * `arm`, `mips`, `s390`, `ppc`

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -29,6 +29,7 @@
 | upgrading c-ares | @jbergstroem |
 | upgrading http-parser | @jbergstroem, @nodejs/http |
 | upgrading libuv | @saghul |
+| platform specific | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows} |
 
 
 When things need extra attention, are controversial, or `semver-major`: @nodejs/ctc

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -77,7 +77,7 @@ Please use these when possible / appropriate
 ### Other Labels
 
 * Operating system labels
-  * `os x`, `windows`, `solaris`, `aix`
+  * `os x`, `windows`, `smartos`, `aix`
   * No linux, linux is the implied default
 * Architecture labels
   * `arm`, `mips`, `s390`, `ppc`

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -76,10 +76,10 @@ Please use these when possible / appropriate
 ### Other Labels
 
 * Operating system labels
-  * `os x`, `windows`, `solaris`
+  * `os x`, `windows`, `solaris`, `aix`
   * No linux, linux is the implied default
 * Architecture labels
-  * `arm`, `mips`
+  * `arm`, `mips`, `s390`, `ppc`
   * No x86{_64}, since that is the implied default
 * `lts-agenda`, `lts-watch-v*`
   * tag things that should be discussed to go into LTS or should go into a specific LTS branch


### PR DESCRIPTION
## Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

## Affected core subsystem(s)
doc


## Description of change

This is three separate changes (which can probably be squashed on landing):

**_EDIT:_** To clarify, the label changes haven't been done yet. I guess it makes sense to do it as part of the landing process (cc. @Fishrock123 )

#### 1. Add OS/ARCH labels for `aix`, `ppc`, and `s390`:
 - Should be non-controversial, but requires the labels to be created

#### 2. Change `solaris` tag to `smartos`:
 - Might make sense as per https://github.com/nodejs/build/issues/500, if the existing labels update (but I defer to @nodejs/platform-solaris )

#### 3. Add teams for platform-specific issues
 - Adds platform-specific teams as per https://github.com/nodejs/build/issues/500#issuecomment-250614479
 - Already existing teams: @nodejs/platform-arm , @nodejs/platform-freebsd , and @nodejs/platform-windows 
 - New teams: @nodejs/platform-s390, @nodejs/platform-aix **_Edit:_** @nodejs/platform-macos
 - Changed team name: @nodejs/platform-solaris  -> @nodejs/platform-smartos

## Members for new teams:

Feel free to volunteer!

 - All three: @mhdawson @gireeshpunathil @gibfahn @joransiu @sxa555 @bnoordhuis @richardlau @jbajwa @john-yan 
 - @nodejs/platform-s390: 
 - @nodejs/platform-aix: 
 - @nodejs/platform-ppc: 


Do members of teams need to be collaborators? **_EDIT:_** I think the answer is yes