### PR TITLE
doc: update AUTHORS list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,16 +1,23 @@
 Aaron Heckmann <aaron.heckmann@gmail.com> <aaron.heckmann+github@gmail.com>
+Alex Hultman <alexhultman@gmail.com> <alexhultman@localhost.localdomain>
 Abe Fettig <abefettig@gmail.com> <abe@fettig.net>
+akki <akki@> <akki@users.noreply.github.com>
+Alejandro Oviedo Garcia <alejandro.oviedo.g@gmail.com>
 Alex Hultman <alexhultman@gmail.com>
 Alex Kocharin <rlidwka@kocharin.ru>
 Alex Kocharin <rlidwka@kocharin.ru> <alex@kocharin.ru>
+Alexander Marchenko <axvmindaweb@gmail.com>
 Alexey Kupershtokh <alexey.kupershtokh@gmail.com> <wicked@alawar.com>
 Alexis Campailla <alexis@janeasystems.com> <orangemocha@github.com>
 Alexis Sellier <self@cloudhead.net>
 Alexis Sellier <self@cloudhead.net> <alexis@cloudhead.io>
+Allen Hernandez <allensh12@> <allensh12@users.noreply.github.com>
 Andy Bettisworth <andy.bettisworth@accreu.com>
-Anna Henningsen <anna@addaleax.net>
+Anna Henningsen <anna@addaleax.net> <sqrt@entless.org>
+AnnaMag <AnnaMag@> <AnnaMag@users.noreply.github.com>
 Aria Stewart <aredridel@dinhe.net> <aredridel@nbtsc.org>
 Arlo Breault <arlolra@gmail.com>
+Arnaud Lefebvre <a.lefebvre@outlook.fr>
 Artem Zaytsev <a.arepo@gmail.com>
 Arnout Kazemier <info@3rd-Eden.com> <3rd-Eden@users.noreply.github.com>
 Atsuo Fukaya <fukayatsu@gmail.com>
@@ -19,7 +26,10 @@ Ben Taber <ben.taber@gmail.com>
 Bert Belder <bertbelder@gmail.com> <bert@piscisaureus2.(none)>
 Bert Belder <bertbelder@gmail.com> <info@2bs.nl>
 Bert Belder <bertbelder@gmail.com> <piscisaureus@Berts-MacBook-Pro.local>
+Bethany N Griggs <Bethany.Griggs@uk.ibm.com>
+Bill Automata <billautomata@> <billautomata@users.noreply.github.com>
 Brandon Benvie <brandon@bbenvie.com> <brandon@brandonbenvie.com>
+Brenard Cubacub <bcbcb@> <bcbcb@users.noreply.github.com>
 Brian White <mscdex@mscdex.net>
 Brian White <mscdex@mscdex.net> <mscdex@gmail.com>
 Caleb Boyd <caleb.boyd@gmail.com>
@@ -27,57 +37,75 @@ Charles <ineedpracticing@gmail.com> <cydjudge@users.noreply.github.com>
 Chew Choon Keat <choonkeat@gmail.com>
 Charles Rudolph <charles.rudolph@originate.com>
 Chris Johnson <chris.s.johnson4@gmail.com>
+Christophe Naud-Dulude <christophe.naud.dulude@gmail.com>
 Claudio Rodriguez <cjrodr@yahoo.com> <cr@fansworld.tv>
 Colin Ihrig <cjihrig@gmail.com>
 Christopher Lenz <cmlenz@gmail.com> <chris@lamech.local>
+Craig Akimoto <strawbrary@> <strawbrary@users.noreply.github.com>
+Сковорода Никита Андреевич <chalkerx@gmail.com>
 Dan Kaplun <dbkaplun@gmail.com> <dan@beardtree.com>
+Dan Williams <daniel@chat.za.net>
 Daniel Berger <code+node@dpbis.net>
 Daniel Chcouri <333222@gmail.com>
 Daniel Gröber <darklord@darkboxed.org>
 Daniel Gröber <darklord@darkboxed.org> <dxld@darkboxed.org>
 Daniel Pihlström <sciolist.se@gmail.com>
 Daniel Wang <wangyang0123@gmail.com>
+Daniel Wang <wangyang0123@gmail.com> <wangyang02@baidu.com>
 Danny Nemer <hi@dannynemer.com> <DannyNemer@users.noreply.github.com>
 Dave Pacheco <dap@joyent.com> <dap@cs.brown.edu>
 David Siegel <david@artcom.de> <david.siegel@artcom.de>
+DC <dcposch@dcpos.ch>
+Dmitriy Lazarev <wKich@> <wKich@users.noreply.github.com>
 Domenic Denicola <domenic@domenicdenicola.com>
 Domenic Denicola <domenic@domenicdenicola.com> <d@domenic.me>
