### PR TITLE
test: add test for broken child process stdio

### DIFF
--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -1,0 +1,63 @@
+'use strict';
+// Flags: --expose_internals
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  setTimeout(() => {}, common.platformTimeout(100));
+  return;
+}
+
+// Monkey patch spawn() to create a child process normally, but destroy the
+// stdout and stderr streams. This replicates the conditions where the streams
+// cannot be properly created.
+const ChildProcess = require('internal/child_process').ChildProcess;
+const original = ChildProcess.prototype.spawn;
+
+ChildProcess.prototype.spawn = function() {
+  const err = original.apply(this, arguments);
+
+  this.stdout.destroy();
+  this.stderr.destroy();
+  this.stdout = null;
+  this.stderr = null;
+
+  return err;
+};
+
+function createChild(options, callback) {
+  const cmd = `${process.execPath} ${__filename} child`;
+
+  return cp.exec(cmd, options, common.mustCall(callback));
+}
+
+// Verify that normal execution of a child process is handled.
+{
+  createChild({}, (err, stdout, stderr) => {
+    assert.strictEqual(err, null);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(stderr, '');
+  });
+}
+
+// Verify that execution with an error event is handled.
+{
+  const error = new Error('foo');
+  const child = createChild({}, (err, stdout, stderr) => {
+    assert.strictEqual(err, error);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(stderr, '');
+  });
+
+  child.emit('error', error);
+}
+
+// Verify that execution with a killed process is handled.
+{
+  createChild({ timeout: 1 }, (err, stdout, stderr) => {
+    assert.strictEqual(err.killed, true);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(stderr, '');
+  });
+}


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
This commit adds a test for the scenario where a child process is spawned, but the stdio streams could not be created.

If you look at [child process coverage](https://coverage.nodejs.org/coverage-34febfbf4dbe9a28/root/child_process.js.html), this adds coverage for the `else` conditions on lines 224, 227, 234, 237, 256, and 275.