### PR TITLE
readline: use icu based string width calculation

### DIFF
--- a/lib/internal/readline.js
+++ b/lib/internal/readline.js
@@ -1,103 +1,117 @@
 'use strict';
 
-// Regexes used for ansi escape code splitting
+// Regex used for ansi escape code splitting
 // eslint-disable-next-line no-control-regex
-const metaKeyCodeReAnywhere = /(?:\x1b)([a-zA-Z0-9])/;
-const functionKeyCodeReAnywhere = new RegExp('(?:\x1b+)(O|N|\\[|\\[\\[)(?:' + [
-  '(\\d+)(?:;(\\d+))?([~^$])',
-  '(?:M([@ #!a`])(.)(.))', // mouse
-  '(?:1;)?(\\d+)?([a-zA-Z])'
-].join('|') + ')');
+// Adopted from https://github.com/chalk/ansi-regex/blob/master/index.js
+// License: MIT, authors: @sindresorhus, Qix-, and arjunmehta
+// Matches all ansi escape code sequences in a string
+const ansi =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
 
 
 module.exports = {
   emitKeys,
-  getStringWidth,
-  isFullWidthCodePoint,
   stripVTControlCharacters
 };
 
+if (process.binding('config').hasIntl) {
+  const icu = process.binding('icu');
+  module.exports.getStringWidth = function getStringWidth(str, options) {
+    options = options || {};
+    if (!Number.isInteger(str))
+      str = stripVTControlCharacters(String(str));
+    return icu.getStringWidth(str,
+                              Boolean(options.ambiguousAsFullWidth),
+                              Boolean(options.expandEmojiSequence));
+  };
+  module.exports.isFullWidthCodePoint =
+    function isFullWidthCodePoint(code, options) {
+      if (typeof code !== 'number')
+        return false;
+      return icu.getStringWidth(code, options) === 2;
+    };
+} else {
+  /**
+   * Returns the number of columns required to display the given string.
+   */
+  module.exports.getStringWidth = function getStringWidth(str) {
+    if (Number.isInteger(str))
+      return module.exports.isFullWidthCodePoint(str) ? 2 : 1;
 
-/**
- * Returns the number of columns required to display the given string.
- */
-function getStringWidth(str) {
-  let width = 0;
+    let width = 0;
 
-  str = stripVTControlCharacters(str);
+    str = stripVTControlCharacters(String(str));
 
-  for (var i = 0; i < str.length; i++) {
-    const code = str.codePointAt(i);
+    for (var i = 0; i < str.length; i++) {
+      const code = str.codePointAt(i);
 
-    if (code >= 0x10000) { // surrogates
-      i++;
+      if (code >= 0x10000) { // surrogates
+        i++;
+      }
+
+      if (module.exports.isFullWidthCodePoint(code)) {
+        width += 2;
+      } else {
+        width++;
+      }
     }
 
-    if (isFullWidthCodePoint(code)) {
-      width += 2;
-    } else {
-      width++;
+    return width;
+  };
+
+  /**
+   * Returns true if the character represented by a given
+   * Unicode code point is full-width. Otherwise returns false.
+   */
+  module.exports.isFullWidthCodePoint = function isFullWidthCodePoint(code) {
+    if (!Number.isInteger(code)) {
+      return false;
     }
-  }
 
-  return width;
-}
+    // Code points are derived from:
+    // http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
+    if (code >= 0x1100 && (
+        code <= 0x115f ||  // Hangul Jamo
+        0x2329 === code || // LEFT-POINTING ANGLE BRACKET
+        0x232a === code || // RIGHT-POINTING ANGLE BRACKET
+        // CJK Radicals Supplement .. Enclosed CJK Letters and Months
+        (0x2e80 <= code && code <= 0x3247 && code !== 0x303f) ||
+        // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
+        0x3250 <= code && code <= 0x4dbf ||
+        // CJK Unified Ideographs .. Yi Radicals
+        0x4e00 <= code && code <= 0xa4c6 ||
+        // Hangul Jamo Extended-A
+        0xa960 <= code && code <= 0xa97c ||
+        // Hangul Syllables
+        0xac00 <= code && code <= 0xd7a3 ||
+        // CJK Compatibility Ideographs
+        0xf900 <= code && code <= 0xfaff ||
+        // Vertical Forms
+        0xfe10 <= code && code <= 0xfe19 ||
+        // CJK Compatibility Forms .. Small Form Variants
+        0xfe30 <= code && code <= 0xfe6b ||
+        // Halfwidth and Fullwidth Forms
+        0xff01 <= code && code <= 0xff60 ||
+        0xffe0 <= code && code <= 0xffe6 ||
+        // Kana Supplement
+        0x1b000 <= code && code <= 0x1b001 ||
+        // Enclosed Ideographic Supplement
+        0x1f200 <= code && code <= 0x1f251 ||
+        // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
+        0x20000 <= code && code <= 0x3fffd)) {
+      return true;
+    }
 
-
-/**
- * Returns true if the character represented by a given
- * Unicode code point is full-width. Otherwise returns false.
- */
-function isFullWidthCodePoint(code) {
-  if (isNaN(code)) {
     return false;
-  }
-
-  // Code points are derived from:
-  // http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
-  if (code >= 0x1100 && (
-      code <= 0x115f ||  // Hangul Jamo
-      0x2329 === code || // LEFT-POINTING ANGLE BRACKET
-      0x232a === code || // RIGHT-POINTING ANGLE BRACKET
-      // CJK Radicals Supplement .. Enclosed CJK Letters and Months
-      (0x2e80 <= code && code <= 0x3247 && code !== 0x303f) ||
-      // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
-      0x3250 <= code && code <= 0x4dbf ||
-      // CJK Unified Ideographs .. Yi Radicals
-      0x4e00 <= code && code <= 0xa4c6 ||
-      // Hangul Jamo Extended-A
-      0xa960 <= code && code <= 0xa97c ||
-      // Hangul Syllables
-      0xac00 <= code && code <= 0xd7a3 ||
-      // CJK Compatibility Ideographs
-      0xf900 <= code && code <= 0xfaff ||
-      // Vertical Forms
-      0xfe10 <= code && code <= 0xfe19 ||
-      // CJK Compatibility Forms .. Small Form Variants
-      0xfe30 <= code && code <= 0xfe6b ||
-      // Halfwidth and Fullwidth Forms
-      0xff01 <= code && code <= 0xff60 ||
-      0xffe0 <= code && code <= 0xffe6 ||
-      // Kana Supplement
-      0x1b000 <= code && code <= 0x1b001 ||
-      // Enclosed Ideographic Supplement
-      0x1f200 <= code && code <= 0x1f251 ||
-      // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
-      0x20000 <= code && code <= 0x3fffd)) {
-    return true;
-  }
-
-  return false;
+  };
 }
-
 
 /**
  * Tries to remove all VT control characters. Use to estimate displayed
  * string width. May be buggy due to not running a real state machine
  */
 function stripVTControlCharacters(str) {
-  str = str.replace(new RegExp(functionKeyCodeReAnywhere.source, 'g'), '');
-  return str.replace(new RegExp(metaKeyCodeReAnywhere.source, 'g'), '');
+  return str.replace(ansi, '');
 }
 
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -124,6 +124,14 @@ function Interface(input, output, completer, terminal) {
 
   function onkeypress(s, key) {
     self._ttyWrite(s, key);
+    if (key && key.sequence) {
+      // if the key.sequence is half of a surrogate pair
+      // (>= 0xd800 and <= 0xdfff), refresh the line so
+      // the character is displayed appropriately.
+      const ch = key.sequence.codePointAt(0);
+      if (ch >= 0xd800 && ch <= 0xdfff)
+        self._refreshLine();
+    }
   }
 
   function onresize() {

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -1,0 +1,43 @@
+// Flags: --expose_internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const readline = require('internal/readline');
+
+if (!process.binding('config').hasIntl) {
+  common.skip('missing intl... skipping test');
+  return;
+}
+
+// Test column width
+assert.strictEqual(readline.getStringWidth('a'), 1);
+assert.strictEqual(readline.getStringWidth('丁'), 2);
+assert.strictEqual(readline.getStringWidth('\ud83d\udc78\ud83c\udfff'), 2);
+assert.strictEqual(readline.getStringWidth('👅'), 2);
+assert.strictEqual(readline.getStringWidth('\n'), 0);
+assert.strictEqual(readline.getStringWidth('\u200Ef\u200F'), 1);
+assert.strictEqual(readline.getStringWidth(97), 1);
+
+// The following is an emoji sequence. In some implementations, it is
+// represented as a single glyph, in other implementations as a sequence
+// of individual glyphs. By default, the algorithm will assume the single
+// glyph interpretation and return a value of 2. By passing the
+// expandEmojiSequence: true option, each component will be counted
+// individually.
+assert.strictEqual(readline.getStringWidth('👩‍👩‍👧‍👧'), 2);
+assert.strictEqual(
+    readline.getStringWidth('👩‍👩‍👧‍👧', {expandEmojiSequence: true}), 8);
+
+// By default, unicode characters whose width is considered ambiguous will
+// be considered half-width. For these characters, getStringWidth will return
+// 1. In some contexts, however, it is more appropriate to consider them full
+// width. By default, the algorithm will assume half width. By passing
+// the ambiguousAsFullWidth: true option, ambiguous characters will be counted
+// as 2 columns.
+assert.strictEqual(readline.getStringWidth('\u01d4'), 1);
+assert.strictEqual(
+    readline.getStringWidth('\u01d4', {ambiguousAsFullWidth: true}), 2);
+
+// Control chars and combining chars are zero
+assert.strictEqual(readline.getStringWidth('\u200E\n\u220A\u20D2'), 1);


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

readline, internal

##### Description of change
Rather than the pseudo-wcwidth impl used currently, use the ICU character properties database to calculate string width and determine if a character is full width or not. This allows the algorithm to correctly identify emoji's as full width, ensures the algorithm will continue to fucntion properly as new unicode codepoints are added, and it's faster.

This was originally part of a proposal to add a new unicode module, but has been split out.

Refs: https://github.com/nodejs/node/pull/8075