### PR TITLE
test: remove timers from streams test

### DIFF
--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const Readable = require('stream').Readable;
@@ -37,10 +37,10 @@ function test1() {
           return r.push(Buffer.alloc(0));
         });
       case 4:
-        setImmediate(setImmediate, r.read.bind(r, 0));
-        return setImmediate(function() {
+        setImmediate(function() {
           return r.push(Buffer.alloc(0));
         });
+        return setImmediate(r.read.bind(r, 0));
       case 5:
         return setImmediate(function() {
           return r.push(buf);

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -24,27 +24,27 @@ function test1() {
   let reads = 5;
   r._read = function(n) {
     switch (reads--) {
-      case 0:
-        return r.push(null); // EOF
-      case 1:
-        return r.push(buf);
-      case 2:
-        setImmediate(r.read.bind(r, 0));
-        return r.push(Buffer.alloc(0)); // Not-EOF!
-      case 3:
-        setImmediate(r.read.bind(r, 0));
-        return process.nextTick(function() {
-          return r.push(Buffer.alloc(0));
+      case 5:
+        return setImmediate(function() {
+          return r.push(buf);
         });
       case 4:
         setImmediate(function() {
           return r.push(Buffer.alloc(0));
         });
         return setImmediate(r.read.bind(r, 0));
-      case 5:
-        return setImmediate(function() {
-          return r.push(buf);
+      case 3:
+        setImmediate(r.read.bind(r, 0));
+        return process.nextTick(function() {
+          return r.push(Buffer.alloc(0));
         });
+      case 2:
+        setImmediate(r.read.bind(r, 0));
+        return r.push(Buffer.alloc(0)); // Not-EOF!
+      case 1:
+        return r.push(buf);
+      case 0:
+        return r.push(null); // EOF
       default:
         throw new Error('unreachable');
     }

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -16,7 +16,7 @@ function test1() {
   //
   // note that this is very unusual.  it only works for crypto streams
   // because the other side of the stream will call read(0) to cycle
-  // data through openssl.  that's why we set the timeouts to call
+  // data through openssl.  that's why setImmediate() is used to call
   // r.read(0) again later, otherwise there is no more work being done
   // and the process just exits.
 

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -22,7 +22,6 @@ function test1() {
 
   const buf = Buffer.alloc(5, 'x');
   let reads = 5;
-  const timeout = common.platformTimeout(50);
   r._read = function(n) {
     switch (reads--) {
       case 0:
@@ -30,20 +29,20 @@ function test1() {
       case 1:
         return r.push(buf);
       case 2:
-        setTimeout(r.read.bind(r, 0), timeout);
+        setImmediate(r.read.bind(r, 0));
         return r.push(Buffer.alloc(0)); // Not-EOF!
       case 3:
-        setTimeout(r.read.bind(r, 0), timeout);
+        setImmediate(r.read.bind(r, 0));
         return process.nextTick(function() {
           return r.push(Buffer.alloc(0));
         });
       case 4:
-        setTimeout(r.read.bind(r, 0), timeout);
-        return setTimeout(function() {
+        setImmediate(setImmediate, r.read.bind(r, 0));
+        return setImmediate(function() {
           return r.push(Buffer.alloc(0));
         });
       case 5:
-        return setTimeout(function() {
+        return setImmediate(function() {
           return r.push(buf);
         });
       default:


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

test stream
##### Description of change

This is a proposed alternative to #9359, and I’ve taken the liberty to basically use @Trott’s commit message from there:
---

test-stream2-readable-empty-buffer-no-eof fails on resource-constrained
machines due to its use of timers. Removing timers makes it more
reliable and doesn’t affect the validity of the test, as it only uses
relative timing relations.

Failures were noticed on freebsd10-64 in CI. I am able to replicate the
failure with `tools/test.py --repeat=100 -j 100`. When run alone, it
passes reliably.
