### PR TITLE
timers: fix regression with clearImmediate()

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -575,12 +575,21 @@ function processImmediate() {
       domain.enter();
 
     immediate._callback = immediate._onImmediate;
+
+    // Save next in case `clearImmediate(immediate)` is called from callback
+    var next = immediate._idleNext;
+
     tryOnImmediate(immediate, tail);
 
     if (domain)
       domain.exit();
 
-    immediate = immediate._idleNext;
+    // If `clearImmediate(immediate)` wasn't called from the callback, use the
+    // `immediate`'s next item
+    if (immediate._idleNext)
+      immediate = immediate._idleNext;
+    else
+      immediate = next;
   }
 
   // Only round-trip to C++ land if we have to. Calling clearImmediate() on an

--- a/test/parallel/test-timers-clearImmediate.js
+++ b/test/parallel/test-timers-clearImmediate.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const N = 3;
+var count = 0;
+function next() {
+  const immediate = setImmediate(function() {
+    clearImmediate(immediate);
+    ++count;
+  });
+}
+for (var i = 0; i < N; ++i)
+  next();
+
+process.on('exit', () => {
+  assert.strictEqual(count, N, `Expected ${N} immediate callback executions`);
+});


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* timers

##### Description of change

This commit fixes a regression introduced in 0ed8839a27 that caused additional queued immediate callbacks to be ignored if `clearImmediate(immediate)` was called within the callback for `immediate`.

Fixes: https://github.com/nodejs/node/issues/9084

CI: https://ci.nodejs.org/job/node-test-pull-request/4513/
CITGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/415/