### PR TITLE
src: allow loading lib/ files from disk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,11 @@ $ ./node ./test/parallel/test-stream2-transform.js
 Remember to recompile with `make -j8` in between test runs if you change
 core modules.
 
+*Note*: If you only change the JavaScript source files in `lib/` and
+compiling Node takes a long time on your machine, you can use
+`./node --internal-modules-source-dir=lib test/parallel/...` instead to avoid
+rebuilding.
+
 ### Step 6: Push
 
 ```text

--- a/src/node.cc
+++ b/src/node.cc
@@ -166,6 +166,8 @@ static node_module* modlist_addon;
 static const char* icu_data_dir = nullptr;
 #endif
 
+const char* internal_modules_source_dir = nullptr;
+
 // used by C++ modules as well
 bool no_deprecation = false;
 
@@ -3758,6 +3760,8 @@ static void ParseArgs(int* argc,
     } else if (strncmp(arg, "--icu-data-dir=", 15) == 0) {
       icu_data_dir = arg + 15;
 #endif
+    } else if (strncmp(arg, "--internal-modules-source-dir=", 30) == 0) {
+      internal_modules_source_dir = arg + 30;
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js

--- a/src/node.cc
+++ b/src/node.cc
@@ -167,6 +167,7 @@ static const char* icu_data_dir = nullptr;
 #endif
 
 const char* internal_modules_source_dir = nullptr;
+const char* js_entry_point = nullptr;
 
 // used by C++ modules as well
 bool no_deprecation = false;
@@ -3762,6 +3763,8 @@ static void ParseArgs(int* argc,
 #endif
     } else if (strncmp(arg, "--internal-modules-source-dir=", 30) == 0) {
       internal_modules_source_dir = arg + 30;
+    } else if (strncmp(arg, "--js-entry-point=", 17) == 0) {
+      js_entry_point = arg + 17;
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -44,6 +44,10 @@ extern bool config_preserve_symlinks;
 // Tells whether it is safe to call v8::Isolate::GetCurrent().
 extern bool v8_initialized;
 
+// Source file directory to load instead of the ones baked into the executable
+// for hacking.
+extern const char* internal_modules_source_dir;
+
 // Forward declaration
 class Environment;
 
@@ -195,6 +199,9 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
 // Mixing operator new and free() is undefined behavior so don't do that.
 v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
 }  // namespace Buffer
+
+v8::MaybeLocal<v8::String> InternalModuleReadFile(Environment* env,
+                                                  const char* path);
 
 }  // namespace node
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -47,6 +47,9 @@ extern bool v8_initialized;
 // Source file directory to load instead of the ones baked into the executable
 // for hacking.
 extern const char* internal_modules_source_dir;
+// Source file to load instead of the `bootstrap_node.js` one baked into the
+// executable.
+extern const char* js_entry_point;
 
 // Forward declaration
 class Environment;

--- a/src/node_javascript.cc
+++ b/src/node_javascript.cc
@@ -1,5 +1,6 @@
 #include "node.h"
 #include "node_natives.h"
+#include "node_internals.h"
 #include "v8.h"
 #include "env.h"
 #include "env-inl.h"
@@ -7,6 +8,7 @@
 namespace node {
 
 using v8::Local;
+using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Object;
 using v8::String;
@@ -23,7 +25,29 @@ using v8::String;
 NODE_NATIVES_MAP(V)
 #undef V
 
+static MaybeLocal<String> MaybeLoadSourceFromDisk(Environment* env,
+                                                  const uint8_t* name,
+                                                  size_t name_length) {
+  if (internal_modules_source_dir == nullptr) {
+    return MaybeLocal<String>();
+  }
+
+  std::string name_str(reinterpret_cast<const char*>(name), name_length);
+
+  std::string path = std::string(internal_modules_source_dir) +
+      '/' + name_str + ".js";
+  return InternalModuleReadFile(env, path.c_str());
+}
+
 Local<String> MainSource(Environment* env) {
+  auto maybe_disk_src =
+      MaybeLoadSourceFromDisk(env,
+                              internal_bootstrap_node_name,
+                              sizeof(internal_bootstrap_node_name));
+  if (!maybe_disk_src.IsEmpty()) {
+    return maybe_disk_src.ToLocalChecked();
+  }
+
   auto maybe_string =
       String::NewExternalOneByte(
           env->isolate(),
@@ -39,9 +63,15 @@ void DefineJavaScript(Environment* env, Local<Object> target) {
         String::NewFromOneByte(                                               \
             env->isolate(), id##_name, NewStringType::kNormal,                \
             sizeof(id##_name)).ToLocalChecked();                              \
-    auto value =                                                              \
-        String::NewExternalOneByte(                                           \
+    Local<String> value;                                                      \
+    auto maybe_disk_src =                                                     \
+        MaybeLoadSourceFromDisk(env, id##_name, sizeof(id##_name));           \
+    if (!maybe_disk_src.IsEmpty()) {                                          \
+      value = maybe_disk_src.ToLocalChecked();                                \
+    } else {                                                                  \
+        value = String::NewExternalOneByte(                                   \
             env->isolate(), &id##_external_data).ToLocalChecked();            \
+    }                                                                         \
     CHECK(target->Set(context, key, value).FromJust());                       \
   } while (0);
   NODE_NATIVES_MAP(V)

--- a/src/node_javascript.cc
+++ b/src/node_javascript.cc
@@ -40,6 +40,10 @@ static MaybeLocal<String> MaybeLoadSourceFromDisk(Environment* env,
 }
 
 Local<String> MainSource(Environment* env) {
+  if (js_entry_point != nullptr) {
+    return InternalModuleReadFile(env, js_entry_point).ToLocalChecked();
+  }
+
   auto maybe_disk_src =
       MaybeLoadSourceFromDisk(env,
                               internal_bootstrap_node_name,

--- a/test/fixtures/fake-internal-module-source-dir/with-bootstrap_node/internal/bootstrap_node.js
+++ b/test/fixtures/fake-internal-module-source-dir/with-bootstrap_node/internal/bootstrap_node.js
@@ -1,0 +1,4 @@
+'use strict';
+(function(process) {
+  process.reallyExit(42);
+});

--- a/test/fixtures/fake-internal-module-source-dir/with-zlib/zlib.js
+++ b/test/fixtures/fake-internal-module-source-dir/with-zlib/zlib.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = 'foobar';

--- a/test/parallel/test-internal-modules-src-dir.js
+++ b/test/parallel/test-internal-modules-src-dir.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const child_process = require('child_process');
+const assert = require('assert');
+const path = require('path');
+
+const fakeDirs = path.join(common.fixturesDir,
+                           'fake-internal-module-source-dir');
+
+const with_zlib_dir = path.join(fakeDirs, 'with-zlib');
+const bootstrap_node = path.join(fakeDirs, 'with-bootstrap_node');
+
+assert.strictEqual(
+    'foobar\n',
+    child_process.execSync(`${process.execPath} ` +
+                           `--internal-modules-source-dir=${with_zlib_dir} ` +
+                           '-p zlib',
+                           { encoding: 'utf8' }));
+
+assert.strictEqual(
+    42,
+    child_process.spawnSync(process.execPath,
+                            [`--internal-modules-source-dir=${bootstrap_node}`,
+                             '-p', '0']).status);

--- a/test/parallel/test-internal-modules-src-dir.js
+++ b/test/parallel/test-internal-modules-src-dir.js
@@ -22,3 +22,11 @@ assert.strictEqual(
     child_process.spawnSync(process.execPath,
                             [`--internal-modules-source-dir=${bootstrap_node}`,
                              '-p', '0']).status);
+
+const entry = path.join(bootstrap_node, 'internal/bootstrap_node.js');
+
+assert.strictEqual(
+    42,
+    child_process.spawnSync(process.execPath,
+                            [`--js-entry-point=${entry}`,
+                             '-p', '0']).status);


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [½] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

src

##### Description of change

Introduce a `--internal-modules-source-dir=` CLI option that allows
developers to test a modified version of the Node JavaScript source
files without rebuilding the Node executable and instead loading
the files from a directory on the disk.

This can be useful in situations where compiling and linking takes a
disproportionately long time, e.g. debugging Node core on slow machines
or inside of VMs, or installing a full compiler toolchain to build
Node does not seem reasonable.

This change does not document the CLI option in the official
documentation as it targets developers, not users, of Node.
Instead, a note is left in `CONTRIBUTING.md`.

CI: https://ci.nodejs.org/job/node-test-commit/6037/