### PR TITLE
repl: don’t write to input stream in editor mode

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -601,6 +601,7 @@ function REPLServer(prompt,
   // Wrap readline tty to enable editor mode
   const ttyWrite = self._ttyWrite.bind(self);
   self._ttyWrite = (d, key) => {
+    key = key || {};
     if (!self.editorMode || !self.terminal) {
       ttyWrite(d, key);
       return;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -476,7 +476,7 @@ function REPLServer(prompt,
       const matches = self._sawKeyPress ? cmd.match(/^\s+/) : null;
       if (matches) {
         const prefix = matches[0];
-        self.inputStream.write(prefix);
+        self.write(prefix);
         self.line = prefix;
         self.cursor = prefix.length;
       }

--- a/test/parallel/test-repl-.editor.js
+++ b/test/parallel/test-repl-.editor.js
@@ -75,12 +75,15 @@ tests.forEach(run);
 // Auto code alignment for .editor mode
 function testCodeAligment({input, cursor = 0, line = ''}) {
   const stream = new common.ArrayStream();
+  const outputStream = new common.ArrayStream();
+
+  stream.write = () => { throw new Error('Writing not allowed!'); };
 
   const replServer = repl.start({
     prompt: '> ',
     terminal: true,
     input: stream,
-    output: stream,
+    output: outputStream,
     useColors: false
   });
 

--- a/test/parallel/test-repl-.editor.js
+++ b/test/parallel/test-repl-.editor.js
@@ -8,6 +8,7 @@ const repl = require('repl');
 // \u001b[0J - Clear screen
 // \u001b[3G - Moves the cursor to 3rd column
 const terminalCode = '\u001b[1G\u001b[0J> \u001b[3G';
+const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
 
 function run({input, output, event, checkTerminalCodes = true}) {
   const stream = new common.ArrayStream();
@@ -33,13 +34,8 @@ function run({input, output, event, checkTerminalCodes = true}) {
   replServer.close();
 
   if (!checkTerminalCodes) {
-    while (found.includes(terminalCode))
-      found = found.replace(terminalCode, '');
-    while (expected.includes(terminalCode))
-      expected = expected.replace(terminalCode, '');
-
-    found = found.replace(/\n/g, '');
-    expected = expected.replace(/\n/g, '');
+    found = found.replace(terminalCodeRegex, '').replace(/\n/g, '');
+    expected = expected.replace(terminalCodeRegex, '').replace(/\n/g, '');
   }
 
   assert.strictEqual(found, expected);


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

repl

##### Description of change

- In `.editor` mode, `repl.write()` would have crashed when the `key` argument was not present, because the overwritten `_ttyWrite` of REPLs doesn’t check for the absence of a second argument like `readline.write()` does.
Since the docs indicate that the argument is optional, add a check paralleling the one in `readline.write()`.
- Instead of writing to the REPL’s input stream for the alignment
spaces in `.editor` mode, let `readline` handle the spaces
properly (echoing them using `_ttyWrite` and adding them to the
current line buffer).

Fixes: #9189 