### PR TITLE
test: enable node-module-version/test.js with debug

### DIFF
--- a/test/addons/node-module-version/test.js
+++ b/test/addons/node-module-version/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../../common');
+const common = require('../../common');
 const assert = require('assert');
 
 const re = new RegExp(
@@ -8,4 +8,4 @@ const re = new RegExp(
   'NODE_MODULE_VERSION 42. This version of Node.js requires\n' +
   `NODE_MODULE_VERSION ${process.versions.modules}.`);
 
-assert.throws(() => require('./build/Release/binding'), re);
+assert.throws(() => require(`./build/${common.buildType}/binding`), re);


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test:

##### Description of change
<!-- Provide a description of the change below this comment. -->

Commit fdca79fbc0a797206fa690d51b8844ed4fd596d6 ("test: enable addons
test to pass with debug build") enabled the addons tests to pass when
the build type is of type debug (configure --debug).

test/addons/node-module-version/test.js was recently added and expects
the the build type to be of type Release (like most of the others until
recently). This commit allows this test to pass when the build type if
of type debug.