### PR TITLE
net: fix ambiguity in EOF handling

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -574,13 +574,15 @@ function onread(nread, buffer) {
 
   debug('EOF');
 
+  // push a null to signal the end of data.
+  // Do it before `maybeDestroy` for correct order of events:
+  // `end` -> `close`
+  self.push(null);
+
   if (self._readableState.length === 0) {
     self.readable = false;
     maybeDestroy(self);
   }
-
-  // push a null to signal the end of data.
-  self.push(null);
 
   // internal end event so that we know that the actual socket
   // is no longer readable, and we can start the shutdown

--- a/test/parallel/test-net-end-close.js
+++ b/test/parallel/test-net-end-close.js
@@ -1,0 +1,26 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const uv = process.binding('uv');
+
+const s = new net.Socket({
+  handle: {
+    readStart: function() {
+      process.nextTick(() => this.onread(uv.UV_EOF, null));
+    },
+    close: (cb) => process.nextTick(cb)
+  },
+  writable: false
+});
+s.resume();
+
+const events = [];
+
+s.on('end', () => events.push('end'));
+s.on('close', () => events.push('close'));
+
+process.on('exit', () => {
+  assert.deepStrictEqual(events, [ 'end', 'close' ]);
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

net

##### Description of change
<!-- Provide a description of the change below this comment. -->

`end` MUST always be emitted **before** `close`. However, if a handle
will invoke `uv_close_cb` immediately, or in the same JS tick - `close`
may be emitted first.

cc @nodejs/collaborators 