### PR TITLE
v6.x backport: fs: make `SyncWriteStream` inherit from `Writable`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2196,17 +2196,18 @@ WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 // SyncWriteStream is internal. DO NOT USE.
 // Temporary hack for process.stdout and process.stderr when piped to files.
 function SyncWriteStream(fd, options) {
-  Stream.call(this);
+  Writable.call(this);
 
   options = options || {};
 
   this.fd = fd;
-  this.writable = true;
   this.readable = false;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
+
+  this.on('end', () => this._destroy());
 }
 
-util.inherits(SyncWriteStream, Stream);
+util.inherits(SyncWriteStream, Writable);
 
 
 // Export
@@ -2216,51 +2217,26 @@ Object.defineProperty(fs, 'SyncWriteStream', {
   value: SyncWriteStream
 });
 
-SyncWriteStream.prototype.write = function(data, arg1, arg2) {
-  var encoding, cb;
-
-  // parse arguments
-  if (arg1) {
-    if (typeof arg1 === 'string') {
-      encoding = arg1;
-      cb = arg2;
-    } else if (typeof arg1 === 'function') {
-      cb = arg1;
-    } else {
-      throw new Error('Bad arguments');
-    }
-  }
-  assertEncoding(encoding);
-
-  // Change strings to buffers. SLOW
-  if (typeof data === 'string') {
-    data = Buffer.from(data, encoding);
-  }
-
-  fs.writeSync(this.fd, data, 0, data.length);
-
-  if (cb) {
-    process.nextTick(cb);
-  }
-
+SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
+  fs.writeSync(this.fd, chunk, 0, chunk.length);
+  cb();
   return true;
 };
 
+SyncWriteStream.prototype._destroy = function() {
+  if (this.fd === null) // already destroy()ed
+    return;
 
-SyncWriteStream.prototype.end = function(data, arg1, arg2) {
-  if (data) {
-    this.write(data, arg1, arg2);
-  }
-  this.destroy();
-};
-
-
-SyncWriteStream.prototype.destroy = function() {
   if (this.autoClose)
     fs.closeSync(this.fd);
+
   this.fd = null;
+  return true;
+};
+
+SyncWriteStream.prototype.destroySoon =
+SyncWriteStream.prototype.destroy = function() {
+  this._destroy();
   this.emit('close');
   return true;
 };
-
-SyncWriteStream.prototype.destroySoon = SyncWriteStream.prototype.destroy;

--- a/test/parallel/test-fs-syncwritestream.js
+++ b/test/parallel/test-fs-syncwritestream.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const stream = require('stream');
+const fs = require('fs');
+const path = require('path');
+
+// require('internal/fs').SyncWriteStream is used as a stdio implementation
+// when stdout/stderr point to files.
+
+if (process.argv[2] === 'child') {
+  // Note: Calling console.log() is part of this test as it exercises the
+  // SyncWriteStream#_write() code path.
+  console.log(JSON.stringify([process.stdout, process.stderr].map((stdio) => ({
+    instance: stdio instanceof stream.Writable,
+    readable: stdio.readable,
+    writable: stdio.writable,
+  }))));
+
+  return;
+}
+
+common.refreshTmpDir();
+
+const filename = path.join(common.tmpDir, 'stdout');
+const stdoutFd = fs.openSync(filename, 'w');
+
+const proc = spawn(process.execPath, [__filename, 'child'], {
+  stdio: ['inherit', stdoutFd, stdoutFd ]
+});
+
+proc.on('close', common.mustCall(() => {
+  fs.closeSync(stdoutFd);
+
+  assert.deepStrictEqual(JSON.parse(fs.readFileSync(filename, 'utf8')), [
+    { instance: true, readable: false, writable: true },
+    { instance: true, readable: false, writable: true }
+  ]);
+}));


### PR DESCRIPTION
Backport #8830 to v6.x

btw, the linter is failing for me with unrelated changes:

```
/home/sqrt/src/node/benchmark/common.js
  266:1  error  Too many blank lines at the end of file. Max of 0 allowed  no-multiple-empty-lines

/home/sqrt/src/node/benchmark/http/http_server_for_chunky_client.js
  55:1  error  Too many blank lines at the end of file. Max of 0 allowed  no-multiple-empty-lines

/home/sqrt/src/node/benchmark/idle_clients.js
  48:1  error  Too many blank lines at the end of file. Max of 0 allowed  no-multiple-empty-lines

/home/sqrt/src/node/test/parallel/test-readline-interface.js
  393:7  error  Function argument in column 7, expected in 16  align-function-arguments
  395:7  error  Function argument in column 7, expected in 16  align-function-arguments

✖ 5 problems (5 errors, 0 warnings)
```

/cc @Fishrock123 