### PR TITLE
test: make test-fs-watch-recursive more robust

### DIFF
--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -16,7 +16,8 @@ const filenameOne = 'watch.txt';
 
 common.refreshTmpDir();
 
-const testsubdir = fs.mkdtempSync(testDir + path.sep);
+const testsubdir = path.join(testDir, 'watch_me');
+fs.mkdirSync(testsubdir);
 const relativePathOne = path.join(path.basename(testsubdir), filenameOne);
 const filepathOne = path.join(testsubdir, filenameOne);
 
@@ -34,7 +35,7 @@ watcher.on('change', function(event, filename) {
   watcherClosed = true;
 });
 
-if (process.platform === 'darwin') {
+if (common.isOSX) {
   setTimeout(function() {
     fs.writeFileSync(filepathOne, 'world');
   }, 100);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test was failing on OS X when run in parallel with:

```
tools/test.py --repeat=99 -J parallel/test-fs-watch-recursive
```

ENOENT was arising when trying to create a file in the directory created
with `fs.mkdtempSync()`. I do not know if this is a bug in OS X, a bug
in libuv, or something else. I also do not know this is partially or
completely the cause of the flakiness of the test in CI and locally
(when run as part of `make test`).

In any event, changing to `fs.mkdirSync()` resolved the issue.

/cc @nodejs/testing 