### PR TITLE
build: add working lint-ci make target (v0.12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -585,6 +585,17 @@ cpplint:
 
 lint: jslint cpplint
 
+CONFLICT_RE=^>>>>>>> [0-9A-Fa-f]+|^<<<<<<< [A-Za-z]+
+lint-ci: jslint cpplint
+	@if ! ( grep -IEqrs "$(CONFLICT_RE)" benchmark deps doc lib src test tools ) \
+		&& ! ( find . -maxdepth 1 -type f | xargs grep -IEqs "$(CONFLICT_RE)" ); then \
+		exit 0 ; \
+	else \
+		echo "" >&2 ; \
+		echo "Conflict marker detected in one or more files. Please fix them first." >&2 ; \
+		exit 1 ; \
+	fi
+
 .PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean \
 	check uninstall install install-includes install-bin all staticlib \
 	dynamiclib test test-all test-addons build-addons website-upload pkg \

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -117,9 +117,10 @@ function check(hostParts, pattern, wildcards) {
     return false;
 
   // Check host parts from right to left first.
-  for (var i = hostParts.length - 1; i > 0; i -= 1)
+  for (var i = hostParts.length - 1; i > 0; i -= 1) {
     if (hostParts[i] !== patternParts[i])
       return false;
+  }
 
   var hostSubdomain = hostParts[0];
   var patternSubdomain = patternParts[0];


### PR DESCRIPTION
Make linting work again on v0.12! We've been missing this since we switched to lint-ci on Jenkins but nobody noticed (cause I'm pretty much the only one who runs it and I'd forgotten that it was only v0.10 that should fail linting).

/cc @nodejs/build 