### PR TITLE
test: add child_process customFds test

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -305,7 +305,7 @@ var _deprecatedCustomFds = internalUtil.deprecate(function(options) {
    'Use options.stdio instead.');
 
 function _convertCustomFds(options) {
-  if (options && options.customFds && !options.stdio) {
+  if (options.customFds && !options.stdio) {
     _deprecatedCustomFds(options);
   }
 }

--- a/test/parallel/test-child-process-custom-fds.js
+++ b/test/parallel/test-child-process-custom-fds.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+// Verify that customFds is used if stdio is not provided.
+{
+  const msg = 'child_process: options.customFds option is deprecated. ' +
+              'Use options.stdio instead.';
+  common.expectWarning('DeprecationWarning', msg);
+
+  const customFds = [-1, process.stdout.fd, process.stderr.fd];
+  const child = common.spawnSyncPwd({ customFds });
+
+  assert.deepStrictEqual(child.options.customFds, customFds);
+  assert.deepStrictEqual(child.options.stdio, [
+    { type: 'pipe', readable: true, writable: false },
+    { type: 'fd', fd: process.stdout.fd },
+    { type: 'fd', fd: process.stderr.fd }
+  ]);
+}
+
+// Verify that customFds is ignored when stdio is present.
+{
+  const customFds = [0, 1, 2];
+  const child = common.spawnSyncPwd({ customFds, stdio: 'pipe' });
+
+  assert.deepStrictEqual(child.options.customFds, customFds);
+  assert.deepStrictEqual(child.options.stdio, [
+    { type: 'pipe', readable: true, writable: false },
+    { type: 'pipe', readable: false, writable: true },
+    { type: 'pipe', readable: false, writable: true }
+  ]);
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test, child_process

##### Description of change

This PR adds a test for `spawn()`'s deprecated `customFds` option.