### PR TITLE
crypto: bypass FIPS_mode if not compiled for FIPS

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5866,11 +5866,15 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
 #endif  // !OPENSSL_NO_ENGINE
 
 void GetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
+#ifdef NODE_FIPS_MODE
   if (FIPS_mode()) {
     args.GetReturnValue().Set(1);
   } else {
     args.GetReturnValue().Set(0);
   }
+#else
+  args.GetReturnValue().Set(0);
+#endif // NODE_FIPS_MODE
 }
 
 void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
This isn't _strictly_ necessary but it's the remaining piece of FIPS code that is exposed in a build that hasn't been compiled with FIPS enabled. So, it's for consistency sake, mainly.

/R=@nodejs/crypto