### PR TITLE
doc: improve description of urlObject.query

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -114,9 +114,10 @@ No decoding of the `path` is performed.
 
 ### urlObject.query
 
-The `query` property is either the "params" portion of the query string (
-everything *except* the leading ASCII question mark (`?`), or an object
-returned by the [`querystring`][] module's `parse()` method:
+The `query` property is either the query string without the leading ASCII
+question mark (`?`), or an object returned by the [`querystring`][] module's
+`parse()` method. Whether the `query` property is a string or object is
+determined by the `parseQueryString` argument passed to `url.parse()`.
 
 For example: `'query=string'` or `{'query': 'string'}`
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

There's a bit of a disconnect in the description of `urlObject.query`. It says it can be either an object or string, but doesn't explain the ambiguity. Added a sentence pointing to the option that determines this in url.parse().

Also fixed a missing parentheses.