### PR TITLE
buffer: add buffer.transcode

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2302,6 +2302,33 @@ added: v3.0.0
 On 32-bit architectures, this value is `(2^30)-1` (~1GB).
 On 64-bit architectures, this value is `(2^31)-1` (~2GB).
 
+## buffer.transcode(source, fromEnc, toEnc)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `source` {Buffer} A `Buffer` instance
+* `fromEnc` {String} The current encoding
+* `toEnc` {String} To target encoding
+
+Re-encodes the given `Buffer` instance from one character encoding to another.
+Returns a new `Buffer` instance.
+
+Throws if the `fromEnc` or `toEnc` specify invalid character encodings or if
+conversion from `fromEnc` to `toEnc` is not permitted.
+
+The transcoding process will use substitution characters if a given byte
+sequence cannot be adequately represented in the target encoding. For instance:
+
+```js
+const newBuf = buffer.transcode(Buffer.from('€'), 'utf8', 'ascii');
+console.log(newBuf.toString('ascii'));
+  // prints '?'
+```
+
+Because the Euro (`€`) sign is not representable in US-ASCII, it is replaced
+with `?` in the transcoded `Buffer`.
+
 ## Class: SlowBuffer
 <!-- YAML
 deprecated: v6.0.0

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1360,3 +1360,7 @@ Buffer.prototype.swap64 = function swap64() {
 };
 
 Buffer.prototype.toLocaleString = Buffer.prototype.toString;
+
+// Put this at the end because internal/buffer has a circular
+// dependency on Buffer.
+exports.transcode = require('internal/buffer').transcode;

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1,0 +1,30 @@
+'use strict';
+
+if (!process.binding('config').hasIntl) {
+  return;
+}
+
+const normalizeEncoding = require('internal/util').normalizeEncoding;
+const Buffer = require('buffer').Buffer;
+
+const icu = process.binding('icu');
+
+// Transcodes the Buffer from one encoding to another, returning a new
+// Buffer instance.
+exports.transcode = function transcode(source, fromEncoding, toEncoding) {
+  if (!Buffer.isBuffer(source))
+    throw new TypeError('"source" argument must be a Buffer');
+  if (source.length === 0) return Buffer.alloc(0);
+
+  fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;
+  toEncoding = normalizeEncoding(toEncoding) || toEncoding;
+  const result = icu.transcode(source, fromEncoding, toEncoding);
+  if (Buffer.isBuffer(result))
+    return result;
+
+  const code = icu.icuErrName(result);
+  const err = new Error(`Unable to transcode Buffer [${code}]`);
+  err.code = code;
+  err.errno = result;
+  throw err;
+};

--- a/node.gyp
+++ b/node.gyp
@@ -74,6 +74,7 @@
       'lib/v8.js',
       'lib/vm.js',
       'lib/zlib.js',
+      'lib/internal/buffer.js',
       'lib/internal/child_process.js',
       'lib/internal/cluster.js',
       'lib/internal/freelist.js',

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -1,0 +1,48 @@
+'use strict';
+
+require('../common');
+const buffer = require('buffer');
+const assert = require('assert');
+
+const orig = Buffer.from('tést €', 'utf8');
+
+// Test Transcoding
+const tests = {
+  'latin1': [0x74, 0xe9, 0x73, 0x74, 0x20, 0x3f],
+  'ascii': [0x74, 0x3f, 0x73, 0x74, 0x20, 0x3f],
+  'ucs2': [0x74, 0x00, 0xe9, 0x00, 0x73,
+           0x00, 0x74, 0x00, 0x20, 0x00,
+           0xac, 0x20]
+};
+
+for (const test in tests) {
+  const dest = buffer.transcode(orig, 'utf8', test);
+  assert.strictEqual(dest.length, tests[test].length);
+  for (var n = 0; n < tests[test].length; n++)
+    assert.strictEqual(dest[n], tests[test][n]);
+}
+
+{
+  const dest = buffer.transcode(Buffer.from(tests.ucs2), 'ucs2', 'utf8');
+  assert.strictEqual(dest.toString(), orig.toString());
+}
+
+{
+  const utf8 = Buffer.from('€'.repeat(4000), 'utf8');
+  const ucs2 = Buffer.from('€'.repeat(4000), 'ucs2');
+  const utf8_to_ucs2 = buffer.transcode(utf8, 'utf8', 'ucs2');
+  const ucs2_to_utf8 = buffer.transcode(ucs2, 'ucs2', 'utf8');
+  assert.deepStrictEqual(utf8, ucs2_to_utf8);
+  assert.deepStrictEqual(ucs2, utf8_to_ucs2);
+  assert.strictEqual(ucs2_to_utf8.toString('utf8'),
+                     utf8_to_ucs2.toString('ucs2'));
+}
+
+assert.throws(
+  () => buffer.transcode(Buffer.from('a'), 'b', 'utf8'),
+  /Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]/
+);
+assert.throws(
+  () => buffer.transcode(Buffer.from('a'), 'uf8', 'b'),
+  /Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]/
+);

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -20,9 +20,7 @@
       'type': 'none',
       'toolsets': [ 'target' ],
       'direct_dependent_settings': {
-        'defines': [
-          'UCONFIG_NO_CONVERSION=1',
-        ]
+        'defines': []
       },
     },
     {


### PR DESCRIPTION

##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change
Add buffer.transcode(source, from, to) method. Primarily uses ICU to transcode a buffer's content from one of Node.js' supported encodings to another.

Originally part of a proposal to add a new unicode module. Decided to refactor the approach towrds individual PRs without a new module.

Refs: https://github.com/nodejs/node/pull/8075
/cc @trevnorris @addaleax 