### PR TITLE
tools,doc: better manpage refs

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -824,7 +824,7 @@ added: v0.1.90
 * `signal` {String}
 
 The `child.kill()` methods sends a signal to the child process. If no argument
-is given, the process will be sent the `'SIGTERM'` signal. See `signal(7)` for
+is given, the process will be sent the `'SIGTERM'` signal. See signal(7) for
 a list of available signals.
 
 ```js

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -184,7 +184,7 @@ added: v0.1.100
 
 Prints to `stderr` with newline. Multiple arguments can be passed, with the
 first used as the primary message and all additional used as substitution
-values similar to `printf(3)` (the arguments are all passed to
+values similar to printf(3) (the arguments are all passed to
 [`util.format()`][]).
 
 ```js
@@ -213,7 +213,7 @@ added: v0.1.100
 
 Prints to `stdout` with newline. Multiple arguments can be passed, with the
 first used as the primary message and all additional used as substitution
-values similar to `printf(3)` (the arguments are all passed to
+values similar to printf(3) (the arguments are all passed to
 [`util.format()`][]).
 
 ```js

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -407,14 +407,14 @@ Under the hood, [`dns.lookup()`][] uses the same operating system facilities
 as most other programs. For instance, [`dns.lookup()`][] will almost always
 resolve a given name the same way as the `ping` command. On most POSIX-like
 operating systems, the behavior of the [`dns.lookup()`][] function can be
-modified by changing settings in `nsswitch.conf(5)` and/or `resolv.conf(5)`,
+modified by changing settings in nsswitch.conf(5) and/or resolv.conf(5),
 but note that changing these files will change the behavior of _all other
 programs running on the same operating system_.
 
 Though the call to `dns.lookup()` will be asynchronous from JavaScript's
-perspective, it is implemented as a synchronous call to `getaddrinfo(3)` that
+perspective, it is implemented as a synchronous call to getaddrinfo(3) that
 runs on libuv's threadpool. Because libuv's threadpool has a fixed size, it
-means that if for whatever reason the call to `getaddrinfo(3)` takes a long
+means that if for whatever reason the call to getaddrinfo(3) takes a long
 time, other operations that could run on libuv's threadpool (such as filesystem
 operations) will experience degraded performance. In order to mitigate this
 issue, one potential solution is to increase the size of libuv's threadpool by
@@ -425,7 +425,7 @@ setting the `'UV_THREADPOOL_SIZE'` environment variable to a value greater than
 ### `dns.resolve()`, `dns.resolve*()` and `dns.reverse()`
 
 These functions are implemented quite differently than [`dns.lookup()`][]. They
-do not use `getaddrinfo(3)` and they _always_ perform a DNS query on the
+do not use getaddrinfo(3) and they _always_ perform a DNS query on the
 network. This network communication is always done asynchronously, and does not
 use libuv's threadpool.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -251,13 +251,13 @@ page.
 The times in the stat object have the following semantics:
 
 * `atime` "Access Time" - Time when file data last accessed.  Changed
-  by the `mknod(2)`, `utimes(2)`, and `read(2)` system calls.
+  by the mknod(2), utimes(2), and read(2) system calls.
 * `mtime` "Modified Time" - Time when file data last modified.
-  Changed by the `mknod(2)`, `utimes(2)`, and `write(2)` system calls.
+  Changed by the mknod(2), utimes(2), and write(2) system calls.
 * `ctime` "Change Time" - Time when file status was last changed
-  (inode data modification).  Changed by the `chmod(2)`, `chown(2)`,
-  `link(2)`, `mknod(2)`, `rename(2)`, `unlink(2)`, `utimes(2)`,
-  `read(2)`, and `write(2)` system calls.
+  (inode data modification).  Changed by the chmod(2), chown(2),
+  link(2), mknod(2), rename(2), unlink(2), utimes(2),
+  read(2), and write(2) system calls.
 * `birthtime` "Birth Time" -  Time of file creation. Set once when the
   file is created.  On filesystems where birthtime is not available,
   this field may instead hold either the `ctime` or
@@ -265,7 +265,7 @@ The times in the stat object have the following semantics:
   value may be greater than `atime` or `mtime` in this case. On Darwin
   and other FreeBSD variants, also set if the `atime` is explicitly
   set to an earlier value than the current `birthtime` using the
-  `utimes(2)` system call.
+  utimes(2) system call.
 
 Prior to Node v0.12, the `ctime` held the `birthtime` on Windows
 systems.  Note that as of v0.12, `ctime` is not "creation time", and

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -124,7 +124,7 @@ added: v0.7.5
 
 The `'SIGCONT'` event is emitted when a Node.js process previously moved into
 the background using `<ctrl>-Z` (i.e. `SIGTSTP`) is then brought back to the
-foreground using `fg(1)`.
+foreground using fg(1).
 
 If the `input` stream was paused *before* the `SIGTSTP` request, this event will
 not be emitted.
@@ -174,7 +174,7 @@ input, typically known as `SIGTSTP`. If there are no `SIGTSTP` event listeners
 registered when the `input` stream receives a `SIGTSTP`, the Node.js process
 will be sent to the background.
 
-When the program is resumed using `fg(1)`, the `'pause'` and `SIGCONT` events
+When the program is resumed using fg(1), the `'pause'` and `SIGCONT` events
 will be emitted. These can be used to resume the `input` stream.
 
 The `'pause'` and `'SIGCONT'` events will not be emitted if the `input` was

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -535,7 +535,7 @@ possible to connect to a long-running Node.js process without restarting it.
 For an example of running a "full-featured" (`terminal`) REPL over
 a `net.Server` and `net.Socket` instance, see: https://gist.github.com/2209310
 
-For an example of running a REPL instance over `curl(1)`,
+For an example of running a REPL instance over curl(1),
 see: https://gist.github.com/2053342
 
 [stream]: stream.html

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -263,7 +263,7 @@ var BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 // Returns modified text, with such refs replace with HTML links, for example
 // '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
 function linkManPages(text) {
-  return text.replace(/ ([a-z]+)\((\d)\)/gm, function(match, name, number) {
+  return text.replace(/ ([a-z.]+)\((\d)\)/gm, function(match, name, number) {
     // name consists of lowercase letters, number is a single digit
     var displayAs = name + '(' + number + ')';
     if (BSD_ONLY_SYSCALLS.has(name)) {


### PR DESCRIPTION
Minor doc cleanup to make the doctool emit manpage references in more cases where it’s appropriate:

- tools: use better regexp for manpage references:
  In practice, manpage names may contain dots (e.g. `resolv.conf(5)`) ~~but can only have a section in the range 1–9 as opposed to 0–9~~.
- doc: remove backtick escaping for manpage refs:
   Removing backticks will make the doctool emit links to the man pages.