### PR TITLE
test: skip whatwg url parse tests when icu is missing

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -525,3 +525,9 @@ exports.expectWarning = function(name, expected) {
     expected.splice(expected.indexOf(warning.message), 1);
   }, expected.length));
 };
+
+Object.defineProperty(exports, 'hasIntl', {
+  get: function() {
+    return process.binding('config').hasIntl;
+  }
+});

--- a/test/parallel/test-intl-v8BreakIterator.js
+++ b/test/parallel/test-intl-v8BreakIterator.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (global.Intl === undefined || Intl.v8BreakIterator === undefined) {
+if (!common.hasIntl || Intl.v8BreakIterator === undefined) {
   return common.skip('no Intl');
 }
 

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -8,9 +8,6 @@ if (enablei18n === undefined) {
   enablei18n = 0;
 }
 
-// is the Intl object present?
-const haveIntl = (global.Intl !== undefined);
-
 // Returns true if no specific locale ids were configured (i.e. "all")
 // Else, returns true if loc is in the configured list
 // Else, returns false
@@ -19,7 +16,7 @@ function haveLocale(loc) {
   return locs.indexOf(loc) !== -1;
 }
 
-if (!haveIntl) {
+if (!common.hasIntl) {
   const erMsg =
       '"Intl" object is NOT present but v8_enable_i18n_support is ' +
       enablei18n;

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -9,7 +9,7 @@ if (common.hasCrypto) {
   expected_keys.push('openssl');
 }
 
-if (typeof Intl !== 'undefined') {
+if (common.hasIntl) {
   expected_keys.push('icu');
 }
 

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -277,7 +277,7 @@ const testNonGlobal = repl.start({
 const builtins = [['Infinity', '', 'Int16Array', 'Int32Array',
                                  'Int8Array'], 'I'];
 
-if (typeof Intl === 'object') {
+if (common.hasIntl) {
   builtins[0].push('Intl');
 }
 testNonGlobal.complete('I', common.mustCall((error, data) => {

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const common = require('../common');
+
+if (!common.hasIntl) {
+  // A handful of the tests fail when ICU is not included.
+  common.skip('missing Intl... skipping test');
+  return;
+}
+
 const URL = require('url').URL;
 const path = require('path');
 const assert = require('assert');

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const common = require('../common');
+
+if (!common.hasIntl) {
+  // A handful of the tests fail when ICU is not included.
+  common.skip('missing Intl... skipping test');
+  return;
+}
+
 const path = require('path');
 const URL = require('url').URL;
 const assert = require('assert');


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change
The WHATWG url parser relies on ICU's punycode implementation. A handful of the standard tests fail when ICU is not present because of the additional checks that are not implemented. For now, skip the parse tests if ICU is not present.