### PR TITLE
tools: use long format for gpg fingerprint

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -50,7 +50,7 @@ elif [ $keycount -ne 1 ]; then
   done
 fi
 
-gpgfing=$(gpg --fingerprint $gpgkey | grep 'Key fingerprint =' | awk -F' = ' '{print $2}' | tr -d ' ')
+gpgfing=$(gpg --keyid-format 0xLONG --fingerprint $gpgkey | grep 'Key fingerprint =' | awk -F' = ' '{print $2}' | tr -d ' ')
 
 if ! test "$(grep $gpgfing README.md)"; then
   echo 'Error: this GPG key fingerprint is not listed in ./README.md'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tools
##### Description of change

<!-- Provide a description of the change below this comment. -->

Git has been using my Long format fingerprint in the tagging messages,
this has been causing the release script to fail on my keys.

It would also be wise to be using the long format on keys based on some
attacks that hack been found in the while around short keys.

@nodejs/release can you test that this works on your machine? You should be able to run it on a release you have signed with the following command

`./tools/release.sh -s v6.9.1`

This should take you through the entire signing process, and you can then opt not to upload
