### PR TITLE
process: reintroduce ares to versions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2668,6 +2668,9 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(versions,
                     "zlib",
                     FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION));
+  READONLY_PROPERTY(versions,
+                    "ares",
+                    FIXED_ONE_BYTE_STRING(env->isolate(), ARES_VERSION_STR));
 
   const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);
   READONLY_PROPERTY(


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
process

##### Description of change
`process.versions.ares` is missing in v0.12.17 (and earlier v0.12.x):
```
-bash-4.2$ ./node
> process.versions
{ http_parser: '2.3',
  node: '0.12.17',
  v8: '3.28.71.19',
  uv: '1.6.1',
  zlib: '1.2.8',
  modules: '14',
  openssl: '1.0.1u' }
> .exit
-bash-4.2$
```
Fixed by cherry-picking 01736dd (reference nodejs/node#347)