### PR TITLE
validate arguments to mustCall(), default value

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -402,8 +402,10 @@ function runCallChecks(exitCode) {
 }
 
 
-exports.mustCall = function(fn, expected) {
-  if (typeof expected !== 'number') expected = 1;
+exports.mustCall = function(fn, expected = 1) {
+  if (typeof expected !== 'number' || expected < 0) {
+    throw new RangeError(`Invalid expected value: ${expected}`);
+  }
 
   var context = {
     expected: expected,

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -5,3 +5,12 @@ var assert = require('assert');
 common.globalCheck = false;
 global.gc = 42;  // Not a valid global unless --expose_gc is set.
 assert.deepStrictEqual(common.leakedGlobals(), ['gc']);
+
+
+assert.throws(function() {
+  common.mustCall(function() {},'foo')();
+}, /invalid expected value: foo/i);
+
+assert.throws(function() {
+  common.mustCall(function() {},/foo/)();
+}, /invalid expected value: \/foo\//i);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Updates the `mustCall()` function in `test/common.js` to use to default the `expected` parameter to 1 and validate that it is a non-negative number. 

This change will prevent issues such as the one fixed in the first commit on
https://github.com/nodejs/node/pull/9031