### PR TITLE
tools: remove dangling eslint symlink

### DIFF
--- a/tools/eslint/node_modules/.bin/eslint
+++ b/tools/eslint/node_modules/.bin/eslint
@@ -1,1 +1,0 @@
-../eslint/bin/eslint.js


### PR DESCRIPTION

##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description of change

The tools/eslint/node_modules/.bin/eslint symlink was unused by node,
but was present, and pointed at a non-existent file. This causes
problems for tooling.

@Trott 