### PR TITLE
crypto: fix faulty logic in iv size check

### DIFF
--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -307,10 +307,10 @@ const TEST_CASES = [
     tag: 'a44a8266ee1c8eb0c8b5d4cf5ae9f19a', tampered: false },
 ];
 
-var ciphers = crypto.getCiphers();
+const ciphers = crypto.getCiphers();
 
-for (var i in TEST_CASES) {
-  var test = TEST_CASES[i];
+for (const i in TEST_CASES) {
+  const test = TEST_CASES[i];
 
   if (ciphers.indexOf(test.algo) === -1) {
     common.skip('unsupported ' + test.algo + ' test');
@@ -359,8 +359,7 @@ for (var i in TEST_CASES) {
     }
   }
 
-  {
-    if (!test.password) return;
+  if (test.password) {
     if (common.hasFipsCrypto) {
       assert.throws(() => { crypto.createCipher(test.algo, test.password); },
                     /not supported in FIPS mode/);
@@ -379,8 +378,7 @@ for (var i in TEST_CASES) {
     }
   }
 
-  {
-    if (!test.password) return;
+  if (test.password) {
     if (common.hasFipsCrypto) {
       assert.throws(() => { crypto.createDecipher(test.algo, test.password); },
                     /not supported in FIPS mode/);
@@ -398,24 +396,6 @@ for (var i in TEST_CASES) {
         assert.throws(function() { decrypt.final('ascii'); }, / auth/);
       }
     }
-  }
-
-  // after normal operation, test some incorrect ways of calling the API:
-  // it's most certainly enough to run these tests with one algorithm only.
-
-  if (i > 0) {
-    continue;
-  }
-
-  {
-    // non-authenticating mode:
-    const encrypt = crypto.createCipheriv('aes-128-cbc',
-      'ipxp9a6i1Mb4USb4', '6fKjEjR3Vl30EUYC');
-    encrypt.update('blah', 'ascii');
-    encrypt.final();
-    assert.throws(() => { encrypt.getAuthTag(); }, / state/);
-    assert.throws(() => { encrypt.setAAD(Buffer.from('123', 'ascii')); },
-                  / state/);
   }
 
   {
@@ -451,4 +431,16 @@ for (var i in TEST_CASES) {
       );
     }, /Invalid IV length/);
   }
+}
+
+// Non-authenticating mode:
+{
+  const encrypt =
+      crypto.createCipheriv('aes-128-cbc',
+                            'ipxp9a6i1Mb4USb4',
+                            '6fKjEjR3Vl30EUYC');
+  encrypt.update('blah', 'ascii');
+  encrypt.final();
+  assert.throws(() => encrypt.getAuthTag(), / state/);
+  assert.throws(() => encrypt.setAAD(Buffer.from('123', 'ascii')), / state/);
 }

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -61,5 +61,39 @@ testCipher1('0123456789abcd0123456789', '12345678');
 testCipher1('0123456789abcd0123456789', Buffer.from('12345678'));
 testCipher1(Buffer.from('0123456789abcd0123456789'), '12345678');
 testCipher1(Buffer.from('0123456789abcd0123456789'), Buffer.from('12345678'));
-
 testCipher2(Buffer.from('0123456789abcd0123456789'), Buffer.from('12345678'));
+
+// Zero-sized IV should be accepted in ECB mode.
+crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16), Buffer.alloc(0));
+
+// But non-empty IVs should be rejected.
+for (let n = 1; n < 256; n += 1) {
+  assert.throws(
+      () => crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16),
+                                  Buffer.alloc(n)),
+      /Invalid IV length/);
+}
+
+// Correctly sized IV should be accepted in CBC mode.
+crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16), Buffer.alloc(16));
+
+// But all other IV lengths should be rejected.
+for (let n = 0; n < 256; n += 1) {
+  if (n === 16) continue;
+  assert.throws(
+      () => crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16),
+                                  Buffer.alloc(n)),
+      /Invalid IV length/);
+}
+
+// Zero-sized IV should be rejected in GCM mode.
+assert.throws(
+    () => crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16),
+                                Buffer.alloc(0)),
+    /Invalid IV length/);
+
+// But all other IV lengths should be accepted.
+for (let n = 1; n < 256; n += 1) {
+  if (common.hasFipsCrypto && n < 12) continue;
+  crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16), Buffer.alloc(n));
+}


### PR DESCRIPTION
Fix a regression introduced in commit 2996b5c ("crypto: Allow GCM
ciphers to have a longer IV length") from April 2016 where a misplaced
parenthesis in a 'is ECB cipher?' check made it possible to use empty
IVs with non-ECB ciphers.

Refs: #6376
Refs: #9024

R=@nodejs/crypto @addaleax