### PR TITLE
buffer: empty string is not a valid encoding

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -308,6 +308,7 @@ Buffer.compare = function compare(a, b) {
 
 Buffer.isEncoding = function(encoding) {
   return typeof encoding === 'string' &&
+         encoding !== '' &&
          typeof internalUtil.normalizeEncoding(encoding) === 'string';
 };
 Buffer[internalUtil.kIsEncodingSymbol] = Buffer.isEncoding;

--- a/test/parallel/test-buffer-isencoding.js
+++ b/test/parallel/test-buffer-isencoding.js
@@ -21,6 +21,7 @@ const assert = require('assert');
   'utf-7',
   'Unicode-FTW',
   'new gnu gun',
+  '',
   false,
   NaN,
   {},


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer

##### Description of change
`Buffer.isEncoding()` relies on the internal utility function `normalizeEncoding()`, which converts falsey values to `'utf8'`. This commit adds a check to `Buffer.isEncoding()` to catch the empty
string, and return `false`.

Fixes: https://github.com/nodejs/node/issues/9654