### PR TITLE
test: use port 0 instead of common.PORT

### DIFF
--- a/test/parallel/test-http-status-reason-invalid-chars.js
+++ b/test/parallel/test-http-status-reason-invalid-chars.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');
+const net = require('net');
 
 function explicit(req, res) {
   assert.throws(() => {
@@ -32,8 +33,10 @@ const server = http.createServer((req, res) => {
   } else {
     implicit(req, res);
   }
-}).listen(common.PORT, common.mustCall(() => {
-  const url = `http://localhost:${common.PORT}`;
+}).listen(0, common.mustCall(() => {
+  const addr = server.address().address;
+  const hostname = net.isIPv6(addr) ? `[${addr}1]` : addr;
+  const url = `http://${hostname}:${server.address().port}`;
   let left = 2;
   const check = common.mustCall((res) => {
     left--;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Use port 0 instead of common.PORT to follow writing test guideline.
This is a part of Code And Learn at NodeFest 2016 Challenge in Tokyo.