### PR TITLE
win,build: try multiple timeservers when signing

### DIFF
--- a/tools/sign.bat
+++ b/tools/sign.bat
@@ -1,0 +1,15 @@
+@echo off
+
+set timeservers=(http://timestamp.globalsign.com/scripts/timestamp.dll http://timestamp.comodoca.com/authenticode http://timestamp.verisign.com/scripts/timestamp.dll http://tsa.starfieldtech.com)
+
+for %%s in %timeservers% do (
+    signtool sign /a /d "Node.js" /du "https://nodejs.org" /t %%s %1
+    if ERRORLEVEL 0 (
+        echo Successfully signed %1 using timeserver %%s
+        exit /b 0
+    )
+    echo Signing %1 failed using %%s
+)
+
+echo Could not sign %1 using any available timeserver
+exit /b 1

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -191,7 +191,7 @@ if "%target%" == "Clean" goto exit
 @rem Skip signing if the `nosign` option was specified.
 if defined nosign goto licensertf
 
-signtool sign /a /d "Node.js" /du "https://nodejs.org" /t http://timestamp.globalsign.com/scripts/timestamp.dll Release\node.exe
+call tools\sign.bat Release\node.exe
 if errorlevel 1 echo Failed to sign exe&goto exit
 
 :licensertf
@@ -269,7 +269,7 @@ msbuild "%~dp0tools\msvs\msi\nodemsi.sln" /m /t:Clean,Build /p:PlatformToolset=%
 if errorlevel 1 goto exit
 
 if defined nosign goto upload
-signtool sign /a /d "Node.js" /du "https://nodejs.org" /t http://timestamp.globalsign.com/scripts/timestamp.dll node-v%FULLVERSION%-%target_arch%.msi
+call tools\sign.bat node-v%FULLVERSION%-%target_arch%.msi
 if errorlevel 1 echo Failed to sign msi&goto exit
 
 :upload


### PR DESCRIPTION
Can't get any release builds done right now because globalsign's timeserver isn't responding properly for Authenticode signing requests on Windows!

This PR adds a new file, tools/sign.bat, to do the signing, it tries each of the big available timeservers (globalsign, comodo, verisign, starfield) until it finds one that it can actually use.

Looking for a very speedy review so I can land this and backport to v6, v4, v0.12 and v0.10 and get these releases built! It does work but I've had to make a couple of tweaks while testing. Final testing build should be ready soon in download/release/test/

/cc @nodejs/build @nodejs/platform-windows 