### PR TITLE
process: maintain constructor descriptor

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -13,10 +13,9 @@
     const EventEmitter = NativeModule.require('events');
     process._eventsCount = 0;
 
+    const origProcProto = Object.getPrototypeOf(process);
     Object.setPrototypeOf(process, Object.create(EventEmitter.prototype, {
-      constructor: {
-        value: process.constructor
-      }
+      constructor: Object.getOwnPropertyDescriptor(origProcProto, 'constructor')
     }));
 
     EventEmitter.call(process);

--- a/test/parallel/test-process-prototype.js
+++ b/test/parallel/test-process-prototype.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const proto = Object.getPrototypeOf(process);
+
+assert(proto instanceof EventEmitter);
+
+const desc = Object.getOwnPropertyDescriptor(proto, 'constructor');
+
+assert.strictEqual(desc.value, process.constructor);
+assert.strictEqual(desc.writable, true);
+assert.strictEqual(desc.enumerable, false);
+assert.strictEqual(desc.configurable, true);


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

process
##### Description of change

Use the original property descriptor instead of just taking the value,
which would previously, by default, be non-writable and non-configurable.

It didn't appear that it was intentional for `process.constructor`'s descriptor
to be locked down, but it was, by using a simple `{value: ...}` descriptor.
