### PR TITLE
http: make `globalAgent` of `http` and `https` as overridable properties

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -23,6 +23,7 @@ const client = require('_http_client');
 const ClientRequest = exports.ClientRequest = client.ClientRequest;
 
 exports.request = function request(options, cb) {
+  options._defaultAgent = options._defaultAgent || exports.globalAgent || agent.globalAgent;
   return new ClientRequest(options, cb);
 };
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -195,7 +195,7 @@ exports.request = function(options, cb) {
   } else {
     options = util._extend({}, options);
   }
-  options._defaultAgent = globalAgent;
+  options._defaultAgent = exports.globalAgent || globalAgent;
   return http.request(options, cb);
 };
 


### PR DESCRIPTION
##### Checklist
- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http, https

##### Description of change

The `http.globalAgent` and `https.globalAgent` previously cannot be overridden directly by reassigning new a value.

By exposing the `globalAgent`s of `http` and `https`, now it can be reassigned by:

    http.globalAgent = new MyAgent();
    https.globalAgent = new MySecureAgent();

Fix #9057