### PR TITLE
test: ensure nextTick is not scheduled in exit

### DIFF
--- a/test/parallel/test-next-tick-when-exiting.js
+++ b/test/parallel/test-next-tick-when-exiting.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+process.on('exit', () => {
+  assert.strictEqual(process._exiting, true, 'process._exiting was not set!');
+
+  process.nextTick(() => {
+    common.fail('process is exiting, should not be called.');
+  });
+});
+
+process.exit();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, process

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously our tests did not check this codepath as seen at
coverage.nodejs.org

See https://coverage.nodejs.org/coverage-fb05e31466ac0bad/root/internal/process/next_tick.js.html (scroll down to the bottom).

CI: https://ci.nodejs.org/job/node-test-pull-request/4824/

_(This patch was made live during https://www.twitch.tv/nodesource/v/100431274 if you'd like to see me working on this in retrospect. :P)_