### PR TITLE
Add --coverage option to configure to produce C based coverage reports

### DIFF
--- a/configure
+++ b/configure
@@ -59,6 +59,11 @@ parser.add_option('--prefix',
     default='/usr/local',
     help='select the install prefix [default: %default]')
 
+parser.add_option('--coverage',
+    action='store_true',
+    dest='coverage',
+    help='Build node with code coverage enabled')
+
 parser.add_option('--debug',
     action='store_true',
     dest='debug',
@@ -857,6 +862,11 @@ def configure_node(o):
 
   if options.use_xcode and options.use_ninja:
     raise Exception('--xcode and --ninja cannot be used together.')
+
+  if options.coverage:
+    o['variables']['coverage'] = 'true'
+  else:
+    o['variables']['coverage'] = 'false'
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/node.gyp
+++ b/node.gyp
@@ -550,10 +550,21 @@
             'NODE_PLATFORM="sunos"',
           ],
         }],
-        [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"', {
+        [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="false"', {
           'ldflags': [ '-Wl,-z,noexecstack',
                        '-Wl,--whole-archive <(V8_BASE)',
                        '-Wl,--no-whole-archive' ]
+        }],
+        [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="true"', {
+          'ldflags': [ '-Wl,-z,noexecstack',
+                       '-Wl,--whole-archive <(V8_BASE)',
+                       '-Wl,--no-whole-archive',
+                       '--coverage',
+                       '-g',
+                       '-O0' ],
+           'cflags': [ '--coverage',
+                       '-g',
+                       '-O0' ]
         }],
         [ 'OS=="sunos"', {
           'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],


### PR DESCRIPTION
This PR is to support the ongoing efforts of the Nodejs testing workgroup under the following issue https://github.com/nodejs/testing/issues/36#issuecomment-255731077

Code coverage has currently been implemented by patching files on the fly in order to add in additional compilation options, but this has obvious limitations should the affected riles change in master.

This initial PR implements a `--coverage` option for the configure script which will then add the necessary cflags/ldflags in node.gyp in order to build node with C++ code coverage on Linux.  Obviously, node builds as per normal without the `--coverage` option specified in configure.
