### PR TITLE
doc: correct metadata of `Buffer.from`

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -595,7 +595,7 @@ console.log(bufA.length);
 
 ### Class Method: Buffer.from(array)
 <!-- YAML
-added: v3.0.0
+added: v4.5.0
 -->
 
 * `array` {Array}
@@ -643,7 +643,7 @@ A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer`.
 
 ### Class Method: Buffer.from(buffer)
 <!-- YAML
-added: v3.0.0
+added: v4.5.0
 -->
 
 * `buffer` {Buffer}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added

##### Affected core subsystem(s)

doc, buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

`Buffer.from` was present in `v3.0.0` but didn’t work for any
combination of arguments as it was inherited from `Uint8Array`.

This corrects the data to contain the version in which Node’s
own `Buffer.from` was added, namely `v4.5.0`.

Fixes: https://github.com/nodejs/node/issues/9165