### PR TITLE
tls: fix leak of WriteWrap+TLSWrap combination

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -317,14 +317,31 @@ proxiedMethods.forEach(function(name) {
 });
 
 tls_wrap.TLSWrap.prototype.close = function closeProxy(cb) {
-  if (this.owner)
+  let ssl;
+  if (this.owner) {
+    ssl = this.owner.ssl;
     this.owner.ssl = null;
+  }
+
+  // Invoke `destroySSL` on close to clean up possibly pending write requests
+  // that may self-reference TLSWrap, leading to leak
+  const done = () => {
+    if (ssl) {
+      ssl.destroySSL();
+      if (ssl._secureContext.singleUse) {
+        ssl._secureContext.context.close();
+        ssl._secureContext.context = null;
+      }
+    }
+    if (cb)
+      cb();
+  };
 
   if (this._parentWrap && this._parentWrap._handle === this._parent) {
-    this._parentWrap.once('close', cb);
+    this._parentWrap.once('close', done);
     return this._parentWrap.destroy();
   }
-  return this._parent.close(cb);
+  return this._parent.close(done);
 };
 
 TLSSocket.prototype._wrapHandle = function(wrap) {

--- a/test/parallel/test-tls-writewrap-leak.js
+++ b/test/parallel/test-tls-writewrap-leak.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+
+const server = net.createServer(common.mustCall((c) => {
+  c.destroy();
+})).listen(0, common.mustCall(() => {
+  const c = tls.connect({ port: server.address().port });
+  c.on('error', () => {
+    // Otherwise `.write()` callback won't be invoked.
+    c.destroyed = false;
+  });
+
+  c.write('hello', common.mustCall((err) => {
+    assert.equal(err.code, 'ECANCELED');
+    server.close();
+  }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tls

##### Description of change
<!-- Provide a description of the change below this comment. -->

Writing data to TLSWrap instance during handshake will result in it
being queued in `write_item_queue_`. This queue won't get cleared up
until the end of the handshake.

Technically, it gets cleared on `~TLSWrap` invocation, however this
won't ever happen because every `WriteWrap` holds a reference to the
`TLSWrap` through JS object, meaning that they are doomed to be alive
for eternity.

To breach this dreadful contract a knight shall embark from the
`close` function to kill the dragon of memory leak with his magic
spear of `destroySSL`.

`destroySSL` cleans up `write_item_queue_` and frees `SSL` structure,
both are good for memory usage.

PR-URL: https://github.com/nodejs/node/pull/9586
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>

----------

Backport of #9586, same PR should apply to v6.x too.

cc @TheAlphaNerd @nodejs/lts 