+Doug Wade <doug@dougwade.io> <doug.wade@redfin.com>
 Eduard Burtescu <eddy_me08@yahoo.com>
 Einar Otto Stangvik <einaros@gmail.com>
 Elliott Cable <me@ell.io>
 Eric Phetteplace <phette23@gmail.com>
 EungJun Yi <semtlenori@gmail.com>
+Eugene Obrezkov <ghaiklor@gmail.com>
 Evan Larkin <evan.larkin.il.com> <evan.larkin.iit@gmail.com>
 Evan Lucas <evanlucas@me.com> <evan@btc.com>
 Evan Lucas <evanlucas@me.com> <evan.lucas@help.com>
+Fangdun Cai (Fundon) <cfddream@gmail.com>
+Fangshi He <hefangshi@gmail.com>
 Farid Neshat <FaridN_SOAD@yahoo.com>
 Fedor Indutny <fedor@indutny.com> <fedor.indutny@gmail.com>
 Felix Böhm <felixboehm55@googlemail.com> <me@feedic.com>
 Felix Geisendörfer <felix@debuggable.com>
 Felix Geisendörfer <felix@debuggable.com>
+Florian Margaine <florian@margaine.com>
 Friedemann Altrock <frodenius@gmail.com>
 Fuji Goro <gfuji@cpan.org>
 Gabriel de Perthuis <g2p.code@gmail.com>
 Gil Pedersen <git@gpost.dk> <github@gpost.dk>
+Graham Fairweather <xotic750@gmail.com> <xotic750@gmail>
 Henry Chin <hheennrryy@gmail.com>
 Herbert Vojčík <herby@mailbox.sk>
 Icer Liang <liangshuangde@163.com> <wizicer@users.noreply.github.com>
 Igor Soarez <igorsoarez@gmail.com>
+Igor Savin <iselwin@gmail.com>
 Igor Zinkovsky <igorzi@microsoft.com>
-Imran Iqbal <imran@imraniqbal.org>
+Imran Iqbal <imran@imraniqbal.org> <imrani@ca.ibm.com>
+Irina Shestak <shestak.irina@gmail.com>
 Isaac Z. Schlueter <i@izs.me>
 Isaac Z. Schlueter <i@izs.me> <i@foohack.com>
 Jake Verbaten <raynos2@gmail.com>
 James Hartig <fastest963@gmail.com> <james.hartig@grooveshark.com>
 James M Snell <jasnell@gmail.com>
 Jan Krems <jan.krems@gmail.com> <jan.krems@groupon.com>
+janriemer <janriemer@> <janriemer@users.noreply.github.com>
 Jered Schmidt <tr@nslator.jp>
 Jeremiah Senkpiel <fishrock123@rocketmail.com>
 Jerry Chin <qinjia@outlook.com>
+Jimmy Hsu <jimmyhsu@> <jimmyhsu@users.noreply.github.com>
 Joe Shaw <joe@joeshaw.org> <joeshaw@litl.com>
 Johan Bergström <bugs@bergstroem.nu>
 Johan Dahlberg <jfd@distrop.com> <dahlberg.johan@gmail.com>
 Johann Hofmann <git@johann-hofmann.com>
+John Gardner <gardnerjohng@gmail.com>
 Jonas Pfenniger <jonas@pfenniger.name> <jonas@stvs.ch>
 Jonathan Ong <jonathanrichardong@gmail.com> <jonathanong@users.noreply.github.com>
 Jonathan Persson <persson.jonathan@gmail.com> <jonathan.persson@creuna.se>
@@ -85,8 +113,10 @@ Jonathan Rentzsch <jwr.git@redshed.net>
 Josh Erickson <josh@snoj.us>
 Joshua S. Weinstein <josher19@users.sf.net>
 Juan Soto <juan@juansoto.me>
+Julien Waechter <julien.waechter@gmail.com>
 Junliang Yan <john.yan1019@gmail.com>
 Junliang Yan <jyan@ca.ibm.com> <jyan@ca.ibm.ca>
+Junshu Okamoto <o_askgulf@icloud.com>
 Jérémy Lal <kapouer@melix.org>
 Jérémy Lal <kapouer@melix.org> <holisme@gmail.com>
 Kai Sasaki Lewuathe <sasaki_kai@lewuathe.sakura.ne.jp>
@@ -98,40 +128,57 @@ Koichi Kobayashi <koichik@improvement.jp>
 Kris Kowal <kris.kowal@cixar.com>
 Kyle Robinson Young <kyle@dontkry.com>
 Luke Bayes <lbayes@patternpark.com>
