### PR TITLE
module: fix loading from global folders on Windows

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -617,7 +617,16 @@ Module._initPaths = function() {
     homeDir = process.env.HOME;
   }
 
-  var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];
+  // $PREFIX/lib/node, where $PREFIX is the root of the Node.js installation.
+  var prefixDir;
+  // process.execPath is $PREFIX/bin/node except on Windows where it is
+  // $PREFIX\node.exe.
+  if (isWindows) {
+    prefixDir = path.resolve(process.execPath, '..');
+  } else {
+    prefixDir = path.resolve(process.execPath, '..', '..');
+  }
+  var paths = [path.resolve(prefixDir, 'lib', 'node')];
 
   if (homeDir) {
     paths.unshift(path.resolve(homeDir, '.node_libraries'));

--- a/test/fixtures/test-module-loading-globalpaths/home-pkg-in-both/.node_libraries/foo.js
+++ b/test/fixtures/test-module-loading-globalpaths/home-pkg-in-both/.node_libraries/foo.js
@@ -1,0 +1,1 @@
+exports.string = '$HOME/.node_libraries';

--- a/test/fixtures/test-module-loading-globalpaths/home-pkg-in-both/.node_modules/foo.js
+++ b/test/fixtures/test-module-loading-globalpaths/home-pkg-in-both/.node_modules/foo.js
@@ -1,0 +1,1 @@
+exports.string = '$HOME/.node_modules';

--- a/test/fixtures/test-module-loading-globalpaths/home-pkg-in-node_libraries/.node_libraries/foo.js
+++ b/test/fixtures/test-module-loading-globalpaths/home-pkg-in-node_libraries/.node_libraries/foo.js
@@ -1,0 +1,1 @@
+exports.string = '$HOME/.node_libraries';

--- a/test/fixtures/test-module-loading-globalpaths/home-pkg-in-node_modules/.node_modules/foo.js
+++ b/test/fixtures/test-module-loading-globalpaths/home-pkg-in-node_modules/.node_modules/foo.js
@@ -1,0 +1,1 @@
+exports.string = '$HOME/.node_modules';

--- a/test/fixtures/test-module-loading-globalpaths/local-pkg/node_modules/foo.js
+++ b/test/fixtures/test-module-loading-globalpaths/local-pkg/node_modules/foo.js
@@ -1,0 +1,1 @@
+exports.string = 'local';

--- a/test/fixtures/test-module-loading-globalpaths/local-pkg/test.js
+++ b/test/fixtures/test-module-loading-globalpaths/local-pkg/test.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log(require('foo').string);

--- a/test/fixtures/test-module-loading-globalpaths/node_path/foo.js
+++ b/test/fixtures/test-module-loading-globalpaths/node_path/foo.js
@@ -1,0 +1,1 @@
+exports.string = '$NODE_PATH';

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -1,0 +1,101 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const child_process = require('child_process');
+const pkgName = 'foo';
+
+if (process.argv[2] === 'child') {
+  console.log(require(pkgName).string);
+} else {
+  common.refreshTmpDir();
+
+  // Copy node binary into a test $PREFIX directory.
+  const prefixPath = path.join(common.tmpDir, 'install');
+  fs.mkdirSync(prefixPath);
+  let testExecPath;
+  if (common.isWindows) {
+    testExecPath = path.join(prefixPath, path.basename(process.execPath));
+  } else {
+    const prefixBinPath = path.join(prefixPath, 'bin');
+    fs.mkdirSync(prefixBinPath);
+    testExecPath = path.join(prefixBinPath, path.basename(process.execPath));
+  }
+  const mode = fs.statSync(process.execPath).mode;
+  fs.writeFileSync(testExecPath, fs.readFileSync(process.execPath));
+  fs.chmodSync(testExecPath, mode);
+
+  const runTest = (expectedString, env) => {
+    const child = child_process.execFileSync(testExecPath,
+                                             [ __filename, 'child' ],
+                                             { encoding: 'utf8', env: env });
+    assert.strictEqual(child.trim(), expectedString);
+  };
+
+  const testFixturesDir = path.join(common.fixturesDir,
+                                    path.basename(__filename, '.js'));
+
+  const env = Object.assign({}, process.env);
+  // Turn on module debug to aid diagnosing failures.
+  env['NODE_DEBUG'] = 'module';
+  // Unset NODE_PATH.
+  delete env['NODE_PATH'];
+
+  // Test empty global path.
+  const noPkgHomeDir = path.join(common.tmpDir, 'home-no-pkg');
+  fs.mkdirSync(noPkgHomeDir);
+  env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
+  assert.throws(
+      () => {
+        child_process.execFileSync(testExecPath, [ __filename, 'child' ],
+                                   { encoding: 'utf8', env: env });
+      },
+      new RegExp('Cannot find module \'' + pkgName + '\''));
+
+  // Test module in $HOME/.node_modules.
+  const modHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_modules');
+  env['HOME'] = env['USERPROFILE'] = modHomeDir;
+  runTest('$HOME/.node_modules', env);
+
+  // Test module in $HOME/.node_libraries.
+  const libHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_libraries');
+  env['HOME'] = env['USERPROFILE'] = libHomeDir;
+  runTest('$HOME/.node_libraries', env);
+
+  // Test module both $HOME/.node_modules and $HOME/.node_libraries.
+  const bothHomeDir = path.join(testFixturesDir, 'home-pkg-in-both');
+  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
+  runTest('$HOME/.node_modules', env);
+
+  // Test module in $PREFIX/lib/node.
+  // Write module into $PREFIX/lib/node.
+  const expectedString = '$PREFIX/lib/node';
+  const prefixLibPath = path.join(prefixPath, 'lib');
+  fs.mkdirSync(prefixLibPath);
+  const prefixLibNodePath = path.join(prefixLibPath, 'node');
+  fs.mkdirSync(prefixLibNodePath);
+  const pkgPath = path.join(prefixLibNodePath, pkgName + '.js');
+  fs.writeFileSync(pkgPath, 'exports.string = \'' + expectedString + '\';');
+
+  env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
+  runTest(expectedString, env);
+
+  // Test module in all global folders.
+  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
+  runTest('$HOME/.node_modules', env);
+
+  // Test module in NODE_PATH is loaded ahead of global folders.
+  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
+  env['NODE_PATH'] = path.join(testFixturesDir, 'node_path');
+  runTest('$NODE_PATH', env);
+
+  // Test module in local folder is loaded ahead of global folders.
+  const localDir = path.join(testFixturesDir, 'local-pkg');
+  env['HOME'] = env['USERPROFILE'] = bothHomeDir;
+  env['NODE_PATH'] = path.join(testFixturesDir, 'node_path');
+  const child = child_process.execFileSync(testExecPath,
+                                           [ path.join(localDir, 'test.js') ],
+                                           { encoding: 'utf8', env: env });
+  assert.strictEqual(child.trim(), 'local');
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

module
##### Description of change

According to [the `module` documentation](https://nodejs.org/dist/latest-v6.x/docs/api/modules.html#modules_loading_from_the_global_folders):

```
Additionally, Node.js will search in the following locations:

    1: $HOME/.node_modules
    2: $HOME/.node_libraries
    3: $PREFIX/lib/node

Where $HOME is the user's home directory, and $PREFIX is Node.js's configured node_prefix.
```

Loading from `$PREFIX/lib/node` is broken on Windows as the code is calculating  `$PREFIX/lib/node` 
relative to `process.execPath`, but on Windows `process.execPath` is `$PREFIX\node.exe` whereas everywhere else `process.execPath` is `$PREFIX/bin/node` (where `$PREFIX` is the root of the
installed Node.js).

e.g. If Node.js is in `c:\node`, the code is adding `c:\lib\node` to the lookup path instead of `c:\node\lib\node`:
```
C:\node>set NODE_DEBUG=module

C:\node>node nosuchfile
MODULE 12780: looking for "C:\\node\\nosuchfile" in ["C:\\Users\\IBM_ADMIN\\.nod
e_modules","C:\\Users\\IBM_ADMIN\\.node_libraries","C:\\lib\\node"]
module.js:472
    throw err;
    ^

Error: Cannot find module 'C:\node\nosuchfile'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:535:3

C:\node>
```