### PR TITLE
doc: fix link to cli.md in vm.md

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -455,3 +455,4 @@ associating it with the `sandbox` object is what this document refers to as
 [`eval()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
 [V8 Embedder's Guide]: https://developers.google.com/v8/embed#contexts
 [contextified]: #vm_what_does_it_mean_to_contextify_an_object
+[cli.md]: cli.html

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -297,7 +297,7 @@ console.log(Debug.findScript(process.exit).name);  // 'internal/process.js'
 implementation and may change (or even be removed) without prior warning.
 
 The `Debug` object can also be made available using the V8-specific
-`--expose_debug_as=` [command line option][cli.md].
+`--expose_debug_as=` [command line option][].
 
 ## vm.runInNewContext(code[, sandbox][, options])
 <!-- YAML
@@ -455,4 +455,4 @@ associating it with the `sandbox` object is what this document refers to as
 [`eval()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
 [V8 Embedder's Guide]: https://developers.google.com/v8/embed#contexts
 [contextified]: #vm_what_does_it_mean_to_contextify_an_object
-[cli.md]: cli.html
+[command line option]: cli.html


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change

Looks like the link for cli.md is missing:
https://nodejs.org/api/vm.html#vm_vm_runindebugcontext_code

Added the link which can be verified by using the following commands:
```shell
$ make doc
$ open out/doc/api/vm.html
```