### PR TITLE
test: fix minor stream-writableState linter error

### DIFF
--- a/test/parallel/test-stream-writableState-ending.js
+++ b/test/parallel/test-stream-writableState-ending.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const stream = require('stream');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
A minor linter error was introduced in a recent commit.

```js
/Users/gib/wrk/com/DANGER/node/test/parallel/test-stream-writableState-ending.js
  3:7  error  'common' is assigned a value but never used  no-unused-vars
```

Refs: https://github.com/nodejs/node/pull/8707

cc/ @mcollina 