### PR TITLE
https: Use secureProtocol in Agent#getName

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -143,6 +143,10 @@ Agent.prototype.getName = function(options) {
   if (options.servername && options.servername !== options.host)
     name += options.servername;
 
+  name += ':';
+  if (options.secureProtocol)
+    name += options.secureProtocol;
+
   return name;
 };
 

--- a/test/parallel/test-https-agent-getname.js
+++ b/test/parallel/test-https-agent-getname.js
@@ -14,7 +14,7 @@ const agent = new https.Agent();
 // empty options
 assert.strictEqual(
   agent.getName({}),
-  'localhost:::::::::'
+  'localhost::::::::::'
 );
 
 // pass all options arguments
@@ -33,5 +33,5 @@ const options = {
 
 assert.strictEqual(
   agent.getName(options),
-  '0.0.0.0:443:192.168.1.1:ca:cert:ciphers:key:pfx:false:localhost'
+  '0.0.0.0:443:192.168.1.1:ca:cert:ciphers:key:pfx:false:localhost:'
 );

--- a/test/parallel/test-https-agent-secure-protocol.js
+++ b/test/parallel/test-https-agent-secure-protocol.js
@@ -1,0 +1,60 @@
+'use strict';
+const assert = require('assert');
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const https = require('https');
+const fs = require('fs');
+
+const options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+};
+
+const server = https.Server(options, function(req, res) {
+  res.writeHead(200);
+  res.end('hello world\n');
+});
+
+server.listen(0, common.mustCall(function() {
+  const port = this.address().port;
+  const globalAgent = https.globalAgent;
+  globalAgent.keepAlive = true;
+  https.get({
+    path: '/',
+    port: port,
+    ca: options.ca,
+    rejectUnauthorized: true,
+    servername: 'agent1',
+    secureProtocol: 'SSLv23_method'
+  }, common.mustCall(function(res) {
+    res.resume();
+    globalAgent.once('free', common.mustCall(function() {
+      https.get({
+        path: '/',
+        port: port,
+        ca: options.ca,
+        rejectUnauthorized: true,
+        servername: 'agent1',
+        secureProtocol: 'TLSv1_method'
+      }, common.mustCall(function(res) {
+        res.resume();
+        globalAgent.once('free', common.mustCall(function() {
+          // Verify that two keep-alived connections are created
+          // due to the different secureProtocol settings:
+          const keys = Object.keys(globalAgent.freeSockets);
+          assert.strictEqual(keys.length, 2);
+          assert.ok(keys[0].includes(':SSLv23_method'));
+          assert.ok(keys[1].includes(':TLSv1_method'));
+          globalAgent.destroy();
+          server.close();
+        }));
+      }));
+    }));
+  }));
+}));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

https

##### Description of change

Fix oversight pointed out by @bnoordhuis in #9324. The value of the `secureProtocol` option should be used as a "discriminator" when determining whether an existing HTTPS connection can be reused.