### PR TITLE
doc: fix minor style issue in code examples

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -274,6 +274,7 @@ pre {
 
 pre > code {
   font-size: .8em;
+  padding: 0;
 }
 
 pre + h3 {


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

I've noticed that a few of the code examples have an minor indentation
issue with the first line, for example:
https://nodejs.org/api/child_process.html#child_process_child_process

This commit attempt to fix this issue by using the suggestion provided
by Brain White which is to add a separate style for code with a
padding-right and padding-left of .0em.

Fixes: https://github.com/nodejs/node/issues/9381