### PR TITLE
http: remove stale timeout listeners

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -562,7 +562,13 @@ function tickOnSocket(req, socket) {
   socket.on('close', socketCloseListener);
 
   if (req.timeout) {
-    socket.once('timeout', () => req.emit('timeout'));
+    const emitRequestTimeout = () => req.emit('timeout');
+    socket.once('timeout', emitRequestTimeout);
+    req.on('response', (r) => {
+      r.on('end', () => {
+        socket.removeListener('timeout', emitRequestTimeout);
+      });
+    });
   }
   req.emit('socket', socket);
 }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -564,8 +564,8 @@ function tickOnSocket(req, socket) {
   if (req.timeout) {
     const emitRequestTimeout = () => req.emit('timeout');
     socket.once('timeout', emitRequestTimeout);
-    req.on('response', (r) => {
-      r.on('end', () => {
+    req.once('response', (res) => {
+      res.once('end', () => {
         socket.removeListener('timeout', emitRequestTimeout);
       });
     });

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -18,17 +18,17 @@ const options = {
   timeout: common.platformTimeout(100)
 };
 
-server.listen(0, options.host, () => {
+server.listen(0, options.host, common.mustCall(() => {
   options.port = server.address().port;
-  doRequest((numListeners) => {
+  doRequest(common.mustCall((numListeners) => {
     assert.strictEqual(numListeners, 1);
-    doRequest((numListeners) => {
+    doRequest(common.mustCall((numListeners) => {
       assert.strictEqual(numListeners, 1);
       server.close();
       agent.destroy();
-    });
-  });
-});
+    }));
+  }));
+}));
 
 function doRequest(cb) {
   http.request(options, common.mustCall((response) => {
@@ -37,8 +37,8 @@ function doRequest(cb) {
     const socket = sockets[0];
     const numListeners = socket.listeners('timeout').length;
     response.resume();
-    response.once('end', () => {
+    response.once('end', common.mustCall(() => {
       process.nextTick(cb, numListeners);
-    });
+    }));
   })).end();
 }

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const http = require('http');
 const assert = require('assert');
 
@@ -18,6 +18,10 @@ const options = {
   timeout: 10
 };
 
+process.on('unhandledRejection', function() {
+  common.fail('A promise rejection was unhandled');
+});
+
 server.listen(0, options.host, (e) => {
   options.port = server.address().port;
 
@@ -27,10 +31,6 @@ server.listen(0, options.host, (e) => {
                          'Should be a single timeout listener on the socket');
       server.close();
       agent.destroy();
-    })
-    .catch((e) => {
-      console.log(e);
-      process.exit(1);
     });
 });
 

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -38,7 +38,7 @@ function doRequest() {
     http.request(options, (response) => {
       const sockets = agent.sockets[`${options.host}:${options.port}:`];
       if (sockets.length !== 1) {
-        reject(new Error('Only one socket should be created'));
+        return reject(new Error('Only one socket should be created'));
       }
       const socket = sockets[0];
       const timeoutEvent = socket._events.timeout;

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -15,41 +15,35 @@ const options = {
   port: undefined,
   host: common.localhostIPv4,
   path: '/',
-  timeout: common.platformTimeout(20)
+  timeout: common.platformTimeout(100)
 };
-
-process.on('unhandledRejection', function(reason) {
-  common.fail('A promise rejection was unhandled: ' + reason);
-});
 
 server.listen(0, options.host, (e) => {
   options.port = server.address().port;
-
-  doRequest().then(doRequest)
-    .then((numListeners) => {
+  doRequest(() => {
+    doRequest((numListeners) => {
       assert.strictEqual(numListeners, 1);
       server.close();
       agent.destroy();
     });
+  });
 });
 
-function doRequest() {
-  return new Promise((resolve, reject) => {
-    http.request(options, (response) => {
-      const sockets = agent.sockets[`${options.host}:${options.port}:`];
-      if (sockets.length !== 1) {
-        return reject(new Error('Only one socket should be created'));
-      }
-      const socket = sockets[0];
-      const timeoutEvent = socket._events.timeout;
-      let numListeners = 0;
-      if (Array.isArray(timeoutEvent)) {
-        numListeners = timeoutEvent.length;
-      } else if (timeoutEvent) {
-        numListeners = 1;
-      }
-      response.resume();
-      response.on('end', () => resolve(numListeners));
-    }).end();
-  });
+function doRequest(cb) {
+  http.request(options, (response) => {
+    const sockets = agent.sockets[`${options.host}:${options.port}:`];
+    assert.strictEqual(sockets.length, 1)
+    const socket = sockets[0];
+    const timeoutEvent = socket._events.timeout;
+    let numListeners = 0;
+    if (Array.isArray(timeoutEvent)) {
+      numListeners = timeoutEvent.length;
+    } else if (timeoutEvent) {
+      numListeners = 1;
+    }
+    response.resume();
+    response.once('end', () => {
+      process.nextTick(cb, numListeners);
+    });
+  }).end();
 }

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -1,0 +1,56 @@
+'use strict';
+require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const agent = new http.Agent({ keepAlive: true });
+
+const server = http.createServer((req, res) => {
+  res.end('');
+});
+
+const options = {
+  agent,
+  method: 'GET',
+  port: undefined,
+  host: '127.0.0.1',
+  path: '/',
+  timeout: 10
+};
+
+server.listen(0, options.host, (e) => {
+  options.port = server.address().port;
+
+  doRequest().then(doRequest)
+    .then((numListeners) => {
+      assert.strictEqual(numListeners, 1,
+                         'Should be a single timeout listener on the socket');
+      server.close();
+      agent.destroy();
+    })
+    .catch((e) => {
+      console.log(e);
+      process.exit(1);
+    });
+});
+
+function doRequest() {
+  return new Promise((resolve, reject) => {
+    http.request(options, (response) => {
+      const sockets = agent.sockets[`127.0.0.1:${options.port}:`];
+      if (sockets.length !== 1) {
+        reject(new Error('Only one socket should be created'));
+      }
+      const socket = sockets[0];
+      const timeoutEvent = socket._events.timeout;
+      let numListeners = 0;
+      if (Array.isArray(timeoutEvent)) {
+        numListeners = timeoutEvent.length;
+      } else if (timeoutEvent) {
+        numListeners = 1;
+      }
+      response.resume();
+      response.on('end', () => resolve(numListeners));
+    }).end();
+  });
+}

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -13,7 +13,7 @@ const options = {
   agent,
   method: 'GET',
   port: undefined,
-  host: '127.0.0.1',
+  host: common.localhostIPv4,
   path: '/',
   timeout: 10
 };
@@ -37,7 +37,7 @@ server.listen(0, options.host, (e) => {
 function doRequest() {
   return new Promise((resolve, reject) => {
     http.request(options, (response) => {
-      const sockets = agent.sockets[`127.0.0.1:${options.port}:`];
+      const sockets = agent.sockets[`${options.host}:${options.port}:`];
       if (sockets.length !== 1) {
         reject(new Error('Only one socket should be created'));
       }

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -15,11 +15,11 @@ const options = {
   port: undefined,
   host: common.localhostIPv4,
   path: '/',
-  timeout: 10
+  timeout: 100
 };
 
-process.on('unhandledRejection', function() {
-  common.fail('A promise rejection was unhandled');
+process.on('unhandledRejection', function(reason) {
+  common.fail('A promise rejection was unhandled: ' + reason);
 });
 
 server.listen(0, options.host, (e) => {
@@ -27,8 +27,7 @@ server.listen(0, options.host, (e) => {
 
   doRequest().then(doRequest)
     .then((numListeners) => {
-      assert.strictEqual(numListeners, 1,
-                         'Should be a single timeout listener on the socket');
+      assert.strictEqual(numListeners, 1);
       server.close();
       agent.destroy();
     });

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -15,7 +15,7 @@ const options = {
   port: undefined,
   host: common.localhostIPv4,
   path: '/',
-  timeout: 100
+  timeout: common.platformTimeout(20)
 };
 
 process.on('unhandledRejection', function(reason) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http

##### Description of change
In order to prevent a memory leak when using keep alive, ensure that the
timeout listener for the request is removed when the response has ended.

This fixes https://github.com/nodejs/node/issues/9268