### PR TITLE
http: add debug message for invalid header value

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -317,6 +317,7 @@ function storeHeader(self, state, field, value) {
       'Header name must be a valid HTTP Token ["' + field + '"]');
   }
   if (common._checkInvalidHeaderChar(value) === true) {
+    debug('Header "%s" contains invalid characters', field);
     throw new TypeError('The header content contains invalid characters');
   }
   state.messageHeader += field + ': ' + escapeHeaderValue(value) + CRLF;
@@ -357,6 +358,7 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   if (this._header)
     throw new Error('Can\'t set headers after they are sent.');
   if (common._checkInvalidHeaderChar(value) === true) {
+    debug('Header "%s" contains invalid characters', name);
     throw new TypeError('The header content contains invalid characters');
   }
   if (this._headers === null)
@@ -534,6 +536,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
         'Trailer name must be a valid HTTP Token ["' + field + '"]');
     }
     if (common._checkInvalidHeaderChar(value) === true) {
+      debug('Trailer "%s" contains invalid characters', field);
       throw new TypeError('The trailer content contains invalid characters');
     }
     this._trailer += field + ': ' + escapeHeaderValue(value) + CRLF;


### PR DESCRIPTION


##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http

##### Description of change
<!-- Provide a description of the change below this comment. -->

This makes it easier to see what header has an invalid value. As discussed on the CTC call today (10/19/2016), this is a way to get which header is causing the throw without introducing a breaking change (changing error messages is considered breaking)

Ref: https://github.com/nodejs/node/pull/9010