### PR TITLE
build: do not define ZLIB_CONST

### DIFF
--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -12,7 +12,6 @@
         {
           'target_name': 'zlib',
           'type': 'static_library',
-          'defines': [ 'ZLIB_CONST' ],
           'sources': [
             'adler32.c',
             'compress.c',
@@ -45,7 +44,6 @@
             '.',
           ],
           'direct_dependent_settings': {
-            'defines': [ 'ZLIB_CONST' ],
             'include_dirs': [
               '.',
             ],
@@ -74,12 +72,10 @@
           'direct_dependent_settings': {
             'defines': [
               'USE_SYSTEM_ZLIB',
-              'ZLIB_CONST',
             ],
           },
           'defines': [
             'USE_SYSTEM_ZLIB',
-            'ZLIB_CONST',
           ],
           'link_settings': {
             'libraries': [

--- a/node.gyp
+++ b/node.gyp
@@ -480,8 +480,6 @@
         }],
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
-        }, {
-          'defines': [ 'ZLIB_CONST' ],
         }],
 
         [ 'node_shared_http_parser=="false"', {

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -176,7 +176,7 @@ void SendProtocolJson(InspectorSocket* socket) {
       PROTOCOL_JSON[0] * 0x10000u +
       PROTOCOL_JSON[1] * 0x100u +
       PROTOCOL_JSON[2];
-  strm.next_in = PROTOCOL_JSON + 3;
+  strm.next_in = const_cast<uint8_t*>(PROTOCOL_JSON + 3);
   strm.avail_in = sizeof(PROTOCOL_JSON) - 3;
   std::vector<char> data(kDecompressedSize);
   strm.next_out = reinterpret_cast<Byte*>(&data[0]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

This define is not available in zlib prior to version 1.2.5.2. See
#9110 for details. Workaround the build breakage reported by
casting away const in src/inspector_agent.cc instead.