### PR TITLE
tools: make --repeat work with -j in test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -42,6 +42,7 @@ import threading
 import utils
 import multiprocessing
 import errno
+import copy
 
 from os.path import join, dirname, abspath, basename, isdir, exists
 from datetime import datetime
@@ -773,7 +774,9 @@ class TestRepository(TestSuite):
       tests = self.GetConfiguration(context).ListTests(current_path, path,
                                                        arch, mode)
       for t in tests: t.variant_flags = v
-      result += tests * context.repeat
+      result += tests
+      for i in range(1, context.repeat):
+        result += copy.deepcopy(tests)
 
   def GetTestStatus(self, context, sections, defs):
     self.GetConfiguration(context).GetTestStatus(sections, defs)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test

##### Description of change
<!-- Provide a description of the change below this comment. -->

The repeat option in test.py did not work as expected if `-j` was set to
more than one. Repeated tests running at the same time could share temp
directories and cause test failures. This was observed with:

    tools/test.py -J --repeat=10 parallel/test-fs-watch-recursive

By using copy.deepCopy(), the repeated tests are separate objects and
not references to the same objects. Setting `thread_id` on one of them
will now not change the `thread_id` on all of them. And `thread_id` is
how the temp directory (and common.PORT as well) are determined.

@santigimeno @mhdawson 