### PR TITLE
events: remove unnecessary checks

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -327,7 +327,7 @@ EventEmitter.prototype.removeListener =
       if (!list)
         return this;
 
-      if (list === listener || (list.listener && list.listener === listener)) {
+      if (list === listener || list.listener === listener) {
         if (--this._eventsCount === 0)
           this._events = new EventHandlers();
         else {
@@ -339,8 +339,7 @@ EventEmitter.prototype.removeListener =
         position = -1;
 
         for (i = list.length; i-- > 0;) {
-          if (list[i] === listener ||
-              (list[i].listener && list[i].listener === listener)) {
+          if (list[i] === listener || list[i].listener === listener) {
             originalListener = list[i].listener;
             position = i;
             break;


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

events
##### Description of change

This commit removes two truthy checks for object properties that are immediately followed by a strict equality check. The other item in the comparison is guaranteed to be a function by this point in the code, so the truthy check is redundant.
