### PR TITLE
doc: correctly reference where to list hash algorithms.

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1241,18 +1241,18 @@ input.on('readable', () => {
 added: v0.1.92
 -->
 
-Creates and returns a `Sign` object that uses the given `algorithm`. On
-recent OpenSSL releases, `openssl list-public-key-algorithms` will
-display the available signing algorithms. One example is `'RSA-SHA256'`.
+Creates and returns a `Sign` object that uses the given `algorithm`.
+Use [`crypto.getHashes()`][] to obtain an array of names of the available
+signing algorithms.
 
 ### crypto.createVerify(algorithm)
 <!-- YAML
 added: v0.1.92
 -->
 
-Creates and returns a `Verify` object that uses the given algorithm. On
-recent OpenSSL releases, `openssl list-public-key-algorithms` will
-display the available signing algorithms. One example is `'RSA-SHA256'`.
+Creates and returns a `Verify` object that uses the given algorithm. 
+Use [`crypto.getHashes()`][] to obtain an array of names of the available
+signing algorithms.
 
 ### crypto.getCiphers()
 <!-- YAML
@@ -1320,7 +1320,8 @@ console.log(alice_secret == bob_secret);
 added: v0.9.3
 -->
 
-Returns an array with the names of the supported hash algorithms.
+Returns an array of the names of the supported hash algorithms,
+such as `RSA-SHA256`.
 
 Example:
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Docs.

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes Issue: https://github.com/nodejs/node/issues/9005.

Update crypto docs by removing inaccurate command explanation from `crypto.createSign(algorithm)` and `crypto.createVerify(algorithm)`,
 accurately referencing how to get available hash algorithms from `crypto.getHashes()`.
