### PR TITLE
test: fix flaky test by removing timer

### DIFF
--- a/test/parallel/test-dgram-send-callback-buffer.js
+++ b/test/parallel/test-dgram-send-callback-buffer.js
@@ -9,14 +9,9 @@ const client = dgram.createSocket('udp4');
 const buf = Buffer.allocUnsafe(256);
 
 const onMessage = common.mustCall(function(err, bytes) {
-  assert.strictEqual(err, null);
-  assert.equal(bytes, buf.length);
-  clearTimeout(timer);
+  assert.ifError(err);
+  assert.strictEqual(bytes, buf.length);
   client.close();
 });
-
-const timer = setTimeout(function() {
-  throw new Error('Timeout');
-}, common.platformTimeout(200));
 
 client.send(buf, common.PORT, common.localhostIPv4, onMessage);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change

This fixes one of the tests that has been failing on CI on freebsd for
a bit by removing an unnecessary timer.

Fixes: https://github.com/nodejs/node/issues/7929