### PR TITLE
test: remove err timer from test-http-set-timeout

### DIFF
--- a/test/parallel/test-http-set-timeout.js
+++ b/test/parallel/test-http-set-timeout.js
@@ -1,32 +1,26 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
 
 var server = http.createServer(function(req, res) {
-  console.log('got request. setting 1 second timeout');
-  var s = req.connection.setTimeout(500);
-  assert.ok(s instanceof net.Socket);
-  req.connection.on('timeout', function() {
+  console.log('got request. setting 500ms timeout');
+  var socket = req.connection.setTimeout(500);
+  assert.ok(socket instanceof net.Socket);
+  req.connection.on('timeout', common.mustCall(function() {
     req.connection.destroy();
     console.error('TIMEOUT');
     server.close();
-  });
+  }));
 });
 
 server.listen(0, function() {
   console.log(`Server running at http://127.0.0.1:${this.address().port}/`);
 
-  var errorTimer = setTimeout(function() {
-    throw new Error('Timeout was not successful');
-  }, common.platformTimeout(2000));
-
-  var x = http.get({port: this.address().port, path: '/'});
-  x.on('error', function() {
-    clearTimeout(errorTimer);
+  var request = http.get({port: this.address().port, path: '/'});
+  request.on('error', common.mustCall(function() {
     console.log('HTTP REQUEST COMPLETE (this is good)');
-  });
-  x.end();
-
+  }));
+  request.end();
 });


### PR DESCRIPTION
##### Checklist
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change

Removed the errorTimer from test-http-set-timeout.js, as this timer is
not necessary to test the setTimeout functionality.

Also edited the console.log message on line 8 to log the correct
timeout duration.

Fixes: https://github.com/nodejs/node/issues/9256