### PR TITLE
build: reduce noise from doc target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ out/doc/%: doc/%
 # check if ./node is actually set, else use user pre-installed binary
 gen-json = tools/doc/generate.js --format=json $< > $@
 out/doc/api/%.json: doc/api/%.md
-	[ -e tools/doc/node_modules/js-yaml/package.json ] || \
+	@[ -e tools/doc/node_modules/js-yaml/package.json ] || \
 		[ -e tools/eslint/node_modules/js-yaml/package.json ] || \
 		if [ -x $(NODE) ]; then \
 			cd tools/doc && ../../$(NODE) ../../$(NPM) install; \
@@ -327,7 +327,7 @@ out/doc/api/%.json: doc/api/%.md
 # check if ./node is actually set, else use user pre-installed binary
 gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html --template=doc/template.html $< > $@
 out/doc/api/%.html: doc/api/%.md
-	[ -e tools/doc/node_modules/js-yaml/package.json ] || \
+	@[ -e tools/doc/node_modules/js-yaml/package.json ] || \
 		[ -e tools/eslint/node_modules/js-yaml/package.json ] || \
 		if [ -x $(NODE) ]; then \
 			cd tools/doc && ../../$(NODE) ../../$(NPM) install; \


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

The doc target currently echos the complete shell command, which might
produces a lot of output. Using this change the actual commands run
are still shown.

Before:
```shell
[ -e tools/doc/node_modules/js-yaml/package.json ] || \
        [ -e tools/eslint/node_modules/js-yaml/package.json ] || \
        if [ -x ./node ]; then \
            cd tools/doc && ../.././node ../.././deps/npm/bin/npm-cli.js
install; \
        else \
            cd tools/doc && node ../.././deps/npm/bin/npm-cli.js
install; \
        fi
[ -x ./node ] && ./node tools/doc/generate.js --node-version=v8.0.0
--format=html --template=doc/template.html doc/api/assert.md >
out/doc/api/assert.html || node tools/doc/generate.js
--node-version=v8.0.0 --format=html --template=doc/template.html
doc/api/assert.md > out/doc/api/assert.html
Input file = doc/api/assert.md
```

After:
```shell
[ -x ./node ] && ./node tools/doc/generate.js --node-version=v8.0.0
--format=html --template=doc/template.html doc/api/assert.md >
out/doc/api/assert.html || node tools/doc/generate.js
--node-version=v8.0.0 --format=html --template=doc/template.html
doc/api/assert.md > out/doc/api/assert.html
Input file = doc/api/assert.md
```

To verify run:
```shell
$ make docclean
$ make doc
```