### PR TITLE
src: fix LTTNG tracepoint macros

### DIFF
--- a/src/node_lttng_tp.h
+++ b/src/node_lttng_tp.h
@@ -25,6 +25,7 @@ TRACEPOINT_EVENT(
     ctf_string(url, url)
     ctf_string(method, method)
     ctf_string(forwardedFor, forwardedFor))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -37,6 +38,7 @@ TRACEPOINT_EVENT(
     ctf_integer(int, port, port)
     ctf_string(remote, remote)
     ctf_integer(int, fd, fd))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -47,6 +49,7 @@ TRACEPOINT_EVENT(
   TP_FIELDS(
     ctf_string(url, url)
     ctf_string(method, method))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -59,6 +62,7 @@ TRACEPOINT_EVENT(
     ctf_integer(int, port, port)
     ctf_string(remote, remote)
     ctf_integer(int, fd, fd))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -73,6 +77,7 @@ TRACEPOINT_EVENT(
     ctf_integer(int, port, port)
     ctf_integer(int, fd, fd)
     ctf_integer(int, buffered, buffered))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -85,6 +90,7 @@ TRACEPOINT_EVENT(
     ctf_string(remote, remote)
     ctf_integer(int, port, port)
     ctf_integer(int, fd, fd))
+)
 
 TRACEPOINT_EVENT(
   node,
@@ -106,6 +112,7 @@ TRACEPOINT_EVENT(
   TP_FIELDS(
     ctf_string(gctype, gctype)
     ctf_string(gcflags, gcflags))
+)
 
 #endif /* __NODE_LTTNG_TP_H */
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

src

##### Description of change
<!-- Provide a description of the change below this comment. -->

Closing parentheses from `TRACEPOINT_EVENT` were removed accidentally in #7462, specifically f1d2792c1c7ec0473832a9b0b2025be64953820b. As a result, building following `./configure --with-lttng` fails.

This PR simply adds closing parentheses to the LTTNG tracepoint definitions to fix this.