### PR TITLE
Implementation of --adjacent-node-modules to support module symlinking to global cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ _UpgradeReport_Files/
 ipch/
 *.sdf
 *.opensdf
+*.VC.db
 *.VC.opendb
 .vs/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ _UpgradeReport_Files/
 ipch/
 *.sdf
 *.opensdf
-*.VC.db
 *.VC.opendb
 .vs/
 .vscode/

--- a/lib/module.js
+++ b/lib/module.js
@@ -10,6 +10,8 @@ const path = require('path');
 const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;
+const adjacentNodeModules = !!process.binding('config').adjacentNodeModules
+  || (process.env.NODE_ADJACENT_NODE_MODULES || '0') === '1';
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -122,7 +124,7 @@ delete fs.realpathCacheKey;
 // absolute realpath.
 function tryFile(requestPath, isMain) {
   const rc = stat(requestPath);
-  if (preserveSymlinks && !isMain) {
+  if (preserveSymlinks && !isMain || adjacentNodeModules) {
     return rc === 0 && path.resolve(requestPath);
   }
   return rc === 0 && toRealPath(requestPath);
@@ -174,7 +176,7 @@ Module._findPath = function(request, paths, isMain) {
     if (!trailingSlash) {
       const rc = stat(basePath);
       if (rc === 0) {  // File.
-        if (preserveSymlinks && !isMain) {
+        if (preserveSymlinks && !isMain || adjacentNodeModules) {
           filename = path.resolve(basePath);
         } else {
           filename = toRealPath(basePath);
@@ -255,9 +257,22 @@ if (process.platform === 'win32') {
       // Use colon as an extra condition since we can get node_modules
       // path for dirver root like 'C:\node_modules' and don't need to
       // parse driver name.
-      if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/) {
-        if (p !== nmLen)
-          paths.push(from.slice(0, last) + '\\node_modules');
+      if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/
+        || (adjacentNodeModules && code === 47/*.*/)) {
+        if (p !== nmLen) {
+          var parent = from.slice(0, last);
+          paths.push(parent + '\\node_modules');
+
+          if (adjacentNodeModules) {
+            paths.push(parent + '.node_modules');
+            if (code === 46/*.*/ && i >= 0)
+              while (--i >= 0) {
+                const code = from.charCodeAt(i);
+                if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/)
+                  break;
+              }
+          }
+        }
         last = i;
         p = 0;
       } else if (p !== -1) {
@@ -268,6 +283,8 @@ if (process.platform === 'win32') {
         }
       }
     }
+
+    if (adjacentNodeModules) paths.pop();
 
     return paths;
   };
@@ -289,9 +306,21 @@ if (process.platform === 'win32') {
     var last = from.length;
     for (var i = from.length - 1; i >= 0; --i) {
       const code = from.charCodeAt(i);
-      if (code === 47/*/*/) {
-        if (p !== nmLen)
-          paths.push(from.slice(0, last) + '/node_modules');
+      if (code === 47/*/*/ || (adjacentNodeModules && code === 46/*.*/)) {
+        if (p !== nmLen) {
+          var parent = from.slice(0, last);
+          paths.push(parent + '/node_modules');
+
+          if (adjacentNodeModules) {
+            paths.push(parent + '.node_modules');
+            if (code === 46/*.*/ && i >= 0)
+              while (--i >= 0) {
+                const code = from.charCodeAt(i);
+                if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/)
+                  break;
+              }
+          }
+        }
         last = i;
         p = 0;
       } else if (p !== -1) {
@@ -302,6 +331,8 @@ if (process.platform === 'win32') {
         }
       }
     }
+
+    if (adjacentNodeModules) paths.pop();
 
     // Append /node_modules to handle root paths.
     paths.push('/node_modules');

--- a/lib/module.js
+++ b/lib/module.js
@@ -265,7 +265,7 @@ if (process.platform === 'win32') {
 
           if (adjacentNodeModules) {
             paths.push(parent + '.node_modules');
-            if (code === 46/*.*/ && i >= 0)
+            if (code === 46/*.*/ && i > 0)
               while (--i >= 0) {
                 const code = from.charCodeAt(i);
                 if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/)
@@ -313,10 +313,10 @@ if (process.platform === 'win32') {
 
           if (adjacentNodeModules) {
             paths.push(parent + '.node_modules');
-            if (code === 46/*.*/ && i >= 0)
+            if (code === 46/*.*/ && i > 0)
               while (--i >= 0) {
                 const code = from.charCodeAt(i);
-                if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/)
+                if (code === 47/*/*/)
                   break;
               }
           }

--- a/src/node.cc
+++ b/src/node.cc
@@ -185,6 +185,10 @@ bool trace_warnings = false;
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/module.js
 bool config_preserve_symlinks = false;
+// Set in node.cc by ParseArgs when --adjacent-node-modules is used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by lib/module.js
+bool config_adjacent_node_modules = false;
 
 bool v8_initialized = false;
 
@@ -3704,6 +3708,8 @@ static void ParseArgs(int* argc,
       Revert(cve);
     } else if (strcmp(arg, "--preserve-symlinks") == 0) {
       config_preserve_symlinks = true;
+    } else if (strcmp(arg, "--adjacent-node-modules") == 0) {
+      config_adjacent_node_modules = true;
     } else if (strcmp(arg, "--prof-process") == 0) {
       prof_process = true;
       short_circuit = true;

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -44,6 +44,9 @@ void InitConfig(Local<Object> target,
 
   if (config_preserve_symlinks)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinks");
+
+  if (config_adjacent_node_modules)
+    READONLY_BOOLEAN_PROPERTY("adjacentNodeModules");
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -32,9 +32,9 @@ struct sockaddr;
 
 namespace node {
 
-  // Set in node.cc by ParseArgs with the value of --openssl-config.
-  // Used in node_crypto.cc when initializing OpenSSL.
-  extern const char* openssl_config;
+// Set in node.cc by ParseArgs with the value of --openssl-config.
+// Used in node_crypto.cc when initializing OpenSSL.
+extern const char* openssl_config;
 
 // Set in node.cc by ParseArgs when --preserve-symlinks is used.
 // Used in node_config.cc to set a constant on process.binding('config')

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -32,14 +32,19 @@ struct sockaddr;
 
 namespace node {
 
-// Set in node.cc by ParseArgs with the value of --openssl-config.
-// Used in node_crypto.cc when initializing OpenSSL.
-extern const char* openssl_config;
+  // Set in node.cc by ParseArgs with the value of --openssl-config.
+  // Used in node_crypto.cc when initializing OpenSSL.
+  extern const char* openssl_config;
 
 // Set in node.cc by ParseArgs when --preserve-symlinks is used.
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/module.js
 extern bool config_preserve_symlinks;
+
+// Set in node.cc by ParseArgs when --adjacent-node-modules is used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by lib/module.js
+extern bool config_adjacent_node_modules;
 
 // Tells whether it is safe to call v8::Isolate::GetCurrent().
 extern bool v8_initialized;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
Modules

##### Description of change
Branched from v7.0.0 tag.

Using --adjacent-node-modules cmdline arg, or setting NODE_ADJACENT_NODE_MODULES, adds additional search paths for resolving prefix-less requires (i.e. require('somelib') ).

Details provided in this [issue](https://github.com/yarnpkg/rfcs/issues/18)

It's expected this PR will be rejected for now, but there were some who wanted to take a peak first.

##### Test results
[----------] Global test environment tear-down
[==========] 26 tests from 2 test cases ran. (233 ms total)
[  PASSED  ] 26 tests.
running 'python tools\test.py --mode=release  addons doctool known_issues message parallel sequential -J'
=== release test-http-chunk-problem ===
Path: parallel/test-http-chunk-problem
Command: C:\src\node\Release\node.exe C:\src\node\test\parallel\test-http-chunk-problem.js
--- TIMEOUT ---
=== release test-process-kill-null ===
Path: parallel/test-process-kill-null
Command: C:\src\node\Release\node.exe C:\src\node\test\parallel\test-process-kill-null.js
--- TIMEOUT ---
[03:37|% 100|+ 1257|-   2]: Done
running jslint

C:\src\node>