### PR TITLE
cares: sync with upstream, fully adopt v1.12.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -53,20 +53,19 @@ The externally maintained libraries used by Node.js are:
 
 - c-ares, located at deps/cares, is licensed as follows:
   """
-    Copyright 1998 by the Massachusetts Institute of Technology.
-    Copyright (C) 2007-2013 by Daniel Stenberg
+    Copyright (c) 2007 - 2016, Daniel Stenberg with many contributors, see AUTHORS
+    file.
 
-    Permission to use, copy, modify, and distribute this
-    software and its documentation for any purpose and without
-    fee is hereby granted, provided that the above copyright
-    notice appear in all copies and that both that copyright
-    notice and this permission notice appear in supporting
-    documentation, and that the name of M.I.T. not be used in
-    advertising or publicity pertaining to distribution of the
-    software without specific, written prior permission.
-    M.I.T. makes no representations about the suitability of
-    this software for any purpose.  It is provided "as is"
-    without express or implied warranty.
+    Copyright 1998 by the Massachusetts Institute of Technology.
+
+    Permission to use, copy, modify, and distribute this software and its
+    documentation for any purpose and without fee is hereby granted, provided that
+    the above copyright notice appear in all copies and that both that copyright
+    notice and this permission notice appear in supporting documentation, and that
+    the name of M.I.T. not be used in advertising or publicity pertaining to
+    distribution of the software without specific, written prior permission.
+    M.I.T. makes no representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied warranty.
   """
 
 - HTTP Parser, located at deps/http_parser, is licensed as follows:

--- a/deps/cares/LICENSE.md
+++ b/deps/cares/LICENSE.md
@@ -1,0 +1,15 @@
+# c-ares license
+
+Copyright (c) 2007 - 2016, Daniel Stenberg with many contributors, see AUTHORS
+file.
+
+Copyright 1998 by the Massachusetts Institute of Technology.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided that
+the above copyright notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting documentation, and that
+the name of M.I.T. not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior permission.
+M.I.T. makes no representations about the suitability of this software for any
+purpose.  It is provided "as is" without express or implied warranty.

