### PR TITLE
build: add MAKEFLAGS="-j1" to node-gyp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ test/addons/.buildstamp: config.gypi \
 #	embedded addons have been generated from the documentation.
 	for dirname in test/addons/*/; do \
 		echo "\nBuilding addon $$PWD/$$dirname" ; \
-		MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
+		env MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
 		        --loglevel=$(LOGLEVEL) rebuild \
 			--python="$(PYTHON)" \
 			--directory="$$PWD/$$dirname" \

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,9 @@ test/addons/.buildstamp: config.gypi \
 #	Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 #	embedded addons have been generated from the documentation.
 	for dirname in test/addons/*/; do \
-		echo "\nRunning addons test $$PWD/$$dirname" ; \
-		$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp --loglevel=$(LOGLEVEL) rebuild \
+		echo "\nBuilding addon $$PWD/$$dirname" ; \
+		MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
+		        --loglevel=$(LOGLEVEL) rebuild \
 			--python="$(PYTHON)" \
 			--directory="$$PWD/$$dirname" \
 			--nodedir="$$PWD" || exit 1 ; \

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ test/addons/.buildstamp: config.gypi \
 	test/addons/.docbuildstamp
 #	Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 #	embedded addons have been generated from the documentation.
-	for dirname in test/addons/*/; do \
+	@for dirname in test/addons/*/; do \
 		echo "\nBuilding addon $$PWD/$$dirname" ; \
 		env MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
 		        --loglevel=$(LOGLEVEL) rebuild \


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently, when building the addons the following warning is displayed:
```
make[2]: warning: jobserver unavailable: using -j1.  Add `+' to parent
make rule.
```
Adding the `MAKEFLAGS="-j1"` to avoid the warning.

Also updated the log message to say that it is building the addon and
not running the test as I think that is more accurate.