### PR TITLE
doc: add Working Group revocation text

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -12,9 +12,12 @@ Groups are not formed to *begin* a set of tasks but instead are formed
 once that work is already underway and the contributors
 think it would benefit from being done as an autonomous project.
 
-If the work defined in a Working Group charter is completed the Working
-Group should be dissolved and the responsibility for governance absorbed
-back in to the CTC.
+If the work defined in a Working Group's charter is complete, the charter
+should be revoked.
+
+A Working Group's charter can be revoked either by consensus of the Working
+Group's members or by a CTC vote. Once revoked, any future work that arises
+becomes the responsibility of the CTC.
 
 ## Current Working Groups
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

Recently, the Roadmap Working Group was dissolved. I thought we followed a defined process for making that happen- but I was incorrect. The problem is that I confused the text in the TSC's text for [dissolving a Top Level Working Group](https://github.com/nodejs/TSC/blob/master/WORKING_GROUPS.md) as being the process for a Core Working Group. They are identical EXCEPT that the TSC's version ends with:
>A Working Group can be dissolved either through consensus of the Working Group membership or normal TSC motion and vote.

So- Core Working Groups actually do not (technically) have a defined way to dissolve them right now. This is likely just an error of docs being shuffled around.

This PR just adds that same statement to Core's version of WORKING_GROUPS.md.

This will need to be approved by the CTC.
