### PR TITLE
test: fix flaky test-child-process-fork-dgram

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -26,6 +26,3 @@ test-tick-processor-unknown: PASS,FLAKY
 [$system==aix]
 test-fs-watch-enoent                 : FAIL, PASS
 test-fs-watch-encoding               : FAIL, PASS
-
-#covered by https://github.com/nodejs/node/issues/8271
-test-child-process-fork-dgram            : PASS, FLAKY


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram child_process

##### Description of change
<!-- Provide a description of the change below this comment. -->

`test-child-process-fork-dgram` is unreliable on some platforms,
especially FreeBSD and AIX within the project's continuous integration
testing. It has also been observed to be flaky on macos.

* Confirm child has received the server before sending packets
* Close the server instance on the parent or child after receiving a

Alternative to https://github.com/nodejs/node/pull/8697

Believed/hope to fix:
https://github.com/nodejs/node/issues/8949
https://github.com/nodejs/node/issues/8271