### PR TITLE
dns: implement {ttl: true} for dns.resolve4() and dns.resolve6()

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -200,7 +200,7 @@ will contain an array of IPv4 addresses (e.g.
     rather than an array of strings.  The TTL is expressed in seconds.
 * `callback` {Function} An `(err, result)` callback function.
 
-## dns.resolve6(hostname, callback)
+## dns.resolve6(hostname[, options], callback)
 <!-- YAML
 added: v0.1.16
 -->
@@ -208,6 +208,13 @@ added: v0.1.16
 Uses the DNS protocol to resolve a IPv6 addresses (`AAAA` records) for the
 `hostname`. The `addresses` argument passed to the `callback` function
 will contain an array of IPv6 addresses.
+
+* `hostname` {String} Hostname to resolve.
+* `options` {Object}
+  * `ttl` {Boolean} Retrieve the Time-To-Live value (TTL) of each record.
+    The callback receives an array of `{ address: '0:1:2:3:4:5:6:7', ttl: 60 }`
+    objects rather than an array of strings.  The TTL is expressed in seconds.
+* `callback` {Function} An `(err, result)` callback function.
 
 ## dns.resolveCname(hostname, callback)
 <!-- YAML

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -183,7 +183,7 @@ corresponding lookup methods.
 On error, `err` is an [`Error`][] object, where `err.code` is
 one of the error codes listed [here](#dns_error_codes).
 
-## dns.resolve4(hostname, callback)
+## dns.resolve4(hostname[, options], callback)
 <!-- YAML
 added: v0.1.16
 -->
@@ -192,6 +192,13 @@ Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the
 `hostname`. The `addresses` argument passed to the `callback` function
 will contain an array of IPv4 addresses (e.g.
 `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
+
+* `hostname` {String} Hostname to resolve.
+* `options` {Object}
+  * `ttl` {Boolean} Retrieve the Time-To-Live value (TTL) of each record.
+    The callback receives an array of `{ address: '1.2.3.4', ttl: 60 }` objects
+    rather than an array of strings.  The TTL is expressed in seconds.
+* `callback` {Function} An `(err, result)` callback function.
 
 ## dns.resolve6(hostname, callback)
 <!-- YAML

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -211,7 +211,10 @@ exports.lookupService = function lookupService(host, port, callback) {
 };
 
 
-function onresolve(err, result) {
+function onresolve(err, result, ttls) {
+  if (ttls && this.ttl)
+    result = result.map((address, index) => ({ address, ttl: ttls[index] }));
+
   if (err)
     this.callback(errnoException(err, this.bindingName, this.hostname));
   else
@@ -222,7 +225,13 @@ function onresolve(err, result) {
 function resolver(bindingName) {
   var binding = cares[bindingName];
 
-  return function query(name, callback) {
+  return function query(name, /* options, */ callback) {
+    var options;
+    if (arguments.length > 2) {
+      options = callback;
+      callback = arguments[2];
+    }
+
     if (typeof name !== 'string') {
       throw new Error('"name" argument must be a string');
     } else if (typeof callback !== 'function') {
@@ -235,6 +244,7 @@ function resolver(bindingName) {
     req.callback = callback;
     req.hostname = name;
     req.oncomplete = onresolve;
+    req.ttl = !!(options && options.ttl);
     var err = binding(req, name);
     if (err) throw errnoException(err, bindingName);
     callback.immediately = true;

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -336,25 +336,17 @@ class QueryWrap : public AsyncWrap {
     delete wrap;
   }
 
-  void CallOnComplete(Local<Value> answer) {
-    HandleScope handle_scope(env()->isolate());
-    Context::Scope context_scope(env()->context());
-    Local<Value> argv[] = {
-      Integer::New(env()->isolate(), 0),
-      answer
-    };
-    MakeCallback(env()->oncomplete_string(), arraysize(argv), argv);
-  }
-
-  void CallOnComplete(Local<Value> answer, Local<Value> family) {
+  void CallOnComplete(Local<Value> answer,
+                      Local<Value> extra = Local<Value>()) {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
     Local<Value> argv[] = {
       Integer::New(env()->isolate(), 0),
       answer,
-      family
+      extra
     };
-    MakeCallback(env()->oncomplete_string(), arraysize(argv), argv);
+    const int argc = arraysize(argv) - extra.IsEmpty();
+    MakeCallback(env()->oncomplete_string(), argc, argv);
   }
 
   void ParseError(int status) {
@@ -400,18 +392,27 @@ class QueryAWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    struct hostent* host;
+    hostent* host;
+    ares_addrttl addrttls[256];
+    int naddrttls = arraysize(addrttls);
 
-    int status = ares_parse_a_reply(buf, len, &host, nullptr, nullptr);
+    int status = ares_parse_a_reply(buf, len, &host, addrttls, &naddrttls);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
 
     Local<Array> addresses = HostentToAddresses(env(), host);
+    Local<Array> ttls = Array::New(env()->isolate(), naddrttls);
+
+    auto context = env()->context();
+    for (int i = 0; i < naddrttls; i += 1) {
+      auto value = Integer::New(env()->isolate(), addrttls[i].ttl);
+      ttls->Set(context, i, value).FromJust();
+    }
     ares_free_hostent(host);
 
-    this->CallOnComplete(addresses);
+    CallOnComplete(addresses, ttls);
   }
 };
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -440,18 +440,27 @@ class QueryAaaaWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    struct hostent* host;
+    hostent* host;
+    ares_addr6ttl addrttls[256];
+    int naddrttls = arraysize(addrttls);
 
-    int status = ares_parse_aaaa_reply(buf, len, &host, nullptr, nullptr);
+    int status = ares_parse_aaaa_reply(buf, len, &host, addrttls, &naddrttls);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
 
     Local<Array> addresses = HostentToAddresses(env(), host);
+    Local<Array> ttls = Array::New(env()->isolate(), naddrttls);
+
+    auto context = env()->context();
+    for (int i = 0; i < naddrttls; i += 1) {
+      auto value = Integer::New(env()->isolate(), addrttls[i].ttl);
+      ttls->Set(context, i, value).FromJust();
+    }
     ares_free_hostent(host);
 
-    this->CallOnComplete(addresses);
+    CallOnComplete(addresses, ttls);
   }
 };
 

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -81,6 +81,27 @@ TEST(function test_resolve4_ttl(done) {
   checkWrap(req);
 });
 
+TEST(function test_resolve6_ttl(done) {
+  var req = dns.resolve6('google.com', { ttl: true }, function(err, result) {
+    assert.ifError(err);
+    assert.ok(result.length > 0);
+
+    for (var i = 0; i < result.length; i++) {
+      var item = result[i];
+      assert.ok(item);
+      assert.strictEqual(typeof item, 'object');
+      assert.strictEqual(typeof item.ttl, 'number');
+      assert.strictEqual(typeof item.address, 'string');
+      assert.ok(item.ttl > 0);
+      assert.ok(isIPv6(item.address));
+    }
+
+    done();
+  });
+
+  checkWrap(req);
+});
+
 TEST(function test_resolveMx(done) {
   var req = dns.resolveMx('gmail.com', function(err, result) {
     if (err) throw err;

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -60,6 +60,26 @@ TEST(function test_reverse_bogus(done) {
   done();
 });
 
+TEST(function test_resolve4_ttl(done) {
+  var req = dns.resolve4('google.com', { ttl: true }, function(err, result) {
+    assert.ifError(err);
+    assert.ok(result.length > 0);
+
+    for (var i = 0; i < result.length; i++) {
+      var item = result[i];
+      assert.ok(item);
+      assert.strictEqual(typeof item, 'object');
+      assert.strictEqual(typeof item.ttl, 'number');
+      assert.strictEqual(typeof item.address, 'string');
+      assert.ok(item.ttl > 0);
+      assert.ok(isIPv4(item.address));
+    }
+
+    done();
+  });
+
+  checkWrap(req);
+});
 
 TEST(function test_resolveMx(done) {
   var req = dns.resolveMx('gmail.com', function(err, result) {


### PR DESCRIPTION
See discussion in https://github.com/nodejs/node/issues/5893 and other issues.  We can retrieve the TTL for A and AAAA records looked up through the `dns.resolve()` function family.

I'll write up documentation and nice commit logs if we decide this is something we want to do.  Example output:

```
$ out/Release/node -e 'dns.resolve4("google.com", {ttl:true}, console.log)'
null [ { address: '82.94.228.160', ttl: 299 },
  { address: '82.94.228.173', ttl: 299 },
  { address: '82.94.228.166', ttl: 299 },
  { address: '82.94.228.180', ttl: 299 },
  { address: '82.94.228.159', ttl: 299 },
  { address: '82.94.228.167', ttl: 299 },
  { address: '82.94.228.181', ttl: 299 },
  { address: '82.94.228.187', ttl: 299 },
  { address: '82.94.228.153', ttl: 299 },
  { address: '82.94.228.146', ttl: 299 },
  { address: '82.94.228.152', ttl: 299 },
  { address: '82.94.228.174', ttl: 299 } ]
```
