### PR TITLE
test: replace setInterval with setImmediate

### DIFF
--- a/test/parallel/test-stream-transform-objectmode-falsey-value.js
+++ b/test/parallel/test-stream-transform-objectmode-falsey-value.js
@@ -23,11 +23,11 @@ dest.on('data', function(x) {
 src.pipe(tx).pipe(dest);
 
 var i = -1;
-var int = setInterval(function() {
+setImmediate(function int() {
   if (i > 10) {
     src.end();
-    clearInterval(int);
   } else {
     src.write(i++);
+    setImmediate(int);
   }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

The 2nd argument for `setInterval()` was not given, so replaced it with
with `setImmediate()`.

This is a part of Code And Learn at NodeFest 2016
nodejs/code-and-learn#58