### PR TITLE
test: rename target to exports for consistency

### DIFF
--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -33,8 +33,8 @@ static void sanity_check(void) {
   assert(at_exit_cb2_called == 2);
 }
 
-void init(Local<Object> target) {
-  AtExit(at_exit_cb1, target->CreationContext()->GetIsolate());
+void init(Local<Object> exports) {
+  AtExit(at_exit_cb1, exports->GetIsolate());
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);
   atexit(sanity_check);

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -36,9 +36,9 @@ void Check(const v8::FunctionCallbackInfo<v8::Value>& args) {
   assert(alive > 0);
 }
 
-void init(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "alloc", Alloc);
-  NODE_SET_METHOD(target, "check", Check);
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "alloc", Alloc);
+  NODE_SET_METHOD(exports, "check", Check);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -7,8 +7,8 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 
-void init(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "hello", Method);
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "hello", Method);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/load-long-path/binding.cc
+++ b/test/addons/load-long-path/binding.cc
@@ -6,8 +6,8 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 
-void init(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "hello", Method);
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "hello", Method);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -22,8 +22,8 @@ void MakeCallback(const FunctionCallbackInfo<Value>& args) {
   node::MakeCallback(isolate, recv, method, 0, nullptr);
 }
 
-void Initialize(Local<Object> target) {
-  NODE_SET_METHOD(target, "makeCallback", MakeCallback);
+void Initialize(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "makeCallback", MakeCallback);
 }
 
 }  // namespace

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -30,8 +30,8 @@ void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(result);
 }
 
-void Initialize(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "makeCallback", MakeCallback);
+void Initialize(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "makeCallback", MakeCallback);
 }
 
 }  // namespace

--- a/test/addons/null-buffer-neuter/binding.cc
+++ b/test/addons/null-buffer-neuter/binding.cc
@@ -34,8 +34,8 @@ void Run(const v8::FunctionCallbackInfo<v8::Value>& args) {
   assert(alive == 0);
 }
 
-void init(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "run", Run);
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "run", Run);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -29,8 +29,8 @@ void ParseEncoding(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(encoding_string);
 }
 
-void Initialize(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "parseEncoding", ParseEncoding);
+void Initialize(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "parseEncoding", ParseEncoding);
 }
 
 }  // anonymous namespace

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -19,8 +19,8 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                      NULL);
 }
 
-void init(Local<Object> target) {
-  NODE_SET_METHOD(target, "method", Method);
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "method", Method);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -17,8 +17,8 @@ void EnsureAllocation(const v8::FunctionCallbackInfo<v8::Value> &args) {
   args.GetReturnValue().Set(success);
 }
 
-void init(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "ensureAllocation", EnsureAllocation);
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "ensureAllocation", EnsureAllocation);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/symlinked-module/binding.cc
+++ b/test/addons/symlinked-module/binding.cc
@@ -6,8 +6,8 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 
-void init(v8::Local<v8::Object> target) {
-  NODE_SET_METHOD(target, "hello", Method);
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "hello", Method);
 }
 
 NODE_MODULE(binding, init);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change

The doc/api/addons.md document contains examples of Addon
Initialization functions that take a parameter named exports.
This also matches the name used in node.cc when calling:
mp->nm_register_func(exports, module, mp->nm_priv);

Currently, a number of the tests name this same parameter target. This
commit renames target to exports for consistency.