### PR TITLE
test: remove watchdog in test-debug-signal-cluster

### DIFF
--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -65,10 +65,6 @@ function onNoMoreDebuggerAgentsOutput() {
   process.exit();
 }
 
-setTimeout(function testTimedOut() {
-  common.fail('test timed out');
-}, common.platformTimeout(4000)).unref();
-
 process.on('exit', function onExit() {
   // Kill processes in reverse order to avoid timing problems on Windows where
   // the parent process is killed before the children.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test debugger

##### Description of change
<!-- Provide a description of the change below this comment. -->

test-debug-signal-cluster contains a watchdog timer that results in
false positives in CI. Remove the watchdog timer and let the test runner
determine that the test has timed out.

Example failure: https://ci.nodejs.org/job/node-test-commit-smartos/5075/nodes=smartos14-64/console

```
not ok 217 parallel/test-debug-signal-cluster
# got pids [81560,84923,85367]
# 
# assert.js:85
#   throw new assert.AssertionError({
#   ^
# AssertionError: test timed out
#     at Object.exports.fail (/home/iojs/build/workspace/node-test-commit-smartos/nodes/smartos14-64/test/common.js:443:10)
#     at Timeout.testTimedOut [as _onTimeout] (/home/iojs/build/workspace/node-test-commit-smartos/nodes/smartos14-64/test/parallel/test-debug-signal-cluster.js:69:10)
#     at ontimeout (timers.js:365:14)
#     at Timer.unrefdHandle (timers.js:466:3)
# > all workers are running
# > Starting debugger agent.
# > Debugger listening on 127.0.0.1:12646
# > Starting debugger agent.
  ---
  duration_ms: 7.124
```

CI stress test on current master showing failures: https://ci.nodejs.org/job/node-stress-single-test/1053/nodes=smartos14-64/console

CI stress test on this change (will hopefully come up green): https://ci.nodejs.org/job/node-stress-single-test/1054/nodes=smartos14-64/console