### PR TITLE
change for a deprecated method: SetNamedPropertyHandler() to SetHandler()

### DIFF
--- a/test/parallel/test-v8-interceptStrings-not-Symbols.js
+++ b/test/parallel/test-v8-interceptStrings-not-Symbols.js
@@ -1,0 +1,34 @@
+'use strict';
+require('../common');
+
+const assert = require('assert');
+
+// Test that the v8 named property handler intercepts callbacks
+// when properties are defined as Strings and NOT for Symbols.
+//
+// With the kOnlyInterceptStrings flag, manipulating properties via
+// Strings is intercepted by the callbacks, while Symbols adopt
+// the default global behaviour.
+// Removing the kOnlyInterceptStrings flag, adds intercepting to Symbols,
+// which causes Type Error at process.env[symbol]=42 due to process.env being
+// strongly typed for Strings
+// (node::Utf8Value key(info.GetIsolate(), property);).
+
+
+const symbol = Symbol('sym');
+
+// check if its undefined
+assert.strictEqual(process.env[symbol], undefined);
+
+// set a value using a Symbol
+process.env[symbol] = 42;
+
+// set a value using a String (call to EnvSetter, node.cc)
+process.env['s'] = 42;
+
+//check the values after substitutions
+assert.strictEqual(42, process.env[symbol]);
+assert.strictEqual('42', process.env['s']);
+
+delete process.env[symbol];
+assert.strictEqual(undefined, process.env[symbol]);


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Description of change

SetNamedPropertyHandler() method replaced with SetHandler() in process_env_template

PropertyHandlerFlags::kOnlyInterceptStrings flag maintains previous behavior: only Strings as properties are intercepted. In theory, it is now possible to extend the functionality for intercepting properties using Symbols (in practice a fix is required: I will create an issue when this pull request is merged). 
