### PR TITLE
test: add zero, minus and undefined timeout test

### DIFF
--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -7,7 +7,13 @@ var Timer = process.binding('timer_wrap').Timer;
 var assert = require('assert');
 
 var timerFired = false;
+var zeroTimerFired = false;
+var minusTimerFired = false;
+var undefinedTimerFired = false;
 var intervalFired = false;
+var zeroIntervalFired = false;
+var minusIntervalFired = false;
+var undefinedIntervalFired = false;
 
 /*
  * This test case aims at making sure that timing utilities such
@@ -39,7 +45,13 @@ monoTimer[Timer.kOnTimeout] = function() {
      * time drifting or inconsistent time changes.
      */
   assert(timerFired);
+  assert(zeroTimerFired);
+  assert(minusTimerFired);
+  assert(undefinedTimerFired);
   assert(intervalFired);
+  assert(zeroIntervalFired);
+  assert(minusIntervalFired);
+  assert(undefinedIntervalFired);
 };
 
 monoTimer.start(300);
@@ -48,7 +60,34 @@ setTimeout(function() {
   timerFired = true;
 }, 200);
 
+setTimeout(function() {
+  zeroTimerFired = true;
+}, 0);
+
+setTimeout(function() {
+  minusTimerFired = true;
+}, -1);
+
+setTimeout(function() {
+  undefinedTimerFired = true;
+});
+
 var interval = setInterval(function() {
   intervalFired = true;
   clearInterval(interval);
 }, 200);
+
+var zeroInterval = setInterval(function() {
+  zeroIntervalFired = true;
+  clearInterval(zeroInterval);
+}, 0);
+
+var minusInterval = setInterval(function() {
+  minusIntervalFired = true;
+  clearInterval(minusInterval);
+}, -1);
+
+var undefinedInterval = setInterval(function() {
+  undefinedIntervalFired = true;
+  clearInterval(undefinedInterval);
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test only.

##### Description of change
<!-- Provide a description of the change below this comment. -->

`SetTimeout()` and `setInterval()` also accept 0 msec, -1 msec or
no argument. Added a test that works properly even if those
arguments are specified.

```javascript
setTimeout(function () {
  console.log('zero');
}, 0);

setTimeout(function () {
  console.log('minus');
}, -1);

setTimeout(function () {
  console.log('undefined');
});
```