### PR TITLE
url: refactor truncating long hostname

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -416,7 +416,7 @@ function validateHostname(self, rest, hostname) {
                     (code >= 48/*0*/ && code <= 57/*9*/) ||
                     code === 45/*-*/ ||
                     code === 43/*+*/ ||
-                    code === 95/*_*/||
+                    code === 95/*_*/ ||
                     code > 127;
 
     // Invalid host character

--- a/lib/url.js
+++ b/lib/url.js
@@ -408,19 +408,19 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 };
 
 function validateHostname(self, rest, hostname) {
-  for (var i = 0; i <= hostname.length; ++i) {
+  for (var i = 0; i < hostname.length; ++i) {
     const code = hostname.charCodeAt(i);
     const isVc = code === 46/*.*/ ||
-                 code >= 48/*0*/ && code <= 57/*9*/ ||
-                 code >= 97/*a*/ && code <= 122/*\z*/ ||
+                 (code >= 48/*0*/ && code <= 57/*9*/) ||
+                 (code >= 97/*a*/ && code <= 122/*z*/) ||
                  code === 45/*-*/ ||
-                 code >= 65/*A*/ && code <= 90/*Z*/ ||
+                 (code >= 65/*A*/ && code <= 90/*Z*/) ||
                  code === 43/*+*/ ||
                  code === 95/*_*/||
                  code > 127;
 
     // Invalid host character
-    if (!isVc && i !== hostname.length) {
+    if (!isVc) {
       self.hostname = hostname.slice(0, i);
       return '/' + hostname.slice(i) + rest;
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -408,33 +408,22 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 };
 
 function validateHostname(self, rest, hostname) {
-  for (var i = 0, lastPos; i <= hostname.length; ++i) {
-    var code;
-    if (i < hostname.length)
-      code = hostname.charCodeAt(i);
-    if (code === 46/*.*/ || i === hostname.length) {
-      if (i - lastPos > 0) {
-        if (i - lastPos > 63) {
-          self.hostname = hostname.slice(0, lastPos + 63);
-          return '/' + hostname.slice(lastPos + 63) + rest;
-        }
-      }
-      lastPos = i + 1;
-      continue;
-    } else if ((code >= 48/*0*/ && code <= 57/*9*/) ||
-               (code >= 97/*a*/ && code <= 122/*z*/) ||
-               code === 45/*-*/ ||
-               (code >= 65/*A*/ && code <= 90/*Z*/) ||
-               code === 43/*+*/ ||
-               code === 95/*_*/ ||
-               code > 127) {
-      continue;
-    }
+  for (var i = 0; i <= hostname.length; ++i) {
+    const code = hostname.charCodeAt(i);
+    const isVc = code === 46/*.*/ ||
+                 code >= 48/*0*/ && code <= 57/*9*/ ||
+                 code >= 97/*a*/ && code <= 122/*\z*/ ||
+                 code === 45/*-*/ ||
+                 code >= 65/*A*/ && code <= 90/*Z*/ ||
+                 code === 43/*+*/ ||
+                 code === 95/*_*/||
+                 code > 127;
+
     // Invalid host character
-    self.hostname = hostname.slice(0, i);
-    if (i < hostname.length)
+    if (!isVc && i !== hostname.length) {
+      self.hostname = hostname.slice(0, i);
       return '/' + hostname.slice(i) + rest;
-    break;
+    }
   }
 }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -410,17 +410,17 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 function validateHostname(self, rest, hostname) {
   for (var i = 0; i < hostname.length; ++i) {
     const code = hostname.charCodeAt(i);
-    const isVc = code === 46/*.*/ ||
-                 (code >= 48/*0*/ && code <= 57/*9*/) ||
-                 (code >= 97/*a*/ && code <= 122/*z*/) ||
-                 code === 45/*-*/ ||
-                 (code >= 65/*A*/ && code <= 90/*Z*/) ||
-                 code === 43/*+*/ ||
-                 code === 95/*_*/||
-                 code > 127;
+    const isValid = (code >= 97/*a*/ && code <= 122/*z*/) ||
+                    code === 46/*.*/ ||
+                    (code >= 65/*A*/ && code <= 90/*Z*/) ||
+                    (code >= 48/*0*/ && code <= 57/*9*/) ||
+                    code === 45/*-*/ ||
+                    code === 43/*+*/ ||
+                    code === 95/*_*/||
+                    code > 127;
 
     // Invalid host character
-    if (!isVc) {
+    if (!isValid) {
       self.hostname = hostname.slice(0, i);
       return '/' + hostname.slice(i) + rest;
     }

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1225,6 +1225,17 @@ var formatTests = {
     path: '/node'
   },
 
+   // greater than or equal to 63 characters after `.` in hostname
+  [`http://www.${'z'.repeat(63)}example.com/node`]: {
+    href: `http://www.${'z'.repeat(63)}example.com/node`,
+    protocol: 'http:',
+    slashes: true,
+    host: `www.${'z'.repeat(63)}example.com`,
+    hostname: `www.${'z'.repeat(63)}example.com`,
+    pathname: '/node',
+    path: '/node'
+  },
+
   // https://github.com/nodejs/node/issues/3361
   'file:///home/user': {
     href: 'file:///home/user',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib url
test url


##### Description of change
<!-- Provide a description of the change below this comment. -->
I deleted and refactored the line around 417 in url.js which was truncating hostname if hostname length after `.` is more than 63. Thus url parse behavior for hostname should be same as browser's behavior. Now it  doesn’t truncate hostname.