### PR TITLE
tools: enable ES2016 support in ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,9 @@ env:
   node: true
   es6: true
 
+parserOptions:
+  ecmaVersion: 2016
+
 rules:
   # Possible Errors
   # http://eslint.org/docs/rules/#possible-errors


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

This allows to use the exponentiation operator.

Ref: https://github.com/nodejs/node/pull/9208#issuecomment-255309920