### PR TITLE
Don't follow Windows ContainerMappedDirectories

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1543,6 +1543,9 @@ fs.realpathSync = function realpathSync(p, options) {
       if (linkTarget === null) {
         fs.statSync(base);
         linkTarget = fs.readlinkSync(base);
+        if (linkTarget.startsWith('\\ContainerMappedDirectories')) {
+          continue;
+        }
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

fs


##### Description of change

This is my proposal fixing the problem #8897 using `fs.realpathSync()` on Docker shared volumes in Windows containers. The additional check if a symlink target is `\ContainerMappedDirectories` than just ignore that link.

Without that change:

```
PS C:\test> docker run -v "$(pwd):C:\test" nodeexe:4.6.1 node -p "const fs=require('fs'); fs.realpathSync('c:/test')"
fs.js:839
  return binding.lstat(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, lstat 'c:\ContainerMappedDirectories'
```

After applying the change:

```
PS C:\test> docker run -v "$(pwd):C:\test" nodecheck node -p "const fs=require('fs'); fs.realpathSync('c:/test')"
c:\test
```

Any ideas how to add a test for this as it only occurs in Windows containers?