### PR TITLE
test: fix flaky test-fs-watch-recursive on OS X

### DIFF
--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -30,14 +30,17 @@ watcher.on('change', function(event, filename) {
   if (filename !== relativePathOne)
     return;
 
+  if (common.isOSX) {
+    clearInterval(interval);
+  }
   watcher.close();
   watcherClosed = true;
 });
 
-if (process.platform === 'darwin') {
-  setTimeout(function() {
+if (common.isOSX) {
+  var interval = setInterval(function() {
     fs.writeFileSync(filepathOne, 'world');
-  }, 100);
+  }, 10);
 } else {
   fs.writeFileSync(filepathOne, 'world');
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test was sometimes timing out due to a race condition. In OS X,
events for `fs.watch()` might only start showing up after a delay. This
is a limitation of the operating system. To work around that, there was
a timer in the test that delayed the writing of the file by 100ms.
However, sometimes that was not enough, and so the event never fired,
and the test timed out.

Change the timer to an interval so that it fires repeatedly until it is
picked up. This change only affects OS X.

Fixes: https://github.com/nodejs/node/issues/8511

/cc @nodejs/testing 