### PR TITLE
buffer: use correct name for custom inspect symbol

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -527,7 +527,7 @@ Buffer.prototype.equals = function equals(b) {
 
 
 // Override how buffers are presented by util.inspect().
-Buffer.prototype[internalUtil.inspectSymbol] = function inspect() {
+Buffer.prototype[internalUtil.customInspectSymbol] = function inspect() {
   var str = '';
   var max = exports.INSPECT_MAX_BYTES;
   if (this.length > 0) {
@@ -537,7 +537,7 @@ Buffer.prototype[internalUtil.inspectSymbol] = function inspect() {
   }
   return '<' + this.constructor.name + ' ' + str + '>';
 };
-Buffer.prototype.inspect = Buffer.prototype[internalUtil.inspectSymbol];
+Buffer.prototype.inspect = Buffer.prototype[internalUtil.customInspectSymbol];
 
 Buffer.prototype.compare = function compare(target,
                                             start,

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -34,3 +34,6 @@ assert.doesNotThrow(function() {
   assert.strictEqual(util.inspect(b), expected);
   assert.strictEqual(util.inspect(s), expected);
 });
+
+b.inspect = undefined;
+assert.strictEqual(util.inspect(b), expected);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` passes (in only 3 hours!)
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

59714cb7b3918c9e4fcd94013b778078d3710705 introduced the `util.inspect.custom` symbol, but it was exported as `customInspectSymbol` by `internal/util.js` and referenced as `inspectSymbol` by `buffer.js`.