### PR TITLE
Backport of #9098: test: fix flaky test-child-process-fork-dgram

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -31,6 +31,3 @@ test-fs-watch-encoding               : FAIL, PASS
 #covered by  https://github.com/nodejs/node/issues/3796
 # but more frequent on AIX ?
 test-debug-signal-cluster                : PASS, FLAKY
-
-#covered by https://github.com/nodejs/node/issues/8271
-test-child-process-fork-dgram            : PASS, FLAKY


### PR DESCRIPTION
Backport of #9098. /cc @TheAlphaNerd 

##### Description of change
<!-- Provide a description of the change below this comment. -->

`test-child-process-fork-dgram` is unreliable on some platforms,
especially FreeBSD and AIX within the project's continuous integration
testing. It has also been observed to be flaky on macos.

* Confirm child has received the server before sending packets
* Close the server instance on the parent or child after receiving a

Refs: https://github.com/nodejs/node/pull/8697
Fixes: https://github.com/nodejs/node/issues/8949
Fixes: https://github.com/nodejs/node/issues/8271
PR-URL: https://github.com/nodejs/node/pull/9098
Reviewed-By: Santiago Gimeno <santiago.gimeno@gmail.com>