### PR TITLE
deps: cherry-pick bb4974d from v8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 84
+#define V8_PATCH_LEVEL 85
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/heap/mark-compact.cc
+++ b/deps/v8/src/heap/mark-compact.cc
@@ -1674,6 +1674,7 @@ class MarkCompactCollector::EvacuateNewSpaceVisitor final
     const int size = old_object->Size();
     AllocationAlignment alignment = old_object->RequiredAlignment();
     AllocationResult allocation;
+    AllocationSpace space_allocated_in = space_to_allocate_;
     if (space_to_allocate_ == NEW_SPACE) {
       if (size > kMaxLabObjectSize) {
         allocation =
@@ -1684,11 +1685,12 @@ class MarkCompactCollector::EvacuateNewSpaceVisitor final
     }
     if (allocation.IsRetry() || (space_to_allocate_ == OLD_SPACE)) {
       allocation = AllocateInOldSpace(size, alignment);
+      space_allocated_in = OLD_SPACE;
     }
     bool ok = allocation.To(target_object);
     DCHECK(ok);
     USE(ok);
-    return space_to_allocate_;
+    return space_allocated_in;
   }
 
   inline bool NewLocalAllocationBuffer() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

deps

##### Description of change
<!-- Provide a description of the change below this comment. -->

Original commit message:

[heap] Properly propagate allocated space during new space evacuaton in
MC

New space evaucation in MC supports, similar to scavenges, fall back
allocation in old space.

For new space evacuation we support sticky and non-sticky modes for
fallback. The sticky mode essentially removes the capability to allocate
in new space while the non-sticky mode only falls back for a single
allocation.

We use the non-sticky mode for allocations that are too large for a LAB
but should still go in new space. When such an allocation fails in new
space, we allocate in old space in non-sticky mode as we would still
like to reuse the remainder memory in new space. However, in such a case
we fail to properly report the space allocated in resulting in a missed
recorded slot.

BUG=chromium:641270
R=ulan@chromium.org

Review-Url: https://codereview.chromium.org/2280943002
Cr-Commit-Position: refs/heads/master@{#38940}