### PR TITLE
test: fix flaky test-force-repl-with-eval

### DIFF
--- a/test/parallel/test-force-repl-with-eval.js
+++ b/test/parallel/test-force-repl-with-eval.js
@@ -1,14 +1,11 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 // spawn a node child process in "interactive" mode (force the repl) and eval
 const cp = spawn(process.execPath, ['-i', '-e', 'console.log("42")']);
 var gotToEnd = false;
-const timeoutId = setTimeout(function() {
-  throw new Error('timeout!');
-}, common.platformTimeout(1000)); // give node + the repl 1 second to boot up
 
 cp.stdout.setEncoding('utf8');
 
@@ -16,7 +13,6 @@ var output = '';
 cp.stdout.on('data', function(b) {
   output += b;
   if (output === '> 42\n') {
-    clearTimeout(timeoutId);
     gotToEnd = true;
     cp.kill();
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Remove the timer just in case the test takes longer to complete.

It has already failed on the smartos bot: https://ci.nodejs.org/job/node-test-commit-smartos/5075/nodes=smartos14-64/consoleFull
```
not ok 324 parallel/test-force-repl-with-eval
# /home/iojs/build/workspace/node-test-commit-smartos/nodes/smartos14-64/test/parallel/test-force-repl-with-eval.js:10
#   throw new Error('timeout!');
#   ^
# 
# Error: timeout!
#     at Timeout._onTimeout (/home/iojs/build/workspace/node-test-commit-smartos/nodes/smartos14-64/test/parallel/test-force-repl-with-eval.js:10:9)
#     at ontimeout (timers.js:365:14)
#     at tryOnTimeout (timers.js:237:5)
#     at Timer.listOnTimeout (timers.js:207:5)
```