### PR TITLE
docs: clarify eventType in fs.watch

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1702,8 +1702,8 @@ The listener callback gets two arguments `(eventType, filename)`.  `eventType` i
 `'rename'` or `'change'`, and `filename` is the name of the file which triggered
 the event.
 
-Note that on most platforms, `'rename'` is also emitted when a file is deleted or added.
-In other words, it is emitted whenever a filename appears or disappears in the directory.
+Note that on most platforms, `'rename'` is emitted whenever a filename appears
+or disappears in the directory.
 
 Also note the listener callback is attached to the `'change'` event fired by
 [`fs.FSWatcher`][], but it is not the same thing as the `'change'` value of `eventType`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1702,8 +1702,11 @@ The listener callback gets two arguments `(eventType, filename)`.  `eventType` i
 `'rename'` or `'change'`, and `filename` is the name of the file which triggered
 the event.
 
-Please note the listener callback is attached to the `'change'` event
-fired by [`fs.FSWatcher`][], but they are not the same thing.
+Note that `'rename'` is also emitted when a file is deleted or added - in other words,
+it's emitted whenever a filename appears or disappears in the directory.
+
+Also note the listener callback is attached to the `'change'` event fired by
+[`fs.FSWatcher`][], but it's not the same thing as the `'change'` value of `eventType`.
 
 ### Caveats
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1702,11 +1702,11 @@ The listener callback gets two arguments `(eventType, filename)`.  `eventType` i
 `'rename'` or `'change'`, and `filename` is the name of the file which triggered
 the event.
 
-Note that `'rename'` is also emitted when a file is deleted or added - in other words,
-it's emitted whenever a filename appears or disappears in the directory.
+Note that on most platforms, `'rename'` is also emitted when a file is deleted or added.
+In other words, it is emitted whenever a filename appears or disappears in the directory.
 
 Also note the listener callback is attached to the `'change'` event fired by
-[`fs.FSWatcher`][], but it's not the same thing as the `'change'` value of `eventType`.
+[`fs.FSWatcher`][], but it is not the same thing as the `'change'` value of `eventType`.
 
 ### Caveats
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1706,7 +1706,8 @@ Note that on most platforms, `'rename'` is emitted whenever a filename appears
 or disappears in the directory.
 
 Also note the listener callback is attached to the `'change'` event fired by
-[`fs.FSWatcher`][], but it is not the same thing as the `'change'` value of `eventType`.
+[`fs.FSWatcher`][], but it is not the same thing as the `'change'` value of
+`eventType`.
 
 ### Caveats
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc
##### Description of change

<!-- Provide a description of the change below this comment. -->

'rename' is confusing, and it's not clear what "they" refers to.

Fixes: https://github.com/nodejs/node/issues/9082
