### PR TITLE
Add ssh and mongodb to the list of slashed protocols

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -154,7 +154,7 @@ The formatting process operates as follows:
 * For all string values of `urlObject.protocol` that *do not end* with an ASCII
   colon (`:`) character, the literal string `:` will be appended to `result`.
 * If either the `urlObject.slashes` property is true, `urlObject.protocol`
-  begins with one of `http`, `https`, `ftp`, `gopher`, or `file`, or
+  begins with one of `http`, `https`, `ftp`, `gopher`, `file`, `mongodb` or `ssh`, or
   `urlObject.protocol` is `undefined`, the literal string `//` will be appended
   to `result`.
 * If the value of the `urlObject.auth` property is truthy, and either

--- a/lib/url.js
+++ b/lib/url.js
@@ -68,7 +68,11 @@ const slashedProtocol = {
   'gopher': true,
   'gopher:': true,
   'file': true,
-  'file:': true
+  'file:': true,
+  'mongodb': true,
+  'mongodb:': true,
+  'ssh': true,
+  'ssh:': true
 };
 const querystring = require('querystring');
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
I just updated the list of slashed protocols for the url module. MongoDB and SSH are two protocols that were giving issues to my code while using this module. I patched it locally but would like this to be natively implemented. I have also submitted a very similar pull request to the repository maintaining the npm module.

