### PR TITLE
test: check that `process.execPath` is a realpath

### DIFF
--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 assert.strictEqual(process.execPath, fs.realpathSync(process.execPath));
 
 if (process.argv[2] === 'child') {
+  // The console.log() output is part of the test here.
   console.log(process.execPath);
 } else {
   common.refreshTmpDir();

--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -7,6 +7,11 @@ const fs = require('fs');
 
 assert.strictEqual(process.execPath, fs.realpathSync(process.execPath));
 
+if (common.isWindows) {
+  common.skip('symlinks are weird on windows');
+  return;
+}
+
 if (process.argv[2] === 'child') {
   // The console.log() output is part of the test here.
   console.log(process.execPath);

--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -17,6 +17,7 @@ if (process.argv[2] === 'child') {
   fs.symlinkSync(process.execPath, symlinkedNode);
 
   const proc = child_process.spawnSync(symlinkedNode, [__filename, 'child']);
-  assert.strictEqual(proc.status, 0);
+  assert.strictEqual(proc.stderr.toString(), '');
   assert.strictEqual(proc.stdout.toString(), `${process.execPath}\n`);
+  assert.strictEqual(proc.status, 0);
 }

--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+assert.strictEqual(process.execPath, fs.realpathSync(process.execPath));
+
+if (process.argv[2] === 'child') {
+  console.log(process.execPath);
+} else {
+  common.refreshTmpDir();
+
+  const symlinkedNode = path.join(common.tmpDir, 'symlinked-node');
+  fs.symlinkSync(process.execPath, symlinkedNode);
+
+  const proc = child_process.spawnSync(symlinkedNode, [__filename, 'child']);
+  assert.strictEqual(proc.status, 0);
+  assert.strictEqual(proc.stdout.toString(), `${process.execPath}\n`);
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

test
##### Description of change

This test is only here to ensure consistent cross-platform behaviour.