+Lydia Kats <llkats@gmail.com>
 Maciej Małecki <maciej.malecki@notimplemented.org> <me@mmalecki.com>
 Malte-Thorben Bruns <skenqbx@gmail.com>
 Malte-Thorben Bruns <skenqbx@googlemail.com>
+Manuel B <baslr@> <baslr@users.noreply.github.com>
+Marc-Aurèle Darche <ma.darche@cynode.org>
 Marcin Cieślak <saper@marcincieslak.com>
 Marcin Cieślak <saper@marcincieslak.com> <saper@saper.info>
 Marti Martz <thalamew@q.com>
 Martial James Jefferson <martial.jefferson@gmail.com>
 Mathias Pettersson <mape@mape.me>
+Matt Lang <matt@mediasuite.co.nz>
 Matthew Lye <muddletoes@hotmail.com>
 Michael Bernstein <michaelrbernstein@gmail.com>
 Michael Wilber <gcr@sneakygcr.net>
-Michaël Zasso <targos@protonmail.com>
+Michaël Zasso <targos@protonmail.com> <mic.besace@gmail.com>
 Micheil Smith <micheil@brandedcode.com> <micheil@yettobebranded.net>
 Micleusanu Nicu <micnic90@gmail.com>
+Miguel Angel Asencio Hurtado <maasencioh@gmail.com>
 Mikael Bourges-Sevenier <mikeseven@gmail.com> <msevenier@motorola.com>
+Minwoo Jung <jmwsoft@gmail.com>
 Miroslav Bajtoš <miroslav@strongloop.com> <miro.bajtos@gmail.com>
 Mitar Milutinovic <mitar.git@tnode.com>
 Nebu Pookins<nebu@nebupookins.net>
+Netto Farah <nettofarah@gmail.com>
 Nicholas Kinsey <pyrotechnick@feistystudios.com>
 Nikolai Vavilov <vvnicholas@gmail.com>
+not-an-aardvark <not-an-aardvark@> <not-an-aardvark@users.noreply.github.com>
 Onne Gorter <onne@onnlucky.com>
+oogz <oogz@> <oogz@users.noreply.github.com>
 Paul Querna <pquerna@apache.org> <paul@querna.org>
-Peter Flannery <pflannery@users.noreply.github.com>
+Peter Flannery <pflannery@> <pflannery@users.noreply.github.com>
 Phillip Johnsen <johphi@gmail.com> <phillip.johnsen@finn.no>
+piepmatz <piepmatz@> <piepmatz@users.noreply.github.com>
+P.S.V.R <pmq2001@gmail.com>
 Ratikesh Misra <ratikesh92@gmail.com>
+Ravindra Barthwal <ravindrabarthwal@> <ravindrabarthwal@users.noreply.github.com>
 Ray Morgan <rmorgan@zappos.com>
 Ray Solomon <raybsolomon@gmail.com>
 Raymond Feng <enjoyjava@gmail.com> <raymond@strongloop.com>
+Rémy Meja <remy.meja@inist.fr>
 Rick Olson <technoweenie@gmail.com>
 Roman Klauke <romaaan.git@gmail.com> <romankl@users.noreply.github.com>
 Roman Reiss <me@silverwind.io>
 Ron Korving <ron@ronkorving.nl> <rkorving@wizcorp.jp>
+Ron Korving <ron@ronkorving.nl> <ron@ronkorving.nl>
+Ruslan Iusupov <rus0000@> <rus0000@users.noreply.github.com>
 Ryan Dahl <ry@tinyclouds.org>
 Ryan Emery <seebees@gmail.com>
+Ryan Scheel (Havvy) <ryan.havvy@gmail.com> <Ryan.havvy@gmail.com>
+Saad Quadri <saad@saadquadri.com>
 Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
 Sam Mikes <smikes@cubane.com>
 Sam P Gallagher-Bishop <samgallagherb@gmail.com> <SPGB@users.noreply.github.com>
@@ -140,17 +187,25 @@ Sam Shull <brickysam26@gmail.com> <sshull@squaremouth.com>
 Sambasiva Suda <sambasivarao@gmail.com>
 Sam Roberts <vieuxtech@gmail.com> <sam@strongloop.com>
 San-Tai Hsu <v@fatpipi.com>
+Sartrey Lee <sartrey@163.com>
 Scott Blomquist <github@scott.blomqui.st> <sblom@microsoft.com>
+Scott Stern <scott.stern06@gmail.com>
 Sergey Kryzhanovsky <skryzhanovsky@gmail.com> <another@dhcp199-223-red.yandex.net>
 Shannen Saez <shannenlaptop@gmail.com>
