### PR TITLE
src: don't call into VM from AsyncWrap destructor

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -67,23 +67,7 @@ inline AsyncWrap::AsyncWrap(Environment* env,
 }
 
 
-inline AsyncWrap::~AsyncWrap() {
-  if (!ran_init_callback())
-    return;
-
-  v8::Local<v8::Function> fn = env()->async_hooks_destroy_function();
-  if (!fn.IsEmpty()) {
-    v8::HandleScope scope(env()->isolate());
-    v8::Local<v8::Value> uid = v8::Number::New(env()->isolate(), get_uid());
-    v8::TryCatch try_catch(env()->isolate());
-    v8::MaybeLocal<v8::Value> ret =
-        fn->Call(env()->context(), v8::Null(env()->isolate()), 1, &uid);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(env()->isolate(), try_catch);
-    }
-  }
-}
+inline AsyncWrap::~AsyncWrap() {}
 
 
 inline bool AsyncWrap::ran_init_callback() const {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -137,9 +137,6 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   Local<Value> post_v = fn_obj->Get(
       env->context(),
       FIXED_ONE_BYTE_STRING(env->isolate(), "post")).ToLocalChecked();
-  Local<Value> destroy_v = fn_obj->Get(
-      env->context(),
-      FIXED_ONE_BYTE_STRING(env->isolate(), "destroy")).ToLocalChecked();
 
   if (!init_v->IsFunction())
     return env->ThrowTypeError("init callback must be a function");
@@ -150,8 +147,6 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
     env->set_async_hooks_pre_function(pre_v.As<Function>());
   if (post_v->IsFunction())
     env->set_async_hooks_post_function(post_v.As<Function>());
-  if (destroy_v->IsFunction())
-    env->set_async_hooks_destroy_function(destroy_v.As<Function>());
 }
 
 
@@ -177,7 +172,6 @@ static void Initialize(Local<Object> target,
   env->set_async_hooks_init_function(Local<Function>());
   env->set_async_hooks_pre_function(Local<Function>());
   env->set_async_hooks_post_function(Local<Function>());
-  env->set_async_hooks_destroy_function(Local<Function>());
 }
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -227,7 +227,6 @@ namespace node {
 
 #define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
   V(as_external, v8::External)                                                \
-  V(async_hooks_destroy_function, v8::Function)                               \
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_post_function, v8::Function)                                  \
   V(async_hooks_pre_function, v8::Function)                                   \

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const domain = require('domain');
 const spawn = require('child_process').spawn;
-const callbacks = [ 'init', 'pre', 'post', 'destroy' ];
+const callbacks = [ 'init', 'pre', 'post' ];
 const toCall = process.argv[2];
 var msgCalled = 0;
 var msgReceived = 0;
@@ -28,13 +28,9 @@ function post() {
   if (toCall === 'post')
     throw new Error('post');
 }
-function destroy() {
-  if (toCall === 'destroy')
-    throw new Error('destroy');
-}
 
 if (typeof process.argv[2] === 'string') {
-  async_wrap.setupHooks({ init, pre, post, destroy });
+  async_wrap.setupHooks({ init, pre, post });
   async_wrap.enable();
 
   process.on('uncaughtException', () => assert.ok(0, 'UNREACHABLE'));

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
 
 const storage = new Map();
-async_wrap.setupHooks({ init, pre, post, destroy });
+async_wrap.setupHooks({ init, pre, post });
 async_wrap.enable();
 
 function init(uid) {
@@ -14,7 +14,6 @@ function init(uid) {
     init: true,
     pre: false,
     post: false,
-    destroy: false
   });
 }
 
@@ -24,10 +23,6 @@ function pre(uid) {
 
 function post(uid) {
   storage.get(uid).post = true;
-}
-
-function destroy(uid) {
-  storage.get(uid).destroy = true;
 }
 
 fs.access(__filename, function(err) {
@@ -51,7 +46,6 @@ process.once('exit', function() {
       init: true,
       pre: true,
       post: true,
-      destroy: true
     });
   }
 });


### PR DESCRIPTION
R=@trevnorris?

See #8216 and #9465, it's making node crash.

It might be possible to retain the destroy hook by maintaining a per-environment list + a uv_idle_t handle or something like that but it's a lot of work and there might be edge cases so I'm opting for simply removing the hook.  Whoever disagrees volunteers to do the hard work. :-)

CI: https://ci.nodejs.org/job/node-test-pull-request/4782/