### PR TITLE
src: fix use of uninitialized variable

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -586,7 +586,9 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
   TwoByteValue value(env->isolate(), args[0]);
   // reinterpret_cast is required by windows to compile
   UChar* str = reinterpret_cast<UChar*>(*value);
-  UChar32 c;
+  static_assert(sizeof(*str) == sizeof(**value),
+                "sizeof(*str) == sizeof(**value)");
+  UChar32 c = 0;
   UChar32 p;
   size_t n = 0;
   uint32_t width = 0;


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change
Alternative to https://github.com/nodejs/node/pull/9280 ...
The proposed fix in 9280 breaks the calculation algorithm.

Variable was uninitialized in 72547fe28d Initialize the variable and add a static_check

/cc @bnoordhuis @addaleax 