### PR TITLE
doc: fix a typo in the assert.md

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -271,7 +271,7 @@ assert.notDeepEqual(obj1, obj3);
   // AssertionError: { a: { b: 1 } } notDeepEqual { a: { b: 1 } }
 
 assert.notDeepEqual(obj1, obj4);
-  // OK, obj1 and obj2 are not deeply equal
+  // OK, obj1 and obj4 are not deeply equal
 ```
 
 If the values are deeply equal, an `AssertionError` is thrown with a `message`


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
`obj2` => `obj4` in the `assert.notDeepEqual` code example.

Fixes https://github.com/nodejs/node/issues/9597
