### PR TITLE
test: use setImmediate() in test of stream2

### DIFF
--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -111,7 +111,7 @@ function end() {
   source.emit('end');
   assert(!reading);
   writer.end(stream.read());
-  setTimeout(function() {
+  setImmediate(function() {
     assert(ended);
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test of stream2

##### Description of change
<!-- Provide a description of the change below this comment. -->

use setImmediate() insted of setTimeout()
 in test of stream2 push.
The test is in test/parallel/test-stream2-push.js