### PR TITLE
constants: errors -> errno

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,7 +5,7 @@
 // are most relevant.
 const constants = process.binding('constants');
 Object.assign(exports,
-              constants.os.errors,
+              constants.os.errno,
               constants.os.signals,
               constants.fs,
               constants.crypto);

--- a/test/parallel/test-constants.js
+++ b/test/parallel/test-constants.js
@@ -1,12 +1,26 @@
 'use strict';
 
 require('../common');
-const constants = process.binding('constants');
+const binding = process.binding('constants');
+const constants = require('constants');
 const assert = require('assert');
 
-assert.ok(constants);
-assert.ok(constants.os);
-assert.ok(constants.os.signals);
-assert.ok(constants.os.errno);
-assert.ok(constants.fs);
-assert.ok(constants.crypto);
+assert.ok(binding);
+assert.ok(binding.os);
+assert.ok(binding.os.signals);
+assert.ok(binding.os.errno);
+assert.ok(binding.fs);
+assert.ok(binding.crypto);
+
+['os', 'fs', 'crypto'].forEach((l) => {
+  Object.keys(binding[l]).forEach((k) => {
+    if (typeof binding[l][k] === 'object') { //errno and signals
+      Object.keys(binding[l][k]).forEach((j) => {
+        assert.strictEqual(binding[l][k][j], constants[j]);
+      });
+    }
+    if (l !== 'os') { // top level os constant isn't currently copied
+      assert.strictEqual(binding[l][k], constants[k]);
+    }
+  });
+});


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

constants
##### Description of change

lib/constants.js was incorrectly copying the constants from the
binding, by copying from `contants.os.errors` instead of
`constants.os.errno`.
