### PR TITLE
test: increase test-net-GH-5504 timeout

### DIFF
--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -1,7 +1,9 @@
 'use strict';
 var common = require('../common');
 
-// this test only fails with CentOS 6.3 using kernel version 2.6.32
+// https://github.com/nodejs/node-v0.x-archive/issues/5504
+//
+// This test only fails with CentOS 6.3 using kernel version 2.6.32
 // On other linuxes and darwin, the `read` call gets an ECONNRESET in
 // that case.  On sunos, the `write` call fails with EPIPE.
 //
@@ -54,7 +56,7 @@ function parent() {
     setTimeout(function() {
       throw new Error('hang');
     });
-  }, common.platformTimeout(2000)).unref();
+  }, common.platformTimeout(5000)).unref();
 
   var s = spawn(node, [__filename, 'server'], {
     env: Object.assign(process.env, {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net

##### Description of change
<!-- Provide a description of the change below this comment. -->

test-net-GH-5504 failed on smartos14-64 in CI. The internal test timeout
expired. It is currently 2 seconds. That appears to be somewhat
arbitrary. It may be possible to rewrite the test without the timer.  As
an immediate workaround, increase the timeout to 5 seconds.