### PR TITLE
doc: fix broken links to Buffer.from(string)

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2417,7 +2417,7 @@ console.log(buf);
 [`Buffer.from(array)`]: #buffer_class_method_buffer_from_array
 [`Buffer.from(arrayBuffer)`]: #buffer_class_method_buffer_from_arraybuffer_byteoffset_length
 [`Buffer.from(buffer)`]: #buffer_class_method_buffer_from_buffer
-[`Buffer.from(string)`]: #buffer_class_method_buffer_from_str_encoding
+[`Buffer.from(string)`]: #buffer_class_method_buffer_from_string_encoding
 [`Buffer.poolSize`]: #buffer_class_property_buffer_poolsize
 [`RangeError`]: errors.html#errors_class_rangeerror
 [`util.inspect()`]: util.html#util_util_inspect_object_options


### PR DESCRIPTION
##### Checklist
- [X] documentation is changed or added
- [X] commit message follows commit guidelines
##### Affected core subsystem(s)

doc
##### Description of change

Links to `Buffer.from(string)` were broken except for the one in the method list at the top. I didn't look into how the fragment IDs are generated, I just copied this one from the output.
