### PR TITLE
doc: consistent 'Returns:'

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -612,7 +612,7 @@ added: v0.1.90
   calculate the length of
 * `encoding` {String} If `string` is a string, this is its encoding.
   **Default:** `'utf8'`
-* Return: {Integer} The number of bytes contained within `string`
+* Returns: {Integer} The number of bytes contained within `string`
 
 Returns the actual byte length of a string. This is not the same as
 [`String.prototype.length`] since that returns the number of *characters* in
@@ -638,7 +638,7 @@ added: v0.11.13
 
 * `buf1` {Buffer}
 * `buf2` {Buffer}
-* Return: {Integer}
+* Returns: {Integer}
 
 Compares `buf1` to `buf2` typically for the purpose of sorting arrays of
 `Buffer` instances. This is equivalent to calling
@@ -664,7 +664,7 @@ added: v0.7.11
 * `list` {Array} List of `Buffer` instances to concat
 * `totalLength` {Integer} Total length of the `Buffer` instances in `list`
   when concatenated
-* Return: {Buffer}
+* Returns: {Buffer}
 
 Returns a new `Buffer` which is the result of concatenating all the `Buffer`
 instances in the `list` together.
@@ -829,7 +829,7 @@ added: v0.1.101
 -->
 
 * `obj` {Object}
-* Return: {Boolean}
+* Returns: {Boolean}
 
 Returns `true` if `obj` is a `Buffer`, `false` otherwise.
 
@@ -839,7 +839,7 @@ added: v0.9.1
 -->
 
 * `encoding` {String} A character encoding name to check
-* Return: {Boolean}
+* Returns: {Boolean}
 
 Returns `true` if `encoding` contains a supported character encoding, or `false`
 otherwise.
@@ -894,7 +894,7 @@ added: v0.11.13
 * `sourceEnd` {Integer} The offset within `buf` at which to end comparison
   (not inclusive). Ignored when `targetStart` is `undefined`.
   **Default:** [`buf.length`]
-* Return: {Integer}
+* Returns: {Integer}
 
 Compares `buf` with `target` and returns a number indicating whether `buf`
 comes before, after, or is the same as `target` in sort order.
@@ -966,7 +966,7 @@ added: v0.1.90
   Ignored when `targetStart` is `undefined`. **Default:** `0`
 * `sourceEnd` {Integer} The offset within `buf` at which to stop copying (not
   inclusive). Ignored when `sourceStart` is `undefined`. **Default:** [`buf.length`]
-* Return: {Integer} The number of bytes copied.
+* Returns: {Integer} The number of bytes copied.
 
 Copies data from a region of `buf` to a region in `target` even if the `target`
 memory region overlaps with `buf`.
@@ -1011,7 +1011,7 @@ console.log(buf.toString());
 added: v1.1.0
 -->
 
-* Return: {Iterator}
+* Returns: {Iterator}
 
 Creates and returns an [iterator] of `[index, byte]` pairs from the contents of
 `buf`.
@@ -1039,7 +1039,7 @@ added: v0.11.13
 -->
 
 * `otherBuffer` {Buffer} A `Buffer` to compare to
-* Return: {Boolean}
+* Returns: {Boolean}
 
 Returns `true` if both `buf` and `otherBuffer` have exactly the same bytes,
 `false` otherwise.
@@ -1068,7 +1068,7 @@ added: v0.5.0
 * `end` {Integer} Where to stop filling `buf` (not inclusive). **Default:** [`buf.length`]
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
-* Return: {Buffer} A reference to `buf`
+* Returns: {Buffer} A reference to `buf`
 
 Fills `buf` with the specified `value`. If the `offset` and `end` are not given,
 the entire `buf` will be filled. This is meant to be a small simplification to
@@ -1104,7 +1104,7 @@ added: v1.5.0
 * `byteOffset` {Integer} Where to begin searching in `buf`. **Default:** `0`
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
-* Return: {Integer} The index of the first occurrence of `value` in `buf` or `-1`
+* Returns: {Integer} The index of the first occurrence of `value` in `buf` or `-1`
   if `buf` does not contain `value`
 
 If `value` is:
