### PR TITLE
buffer: coerce slice parameters consistenly

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -807,11 +807,10 @@ Buffer.prototype.toJSON = function() {
 
 
 function adjustOffset(offset, length) {
-  offset = +offset;
-  if (offset === 0 || Number.isNaN(offset)) {
+  offset |= 0;
+  if (offset === 0) {
     return 0;
-  }
-  if (offset < 0) {
+  } else if (offset < 0) {
     offset += length;
     return offset > 0 ? offset : 0;
   } else {

--- a/test/parallel/test-buffer-slice.js
+++ b/test/parallel/test-buffer-slice.js
@@ -62,3 +62,13 @@ assert.strictEqual(Buffer.alloc(0).slice(0, 1).length, 0);
 
 // slice(0,0).length === 0
 assert.strictEqual(0, Buffer.from('hello').slice(0, 0).length);
+
+{
+  // Regression tests for https://github.com/nodejs/node/issues/9096
+  const buf = Buffer.from('abcd');
+  assert.strictEqual(buf.slice(buf.length / 3).toString(), 'bcd');
+  assert.strictEqual(
+    buf.slice(buf.length / 3, buf.length).toString(),
+    'bcd'
+  );
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

As shown in https://github.com/nodejs/node/issues/9096, the offset and
end value of the `slice` call are just coerced to numbers and then
passed to `FastBuffer`, which internally truncates the mantissa part
if the number is actually a floating point number. This actually
affects the new length of the slice calculation. For example,

    > const original = Buffer.from('abcd');
    undefined
    > original.slice(original.length / 3).toString()
    'bc'

This happens because, starting value of the slice is 4 / 3, which is
1.33 (approximately). Now, the length of the slice is calculated as
the difference between the actual length of the buffer and the starting
offset. So, it becomes 2.67 (4 - 1.33). Now, a new `FastBuffer` is
constructed, with these values, actual buffer object, starting value
which is 1.33 and the the length 2.67. The underlying C++ code
truncates the numbers and they become 1 and 2. That is why the result
is just `bc`.

This patch makes sure that all the offsets are coerced to an integer.

Fixes: https://github.com/nodejs/node/issues/9096

---

cc @nodejs/buffer 