### PR TITLE
build: default to ppc64 on AIX

### DIFF
--- a/configure
+++ b/configure
@@ -677,7 +677,7 @@ def host_arch_cc():
     '__MIPSEL__'  : 'mipsel',
     '__mips__'    : 'mips',
     '__PPC64__'   : 'ppc64',
-    '__PPC__'     : 'ppc',
+    '__PPC__'     : 'ppc64',
     '__x86_64__'  : 'x64',
     '__s390__'    : 's390',
     '__s390x__'   : 's390x',


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

The ./configure python script searches `gcc -dM -E -` for the ARCH
flags. On AIX, gcc builds in 32 bit mode by default prior to gcc v6, so
you don't get the flag unless you run `gcc -maix64 -dM -E -`.

We don't support ppc 32 bit for any OS, so always use ppc64 as the
host_arch.

cc/ @edelsohn (who confirmed that `__PPC64__` wasn't available below gcc v6)
cc/ @nodejs/platform-aix 