### PR TITLE
crypto: fix handling of root_cert_store

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -773,6 +773,8 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
   }
 
   sc->ca_store_ = root_cert_store;
+  // Increment reference count so global store is not deleted along with CTX.
+  CRYPTO_add(&root_cert_store->references, 1, CRYPTO_LOCK_X509_STORE);
   SSL_CTX_set_cert_store(sc->ctx_, sc->ca_store_);
 }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -76,7 +76,6 @@ class SecureContext : public BaseObject {
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
-  X509_STORE* ca_store_;
   SSL_CTX* ctx_;
   X509* cert_;
   X509* issuer_;
@@ -131,7 +130,6 @@ class SecureContext : public BaseObject {
 
   SecureContext(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),
-        ca_store_(nullptr),
         ctx_(nullptr),
         cert_(nullptr),
         issuer_(nullptr) {
@@ -140,20 +138,19 @@ class SecureContext : public BaseObject {
   }
 
   void FreeCTXMem() {
-    if (ctx_) {
-      env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
-      SSL_CTX_free(ctx_);
-      if (cert_ != nullptr)
-        X509_free(cert_);
-      if (issuer_ != nullptr)
-        X509_free(issuer_);
-      ctx_ = nullptr;
-      ca_store_ = nullptr;
-      cert_ = nullptr;
-      issuer_ = nullptr;
-    } else {
-      CHECK_EQ(ca_store_, nullptr);
+    if (!ctx_) {
+      return;
     }
+
+    env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
+    SSL_CTX_free(ctx_);
+    if (cert_ != nullptr)
+      X509_free(cert_);
+    if (issuer_ != nullptr)
+      X509_free(issuer_);
+    ctx_ = nullptr;
+    cert_ = nullptr;
+    issuer_ = nullptr;
   }
 };
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -142,13 +142,6 @@ class SecureContext : public BaseObject {
   void FreeCTXMem() {
     if (ctx_) {
       env()->isolate()->AdjustAmountOfExternalAllocatedMemory(-kExternalSize);
-      if (ctx_->cert_store == root_cert_store) {
-        // SSL_CTX_free() will attempt to free the cert_store as well.
-        // Since we want our root_cert_store to stay around forever
-        // we just clear the field. Hopefully OpenSSL will not modify this
-        // struct in future versions.
-        ctx_->cert_store = nullptr;
-      }
       SSL_CTX_free(ctx_);
       if (cert_ != nullptr)
         X509_free(cert_);

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -141,3 +141,7 @@ assert.throws(function() {
 
 // Make sure memory isn't released before being returned
 console.log(crypto.randomBytes(16));
+
+assert.throws(function() {
+  tls.createSecureContext({ crl: 'not a CRL' });
+}, '/Failed to parse CRL/');

--- a/test/parallel/test-tls-addca.js
+++ b/test/parallel/test-tls-addca.js
@@ -1,0 +1,62 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const tls = require('tls');
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+const caCert = loadPEM('ca1-cert');
+const contextWithoutCert = tls.createSecureContext({});
+const contextWithCert = tls.createSecureContext({});
+// Adding a CA certificate to contextWithCert should not also add it to
+// contextWithoutCert. This is tested by trying to connect to a server that
+// depends on that CA using contextWithoutCert.
+contextWithCert.context.addCACert(caCert);
+
+const serverOptions = {
+  key: loadPEM('agent1-key'),
+  cert: loadPEM('agent1-cert'),
+};
+const server = tls.createServer(serverOptions, function() {});
+
+const clientOptions = {
+  port: undefined,
+  ca: [caCert],
+  servername: 'agent1',
+  rejectUnauthorized: true,
+};
+
+function startTest() {
+  // This client should fail to connect because it doesn't trust the CA
+  // certificate.
+  clientOptions.secureContext = contextWithoutCert;
+  clientOptions.port = server.address().port;
+  const client = tls.connect(clientOptions, common.fail);
+  client.on('error', common.mustCall(() => {
+    client.destroy();
+
+    // This time it should connect because contextWithCert includes the needed
+    // CA certificate.
+    clientOptions.secureContext = contextWithCert;
+    const client2 = tls.connect(clientOptions, common.mustCall(() => {
+      client2.destroy();
+      server.close();
+    }));
+    client2.on('error', (e) => {
+      console.log(e);
+    });
+  }));
+}
+
+server.listen(0, startTest);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

crypto: fix handling of root_cert_store.

SecureContext::AddRootCerts only parses the root certificates once and keeps the result in root_cert_store, a global X509_STORE. This change addresses the following issues:

1. SecureContext::AddCACert would add certificates to whatever X509_STORE was being used, even if that happened to be root_cert_store. Thus adding a CA certificate to a SecureContext would also cause it to be included in unrelated SecureContexts.

2. AddCRL would crash if neither AddRootCerts nor AddCACert had been called first.

3. Calling AddCACert without calling AddRootCerts first, and with an input that didn't contain any certificates, would leak an X509_STORE.

4. AddCRL would add the CRL to whatever X509_STORE was being used. Thus, like AddCACert, unrelated SecureContext objects could be affected.

The following, non-obvious behaviour remains: calling AddRootCerts doesn't _add_ them, rather it sets the CA certs to be the root set and overrides any previous CA certificates.

Points 1–3 are probably unimportant because the SecureContext is typically configured by `createSecureContext` in `lib/_tls_common.js`. This function either calls AddCACert or AddRootCerts and only calls AddCRL after setting up CA certificates. Point four could still apply in the unlikely case that someone configures a CRL without explicitly configuring the CAs.