### PR TITLE
src: fix typo rval to value

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2711,7 +2711,7 @@ static void EnvSetter(Local<String> property,
     SetEnvironmentVariableW(key_ptr, reinterpret_cast<WCHAR*>(*val));
   }
 #endif
-  // Whether it worked or not, always return rval.
+  // Whether it worked or not, always return value.
   info.GetReturnValue().Set(value);
 }
 


### PR DESCRIPTION
##### Checklist
- [x] commit message follows commit guidelines

##### Description of change

`rval` never existed, it was added as that in 077f9d7293468ad5446b330999fe47bc40e47571

closes #9001