### PR TITLE
doc: better example for http.get

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1354,16 +1354,24 @@ added: v0.3.6
 -->
 
 Since most requests are GET requests without bodies, Node.js provides this
-convenience method. The only difference between this method and [`http.request()`][]
-is that it sets the method to GET and calls `req.end()` automatically.
+convenience method. The only difference between this method and
+[`http.request()`][] is that it sets the method to GET and calls `req.end()`
+automatically. Note that response data must be consumed in the callback
+for reasons stated in [`http.ClientRequest`][] section.
+
+`callback` takes one argument which is an instance of [`http.IncomingMessage`][]
 
 Example:
 
 ```js
 http.get('http://www.google.com/index.html', (res) => {
-  console.log(`Got response: ${res.statusCode}`);
-  // consume response body
-  res.resume();
+  console.log(`STATUS: ${res.statusCode}`);
+  res.setEncoding('utf8');
+  let aggregatedData = '';
+  res.on('data', (chunk) => aggregatedData += chunk);
+  res.on('end', () => {
+    console.log(`Message body: ${aggregatedData}`);
+  });
 }).on('error', (e) => {
   console.log(`Got error: ${e.message}`);
 });

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1365,7 +1365,7 @@ The `callback` is invoked with a single argument that is an instance of
 JSON Fetching Example:
 
 ```js
-http.get('http://jsonplaceholder.typicode.com/posts/1', (res) => {
+http.get('http://nodejs.org/dist/index.json', (res) => {
   const statusCode = res.statusCode;
   const contentType = res.headers['content-type'];
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

I wanted to get some JSON data using Node.js, so I searched the documentation and found `http.get` method that looked like a proper tool for that. But the example was confusing because of `res.resume()` method. My first thought was that it needs to be at the end of  every http.get callback after the code for consuming the response body. But after some research I found (in the `http.ClientRequest` section) that it should be there only if the body won't be consumed in any other manner.  But I still didn't know what the `resume()` method does exactly. So I search further and found that `res` is an instance of `IncomingMessage` which implements readable stream. And that's where I found description of `readable.resume()`.

I've learnt a lot from this experience, but what I really wanted was get things done and fetch JSON.

I propose replacing current example with the one that presents the most common use of that method: getting data. Also, I added information about the type of object being passed to the callback and necessity of consuming response data in it.