### PR TITLE
doc: add the diagnostics team to cc for async_wrap

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -24,6 +24,7 @@
 | `src/node_crypto.*` | @nodejs/crypto |
 | `test/*` | @nodejs/testing |
 | `tools/eslint`, `.eslintrc` | @silverwind, @trott |
+| async_hooks | @nodejs/diagnostics |
 | upgrading V8 | @nodejs/v8, @nodejs/post-mortem |
 | upgrading npm | @fishrock123, @thealphanerd |
 | upgrading c-ares | @jbergstroem |


### PR DESCRIPTION
Add the nodejs/diagnostics team to the “Who to CC in issues” list
as the maintainers of `async_hooks`.

Ref: https://github.com/nodejs/node/pull/9467#issuecomment-258541560