### PR TITLE
test: use npm sandbox in test-npm-install

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -11,6 +11,10 @@ const assert = require('assert');
 const fs = require('fs');
 
 common.refreshTmpDir();
+const npmSandbox = path.join(common.tmpDir, 'npm-sandbox');
+fs.mkdirSync(npmSandbox);
+const installDir = path.join(common.tmpDir, 'install-dir');
+fs.mkdirSync(installDir);
 
 const npmPath = path.join(
   common.testDir,
@@ -32,15 +36,18 @@ const pkgContent = JSON.stringify({
   }
 });
 
-const pkgPath = path.join(common.tmpDir, 'package.json');
+const pkgPath = path.join(installDir, 'package.json');
 
 fs.writeFileSync(pkgPath, pkgContent);
 
 const env = Object.create(process.env);
 env['PATH'] = path.dirname(process.execPath);
+env['NPM_CONFIG_PREFIX'] = path.join(npmSandbox, 'npm-prefix');
+env['NPM_CONFIG_TMP'] = path.join(npmSandbox, 'npm-tmp');
+env['HOME'] = path.join(npmSandbox, 'home');
 
 const proc = spawn(process.execPath, args, {
-  cwd: common.tmpDir,
+  cwd: installDir,
   env: env
 });
 
@@ -48,7 +55,7 @@ function handleExit(code, signalCode) {
   assert.equal(code, 0, 'npm install should run without an error');
   assert.ok(signalCode === null, 'signalCode should be null');
   assert.doesNotThrow(function() {
-    fs.accessSync(common.tmpDir + '/node_modules/package-name');
+    fs.accessSync(installDir + '/node_modules/package-name');
   });
 }
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

npm should run in a sandbox to avoid unwanted interactions. Without this change, npm would read the userconfig file `$HOME/.npmrc` which may contain configs that break this test.

Not completely sure if we should set the `HOME` variable as I decided to do here, or track down all the variables that it influences with `npm config ls -l` and set them all individually. This seems more future-proof, and since it's just to run npm it should be ok.

Taken inspiration from https://github.com/gibfahn/node/blob/a3c1505cd9fd5e26aebdbb2269515f9d3deb11db/tools/test-npm.sh#L44-L48 (ongoing PR https://github.com/nodejs/node/pull/7867) with the `HOME` var change that may be a good idea there as well, cc @gibfahn .

Fixes: https://github.com/nodejs/node/issues/9074 - test run: https://ci.nodejs.org/job/node-test-commit-freebsd/4799/

cc @nodejs/testing @TheAlphaNerd @Trott 