### PR TITLE
v8: update make-v8.sh to use git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ cctest: all
 	@out/$(BUILDTYPE)/$@
 
 v8:
-	tools/make-v8.sh master
+	tools/make-v8.sh
 	$(MAKE) -C deps/v8 $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
 test: all

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ cctest: all
 	@out/$(BUILDTYPE)/$@
 
 v8:
-	tools/make-v8.sh v8
+	tools/make-v8.sh master
 	$(MAKE) -C deps/v8 $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
 test: all

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -16,12 +16,14 @@ function cleanup() {
   rm .gclient || true
   rm .gclient_entries || true
   rm -rf _bad_scm/ || true
-  rm -rf .v8old
   if [ "$BRANCH" == "master" ]; then
     echo "git cleanup if branch is master"
-    git ls-files -m | xargs git checkout --
+    git reset --hard HEAD
     git clean -fd >/dev/null
+    # Copy local files
+    rsync -a .v8old/ v8/
   fi
+  rm -rf .v8old
   exit 0
 }
 

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -16,16 +16,16 @@ function cleanup() {
   find v8 -name ".git" | xargs rm -rf || true
   echo "git cleanup"
   git reset --hard HEAD
-  git clean -e .v8old -fdq
-  # Copy local files
-  rsync -a .v8old/ v8/
-  rm -rf .v8old
+  git clean -fdq
+  # unstash local changes
+  git stash pop
   exit 0
 }
 
 cd deps
-# Preserve local changes
-mv v8 .v8old
+# stash local changes
+git stash
+rm -rf v8
 
 echo "Fetching V8 from chromium.googlesource.com"
 fetch v8

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]; then
-  # Default branch is master
-  BRANCH="master"
-else
-  # eg: 5.4-lkgr
-  BRANCH="$1"
-fi
+# Get V8 branch from v8/include/v8-version.h
+MAJOR=$(grep V8_MAJOR_VERSION deps/v8/include/v8-version.h | cut -d ' ' -f 3)
+MINOR=$(grep V8_MINOR_VERSION deps/v8/include/v8-version.h | cut -d ' ' -f 3)
+BRANCH=$MAJOR.$MINOR
 
 # clean up if someone presses ctrl-c
 trap cleanup INT
@@ -26,6 +23,7 @@ function cleanup() {
 }
 
 cd deps
+# Preserve local changes
 mv v8 .v8old
 
 echo "Fetching v8 from chromium.googlesource.com"
@@ -41,7 +39,7 @@ cd v8
 echo "Checking out branch:$BRANCH"
 if [ "$BRANCH" != "master" ]; then
    git fetch
-   git checkout origin/$BRANCH
+   git checkout remotes/branch-heads/$BRANCH
 fi
 
 echo "Sync dependencies"

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -16,13 +16,11 @@ function cleanup() {
   rm .gclient || true
   rm .gclient_entries || true
   rm -rf _bad_scm/ || true
-  if [ "$BRANCH" == "master" ]; then
-    echo "git cleanup if branch is master"
-    git reset --hard HEAD
-    git clean -fdq
-    # Copy local files
-    rsync -a .v8old/ v8/
-  fi
+  echo "git cleanup"
+  git reset --hard HEAD
+  git clean -e .v8old -ffdq
+  # Copy local files
+  rsync -a .v8old/ v8/
   rm -rf .v8old
   exit 0
 }

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -37,10 +37,8 @@ echo "V8 fetched"
 cd v8
 
 echo "Checking out branch:$BRANCH"
-if [ "$BRANCH" != "master" ]; then
-   git fetch
-   git checkout remotes/branch-heads/$BRANCH
-fi
+git fetch
+git checkout remotes/branch-heads/$BRANCH
 
 echo "Sync dependencies"
 gclient sync

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -26,7 +26,7 @@ cd deps
 # Preserve local changes
 mv v8 .v8old
 
-echo "Fetching v8 from chromium.googlesource.com"
+echo "Fetching V8 from chromium.googlesource.com"
 fetch v8
 if [ "$?" -ne 0 ]; then
   echo "V8 fetch failed"
@@ -37,7 +37,6 @@ echo "V8 fetched"
 cd v8
 
 echo "Checking out branch:$BRANCH"
-git fetch
 git checkout remotes/branch-heads/$BRANCH
 
 echo "Sync dependencies"

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -1,38 +1,51 @@
 #!/bin/bash
 
-
-git_origin=$(git config --get remote.origin.url | sed 's/.\+[\/:]\([^\/]\+\/[^\/]\+\)$/\1/')
-git_branch=$(git rev-parse --abbrev-ref HEAD)
-v8ver=${1:-v8} #default v8
-svn_prefix=https://github.com
-svn_path="$svn_prefix/$git_origin/branches/$git_branch/deps/$v8ver"
-#svn_path="$git_origin/branches/$git_branch/deps/$v8ver"
-gclient_string="solutions = [{'name': 'v8', 'url': '$svn_path', 'managed': False}]"
+if [ $# -eq 0 ]; then
+  # Default branch is master
+  BRANCH="master"
+else
+  # eg: 5.4-lkgr
+  BRANCH="$1"
+fi
 
 # clean up if someone presses ctrl-c
 trap cleanup INT
 
 function cleanup() {
   trap - INT
-
   rm .gclient || true
   rm .gclient_entries || true
   rm -rf _bad_scm/ || true
-
-  #if v8ver isn't v8, move the v8 folders
-  #back to what they were
-  if [ "$v8ver" != "v8" ]; then
-    mv v8 $v8ver
-    mv .v8old v8
+  rm -rf .v8old
+  if [ "$BRANCH" == "master" ]; then
+    echo "git cleanup if branch is master"
+    git ls-files -m | xargs git checkout --
+    git clean -fd >/dev/null
   fi
   exit 0
 }
 
 cd deps
-echo $gclient_string > .gclient
-if [ "$v8ver" != "v8" ]; then
-  mv v8 .v8old
-  mv $v8ver v8
+mv v8 .v8old
+
+echo "Fetching v8 from chromium.googlesource.com"
+fetch v8
+if [ "$?" -ne 0 ]; then
+  echo "V8 fetch failed"
+  exit 1
 fi
+echo "V8 fetched"
+
+cd v8
+
+echo "Checking out branch:$BRANCH"
+if [ "$BRANCH" != "master" ]; then
+   git fetch
+   git checkout origin/$BRANCH
+fi
+
+echo "Sync dependencies"
 gclient sync
+
+cd ..
 cleanup

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -13,9 +13,10 @@ function cleanup() {
   rm .gclient || true
   rm .gclient_entries || true
   rm -rf _bad_scm/ || true
+  find v8 -name ".git" | xargs rm -rf || true
   echo "git cleanup"
   git reset --hard HEAD
-  git clean -e .v8old -ffdq
+  git clean -e .v8old -fdq
   # Copy local files
   rsync -a .v8old/ v8/
   rm -rf .v8old

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -19,7 +19,7 @@ function cleanup() {
   if [ "$BRANCH" == "master" ]; then
     echo "git cleanup if branch is master"
     git reset --hard HEAD
-    git clean -fd >/dev/null
+    git clean -fdq
     # Copy local files
     rsync -a .v8old/ v8/
   fi


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
v8
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

google build tool gclient doesn't support svn anymore. Updating v8 build script 
to use git instead. More info #9222 