### PR TITLE
build: remove valgrind from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,6 @@ test: all
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J
 
-test-valgrind: all
-	$(PYTHON) tools/test.py --mode=release --valgrind sequential parallel message
-
 test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
 	$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
 		--python="$(PYTHON)" \
@@ -190,9 +187,6 @@ test-build: | all build-addons
 
 test-all: test-build test/gc/node_modules/weak/build/Release/weakref.node
 	$(PYTHON) tools/test.py --mode=debug,release
-
-test-all-valgrind: test-build
-	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 CI_NATIVE_SUITES := addons
 CI_JS_SUITES := doctool inspector known_issues message parallel pseudo-tty sequential

--- a/test/message/testcfg.py
+++ b/test/message/testcfg.py
@@ -43,7 +43,7 @@ class MessageTestCase(test.TestCase):
     self.mode = mode
 
   def IgnoreLine(self, str):
-    """Ignore empty lines and valgrind output."""
+    """Ignore empty lines"""
     if not str.strip(): return True
     else: return str.startswith('==') or str.startswith('**')
 

--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -44,7 +44,7 @@ class TTYTestCase(test.TestCase):
     self.mode = mode
 
   def IgnoreLine(self, str):
-    """Ignore empty lines and valgrind output."""
+    """Ignore empty lines"""
     if not str.strip(): return True
     else: return str.startswith('==') or str.startswith('**')
 

--- a/tools/run-valgrind.py
+++ b/tools/run-valgrind.py
@@ -1,1 +1,0 @@
-../deps/v8/tools/run-valgrind.py

--- a/tools/test.py
+++ b/tools/test.py
@@ -1330,8 +1330,6 @@ def BuildOptions():
       default=[], action="append")
   result.add_option("--expect-fail", dest="expect_fail",
       help="Expect test cases to fail", default=False, action="store_true")
-  result.add_option("--valgrind", help="Run tests through valgrind",
-      default=False, action="store_true")
   result.add_option("--cat", help="Print the source of the tests",
       default=False, action="store_true")
   result.add_option("--flaky-tests",
@@ -1517,12 +1515,6 @@ def Main():
     for arg in args:
       path = SplitPath(arg)
       paths.append(path)
-
-  # Check for --valgrind option. If enabled, we overwrite the special
-  # command flag with a command that uses the run-valgrind.py script.
-  if options.valgrind:
-    run_valgrind = join(workspace, "tools", "run-valgrind.py")
-    options.special_command = "python -u " + run_valgrind + " @"
 
   shell = abspath(options.shell)
   buildspace = dirname(shell)


### PR DESCRIPTION
##### Checklist

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

build tools

##### Description of change

Looks like V8 doesn't ship valgrind anymore. So all the valgrind based
targets will fail.