### PR TITLE
inspector: add contexts when using vm module

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -175,7 +175,7 @@ inline Environment::Environment(IsolateData* isolate_data,
       debugger_agent_(this),
 #if HAVE_INSPECTOR
       inspector_agent_(this),
-#endif
+#endif  // HAVE_INSPECTOR
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
       context_(context->GetIsolate(), context) {
@@ -376,7 +376,8 @@ inline void Environment::ContextDestroyed(v8::Local<v8::Context> context) {
     }
   }
 }
-#endif
+
+#endif  // HAVE_INSPECTOR
 
 inline void Environment::ThrowError(const char* errmsg) {
   ThrowError(v8::Exception::Error, errmsg);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -356,16 +356,18 @@ inline IsolateData* Environment::isolate_data() const {
   return isolate_data_;
 }
 
-inline void Environment::context_created(v8_inspector::V8ContextInfo info) {
+#if HAVE_INSPECTOR
+inline void Environment::ContextCreated(node::inspector::ContextInfo* info) {
   contexts()->push_back(info);
   if (inspector_agent()->IsStarted()) {
     inspector_agent()->ContextCreated(info);
   }
 }
-inline void Environment::context_destroyed(v8::Local<v8::Context> context) {
+inline void Environment::ContextDestroyed(v8::Local<v8::Context> context) {
   for (auto i = std::begin(*contexts()); i != std::end(*contexts()); ++i) {
     auto it = *i;
-    if (it.context == context) {
+    if (it->context(isolate()) == context) {
+      delete it;
       contexts()->erase(i);
       if (inspector_agent()->IsStarted()) {
           inspector_agent()->ContextDestroyed(context);
@@ -374,6 +376,7 @@ inline void Environment::context_destroyed(v8::Local<v8::Context> context) {
     }
   }
 }
+#endif
 
 inline void Environment::ThrowError(const char* errmsg) {
   ThrowError(v8::Exception::Error, errmsg);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -356,6 +356,25 @@ inline IsolateData* Environment::isolate_data() const {
   return isolate_data_;
 }
 
+inline void Environment::context_created(v8_inspector::V8ContextInfo info) {
+  contexts()->push_back(info);
+  if (inspector_agent()->IsStarted()) {
+    inspector_agent()->ContextCreated(info);
+  }
+}
+inline void Environment::context_destroyed(v8::Local<v8::Context> context) {
+  for (auto i = std::begin(*contexts()); i != std::end(*contexts()); ++i) {
+    auto it = *i;
+    if (it.context == context) {
+      contexts()->erase(i);
+      if (inspector_agent()->IsStarted()) {
+          inspector_agent()->ContextDestroyed(context);
+      }
+      return;
+    }
+  }
+}
+
 inline void Environment::ThrowError(const char* errmsg) {
   ThrowError(v8::Exception::Error, errmsg);
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -36,7 +36,7 @@ void Environment::Start(int argc,
 
 #if HAVE_INSPECTOR
   ContextCreated(
-    new node::inspector::ContextInfo(context(), 1, "NodeJS Main Context"));
+      new node::inspector::ContextInfo(context(), 1, "NodeJS Main Context"));
 #endif
 
   uv_check_init(event_loop(), immediate_check_handle());

--- a/src/env.cc
+++ b/src/env.cc
@@ -30,6 +30,11 @@ void Environment::Start(int argc,
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context());
 
+  context_created(
+    v8_inspector::V8ContextInfo(context(), 1, "NodeJS Main Context"));
+
+  isolate()->SetAutorunMicrotasks(false);
+
   uv_check_init(event_loop(), immediate_check_handle());
   uv_unref(reinterpret_cast<uv_handle_t*>(immediate_check_handle()));
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -12,6 +12,10 @@
 
 #include <stdio.h>
 
+#if HAVE_INSPECTOR
+#include "inspector_agent.h"
+#endif
+
 namespace node {
 
 using v8::Context;
@@ -30,8 +34,10 @@ void Environment::Start(int argc,
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context());
 
-  context_created(
-    v8_inspector::V8ContextInfo(context(), 1, "NodeJS Main Context"));
+#if HAVE_INSPECTOR
+  ContextCreated(
+    new node::inspector::ContextInfo(context(), 1, "NodeJS Main Context"));
+#endif
 
   isolate()->SetAutorunMicrotasks(false);
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -39,8 +39,6 @@ void Environment::Start(int argc,
     new node::inspector::ContextInfo(context(), 1, "NodeJS Main Context"));
 #endif
 
-  isolate()->SetAutorunMicrotasks(false);
-
   uv_check_init(event_loop(), immediate_check_handle());
   uv_unref(reinterpret_cast<uv_handle_t*>(immediate_check_handle()));
 

--- a/src/env.h
+++ b/src/env.h
@@ -530,9 +530,9 @@ class Environment {
     return &inspector_agent_;
   }
 
-  inline void context_created(v8_inspector::V8ContextInfo context);
-  inline void context_destroyed(v8::Local<v8::Context> context);
-  inline std::vector<v8_inspector::V8ContextInfo>* contexts() {
+  inline void ContextCreated(node::inspector::ContextInfo* info);
+  inline void ContextDestroyed(v8::Local<v8::Context> context);
+  inline std::vector<node::inspector::ContextInfo*>* contexts() {
     return &contexts_;
   }
 #endif
@@ -571,7 +571,7 @@ class Environment {
   debugger::Agent debugger_agent_;
 #if HAVE_INSPECTOR
   inspector::Agent inspector_agent_;
-  std::vector<v8_inspector::V8ContextInfo> contexts_;
+  std::vector<node::inspector::ContextInfo*> contexts_;
 #endif
 
   HandleWrapQueue handle_wrap_queue_;

--- a/src/env.h
+++ b/src/env.h
@@ -7,6 +7,7 @@
 #include "debug-agent.h"
 #if HAVE_INSPECTOR
 #include "inspector_agent.h"
+#include <vector>
 #endif
 #include "handle_wrap.h"
 #include "req-wrap.h"
@@ -528,6 +529,12 @@ class Environment {
   inline inspector::Agent* inspector_agent() {
     return &inspector_agent_;
   }
+
+  inline void context_created(v8_inspector::V8ContextInfo context);
+  inline void context_destroyed(v8::Local<v8::Context> context);
+  inline std::vector<v8_inspector::V8ContextInfo>* contexts() {
+    return &contexts_;
+  }
 #endif
 
   typedef ListHead<HandleWrap, &HandleWrap::handle_wrap_queue_> HandleWrapQueue;
@@ -564,6 +571,7 @@ class Environment {
   debugger::Agent debugger_agent_;
 #if HAVE_INSPECTOR
   inspector::Agent inspector_agent_;
+  std::vector<v8_inspector::V8ContextInfo> contexts_;
 #endif
 
   HandleWrapQueue handle_wrap_queue_;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -191,7 +191,7 @@ class AgentImpl {
   bool Start(v8::Platform* platform, const char* path, int port, bool wait);
   // Stop the inspector agent
   void Stop();
-  void ContextCreated(const v8_inspector::V8ContextInfo& info);
+  void ContextCreated(const node::inspector::ContextInfo* info);
   void ContextDestroyed(v8::Local<v8::Context> context);
 
   bool IsStarted();
@@ -331,9 +331,14 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
     }
   }
 
-  void contextCreated(const v8_inspector::V8ContextInfo& info) {
-    inspector()->contextCreated(info);
+  void contextCreated(const node::inspector::ContextInfo* info) {
+    inspector()->contextCreated(
+      v8_inspector::V8ContextInfo(
+        info->context(env_->isolate()),
+        info->groupId(),
+        info->name()));
   }
+
   void contextDestroyed(v8::Local<v8::Context> context) {
     inspector()->contextDestroyed(context);
   }
@@ -521,7 +526,7 @@ void AgentImpl::Stop() {
   delete inspector_;
 }
 
-void AgentImpl::ContextCreated(const v8_inspector::V8ContextInfo& info) {
+void AgentImpl::ContextCreated(const node::inspector::ContextInfo* info) {
   inspector_->contextCreated(info);
 }
 void AgentImpl::ContextDestroyed(v8::Local<v8::Context> context) {
@@ -883,7 +888,7 @@ void Agent::Stop() {
   impl->Stop();
 }
 
-void Agent::ContextCreated(const v8_inspector::V8ContextInfo& info) {
+void Agent::ContextCreated(const node::inspector::ContextInfo* info) {
   impl->ContextCreated(info);
 }
 void Agent::ContextDestroyed(v8::Local<v8::Context> context) {

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -326,17 +326,17 @@ class V8NodeInspector : public v8_inspector::V8InspectorClient {
                     running_nested_loop_(false),
                     inspector_(V8Inspector::create(env->isolate(), this)) {
     v8::HandleScope handles(env_->isolate());
-    for (auto it : *(env->contexts())) {
+    for (auto it : *env->contexts()) {
       contextCreated(it);
     }
   }
 
   void contextCreated(const node::inspector::ContextInfo* info) {
     inspector()->contextCreated(
-      v8_inspector::V8ContextInfo(
-        info->context(env_->isolate()),
-        info->groupId(),
-        info->name()));
+        v8_inspector::V8ContextInfo(
+          info->context(env_->isolate()),
+          info->groupId(),
+          info->name()));
   }
 
   void contextDestroyed(v8::Local<v8::Context> context) {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -27,23 +27,20 @@ class AgentImpl;
 
 class ContextInfo {
  public:
-  explicit ContextInfo(v8::Local<v8::Context> context, int groupId,
+  explicit ContextInfo(v8::Local<v8::Context> context, const int groupId,
                        const char* name)
-                       : groupId_(groupId),
+                       : group_id_(groupId),
                        name_(name) {
                        context_.Reset(context->GetIsolate(), context);
-  }
-  ~ContextInfo() {
-    context_.Reset();
   }
   inline v8::Local<v8::Context> context(v8::Isolate* isolate) const {
     return context_.Get(isolate);
   }
-  int groupId() const { return groupId_; }
+  int groupId() const { return group_id_; }
   const char* name() const { return name_; }
  private:
   v8::Persistent<v8::Context> context_;
-  int groupId_;
+  const int group_id_;
   const char* name_;
 };
 

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -5,6 +5,8 @@
 #error("This header can only be used when inspector is enabled")
 #endif
 
+#include "platform/v8_inspector/public/V8Inspector.h"
+
 // Forward declaration to break recursive dependency chain with src/env.h.
 namespace node {
 class Environment;
@@ -32,6 +34,9 @@ class Agent {
   bool Start(v8::Platform* platform, const char* path, int port, bool wait);
   // Stop the inspector agent
   void Stop();
+
+  void ContextCreated(const v8_inspector::V8ContextInfo& info);
+  void ContextDestroyed(v8::Local<v8::Context> context);
 
   bool IsStarted();
   bool IsConnected();

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -25,6 +25,28 @@ namespace inspector {
 
 class AgentImpl;
 
+class ContextInfo {
+ public:
+  explicit ContextInfo(v8::Local<v8::Context> context, int groupId,
+                       const char* name)
+                       : groupId_(groupId),
+                       name_(name) {
+                       context_.Reset(context->GetIsolate(), context);
+  }
+  ~ContextInfo() {
+    context_.Reset();
+  }
+  inline v8::Local<v8::Context> context(v8::Isolate* isolate) const {
+    return context_.Get(isolate);
+  }
+  int groupId() const { return groupId_; }
+  const char* name() const { return name_; }
+ private:
+  v8::Persistent<v8::Context> context_;
+  int groupId_;
+  const char* name_;
+};
+
 class Agent {
  public:
   explicit Agent(node::Environment* env);
@@ -35,7 +57,7 @@ class Agent {
   // Stop the inspector agent
   void Stop();
 
-  void ContextCreated(const v8_inspector::V8ContextInfo& info);
+  void ContextCreated(const ContextInfo* info);
   void ContextDestroyed(v8::Local<v8::Context> context);
 
   bool IsStarted();

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -10,7 +10,7 @@
 #include "v8-debug.h"
 
 #if HAVE_INSPECTOR
-#include "platform/v8_inspector/public/V8Inspector.h"
+#include "inspector_agent.h"
 #endif
 
 namespace node {
@@ -212,8 +212,8 @@ class ContextifyContext {
 
     Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
 #if HAVE_INSPECTOR
-    env->context_created(
-      v8_inspector::V8ContextInfo(ctx, 1, "vm Module Context"));
+    env->ContextCreated(
+      new node::inspector::ContextInfo(ctx, 1, "vm Module Context"));
 #endif
 
     if (ctx.IsEmpty()) {
@@ -332,7 +332,7 @@ class ContextifyContext {
   static void WeakCallback(const WeakCallbackInfo<ContextifyContext>& data) {
     ContextifyContext* context = data.GetParameter();
 #if HAVE_INSPECTOR
-    context->env()->context_destroyed(context->context());
+    context->env()->ContextDestroyed(context->context());
 #endif
     delete context;
   }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -9,6 +9,10 @@
 #include "util-inl.h"
 #include "v8-debug.h"
 
+#if HAVE_INSPECTOR
+#include "platform/v8_inspector/public/V8Inspector.h"
+#endif
+
 namespace node {
 
 using v8::Array;
@@ -207,6 +211,10 @@ class ContextifyContext {
     object_template->SetHandler(config);
 
     Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
+#if HAVE_INSPECTOR
+    env->context_created(
+      v8_inspector::V8ContextInfo(ctx, 1, "vm Module Context"));
+#endif
 
     if (ctx.IsEmpty()) {
       env->ThrowError("Could not instantiate context");
@@ -323,6 +331,9 @@ class ContextifyContext {
 
   static void WeakCallback(const WeakCallbackInfo<ContextifyContext>& data) {
     ContextifyContext* context = data.GetParameter();
+#if HAVE_INSPECTOR
+    context->env()->context_destroyed(context->context());
+#endif
     delete context;
   }
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -213,7 +213,7 @@ class ContextifyContext {
     Local<Context> ctx = Context::New(env->isolate(), nullptr, object_template);
 #if HAVE_INSPECTOR
     env->ContextCreated(
-      new node::inspector::ContextInfo(ctx, 1, "vm Module Context"));
+        new node::inspector::ContextInfo(ctx, 1, "vm Module Context"));
 #endif
 
     if (ctx.IsEmpty()) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

inspector
##### Description of change

<!-- Provide a description of the change below this comment. -->

Tracks all `vm` module contexts for usage in v8_inspector. These are tracked even when the inspector is not running so that they are visible when the inspector is started up.

Fixes: https://github.com/nodejs/node/issues/7593
