### PR TITLE
doc: explain why we don't use the GitHub merge button

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -101,6 +101,8 @@ information regarding the change process:
 
 - A `Reviewed-By: Name <email>` line for yourself and any
   other Collaborators who have reviewed the change.
+  - Useful for @mentions / contact list if something goes wrong in the PR.
+  - Protects against the assumption that GitHub will be around forever.
 - A `PR-URL:` line that references the *full* GitHub URL of the original
   pull request being merged so it's easy to trace a commit back to the
   conversation that led up to that change.

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -167,10 +167,11 @@ onboarding session.
 * Please never use GitHub's green ["Merge Pull Request"](https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-using-the-github-web-interface) button.
   * If you do, please force-push removing the merge.
   * Reasons for not using the web interface button:
-    * The old merge method will write an ugly commit message.
-    * The old rebase & merge method adds metadata to the commit title.
-    * The latest rebase method changes the author.
+    * The merge method will add an unnecessary merge commit.
+    * The rebase & merge method adds metadata to the commit title.
+    * The rebase method changes the author.
     * The squash & merge method has been known to add metadata to the commit title.
+    * If more than one author has contributed to the PR, only the latest author will be considered during the squashing.
 
 
 Update your `master` branch (or whichever branch you are landing on, almost always `master`)

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -164,8 +164,14 @@ onboarding session.
 
 ## Landing PRs: Details
 
-* Please never use GitHub's green "Merge Pull Request" button.
+* Please never use GitHub's green ["Merge Pull Request"](https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-using-the-github-web-interface) button.
   * If you do, please force-push removing the merge.
+  * Reasons for not using the web interface button:
+    * The old merge method will write an ugly commit message.
+    * The old rebase & merge method adds metadata to the commit title.
+    * The latest rebase method changes the author.
+    * The squash & merge method has been known to add metadata to the commit title.
+
 
 Update your `master` branch (or whichever branch you are landing on, almost always `master`)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Docs.

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes issue: https://github.com/nodejs/node/issues/8893.

Updates documentation on why the green GitHub merge button is not used. Also mentioned in the above issue was a question on why `Reviewed-By` is important to add on PRs. The documentation has also been updated to answer this.