### PR TITLE
child_process: remove extra newline in errors

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -483,7 +483,7 @@ function checkExecSyncError(ret) {
     if (!err) {
       var msg = 'Command failed: ';
       msg += ret.cmd || ret.args.join(' ');
-      if (ret.stderr)
+      if (ret.stderr && ret.stderr.length > 0)
         msg += '\n' + ret.stderr.toString();
       err = new Error(msg);
     }

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -98,7 +98,7 @@ assert.strictEqual(ret, msg + '\n',
     const msg = `Command failed: ${process.execPath} ${args.join(' ')}`;
 
     assert(err instanceof Error);
-    assert.strictEqual(err.message.trim(), msg);
+    assert.strictEqual(err.message, msg);
     assert.strictEqual(err.status, 1);
     return true;
   });


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

child_process
##### Description of change

`checkExecSyncError()` creates error objects for `execSync()` and `execFileSync()`. If the child process created `stderr` output, then it is attached to the end of the error message. However, `stderr` can be an empty `Buffer` object, which always passes the truthy check, leading to an extra newline in the error message. This commit adds a length check, which will work with both strings and `Buffer`s.
