### PR TITLE
test: add regression test for instanceof

### DIFF
--- a/test/parallel/test-instanceof.js
+++ b/test/parallel/test-instanceof.js
@@ -1,0 +1,10 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+
+// Regression test for instanceof, see
+// https://github.com/nodejs/node/issues/7592
+const F = () => {};
+F.prototype = {};
+assert(Object.create(F.prototype) instanceof F);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add regression test for instanceof, see issue https://github.com/nodejs/node/issues/7592.
The issue was fixed in upstream V8 and this test case was
previously added with a manual cherry pick for v6.x.

Related to: https://github.com/nodejs/node/pull/7638 and
https://github.com/nodejs/node/issues/7592.