### PR TITLE
events: fix TypeError in EventEmitter warning

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -257,8 +257,9 @@ function _addListener(target, type, listener, prepend) {
       if (m && m > 0 && existing.length > m) {
         existing.warned = true;
         const w = new Error('Possible EventEmitter memory leak detected. ' +
-                            `${existing.length} ${type} listeners added. ` +
-                            'Use emitter.setMaxListeners() to increase limit');
+                            `${existing.length} ${String(type)} listeners ` +
+                            'added. Use emitter.setMaxListeners() to ' +
+                            'increase limit');
         w.name = 'MaxListenersExceededWarning';
         w.emitter = target;
         w.type = type;

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -1,7 +1,7 @@
 'use strict';
 require('../common');
-var assert = require('assert');
-var events = require('events');
+const assert = require('assert');
+const events = require('events');
 
 var e = new events.EventEmitter();
 
@@ -12,6 +12,14 @@ for (let i = 0; i < 10; i++) {
 assert.ok(!e._events['default'].hasOwnProperty('warned'));
 e.on('default', function() {});
 assert.ok(e._events['default'].warned);
+
+// symbol
+const symbol = Symbol('symbol');
+e.setMaxListeners(1);
+e.on(symbol, function() {});
+assert.ok(!e._events[symbol].hasOwnProperty('warned'));
+e.on(symbol, function() {});
+assert.ok(e._events[symbol].hasOwnProperty('warned'));
 
 // specific
 e.setMaxListeners(5);

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
@@ -14,9 +14,9 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.name, 'MaxListenersExceededWarning');
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
-  assert.strictEqual(warning.type, 'event-type');
-  assert.ok(warning.message.includes('2 event-type listeners added.'));
+  assert.strictEqual(warning.type, null);
+  assert.ok(warning.message.includes('2 null listeners added.'));
 }));
 
-e.on('event-type', function() {});
-e.on('event-type', function() {});
+e.on(null, function() {});
+e.on(null, function() {});

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
@@ -6,6 +6,8 @@ const common = require('../common');
 const events = require('events');
 const assert = require('assert');
 
+const symbol = Symbol('symbol');
+
 const e = new events.EventEmitter();
 e.setMaxListeners(1);
 
@@ -14,9 +16,9 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.name, 'MaxListenersExceededWarning');
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
-  assert.strictEqual(warning.type, 'event-type');
-  assert.ok(warning.message.includes('2 event-type listeners added.'));
+  assert.strictEqual(warning.type, symbol);
+  assert.ok(warning.message.includes('2 Symbol(symbol) listeners added.'));
 }));
 
-e.on('event-type', function() {});
-e.on('event-type', function() {});
+e.on(symbol, function() {});
+e.on(symbol, function() {});


### PR DESCRIPTION
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

