### PR TITLE
src: remove unneeded AssignToContext() call

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -93,7 +93,6 @@ namespace node {
   V(encoding_string, "encoding")                                              \
   V(enter_string, "enter")                                                    \
   V(env_pairs_string, "envPairs")                                             \
-  V(env_string, "env")                                                        \
   V(errno_string, "errno")                                                    \
   V(error_string, "error")                                                    \
   V(events_string, "_events")                                                 \

--- a/src/node.cc
+++ b/src/node.cc
@@ -3157,7 +3157,7 @@ void SetupProcessObject(Environment* env,
                                                 env->as_external());
   Local<Object> process_env =
       process_env_template->NewInstance(env->context()).ToLocalChecked();
-  process->Set(env->env_string(), process_env);
+  process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "env"), process_env);
 
   READONLY_PROPERTY(process, "pid", Integer::New(env->isolate(), getpid()));
   READONLY_PROPERTY(process, "features", GetFeatures(env));


### PR DESCRIPTION
It was added in commit 681fe59 ("vm: assign Environment to created
context") from April 2014 to work around a segmentation fault when
accessing process.env from another context but that is not necessary
anymore after commit 7e88a93 ("src: make accessors immune to context
confusion") from March 2015.

CI: https://ci.nodejs.org/job/node-test-pull-request/4599/