### PR TITLE
test,lib,benchmark: match function names

### DIFF
--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -44,7 +44,7 @@ Buffer.prototype.htonl = function htonl() {
   return this;
 };
 
-Buffer.prototype.htonll = function htonl() {
+Buffer.prototype.htonll = function htonll() {
   if (this.length % 8 !== 0)
     throw new RangeError();
   for (var i = 0; i < this.length; i += 8) {

--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -159,7 +159,7 @@ function QueueItem(type, req) {
   this.next = this;
 }
 
-StreamWrap.prototype._enqueue = function enqueue(type, req) {
+StreamWrap.prototype._enqueue = function _enqueue(type, req) {
   const item = new QueueItem(type, req);
   if (this._list === null) {
     this._list = item;
@@ -174,7 +174,7 @@ StreamWrap.prototype._enqueue = function enqueue(type, req) {
   return item;
 };
 
-StreamWrap.prototype._dequeue = function dequeue(item) {
+StreamWrap.prototype._dequeue = function _dequeue(item) {
   assert(item instanceof QueueItem);
 
   var next = item.next;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -117,7 +117,7 @@ function WritableState(options, stream) {
   this.corkedRequestsFree = new CorkedRequest(this);
 }
 
-WritableState.prototype.getBuffer = function writableStateGetBuffer() {
+WritableState.prototype.getBuffer = function getBuffer() {
   var current = this.bufferedRequest;
   var out = [];
   while (current) {

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -139,7 +139,7 @@ CryptoStream.prototype.init = function init() {
 };
 
 
-CryptoStream.prototype._write = function write(data, encoding, cb) {
+CryptoStream.prototype._write = function _write(data, encoding, cb) {
   assert(this._pending === null);
 
   // Black-hole data
@@ -220,7 +220,7 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
 };
 
 
-CryptoStream.prototype._writePending = function writePending() {
+CryptoStream.prototype._writePending = function _writePending() {
   const data = this._pending;
   const encoding = this._pendingEncoding;
   const cb = this._pendingCallback;
@@ -232,7 +232,7 @@ CryptoStream.prototype._writePending = function writePending() {
 };
 
 
-CryptoStream.prototype._read = function read(size) {
+CryptoStream.prototype._read = function _read(size) {
   // XXX: EOF?!
   if (!this.pair.ssl) return this.push(null);
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -304,7 +304,7 @@ proxiedMethods.forEach(function(name) {
   };
 });
 
-tls_wrap.TLSWrap.prototype.close = function closeProxy(cb) {
+tls_wrap.TLSWrap.prototype.close = function close(cb) {
   if (this.owner)
     this.owner.ssl = null;
 
@@ -340,10 +340,10 @@ TLSSocket.prototype._wrapHandle = function(wrap) {
   res._secureContext = context;
   res.reading = handle.reading;
   Object.defineProperty(handle, 'reading', {
-    get: function readingGetter() {
+    get: function get() {
       return res.reading;
     },
-    set: function readingSetter(value) {
+    set: function set(value) {
       res.reading = value;
     }
   });

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -58,7 +58,7 @@ Domain.prototype._disposed = undefined;
 
 
 // Called by process._fatalException in case an error was thrown.
-Domain.prototype._errorHandler = function errorHandler(er) {
+Domain.prototype._errorHandler = function _errorHandler(er) {
   var caught = false;
 
   // ignore errors on disposed domains.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -749,7 +749,7 @@ fs.truncate = function(path, len, callback) {
   fs.open(path, 'r+', function(er, fd) {
     if (er) return callback(er);
     var req = new FSReqWrap();
-    req.oncomplete = function ftruncateCb(er) {
+    req.oncomplete = function oncomplete(er) {
       fs.close(fd, function(er2) {
         callback(er || er2);
       });

--- a/lib/net.js
+++ b/lib/net.js
@@ -198,7 +198,7 @@ function Socket(options) {
 }
 util.inherits(Socket, stream.Duplex);
 
-Socket.prototype._unrefTimer = function unrefTimer() {
+Socket.prototype._unrefTimer = function _unrefTimer() {
   for (var s = this; s !== null; s = s._parent)
     timers._unrefActive(s);
 };

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -664,7 +664,7 @@ exports.start = function(prompt,
   return repl;
 };
 
-REPLServer.prototype.close = function replClose() {
+REPLServer.prototype.close = function close() {
   if (this.terminal && this._flushing && !this._closingOnFlush) {
     this._closingOnFlush = true;
     this.once('flushHistory', () =>

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -57,7 +57,7 @@ assert.throws(function() {
 // Argument types for combinatorics
 const a = [];
 const o = {};
-const c = function callback() {};
+const c = function c() {};
 const s = 'string';
 const u = undefined;
 const n = null;

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -31,7 +31,7 @@ FakeAgent.prototype.createConnection = function createConnection() {
     cb();
   };
 
-  s.destroy = s.destroySoon = function destroySoon() {
+  s.destroy = s.destroySoon = function destroy() {
     this.writable = false;
   };
 

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -15,7 +15,7 @@ FakeAgent.prototype.createConnection = function createConnection() {
   var s = new Duplex();
   var once = false;
 
-  s._read = function read() {
+  s._read = function _read() {
     if (once)
       return this.push(null);
     once = true;
@@ -27,11 +27,11 @@ FakeAgent.prototype.createConnection = function createConnection() {
   };
 
   // Blackhole
-  s._write = function write(data, enc, cb) {
+  s._write = function _write(data, enc, cb) {
     cb();
   };
 
-  s.destroy = s.destroySoon = function destroy() {
+  s.destroy = s.destroySoon = function destroySoon() {
     this.writable = false;
   };
 

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -166,7 +166,7 @@ const tests = [
     expected: [prompt, replFailedRead, prompt, replDisabled, prompt]
   },
   { // Make sure this is always the last test, since we change os.homedir()
-    before: function mockHomedirFailure() {
+    before: function before() {
       // Mock os.homedir() failure
       os.homedir = function() {
         throw new Error('os.homedir() failure');

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -291,7 +291,7 @@ const testCustomCompleterSyncMode = repl.start({
   prompt: '',
   input: putIn,
   output: putIn,
-  completer: function completerSyncMode(line) {
+  completer: function completer(line) {
     const hits = customCompletions.filter((c) => {
       return c.indexOf(line) === 0;
     });
@@ -323,7 +323,7 @@ const testCustomCompleterAsyncMode = repl.start({
   prompt: '',
   input: putIn,
   output: putIn,
-  completer: function completerAsyncMode(line, callback) {
+  completer: function completer(line, callback) {
     const hits = customCompletions.filter((c) => {
       return c.indexOf(line) === 0;
     });

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -25,7 +25,7 @@ function Mediator() {
 }
 util.inherits(Mediator, stream.Writable);
 
-Mediator.prototype._write = function write(data, enc, cb) {
+Mediator.prototype._write = function _write(data, enc, cb) {
   this.buf += data;
   setTimeout(cb, 0);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test lib benchmark

##### Description of change
<!-- Provide a description of the change below this comment. -->

In most cases, named functions match the variable or property to which
they are being assigned. That also seems to be the practice in a series
of PRs currently being evaluated that name currently-anonymous
functions.

This change applies that rule to instances in the code base that don't
comply with that practice.

This will be enforceable with a lint rule once we upgrade to ESLint
3.8.0.