### PR TITLE
doc: remove confusing reference in governance doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,8 +38,7 @@ responsibility for the change. In the case of pull requests proposed
 by an existing Collaborator, an additional Collaborator is required
 for sign-off. Consensus should be sought if additional Collaborators
 participate and there is disagreement around a particular
-modification. See [Consensus Seeking Process](#consensus-seeking-process) below
-for further detail on the consensus model used for governance.
+modification.
 
 Collaborators may opt to elevate significant or controversial modifications to
 the CTC by assigning the ***ctc-agenda*** tag to a pull request or issue. The

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -42,7 +42,7 @@ If there is disagreement among Collaborators about whether a proposed change
 should be accepted, then the change may not be accepted unless:
 
 * discussion and/or additional changes result in no Collaborators objecting to
-  the change; previously objecting Collaborators do not necessarily have to
+  the change; previously-objecting Collaborators do not necessarily have to
   sign-off on the change, but they should not be opposed to it
 * the change is escalated to the CTC and the CTC approves the change; this
   should be used only after other options (especially discussion among

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,9 +36,17 @@ Collaborators. All pull requests must be reviewed and accepted by a
 Collaborator with sufficient expertise who is able to take full
 responsibility for the change. In the case of pull requests proposed
 by an existing Collaborator, an additional Collaborator is required
-for sign-off. Consensus should be sought if additional Collaborators
-participate and there is disagreement around a particular
-modification.
+for sign-off.
+
+If there is disagreement among Collaborators about whether a proposed change
+should be accepted, then the change may not be accepted unless:
+
+* discussion and/or additional changes result in no Collaborators objecting to
+  the change; previously objecting Collaborators do not necessarily have to
+  sign-off on the change, but they should not be opposed to it
+* the change is escalated to the CTC and the CTC approves the change; this
+  should be used only after other options (especially discussion among
+  the disagreeing Collaborators) have been exhausted
 
 Collaborators may opt to elevate significant or controversial modifications to
 the CTC by assigning the ***ctc-agenda*** tag to a pull request or issue. The

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,12 +41,12 @@ for sign-off.
 If one or more Collaborators oppose a proposed change, then the change can not
 be accepted unless:
 
-* discussion and/or additional changes result in no Collaborators objecting to
-  the change; previously-objecting Collaborators do not necessarily have to
-  sign-off on the change, but they should not be opposed to it
-* the change is escalated to the CTC and the CTC votes to approve the change;
-  this should be used only after other options (especially discussion among
-  the disagreeing Collaborators) have been exhausted
+* Discussions and/or additional changes result in no Collaborators objecting to
+  the change. Previously-objecting Collaborators do not necessarily have to
+  sign-off on the change, but they should not be opposed to it.
+* The change is escalated to the CTC and the CTC votes to approve the change.
+  This should be used only after other options (especially discussion among
+  the disagreeing Collaborators) have been exhausted.
 
 Collaborators may opt to elevate significant or controversial modifications to
 the CTC by assigning the ***ctc-agenda*** tag to a pull request or issue. The

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,14 +38,14 @@ responsibility for the change. In the case of pull requests proposed
 by an existing Collaborator, an additional Collaborator is required
 for sign-off.
 
-If there is disagreement among Collaborators about whether a proposed change
-should be accepted, then the change may not be accepted unless:
+If one or more Collaborators oppose a proposed change, then the change can not
+be accepted unless:
 
 * discussion and/or additional changes result in no Collaborators objecting to
   the change; previously-objecting Collaborators do not necessarily have to
   sign-off on the change, but they should not be opposed to it
-* the change is escalated to the CTC and the CTC approves the change; this
-  should be used only after other options (especially discussion among
+* the change is escalated to the CTC and the CTC votes to approve the change;
+  this should be used only after other options (especially discussion among
   the disagreeing Collaborators) have been exhausted
 
 Collaborators may opt to elevate significant or controversial modifications to


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc meta

##### Description of change
<!-- Provide a description of the change below this comment. -->

At the CTC meeting today, Sakthipriyan noted that there was a link to
the CTC consensus material from the pull request consensus material. The
link was confusing because the CTC consensus material is
meeting-specific, which does not apply to pull requests. I have removed
that link.

/cc @nodejs/ctc @thefourtheye 

I don't think this needs to go on the CTC agenda because it is not a change to our governance process, but if anyone else feels differently, feel free to add the `ctc-agenda` label.