### PR TITLE
lib: make `String(global) === '[object global]'`

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -188,6 +188,12 @@
   }
 
   function setupGlobalVariables() {
+    Object.defineProperty(global, Symbol.toStringTag, {
+      value: 'global',
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
     global.process = process;
     const util = NativeModule.require('util');
 

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -21,3 +21,5 @@ const fooBar = module.fooBar;
 assert.strictEqual('foo', fooBar.foo, 'x -> global.x in sub level not working');
 
 assert.strictEqual('bar', fooBar.bar, 'global.x -> x in sub level not working');
+
+assert.strictEqual(Object.prototype.toString.call(global), '[object global]');


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

lib
##### Description of change

This inadvertently changed to `[object Object]` with the V8 upgrade in 8a24728...96933df. Use `Symbol.toStringTag` to undo this particular change.

Fixes: https://github.com/nodejs/node/issues/9274

CI: https://ci.nodejs.org/job/node-test-commit/5899/