### PR TITLE
test: run tests even if os.cpus() fails

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -32,7 +32,8 @@ exports.isOSX = process.platform === 'darwin';
 exports.enoughTestMem = os.totalmem() > 0x40000000; /* 1 Gb */
 
 const cpus = os.cpus();
-exports.enoughTestCpu = cpus.length > 1 || cpus[0].speed > 999;
+exports.enoughTestCpu = Array.isArray(cpus) &&
+                        (cpus.length > 1 || cpus[0].speed > 999);
 
 exports.rootDir = exports.isWindows ? 'c:\\' : '/';
 exports.buildType = process.config.target_defaults.default_configuration;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently if the os.cpus() call fails every test will fail. As there is
already a [test](https://github.com/nodejs/node/blob/master/test/parallel/test-os.js#L66-L69) for os.cpus(), the other tests should run even if the
os.cpus() call fails.
 