### PR TITLE
doc: fixes formatting in process

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1271,13 +1271,13 @@ tarball.
 
 * `name` {String} A value that will always be `'node'` for Node.js. For
   legacy io.js releases, this will be `'io.js'`.
-* `sourceUrl` {String} an absolute URL pointing to a `_.tar.gz_` file containing
+* `sourceUrl` {String} an absolute URL pointing to a _`.tar.gz`_ file containing
   the source code of the current release.
-* `headersUrl`{String} an absolute URL pointing to a `_.tar.gz_` file containing
+* `headersUrl`{String} an absolute URL pointing to a _`.tar.gz`_ file containing
   only the source header files for the current release. This file is
   significantly smaller than the full source file and can be used for compiling
   Node.js native add-ons.
-* `libUrl` {String} an absolute URL pointing to a `_node.lib_` file matching the
+* `libUrl` {String} an absolute URL pointing to a _`node.lib`_ file matching the
   architecture and version of the current release. This file is used for
   compiling Node.js native add-ons. _This property is only present on Windows
   builds of Node.js and will be missing on all other platforms._
@@ -1427,7 +1427,7 @@ Android)
 added: v0.1.28
 -->
 
-The `process.setuid(id) method sets the user identity of the process. (See
+The `process.setuid(id)` method sets the user identity of the process. (See
 setuid(2).)  The `id` can be passed as either a numeric ID or a username string.
 If a username is specified, the method blocks while resolving the associated
 numeric ID.
@@ -1714,3 +1714,5 @@ cases:
 [Readable]: stream.html
 [Child Process]: child_process.html
 [Cluster]: cluster.html
+[`process.exitCode`]: #processexitcode-1
+[LTS]: https://github.com/nodejs/LTS/


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes several formatting errors in the process doc, including missing
link references, misplaced underscores, and a missing backtick.

Fixes: https://github.com/nodejs/node/issues/9223