@@ -1159,7 +1159,7 @@ added: v5.3.0
 * `byteOffset` {Integer} Where to begin searching in `buf`. **Default:** `0`
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
-* Return: {Boolean} `true` if `value` was found in `buf`, `false` otherwise
+* Returns: {Boolean} `true` if `value` was found in `buf`, `false` otherwise
 
 Equivalent to [`buf.indexOf() !== -1`][`buf.indexOf()`].
 
@@ -1196,7 +1196,7 @@ console.log(buf.includes('this', 4));
 added: v1.1.0
 -->
 
-* Return: {Iterator}
+* Returns: {Iterator}
 
 Creates and returns an [iterator] of `buf` keys (indices).
 
@@ -1227,7 +1227,7 @@ added: v6.0.0
   **Default:** [`buf.length`]
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
-* Return: {Integer} The index of the last occurrence of `value` in `buf` or `-1`
+* Returns: {Integer} The index of the last occurrence of `value` in `buf` or `-1`
   if `buf` does not contain `value`
 
 Identical to [`buf.indexOf()`], except `buf` is searched from back to front
@@ -1323,7 +1323,7 @@ added: v0.11.15
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Number}
+* Returns: {Number}
 
 Reads a 64-bit double from `buf` at the specified `offset` with specified
 endian format (`readDoubleBE()` returns big endian, `readDoubleLE()` returns
@@ -1359,7 +1359,7 @@ added: v0.11.15
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Number}
+* Returns: {Number}
 
 Reads a 32-bit float from `buf` at the specified `offset` with specified
 endian format (`readFloatBE()` returns big endian, `readFloatLE()` returns
@@ -1394,7 +1394,7 @@ added: v0.5.0
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 1`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads a signed 8-bit integer from `buf` at the specified `offset`.
 
@@ -1426,7 +1426,7 @@ added: v0.5.5
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 2`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads a signed 16-bit integer from `buf` at the specified `offset` with
 the specified endian format (`readInt16BE()` returns big endian,
@@ -1460,7 +1460,7 @@ added: v0.5.5
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads a signed 32-bit integer from `buf` at the specified `offset` with
 the specified endian format (`readInt32BE()` returns big endian,
@@ -1495,7 +1495,7 @@ added: v0.11.15
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - byteLength`
 * `byteLength` {Integer} How many bytes to read. Must satisfy: `0 < byteLength <= 6`
 * `noAssert` {Boolean} Skip `offset` and `byteLength` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as a two's complement signed value. Supports up to 48
@@ -1526,7 +1526,7 @@ added: v0.5.0
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 1`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads an unsigned 8-bit integer from `buf` at the specified `offset`.
 
@@ -1556,7 +1556,7 @@ added: v0.5.5
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 2`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads an unsigned 16-bit integer from `buf` at the specified `offset` with
 specified endian format (`readUInt16BE()` returns big endian, `readUInt16LE()`
@@ -1594,7 +1594,7 @@ added: v0.5.5
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads an unsigned 32-bit integer from `buf` at the specified `offset` with
 specified endian format (`readUInt32BE()` returns big endian,
@@ -1627,7 +1627,7 @@ added: v0.11.15
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - byteLength`
 * `byteLength` {Integer} How many bytes to read. Must satisfy: `0 < byteLength <= 6`
 * `noAssert` {Boolean} Skip `offset` and `byteLength` validation? **Default:** `false`
-* Return: {Integer}
+* Returns: {Integer}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as an unsigned integer. Supports up to 48
@@ -1659,7 +1659,7 @@ added: v0.3.0
 * `start` {Integer} Where the new `Buffer` will start. **Default:** `0`
 * `end` {Integer} Where the new `Buffer` will end (not inclusive).
   **Default:** [`buf.length`]
-* Return: {Buffer}
+* Returns: {Buffer}
 
 Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
@@ -1715,7 +1715,7 @@ console.log(buf.slice(-5, -2).toString());
 added: v5.10.0
 -->
 
-* Return: {Buffer} A reference to `buf`
+* Returns: {Buffer} A reference to `buf`
 
 Interprets `buf` as an array of unsigned 16-bit integers and swaps the byte-order
 *in-place*. Throws a `RangeError` if [`buf.length`] is not a multiple of 2.
@@ -1745,7 +1745,7 @@ buf2.swap32();
 added: v5.10.0
 -->
 
-* Return: {Buffer} A reference to `buf`
+* Returns: {Buffer} A reference to `buf`
 
 Interprets `buf` as an array of unsigned 32-bit integers and swaps the byte-order
 *in-place*. Throws a `RangeError` if [`buf.length`] is not a multiple of 4.
@@ -1775,7 +1775,7 @@ buf2.swap32();
 added: v6.3.0
 -->
 
-* Return: {Buffer} A reference to `buf`
+* Returns: {Buffer} A reference to `buf`
 
 Interprets `buf` as an array of 64-bit numbers and swaps the byte-order *in-place*.
 Throws a `RangeError` if [`buf.length`] is not a multiple of 8.
@@ -1812,7 +1812,7 @@ added: v0.1.90
 * `start` {Integer} The byte offset to start decoding at. **Default:** `0`
 * `end` {Integer} The byte offset to stop decoding at (not inclusive).
   **Default:** [`buf.length`]
-* Return: {String}
+* Returns: {String}
 
 Decodes `buf` to a string according to the specified character encoding in
 `encoding`. `start` and `end` may be passed to decode only a subset of `buf`.
@@ -1851,7 +1851,7 @@ console.log(buf2.toString(undefined, 0, 3));
 added: v0.9.2
 -->
 
-* Return: {Object}
+* Returns: {Object}
 
 Returns a JSON representation of `buf`. [`JSON.stringify()`] implicitly calls
 this function when stringifying a `Buffer` instance.
@@ -1880,7 +1880,7 @@ console.log(copy);
 added: v1.1.0
 -->
 
-* Return: {Iterator}
+* Returns: {Iterator}
 
 Creates and returns an [iterator] for `buf` values (bytes). This function is
 called automatically when a `Buffer` is used in a `for..of` statement.
@@ -1922,7 +1922,7 @@ added: v0.1.90
 * `offset` {Integer} Where to start writing `string`. **Default:** `0`
 * `length` {Integer} How many bytes to write. **Default:** `buf.length - offset`
 * `encoding` {String} The character encoding of `string`. **Default:** `'utf8'`
-* Return: {Integer} Number of bytes written
+* Returns: {Integer} Number of bytes written
 
 Writes `string` to `buf` at `offset` according to the character encoding in `encoding`.
 The `length` parameter is the number of bytes to write. If `buf` did not contain
@@ -1949,7 +1949,7 @@ added: v0.11.15
 * `value` {Number} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 8`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeDoubleBE()` writes big endian, `writeDoubleLE()` writes little
@@ -1984,7 +1984,7 @@ added: v0.11.15
 * `value` {Number} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeFloatBE()` writes big endian, `writeFloatLE()` writes little
@@ -2018,7 +2018,7 @@ added: v0.5.0
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 1`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset`. `value` *should* be a valid
 signed 8-bit integer. Behavior is undefined when `value` is anything other than
@@ -2050,7 +2050,7 @@ added: v0.5.5
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 2`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeInt16BE()` writes big endian, `writeInt16LE()` writes little
@@ -2083,7 +2083,7 @@ added: v0.5.5
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeInt32BE()` writes big endian, `writeInt32LE()` writes little
@@ -2118,7 +2118,7 @@ added: v0.11.15
 * `byteLength` {Integer} How many bytes to write. Must satisfy: `0 < byteLength <= 6`
 * `noAssert` {Boolean} Skip `value`, `offset`, and `byteLength` validation?
   **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`.
 Supports up to 48 bits of accuracy. Behavior is undefined when `value` is
@@ -2151,7 +2151,7 @@ added: v0.5.0
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 1`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset`. `value` *should* be a
 valid unsigned 8-bit integer. Behavior is undefined when `value` is anything
@@ -2183,7 +2183,7 @@ added: v0.5.5
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 2`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeUInt16BE()` writes big endian, `writeUInt16LE()` writes little
@@ -2220,7 +2220,7 @@ added: v0.5.5
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 4`
 * `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeUInt32BE()` writes big endian, `writeUInt32LE()` writes little
@@ -2257,7 +2257,7 @@ added: v0.5.5
 * `byteLength` {Integer} How many bytes to write. Must satisfy: `0 < byteLength <= 6`
 * `noAssert` {Boolean} Skip `value`, `offset`, and `byteLength` validation?
   **Default:** `false`
-* Return: {Integer} `offset` plus the number of bytes written
+* Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`.
 Supports up to 48 bits of accuracy. Behavior is undefined when `value` is

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -144,7 +144,7 @@ added: v0.1.90
   * `error` {Error}
   * `stdout` {String|Buffer}
   * `stderr` {String|Buffer}
-* Return: {ChildProcess}
+* Returns: {ChildProcess}
 
 Spawns a shell then executes the `command` within that shell, buffering any
 generated output.
@@ -217,7 +217,7 @@ added: v0.1.91
   * `error` {Error}
   * `stdout` {String|Buffer}
   * `stderr` {String|Buffer}
-* Return: {ChildProcess}
+* Returns: {ChildProcess}
 
 The `child_process.execFile()` function is similar to [`child_process.exec()`][]
 except that it does not spawn a shell. Rather, the specified executable `file`
@@ -267,7 +267,7 @@ added: v0.5.0
     be thrown. For instance `[0, 1, 2, 'ipc']`.
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-* Return: {ChildProcess}
+* Returns: {ChildProcess}
 
 The `child_process.fork()` method is a special case of
 [`child_process.spawn()`][] used specifically to spawn new Node.js processes.
@@ -901,7 +901,7 @@ added: v0.5.9
 * `sendHandle` {Handle}
 * `options` {Object}
 * `callback` {Function}
-* Return: {Boolean}
+* Returns: {Boolean}
 
 When an IPC channel has been established between the parent and child (
 i.e. when using [`child_process.fork()`][]), the `child.send()` method can be

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -414,7 +414,7 @@ added: v0.7.0
 * `message` {Object}
 * `sendHandle` {Handle}
 * `callback` {Function}
-* Return: Boolean
+* Returns: Boolean
 
 Send a message to a worker or master, optionally with a handle.
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -601,7 +601,7 @@ added: v0.5.1
 -->
 
 * `id` {String}
-* Return: {Object} `module.exports` from the resolved module
+* Returns: {Object} `module.exports` from the resolved module
 
 The `module.require` method provides a way to load a module as if
 `require()` was called from the original module.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -61,7 +61,7 @@ added: v0.1.25
 
 * `path` {String}
 * `ext` {String} An optional file extension
-* Return: {String}
+* Returns: {String}
 
 The `path.basename()` methods returns the last portion of a `path`, similar to
 the Unix `basename` command.
@@ -117,7 +117,7 @@ added: v0.1.16
 -->
 
 * `path` {String}
-* Return: {String}
+* Returns: {String}
 
 The `path.dirname()` method returns the directory name of a `path`, similar to
 the Unix `dirname` command.
@@ -137,7 +137,7 @@ added: v0.1.25
 -->
 
 * `path` {String}
-* Return: {String}
+* Returns: {String}
 
 The `path.extname()` method returns the extension of the `path`, from the last
 occurrence of the `.` (period) character to end of string in the last portion of
@@ -177,7 +177,7 @@ added: v0.11.15
   * `base` {String}
   * `name` {String}
   * `ext` {String}
-* Return: {String}
+* Returns: {String}
 
 The `path.format()` method returns a path string from an object. This is the
 opposite of [`path.parse()`][].
@@ -250,7 +250,7 @@ added: v0.11.2
 -->
 
 * `path` {String}
-* Return: {Boolean}
+* Returns: {Boolean}
 
 The `path.isAbsolute()` method determines if `path` is an absolute path.
 
@@ -285,7 +285,7 @@ added: v0.1.16
 -->
 
 * `...paths` {String} A sequence of path segments
-* Return: {String}
+* Returns: {String}
 
 The `path.join()` method joins all given `path` segments together using the
 platform specific separator as a delimiter, then normalizes the resulting path.
@@ -312,7 +312,7 @@ added: v0.1.23
 -->
 
 * `path` {String}
-* Return: {String}
+* Returns: {String}
 
 The `path.normalize()` method normalizes the given `path`, resolving `'..'` and
 `'.'` segments.
@@ -346,7 +346,7 @@ added: v0.11.15
 -->
 
 * `path` {String}
-* Return: {Object}
+* Returns: {Object}
 
 The `path.parse()` method returns an object whose properties represent
 significant elements of the `path`.
@@ -426,7 +426,7 @@ added: v0.5.0
 
 * `from` {String}
 * `to` {String}
-* Return: {String}
+* Returns: {String}
 
 The `path.relative()` method returns the relative path from `from` to `to`.
 If `from` and `to` each resolve to the same path (after calling `path.resolve()`
@@ -457,7 +457,7 @@ added: v0.3.4
 -->
 
 * `...paths` {String} A sequence of paths or path segments
-* Return: {String}
+* Returns: {String}
 
 The `path.resolve()` method resolves a sequence of paths or path segments into
 an absolute path.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -613,7 +613,7 @@ added: v6.1.0
 
 * `previousValue` {Object} A previous return value from calling
   `process.cpuUsage()`
-* Return: {Object}
+* Returns: {Object}
     * `user` {Integer}
     * `system` {Integer}
 
@@ -643,7 +643,7 @@ console.log(process.cpuUsage(startUsage));
 added: v0.1.8
 -->
 
-* Return: {String}
+* Returns: {String}
 
 The `process.cwd()` method returns the current working directory of the Node.js
 process.
@@ -984,7 +984,7 @@ or Android)
 added: v2.0.0
 -->
 
-* Return: {Object}
+* Returns: {Object}
 
 The `process.geteuid()` method returns the numerical effective user identity of
 the process. (See geteuid(2).)
@@ -1003,7 +1003,7 @@ Android)
 added: v0.1.31
 -->
 
-* Return: {Object}
+* Returns: {Object}
 
 The `process.getgid()` method returns the numerical group identity of the
 process. (See getgid(2).)
@@ -1023,7 +1023,7 @@ Android)
 added: v0.9.4
 -->
 
-* Return: {Array}
+* Returns: {Array}
 
 The `process.getgroups()` method returns an array with the supplementary group
 IDs. POSIX leaves it unspecified if the effective group ID is included but
@@ -1037,7 +1037,7 @@ Android)
 added: v0.1.28
 -->
 
-* Return: {Integer}
+* Returns: {Integer}
 
 The `process.getuid()` method returns the numeric user identity of the process.
 (See getuid(2).)
@@ -1171,7 +1171,7 @@ is no entry script.
 added: v0.1.16
 -->
 
-* Return: {Object}
+* Returns: {Object}
     * `rss` {Integer}
     * `heapTotal` {Integer}
     * `heapUsed` {Integer}
@@ -1369,7 +1369,7 @@ added: v0.5.9
 * `sendHandle` {Handle object}
 * `options` {Object}
 * `callback` {Function}
-* Return: {Boolean}
+* Returns: {Boolean}
 
 If Node.js is spawned with an IPC channel, the `process.send()` method can be
 used to send messages to the parent process. Messages will be received as a
@@ -1663,7 +1663,7 @@ console.log(
 added: v0.5.0
 -->
 
-* Return: {Number}
+* Returns: {Number}
 
 The `process.uptime()` method returns the number of seconds the current Node.js
 process has been running.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -381,7 +381,7 @@ added: v0.11.15
 -->
 
 * `encoding` {String} The new default encoding
-* Return: `this`
+* Returns: `this`
 
 The `writable.setDefaultEncoding()` method sets the default `encoding` for a
 [Writable][] stream.
@@ -689,7 +689,7 @@ preferred over the use of the `'readable'` event.
 added: v0.11.14
 -->
 
-* Return: {Boolean}
+* Returns: {Boolean}
 
 The `readable.isPaused()` method returns the current operating state of the
 Readable. This is used primarily by the mechanism that underlies the
@@ -711,7 +711,7 @@ readable.isPaused() // === false
 added: v0.9.4
 -->
 
-* Return: `this`
+* Returns: `this`
 
 The `readable.pause()` method will cause a stream in flowing mode to stop
 emitting [`'data'`][] events, switching out of flowing mode. Any data that
@@ -843,7 +843,7 @@ event has been emitted will return `null`. No runtime error will be raised.
 added: v0.9.4
 -->
 
-* Return: `this`
+* Returns: `this`
 
 The `readable.resume()` method causes an explicitly paused Readable stream to
 resume emitting [`'data'`][] events, switching the stream into flowing mode.
@@ -866,7 +866,7 @@ added: v0.9.4
 -->
 
 * `encoding` {String} The encoding to use.
-* Return: `this`
+* Returns: `this`
 
 The `readable.setEncoding()` method sets the default character encoding for
 data read from the Readable stream.


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
We were a bit inconsistent with these. While the majority were `Return:` before, I think `Returns:` is better.
