### PR TITLE
build: fix config.gypi target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,12 @@ out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
 	$(PYTHON) tools/gyp_node.py -f make
 
 config.gypi: configure
-	if [ -f $@ ]; then
-		$(error Stale $@, please re-run ./configure)
-	else
-		$(error No $@, please run ./configure first)
+	@if [ -f $@ ]; then \
+		echo Stale $@, please re-run ./$<; \
+	else \
+		echo No $@, please run ./$< first; \
 	fi
+	@exit 1;
 
 install: all
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,7 @@ out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
 	$(PYTHON) tools/gyp_node.py -f make
 
 config.gypi: configure
-	@if [ -f $@ ]; then \
-		echo Stale $@, please re-run ./$<; \
-	else \
-		echo No $@, please run ./$< first; \
-	fi
-	@exit 1;
+	$(error Missing or stale $@, please re-run ./$<)
 
 install: all
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
 	$(PYTHON) tools/gyp_node.py -f make
 
 config.gypi: configure
-	$(error Missing or stale $@, please re-run ./$<)
+	$(error Missing or stale $@, please run ./$<)
 
 install: all
 	$(PYTHON) tools/install.py $@ '$(DESTDIR)' '$(PREFIX)'


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change

The config.gypi target has a recipe that uses the control function error
to report if the config.gypi file is missing or if it is stale (the
configure file was updated which is a prerequisite of this rule).

GNU make has two phases, immediate and deferred. During the first phase
 it will expand any variables or functions as the makefile is parsed.
The recipe in this case is a shell if statement, which is a deferred
construct. But the control function $(error) is an immediate construct
which will cause the makefile processing to stop during the first phase
of the Make process.

If I understand this correctly the only possible outcome of this rule is
the "Stale config.gypi, please re-run ./configure"  message which will
be done in the first phase and then exit. The shell condition will not
be considered. So it will never report that the config.gypi is missing.

I've updated the recipe to use the echo command and an exit status. The
downside of this is that the error message is not as nice.

Current error message:
Makefile:81: *** Stale config.gypi, please re-run ./configure.  Stop.

"New error message":
$ make config.gypi
Stale config.gypi, please re-run ./configure
make: *** [config.gypi] Error 1

To verify the stale config.gypi:
$ touch configure
$ make

To verfify that config.gypi is missing:
$ rm config.gypi
$ make