### PR TITLE
build: add -DZLIB_CONST when building with --shared-zlib

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -480,6 +480,8 @@
         }],
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
+        }, {
+          'defines': [ 'ZLIB_CONST' ],
         }],
 
         [ 'node_shared_http_parser=="false"', {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

Commit 782620f added the define only when building with the bundled
zlib. Using a shared zlib results in build breakage:

```
../src/inspector_agent.cc:179:16: error: assigning to 'Bytef *' (aka 'unsigned char *') from incompatible type
      'const uint8_t *' (aka 'const unsigned char *')
  strm.next_in = PROTOCOL_JSON + 3;
               ^ ~~~~~~~~~~~~~~~~~
1 error generated.
```