### PR TITLE
Backport fix for zlib inflation with custom dicts to 4.x

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -238,8 +238,11 @@ class ZCtx : public AsyncWrap {
       case INFLATERAW:
         ctx->err_ = inflate(&ctx->strm_, ctx->flush_);
 
-        // If data was encoded with dictionary
-        if (ctx->err_ == Z_NEED_DICT && ctx->dictionary_ != nullptr) {
+        // If data was encoded with dictionary (INFLATERAW will have it set in
+        // SetDictionary, don't repeat that here)
+        if (ctx->mode_ != INFLATERAW &&
+            ctx->err_ == Z_NEED_DICT &&
+            ctx->dictionary_ != nullptr) {
           // Load it
           ctx->err_ = inflateSetDictionary(&ctx->strm_,
                                            ctx->dictionary_,
@@ -488,6 +491,13 @@ class ZCtx : public AsyncWrap {
       case DEFLATE:
       case DEFLATERAW:
         ctx->err_ = deflateSetDictionary(&ctx->strm_,
+                                         ctx->dictionary_,
+                                         ctx->dictionary_len_);
+        break;
+      case INFLATERAW:
+        // The other inflate cases will have the dictionary set when inflate()
+        // returns Z_NEED_DICT in Process()
+        ctx->err_ = inflateSetDictionary(&ctx->strm_,
                                          ctx->dictionary_,
                                          ctx->dictionary_len_);
         break;

--- a/test/parallel/test-zlib-dictionary-fail.js
+++ b/test/parallel/test-zlib-dictionary-fail.js
@@ -26,3 +26,17 @@ var zlib = require('zlib');
   // String "test" encoded with dictionary "dict".
   stream.write(Buffer([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
 })();
+
+// Should raise an error, not trigger an assertion in src/node_zlib.cc
+(function() {
+  var stream = zlib.createInflateRaw({ dictionary: Buffer('fail') });
+
+  stream.on('error', common.mustCall(function(err) {
+    // It's not possible to separate invalid dict and invalid data when using
+    // the raw format
+    assert(/invalid/.test(err.message));
+  }));
+
+  // String "test" encoded with dictionary "dict".
+  stream.write(Buffer([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]));
+})();


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

zlib
##### Description of change

<!-- Provide a description of the change below this comment. -->

Backport of #8512 as requested in comments.
