### PR TITLE
doc: move stray sentences in zlib doc

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -384,12 +384,12 @@ Only applicable to deflate algorithm.
 added: v0.7.0
 -->
 
+Reset the compressor/decompressor to factory defaults. Only applicable to
+the inflate and deflate algorithms.
+
 ## zlib.constants
 
 Provides an object enumerating Zlib-related constants.
-
-Reset the compressor/decompressor to factory defaults. Only applicable to
-the inflate and deflate algorithms.
 
 ## zlib.createDeflate([options])
 <!-- YAML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc zlib
##### Description of change

<!-- Provide a description of the change below this comment. -->

Move mislocated sentences to correct location.
