### PR TITLE
Backport --shared to V4.x codebase to allow building as a shared library / DLL

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -79,6 +79,20 @@
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
             'ldflags': [ '-fPIE', '-pie' ]
+          }],
+          ['node_shared=="true"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': 3 # MultiThreadedDebugDLL (/MDd)
+              }
+            }
+          }],
+          ['node_shared=="false"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': 1 # MultiThreadedDebug (/MTd)
+              }
+            }
           }]
         ],
         'msvs_settings': {
@@ -116,11 +130,24 @@
           ['OS == "android"', {
             'cflags': [ '-fPIE' ],
             'ldflags': [ '-fPIE', '-pie' ]
+          }],
+          ['node_shared=="true"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': 2 # MultiThreadedDLL (/MD)
+              }
+            }
+          }],
+          ['node_shared=="false"', {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': 0 # MultiThreaded (/MT)
+              }
+            }
           }]
         ],
         'msvs_settings': {
           'VCCLCompilerTool': {
-            'RuntimeLibrary': 0, # static release
             'Optimization': 3, # /Ox, full optimization
             'FavorSizeOrSpeed': 1, # /Ot, favour speed over size
             'InlineFunctionExpansion': 2, # /Ob2, inline anything eligible

--- a/common.gypi
+++ b/common.gypi
@@ -11,6 +11,12 @@
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
     'python%': 'python',
 
+    'node_shared%': 'false',
+    'force_dynamic_crt%': 0,
+    'node_use_v8_platform%': 'true',
+    'node_use_bundled_v8%': 'true',
+    'node_module_version%': '',
+
     'node_tag%': '',
     'uv_library%': 'static_library',
 
@@ -291,6 +297,9 @@
             ],
             'ldflags!': [ '-rdynamic' ],
           }],
