### PR TITLE
build: use wxneeded on openbsd

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -278,6 +278,9 @@
           ['_type=="static_library" and OS=="solaris"', {
             'standalone_static_library': 1,
           }],
+          ['OS=="openbsd"', {
+            'ldflags': [ '-Wl,-z,wxneeded' ],
+          }],
         ],
         'conditions': [
           [ 'target_arch=="ia32"', {

--- a/deps/cares/include/ares.h
+++ b/deps/cares/include/ares.h
@@ -38,7 +38,7 @@
    require it! */
 #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
-    defined(ANDROID) || defined(__ANDROID__)
+    defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__)
 #include <sys/select.h>
 #endif
 #if (defined(NETWARE) && !defined(__NOVELL_LIBC__))


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

On OpenBSD 6.0 and greater W^X is enabled by default. All executables
that violate W^X need to be marked with PT_OPENBSD_WXNEEDED. In
addition to this, they must be executed from a filesystem mounted with
'wxallowed'.

More info on W^X: https://en.wikipedia.org/wiki/W%5EX