### PR TITLE
lib,test: remove unneeded escaping of /

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1436,13 +1436,13 @@ fs.unwatchFile = function(filename, listener) {
 // Regexp that finds the next portion of a (partial) path
 // result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
 const nextPartRe = isWindows ?
-  /(.*?)(?:[\/\\]+|$)/g :
-  /(.*?)(?:[\/]+|$)/g;
+  /(.*?)(?:[/\\]+|$)/g :
+  /(.*?)(?:[/]+|$)/g;
 
 // Regex to find the device root, including trailing slash. E.g. 'c:\\'.
 const splitRootRe = isWindows ?
-  /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/ :
-  /^[\/]*/;
+  /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/ :
+  /^[/]*/;
 
 function encodeRealpathResult(result, options, err) {
   if (!options || !options.encoding || options.encoding === 'utf8' || err)

--- a/lib/url.js
+++ b/lib/url.js
@@ -204,7 +204,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // user@server is *always* interpreted as a hostname, and url
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || /^\/\/[^@\/]+@[^@\/]+/.test(rest)) {
+  if (slashesDenoteHost || proto || /^\/\/[^@/]+@[^@/]+/.test(rest)) {
     var slashes = rest.charCodeAt(0) === 47/*/*/ &&
                   rest.charCodeAt(1) === 47/*/*/;
     if (slashes && !(proto && hostlessProtocol[proto])) {

--- a/test/debugger/test-debugger-repl-break-in-module.js
+++ b/test/debugger/test-debugger-repl-break-in-module.js
@@ -20,7 +20,7 @@ repl.addTest('sb(")^$*+?}{|][(.js\\\\", 1)', [
 
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
-  /break in .*[\\\/]mod\.js:2/,
+  /break in .*[\\/]mod\.js:2/,
   /1/, /2/, /3/, /4/
 ]);
 
@@ -42,7 +42,7 @@ repl.addTest('restart', [].concat(
 
 // continue - the breakpoint should be triggered
 repl.addTest('c', [
-  /break in .*[\\\/]mod\.js:2/,
+  /break in .*[\\/]mod\.js:2/,
   /1/, /2/, /3/, /4/
 ]);
 
@@ -53,7 +53,7 @@ repl.addTest('cb("mod.js", 2)', [
 ]);
 
 repl.addTest('c', [
-  /break in .*[\\\/]main\.js:4/,
+  /break in .*[\\/]main\.js:4/,
   /2/, /3/, /4/, /5/, /6/
 ]);
 

--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 try {
   require(path.join(common.fixturesDir, 'invalid.json'));
 } catch (err) {
-  var re = /test[\/\\]fixtures[\/\\]invalid.json: Unexpected string/;
+  var re = /test[/\\]fixtures[/\\]invalid.json: Unexpected string/;
   var i = err.message.match(re);
   assert.notStrictEqual(null, i, 'require() json error should include path');
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib test

##### Description of change
<!-- Provide a description of the change below this comment. -->

The `/` character does not need to be escaped when occurring inside a
character class in a regular expression. Remove such instances of
escaping in the code base.

/cc @silverwind 