### PR TITLE
doc: update minute-taking procedure for CTC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -143,8 +143,8 @@ items.
 The CTC may invite persons or representatives from certain projects to
 participate in a non-voting capacity.
 
-The meeting chair is responsible for summarizing the discussion of each agenda
-item and sending it as a pull request after the meeting.
+The meeting chair is responsible for ensuring that minutes are taken and that a
+pull request with the minutes is submitted after the meeting.
 
 Due to the challenges of scheduling a global meeting with participants in
 several timezones, the CTC will seek to resolve as many agenda items as possible


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

The doc says that the CTC moderator is responsible for taking minutes
and that the minutes for each agenda item should be a separate pull
request.

This change updates the doc to say that the moderator is responsible for
making sure that notes are taken, but not necessarily taking the notes
themselves. Furthermore, it removes the separate-pull-request
requirement as that is not what happens in practice.

@nodejs/ctc