-Shigeki Ohtsu <ohtsu@d.jp> <ohtsu@iij.ad.jp>
+Shigeki Ohtsu <ohtsu@ohtsu.org> <ohtsu@d.jp>
+Shigeki Ohtsu <ohtsu@ohtsu.org> <ohtsu@iij.ad.jp>
 Siddharth Mahendraker <siddharth_mahen@hotmail.com> <siddharth_mahen@me.com>
 Simon Willison <simon@simonwillison.net>
+Siobhan O'Donovan <siobhan@justshiv.com>
 Stanislav Opichal <opichals@gmail.com>
-Stefan Budeanu <stefan@budeanu.com>
+ss22ever <ss22ever@> <ss22ever@users.noreply.github.com>
+Stefan Budeanu <stefan@budeanu.com> <stefanbu@ca.ibm.com>
 Stefan Bühler <stbuehler@web.de>
 Steve Mao <maochenyan@msn.com>
 Steven R. Loomis <srl@icu-project.org> <srloomis@us.ibm.com>
+Steven Vercruysse <stcruy@> <stcruy@users.noreply.github.com>
+Surya Panikkal <surya.com@gmail.com>
+Taehee Kang <hugnosis@gmail.com>
 Todd Kennedy <todd@selfassembled.org> <toddself@users.noreply.github.com>
 TJ Holowaychuk <tj@vision-media.ca>
 TJ Holowaychuk <tj@vision-media.ca> <tjholowayhuk@gmail.com>
@@ -166,9 +221,12 @@ Tim Smart <timehandgod@gmail.com> <timehandgod@gmail.com>
 Tom Hughes <tom.hughes@palm.com> <tomtheengineer@gmail.com>
 Tom Hughes-Croucher <tom_croucher@yahoo.com>
 Trevor Burnham <trevor@databraid.com> <trevorburnham@gmail.com>
+Tsarevich Dmitry <dimhotepus@> <dimhotepus@users.noreply.github.com>
 Tyler Larson <talltyler@gmail.com>
 Vincent Voyer <v@fasterize.com>
+Vitaly Tomilov <vitaly-t@> <vitaly-t@users.noreply.github.com>
 Vladimir de Turckheim <vlad2t@hotmail.com>
+Vse Mozhet Byt <vsemozhetbyt@gmail.com>
 Willi Eggeling <email@wje-online.de>
 Yazhong Liu <yorkiefixer@gmail.com> Yazhong Liu <l900422@vip.qq.com>
 Yazhong Liu <yorkiefixer@gmail.com> Yorkie <l900422@vip.qq.com>
@@ -176,6 +234,8 @@ Yazhong Liu <yorkiefixer@gmail.com> Yorkie <yorkiefixer@gmail.com>
 Yoshihiro KIKUCHI <yknetg@gmail.com>
 Yosuke Furukawa <yosuke.furukawa@gmail.com> <furukawa.yosuke@dena.jp>
 Yuichiro MASUI <masui@masuidrive.jp>
+Yuta Hiroto <git@about-hiroppy.com>
+Zach Bjornson <zbbjornson@gmail.com> <bjornson@stanford.edu>
 Zachary Scott <zachary@zacharyscott.net> <zachary.s.scott@gmail.com>
 Zoran Tomicic <ztomicic@gmail.com>
 
@@ -190,3 +250,5 @@ Michael Starzinger <mstarzinger@chromium.org>
 Toon Verwaest <verwaest@chromium.org>
 Vyacheslav Egorov <vegorov@chromium.org>
 Yang Guo <yangguo@chromium.org>
+# Contribute via c-ares patches:
+Daniel Stenberg <daniel@haxx.se>

--- a/AUTHORS
+++ b/AUTHORS
@@ -196,7 +196,7 @@ Jeremy Selier <jeremy@jolicloud.com>
 Igor Zinkovsky <igorzi@microsoft.com>
 Kip Gebhardt <kip.gebhardt@voxer.com>
 Stefan Rusu <saltwaterc@gmail.com>
-Shigeki Ohtsu <ohtsu@d.jp>
+Shigeki Ohtsu <ohtsu@ohtsu.org>
 Wojciech Wnętrzak <w.wnetrzak@gmail.com>
 Devon Govett <devongovett@gmail.com>
 Steve Engledow <steve.engledow@proxama.com>
@@ -359,7 +359,7 @@ Gil Pedersen <git@gpost.dk>
 Tyler Neylon <tylerneylon@gmail.com>
 Josh Erickson <josh@snoj.us>
 Golo Roden <webmaster@goloroden.de>
-Ron Korving <rkorving@wizcorp.jp>
+Ron Korving <ron@ronkorving.nl>
 Brandon Wilson <chlavois@gmail.com>
 Ian Babrou <ibobrik@gmail.com>
 Bearice Ren <bearice@gmail.com>
