### PR TITLE
doc: mention case-insensitive env on windows

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -708,6 +708,16 @@ console.log(process.env.TEST);
 // => undefined
 ```
 
+On Windows operating systems, environment variables are case-insensitive.
+
+Example:
+
+```js
+process.env.TEST = 1;
+console.log(process.env.test);
+// => 1
+```
+
 ## process.emitWarning(warning[, name][, ctor])
 <!-- YAML
 added: v6.0.0

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // changes in environment should be visible to child processes
@@ -67,3 +67,17 @@ assert.equal(3, date.getUTCHours());
 assert.equal(5, date.getHours());
 */
 /* eslint-enable max-len */
+
+// Environment variables should be case-insensitive on Windows, and
+// case-sensitive on other platforms.
+process.env.TEST = 'test';
+assert.strictEqual(process.env.TEST, 'test');
+// Check both mixed case and lower case, to avoid any regressions that might
+// simply convert input to lower case.
+if (common.isWindows) {
+  assert.strictEqual(process.env.test, 'test');
+  assert.strictEqual(process.env.teST, 'test');
+} else {
+  assert.strictEqual(process.env.test, undefined);
+  assert.strictEqual(process.env.teST, undefined);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

On Windows OS, environment variables are case-insensitive and are treated likewise in NodeJS. This can be confusing and can lead to hard-to-debug problems when moving code from one environment to another.

Closes #9157