### PR TITLE
child_process: remove unreachable execSync() code

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -517,7 +517,7 @@ exports.execFileSync = execFileSync;
 
 function execSync(command /*, options*/) {
   var opts = normalizeExecArgs.apply(null, arguments);
-  var inheritStderr = opts.options ? !opts.options.stdio : true;
+  var inheritStderr = !opts.options.stdio;
 
   var ret = spawnSync(opts.file, opts.options);
   ret.cmd = command;


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process

##### Description of change
Code coverage showed that the `execSync()` variable `inheritStderr` was never set to the default value of `true`. This is because the default case is hit whenever `normalizeExecArgs()` returns an object without an `options` property. However, this can never be the case because `normalizeExecArgs()` unconditionally creates the `options` object. This commit removes the unreachable code.