### PR TITLE
doc: add more internal links to fs.Stats object

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -877,7 +877,7 @@ added: v0.1.95
 
 * `fd` {Integer}
 
-Synchronous fstat(2). Returns an instance of `fs.Stats`.
+Synchronous fstat(2). Returns an instance of [`fs.Stats`][].
 
 ## fs.fsync(fd, callback)
 <!-- YAML
@@ -1076,7 +1076,7 @@ added: v0.1.30
 
 * `path` {String | Buffer}
 
-Synchronous lstat(2). Returns an instance of `fs.Stats`.
+Synchronous lstat(2). Returns an instance of [`fs.Stats`][].
 
 ## fs.mkdir(path[, mode], callback)
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -867,7 +867,7 @@ added: v0.1.95
 * `callback` {Function}
 
 Asynchronous fstat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a [`fs.Stats`][] object. `fstat()` is identical to [`stat()`][],
+`stats` is an [`fs.Stats`][] object. `fstat()` is identical to [`stat()`][],
 except that the file to be stat-ed is specified by the file descriptor `fd`.
 
 ## fs.fstatSync(fd)
@@ -1521,8 +1521,7 @@ added: v0.0.2
 * `callback` {Function}
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
-`stats` is a [`fs.Stats`][] object.  See the [`fs.Stats`][] section for more
-information.
+`stats` is an [`fs.Stats`][] object.
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

doc
##### Description of change

Added a few internal links, so when you're reading the documentation a method like `fs.stat` you can easily click to jump to the `Stats` object documentation without having to search for it in the page.

Also made a few minor wording improvements for readability.
