### PR TITLE
test: move timer-dependent test to sequential

### DIFF
--- a/test/sequential/test-repl-timeout-throw.js
+++ b/test/sequential/test-repl-timeout-throw.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var spawn = require('child_process').spawn;
+const spawn = require('child_process').spawn;
 
-var child = spawn(process.execPath, [ '-i' ], {
+const child = spawn(process.execPath, [ '-i' ], {
   stdio: [null, null, 2]
 });
 
@@ -52,8 +52,8 @@ child.stdout.once('data', function() {
 });
 
 child.on('close', function(c) {
-  assert(!c);
+  assert.strictEqual(c, 0);
   // make sure we got 3 throws, in the end.
   var lastLine = stdout.trim().split(/\r?\n/).pop();
-  assert.equal(lastLine, '> 3');
+  assert.strictEqual(lastLine, '> 3');
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

Timer-dependent tests fail frequently on certain platforms in CI when
run in parallel with other tests, likely due to competition for
resources. Move test-repl-timeout-throw to sequential to avoid this
problem. Also did some minor refactoring (var->const and more use of
assert.strictEqual of looser assertions).

@nodejs/testing @jbergstroem 

Example failure: https://ci.nodejs.org/job/node-test-commit-freebsd/5147/nodes=freebsd10-64/console