@@ -517,7 +517,7 @@ Cam Swords <cam.swords@gmail.com>
 Paul Loyd <pavelko95@gmail.com>
 Benjamin Waters <benjamin.waters@outlook.com>
 Lev Gimelfarb <lev.gimelfarb@gmail.com>
-Peter Flannery <pflannery@users.noreply.github.com>
+Peter Flannery <pflannery@>
 Tuğrul Topuz <tugrultopuz@gmail.com>
 Lorenz Leutgeb <lorenz.leutgeb@gmail.com>
 ayanamist <contact@ayanamist.com>
@@ -656,7 +656,7 @@ Juanjo <juanjo@bitrock.com>
 brian m. carlson <sandals@crustytoothpaste.net>
 Kevin O'Hara <kevinohara80@gmail.com>
 Micleusanu Nicu <micnic90@gmail.com>
-Alejandro Oviedo <alejandro.oviedo.g@gmail.com>
+Alejandro Oviedo Garcia <alejandro.oviedo.g@gmail.com>
 Ben Burns <benjamin.c.burns@gmail.com>
 Julian Duque <julianduquej@gmail.com>
 teppeis <teppeis@gmail.com>
@@ -681,7 +681,7 @@ Michal Tehnik <michal.tehnik@mictech.cz>
 Aaron Bieber <deftly@gmail.com>
 Phil Hughes <me@iamphill.com>
 Jongyeol Choi <jongyeol.choi@gmail.com>
-Brenard Cubacub <bcbcb@users.noreply.github.com>
+Brenard Cubacub <bcbcb@>
 Thomas Jensen <thomas@src.agency>
 Jay Jaeho Lee <sairion@gmail.com>
 Roman Reiss <me@silverwind.io>
@@ -711,14 +711,14 @@ Jan Schär <jscissr@gmail.com>
 Debjeet Biswas <debjeet@leftshift.io>
 Amir Saboury <amir.s@acm.org>
 Charmander <~@charmander.me>
-Jimmy Hsu <jimmyhsu@users.noreply.github.com>
+Jimmy Hsu <jimmyhsu@>
 jigsaw <jigsaw@live.jp>
 Emily Rose <nexxy@symphonysubconscious.com>
 Shinnosuke Watanabe <snnskwtnb@gmail.com>
 Bruno Jouhier <bjouhier@gmail.com>
 René Kooi <rene@kooi.me>
 Petka Antonov <petka_antonov@hotmail.com>
-Ryan Scheel <Ryan.havvy@gmail.com>
+Ryan Scheel (Havvy) <ryan.havvy@gmail.com>
 Benjamin Gruenbaum <inglor@gmail.com>
 Pavel Medvedev <pmedvedev@gmail.com>
 Russell Dempsey <sgtpooki@gmail.com>
@@ -730,9 +730,9 @@ Ken Perkins <ken.perkins@rackspace.com>
 Malte-Thorben Bruns <skenqbx@gmail.com>
 Santiago Gimeno <santiago.gimeno@gmail.com>
 Ali Ijaz Sheikh <ofrobots@google.com>
-FangDun Cai <cfddream@gmail.com>
+Fangdun Cai (Fundon) <cfddream@gmail.com>
 Alex Yursha <alexyursha@gmail.com>
-Steven Vercruysse <stcruy@users.noreply.github.com>
+Steven Vercruysse <stcruy@>
 Aleksanteri Negru-Vode <aleksanteri.negru-vode@aalto.fi>
 Mathieu Darse <mattdarse@gmail.com>
 Connor Peet <connor@peet.io>
@@ -782,7 +782,7 @@ Chad Johnston <cjohnston@megatome.com>
 Sam Stites <sam@stites.io>
 Matthew Lye <muddletoes@hotmail.com>
 Matt Loring <mattloring@google.com>
-Minqi Pan <pmq2001@gmail.com>
+P.S.V.R <pmq2001@gmail.com>
 Jacob Edelman <edelman.jd@gmail.com>
 Mike Atkins <mike.atkins@lanetix.com>
 hackerjs <4141095@qq.com>
@@ -846,7 +846,7 @@ Ashley Williams <ashley666ashley@gmail.com>
 Bryan English <bryan@bryanenglish.com>
 Devin Nakamura <devinn@ca.ibm.com>
 Vladimir Varankin <nek.narqo+git@gmail.com>
-Manuel B <baslr@users.noreply.github.com>
+Manuel B <baslr@>
 Jesse McCarthy <git_commits@jessemccarthy.net>
 Craig Cavalier <craigcav@gmail.com>
 Michael Cornacchia <cornacch@ca.ibm.com>
@@ -871,15 +871,13 @@ Andy Bettisworth <andy.bettisworth@accreu.com>
 Jörg Krause <joerg.krause@embedded.rocks>
 Alexander Martin <alex@suitupalex.com>
 Prince J Wesley <princejohnwesley@gmail.com>
