### PR TITLE
http: defines all the fields in the constructor

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -135,6 +135,14 @@ function ClientRequest(options, cb) {
                       self._renderHeaders());
   }
 
+  this._ended = false;
+  this.res = null;
+  this.aborted = undefined;
+  this.timeoutCb = null;
+  this.upgradeOrConnect = false;
+  this.parser = null;
+  this.maxHeadersCount = null;
+
   var called = false;
   if (self.socketPath) {
     self._last = true;
@@ -202,15 +210,11 @@ function ClientRequest(options, cb) {
     self._flush();
     self = null;
   });
-
-  this._ended = false;
 }
 
 util.inherits(ClientRequest, OutgoingMessage);
 
 exports.ClientRequest = ClientRequest;
-
-ClientRequest.prototype.aborted = undefined;
 
 ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);
@@ -225,7 +229,7 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
 };
 
 ClientRequest.prototype.abort = function abort() {
-  if (this.aborted === undefined) {
+  if (!this.aborted) {
     process.nextTick(emitAbortNT, this);
   }
   // Mark as aborting so we can avoid sending queued request data
@@ -454,7 +458,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
 
   if (res.statusCode === 100) {
     // restart the parser, as this is a continue message.
-    delete req.res; // Clear res so that we don't hit double-responses.
+    req.res = null; // Clear res so that we don't hit double-responses.
     req.emit('continue');
     return true;
   }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -248,6 +248,7 @@ function Server(requestListener) {
   this.timeout = 2 * 60 * 1000;
 
   this._pendingResponseData = 0;
+  this.maxHeadersCount = null;
 }
 util.inherits(Server, net.Server);
 


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Description of change

res and abort fields are now defined in the constructor and not suddenly appear during the runtime. This makes hidden class stable and the heap snapshot more verbose.

Ref: #8912
PR-URL: #9116
