### PR TITLE
buffer: convert range to numbers before validation

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -703,6 +703,9 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
     val = val & 255;
   }
 
+  start = +start;
+  end = end === undefined ? this.length : +end;
+
   // Invalid ranges are not set to a default, so can range check early.
   if (start < 0 || end > this.length)
     throw new RangeError('Out of range index');
@@ -711,7 +714,7 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
     return this;
 
   start = start >>> 0;
-  end = end === undefined ? this.length : end >>> 0;
+  end = end >>> 0;
 
   binding.fill(this, val, start, end, encoding);
 

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -314,3 +314,24 @@ Buffer.alloc(8, '');
   buf.fill('է');
   assert.strictEqual(buf.toString(), 'էէէէէ');
 }
+
+{
+  const buff = Buffer.alloc(1);
+  const start = {
+    ctr: 0,
+    [Symbol.toPrimitive](hint) {
+      if (this.ctr <= 0) {
+        this.ctr++;
+        return 0;
+      } else {
+        return -1;
+      }
+    }
+  };
+
+  assert.deepStrictEqual(buff.fill(0xff, start, 1),
+                         Buffer.from([0xff]));
+  assert.throws(() => {
+    buff.fill(0xee, start, 1);
+  }, /RangeError: Out of range index/);
+}


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer

##### Description of change
Prior to this commit, a carefully crafted object with a `Symbol.toPrimitive` could bypass range validation. This commit converts the range values to numbers before performing any validation.

Note, this commit converts `start` and `end` to a number before later converting to unsigned ints. This is a bit of duplicate work, but maintains backwards compatibility.

Fixes: https://github.com/nodejs/node/issues/9149