### PR TITLE
Benchmark fixes

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -208,11 +208,14 @@ Benchmark.prototype.report = function(rate, elapsed) {
   });
 };
 
-exports.v8ForceOptimization = function(method, ...args) {
+exports.v8ForceOptimization = function(method) {
   if (typeof method !== 'function')
     return;
+
   const v8 = require('v8');
   v8.setFlagsFromString('--allow_natives_syntax');
+
+  const args = Array.prototype.slice.call(arguments, 1);
   method.apply(null, args);
   eval('%OptimizeFunctionOnNextCall(method)');
   method.apply(null, args);

--- a/benchmark/compare.R
+++ b/benchmark/compare.R
@@ -16,8 +16,12 @@ if (!is.null(args.options$help) ||
 
 plot.filename = args.options$plot;
 
-dat = read.csv(file('stdin'));
+dat = read.csv(
+  file('stdin'),
+  colClasses=c('character', 'character', 'character', 'numeric', 'numeric')
+);
 dat = data.frame(dat);
+
 dat$nameTwoLines = paste0(dat$filename, '\n', dat$configuration);
 dat$name = paste0(dat$filename, dat$configuration);
 

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -40,8 +40,8 @@ if (benchmarks.length === 0) {
 // Create queue from the benchmarks list such both node versions are tested
 // `runs` amount of times each.
 const queue = [];
-for (let iter = 0; iter < runs; iter++) {
-  for (const filename of benchmarks) {
+for (const filename of benchmarks) {
+  for (let iter = 0; iter < runs; iter++) {
     for (const binary of binaries) {
       queue.push({ binary, filename, iter });
     }


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark

##### Description of change

Some minor benchmark fixes. I can create 3 separate pull requests if that makes the review process easier.

**benchmark: fixes csv parsing given no parameters**

When a benchmark did not contain any parameters the csv configuration
filed would be "". In R this is by default parsed as NA, causing NA in
the printout too.

Fixes: #9061

**benchmark: change the execution order**

This changes the execution order from "iter, file, binary" to "file,
iter, binary". This means the csv no longer has to buffered completely.

This also has the added effect that stopping compare.js early or
interfering with performance only affects a single benchmark, instead of
all of them.

Refs: #8659

**benchmark: use node v4 syntax in common.js**

Using new syntax such as `...args` means that the benchmark suite can't
be used with older node versions. This changes the `...args` syntax to a
good old `Array.prototype.slice`.

Refs: https://github.com/nodejs/node/pull/8932#issuecomment-252924107