### PR TITLE
Backport removing let in for loop declaration

### DIFF
--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,3 +1,4 @@
 rules:
   # Custom rules in tools/eslint-rules
   require-buffer: 2
+  no-let-in-for-declaration: 2

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -654,14 +654,14 @@ Readable.prototype.unpipe = function(dest) {
     state.pipesCount = 0;
     state.flowing = false;
 
-    for (let i = 0; i < len; i++)
+    for (var i = 0; i < len; i++)
       dests[i].emit('unpipe', this);
     return this;
   }
 
   // try to find the right one.
-  const i = state.pipes.indexOf(dest);
-  if (i === -1)
+  const index = state.pipes.indexOf(dest);
+  if (index === -1)
     return this;
 
   state.pipes.splice(i, 1);

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -664,7 +664,7 @@ Readable.prototype.unpipe = function(dest) {
   if (index === -1)
     return this;
 
-  state.pipes.splice(i, 1);
+  state.pipes.splice(index, 1);
   state.pipesCount -= 1;
   if (state.pipesCount === 1)
     state.pipes = state.pipes[0];

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -34,6 +34,8 @@ exports.SecureContext = SecureContext;
 
 exports.createSecureContext = function createSecureContext(options, context) {
   if (!options) options = {};
+  var i;
+  var len;
 
   var secureOptions = options.secureOptions;
   if (options.honorCipherOrder)
@@ -47,7 +49,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // cert's issuer in C++ code.
   if (options.ca) {
     if (Array.isArray(options.ca)) {
-      for (let i = 0, len = options.ca.length; i < len; i++) {
+      for (i = 0, len = options.ca.length; i < len; i++) {
         c.context.addCACert(options.ca[i]);
       }
     } else {
@@ -59,7 +61,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.cert) {
     if (Array.isArray(options.cert)) {
-      for (let i = 0; i < options.cert.length; i++)
+      for (i = 0; i < options.cert.length; i++)
         c.context.setCert(options.cert[i]);
     } else {
       c.context.setCert(options.cert);
@@ -72,7 +74,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // which leads to the crash later on.
   if (options.key) {
     if (Array.isArray(options.key)) {
-      for (let i = 0; i < options.key.length; i++) {
+      for (i = 0; i < options.key.length; i++) {
         var key = options.key[i];
 
         if (key.passphrase)
@@ -103,7 +105,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.crl) {
     if (Array.isArray(options.crl)) {
-      for (let i = 0, len = options.crl.length; i < len; i++) {
+      for (i = 0, len = options.crl.length; i < len; i++) {
         c.context.addCRL(options.crl[i]);
       }
     } else {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -286,7 +286,7 @@ function REPLServer(prompt,
 
     // After executing the current expression, store the values of RegExp
     // predefined properties back in `savedRegExMatches`
-    for (let idx = 1; idx < savedRegExMatches.length; idx += 1) {
+    for (var idx = 1; idx < savedRegExMatches.length; idx += 1) {
       savedRegExMatches[idx] = RegExp[`$${idx}`];
     }
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -90,7 +90,7 @@ function check(hostParts, pattern, wildcards) {
     return false;
 
   // Check host parts from right to left first.
-  for (let i = hostParts.length - 1; i > 0; i -= 1)
+  for (var i = hostParts.length - 1; i > 0; i -= 1)
     if (hostParts[i] !== patternParts[i])
       return false;
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -89,7 +89,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   if (typeof url !== 'string') {
     throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
   }
-
+  var i, j, k, l;
   // Copy chrome, IE, opera backslash-handling behavior.
   // Back slashes before the query string get converted to forward slashes
   // See: https://code.google.com/p/chromium/issues/detail?id=25916
@@ -169,7 +169,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 
     // find the first instance of any hostEndingChars
     var hostEnd = -1;
-    for (let i = 0; i < hostEndingChars.length; i++) {
+    for (i = 0; i < hostEndingChars.length; i++) {
       const hec = rest.indexOf(hostEndingChars[i]);
       if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
         hostEnd = hec;
@@ -197,7 +197,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
 
     // the host is the remaining to the left of the first non-host char
     hostEnd = -1;
-    for (let i = 0; i < nonHostChars.length; i++) {
+    for (i = 0; i < nonHostChars.length; i++) {
       const hec = rest.indexOf(nonHostChars[i]);
       if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
         hostEnd = hec;
@@ -224,12 +224,12 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // validate a little.
     if (!ipv6Hostname) {
       var hostparts = this.hostname.split(/\./);
-      for (let i = 0, l = hostparts.length; i < l; i++) {
+      for (i = 0, l = hostparts.length; i < l; i++) {
         var part = hostparts[i];
         if (!part) continue;
         if (!part.match(hostnamePartPattern)) {
           var newpart = '';
-          for (let j = 0, k = part.length; j < k; j++) {
+          for (j = 0, k = part.length; j < k; j++) {
             if (part.charCodeAt(j) > 127) {
               // we replace non-ASCII char with a temporary placeholder
               // we need this to make sure size of hostname is not
@@ -294,7 +294,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // First, make 100% sure that any "autoEscape" chars get
     // escaped, even if encodeURIComponent doesn't think they
     // need to be.
-    for (let i = 0, l = autoEscape.length; i < l; i++) {
+    for (i = 0, l = autoEscape.length; i < l; i++) {
       var ae = autoEscape[i];
       if (rest.indexOf(ae) === -1)
         continue;

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const Stream = require('stream');
+const Readable = Stream.Readable;
+const Writable = Stream.Writable;
+
+const source = Readable({read: () => {}});
+const dest1 = Writable({write: () => {}});
+const dest2 = Writable({write: () => {}});
+
+source.pipe(dest1);
+source.pipe(dest2);
+
+dest1.on('unpipe', common.mustCall(() => {}));
+dest2.on('unpipe', common.mustCall(() => {}));
+
+assert.strictEqual(source._readableState.pipes[0], dest1);
+assert.strictEqual(source._readableState.pipes[1], dest2);
+assert.strictEqual(source._readableState.pipes.length, 2);
+
+// Should be able to unpipe them in the reverse order that they were piped.
+
+source.unpipe(dest2);
+
+assert.strictEqual(source._readableState.pipes, dest1);
+assert.notStrictEqual(source._readableState.pipes, dest2);
+
+source.unpipe(dest1);
+
+assert.strictEqual(source._readableState.pipes, null);

--- a/tools/eslint-rules/no-let-in-for-declaration.js
+++ b/tools/eslint-rules/no-let-in-for-declaration.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Prohibit the use of `let` as the loop variable
+ *               in the initialization of for, and the left-hand
+ *               iterator in forIn and forOf loops.
+ *
+ * @author Jessica Quynh Tran
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  create(context) {
+
+    const msg = 'Use of `let` as the loop variable in a for-loop is ' +
+                'not recommended. Please use `var` instead.';
+
+    /**
+     * Report function to test if the for-loop is declared using `let`.
+     */
+    function testForLoop(node) {
+      if (node.init && node.init.kind === 'let') {
+        context.report(node.init, msg);
+      }
+    }
+
+    /**
+     * Report function to test if the for-in or for-of loop
+     * is declared using `let`.
+     */
+    function testForInOfLoop(node) {
+      if (node.left && node.left.kind === 'let') {
+        context.report(node.left, msg);
+      }
+    }
+
+    return {
+      'ForStatement': testForLoop,
+      'ForInStatement': testForInOfLoop,
+      'ForOfStatement': testForInOfLoop
+    };
+  }
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib, tools, test, streams

##### Description of change
<!-- Provide a description of the change below this comment. -->
This is a backport of a number of commits that remove the use of `let` in for loop declarations.

It starts with #8873 that removes all instances of let, followed by #9171 to fix a regression introduced in streams, and finally #9049 which adds a linting rule to avoid regressing.

These changes have been living on v6.x and v7.x for a while and did show a decent improvement in performance. I would imagine it will only be more noticeable for v4.x. If anyone from @nodejs/benchmarking wants to chime in here that would be awesome