### PR TITLE
test: use port 0 instead of common.PORT

### DIFF
--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -18,10 +18,10 @@ function runTest() {
   const ciphers = 'AECDH-NULL-SHA';
   tls.createServer({ ciphers }, common.mustCall(function() {
     this.close();
-  })).listen(common.PORT, '::1', common.mustCall(function() {
+  })).listen(0, '::1', common.mustCall(function() {
     const options = {
       host: 'localhost',
-      port: common.PORT,
+      port: this.address().port,
       family: 6,
       ciphers: ciphers,
       rejectUnauthorized: false,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Use port 0 instead of common.PORT.