### PR TITLE
child_process: add detached option to .exec()

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -137,6 +137,9 @@ added: v0.1.90
   * `timeout` {Number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
     stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
+  * `detached` {Boolean} Prepare child to run independently of its parent
+    process. Specific behavior depends on the platform, see
+    [`options.detached`][])
   * `killSignal` {String} (Default: `'SIGTERM'`)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
@@ -183,6 +186,7 @@ the process is spawned. The default options are:
   encoding: 'utf8',
   timeout: 0,
   maxBuffer: 200*1024,
+  detached: false,
   killSignal: 'SIGTERM',
   cwd: null,
   env: null
@@ -625,6 +629,9 @@ added: v0.11.12
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
   * `timeout` {Number} In milliseconds the maximum amount of time the process
     is allowed to run. (Default: `undefined`)
+  * `detached` {Boolean} Prepare child to run independently of its parent
+    process. Specific behavior depends on the platform, see
+    [`options.detached`][])
   * `killSignal` {String} The signal value to be used when the spawned process
     will be killed. (Default: `'SIGTERM'`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -139,7 +139,7 @@ added: v0.1.90
     stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
   * `detached` {Boolean} Prepare child to run independently of its parent
     process. Specific behavior depends on the platform, see
-    [`options.detached`][])
+    [`options.detached`][]
   * `killSignal` {String} (Default: `'SIGTERM'`)
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
@@ -315,7 +315,7 @@ added: v0.1.90
     [`options.stdio`][`stdio`])
   * `detached` {Boolean} Prepare child to run independently of its parent
     process. Specific behavior depends on the platform, see
-    [`options.detached`][])
+    [`options.detached`][]
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
   * `shell` {Boolean|String} If `true`, runs `command` inside of a shell. Uses
@@ -587,6 +587,9 @@ added: v0.11.12
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
   * `timeout` {Number} In milliseconds the maximum amount of time the process
     is allowed to run. (Default: `undefined`)
+  * `detached` {Boolean} Prepare child to run independently of its parent
+    process. Specific behavior depends on the platform, see
+    [`options.detached`][]
   * `killSignal` {String} The signal value to be used when the spawned process
     will be killed. (Default: `'SIGTERM'`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
@@ -631,7 +634,7 @@ added: v0.11.12
     is allowed to run. (Default: `undefined`)
   * `detached` {Boolean} Prepare child to run independently of its parent
     process. Specific behavior depends on the platform, see
-    [`options.detached`][])
+    [`options.detached`][]
   * `killSignal` {String} The signal value to be used when the spawned process
     will be killed. (Default: `'SIGTERM'`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -151,6 +151,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     gid: options.gid,
     uid: options.uid,
     shell: options.shell,
+    detached: !!options.detached,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 

--- a/test/fixtures/parent-process-exec-nonpersistent.js
+++ b/test/fixtures/parent-process-exec-nonpersistent.js
@@ -1,13 +1,14 @@
-
-var execFile = require('child_process').execFile,
-    path = require('path'),
-    childPath = path.join(__dirname, 'child-process-persistent.js');
+'use strict';
+const execFile = require('child_process').execFile;
+const path = require('path');
+const childPath = path.join(__dirname, 'child-process-persistent.js');
 
 var child = execFile(process.execPath, [ childPath ], {
   detached: true,
+  timeout: 100,
   stdio: 'ignore'
 });
 
-console.log(child.pid);
+process.send(child.pid);
 
 child.unref();

--- a/test/fixtures/parent-process-exec-nonpersistent.js
+++ b/test/fixtures/parent-process-exec-nonpersistent.js
@@ -5,7 +5,6 @@ const childPath = path.join(__dirname, 'child-process-persistent.js');
 
 var child = execFile(process.execPath, [ childPath ], {
   detached: true,
-  timeout: 100,
   stdio: 'ignore'
 });
 

--- a/test/fixtures/parent-process-exec-nonpersistent.js
+++ b/test/fixtures/parent-process-exec-nonpersistent.js
@@ -1,0 +1,13 @@
+
+var execFile = require('child_process').execFile,
+    path = require('path'),
+    childPath = path.join(__dirname, 'child-process-persistent.js');
+
+var child = execFile(process.execPath, [ childPath ], {
+  detached: true,
+  stdio: 'ignore'
+});
+
+console.log(child.pid);
+
+child.unref();

--- a/test/parallel/test-child-process-exec-detached.js
+++ b/test/parallel/test-child-process-exec-detached.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const execFile = require('child_process').execFile;
+const childPath = require.resolve(common.fixturesDir + '/parent-process-exec-nonpersistent.js');
+
+var persistentPid = -1;
+
+const execParent = execFile(process.execPath, [ childPath], {
+  timeout: 1000
+});
+
+execParent.stdout.on('data', function(data) {
+  persistentPid = data;
+});
+
+process.on('exit', () => {
+  assert.notStrictEqual(persistentPid, -1);
+  assert.throws(function(data) {
+    process.kill(execParent.pid);
+  });
+  assert.doesNotThrow(function() {
+    process.kill(persistentPid);
+  });
+});

--- a/test/parallel/test-child-process-exec-detached.js
+++ b/test/parallel/test-child-process-exec-detached.js
@@ -7,16 +7,17 @@ const childPath = path.join(common.fixturesDir, 'parent-process-exec-nonpersiste
 
 let persistentPid = -1;
 
-const execParent = cp.fork(childPath);
+const child = cp.fork(childPath);
 
-execParent.on('message', common.mustCall((msg) => {
+child.on('message', common.mustCall((msg) => {
   persistentPid = msg;
-}));
-
-execParent.on('close', common.mustCall((code, sig) => {
-  assert.equal(sig, null);
 }));
 
 process.on('exit', () => {
   assert.notStrictEqual(persistentPid, -1);
 });
+
+setTimeout(function() {
+  // *nix: test that the child process it has the gid === pid
+  process.kill(persistentPid);
+}, 150);


### PR DESCRIPTION
##### Checklist

- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Doc, child_process


##### Description of change
<!-- Provide a description of the change below this comment. -->
This PR adds `detached` as an option for `child_process.exec()`
to maintain consistency across the `child_process` functions.

It also adds the `detached` as an option to the documentation 
for `.execSync()`, which was previously undocumented.

Ref: https://github.com/nodejs/node/issues/9146