### PR TITLE
doc: small improvements in readline code examples

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -403,8 +403,8 @@ For instance: `[[substr1, substr2, ...], originalsubstring]`.
 
 ```js
 function completer(line) {
-  var completions = '.help .error .exit .quit .q'.split(' ');
-  var hits = completions.filter((c) => { return c.indexOf(line) === 0 });
+  const completions = '.help .error .exit .quit .q'.split(' ');
+  const hits = completions.filter((c) => { return c.indexOf(line) === 0 });
   // show all completions if none found
   return [hits.length ? hits : completions, line];
 }

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -21,7 +21,7 @@ const rl = readline.createInterface({
 
 rl.question('What do you think of Node.js? ', (answer) => {
   // TODO: Log the answer in a database
-  console.log('Thank you for your valuable feedback:', answer);
+  console.log(`Thank you for your valuable feedback: ${answer}`);
 
   rl.close();
 });
@@ -404,7 +404,7 @@ For instance: `[[substr1, substr2, ...], originalsubstring]`.
 ```js
 function completer(line) {
   var completions = '.help .error .exit .quit .q'.split(' ');
-  var hits = completions.filter((c) => { return c.indexOf(line) == 0 });
+  var hits = completions.filter((c) => { return c.indexOf(line) === 0 });
   // show all completions if none found
   return [hits.length ? hits : completions, line];
 }
@@ -512,7 +512,7 @@ const rl = readline.createInterface({
 });
 
 rl.on('line', (line) => {
-  console.log('Line from file:', line);
+  console.log(`Line from file: ${line}`);
 });
 ```
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change
1. Consistent template literals in `console.log()`.

2. === instead of ==.

3. const instead of var.

-----------------------------------------------

I am not sure about these two fragments:

1. In the [**Use of the completer Function**](https://github.com/nodejs/node/blob/master/doc/api/readline.md#use-of-the-completer-function)
    ```js
      var hits = completions.filter((c) => { return c.indexOf(line) == 0 });
    ```
    a. Should it be `(c) => c.indexOf(line) == 0` or is this a case of `no-confusing-arrow` eslint rule?
    b. Should a semicolon be added after `0` if the current variant remains?

2. In the [**readline.emitKeypressEvents(stream[, interface])**](https://github.com/nodejs/node/blob/master/doc/api/readline.md#readlineemitkeypresseventsstream-interface)
    ```js
    if (process.stdin.isTTY)
      process.stdin.setRawMode(true);
    ```
    Should it be in one line (like the similar fragment in the [**Event: 'SIGINT'**](https://github.com/nodejs/node/blob/master/doc/api/readline.md#event-sigint))?

If these ones should be somehow addressed, please, let me know.