### PR TITLE
tools,test: provide duration/interval to timers, require it with lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -128,6 +128,7 @@ rules:
   assert-fail-single-argument: 2
   assert-throws-arguments: [2, { requireTwo: false }]
   new-with-error: [2, Error, RangeError, TypeError, SyntaxError, ReferenceError]
+  timer-arguments: 2
 
 # Global scoped method and vars
 globals:

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -4,4 +4,4 @@ require('../common');
 setTimeout(function() {
   // eslint-disable-next-line no-undef
   undefined_reference_error_maker;
-});
+}, 1);

--- a/test/parallel/test-handle-wrap-close-abort.js
+++ b/test/parallel/test-handle-wrap-close-abort.js
@@ -13,4 +13,4 @@ setTimeout(function() {
   setTimeout(function() {
     throw new Error('setTimeout');
   }, 1);
-});
+}, 1);

--- a/test/parallel/test-stream-end-paused.js
+++ b/test/parallel/test-stream-end-paused.js
@@ -21,7 +21,7 @@ stream.pause();
 setTimeout(common.mustCall(function() {
   stream.on('end', common.mustCall(function() {}));
   stream.resume();
-}));
+}), 1);
 
 process.on('exit', function() {
   assert(calledRead);

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -20,7 +20,7 @@ const Readable = require('stream').Readable;
     // we're testing what we think we are
     assert(!r._readableState.reading);
     r.on('readable', common.mustCall(function() {}));
-  });
+  }, 1);
 }
 
 {
@@ -40,7 +40,7 @@ const Readable = require('stream').Readable;
     // assert we're testing what we think we are
     assert(r._readableState.reading);
     r.on('readable', common.mustCall(function() {}));
-  });
+  }, 1);
 }
 
 {
@@ -60,5 +60,5 @@ const Readable = require('stream').Readable;
     // assert we're testing what we think we are
     assert(!r._readableState.reading);
     r.on('readable', common.mustCall(function() {}));
-  });
+  }, 1);
 }

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -46,7 +46,7 @@ function push() {
 
   console.error('   push #%d', pushes);
   if (r.push(Buffer.allocUnsafe(PUSHSIZE)))
-    setTimeout(push);
+    setTimeout(push, 1);
 }
 
 process.on('exit', function() {

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -16,7 +16,7 @@ test._read = function(size) {
   var chunk = chunks[n++];
   setTimeout(function() {
     test.push(chunk === undefined ? null : chunk);
-  });
+  }, 1);
 };
 
 test.on('end', thrower);
@@ -31,7 +31,7 @@ test.on('readable', function() {
   if (res) {
     bytesread += res.length;
     console.error('br=%d len=%d', bytesread, len);
-    setTimeout(next);
+    setTimeout(next, 1);
   }
   test.read(0);
 });

--- a/tools/eslint-rules/timer-arguments.js
+++ b/tools/eslint-rules/timer-arguments.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Require at least two arguments when calling setTimeout() or
+ * setInterval().
+ * @author Rich Trott
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+function isTimer(name) {
+  return ['setTimeout', 'setInterval'].includes(name);
+}
+
+module.exports = function(context) {
+  return {
+    'CallExpression': function(node) {
+      const name = node.callee.name;
+      if (isTimer(name) && node.arguments.length < 2) {
+        context.report(node, `${name} must have at least 2 arguments`);
+      }
+    }
+  };
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test timers

##### Description of change
<!-- Provide a description of the change below this comment. -->

###### First commit

    There are several places in the code base where setTimeout() or
    setInterval() are called with just a callback and no duration/interval.
    The timers module will use a value of `1` in that situation.
    
    I find an unspecified duration or interval confusing. I always spend a
    moment wondering if it is a mistake. Did the original author simply
    forget to provide a value? Did they intend to use setImmediate() or even
    process.nextTick() instead of setTimeout()? And so on.
    
    This change provides a duration or interval of `1` to all calls in the
    codebase where it is missing. `parallel/test-timers.js` still tests the
    situation where `setTimeout()` and `setInterval()` are called with
    `undefined` and other non-numeric values for the duration/interval.

###### Second commit

    Add a custom ESLint rule to require that setTimeout() and setInterval()
    get called with at least two arguments. This prevents omitting the
    duration or interval.