### PR TITLE
url: add a got host pattern in url.js

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -42,6 +42,7 @@ function Url() {
 // compiled once on the first module load.
 const protocolPattern = /^([a-z0-9.+-]+:)/i;
 const portPattern = /:[0-9]*$/;
+const hostPattern = /^\/\/[^@/]+@[^@/]+/;
 
 // Special case for a simple path URL
 const simplePathPattern = /^(\/\/?(?!\/)[^?\s]*)(\?[^\s]*)?$/;
@@ -204,7 +205,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // user@server is *always* interpreted as a hostname, and url
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || /^\/\/[^@/]+@[^@/]+/.test(rest)) {
+  if (slashesDenoteHost || proto || hostPattern.test(rest)) {
     var slashes = rest.charCodeAt(0) === 47/*/*/ &&
                   rest.charCodeAt(1) === 47/*/*/;
     if (slashes && !(proto && hostlessProtocol[proto])) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add a hostPattern variable for readable purposes