### PR TITLE
timers: handle unrefed intervals in clearTimeout()

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -396,6 +396,7 @@ function rearm(timer) {
 
 const clearTimeout = exports.clearTimeout = function(timer) {
   if (timer && (timer[kOnTimeout] || timer._onTimeout)) {
+    timer._repeat = null;
     timer[kOnTimeout] = timer._onTimeout = null;
     if (timer instanceof Timeout) {
       timer.close(); // for after === 0
@@ -444,7 +445,6 @@ function createRepeatTimeout(callback, repeat, args) {
 
 exports.clearInterval = function(timer) {
   if (timer && timer._repeat) {
-    timer._repeat = null;
     clearTimeout(timer);
   }
 };

--- a/test/parallel/test-timers-cleartimeout-unref-interval.js
+++ b/test/parallel/test-timers-cleartimeout-unref-interval.js
@@ -1,0 +1,9 @@
+'use strict';
+const common = require('../common');
+const timeout = setTimeout(common.fail, 2 ** 30); // Keep event loop open.
+const interval = setInterval(common.mustCall(() => {
+  // Use clearTimeout() instead of clearInterval().
+  // The interval should still be cleared.
+  clearTimeout(interval);
+  setImmediate(() => { clearTimeout(timeout); });
+}), 1).unref();


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
timers

##### Description of change
This commit clears the `_repeat` property of all timer objects in `clearTimeout()`. This prevents intervals passed to `clearTimeout()` from being rearmed.

Fixes: https://github.com/nodejs/node/issues/9561 (although it does not directly address `wrap->object()` issue described in https://github.com/nodejs/node/issues/9561#issuecomment-260340127)

R= @bnoordhuis 