### PR TITLE
doc: do not link in the headings

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -124,7 +124,7 @@ $ node --zero-fill-buffers
 <Buffer 00 00 00 00 00>
 ```
 
-### What makes [`Buffer.allocUnsafe()`] and [`Buffer.allocUnsafeSlow()`] "unsafe"?
+### What makes `Buffer.allocUnsafe()` and `Buffer.allocUnsafeSlow()` "unsafe"?
 
 When calling [`Buffer.allocUnsafe()`] and [`Buffer.allocUnsafeSlow()`], the
 segment of allocated memory is *uninitialized* (it is not zeroed-out). While


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc buffer

##### Description of change

If there is a link in the headings, when the ToC is generated, that is
not properly linked, instead the square brackets are left as they are.

Even if we fix this, different parts of the heading will link to
different sections or even different pages. For example,

    ### What makes [`Buffer.allocUnsafe()`] and
          [`Buffer.allocUnsafeSlow()`] "unsafe"?

will point to three different sections. `allocUnsafe` and
`allocUnsafeSlow` will link to their corresponding sections and all
other words actully link to the heading in the document. This could be
visually confusing.

Fixes: https://github.com/nodejs/node/issues/9331

---

cc @mscdex @silverwind 