### PR TITLE
doc: clarify fs.link and fs.linkSync arguments

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1034,25 +1034,25 @@ deprecated: v0.4.7
 
 Synchronous lchown(2). Returns `undefined`.
 
-## fs.link(srcpath, dstpath, callback)
+## fs.link(existingPath, newPath, callback)
 <!-- YAML
 added: v0.1.31
 -->
 
-* `srcpath` {String | Buffer}
-* `dstpath` {String | Buffer}
+* `existingPath` {String | Buffer}
+* `newPath` {String | Buffer}
 * `callback` {Function}
 
 Asynchronous link(2). No arguments other than a possible exception are given to
 the completion callback.
 
-## fs.linkSync(srcpath, dstpath)
+## fs.linkSync(existingPath, newPath)
 <!-- YAML
 added: v0.1.31
 -->
 
-* `srcpath` {String | Buffer}
-* `dstpath` {String | Buffer}
+* `existingPath` {String | Buffer}
+* `newPath` {String | Buffer}
 
 Synchronous link(2). Returns `undefined`.
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -955,24 +955,24 @@ fs.symlinkSync = function(target, path, type) {
                          type);
 };
 
-fs.link = function(srcpath, dstpath, callback) {
+fs.link = function(existingPath, newPath, callback) {
   callback = makeCallback(callback);
-  if (!nullCheck(srcpath, callback)) return;
-  if (!nullCheck(dstpath, callback)) return;
+  if (!nullCheck(existingPath, callback)) return;
+  if (!nullCheck(newPath, callback)) return;
 
   var req = new FSReqWrap();
   req.oncomplete = callback;
 
-  binding.link(pathModule._makeLong(srcpath),
-               pathModule._makeLong(dstpath),
+  binding.link(pathModule._makeLong(existingPath),
+               pathModule._makeLong(newPath),
                req);
 };
 
-fs.linkSync = function(srcpath, dstpath) {
-  nullCheck(srcpath);
-  nullCheck(dstpath);
-  return binding.link(pathModule._makeLong(srcpath),
-                      pathModule._makeLong(dstpath));
+fs.linkSync = function(existingPath, newPath) {
+  nullCheck(existingPath);
+  nullCheck(newPath);
+  return binding.link(pathModule._makeLong(existingPath),
+                      pathModule._makeLong(newPath));
 };
 
 fs.unlink = function(path, callback) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

fs and doc

(Edited this answer 2016-10-19T20:46+0000 to show commits patch both fs and fs doc.)

##### Description of change
<!-- Provide a description of the change below this comment. -->

Clarifies documentation by replacing the `fs.link` and `fs.linkSync` argument names `srcpath` and `dstpath` with more descriptive `existingpath` and `newpath`, reflecting how POSIX describes `link()`.

A few double-takes on my part inspired this small PR. As you're creating a new hard link, the "destination" seems like the new path, until it's actually done, when the "destination" of the new link seems like the prior-existing path.

The Linux manpage currently linked from doc names these arguments `oldpath` and `newpath`. A FreeBSD manpage I found online says `name1` and `name2`. POSIX' listing calls them `path1` and `path2`. Since there's no hope of matching the manpage on every system, I went with the most descriptive names I could come up with, alluding to the POSIX explanatory text.