-janriemer <janriemer@users.noreply.github.com>
+janriemer <janriemer@>
 Arthur Gautier <superbaloo+registrations.github@superbaloo.net>
 Martin von Gagern <Martin.vGagern@gmx.net>
 Hideki Yamamura <hideki.yamamura@gmail.com>
 Lenny Markus <lmarkus@paypal.com>
 Nelson Pecora <nelson@yoshokatana.com>
 Graham Fairweather <xotic750@gmail.com>
-Ron Korving <ron@ronkorving.nl>
-Xotic750 <xotic750@gmail.com>
 Nicholas Young <nicholas@nicholaswyoung.com>
 Chris Johnson <chris.s.johnson4@gmail.com>
 Bo Borgerson <gigabo@gmail.com>
@@ -915,7 +913,7 @@ Alexander Makarenko <estliberitas@gmail.com>
 Drew Folta <drew@folta.net>
 Myles Borins <myles.borins@gmail.com>
 Jimb Esser <wasteland@gmail.com>
-Dmitriy Lazarev <wKich@users.noreply.github.com>
+Dmitriy Lazarev <wKich@>
 Adam Langley <agl@google.com>
 Kári Tristan Helgason <kthelgason@gmail.com>
 Manuel Valls <manolo@vlrz.es>
@@ -923,7 +921,7 @@ Prayag Verma <prayag.verma@gmail.com>
 Gibson Fahnestock <gib@uk.ibm.com>
 Alan Cohen <alan@ripple.com>
 Christophe Naud-Dulude <christophe.naud.dulude@gmail.com>
-Matthias Bastian <dev@matthias-bastian.de>
+piepmatz <piepmatz@>
 Phillip Kovalev <twilightfeel@gmail.com>
 Rainer Oviir <roviir@gmail.com>
 HUANG Wei <grubbyfans@gmail.com>
@@ -933,7 +931,7 @@ Julie Pagano <julie.pagano@gmail.com>
 Ruben Bridgewater <ruben.bridgewater@fintura.de>
 Felix Becker <felix.b@outlook.com>
 Igor Klopov <igor@klopov.com>
-Tsarevich Dmitry <dimhotepus@users.noreply.github.com>
+Tsarevich Dmitry <dimhotepus@>
 Ojas Shirekar <ojas.shirekar@gmail.com>
 Noah Rose <noahroseledesma@seattleacademy.org>
 Rafael Cepeda <rcepeda1993@gmail.com>
@@ -950,7 +948,7 @@ Anton Andesen <a.andersen@readyforsky.com>
 Aayush Naik <aayushnaik17@gmail.com>
 Netto Farah <nettofarah@gmail.com>
 Daniel Wang <wangyang0123@gmail.com>
-Craig Akimoto <strawbrary@users.noreply.github.com>
+Craig Akimoto <strawbrary@>
 Michael Barrett <mike182uk@gmail.com>
 Alexander Marchenko <axvmindaweb@gmail.com>
 Steve Mao <maochenyan@gmail.com>
@@ -966,7 +964,7 @@ Lance Ball <lball@redhat.com>
 Jarrett Widman <jarrett@24m2.com>
 Florian Margaine <florian@margaine.com>
 Wolfgang Steiner <drywolf.dev@gmail.com>
-Bill Automata <billautomata@users.noreply.github.com>
+Bill Automata <billautomata@>
 Robert Chiras <robert.chiras@intel.com>
 Corey Kosak <kosak@kosak.com>
 John Eversole <eversojk@gmail.com>
@@ -989,15 +987,14 @@ Ilya Shaisultanov <ishaisultanov@shutterstock.com>
 James Lal <james@silklabs.com>
 Josh Leder <josh@ha.cr>
 Surya Panikkal <surya.com@gmail.com>
-vsemozhetbyt <vsemozhetbyt@gmail.com>
-Eugene Obrezkov <ghaiklor@gmail.com>
+Vse Mozhet Byt <vsemozhetbyt@gmail.com>
 Alex Lamar <alawi@vt.edu>
 Ian Kronquist <iankronquist@gmail.com>
 DavidCai <davidcai1993@yahoo.com>
 Patrick Mueller <pmuellr@nodesource.com>
 Ben Page <ben.page@openreign.com>
 Juan Soto <juan@juansoto.me>
-Allen Hernandez <allensh12@users.noreply.github.com>
+Allen Hernandez <allensh12@>
 Eric Phetteplace <phette23@gmail.com>
 William Luo <toyota790@gmail.com>
 Siobhan O'Donovan <siobhan@justshiv.com>
