### PR TITLE
crypto: use SSL_get_servername.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2319,18 +2319,13 @@ int SSLWrap<Base>::SSLCertCallback(SSL* s, void* arg) {
 
   Local<Object> info = Object::New(env->isolate());
 
-  SSL_SESSION* sess = SSL_get_session(s);
-  if (sess != nullptr) {
-    if (sess->tlsext_hostname == nullptr) {
-      info->Set(env->servername_string(), String::Empty(env->isolate()));
-    } else {
-      Local<String> servername = OneByteString(env->isolate(),
-                                               sess->tlsext_hostname,
-                                               strlen(sess->tlsext_hostname));
-      info->Set(env->servername_string(), servername);
-    }
-    info->Set(env->tls_ticket_string(),
-              Boolean::New(env->isolate(), sess->tlsext_ticklen != 0));
+  const char* servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+  if (servername == nullptr) {
+    info->Set(env->servername_string(), String::Empty(env->isolate()));
+  } else {
+    Local<String> str = OneByteString(env->isolate(), servername,
+                                      strlen(servername));
+    info->Set(env->servername_string(), str);
   }
 
   bool ocsp = false;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

crypto
##### Description of change

<!-- Provide a description of the change below this comment. -->

(Patch by David Benjamin.)

Rather than reach into the SSL_SESSION, use the intended API,
SSL_get_servername. This will also help the transition to OpenSSL 1.1.0.

Also don't fill in the tlsTicket field here. This is never read by
oncertcb and was always false anyway; that field is maintained by
clients and tracks whether the server issued a ticket or a session ID.

(Note this is distinct from the copy passed to onclienthello which is
used and is not a no-op.)
