### PR TITLE
src: use ABORT() macro instead of abort()

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -698,7 +698,7 @@ static X509_STORE* NewRootCertStore() {
 
       if (x509 == nullptr) {
         // Parse errors from the built-in roots are fatal.
-        abort();
+        ABORT();
         return nullptr;
       }
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src


##### Description of change

This makes sure that we dump a backtrace and use raise(SIGABRT) on
Windows.