### PR TITLE
inspector: do not dereference null pointer

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -687,7 +687,7 @@ bool AgentImpl::RespondToGet(InspectorSocket* socket, const std::string& path) {
     SendVersionResponse(socket);
   } else {
     const char* pid = match_path_segment(command, "activate");
-    if (pid != id_)
+    if (pid == nullptr || pid != id_)
       return false;
     SendHttpResponse(socket, "Target activated");
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
inspector - just a minor bugfix


##### Description of change
<!-- Provide a description of the change below this comment. -->

This issue was caught by Coverity. Apparently, nullptr in std::string
ctor is undefined behaviour.