### PR TITLE
socket.end() can take a callback function

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -540,7 +540,7 @@ listeners for that event will receive `exception` as an argument.
 A Boolean value that indicates if the connection is destroyed or not. Once a
 connection is destroyed no further data can be transferred using it.
 
-### socket.end([data][, encoding])
+### socket.end([data][, encoding][, callback])
 <!-- YAML
 added: v0.1.90
 -->
@@ -550,6 +550,9 @@ server will still send some data.
 
 If `data` is specified, it is equivalent to calling
 `socket.write(data, encoding)` followed by `socket.end()`.
+
+If end is passed a callback function, it will run the function after 
+receiving the FIN packet, but before the final write is completed.
 
 ### socket.localAddress
 <!-- YAML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X ] documentation is changed or added
- [ ] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Documentation
##### Description of change

<!-- Provide a description of the change below this comment. -->

It's undocumented, but socket.end can take a callback function. We discovered this
by passing Mocha's done() callback in, and socket.end does indeed call the function.

You can see the callback code in node/lib/net.js starting line 285
https://github.com/nodejs/node/blob/68ba9aa0fb6693a1fb5dd114a3ddbe447517c0dd/lib/net.js

```
// Provide a better error message when we call end() as a result
// of the other side sending a FIN.  The standard 'write after end'
// is overly vague, and makes it seem like the user's code is to blame.
function writeAfterFIN(chunk, encoding, cb) {
  if (typeof encoding === 'function') {
    cb = encoding;
    encoding = null;
  }

  var er = new Error('This socket has been ended by the other party');
  er.code = 'EPIPE';
  // TODO: defer error events consistently everywhere, not just the cb
  this.emit('error', er);
  if (typeof cb === 'function') {
    process.nextTick(cb, er);
  }
}
```

I'm sure my wording isn't quite right, but please do add the optional [, callback] to the docs!
