### PR TITLE
child_process: catch json parsing error in ipc

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -459,6 +459,7 @@ function setupChannel(target, channel) {
           message = JSON.parse(json);
         // just ignore the case if someone put non-json data into the channel
         } catch (e) {
+          process.nextTick(function(){ target.emit('error',e); });
         }
 
         if (message) {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -453,15 +453,23 @@ function setupChannel(target, channel) {
       //Linebreak is used as a message end sign
       while ((i = jsonBuffer.indexOf('\n', start)) >= 0) {
         var json = jsonBuffer.slice(start, i);
-        var message = JSON.parse(json);
+        var message;
 
-        // There will be at most one NODE_HANDLE message in every chunk we
-        // read because SCM_RIGHTS messages don't get coalesced. Make sure
-        // that we deliver the handle with the right message however.
-        if (message && message.cmd === 'NODE_HANDLE')
-          handleMessage(target, message, recvHandle);
-        else
-          handleMessage(target, message, undefined);
+        try {
+          message = JSON.parse(json);
+        // just ignore the case if someone put non-json data into the channel
+        } catch (e) {
+        }
+
+        if (message) {
+          // There will be at most one NODE_HANDLE message in every chunk we
+          // read because SCM_RIGHTS messages don't get coalesced. Make sure
+          // that we deliver the handle with the right message however.
+          if (message.cmd === 'NODE_HANDLE')
+            handleMessage(target, message, recvHandle);
+          else
+            handleMessage(target, message, undefined);
+        }
 
         start = i + 1;
       }


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process (ipc)


##### Description of change

When starting an ipc with non-nodejs processes, it is possible that
other side of communication will write some non-json data when
sending a handle (socket/server/file descriptor/etc). It led to ipc
being completely blocked - later messages are skipped.

This commit allows to catch errors in json parsing. Errors are
simply ignored, reading of the ipc channel continues with next
available bytes.