### PR TITLE
test: use 0 port instead of Common.PORT

### DIFF
--- a/test/parallel/test-net-socket-destroy-twice.js
+++ b/test/parallel/test-net-socket-destroy-twice.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 var net = require('net');
 
-var conn = net.createConnection(common.PORT);
+var conn = net.createConnection(0);
 
 conn.on('error', common.mustCall(function() {
   conn.destroy();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Use 0 port to create connection in test.

This is a part of Code And Learn at NodeFest 2016 Challenge
nodejs/code-and-learn#58