### PR TITLE
tls: copy the Buffer object before using (backport to v4.x)

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -52,7 +52,7 @@ exports.convertNPNProtocols = function convertNPNProtocols(NPNProtocols, out) {
 
   // If it's already a Buffer - store it
   if (NPNProtocols instanceof Buffer) {
-    out.NPNProtocols = NPNProtocols;
+    out.NPNProtocols = Buffer.from(NPNProtocols);
   }
 };
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+
+{
+  const buffer = Buffer.from('abcd');
+  const out = {};
+  tls.convertNPNProtocols(buffer, out);
+  out.NPNProtocols.write('efgh');
+  assert(buffer.equals(Buffer.from('abcd')));
+  assert(out.NPNProtocols.equals(Buffer.from('efgh')));
+}


### PR DESCRIPTION
This is a backport of #8055 

There was quite a bit of difference between this and the original so I would like to get sign off from @thefourtheye or @jasnell that this is doing what is should be doing.