--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -111,6 +111,7 @@
           'defines': [ 'CARES_BUILDING_LIBRARY' ]
         }],
         [ 'OS=="win"', {
+          'defines': [ 'CARES_PULL_WS2TCPIP_H=1' ],
           'include_dirs': [ 'config/win32' ],
           'sources': [
             'src/config-win32.h',

--- a/deps/cares/config/aix/ares_config.h
+++ b/deps/cares/config/aix/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
-#define CARES_SYMBOL_HIDING 1
+/* Defined for build with symbol hiding. */
+/* #undef CARES_SYMBOL_HIDING */
 
 /* Definition to make a library symbol externally visible. */
-#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((visibility ("default")))
+/* #undef CARES_SYMBOL_SCOPE_EXTERN */
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 #define HAVE_GETADDRINFO_THREADSAFE 1
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
-#define HAVE_INET_NET_PTON 1
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
+/* #undef HAVE_INET_NET_PTON */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,23 +350,20 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 #define NEED_THREAD_SAFE 1
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
-#define OS "rs6000-ibm-aix"
+#define OS "powerpc-ibm-aix6.1.9.0"
 
 /* Name of package */
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -444,24 +446,6 @@
 /* Define to the function return type for send. */
 #define SEND_TYPE_RETV ssize_t
 
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
@@ -472,7 +456,7 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
 
 /* Define to avoid automatic inclusion of winsock.h */
 /* #undef WIN32_LEAN_AND_MEAN */
@@ -494,6 +478,11 @@
 #  define _ALL_SOURCE 1
 #endif
 
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */
 
@@ -511,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/android/ares_config.h
+++ b/deps/cares/config/android/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
+/* Defined for build with symbol hiding. */
 #define CARES_SYMBOL_HIDING 1
 
 /* Definition to make a library symbol externally visible. */
-#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((visibility ("default")))
+#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -35,10 +38,10 @@
 #define GETNAMEINFO_TYPE_ARG2 socklen_t
 
 /* Define to the type of args 4 and 6 for getnameinfo. */
-#define GETNAMEINFO_TYPE_ARG46 size_t
+#define GETNAMEINFO_TYPE_ARG46 socklen_t
 
 /* Define to the type of arg 7 for getnameinfo. */
-#define GETNAMEINFO_TYPE_ARG7 unsigned int
+#define GETNAMEINFO_TYPE_ARG7 int
 
 /* Specifies the number of arguments to getservbyport_r */
 #define GETSERVBYPORT_R_ARGS 6
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 #define HAVE_GETADDRINFO_THREADSAFE 1
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 /* #undef HAVE_INET_NET_PTON */
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,9 +350,6 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
 #define OS "i686-pc-linux-gnu"
 
@@ -358,13 +357,13 @@
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -406,7 +408,7 @@
 /* #undef RECVFROM_TYPE_ARG6_IS_VOID */
 
 /* Define to the function return type for recvfrom. */
-#define RECVFROM_TYPE_RETV int
+#define RECVFROM_TYPE_RETV ssize_t
 
 /* Define to the type of arg 1 for recv. */
 #define RECV_TYPE_ARG1 int
@@ -421,7 +423,7 @@
 #define RECV_TYPE_ARG4 int
 
 /* Define to the function return type for recv. */
-#define RECV_TYPE_RETV int
+#define RECV_TYPE_RETV ssize_t
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -442,25 +444,7 @@
 #define SEND_TYPE_ARG4 int
 
 /* Define to the function return type for send. */
-#define SEND_TYPE_RETV int
-
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
+#define SEND_TYPE_RETV ssize_t
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -491,8 +478,13 @@
 /* #  undef _ALL_SOURCE */
 #endif
 
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
 /* Number of bits in a file offset, on hosts where this is settable. */
-#define _FILE_OFFSET_BITS 64
+/* #undef _FILE_OFFSET_BITS */
 
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/darwin/ares_config.h
+++ b/deps/cares/config/darwin/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
+/* Defined for build with symbol hiding. */
 #define CARES_SYMBOL_HIDING 1
 
 /* Definition to make a library symbol externally visible. */
-#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((visibility ("default")))
+#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 #define HAVE_GETADDRINFO_THREADSAFE 1
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 #define HAVE_INET_NET_PTON 1
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-#define HAVE_INET_NET_PTON_IPV6 1
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,23 +350,20 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
-#define OS "i386-apple-darwin9.8.0"
+#define OS "x86_64-apple-darwin14.5.0"
 
 /* Name of package */
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -444,24 +446,6 @@
 /* Define to the function return type for send. */
 #define SEND_TYPE_RETV ssize_t
 
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -489,6 +476,11 @@
 /* Define to 1 if OS is AIX. */
 #ifndef _ALL_SOURCE
 /* #  undef _ALL_SOURCE */
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/freebsd/ares_config.h
+++ b/deps/cares/config/freebsd/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
+/* Defined for build with symbol hiding. */
 #define CARES_SYMBOL_HIDING 1
 
 /* Definition to make a library symbol externally visible. */
-#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((visibility ("default")))
+#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 #define HAVE_GETADDRINFO_THREADSAFE 1
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 #define HAVE_INET_NET_PTON 1
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,23 +350,20 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
-#define OS "i386-portbld-freebsd8.0"
+#define OS "x86_64-unknown-freebsd10.3"
 
 /* Name of package */
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -406,7 +408,7 @@
 /* #undef RECVFROM_TYPE_ARG6_IS_VOID */
 
 /* Define to the function return type for recvfrom. */
-#define RECVFROM_TYPE_RETV int
+#define RECVFROM_TYPE_RETV ssize_t
 
 /* Define to the type of arg 1 for recv. */
 #define RECV_TYPE_ARG1 int
@@ -421,7 +423,7 @@
 #define RECV_TYPE_ARG4 int
 
 /* Define to the function return type for recv. */
-#define RECV_TYPE_RETV int
+#define RECV_TYPE_RETV ssize_t
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -442,25 +444,7 @@
 #define SEND_TYPE_ARG4 int
 
 /* Define to the function return type for send. */
-#define SEND_TYPE_RETV int
-
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
+#define SEND_TYPE_RETV ssize_t
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -489,6 +476,11 @@
 /* Define to 1 if OS is AIX. */
 #ifndef _ALL_SOURCE
 /* #  undef _ALL_SOURCE */
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/linux/ares_config.h
+++ b/deps/cares/config/linux/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
+/* Defined for build with symbol hiding. */
 #define CARES_SYMBOL_HIDING 1
 
 /* Definition to make a library symbol externally visible. */
-#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((visibility ("default")))
+#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -35,10 +38,10 @@
 #define GETNAMEINFO_TYPE_ARG2 socklen_t
 
 /* Define to the type of args 4 and 6 for getnameinfo. */
-#define GETNAMEINFO_TYPE_ARG46 size_t
+#define GETNAMEINFO_TYPE_ARG46 socklen_t
 
 /* Define to the type of arg 7 for getnameinfo. */
-#define GETNAMEINFO_TYPE_ARG7 unsigned int
+#define GETNAMEINFO_TYPE_ARG7 int
 
 /* Specifies the number of arguments to getservbyport_r */
 #define GETSERVBYPORT_R_ARGS 6
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 #define HAVE_GETADDRINFO_THREADSAFE 1
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 /* #undef HAVE_INET_NET_PTON */
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,9 +350,6 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
 #define OS "i686-pc-linux-gnu"
 
@@ -358,13 +357,13 @@
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -406,7 +408,7 @@
 /* #undef RECVFROM_TYPE_ARG6_IS_VOID */
 
 /* Define to the function return type for recvfrom. */
-#define RECVFROM_TYPE_RETV int
+#define RECVFROM_TYPE_RETV ssize_t
 
 /* Define to the type of arg 1 for recv. */
 #define RECV_TYPE_ARG1 int
@@ -421,7 +423,7 @@
 #define RECV_TYPE_ARG4 int
 
 /* Define to the function return type for recv. */
-#define RECV_TYPE_RETV int
+#define RECV_TYPE_RETV ssize_t
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -442,25 +444,7 @@
 #define SEND_TYPE_ARG4 int
 
 /* Define to the function return type for send. */
-#define SEND_TYPE_RETV int
-
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
+#define SEND_TYPE_RETV ssize_t
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -491,8 +478,13 @@
 /* #  undef _ALL_SOURCE */
 #endif
 
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
 /* Number of bits in a file offset, on hosts where this is settable. */
-#define _FILE_OFFSET_BITS 64
+/* #undef _FILE_OFFSET_BITS */
 
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/netbsd/ares_config.h
+++ b/deps/cares/config/netbsd/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
+/* Defined for build with symbol hiding. */
 /* #undef CARES_SYMBOL_HIDING */
 
 /* Definition to make a library symbol externally visible. */
 /* #undef CARES_SYMBOL_SCOPE_EXTERN */
 
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
+
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 /* #undef HAVE_GETADDRINFO_THREADSAFE */
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 #define HAVE_INET_NET_PTON 1
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,23 +350,20 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
-#define OS "i386-unknown-openbsd4.7"
+#define OS "x86_64-unknown-freebsd10.3"
 
 /* Name of package */
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -406,7 +408,7 @@
 /* #undef RECVFROM_TYPE_ARG6_IS_VOID */
 
 /* Define to the function return type for recvfrom. */
-#define RECVFROM_TYPE_RETV int
+#define RECVFROM_TYPE_RETV ssize_t
 
 /* Define to the type of arg 1 for recv. */
 #define RECV_TYPE_ARG1 int
@@ -421,7 +423,7 @@
 #define RECV_TYPE_ARG4 int
 
 /* Define to the function return type for recv. */
-#define RECV_TYPE_RETV int
+#define RECV_TYPE_RETV ssize_t
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -442,25 +444,7 @@
 #define SEND_TYPE_ARG4 int
 
 /* Define to the function return type for send. */
-#define SEND_TYPE_RETV int
-
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
+#define SEND_TYPE_RETV ssize_t
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -489,6 +476,11 @@
 /* Define to 1 if OS is AIX. */
 #ifndef _ALL_SOURCE
 /* #  undef _ALL_SOURCE */
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/openbsd/ares_config.h
+++ b/deps/cares/config/openbsd/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
+/* Defined for build with symbol hiding. */
 /* #undef CARES_SYMBOL_HIDING */
 
 /* Definition to make a library symbol externally visible. */
 /* #undef CARES_SYMBOL_SCOPE_EXTERN */
 
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
+
 /* if a /etc/inet dir is being used */
 /* #undef ETC_INET */
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 /* #undef HAVE_GETADDRINFO_THREADSAFE */
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 #define HAVE_INET_NET_PTON 1
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,23 +350,20 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
-#define OS "i386-unknown-openbsd4.7"
+#define OS "x86_64-unknown-freebsd10.3"
 
 /* Name of package */
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -406,7 +408,7 @@
 /* #undef RECVFROM_TYPE_ARG6_IS_VOID */
 
 /* Define to the function return type for recvfrom. */
-#define RECVFROM_TYPE_RETV int
+#define RECVFROM_TYPE_RETV ssize_t
 
 /* Define to the type of arg 1 for recv. */
 #define RECV_TYPE_ARG1 int
@@ -421,7 +423,7 @@
 #define RECV_TYPE_ARG4 int
 
 /* Define to the function return type for recv. */
-#define RECV_TYPE_RETV int
+#define RECV_TYPE_RETV ssize_t
 
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE void
@@ -442,25 +444,7 @@
 #define SEND_TYPE_ARG4 int
 
 /* Define to the function return type for send. */
-#define SEND_TYPE_RETV int
-
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
+#define SEND_TYPE_RETV ssize_t
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -489,6 +476,11 @@
 /* Define to 1 if OS is AIX. */
 #ifndef _ALL_SOURCE
 /* #  undef _ALL_SOURCE */
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/config/sunos/ares_config.h
+++ b/deps/cares/config/sunos/ares_config.h
@@ -10,20 +10,23 @@
 /* when building as static part of libcurl */
 /* #undef BUILDING_LIBCURL */
 
-/* when building c-ares library */
-/* #undef CARES_BUILDING_LIBRARY */
+/* Defined for build that exposes internal static functions for testing. */
+/* #undef CARES_EXPOSE_STATICS */
 
-/* when not building a shared library */
-/* #undef CARES_STATICLIB */
-
-/* Define to 1 to enable hiding of library internal symbols. */
-/* #undef CARES_SYMBOL_HIDING */
+/* Defined for build with symbol hiding. */
+#define CARES_SYMBOL_HIDING 1
 
 /* Definition to make a library symbol externally visible. */
-/* #undef CARES_SYMBOL_SCOPE_EXTERN */
+#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 #define ETC_INET 1
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 int
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
 #define GETNAMEINFO_QUAL_ARG1 const
@@ -79,6 +82,9 @@
 /* Define to 1 if you have the connect function. */
 #define HAVE_CONNECT 1
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -103,6 +109,9 @@
 /* Define to 1 if the getaddrinfo function is threadsafe. */
 #define HAVE_GETADDRINFO_THREADSAFE 1
 
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV 1
+
 /* Define to 1 if you have the gethostbyaddr function. */
 #define HAVE_GETHOSTBYADDR 1
 
@@ -124,11 +133,8 @@
 /* Define to 1 if you have the `if_indextoname' function. */
 #define HAVE_IF_INDEXTONAME 1
 
-/* Define to 1 if you have the `inet_net_pton' function. */
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 /* #undef HAVE_INET_NET_PTON */
-
-/* Define to 1 if inet_net_pton supports IPv6. */
-/* #undef HAVE_INET_NET_PTON_IPV6 */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
 #define HAVE_INET_NTOP 1
@@ -329,12 +335,8 @@
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
-
-/* Define to 1 if you are building a native Windows target. */
-/* #undef NATIVE_WINDOWS */
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -348,9 +350,6 @@
 /* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
 /* #undef NEED_THREAD_SAFE */
 
-/* Define to 1 if your C compiler doesn't accept -c and -o together. */
-/* #undef NO_MINUS_C_MINUS_O */
-
 /* cpu-machine-OS */
 #define OS "i386-pc-solaris2.11"
 
@@ -358,13 +357,13 @@
 #define PACKAGE "c-ares"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list => http://cool.haxx.se/mailman/listinfo/c-ares"
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "c-ares"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.7.1"
+#define PACKAGE_STRING "c-ares 1.12.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "c-ares"
@@ -373,10 +372,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.7.1"
+#define PACKAGE_VERSION "1.12.0"
 
 /* a suitable file/device to read random data from */
 #define RANDOM_FILE "/dev/urandom"
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
@@ -444,24 +446,6 @@
 /* Define to the function return type for send. */
 #define SEND_TYPE_RETV int
 
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG 4
-
-/* The size of `size_t', as computed by sizeof. */
-#define SIZEOF_SIZE_T 4
-
-/* The size of `struct in6_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN6_ADDR 16
-
-/* The size of `struct in_addr', as computed by sizeof. */
-#define SIZEOF_STRUCT_IN_ADDR 4
-
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 4
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
@@ -472,7 +456,10 @@
 /* #undef USE_BLOCKING_SOCKETS */
 
 /* Version number of package */
-#define VERSION "1.7.1"
+#define VERSION "1.12.0"
+
+/* Define to avoid automatic inclusion of winsock.h */
+/* #undef WIN32_LEAN_AND_MEAN */
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -489,6 +476,11 @@
 /* Define to 1 if OS is AIX. */
 #ifndef _ALL_SOURCE
 /* #  undef _ALL_SOURCE */
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
@@ -508,5 +500,3 @@
 
 /* the signed version of size_t */
 /* #undef ssize_t */
-
-#define HAVE_GETENV 1

--- a/deps/cares/get_ver.awk
+++ b/deps/cares/get_ver.awk
@@ -1,0 +1,27 @@
+# ***************************************************************************
+# *  Project: c-ares
+# *
+# ***************************************************************************
+# awk script which fetches c-ares version number and string from input
+# file and writes them to STDOUT. Here you can get an awk version for Win32:
+# http://www.gknw.net/development/prgtools/awk-20100523.zip
+#
+BEGIN {
+  while ((getline < ARGV[1]) > 0) {
+    sub("\r", "") # make MSYS gawk work with CRLF header input.
+    if (match ($0, /^#define ARES_COPYRIGHT "[^"]+"$/))
+      copyright_string = substr($0, 25, length($0)-25)
+    else if (match ($0, /^#define ARES_VERSION_STR "[^"]+"$/))
+      version_string = substr($3, 2, length($3)-2)
+    else if (match ($0, /^#define ARES_VERSION_MAJOR [0-9]+$/))
+      version_major = $3
+    else if (match ($0, /^#define ARES_VERSION_MINOR [0-9]+$/))
+      version_minor = $3
+    else if (match ($0, /^#define ARES_VERSION_PATCH [0-9]+$/))
+      version_patch = $3
+  }
+  print "LIBCARES_VERSION = " version_major "," version_minor "," version_patch
+  print "LIBCARES_VERSION_STR = " version_string
+  print "LIBCARES_COPYRIGHT_STR = " copyright_string
+}
+

--- a/deps/cares/include/ares.h
+++ b/deps/cares/include/ares.h
@@ -158,6 +158,7 @@ extern "C" {
 #define ARES_OPT_TIMEOUTMS      (1 << 13)
 #define ARES_OPT_ROTATE         (1 << 14)
 #define ARES_OPT_EDNSPSZ        (1 << 15)
+#define ARES_OPT_NOROTATE       (1 << 16)
 
 /* Nameinfo flag values */
 #define ARES_NI_NOFQDN                  (1 << 0)

--- a/deps/cares/include/ares_build.h
+++ b/deps/cares/include/ares_build.h
@@ -51,19 +51,9 @@
 /*  DEFINITION OF THESE SYMBOLS SHALL NOT TAKE PLACE ANYWHERE ELSE  */
 /* ================================================================ */
 
-#ifdef CARES_SIZEOF_LONG
-#  error "CARES_SIZEOF_LONG shall not be defined except in ares_build.h"
-   Error Compilation_aborted_CARES_SIZEOF_LONG_already_defined
-#endif
-
 #ifdef CARES_TYPEOF_ARES_SOCKLEN_T
 #  error "CARES_TYPEOF_ARES_SOCKLEN_T shall not be defined except in ares_build.h"
    Error Compilation_aborted_CARES_TYPEOF_ARES_SOCKLEN_T_already_defined
-#endif
-
-#ifdef CARES_SIZEOF_ARES_SOCKLEN_T
-#  error "CARES_SIZEOF_ARES_SOCKLEN_T shall not be defined except in ares_build.h"
-   Error Compilation_aborted_CARES_SIZEOF_ARES_SOCKLEN_T_already_defined
 #endif
 
 /* ================================================================ */
@@ -72,14 +62,6 @@
 
 /* Configure process defines this to 1 when it finds out that system  */
 /* header file ws2tcpip.h must be included by the external interface. */
-
-#ifdef WIN32
-#  define CARES_PULL_WS2TCPIP_H 1
-#else
-#  define CARES_PULL_SYS_TYPES_H 1
-#  define CARES_PULL_SYS_SOCKET_H 1
-#endif
-
 /* #undef CARES_PULL_WS2TCPIP_H */
 #ifdef CARES_PULL_WS2TCPIP_H
 #  ifndef WIN32_LEAN_AND_MEAN
@@ -92,24 +74,20 @@
 
 /* Configure process defines this to 1 when it finds out that system   */
 /* header file sys/types.h must be included by the external interface. */
+#define CARES_PULL_SYS_TYPES_H 1
 #ifdef CARES_PULL_SYS_TYPES_H
 #  include <sys/types.h>
 #endif
 
 /* Configure process defines this to 1 when it finds out that system    */
 /* header file sys/socket.h must be included by the external interface. */
+#define CARES_PULL_SYS_SOCKET_H 1
 #ifdef CARES_PULL_SYS_SOCKET_H
 #  include <sys/socket.h>
 #endif
 
-/* The size of `long', as computed by sizeof. */
-/* #undef CARES_SIZEOF_LONG */
-
 /* Integral data type used for ares_socklen_t. */
 #define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
-
-/* The size of `ares_socklen_t', as computed by sizeof. */
-#define CARES_SIZEOF_ARES_SOCKLEN_T 4
 
 /* Data type definition of ares_socklen_t. */
 typedef CARES_TYPEOF_ARES_SOCKLEN_T ares_socklen_t;

--- a/deps/cares/include/ares_build.h
+++ b/deps/cares/include/ares_build.h
@@ -1,9 +1,8 @@
-/* ares_build.h.  Generated from ares_build.h.in by configure.  */
 #ifndef __CARES_BUILD_H
 #define __CARES_BUILD_H
 
 
-/* Copyright (C) 2009 by Daniel Stenberg et al
+/* Copyright (C) 2009 - 2013 by Daniel Stenberg et al
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation for any purpose and without fee is hereby granted, provided
@@ -24,6 +23,20 @@
  * NOTE 1:
  * -------
  *
+ * See file ares_build.h.in, run configure, and forget that this file
+ * exists it is only used for non-configure systems.
+ * But you can keep reading if you want ;-)
+ *
+ */
+
+/* ================================================================ */
+/*                 NOTES FOR NON-CONFIGURE SYSTEMS                  */
+/* ================================================================ */
+
+/*
+ * NOTE 1:
+ * -------
+ *
  * Nothing in this file is intended to be modified or adjusted by the
  * c-ares library user nor by the c-ares library builder.
  *
@@ -31,19 +44,38 @@
  * or fixed in this file, then, report it on the c-ares development
  * mailing list: http://cool.haxx.se/mailman/listinfo/c-ares/
  *
+ * Try to keep one section per platform, compiler and architecture,
+ * otherwise, if an existing section is reused for a different one and
+ * later on the original is adjusted, probably the piggybacking one can
+ * be adversely changed.
+ *
+ * In order to differentiate between platforms/compilers/architectures
+ * use only compiler built in predefined preprocessor symbols.
+ *
  * This header file shall only export symbols which are 'cares' or 'CARES'
  * prefixed, otherwise public name space would be polluted.
  *
  * NOTE 2:
  * -------
  *
- * Right now you might be staring at file ares_build.h.in or ares_build.h,
- * this is due to the following reason:
+ * Right now you might be staring at file ares_build.h.dist or ares_build.h,
+ * this is due to the following reason: file ares_build.h.dist is renamed
+ * to ares_build.h when the c-ares source code distribution archive file is
+ * created.
+ *
+ * File ares_build.h.dist is not included in the distribution archive.
+ * File ares_build.h is not present in the git tree.
+ *
+ * The distributed ares_build.h file is only intended to be used on systems
+ * which can not run the also distributed configure script.
  *
  * On systems capable of running the configure script, the configure process
  * will overwrite the distributed ares_build.h file with one that is suitable
  * and specific to the library being configured and built, which is generated
  * from the ares_build.h.in template file.
+ *
+ * If you check out from git on a non-configure platform, you must run the
+ * appropriate buildconf* script to set up ares_build.h and other local files.
  *
  */
 
@@ -57,39 +89,106 @@
 #endif
 
 /* ================================================================ */
-/*  EXTERNAL INTERFACE SETTINGS FOR CONFIGURE CAPABLE SYSTEMS ONLY  */
+/*    EXTERNAL INTERFACE SETTINGS FOR NON-CONFIGURE SYSTEMS ONLY    */
 /* ================================================================ */
 
-/* Configure process defines this to 1 when it finds out that system  */
-/* header file ws2tcpip.h must be included by the external interface. */
-/* #undef CARES_PULL_WS2TCPIP_H */
-#ifdef CARES_PULL_WS2TCPIP_H
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
+#if defined(__DJGPP__) || defined(__GO32__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__SALFORDC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__BORLANDC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__TURBOC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__WATCOMC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__POCC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__LCC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__SYMBIAN32__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T unsigned int
+
+#elif defined(__MWERKS__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(_WIN32_WCE)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__MINGW32__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+#elif defined(__VMS)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T unsigned int
+
+#elif defined(__OS400__)
+#  if defined(__ILEC400__)
+#    define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#    define CARES_PULL_SYS_TYPES_H      1
+#    define CARES_PULL_SYS_SOCKET_H     1
 #  endif
-#  include <windows.h>
-#  include <winsock2.h>
-#  include <ws2tcpip.h>
+
+#elif defined(__MVS__)
+#  if defined(__IBMC__) || defined(__IBMCPP__)
+#    define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#    define CARES_PULL_SYS_TYPES_H      1
+#    define CARES_PULL_SYS_SOCKET_H     1
+#  endif
+
+#elif defined(__370__)
+#  if defined(__IBMC__) || defined(__IBMCPP__)
+#    define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#    define CARES_PULL_SYS_TYPES_H      1
+#    define CARES_PULL_SYS_SOCKET_H     1
+#  endif
+
+#elif defined(TPF)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+/* ===================================== */
+/*    KEEP MSVC THE PENULTIMATE ENTRY    */
+/* ===================================== */
+
+#elif defined(_MSC_VER)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
+
+/* ===================================== */
+/*    KEEP GENERIC GCC THE LAST ENTRY    */
+/* ===================================== */
+
+#elif defined(__GNUC__)
+#  define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#  define CARES_PULL_SYS_TYPES_H      1
+#  define CARES_PULL_SYS_SOCKET_H     1
+
+#else
+#  error "Unknown non-configure build target!"
+   Error Compilation_aborted_Unknown_non_configure_build_target
 #endif
 
-/* Configure process defines this to 1 when it finds out that system   */
-/* header file sys/types.h must be included by the external interface. */
-#define CARES_PULL_SYS_TYPES_H 1
+/* CARES_PULL_SYS_TYPES_H is defined above when inclusion of header file  */
+/* sys/types.h is required here to properly make type definitions below.  */
 #ifdef CARES_PULL_SYS_TYPES_H
 #  include <sys/types.h>
 #endif
 
-/* Configure process defines this to 1 when it finds out that system    */
-/* header file sys/socket.h must be included by the external interface. */
-#define CARES_PULL_SYS_SOCKET_H 1
+/* CARES_PULL_SYS_SOCKET_H is defined above when inclusion of header file  */
+/* sys/socket.h is required here to properly make type definitions below.  */
 #ifdef CARES_PULL_SYS_SOCKET_H
 #  include <sys/socket.h>
 #endif
 
-/* Integral data type used for ares_socklen_t. */
-#define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
-
 /* Data type definition of ares_socklen_t. */
-typedef CARES_TYPEOF_ARES_SOCKLEN_T ares_socklen_t;
+
+#ifdef CARES_TYPEOF_ARES_SOCKLEN_T
+  typedef CARES_TYPEOF_ARES_SOCKLEN_T ares_socklen_t;
+#endif
 
 #endif /* __CARES_BUILD_H */

--- a/deps/cares/include/ares_rules.h
+++ b/deps/cares/include/ares_rules.h
@@ -73,11 +73,6 @@
    Error Compilation_aborted_CARES_TYPEOF_ARES_SOCKLEN_T_is_missing
 #endif
 
-#ifndef CARES_SIZEOF_ARES_SOCKLEN_T
-#  error "CARES_SIZEOF_ARES_SOCKLEN_T definition is missing!"
-   Error Compilation_aborted_CARES_SIZEOF_ARES_SOCKLEN_T_is_missing
-#endif
-
 /*
  * Macros private to this header file.
  */
@@ -94,7 +89,7 @@
 
 typedef char
   __cares_rule_02__
-    [CareschkszEQ(ares_socklen_t, CARES_SIZEOF_ARES_SOCKLEN_T)];
+    [CareschkszEQ(ares_socklen_t, sizeof(CARES_TYPEOF_ARES_SOCKLEN_T))];
 
 /*
  * Verify at compile time that the size of ares_socklen_t as reported

--- a/deps/cares/include/ares_version.h
+++ b/deps/cares/include/ares_version.h
@@ -3,15 +3,15 @@
 #define ARES__VERSION_H
 
 /* This is the global package copyright */
-#define ARES_COPYRIGHT "2004 - 2013 Daniel Stenberg, <daniel@haxx.se>."
+#define ARES_COPYRIGHT "2004 - 2016 Daniel Stenberg, <daniel@haxx.se>."
 
 #define ARES_VERSION_MAJOR 1
-#define ARES_VERSION_MINOR 10
-#define ARES_VERSION_PATCH 1
+#define ARES_VERSION_MINOR 12
+#define ARES_VERSION_PATCH 0
 #define ARES_VERSION ((ARES_VERSION_MAJOR<<16)|\
                        (ARES_VERSION_MINOR<<8)|\
                        (ARES_VERSION_PATCH))
-#define ARES_VERSION_STR "1.10.1-DEV"
+#define ARES_VERSION_STR "1.12.0"
 
 #if (ARES_VERSION >= 0x010700)
 #  define CARES_HAVE_ARES_LIBRARY_INIT 1

--- a/deps/cares/src/AUTHORS
+++ b/deps/cares/src/AUTHORS
@@ -2,9 +2,13 @@ c-ares is based on ares, and these are the people that have worked on it since
 the fork was made:
 
 Albert Chin
+Alex Loukissas
+Alexander Klauer
 Alexander Lazic
 Alexey Simak
 Andreas Rieke
+Andrew Andkjar
+Andrew Ayer
 Andrew C. Morrow
 Ashish Sharma
 Ben Greear
@@ -13,20 +17,27 @@ BogDan Vatra
 Brad House
 Brad Spencer
 Bram Matthys
+Chris Araman
 Dan Fandrich
 Daniel Johnson
 Daniel Stenberg
+David Drysdale
 David Stuart
 Denis Bilenko
 Dima Tisnek
 Dirk Manske
 Dominick Meglio
 Doug Goldstein
+Doug Kwan
 Duncan Wilcox
 Eino Tuominen
 Erik Kline
+Fedor Indutny
+Frederic Germain
+Geert Uytterhoeven
 George Neill
 Gisle Vanem
+Gregor Jasny
 Guenter Knauf
 Guilherme Balena Versiani
 Gunter Knauf
@@ -34,25 +45,38 @@ Henrik Stoerner
 Jakub Hrozek
 James Bursa
 Jérémy Lal
+Keith Shaw
+Lei Shi
 Marko Kreen
 Michael Wallner
 Mike Crowe
 Nick Alcock
 Nick Mathewson
+Nicolas "Pixel" Noble
+Ning Dong
+Oleg Pudeyev
+Patrick Valsecchi
 Patrik Thunstrom
+Paul Saab
 Peter Pentchev
 Phil Blundell
 Poul Thomas Lomholt
 Ravi Pratap
 Robin Cornelius
+Saúl Ibarra Corretgé
 Sebastian at basti79.de
 Shmulik Regev
 Stefan Bühler
 Steinar H. Gunderson
+Svante Karlsson
 Tofu Linden
 Tom Hughes
 Tor Arntsen
+Viktor Szakats
 Vlad Dinulescu
 William Ahern
 Yang Tse
+hpopescu at ixiacom.com
 liren at vivisimo.com
+nordsturm
+saghul

--- a/deps/cares/src/README.cares
+++ b/deps/cares/src/README.cares
@@ -1,13 +1,15 @@
 c-ares
 ======
 
-This package is based on ares 1.1.1 (written by Greg Hudson). I decided to
-fork and release a separate project since the ares author didn't want the
-improvements that were vital for our use of it.
+This package is based on ares 1.1.1 (written by Greg Hudson). Daniel Stenberg
+decided to fork and release a separate project since the original ares author
+didn't want the improvements that were vital for our use of it.
 
-This package is dubbed 'c-ares' since I (Daniel Stenberg) wanted this for use
-within the curl project (hence the letter C) and it makes a nice pun. Also,
-c-ares is not API compatible with ares: a new name makes that more obvious to
-the public.
+This package is dubbed 'c-ares' since Daniel wanted this for use within the
+curl project (hence the letter C) and it makes a nice pun. c-ares is not API
+compatible with ares: a new name makes that more obvious to the public.
 
-The original libares was distributed at athena-dist.mit.edu:pub/ATHENA/ares.
+The original libares was distributed at
+ftp://athena-dist.mit.edu:pub/ATHENA/ares (which seems to not be alive
+anymore).  A local copy of the original ares package is kept here:
+https://c-ares.haxx.se/download/ares-1.1.1.tar.gz

--- a/deps/cares/src/RELEASE-NOTES
+++ b/deps/cares/src/RELEASE-NOTES
@@ -1,35 +1,46 @@
-c-ares version 1.10.0
+c-ares version 1.12.0
 
 Changes:
 
- o Added ares_create_query(), to be used instead of ares_mkquery()
- o ares_inet_ntop() and ares_inet_pton() are now recognized c-ares functions
-
+ o api: add ARES_OPT_NOROTATE optmask value
+ 
 Bug fixes:
 
- o include the ares_parse_soa_reply.* files in the tarball
- o read_udp_packets: bail out loop on bad sockets
- o get_DNS_AdaptersAddresses: fix IPv6 parsing
- o adig: perror() doesn't work for socket errors on windows
- o ares_parse_aaaa_reply: fix memory leak
- o setup_once.h: HP-UX <sys/socket.h> issue workaround
- o configure: several fixes
- o config-dos.h: define strerror() to strerror_s_() for High-C
- o config-dos.h: define HAVE_CLOSE_S for MSDOS/Watt-32
- o ares_build.h.dist: enhance non-configure GCC ABI detection logic
- o ares.h: stricter CARES_EXTERN linkage decorations logic
- o ares_cancel(): cancel requests safely
- o protocol parsing: check input data stricter
- o library init: be recursive, reference count inits/cleanups
- o ares_parse_txt_reply: return a ares_txt_reply node for each sub-string
- o ares_set_servers_csv: fixed IPv6 address parsing
- o build: fix build on msvc11
+ o CVE-2016-5180: ares_create_query single byte out of buffer write [4]
+ o configure: acknowledge --disable-tests [1]
+ o man pages: fix typos detected by Lintian
+ o test: add missing #includes for dns-proto.cc
+ o test: avoid in6addr_* constants
+ o test: Build with MinGW on AppVeyor
+ o Makefile.m32: add support for extra flags
+ o Makefile.m32: add support for CROSSPREFIX
+ o configure: check if tests can get built before enabled
+ o ares_library_cleanup: reset ares_realloc too
+ o ahost.c: add cast to fix C++ compile
+ o test: Only pass unused args to GoogleTest
+ o build: commonize MSVC version detection
+ o msvc_ver.inc: support Visual Studio 2015 Update 1, 2, 3
+ o test: for AF_UNSPEC, return CNAME only for AAAA, but valid A record
+ o ares_getnameinfo: explicitly clear struct servent before use
+ o test: Update fuzzing function prototype
+ o init: fix nsort initialization
+ o test: add fuzzing check script to tests
+ o web: http => https
+ o read_tcp_data: remove superfluous NULL check
+ o LICENSE.md: add a stand-alone license file
+ o SECURITY.md: suggested "security process" for the project
+ o ares_init_options: only propagate init failures from options [2]
+ o headers: remove checks for and defines of variable sizes
+ o test: fix gMock to work with gcc >= 6.x [3]
  
 Thanks go to these friendly people for their efforts and contributions:
 
- Eugeny Gladkih, Yang Tse, Gisle Vanem, Guenter Knauf, Horatiu Popescu,
- Alexander Klauer, Patrick Valsecchi, Paul Saab, Keith Shaw,
- Alex Loukissas
- 
+  Alexander Drachevskiy, Brad House, Chris Araman, Daniel Stenberg,
+  David Drysdale, Gregor Jasny, Svante Karlsson, Viktor Szakats
 
-Have fun!
+References to bug reports and discussions on issues:
+
+ [1] = https://github.com/c-ares/c-ares/issues/44
+ [2] = https://github.com/c-ares/c-ares/issues/60
+ [3] = https://github.com/google/googletest/issues/705#issuecomment-235067917
+ [4] = https://c-ares.haxx.se/adv_20160929.html

--- a/deps/cares/src/ares_getnameinfo.c
+++ b/deps/cares/src/ares_getnameinfo.c
@@ -299,6 +299,7 @@ static char *lookup_service(unsigned short port, int flags,
           else
             proto = "tcp";
 #ifdef HAVE_GETSERVBYPORT_R
+          memset(&se, 0, sizeof(se));
           sep = &se;
           memset(tmpbuf, 0, sizeof(tmpbuf));
 #if GETSERVBYPORT_R_ARGS == 6

--- a/deps/cares/src/ares_init.c
+++ b/deps/cares/src/ares_init.c
@@ -1029,6 +1029,11 @@ static int get_DNS_AdaptersAddresses(char **outptr)
       }
       else if (namesrvr.sa->sa_family == AF_INET6)
       {
+        /* Windows apparently always reports some IPv6 DNS servers that
+         * prefixed with fec0:0:0:ffff. These ususally do not point to
+         * working DNS servers, so we ignore them. */
+        if (strncmp(txtaddr, "fec0:0:0:ffff:", 14) == 0)
+          continue;
         if (memcmp(&namesrvr.sa6->sin6_addr, &ares_in6addr_any,
                    sizeof(namesrvr.sa6->sin6_addr)) == 0)
           continue;

--- a/deps/cares/src/ares_ipv6.h
+++ b/deps/cares/src/ares_ipv6.h
@@ -47,16 +47,16 @@ struct addrinfo
 #endif
 
 #ifndef NS_IN6ADDRSZ
-#if SIZEOF_STRUCT_IN6_ADDR == 0
+#ifndef HAVE_STRUCT_IN6_ADDR
 /* We cannot have it set to zero, so we pick a fixed value here */
 #define NS_IN6ADDRSZ 16
 #else
-#define NS_IN6ADDRSZ SIZEOF_STRUCT_IN6_ADDR
+#define NS_IN6ADDRSZ sizeof(struct in6_addr)
 #endif
 #endif
 
 #ifndef NS_INADDRSZ
-#define NS_INADDRSZ SIZEOF_STRUCT_IN_ADDR
+#define NS_INADDRSZ sizeof(struct in_addr)
 #endif
 
 #ifndef NS_INT16SZ

--- a/deps/cares/src/ares_library_init.c
+++ b/deps/cares/src/ares_library_init.c
@@ -152,6 +152,7 @@ void ares_library_cleanup(void)
 
   ares_init_flags = ARES_LIB_INIT_NONE;
   ares_malloc = malloc;
+  ares_realloc = realloc;
   ares_free = free;
 }
 
@@ -164,5 +165,3 @@ int ares_library_initialized(void)
 #endif
   return ARES_SUCCESS;
 }
-
-

--- a/deps/cares/src/ares_nowarn.c
+++ b/deps/cares/src/ares_nowarn.c
@@ -40,42 +40,22 @@
 
 #include "ares_nowarn.h"
 
-#if (SIZEOF_SHORT == 2)
+#ifndef HAVE_LIMITS_H
+/* systems without <limits.h> we guess have 16 bit shorts, 32bit ints and
+   32bit longs */
 #  define CARES_MASK_SSHORT  0x7FFF
 #  define CARES_MASK_USHORT  0xFFFF
-#elif (SIZEOF_SHORT == 4)
-#  define CARES_MASK_SSHORT  0x7FFFFFFF
-#  define CARES_MASK_USHORT  0xFFFFFFFF
-#elif (SIZEOF_SHORT == 8)
-#  define CARES_MASK_SSHORT  0x7FFFFFFFFFFFFFFF
-#  define CARES_MASK_USHORT  0xFFFFFFFFFFFFFFFF
+#  define CARES_MASK_SINT    0x7FFFFFFF
+#  define CARES_MASK_UINT    0xFFFFFFFF
+#  define CARES_MASK_SLONG   0x7FFFFFFFL
+#  define CARES_MASK_ULONG   0xFFFFFFFFUL
 #else
-#  error "SIZEOF_SHORT not defined"
-#endif
-
-#if (SIZEOF_INT == 2)
-#  define CARES_MASK_SINT  0x7FFF
-#  define CARES_MASK_UINT  0xFFFF
-#elif (SIZEOF_INT == 4)
-#  define CARES_MASK_SINT  0x7FFFFFFF
-#  define CARES_MASK_UINT  0xFFFFFFFF
-#elif (SIZEOF_INT == 8)
-#  define CARES_MASK_SINT  0x7FFFFFFFFFFFFFFF
-#  define CARES_MASK_UINT  0xFFFFFFFFFFFFFFFF
-#elif (SIZEOF_INT == 16)
-#  define CARES_MASK_SINT  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-#  define CARES_MASK_UINT  0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-#else
-#  error "SIZEOF_INT not defined"
-#endif
-
-#ifndef HAVE_LIMITS_H
-/* systems without <limits.h> we guess have 32 bit longs */
-#define CARES_MASK_SLONG  0x7FFFFFFFL
-#define CARES_MASK_ULONG  0xFFFFFFFFUL
-#else
-#define CARES_MASK_ULONG  ULONG_MAX
-#define CARES_MASK_SLONG  LONG_MAX
+#  define CARES_MASK_SSHORT  SHRT_MAX
+#  define CARES_MASK_USHORT  USHRT_MAX
+#  define CARES_MASK_SINT    INT_MAX
+#  define CARES_MASK_UINT    UINT_MAX
+#  define CARES_MASK_SLONG   LONG_MAX
+#  define CARES_MASK_ULONG   ULONG_MAX
 #endif
 
 /*

--- a/deps/cares/src/ares_process.c
+++ b/deps/cares/src/ares_process.c
@@ -391,8 +391,7 @@ static void read_tcp_data(ares_channel channel, fd_set *read_fds,
                */
               process_answer(channel, server->tcp_buffer, server->tcp_length,
                              i, 1, now);
-              if (server->tcp_buffer)
-                ares_free(server->tcp_buffer);
+              ares_free(server->tcp_buffer);
               server->tcp_buffer = NULL;
               server->tcp_lenbuf_pos = 0;
               server->tcp_buffer_pos = 0;

--- a/deps/cares/src/ares_setup.h
+++ b/deps/cares/src/ares_setup.h
@@ -75,9 +75,6 @@
 /*  please, do it beyond the point further indicated in this file.  */
 /* ================================================================ */
 
-#if 1
-# define SIZEOF_SHORT 2
-#else  /* Disabled for the gyp-ified build. */
 /*
  * c-ares external interface definitions are also used internally,
  * and might also include required system header files to define them.
@@ -90,7 +87,6 @@
  */
 
 #include <ares_rules.h>
-#endif
 
 /* ================================================================= */
 /* No system header file shall be included in this file before this  */

--- a/deps/cares/src/config-win32.h
+++ b/deps/cares/src/config-win32.h
@@ -211,6 +211,11 @@
 /* Define to the return type of signal handlers (int or void). */
 #define RETSIGTYPE void
 
+#ifdef __cplusplus
+/* Compiling headers in C++ mode means bool is available */
+#define HAVE_BOOL_T
+#endif
+
 /* Define if ssize_t is not an available 'typedefed' type. */
 #ifndef _SSIZE_T_DEFINED
 #  if (defined(__WATCOMC__) && (__WATCOMC__ >= 1240)) || \
@@ -228,19 +233,6 @@
 /* ---------------------------------------------------------------- */
 /*                            TYPE SIZES                            */
 /* ---------------------------------------------------------------- */
-
-/* Define to the size of `int', as computed by sizeof. */
-#define SIZEOF_INT 4
-
-/* Define to the size of `short', as computed by sizeof. */
-#define SIZEOF_SHORT 2
-
-/* Define to the size of `size_t', as computed by sizeof. */
-#if defined(_WIN64)
-#  define SIZEOF_SIZE_T 8
-#else
-#  define SIZEOF_SIZE_T 4
-#endif
 
 /* ---------------------------------------------------------------- */
 /*                          STRUCT RELATED                          */

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -29,8 +29,7 @@ fi
 
 
 # Dependencies bundled in distributions
-addlicense "c-ares" "deps/cares" \
-           "$(sed -e '/^ \*\/$/,$d' -e '/^$/d' -e 's/^[/ ]\* *//' ${rootdir}/deps/cares/src/ares_init.c)"
+addlicense "c-ares" "deps/cares" "$(tail -n +3 ${rootdir}/deps/cares/LICENSE.md)"
 addlicense "HTTP Parser" "deps/http_parser" "$(cat deps/http_parser/LICENSE-MIT)"
 if [ -f "${rootdir}/deps/icu/LICENSE" ]; then
   # ICU 57 and following. Drop the BOM


### PR DESCRIPTION
Not a big change but previous sync's have been piecemeal so this is a full job. I've also redone most of the config headers in config/ (haven't touched the AIX one but it still compiles and passes).

Passing CI @ https://ci.nodejs.org/job/node-test-commit/5830/ minus unrelated freebsd failures.

I believe this is ABI and API stable so could be backported through to v4.x.