+          [ 'node_shared=="true"', {
+            'cflags': [ '-fPIC' ],
+          }]
         ],
       }],
       ['OS=="android"', {

--- a/configure
+++ b/configure
@@ -26,6 +26,7 @@ import nodedownload
 
 # imports in tools/
 sys.path.insert(0, os.path.join(root_dir, 'tools'))
+import getmoduleversion
 
 # parse our options
 parser = optparse.OptionParser()

--- a/configure
+++ b/configure
@@ -24,6 +24,9 @@ from gyp.common import GetFlavor
 sys.path.insert(0, os.path.join(root_dir, 'tools', 'configure.d'))
 import nodedownload
 
+# imports in tools/
+sys.path.insert(0, os.path.join(root_dir, 'tools'))
+
 # parse our options
 parser = optparse.OptionParser()
 
@@ -384,6 +387,26 @@ parser.add_option('--enable-static',
     action='store_true',
     dest='enable_static',
     help='build as static library')
+
+parser.add_option('--shared',
+    action='store_true',
+    dest='shared',
+    help='compile shared library for embedding node in another project. ' +
+         '(This mode is not officially supported for regular applications)')
+
+parser.add_option('--without-v8-platform',
+    action='store_true',
+    dest='without_v8_platform',
+    default=False,
+    help='do not initialize v8 platform during node.js startup. ' +
+        '(This mode is not officially supported for regular applications)')
+
+parser.add_option('--without-bundled-v8',
+    action='store_true',
+    dest='without_bundled_v8',
+    default=False,
+    help='do not use V8 includes from the bundled deps folder. ' +
+         '(This mode is not officially supported for regular applications)')
 
 (options, args) = parser.parse_args()
 
@@ -774,7 +797,14 @@ def configure_node(o):
   if options.enable_static:
     o['variables']['node_target_type'] = 'static_library'
 
-  o['variables']['node_module_version'] = 46
+  o['variables']['node_shared'] = b(options.shared)
+  o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
+  o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
+  node_module_version = getmoduleversion.get_version()
+  shlib_suffix = '%s.dylib' if sys.platform == 'darwin' else 'so.%s'
+  shlib_suffix %= node_module_version
+  o['variables']['node_module_version'] = int(node_module_version)
+  o['variables']['shlib_suffix'] = shlib_suffix
 
   if options.linked_module:
     o['variables']['library_files'] = options.linked_module
@@ -820,8 +850,7 @@ def configure_v8(o):
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
   o['variables']['node_enable_d8'] = b(options.enable_d8)
-
-
+  o['variables']['force_dynamic_crt'] = 1 if options.shared else 0
 def configure_openssl(o):
   o['variables']['node_use_openssl'] = b(not options.without_ssl)
   o['variables']['node_shared_openssl'] = b(options.shared_openssl)

--- a/deps/v8/build/toolchain.gypi
+++ b/deps/v8/build/toolchain.gypi
@@ -39,6 +39,7 @@
     'ubsan_vptr%': 0,
     'v8_target_arch%': '<(target_arch)',
     'v8_host_byteorder%': '<!(python -c "import sys; print sys.byteorder")',
+    'force_dynamic_crt%': 0,
     # Native Client builds currently use the V8 ARM JIT and
     # arm/simulator-arm.cc to defer the significant effort required
     # for NaCl JIT support. The nacl_target_arch variable provides
@@ -995,7 +996,7 @@
           'VCCLCompilerTool': {
             'Optimization': '0',
             'conditions': [
-              ['component=="shared_library"', {
+              ['component=="shared_library" or force_dynamic_crt==1', {
                 'RuntimeLibrary': '3',  # /MDd
               }, {
                 'RuntimeLibrary': '1',  # /MTd
@@ -1047,7 +1048,7 @@
             'StringPooling': 'true',
             'BasicRuntimeChecks': '0',
             'conditions': [
-              ['component=="shared_library"', {
+              ['component=="shared_library" or force_dynamic_crt==1', {
                 'RuntimeLibrary': '3',  #/MDd
               }, {
                 'RuntimeLibrary': '1',  #/MTd
@@ -1235,7 +1236,7 @@
                 'FavorSizeOrSpeed': '0',
                 'StringPooling': 'true',
                 'conditions': [
-                  ['component=="shared_library"', {
+                  ['component=="shared_library" or force_dynamic_crt==1', {
                     'RuntimeLibrary': '2',  #/MD
                   }, {
                     'RuntimeLibrary': '0',  #/MT

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 42
+#define V8_PATCH_LEVEL 43
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/node.gyp
+++ b/node.gyp
@@ -243,7 +243,7 @@
          ],
           'conditions': [
             [ 'node_module_version!="" and OS!="win"', {
-              'product_extension': 'so.<(node_module_version)',
+              'product_extension': '<(shlib_suffix)',
             }]
           ],
         }],

--- a/node.gyp
+++ b/node.gyp
@@ -242,7 +242,7 @@
             'NODE_SHARED_MODE',
          ],
           'conditions': [
-            [ 'node_module_version!=""', {
+            [ 'node_module_version!="" and OS!="win"', {
               'product_extension': 'so.<(node_module_version)',
             }]
           ],

--- a/src/node.h
+++ b/src/node.h
@@ -396,17 +396,23 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 # define NODE_MODULE_EXPORT __attribute__((visibility("default")))
 #endif
 
+#ifdef NODE_SHARED_MODE
+# define NODE_CTOR_PREFIX
+#else
+# define NODE_CTOR_PREFIX static
+#endif
+
 #if defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
 #define NODE_C_CTOR(fn)                                               \
-  static void __cdecl fn(void);                                       \
+  NODE_CTOR_PREFIX void __cdecl fn(void);                             \
   __declspec(dllexport, allocate(".CRT$XCU"))                         \
       void (__cdecl*fn ## _)(void) = fn;                              \
-  static void __cdecl fn(void)
+  NODE_CTOR_PREFIX void __cdecl fn(void)
 #else
 #define NODE_C_CTOR(fn)                                               \
-  static void fn(void) __attribute__((constructor));                  \
-  static void fn(void)
+  NODE_CTOR_PREFIX void fn(void) __attribute__((constructor));        \
+  NODE_CTOR_PREFIX void fn(void)
 #endif
 
 #define NODE_MODULE_X(modname, regfunc, priv, flags)                  \

--- a/tools/getmoduleversion.py
+++ b/tools/getmoduleversion.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import os
+import re
+
+def get_version():
+  node_version_h = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'src',
+    'node_version.h')
+
+  f = open(node_version_h)
+
+  regex = '^#define NODE_MODULE_VERSION [0-9]+'
+
+  for line in f:
+    if re.match(regex, line):
+      major = line.split()[2]
+      return major
+  
+  raise Exception('Could not find pattern matching %s' % regex)
+
+if __name__ == '__main__':
+  print(get_version())

--- a/tools/getnodeversion.py
+++ b/tools/getnodeversion.py
@@ -1,16 +1,20 @@
-import os,re
+import os
+import re
 
-node_version_h = os.path.join(os.path.dirname(__file__), '..', 'src',
+node_version_h = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'src',
     'node_version.h')
 
 f = open(node_version_h)
 
 for line in f:
-  if re.match('#define NODE_MAJOR_VERSION', line):
+  if re.match('^#define NODE_MAJOR_VERSION', line):
     major = line.split()[2]
-  if re.match('#define NODE_MINOR_VERSION', line):
+  if re.match('^#define NODE_MINOR_VERSION', line):
     minor = line.split()[2]
-  if re.match('#define NODE_PATCH_VERSION', line):
+  if re.match('^#define NODE_PATCH_VERSION', line):
     patch = line.split()[2]
 
 print '%(major)s.%(minor)s.%(patch)s'% locals()

--- a/tools/install.py
+++ b/tools/install.py
@@ -133,10 +133,11 @@ def files(action):
     if is_windows:
       output_file += '.dll'
     else:
-      # GYP will output to lib.target, this is hardcoded in its source,
-      # see the _InstallablaeTargetInstallPath function.
-      output_prefix += 'lib.target/'
-      output_file = 'lib' + output_file + '.so'
+      output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
+      # GYP will output to lib.target except on OS X, this is hardcoded
+      # in its source - see the _InstallableTargetInstallPath function.
+      if sys.platform != 'darwin':
+        output_prefix += 'lib.target/'
 
   action([output_prefix + output_file], 'bin/' + output_file)
 

--- a/tools/install.py
+++ b/tools/install.py
@@ -123,9 +123,22 @@ def subdir_files(path, dest, action):
 
 def files(action):
   is_windows = sys.platform == 'win32'
+  output_file = 'node'
+  output_prefix = 'out/Release/'
 
-  exeext = '.exe' if is_windows else ''
-  action(['out/Release/node' + exeext], 'bin/node' + exeext)
+  if 'false' == variables.get('node_shared'):
+    if is_windows:
+      output_file += '.exe'
+  else:
+    if is_windows:
+      output_file += '.dll'
+    else:
+      # GYP will output to lib.target, this is hardcoded in its source,
+      # see the _InstallablaeTargetInstallPath function.
+      output_prefix += 'lib.target/'
+      output_file = 'lib' + output_file + '.so'
+
+  action([output_prefix + output_file], 'bin/' + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -37,6 +37,7 @@ set build_release=
 set configure_flags=
 set build_addons=
 set enable_vtune_profiling=
+set dll=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -76,6 +77,7 @@ if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_profiling="--enable-vtune-profiling"&goto arg-ok
+if /i "%1"=="dll"           set dll=1&goto arg-ok
 
 echo Error: invalid command line option `%1`.
 exit /b 1
@@ -105,6 +107,7 @@ if defined noetw set configure_flags=%configure_flags% --without-etw& set noetw_
 if defined noperfctr set configure_flags=%configure_flags% --without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
 if defined release_urlbase set configure_flags=%configure_flags% --release-urlbase=%release_urlbase%
 if defined download_arg set configure_flags=%configure_flags% %download_arg%
+if defined dll set configure_flags=%configure_flags% --shared
 
 if "%i18n_arg%"=="full-icu" set configure_flags=%configure_flags% --with-intl=full-icu
 if "%i18n_arg%"=="small-icu" set configure_flags=%configure_flags% --with-intl=small-icu


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build

##### Description of change
Enable the --shared parameter for building node as a shared library on Linux/OS X/Windows. This is a backport of the support that's already in the V6 codebase. Reference https://github.com/nodejs/node/pull/7687 - FYI @TheAlphaNerd 