### PR TITLE
doc: strip trailing whitespace

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1620,7 +1620,7 @@ See the reference for other recommendations and details.
 
 ## Crypto Constants
 
-The following constants exported by `crypto.constants` apply to various uses of 
+The following constants exported by `crypto.constants` apply to various uses of
 the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 
 ### OpenSSL Options
@@ -1639,13 +1639,13 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
   <tr>
     <td><code>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</code></td>
     <td>Allows legacy insecure renegotiation between OpenSSL and unpatched
-    clients or servers. See 
+    clients or servers. See
     https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html.</td>
   </tr>
   <tr>
     <td><code>SSL_OP_CIPHER_SERVER_PREFERENCE</code></td>
     <td>Uses the server's preferences instead of the clients when selecting a
-    cipher. See 
+    cipher. See
     https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html.</td>
   </tr>
   <tr>

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -765,7 +765,7 @@ A factory function, which returns a new [`net.Socket`][] and automatically
 connects with the supplied `options`.
 
 The options are passed to both the [`net.Socket`][] constructor and the
-[`socket.connect`][] method. 
+[`socket.connect`][] method.
 
 Passing `timeout` as an option will call [`socket.setTimeout()`][] after the socket is created, but before it is connecting.
 

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -101,7 +101,7 @@ For example:
 added: v1.0.0
 -->
 
-The `v8.setFlagsFromString()` method can be used to programmatically set 
+The `v8.setFlagsFromString()` method can be used to programmatically set
 V8 command line flags. This method should be used with care. Changing settings
 after the VM has started may result in unpredictable behavior, including
 crashes and data loss; or it may simply do nothing.

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -9,7 +9,7 @@ Deflate/Inflate. It can be accessed using:
 const zlib = require('zlib');
 ```
 
-Compressing or decompressing a stream (such as a file) can be accomplished by 
+Compressing or decompressing a stream (such as a file) can be accomplished by
 piping the source stream data through a `zlib` stream into a destination stream:
 
 ```js
@@ -46,12 +46,12 @@ zlib.unzip(buffer, (err, buffer) => {
 ## Compressing HTTP requests and responses
 
 The `zlib` module can be used to implement support for the `gzip` and `deflate`
-content-encoding mechanisms defined by 
+content-encoding mechanisms defined by
 [HTTP](https://tools.ietf.org/html/rfc7230#section-4.2).
 
 The HTTP [`Accept-Encoding`][] header is used within an http request to identify
-the compression encodings accepted by the client. The [`Content-Encoding`][] 
-header is used to identify the compression encodings actually applied to a 
+the compression encodings accepted by the client. The [`Content-Encoding`][]
+header is used to identify the compression encodings actually applied to a
 message.
 
 **Note: the examples given below are drastically simplified to show
@@ -230,7 +230,7 @@ not surprising. This section is taken almost directly from the
 [zlib documentation][].  See <http://zlib.net/manual.html#Constants> for more
 details.
 
-*Note*: Previously, the constants were available directly from 
+*Note*: Previously, the constants were available directly from
 `require('zlib')`, for instance `zlib.Z_NO_FLUSH`. Accessing the constants
 directly from the module is currently still possible but should be considered
 deprecated.
@@ -444,8 +444,8 @@ Returns a new [Unzip][] object with an [options][].
 
 <!--type=misc-->
 
-All of these take a [Buffer][] or string as the first argument, an optional 
-second argument to supply options to the `zlib` classes and will call the 
+All of these take a [Buffer][] or string as the first argument, an optional
+second argument to supply options to the `zlib` classes and will call the
 supplied callback with `callback(error, result)`.
 
 Every method has a `*Sync` counterpart, which accept the same arguments, but


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

lines should not end in trailing whitespace
