### PR TITLE
test: simplify test-http-client-unescaped-path

### DIFF
--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -3,12 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-function* bad() {
-  for (let i = 0; i <= 32; i += 1)
-    yield 'bad' + String.fromCharCode(i) + 'path';
-}
-
-for (const path of bad()) {
+for (let i = 0; i <= 32; i += 1) {
+  let path = 'bad' + String.fromCharCode(i) + 'path';
   assert.throws(() => http.get({ path }, common.fail),
                 /contains unescaped characters/);
 }


### PR DESCRIPTION
the generator is unnecessarily obfuscating what the test is trying to do and there's no async here