### PR TITLE
test.py tap13 output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ deps/npm/node_modules/.bin/
 # test artifacts
 tools/faketime
 icu_config.gypi
-test.tap
+*.tap
 
 # Xcode workspaces and project folders
 *.xcodeproj

--- a/deps/gtest/src/gtest.cc
+++ b/deps/gtest/src/gtest.cc
@@ -3596,13 +3596,15 @@ void TapUnitTestResultPrinter::OutputTapTestInfo(int* count,
   *stream << "  ---\n";
   *stream << "  duration_ms: " <<
              FormatTimeInMillisAsSeconds(result.elapsed_time()) << "\n";
-  *stream << "  ...\n";
 
-  for (int i = 0; i < result.total_part_count(); ++i) {
-    const TestPartResult& part = result.GetTestPartResult(i);
-    OutputTapComment(stream, part.message());
+  if (result.total_part_count() > 0) {
+    *stream << "  stack: |-\n";
+    for (int i = 0; i < result.total_part_count(); ++i) {
+      const TestPartResult& part = result.GetTestPartResult(i);
+      OutputTapComment(stream, part.message());
+    }
   }
-
+  *stream << "  ...\n";
   *count += 1;
 }
 
@@ -3610,11 +3612,11 @@ void TapUnitTestResultPrinter::OutputTapComment(::std::ostream* stream,
                                                 const char* comment) {
   const char* start = comment;
   while (const char* end = strchr(start, '\n')) {
-    *stream << "# " << std::string(start, end) << "\n";
+    *stream << "    " << std::string(start, end) << "\n";
     start = end + 1;
   }
   if (*start)
-    *stream << "# " << start << "\n";
+    *stream << "    " << start << "\n";
 }
 
 // Formats the given time in milliseconds as seconds.

--- a/tools/test.py
+++ b/tools/test.py
@@ -256,11 +256,15 @@ class DotsProgressIndicator(SimpleProgressIndicator):
 
 class TapProgressIndicator(SimpleProgressIndicator):
 
-  def _printDiagnostic(self, messages):
-    for l in messages.splitlines():
-      logger.info('# ' + l)
+  def _printDiagnostic(self, traceback, severity):
+    logger.info('  severity: %s', severity)
+    logger.info('  stack: |-')
+
+    for l in traceback.splitlines():
+      logger.info('    ' + l)
 
   def Starting(self):
+    logger.info('TAP version 13')
     logger.info('1..%i' % len(self.cases))
     self._done = 0
 
@@ -269,6 +273,8 @@ class TapProgressIndicator(SimpleProgressIndicator):
 
   def HasRun(self, output):
     self._done += 1
+    self.traceback = ''
+    self.severity = 'ok'
 
     # Print test name as (for example) "parallel/test-assert".  Tests that are
     # scraped from the addons documentation are all named test.js, making it
@@ -281,19 +287,23 @@ class TapProgressIndicator(SimpleProgressIndicator):
 
     if output.UnexpectedOutput():
       status_line = 'not ok %i %s' % (self._done, command)
+      self.severity = 'fail'
+      self.traceback = output.output.stdout + output.output.stderr
+
       if FLAKY in output.test.outcomes and self.flaky_tests_mode == DONTCARE:
         status_line = status_line + ' # TODO : Fix flaky test'
+        self.severity = 'flaky'
+
       logger.info(status_line)
-      self._printDiagnostic("\n".join(output.diagnostic))
 
       if output.HasCrashed():
-        self._printDiagnostic(PrintCrashed(output.output.exit_code))
+        self.severity = 'crashed'
+        exit_code = output.output.exit_code 
+        self.traceback = "oh no!\nexit code: " + PrintCrashed(exit_code)
 
       if output.HasTimedOut():
-        self._printDiagnostic('TIMEOUT')
+        self.severity = 'fail'
 
-      self._printDiagnostic(output.output.stderr)
-      self._printDiagnostic(output.output.stdout)
     else:
       skip = skip_regex.search(output.output.stdout)
       if skip:
@@ -304,7 +314,11 @@ class TapProgressIndicator(SimpleProgressIndicator):
         if FLAKY in output.test.outcomes:
           status_line = status_line + ' # TODO : Fix flaky test'
         logger.info(status_line)
-      self._printDiagnostic("\n".join(output.diagnostic))
+
+      if output.diagnostic:
+        self.severity = 'ok'
+        self.traceback = output.diagnostic
+
 
     duration = output.test.duration
 
@@ -315,7 +329,12 @@ class TapProgressIndicator(SimpleProgressIndicator):
     # duration_ms is measured in seconds and is read as such by TAP parsers.
     # It should read as "duration including ms" rather than "duration in ms"
     logger.info('  ---')
-    logger.info('  duration_ms: %d.%d' % (total_seconds, duration.microseconds / 1000))
+    logger.info('  duration_ms: %d.%d' %
+      (total_seconds, duration.microseconds / 1000))
+    if self.severity is not 'ok' or self.traceback is not '':
+      if output.HasTimedOut():
+        self.traceback = 'timeout'
+      self._printDiagnostic(self.traceback, self.severity)
     logger.info('  ...')
 
   def Done(self):


### PR DESCRIPTION
Here's a work in progress that generates valid (ish -- haven't tested all kinds of stuff just yet) tap13 output from the test runner. I was initially thinking that we'd do a separate test runner (tap and tap13) but seeing how our current tap is invalid at best and this diff is easier to read I thought I'd post it in its current state for feedback/discussion.

Together with https://pypi.python.org/pypi/tap2junit we now generate junit that [jenkins like](https://ci.nodejs.org/job/node-test-commit-jbergstroem-alpine34/31/).

Open issues/things to discuss:
- ~~cctest output needs to be changed -- invalid failures~
- ~~do we split up tap vs tap13 (i prefer not)~~
- ~~if not, is this a semver major or minor? hard to say with tooling; especially seeing how our tooling has been invalid for so long.~~

I'll rebase/clean up once we converge on what to do. Hopefully we can get this in as quick as possible -- the build groups general theory is that this will Make Jenkins Great Again.
