### PR TITLE
streams: fix regression in `unpipe()`

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -671,7 +671,7 @@ Readable.prototype.unpipe = function(dest) {
   if (index === -1)
     return this;
 
-  state.pipes.splice(i, 1);
+  state.pipes.splice(index, 1);
   state.pipesCount -= 1;
   if (state.pipesCount === 1)
     state.pipes = state.pipes[0];

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -14,6 +14,10 @@ source.pipe(dest2);
 dest1.on('unpipe', common.mustCall(() => {}));
 dest2.on('unpipe', common.mustCall(() => {}));
 
+assert.strictEqual(source._readableState.pipes[0], dest1);
+assert.strictEqual(source._readableState.pipes[1], dest2);
+assert.strictEqual(source._readableState.pipes.length, 2);
+
 // Should be able to unpipe them in the reverse order that they were piped.
 
 source.unpipe(dest2);

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { Readable, Writable } = require('stream');
+
+const source = Readable({read: () => {}});
+const dest1 = Writable({write: () => {}});
+const dest2 = Writable({write: () => {}});
+
+source.pipe(dest1);
+source.pipe(dest2);
+
+dest1.on('unpipe', common.mustCall(() => {}));
+dest2.on('unpipe', common.mustCall(() => {}));
+
+// Should be able to unpipe them in the reverse order that they were piped.
+
+source.unpipe(dest2);
+
+assert.strictEqual(source._readableState.pipes, dest1);
+assert.notStrictEqual(source._readableState.pipes, dest2);
+
+source.unpipe(dest1);
+
+assert.strictEqual(source._readableState.pipes, null);


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

stream

##### Description of change

Since 2e568d9 there is a bug where unpiping a stream from a readable stream that has `_readableState.pipesCount > 1` will cause it to remove the first stream in the `_.readableState.pipes` array no matter where in the list the `dest` stream was.

This patch corrects that problem.

Credit for the bug report and the test case go to @niels4. Since it’s a rather big bug, I’ve opened a PR myself. (If you let me know an email address/name in time, I can add you as the git author of the test file.)

Fixes: https://github.com/nodejs/node/issues/9170