### PR TITLE
test: fix flaky test-net-GH-5504

### DIFF
--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -48,14 +48,6 @@ function parent() {
   var spawn = require('child_process').spawn;
   var node = process.execPath;
 
-  setTimeout(function() {
-    if (s) s.kill();
-    if (c) c.kill();
-    setTimeout(function() {
-      throw new Error('hang');
-    });
-  }, common.platformTimeout(2000)).unref();
-
   var s = spawn(node, [__filename, 'server'], {
     env: Object.assign(process.env, {
       NODE_DEBUG: 'net'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

The test is failing on `SmartOS` quite often. Removing the timeout seems
to fix it.

It's an alternate fix to https://github.com/nodejs/node/pull/9444