### PR TITLE
src: default --icu_case_mapping on as a v8 option

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4191,6 +4191,14 @@ void Init(int* argc,
                             DispatchDebugMessagesAsyncCallback));
   uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
+#if defined(NODE_HAVE_I18N_SUPPORT)
+  // Set the ICU casing flag early
+  // so the user can disable a flag --foo at run-time by passing
+  // --no_foo from the command line.
+  const char icu_case_mapping[] = "--icu_case_mapping";
+  V8::SetFlagsFromString(icu_case_mapping, sizeof(icu_case_mapping) - 1);
+#endif
+
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()
   // so the user can disable a flag --foo at run-time by passing

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -50,6 +50,11 @@ if (!common.hasIntl) {
     return;
   }
 
+  // Check casing
+  {
+    assert.strictEqual('I'.toLocaleLowerCase('tr'), 'ı');
+  }
+
   // Check with toLocaleString
   {
     const localeString = dtf.format(date0);


### PR DESCRIPTION
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

* toLocaleUpperCase() and toLocaleLowerCase() do not function properly
without this flag.
* basic test case. The test case would fail if `--no_icu_case_mapping`
was set.

Fixes: https://github.com/nodejs/node/issues/9445