### PR TITLE
tls: fix minor jslint failure for v0.10

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -135,9 +135,10 @@ function check(hostParts, pattern, wildcards) {
     return false;
 
   // Check host parts from right to left first.
-  for (var i = hostParts.length - 1; i > 0; i -= 1)
+  for (var i = hostParts.length - 1; i > 0; i -= 1) {
     if (hostParts[i] !== patternParts[i])
       return false;
+  }
 
   var hostSubdomain = hostParts[0];
   var patternSubdomain = patternParts[0];


### PR DESCRIPTION
Really minor but it passes `make jslint` on v0.10, we broke it backporting the TLS wildcard checking vulnerability in the last release @ 0d7e21ee. As long as we're doing another release we may as well clean up!