@@ -1036,13 +1033,13 @@ Daniel Bevenius <daniel.bevenius@gmail.com>
 Bryce Simonds <bryce.simonds@q2ebanking.com>
 Tushar Mathur <tusharmath@gmail.com>
 Kyle E. Mitchell <kyle@kemitchell.com>
-akki <akki@users.noreply.github.com>
+akki <akki@>
 Josh Gavant <josh.gavant@outlook.com>
 Sartrey Lee <sartrey@163.com>
 Guy Fraser <guy.fraser1@gmail.com>
-Ruslan Iusupov <rus0000@users.noreply.github.com>
+Ruslan Iusupov <rus0000@>
 Michael Wain <michael.wain@skybettingandgaming.com>
-Zach Bjornson <bjornson@stanford.edu>
+Zach Bjornson <zbbjornson@gmail.com>
 Andras <andras@kinvey.com>
 Chuck Langford <field.email@gmail.com>
 Ryan Lewis <ryanharrisonlewis@gmail.com>
@@ -1050,16 +1047,16 @@ Tarun Garg <tarungarg546@gmail.com>
 Diosney Sarmiento <diosney.s@gmail.com>
 Quentin Headen <qheaden@phaseshiftsoftware.com>
 Alex Hultman <alexhultman@gmail.com>
-Saad Quadri <saad@saadq.com>
+Saad Quadri <saad@saadquadri.com>
 Hargobind S. Khalsa <khalsah@gmail.com>
 Joran Siu <joransiu@ca.ibm.com>
-Vitaly Tomilov <vitaly-t@users.noreply.github.com>
+Vitaly Tomilov <vitaly-t@>
 Ratikesh Misra <ratikesh92@gmail.com>
 Alex Perkins <aperkin@rei.com>
 Bethany N Griggs <Bethany.Griggs@uk.ibm.com>
 Joe Esposito <joe@joeyespo.com>
 Erin Spiceland <yes@erin.codes>
-Ravindra Barthwal <ravindrabarthwal@users.noreply.github.com>
+Ravindra Barthwal <ravindrabarthwal@>
 Joey Cozza <joeycozza@gmail.com>
 Vladimir de Turckheim <vlad2t@hotmail.com>
 Taehee Kang <hugnosis@gmail.com>
@@ -1074,7 +1071,7 @@ Kunal Pathak <Kunal.Pathak@microsoft.com>
 Tracy Hinds <tracyhinds@gmail.com>
 lazlojuly <lazlo.gy@gmail.com>
 Arnaud Lefebvre <a.lefebvre@outlook.fr>
-not-an-aardvark <not-an-aardvark@users.noreply.github.com>
+not-an-aardvark <not-an-aardvark@>
 Junshu Okamoto <o_askgulf@icloud.com>
 Shahid Shaikh <rwtc66@gmail.com>
 Simen Bekkhus <sbekkhus91@gmail.com>
@@ -1082,5 +1079,94 @@ Jason Hedrick <thecoolestguy@gmail.com>
 David Keeler <dkeeler@mozilla.com>
 Zwb <zwb.ict@gmail.com>
 Paul Grock <paulgrock@gmail.com>
