### PR TITLE
doc: fix header level for crypto.constants

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -992,7 +992,7 @@ thrown.
 
 ## `crypto` module methods and properties
 
-## crypto.constants
+### crypto.constants
 <!-- YAML
 added: v6.3.0
 -->


### PR DESCRIPTION

##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change

The header level for crypto.constants was off by one.