### PR TITLE
tools: enforce function name matching in linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -82,6 +82,7 @@ rules:
   computed-property-spacing: 2
   eol-last: 2
   func-call-spacing: 2
+  func-name-matching: 2
   indent: [2, 2, {SwitchCase: 1, MemberExpression: 1}]
   key-spacing: [2, {mode: minimum}]
   keyword-spacing: 2


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

ESLint has a `func-name-matching` rule that requires that function names
match the variable or property to which they are being assigned.

The code base currently has 100% compliance with this rule.

Enable the rule to keep it that way.