### PR TITLE
intl: Add more versions from ICU

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1643,8 +1643,10 @@ Will generate output similar to:
   ares: '1.10.0-DEV',
   modules: '43',
   icu: '55.1',
-  openssl: '1.0.1k'
-}
+  openssl: '1.0.1k',
+  unicode: '8.0',
+  cldr: '29.0',
+  tz: '2016b' }
 ```
 
 ## Exit Codes

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -26,6 +26,8 @@
     // do this good and early, since it handles errors.
     setupProcessFatal();
 
+    setupProcessICUVersions();
+
     setupGlobalVariables();
     if (!process._noBrowserGlobals) {
       setupGlobalTimeouts();
@@ -302,6 +304,36 @@
 
       return caught;
     };
+  }
+
+  function setupProcessICUVersions() {
+    const icu = process.binding('config').hasIntl ?
+      process.binding('icu') : undefined;
+    if (!icu) return;  // no Intl/ICU: nothing to add here.
+    // With no argument, getVersion() returns a comma separated list
+    // of possible types.
+    const versionTypes = icu.getVersion().split(',');
+    versionTypes.forEach((name) => {
+      // Copied from module.js:addBuiltinLibsToObject
+      Object.defineProperty(process.versions, name, {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          // With an argument, getVersion(type) returns
+          // the actual version string.
+          const version = icu.getVersion(name);
+          // Replace the current getter with a new
+          // property.
+          delete process.versions[name];
+          Object.defineProperty(process.versions, name, {
+            value: version,
+            writable: false,
+            enumerable: true
+          });
+          return version;
+        }
+      });
+    });
   }
 
   function tryGetCwd(path) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1049,3 +1049,7 @@ exports._exceptionWithHostPort = function(err,
   }
   return ex;
 };
+
+// process.versions needs a custom function as some values are lazy-evaluated.
+process.versions[exports.inspect.custom] =
+  (depth) => exports.format(JSON.parse(JSON.stringify(process.versions)));

--- a/src/node.cc
+++ b/src/node.cc
@@ -3032,9 +3032,7 @@ void SetupProcessObject(Environment* env,
                     FIXED_ONE_BYTE_STRING(env->isolate(), ARES_VERSION_STR));
 
 #if defined(NODE_HAVE_I18N_SUPPORT) && defined(U_ICU_VERSION)
-  READONLY_PROPERTY(versions,
-                    "icu",
-                    OneByteString(env->isolate(), U_ICU_VERSION));
+  // ICU-related versions are now handled on the js side, see bootstrap_node.js
 
   if (icu_data_dir != nullptr) {
     // Did the user attempt (via env var or parameter) to set an ICU path?

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -11,6 +11,9 @@ if (common.hasCrypto) {
 
 if (common.hasIntl) {
   expected_keys.push('icu');
+  expected_keys.push('cldr');
+  expected_keys.push('tz');
+  expected_keys.push('unicode');
 }
 
 expected_keys.sort();


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
intl, bootstrap_node.js

##### Description of change

* Adds process.versions.cldr, .tz, and .unicode
* Changes how process.versions.icu is loaded
* Lazy loads the process.versions.* values for these
* Note: "node -p process.versions" shows "[Getter]" for these values

Fixes: https://github.com/nodejs/node/issues/9237