### PR TITLE
benchmark,lib,test,tools: remove unneeded . escape

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -37,7 +37,7 @@ AutocannonBenchmarker.prototype.processResults = function(output) {
 
 function WrkBenchmarker() {
   this.name = 'wrk';
-  this.regexp = /Requests\/sec:[ \t]+([0-9\.]+)/;
+  this.regexp = /Requests\/sec:[ \t]+([0-9.]+)/;
   const result = child_process.spawnSync('wrk', ['-h']);
   this.present = !(result.error && result.error.code === 'ENOENT');
 }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -919,7 +919,7 @@ Server.prototype.addContext = function(servername, context) {
   }
 
   var re = new RegExp('^' +
-                      servername.replace(/([\.^$+?\-\\[\]{}])/g, '\\$1')
+                      servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')
                                 .replace(/\*/g, '[^.]*') +
                       '$');
   this._contexts.push([re, tls.createSecureContext(context).context]);

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -72,7 +72,7 @@ function error_test() {
       if (read_buffer !== client_unix.expect) {
         var expect = client_unix.expect;
         if (expect === prompt_multiline)
-          expect = /[\.]{3} /;
+          expect = /[.]{3} /;
         assert.ok(read_buffer.match(expect));
         console.error('match');
       }

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -545,12 +545,12 @@ function deepCopy_(src) {
 // these parse out the contents of an H# tag
 var eventExpr = /^Event(?::|\s)+['"]?([^"']+).*$/i;
 var classExpr = /^Class:\s*([^ ]+).*?$/i;
-var propExpr = /^(?:property:?\s*)?[^\.]+\.([^ \.\(\)]+)\s*?$/i;
-var braceExpr = /^(?:property:?\s*)?[^\.\[]+(\[[^\]]+\])\s*?$/i;
+var propExpr = /^(?:property:?\s*)?[^.]+\.([^ .()]+)\s*?$/i;
+var braceExpr = /^(?:property:?\s*)?[^.\[]+(\[[^\]]+\])\s*?$/i;
 var classMethExpr =
-  /^class\s*method\s*:?[^\.]+\.([^ \.\(\)]+)\([^\)]*\)\s*?$/i;
+  /^class\s*method\s*:?[^.]+\.([^ .()]+)\([^)]*\)\s*?$/i;
 var methExpr =
-  /^(?:method:?\s*)?(?:[^\.]+\.)?([^ \.\(\)]+)\([^\)]*\)\s*?$/i;
+  /^(?:method:?\s*)?(?:[^.]+\.)?([^ .()]+)\([^)]*\)\s*?$/i;
 var newExpr = /^new ([A-Z][a-zA-Z]+)\([^\)]*\)\s*?$/;
 var paramExpr = /\((.*)\);?$/;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark lib test tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

The `.` character does not need to be escaped when it appears inside a
regular expression character class. This removes instances of
unnecessary escapes of the `.` character.