+Hubert Mine <hubertmine@hotmail.fr>
+Dan Fabulich <dan.fabulich@redfin.com>
+Mike Ralphson <mike.ralphson@gmail.com>
+Alexis374 <879736822@qq.com>
+atstojanov <atstojanov@gmail.com>
+Thomas Hunter II <me@thomashunter.name>
+Christopher Dunavan <github@hypersprite.com>
+Peter Ogilvie <code@ogilvie.us.com>
+Dan Williams <daniel@chat.za.net>
+Teddy Katz <teddy.katz@gmail.com>
+Kalman Hazins <kalmanh@gmail.com>
+Ltrlg <ltrlg.wp@gmail.com>
+Dennis Schwartz <dennis@repositive.io>
+Yevgen Safronov <sejoker@gmail.com>
+Tobias Kahse <tobias.kahse@hpe.com>
+Sébastien Barbieri <seba@rtbf.be>
+Pavol Otcenas <pavol@otcenas.eu>
+Alessandro Metta <n0f3@outlook.com>
+Dany Shaanan <danyshaanan@gmail.com>
+Ishan Aditya <ishanaditya@gmail.com>
+Rachel <rachel.black@flashtalking.com>
+Jason Ginchereau <jasongin@microsoft.com>
+Paul Kiddie <paul@paulkiddie.com>
+Scott Stern <scott.stern06@gmail.com>
+Danny Guo <dannyguo91@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
+Matt Lang <matt@mediasuite.co.nz>
+Thomas van Lankveld <thomas@cell-0.com>
+Tarjei Husøy <git@thusoy.com>
+Wietse Venema <wvenema@xebia.com>
+Jonathan Prince <jonathan.prince@gmail.com>
+Fikret Burak Gazioglu <burakgazi@static.ip-217-149-135-181.signet.nl>
+delvedor <tommydelved@gmail.com>
+Jermaine Oppong <jeropp00@gmail.com>
+Richard Walker <digitalsadhu@gmail.com>
+matzavinos <matzavinos@workable.com>
+Alfred Cepeda <AlfredJCepeda@gmail.com>
+Niklas Ingholt <niklas@ingholt.com>
+rainabba <rainabba@gmail.com>
+oogz <oogz@>
+Rene Weber <weber.rene@live.de>
+Lauren Spiegel <lhspiegel@gmail.com>
+Lydia Kats <llkats@gmail.com>
+mpmckenna8 <mpmckenna8@me.com>
+nohmapp <nohman20@gmail.com>
+Marc-Aurèle Darche <ma.darche@cynode.org>
+fen <jonairl@icloud.com>
+Christopher Fujino <christopherfujino@gmail.com>
+Richard Hong <rich.hong@gmail.com>
+Akito Ito <akito_ito@r.recruit.co.jp>
+Madhav Gharmalkar <gharmalkar.madhav@gmail.com>
+Mike Woods <mikeswoods@gmail.com>
+Daniel Stenberg <daniel@haxx.se>
+Abner Chou <zhcjtht@hotmail.com>
+Bryan Bess <squarejaw@bsbess.com>
+Michael Macherey <macherey@gmx.net>
+Sudaraka Wijesinghe <sudaraka@sudaraka.org>
+Miguel Angel Asencio Hurtado <maasencioh@gmail.com>
+ss22ever <ss22ever@>
+AnnaMag <AnnaMag@>
+Christopn Noelke <c.noelke@meteocontrol.de>
+Rémy Meja <remy.meja@inist.fr>
+Alex Jordan <alex@strugee.net>
+Mariusz 'koder' Chwalba <mariusz.chwalba@cashbill.pl>
+Juan Andres Andrango <andrango.juanandres@gmail.com>
+larissayvette <larissayvette55@gmail.com>
+jessicaquynh <jessica.quynh.tran@gmail.com>
+Ilya Frolov <ilfroloff@gmail.com>
+Tanuja-Sawant <thinkbigtanu@gmail.com>
+Bradley T. Hughes <bradleythughes@fastmail.fm>
+solebox <solekiller@gmail.com>
+John Vilk <jvilk@cs.umass.edu>
+Tyler Brazier <tyler@tylerbrazier.com>
+marzelin <marzelin@gmail.com>
+Benji Marinacci <bcmarinacci@icloud.com>
+Indrek Ardel <indrek@ardel.eu>
+Parambir Singh <parambirs@gmail.com>
+Niels Nielsen <niels@protectwise.com>
+Rod Machen <rod.machen@help.com>
+Marc Udoff <udoff@deshaw.com>
+Oliver Salzburg <oliver.salzburg@gmail.com>
+Jeena Lee <ijeenalee@gmail.com>
+Deverick <deverick@me.com>
+anu0012 <anurag30671371@gmail.com>
+jseagull <jseagull@aliyun.com>
+Olan Byrne <obyrne@turnitin.com>
+Emanuele DelBono <emanuele@codiceplastico.com>
+Aaron Bieber <aaron@bolddaemon.com>
+Gerges Beshay <gerges@beshay.xyz>
 
 # Generated by tools/update-authors.sh


### PR DESCRIPTION
Update AUTHORS list using tools/update-authors.sh

Includes modifications to .mailmap

Adds 86 new contributors.

I've replaced all of the nonsense email addresses (mainly noreply.github) with `<user@>` too.

Contributors non-trivially impacted by this change, please see how .mailmap changes are impacting your entry and speak up if there is a problem.

@shigeki
@ronkorving
@a0viedo
@Havvy
@fundon
@pmq20
@zbjornson
@saadq

New contributors without full names. It's not a strict requirement that we have real names for everyone, you're free to leave your entry in AUTHORS as it is here, however, having more information may assist us in the future on the legal side. e.g. if we were to attempt to change license. If you'd like your entry updated please let me know and I'll add a .mailmap entry for you to insert a new name.

@Alexis374
@atstojanov 
@Ltrlg 
@RachBLondon
@pmatzavin
@rainabba
@mpmckenna8
@nohmapp
@fene
@larissayvette
@jessicaquynh
@soleboxy 
@marzelin
@Deverick-Simpson
@anu0012 
@jseagull

New contributors with no full name or email address. You're welcome to keep your entry blank but if you could provide more information about yourself, including full name and/or contact address it would be appreciated. Let me know.

@oogz 
@ss22ever
@AnnaMag
