### PR TITLE
doc: fix an SNI mistyped as SNS

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -513,7 +513,7 @@ added: v0.1.90
 -->
 
 As [`socket.connect(options[, connectListener])`][`socket.connect(options, connectListener)`],
-with options either as either `{port: port, host: host}` or `{path: path}`.
+with options as either `{port: port, host: host}` or `{path: path}`.
 
 ### socket.connecting
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -365,7 +365,7 @@ added: v0.3.2
 The `server.close()` method stops the server from accepting new connections.
 
 This function operates asynchronously. The `'close'` event will be emitted
-when the the server is finally closed.
+when the server has no more open connections.
 
 ### server.connections
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -394,7 +394,7 @@ added: v0.3.2
   on any IPv6 address (`::`) when IPv6 is available, or any IPv4 address
   (`0.0.0.0`) otherwise.
 * `callback` {Function} A callback function to be invoked when the server has
-  begun listening the the `port` and `hostname`.
+  begun listening on the `port` and `hostname`.
 
 The `server.listen()` methods instructs the server to begin accepting
 connections on the specified `port` and `hostname`.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -343,7 +343,7 @@ added: v0.5.3
   `cert`, `ca`, etc).
 
 The `server.addContext()` method adds a secure context that will be used if
-the client request's SNS hostname matches the supplied `hostname` (or wildcard).
+the client request's SNI hostname matches the supplied `hostname` (or wildcard).
 
 ### server.address()
 <!-- YAML


### PR DESCRIPTION


##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc, tls

##### Description of change

"SNS" is a typo, it should be "SNI"

@indutny @shigeki @bnoordhuis 