### PR TITLE
buffer: fix `fill` with encoding in Buffer.alloc()

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -91,6 +91,14 @@ Object.setPrototypeOf(Buffer, Uint8Array);
 /**
  * Creates a new filled Buffer instance.
  * alloc(size[, fill[, encoding]])
+ *
+ * Only pay attention to encoding if it's a string. This
+ * prevents accidentally sending in a number that would
+ * be interpretted as a start offset.
+ * Also, don't apply encoding if fill is a number.
+ *
+ * These comments are placed before the function to keep the text length
+ * down, to ensure that it remains inlineable by V8.
  **/
 Buffer.alloc = function(size, fill, encoding) {
   if (typeof size !== 'number')
@@ -98,10 +106,6 @@ Buffer.alloc = function(size, fill, encoding) {
   if (size <= 0)
     return createBuffer(size);
   if (fill !== undefined) {
-    // Only pay attention to encoding if it's a string. This
-    // prevents accidentally sending in a number that would
-    // be interpretted as a start offset.
-    // Also, don't apply encoding if fill is a number.
     if (typeof fill !== 'number' && typeof encoding === 'string')
       fill = Buffer.from(fill, encoding);
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -105,7 +105,11 @@ Buffer.alloc = function(size, fill, encoding) {
     if (typeof fill !== 'number' && typeof encoding === 'string')
       fill = Buffer.from(fill, encoding);
 
-    return createBuffer(size, true).fill(fill);
+    const buf = createBuffer(size, true);
+    // Buffer.prototype.fill does not support filling with other buffers in v4.
+    // Instead, call binding.fill directly.
+    binding.fill(buf, fill, 0, buf.length);
+    return buf;
   }
   return createBuffer(size);
 };

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -94,7 +94,7 @@ Object.setPrototypeOf(Buffer, Uint8Array);
  *
  * Only pay attention to encoding if it's a string. This
  * prevents accidentally sending in a number that would
- * be interpretted as a start offset.
+ * be interpreted as a start offset.
  * Also, don't apply encoding if fill is a number.
  *
  * These comments are placed before the function to keep the text length

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1060,6 +1060,17 @@ assert.throws(function() {
   Buffer.allocUnsafe(0xFFFFFFFFF);
 }, RangeError);
 
+// issue GH-9226
+{
+  const buf = Buffer.alloc(4, 'YQ==', 'base64');
+  const expectedBuf = new Buffer([97, 97, 97, 97]);
+  assert(buf.equals(expectedBuf));
+}
+{
+  const buf = Buffer.alloc(4, 'ab', 'ascii');
+  const expectedBuf = new Buffer([97, 98, 97, 98]);
+  assert(buf.equals(expectedBuf));
+}
 
 // attempt to overflow buffers, similar to previous bug in array buffers
 assert.throws(function() {

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1063,12 +1063,12 @@ assert.throws(function() {
 // issue GH-9226
 {
   const buf = Buffer.alloc(4, 'YQ==', 'base64');
-  const expectedBuf = new Buffer([97, 97, 97, 97]);
+  const expectedBuf = Buffer.from([97, 97, 97, 97]);
   assert(buf.equals(expectedBuf));
 }
 {
   const buf = Buffer.alloc(4, 'ab', 'ascii');
-  const expectedBuf = new Buffer([97, 98, 97, 98]);
+  const expectedBuf = Buffer.from([97, 98, 97, 98]);
   assert(buf.equals(expectedBuf));
 }
 

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1060,7 +1060,7 @@ assert.throws(function() {
   Buffer.allocUnsafe(0xFFFFFFFFF);
 }, RangeError);
 
-// issue GH-9226
+// https://github.com/nodejs/node/issues/9226
 {
   const buf = Buffer.alloc(4, 'YQ==', 'base64');
   const expectedBuf = Buffer.from([97, 97, 97, 97]);

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1060,6 +1060,8 @@ assert.throws(function() {
   Buffer.allocUnsafe(0xFFFFFFFFF);
 }, RangeError);
 
+assert(Buffer.alloc.toString().length < 600, 'Buffer.alloc is not inlineable');
+
 // https://github.com/nodejs/node/issues/9226
 {
   const buf = Buffer.alloc(4, 'YQ==', 'base64');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously, the implementation of Buffer.alloc() called Buffer#fill()
with another Buffer as an argument. However, in v4.x, Buffer#fill does
not support a Buffer as an argument. As a workaround, call
binding.fill() directly in the Buffer.alloc() implementation.

Fixes: https://github.com/nodejs/node/issues/9226