### PR TITLE
test: remove arbitrary timer

### DIFF
--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -6,18 +6,13 @@ const assert = require('assert');
 const dgram = require('dgram');
 const client = dgram.createSocket('udp4');
 
-const timer = setTimeout(function() {
-  throw new Error('Timeout');
-}, common.platformTimeout(200));
-
 const buf = Buffer.allocUnsafe(256);
 const offset = 20;
 const len = buf.length - offset;
 
 const messageSent = common.mustCall(function messageSent(err, bytes) {
-  assert.notEqual(bytes, buf.length);
-  assert.equal(bytes, buf.length - offset);
-  clearTimeout(timer);
+  assert.notStrictEqual(bytes, buf.length);
+  assert.strictEqual(bytes, buf.length - offset);
   client.close();
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram

##### Description of change
<!-- Provide a description of the change below this comment. -->
This test was timing out (via the 200ms timeout in the code) on FreeBSD in CI. The 200ms timeout is arbitrary and not necessary. Remove it.

/cc @nodejs/testing 