### PR TITLE
tools: release signing improvements

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -98,6 +98,7 @@ function sign {
   scp ${webuser}@${webhost}:${shapath} ${tmpdir}/${shafile}
 
   gpg --default-key $gpgkey --clearsign --digest-algo SHA256 ${tmpdir}/${shafile}
+  gpg --default-key $gpgkey --detach-sign --digest-algo SHA256 ${tmpdir}/${shafile}
 
   echo "Wrote to ${tmpdir}/"
 
@@ -117,7 +118,7 @@ function sign {
     fi
 
     if [ "X${yorn}" == "Xy" ]; then
-      scp ${tmpdir}/${shafile} ${tmpdir}/${shafile}.asc ${webuser}@${webhost}:${shadir}/
+      scp ${tmpdir}/${shafile} ${tmpdir}/${shafile}.asc ${tmpdir}/${shafile}.sig ${webuser}@${webhost}:${shadir}/
       break
     fi
   done

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -97,7 +97,7 @@ function sign {
 
   scp ${webuser}@${webhost}:${shapath} ${tmpdir}/${shafile}
 
-  gpg --default-key $gpgkey --clearsign ${tmpdir}/${shafile}
+  gpg --default-key $gpgkey --clearsign --digest-algo SHA256 ${tmpdir}/${shafile}
 
   echo "Wrote to ${tmpdir}/"
 


### PR DESCRIPTION
Fixes confusion around the `Hash: SHA-1` that comes with releases in the SHASUMS256.txt.asc, e.g. https://github.com/nodejs/nodejs.org/issues/956 (this has come up multiple times!). Newer versions of gpg I _think_ default to SHA-512 and we now have a mix of SHA-1 and SHA-512 in our releases (195 SHA-1 and 63 SHA-512)! By setting it to 256 we make it the same as the hash we use for the binaries themselves, so even though these are two separate hashes we don't have the confusion when someone misinterprets what it means.

The second commit in here finally fixes https://github.com/nodejs/node/issues/6821 by adding a detached signature file along with releases. So we'll have SHASUMS256.txt (bare), SHASUMS256.txt.asc (with clear text hash included) and SHASUMS256.txt.sig (binary, signature only) in our releases. So our recommendation for verifying releases will be to download both the .txt and the .sig and doing `gpg --verify SHASUMS256.txt.sig SHASUMS256.txt`. This commit doesn't update the README.md with the new instructions yet, I figure that can be done later once we actually have some .sig files out there.

Currently I don't imagine we want to remove the .asc files from releases, that'd probably cause more chaos than we need right now.

I'll test this with the v6 LTS release next week to confirm all is good if I can get some 👍's  to do so.