### PR TITLE
util: use template literals

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -144,7 +144,7 @@ exports.debuglog = function(set) {
     debugEnviron = process.env.NODE_DEBUG || '';
   set = set.toUpperCase();
   if (!debugs[set]) {
-    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
+    if (new RegExp(`\\b${set}\\b`, 'i').test(debugEnviron)) {
       var pid = process.pid;
       debugs[set] = function() {
         var msg = exports.format.apply(exports, arguments);
@@ -239,8 +239,8 @@ function stylizeWithColor(str, styleType) {
   var style = inspect.styles[styleType];
 
   if (style) {
-    return '\u001b[' + inspect.colors[style][0] + 'm' + str +
-           '\u001b[' + inspect.colors[style][1] + 'm';
+    return `\u001b[${inspect.colors[style][0]}m${str}` +
+           `\u001b[${inspect.colors[style][1]}m`;
   } else {
     return str;
   }
@@ -402,8 +402,8 @@ function formatValue(ctx, value, recurseTimes) {
   // Some type of object without properties can be shortcutted.
   if (keys.length === 0) {
     if (typeof value === 'function') {
-      var name = value.name ? ': ' + value.name : '';
-      return ctx.stylize('[Function' + name + ']', 'special');
+      return ctx.stylize(`[Function${value.name ? `: ${value.name}` : ''}]`,
+        'special');
     }
     if (isRegExp(value)) {
       return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
@@ -421,19 +421,19 @@ function formatValue(ctx, value, recurseTimes) {
     // now check the `raw` value to handle boxed primitives
     if (typeof raw === 'string') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[String: ' + formatted + ']', 'string');
+      return ctx.stylize(`[String: ${formatted}]`, 'string');
     }
     if (typeof raw === 'symbol') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[Symbol: ' + formatted + ']', 'symbol');
+      return ctx.stylize(`[Symbol: ${formatted}]`, 'symbol');
     }
     if (typeof raw === 'number') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[Number: ' + formatted + ']', 'number');
+      return ctx.stylize(`[Number: ${formatted}]`, 'number');
     }
     if (typeof raw === 'boolean') {
       formatted = formatPrimitiveNoColor(ctx, raw);
-      return ctx.stylize('[Boolean: ' + formatted + ']', 'boolean');
+      return ctx.stylize(`[Boolean: ${formatted}]`, 'boolean');
     }
     // Fast path for ArrayBuffer and SharedArrayBuffer.
     // Can't do the same for DataView because it has a non-primitive
@@ -535,8 +535,7 @@ function formatValue(ctx, value, recurseTimes) {
 
   // Make functions say that they are functions
   if (typeof value === 'function') {
-    var n = value.name ? ': ' + value.name : '';
-    base = ' [Function' + n + ']';
+    base = ` [Function${value.name ? `: ${value.name}` : ''}]`;
   }
 
   // Make RegExps say that they are RegExps
@@ -557,24 +556,24 @@ function formatValue(ctx, value, recurseTimes) {
   // Make boxed primitive Strings look like such
   if (typeof raw === 'string') {
     formatted = formatPrimitiveNoColor(ctx, raw);
-    base = ' ' + '[String: ' + formatted + ']';
+    base = ` [String: ${formatted}]`;
   }
 
   // Make boxed primitive Numbers look like such
   if (typeof raw === 'number') {
     formatted = formatPrimitiveNoColor(ctx, raw);
-    base = ' ' + '[Number: ' + formatted + ']';
+    base = ` [Number: ${formatted}]`;
   }
 
   // Make boxed primitive Booleans look like such
   if (typeof raw === 'boolean') {
     formatted = formatPrimitiveNoColor(ctx, raw);
-    base = ' ' + '[Boolean: ' + formatted + ']';
+    base = ` [Boolean: ${formatted}]`;
   }
 
   // Add constructor name if available
   if (base === '' && constructor)
-    braces[0] = constructor.name + ' ' + braces[0];
+    braces[0] = `${constructor.name} ${braces[0]}`;
 
   if (empty === true) {
     return braces[0] + base + braces[1];
@@ -646,7 +645,7 @@ function formatPrimitiveNoColor(ctx, value) {
 
 
 function formatError(value) {
-  return value.stack || '[' + Error.prototype.toString.call(value) + ']';
+  return value.stack || `[${Error.prototype.toString.call(value)}]`;
 }
 
 
@@ -782,9 +781,9 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
   }
   if (!hasOwnProperty(visibleKeys, key)) {
     if (typeof key === 'symbol') {
-      name = '[' + ctx.stylize(key.toString(), 'symbol') + ']';
+      name = `[${ctx.stylize(key.toString(), 'symbol')}]`;
     } else {
-      name = '[' + key + ']';
+      name = `[${key}]`;
     }
   }
   if (!str) {
@@ -822,7 +821,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
 
-  return name + ': ' + str;
+  return `${name}: ${str}`;
 }
 
 
@@ -837,13 +836,10 @@ function reduceToSingleString(output, base, braces, breakLength) {
            // we need to force the first item to be on the next line or the
            // items will not line up correctly.
            (base === '' && braces[0].length === 1 ? '' : base + '\n ') +
-           ' ' +
-           output.join(',\n  ') +
-           ' ' +
-           braces[1];
+           ` ${output.join(',\n  ')} ${braces[1]}`;
   }
 
-  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
+  return `${braces[0]}${base} ${output.join(', ')} ${braces[1]}`;
 }
 
 
@@ -1007,7 +1003,7 @@ exports.puts = internalUtil.deprecate(function() {
 
 
 exports.debug = internalUtil.deprecate(function(x) {
-  process.stderr.write('DEBUG: ' + x + '\n');
+  process.stderr.write(`DEBUG: ${x}\n`);
 }, 'util.debug is deprecated. Use console.error instead.');
 
 
@@ -1020,7 +1016,7 @@ exports.error = internalUtil.deprecate(function(x) {
 
 exports._errnoException = function(err, syscall, original) {
   var errname = uv.errname(err);
-  var message = syscall + ' ' + errname;
+  var message = `${syscall} ${errname}`;
   if (original)
     message += ' ' + original;
   var e = new Error(message);
@@ -1038,13 +1034,13 @@ exports._exceptionWithHostPort = function(err,
                                           additional) {
   var details;
   if (port && port > 0) {
-    details = address + ':' + port;
+    details = `${address}:${port}`;
   } else {
     details = address;
   }
 
   if (additional) {
-    details += ' - Local (' + additional + ')';
+    details += ` - Local (${additional})`;
   }
   var ex = exports._errnoException(err, syscall, details);
   ex.address = address;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Util


##### Description of change
This commit changes string manipulation in favor of template literals in the `util` module.