### PR TITLE
test: add coverage for execFileSync() errors

### DIFF
--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -87,3 +87,19 @@ assert.strictEqual(ret, msg + '\n',
     execSync('exit -1', {stdio: 'ignore'});
   }, /Command failed: exit -1/);
 }
+
+// Verify the execFileSync() behavior when the child exits with a non-zero code.
+{
+  const args = ['-e', 'process.exit(1)'];
+
+  assert.throws(() => {
+    execFileSync(process.execPath, args);
+  }, (err) => {
+    const msg = `Command failed: ${process.execPath} ${args.join(' ')}`;
+
+    assert(err instanceof Error);
+    assert.strictEqual(err.message.trim(), msg);
+    assert.strictEqual(err.status, 1);
+    return true;
+  });
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This commit adds coverage for errors returned by `execFileSync()` when the child process exits with a non-zero code.