### PR TITLE
Updated reference to signal list in "signal events" section 

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -374,7 +374,7 @@ The `*-deprecation` command line flags only affect warnings that use the name
 <!--name=SIGINT, SIGHUP, etc.-->
 
 Signal events will be emitted when the Node.js process receives a signal. Please
-refer to sigaction(2) for a listing of standard POSIX signal names such as
+refer to [signal(7)](http://man7.org/linux/man-pages/man7/signal.7.html) for a listing of standard POSIX signal names such as
 `SIGINT`, `SIGHUP`, etc.
 
 The name of each event will be the uppercase common name for the signal (e.g.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -374,7 +374,7 @@ The `*-deprecation` command line flags only affect warnings that use the name
 <!--name=SIGINT, SIGHUP, etc.-->
 
 Signal events will be emitted when the Node.js process receives a signal. Please
-refer to [signal(7)](http://man7.org/linux/man-pages/man7/signal.7.html) for a listing of standard POSIX signal names such as
+refer to [signal(7)][] for a listing of standard POSIX signal names such as
 `SIGINT`, `SIGHUP`, etc.
 
 The name of each event will be the uppercase common name for the signal (e.g.
@@ -1728,3 +1728,4 @@ cases:
 [Cluster]: cluster.html
 [`process.exitCode`]: #processexitcode-1
 [LTS]: https://github.com/nodejs/LTS/
+[signal(7)]: http://man7.org/linux/man-pages/man7/signal.7.html

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -374,7 +374,7 @@ The `*-deprecation` command line flags only affect warnings that use the name
 <!--name=SIGINT, SIGHUP, etc.-->
 
 Signal events will be emitted when the Node.js process receives a signal. Please
-refer to [signal(7)][] for a listing of standard POSIX signal names such as
+refer to signal(7) for a listing of standard POSIX signal names such as
 `SIGINT`, `SIGHUP`, etc.
 
 The name of each event will be the uppercase common name for the signal (e.g.
@@ -1728,4 +1728,3 @@ cases:
 [Cluster]: cluster.html
 [`process.exitCode`]: #processexitcode-1
 [LTS]: https://github.com/nodejs/LTS/
-[signal(7)]: http://man7.org/linux/man-pages/man7/signal.7.html


### PR DESCRIPTION
Documentation is changed or added.
Changed the reference from sigaction(2) to signal(7) like requested in issue #9309