### PR TITLE
child_process: Check stderr before accessing it

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -479,7 +479,7 @@ function execFileSync(/*command, args, options*/) {
 
   var ret = spawnSync(opts.file, opts.args.slice(1), opts.options);
 
-  if (inheritStderr)
+  if (inheritStderr && ret.stderr)
     process.stderr.write(ret.stderr);
 
   var err = checkExecSyncError(ret);
@@ -499,7 +499,7 @@ function execSync(/*command, options*/) {
   var ret = spawnSync(opts.file, opts.args, opts.options);
   ret.cmd = opts.cmd;
 
-  if (inheritStderr)
+  if (inheritStderr && ret.stderr)
     process.stderr.write(ret.stderr);
 
   var err = checkExecSyncError(ret);

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -12,6 +12,18 @@ var start = Date.now();
 var err;
 var caught = false;
 
+// Verify that stderr is not accessed when a bad shell is used
+assert.throws(
+  function() { execSync('exit -1', {shell: 'bad_shell'}); },
+  /ENOENT/,
+  'execSync did not throw the expected exception!'
+);
+assert.throws(
+  function() { execFileSync('exit -1', {shell: 'bad_shell'}); },
+  /ENOENT/,
+  'execFileSync did not throw the expected exception!'
+);
+
 try {
   var cmd = `"${process.execPath}" -e "setTimeout(function(){}, ${SLEEP});"`;
   var ret = execSync(cmd, {timeout: TIMER});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process

##### Description of change
<!-- Provide a description of the change below this comment. -->

If something bad happens in spawnSync, stderr might be null. Therefore,
we have to check it before using it, so we won't mask the actual
exception.

PR-URL: https://github.com/nodejs/node/pull/6877
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Robert Jefe Lindstädt <robert.lindstaedt@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Jeremiah Senkpiel <fishrock123@rocketmail.com>