### PR TITLE
tools: improve docopen target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,15 +292,14 @@ test-v8 test-v8-intl test-v8-benchmarks test-v8-all:
 endif
 
 apidoc_sources = $(wildcard doc/api/*.md)
-apidocs = $(addprefix out/,$(apidoc_sources:.md=.html)) \
-		$(addprefix out/,$(apidoc_sources:.md=.json))
+apidocs_html = $(apidoc_dirs) $(apiassets) $(addprefix out/,$(apidoc_sources:.md=.html))
+apidocs_json = $(apidoc_dirs) $(apiassets) $(addprefix out/,$(apidoc_sources:.md=.json))
 
 apidoc_dirs = out/doc out/doc/api/ out/doc/api/assets
 
 apiassets = $(subst api_assets,api/assets,$(addprefix out/,$(wildcard doc/api_assets/*)))
 
-doc-only: $(apidoc_dirs) $(apiassets) $(apidocs) tools/doc/
-
+doc-only: $(apidocs_html) $(apidocs_json)
 doc: $(NODE_EXE) doc-only
 
 $(apidoc_dirs):
@@ -336,8 +335,8 @@ out/doc/api/%.html: doc/api/%.md
 		fi
 	[ -x $(NODE) ] && $(NODE) $(gen-html) || node $(gen-html)
 
-docopen: out/doc/api/all.html
-	-google-chrome out/doc/api/all.html
+docopen: $(apidocs_html)
+	@$(PYTHON) -mwebbrowser file://$(PWD)/out/doc/api/all.html
 
 docclean:
 	-rm -rf out/doc


### PR DESCRIPTION
##### Checklist

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tools Makefile

##### Description of change

1. As it is, it just tries to build only the `all.html` file. If none of
   the other files are built already, generated page will not be good.
   To fix this, we process the assets and generate HTML files first.

2. After the HTML is generated, `google-chrome` is used to open the
   generated file in browser. This is not very portable as it might not
   be installed or installations might have used a different name. So,
   we use Python's webbrowser module to open the file.

---

cc @nodejs/documentation @nodejs/build 