### PR TITLE
internal/util: move the case 'latin1'

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -112,15 +112,15 @@ exports.normalizeEncoding = function normalizeEncoding(enc) {
       case 'utf-8':
         return 'utf8';
       case 'ucs2':
-      case 'utf16le':
       case 'ucs-2':
+      case 'utf16le':
       case 'utf-16le':
         return 'utf16le';
+      case 'latin1':
       case 'binary':
         return 'latin1';
       case 'base64':
       case 'ascii':
-      case 'latin1':
       case 'hex':
         return enc;
       default:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
internal/util

##### Description of change
<!-- Provide a description of the change below this comment. -->

make the `case 'latin1':` near by `case 'binary':`.