### PR TITLE
doc: Fix inaccuracy in https.request docs

### DIFF
--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -192,8 +192,7 @@ The options argument has the following options
  - `false`: opts out of connection pooling with an Agent, defaults request to
    `Connection: close`.
 
-The following options from [`tls.connect()`][] can also be specified. However, a
-[`globalAgent`][] silently ignores these.
+The following options from [`tls.connect()`][] can also be specified:
 
 - `pfx`: Certificate, Private key and CA certificates to use for SSL. Default `null`.
 - `key`: Private key to use for SSL. Default `null`.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc (https)

##### Description of change

Remove misleading statement about `require('https').globalAgent` silently ignoring options passed to `require('https').request`. Refer to discussion in #9324.