### PR TITLE
child_process: support numeric signal argument to kill.

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1,4 +1,4 @@
-# Child Process
+#n Child Process
 
 > Stability: 2 - Stable
 
@@ -821,10 +821,11 @@ within the child process to close the IPC channel as well.
 added: v0.1.90
 -->
 
-* `signal` {String}
+* `signal` {String|Number} The signal to send, either as a string or number.
+  Defaults to `'SIGTERM'`.
 
-The `child.kill()` methods sends a signal to the child process. If no argument
-is given, the process will be sent the `'SIGTERM'` signal. See signal(7) for
+The `child.kill()` method sends a signal to the child process. If no argument
+is given, the process will be sent the `'SIGTERM'` signal. See `signal(7)` for
 a list of available signals.
 
 ```js

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -363,8 +363,8 @@ function onErrorNT(self, err) {
 ChildProcess.prototype.kill = function(sig) {
   var signal;
 
-  if (sig === 0) {
-    signal = 0;
+  if (typeof sig === 'number' && sig >>> 0 === sig) {
+    signal = sig;
   } else if (!sig) {
     signal = constants['SIGTERM'];
   } else {

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -1,18 +1,25 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var spawn = require('child_process').spawn;
-var cat = spawn(common.isWindows ? 'cmd' : 'cat');
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const constants = process.binding('constants');
 
-cat.stdout.on('end', common.mustCall(function() {}));
-cat.stderr.on('data', common.fail);
-cat.stderr.on('end', common.mustCall(function() {}));
+function runTest(sig) {
+  const cat = spawn(common.isWindows ? 'cmd' : 'cat');
 
-cat.on('exit', common.mustCall(function(code, signal) {
-  assert.strictEqual(code, null);
-  assert.strictEqual(signal, 'SIGTERM');
-}));
+  cat.stdout.on('end', common.mustCall(function() {}));
+  cat.stderr.on('data', common.fail);
+  cat.stderr.on('end', common.mustCall(function() {}));
 
-assert.equal(cat.killed, false);
-cat.kill();
-assert.equal(cat.killed, true);
+  cat.on('exit', common.mustCall(function(code, signal) {
+    assert.strictEqual(code, null);
+    assert.strictEqual(signal, 'SIGTERM');
+  }));
+
+  assert.equal(cat.killed, false);
+  cat.kill();
+  assert.equal(cat.killed, true);
+}
+
+runTest(constants.os.signals.SIGTERM);
+runTest('SIGTERM');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process

##### Description of change
<!-- Provide a description of the change below this comment. -->
Modifies the kill function to support numeric signals. I used a type check instead of `Number.isInteger` because that was the pattern used elsewhere in the code base.

Addresses: https://github.com/nodejs/node/issues/9519
