### PR TITLE
stream: fix `Writable` subclass instanceof checks

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -144,8 +144,6 @@ if (typeof Symbol === 'function' && Symbol.hasInstance) {
       if (realHasInstance.call(this, object))
         return true;
 
-      // Trying to move the `realHasInstance` from the Writable constructor
-      // to here will break the Node.js LazyTransform implementation.
       return object && object._writableState instanceof WritableState;
     }
   });
@@ -159,6 +157,10 @@ function Writable(options) {
   // Writable ctor is applied to Duplexes, too.
   // `realHasInstance` is necessary because using plain `instanceof`
   // would return false, as no `_writableState` property is attached.
+
+  // Trying to use the custom `instanceof` for Writable here will also break the
+  // Node.js LazyTransform implementation, which has a non-trivial getter for
+  // `_writableState` that would lead to infinite recursion.
   if (!(realHasInstance.call(Writable, this)) &&
       !(this instanceof Stream.Duplex)) {
     return new Writable(options);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -141,9 +141,12 @@ if (typeof Symbol === 'function' && Symbol.hasInstance) {
   realHasInstance = Function.prototype[Symbol.hasInstance];
   Object.defineProperty(Writable, Symbol.hasInstance, {
     value: function(object) {
+      if (realHasInstance.call(this, object))
+        return true;
+
       // Trying to move the `realHasInstance` from the Writable constructor
       // to here will break the Node.js LazyTransform implementation.
-      return object._writableState instanceof WritableState;
+      return object && object._writableState instanceof WritableState;
     }
   });
 } else {

--- a/test/parallel/test-stream-inheritance.js
+++ b/test/parallel/test-stream-inheritance.js
@@ -27,3 +27,19 @@ assert.ok(!(readable instanceof Transform));
 assert.ok(!(writable instanceof Transform));
 assert.ok(!(duplex instanceof Transform));
 assert.ok(transform instanceof Transform);
+
+assert.ok(!(null instanceof Writable));
+assert.ok(!(undefined instanceof Writable));
+
+// Simple inheritance check for `Writable` works fine in a subclass constructor.
+function CustomWritable() {
+  assert.ok(this instanceof Writable, 'inhertis from Writable');
+  assert.ok(this instanceof CustomWritable, 'inherits from CustomWritable');
+}
+
+Object.setPrototypeOf(CustomWritable, Writable);
+Object.setPrototypeOf(CustomWritable.prototype, Writable.prototype);
+
+new CustomWritable();
+
+assert.throws(CustomWritable, /AssertionError: inhertis from Writable/);

--- a/test/parallel/test-stream-inheritance.js
+++ b/test/parallel/test-stream-inheritance.js
@@ -33,7 +33,7 @@ assert.ok(!(undefined instanceof Writable));
 
 // Simple inheritance check for `Writable` works fine in a subclass constructor.
 function CustomWritable() {
-  assert.ok(this instanceof Writable, 'inhertis from Writable');
+  assert.ok(this instanceof Writable, 'inherits from Writable');
   assert.ok(this instanceof CustomWritable, 'inherits from CustomWritable');
 }
 
@@ -42,4 +42,4 @@ Object.setPrototypeOf(CustomWritable.prototype, Writable.prototype);
 
 new CustomWritable();
 
-assert.throws(CustomWritable, /AssertionError: inhertis from Writable/);
+assert.throws(CustomWritable, /AssertionError: inherits from Writable/);


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

stream

##### Description of change

2a4b068acaa160 introduced a regression in where checking `instanceof` would fail for `Writable` subclasses inside the subclass constructor, i.e. before `Writable()` was called.

Also, calling `null instanceof Writable` or `undefined instanceof Writable` would fail due to accessing the `_writableState` property of the target object.

This fixes these problems.

Ref: https://github.com/nodejs/node/pull/8834#issuecomment-253640692