### PR TITLE
test: use 'strictEqual' instead of 'equal'

### DIFF
--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -119,6 +119,6 @@ process.on('exit', function() {
   if (keyList.length !== 0) {
     process._rawDebug('Not all keys have been used:');
     process._rawDebug(keyList);
-    assert.equal(keyList.length, 0);
+    assert.strictEqual(keyList.length, 0);
   }
 });

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -36,7 +36,7 @@ if (common.isAix) {
 }
 
 function init(id, provider) {
-  keyList = keyList.filter((e) => e != pkeys[provider]);
+  keyList = keyList.filter((e) => e !== pkeys[provider]);
 }
 
 function noop() { }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Description of change
Use 'strictEqual' instead of 'equal' in 'test-async-wrap-check-providers'.

