### PR TITLE
buffer: fix range checks for slice()

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -585,7 +585,8 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
   Local<String> str_obj;
   size_t str_length;
   enum encoding enc;
-  CHECK(fill_length + start <= ts_obj_length);
+  THROW_AND_RETURN_IF_OOB(start <= end);
+  THROW_AND_RETURN_IF_OOB(fill_length + start <= ts_obj_length);
 
   // First check if Buffer has been passed.
   if (Buffer::HasInstance(args[1])) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer

##### Description of change

Using the black magic of `Symbol.toPrimitive` the numeric value of
start/end can be changed when `Uint32Value()` is called once
`Buffer::Fill()` is entered. Allowing the `CHECK()` to be bypassed.

The bug report was only for "start", but the same can be done with
"end". Perform checks for both in `node::Buffer::Fill()` to make sure the
issue can't be triggered, even if process.binding is used directly.

Include tests for each case. Along with a check to make sure the last
time the value is accessed returns `-1`. This should be enough to make
sure `Buffer::Fill()` is receiving the correct value. Along with two tests
against `process.binding` directly.

Fixes: https://github.com/nodejs/node/issues/9149

R=@nodejs/buffer 