### PR TITLE
zlib: fix linting recently-introduced lint error

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -346,7 +346,7 @@ function Zlib(opts, mode) {
 
   var self = this;
   this._hadError = false;
-  this._handle.onerror = function onErrorHandler(message, errno) {
+  this._handle.onerror = function(message, errno) {
     // there is no way to cleanly recover.
     // continuing only obscures problems.
     _close(self);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib

##### Description of change
<!-- Provide a description of the change below this comment. -->

Remove unnecessary named function. V8 will do a better job inferring the
name from the assignment to a property. The current formulation does not
pass linting.

Refs: https://github.com/nodejs/node/pull/9389#issuecomment-259303279