### PR TITLE
doc: readline.emitKeypressEvents note

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -27,7 +27,7 @@ rl.question('What do you think of Node.js? ', (answer) => {
 });
 ```
 
-*Note* Once this code is invoked, the Node.js application will not
+*Note*: Once this code is invoked, the Node.js application will not
 terminate until the `readline.Interface` is closed because the interface
 waits for data to be received on the `input` stream.
 
@@ -446,6 +446,10 @@ Optionally, `interface` specifies a `readline.Interface` instance for which
 autocompletion is disabled when copy-pasted input is detected.
 
 If the `stream` is a [TTY][], then it must be in raw mode.
+
+*Note*: This is automatically called by any readline instance on its `input`
+if the `input` is a terminal. Closing the `readline` instance does not stop
+the `input` from emitting `'keypress'` events.
 
 ```js
 readline.emitKeypressEvents(process.stdin);


### PR DESCRIPTION
##### Affected core subsystem(s)
doc


##### Description of change

It is not noted in the docs that `emitKeypressEvents` is [automatically called](https://github.com/nodejs/node/blob/72547fe28de95be435789716e0fd970e66c58477/lib/readline.js#L153) on any `input` stream where `input.terminal` or `input.isTTY` is `true`.

This can cause incompatibility with libraries that fire their own `keypress` events, like [blessed](https://github.com/chjj/blessed/blob/a79e8106ea737292d4c7e21ee7dd5bf1960dee15/lib/keys.js#L41).

I am working to fix the incompatibility but I thought it was worth noting in the docs.

