### PR TITLE
test: move module out of fixture directory

### DIFF
--- a/test/parallel/test-tick-processor-builtin.js
+++ b/test/parallel/test-tick-processor-builtin.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const path = require('path');
 
 if (common.isWindows ||
     common.isSunOS ||
@@ -16,7 +15,7 @@ if (!common.enoughTestCpu) {
   return;
 }
 
-const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
+const base = require('./tick-processor-base.js');
 
 base.runTest({
   pattern: /Builtin_DateNow/,

--- a/test/parallel/test-tick-processor-cpp-core.js
+++ b/test/parallel/test-tick-processor-cpp-core.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const path = require('path');
 
 if (common.isWindows ||
     common.isSunOS ||
@@ -16,7 +15,7 @@ if (!common.enoughTestCpu) {
   return;
 }
 
-const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
+const base = require('./tick-processor-base.js');
 
 base.runTest({
   pattern: /RunInDebugContext/,

--- a/test/parallel/test-tick-processor-unknown.js
+++ b/test/parallel/test-tick-processor-unknown.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const path = require('path');
 
 // TODO(mhdawson) Currently the test-tick-processor functionality in V8
 // depends on addresses being smaller than a full 64 bits.  Aix supports
@@ -17,7 +16,7 @@ if (!common.enoughTestCpu) {
   return;
 }
 
-const base = require(path.join(common.fixturesDir, 'tick-processor-base.js'));
+const base = require('./tick-processor-base.js');
 
 // Unknown checked for to prevent flakiness, if pattern is not found,
 // then a large number of unknown ticks should be present

--- a/test/parallel/tick-processor-base.js
+++ b/test/parallel/tick-processor-base.js
@@ -20,7 +20,7 @@ function runTest(test) {
   });
 
   let ticks = '';
-  proc.stdout.on('data', chunk => ticks += chunk);
+  proc.stdout.on('data', (chunk) => ticks += chunk);
 
   // Try to match after timeout
   setTimeout(() => {
@@ -41,7 +41,7 @@ function match(pattern, parent, ticks) {
   });
 
   let out = '';
-  proc.stdout.on('data', chunk => out += chunk);
+  proc.stdout.on('data', (chunk) => out += chunk);
   proc.stdout.once('end', () => {
     proc.once('exit', () => {
       fs.unlinkSync(LOG_FILE);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

tick-processor-base.js is a module used by three other tests. It is not
a test fixture so move it out of the fixture directory. (One downside to
having it in the fixture directory is that fixture code is not currently
linted.)

It is possible that the code in tick-processor-base.js should be
integrated into common.js. This can potentially happen subsequently (and
might make a reasonable good first contribution for a new contributor).

(This does nothing for the flakiness issues with the `test-tick-processor-*` tests.)

/cc @nodejs/testing