### PR TITLE
doc: fix the inconsistence between doc and impl on url

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -176,8 +176,9 @@ The formatting process operates as follows:
   * If the `urlObject.pathname` *does not start* with an ASCII forward slash
     (`/`), then the literal string '/' is appended to `result`.
   * The value of `urlObject.pathname` is appended to `result`.
-* Otherwise, if `urlObject.pathname` is not `undefined` and is not a string, an
-  [`Error`][] is thrown.
+* Otherwise, if `urlObject.pathname` is not `undefined` and is not a string, the
+  value of `urlObject.pathname` will be the result of `urlObject.pathname.toString()`
+  in place.
 * If the `urlObject.search` property is `undefined` and if the `urlObject.query`
   property is an `Object`, the literal string `?` is appended to `result`
   followed by the output of calling the [`querystring`][] module's `stringify()`

--- a/lib/url.js
+++ b/lib/url.js
@@ -563,7 +563,7 @@ Url.prototype.format = function() {
   }
 
   var protocol = this.protocol || '';
-  var pathname = this.pathname || '';
+  var pathname = (this.pathname + '') || '';
   var hash = this.hash || '';
   var host = '';
   var query = '';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, url

##### Description of change
<!-- Provide a description of the change below this comment. -->
This fixes the inconsistence between doc and impl on url.
