### PR TITLE
fs: do not pass Buffer when toString() fails

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -396,8 +396,8 @@ function readFileAfterClose(err) {
   var buffer = null;
   var callback = context.callback;
 
-  if (context.err)
-    return callback(context.err);
+  if (context.err || err)
+    return callback(context.err || err);
 
   if (context.size === 0)
     buffer = Buffer.concat(context.buffers, context.pos);
@@ -405,8 +405,6 @@ function readFileAfterClose(err) {
     buffer = context.buffer.slice(0, context.pos);
   else
     buffer = context.buffer;
-
-  if (err) return callback(err, buffer);
 
   if (context.encoding) {
     return tryToString(buffer, context.encoding, callback);
@@ -416,13 +414,12 @@ function readFileAfterClose(err) {
 }
 
 function tryToString(buf, encoding, callback) {
-  var e = null;
   try {
     buf = buf.toString(encoding);
   } catch (err) {
-    e = err;
+    return callback(err);
   }
-  callback(e, buf);
+  callback(null, buf);
 }
 
 function tryStatSync(fd, isUserFd) {

--- a/test/parallel/test-fs-readfile-tostring-fail.js
+++ b/test/parallel/test-fs-readfile-tostring-fail.js
@@ -33,6 +33,7 @@ stream.on('finish', common.mustCall(function() {
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
     assert.ok(err instanceof Error);
     assert.strictEqual('"toString()" failed', err.message);
+    assert.strictEqual(buf, undefined);
   }));
 }));
 


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* fs


##### Description of change

Even though an Error object is passed to the callback when `readFile()` fails due to `toString()` failing, it is a bit strange to still see data passed as the second argument. This commit changes that and only
passes the Error object in that case.

CI: https://ci.nodejs.org/job/node-test-pull-request/4877/