### PR TITLE
src: make Environment optional for RunAtExit

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4275,7 +4275,7 @@ static AtExitCallback* at_exit_functions_;
 
 
 // TODO(bnoordhuis) Turn into per-context event.
-void RunAtExit(Environment* env) {
+void RunAtExit(Environment* env = nullptr) {
   AtExitCallback* p = at_exit_functions_;
   at_exit_functions_ = nullptr;
 
@@ -4451,7 +4451,7 @@ static void StartNodeInstance(void* arg) {
     int exit_code = EmitExit(&env);
     if (instance_data->is_main())
       instance_data->set_exit_code(exit_code);
-    RunAtExit(&env);
+    RunAtExit();
 
     WaitForInspectorDisconnect(&env);
 #if defined(LEAK_SANITIZER)

--- a/src/node.cc
+++ b/src/node.cc
@@ -4275,7 +4275,7 @@ static AtExitCallback* at_exit_functions_;
 
 
 // TODO(bnoordhuis) Turn into per-context event.
-void RunAtExit(Environment* env = nullptr) {
+void RunAtExit(Environment* env) {
   AtExitCallback* p = at_exit_functions_;
   at_exit_functions_ = nullptr;
 

--- a/src/node.h
+++ b/src/node.h
@@ -209,7 +209,7 @@ NODE_EXTERN void FreeEnvironment(Environment* env);
 
 NODE_EXTERN void EmitBeforeExit(Environment* env);
 NODE_EXTERN int EmitExit(Environment* env);
-NODE_EXTERN void RunAtExit(Environment* env);
+NODE_EXTERN void RunAtExit(Environment* env = nullptr);
 
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(v8::Isolate::GetCurrent(),          \


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently, the RunAtExit function definition does not use the
Environment parameter. This commit makes the parameter optional
and removes it from the call site.

I noticed this when trying to figure out how to tackle the TODO for
RunAtExit which part of https://github.com/nodejs/node/issues/4641.