### PR TITLE
doc: fix typo (zlib)

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -113,7 +113,7 @@ http.createServer((request, response) => {
 }).listen(1337);
 ```
 
-By default, the `zlib` methods with throw an error when decompressing
+By default, the `zlib` methods will throw an error when decompressing
 truncated data. However, if it is known that the data is incomplete, or
 the desire is to inspect only the beginning of a compressed file, it is
 possible to suppress the default error handling by changing the flushing


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
Fix a typo in documentation for zlib module. Change 'methods with throw an error' to 'methods will throw an error'.