### PR TITLE
test: remove timer in test-dgram-send-empty-array

### DIFF
--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -11,14 +11,9 @@ if (common.isOSX) {
 
 const client = dgram.createSocket('udp4');
 
-const timer = setTimeout(function() {
-  throw new Error('Timeout');
-}, common.platformTimeout(200));
-
 client.on('message', common.mustCall(function onMessage(buf, info) {
   const expected = Buffer.alloc(0);
   assert.ok(buf.equals(expected), 'message was received correctly');
-  clearTimeout(timer);
   client.close();
 }));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test dgram
##### Description of change

<!-- Provide a description of the change below this comment. -->

The timer is not necessary. The test will timeout via the test harness
if the test fails. This should resolve spurious CI failures.
