### PR TITLE
test: fix helper-debugger-repl.js

### DIFF
--- a/test/debugger/helper-debugger-repl.js
+++ b/test/debugger/helper-debugger-repl.js
@@ -108,7 +108,7 @@ function addTest(input, output) {
 }
 
 var handshakeLines = [
-  /listening on port \d+/,
+  /listening on /,
   /connecting.* ok/
 ];
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test debugger

##### Description of change
<!-- Provide a description of the change below this comment. -->

The test `debugger/test-debugger-repl-break-in-module` (and probably
others) was failing because the handshake message for debugging is no
longer `listening on port <port>` but is instead `listening on <address>:<port>`.

This change makes the check less strict so as to hopefully future-proof
it at least a little bit against subsequent changes.

This test failure is not caught in CI because currently debugger tests
are not run in CI.