### PR TITLE
src: allow getting Symbols on process.env

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2681,6 +2681,9 @@ static void ProcessTitleSetter(Local<Name> property,
 static void EnvGetter(Local<Name> property,
                       const PropertyCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
+  if (property->IsSymbol()) {
+    return info.GetReturnValue().SetUndefined();
+  }
 #ifdef __POSIX__
   node::Utf8Value key(isolate, property);
   const char* val = getenv(*key);

--- a/test/parallel/test-process-env-symbols.js
+++ b/test/parallel/test-process-env-symbols.js
@@ -5,10 +5,8 @@ const assert = require('assert');
 const symbol = Symbol('sym');
 const errRegExp = /^TypeError: Cannot convert a Symbol value to a string$/;
 
-// Verify that getting via a symbol key throws.
-assert.throws(() => {
-  process.env[symbol];
-}, errRegExp);
+// Verify that getting via a symbol key returns undefined.
+assert.strictEqual(process.env[symbol], undefined);
 
 // Verify that assigning via a symbol key throws.
 assert.throws(() => {
@@ -24,3 +22,6 @@ assert.throws(() => {
 assert.throws(() => {
   symbol in process.env;
 }, errRegExp);
+
+// Checks that well-known symbols like `Symbol.toStringTag` won’t throw.
+assert.doesNotThrow(() => Object.prototype.toString.call(process.env));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -925,3 +925,5 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
     util.inspect.defaultOptions = 'bad';
   }, /"options" must be an object/);
 }
+
+assert.doesNotThrow(() => util.inspect(process));


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

process

##### Description of change

1aa595e5bd6 introduced a `throw` for accessing `Symbol` properties of `process.env`. However, this breaks `util.inspect(process)` and things like `Object.prototype.toString.call(process.env)`, so this patch changes the behaviour for the getter to just always return `undefined`.

/cc @cjihrig 