### PR TITLE
tools: disallow trailing whitespace for markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,9 +9,6 @@ insert_final_newline = true
 [vcbuild.bat]
 end_of_line = crlf
 
-[*.{md,markdown}]
-trim_trailing_whitespace = false
-
 [{lib,src,test}/**.js]
 indent_style = space
 indent_size = 2

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ Prerequisites:
 
 On OS X, you will also need:
 * [Xcode](https://developer.apple.com/xcode/download/)
-  * You also need to install the `Command Line Tools` via Xcode. You can find 
+  * You also need to install the `Command Line Tools` via Xcode. You can find
     this under the menu `Xcode -> Preferences -> Downloads`
   * This step will install `gcc` and the related toolchain containing `make`
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -326,7 +326,7 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   const http = require('http');
   const len = conf.kb * 1024;
-  const chunk = Buffer.alloc(len, 'x'); 
+  const chunk = Buffer.alloc(len, 'x');
   const server = http.createServer(function(req, res) {
     res.end(chunk);
   });

--- a/doc/changelogs/CHANGELOG_V010.md
+++ b/doc/changelogs/CHANGELOG_V010.md
@@ -70,7 +70,7 @@
   * [io.js](CHANGELOG_IOJS.md)
   * [Archive](CHANGELOG_ARCHIVE.md)
 
-**Note:** Node.js v0.10 is covered by the 
+**Note:** Node.js v0.10 is covered by the
 [Node.js Long Term Support Plan](https://github.com/nodejs/LTS) and
 will be maintained until October 2016.
 
@@ -359,11 +359,11 @@ https://github.com/nodejs/node/commit/8d045a30e95602b443eb259a5021d33feb4df079
 * child_process: properly support optional args (cjihrig)
 * crypto: Disable autonegotiation for SSLv2/3 by default (Fedor Indutny,
   Timothy J Fontaine, Alexis Campailla)
- 
+
   This is a behavior change, by default we will not allow the negotiation to
   SSLv2 or SSLv3. If you want this behavior, run Node.js with either
   `--enable-ssl2` or `--enable-ssl3` respectively.
- 
+
   This does not change the behavior for users specifically requesting
   `SSLv2_method` or `SSLv3_method`. While this behavior is not advised, it is
   assumed you know what you're doing since you're specifically asking to use

--- a/doc/changelogs/CHANGELOG_V012.md
+++ b/doc/changelogs/CHANGELOG_V012.md
@@ -37,7 +37,7 @@
   * [io.js](CHANGELOG_IOJS.md)
   * [Archive](CHANGELOG_ARCHIVE.md)
 
-**Note:** Node.js v0.12 is covered by the 
+**Note:** Node.js v0.12 is covered by the
 [Node.js Long Term Support Plan](https://github.com/nodejs/LTS) and
 will be maintained until December 31st, 2016.
 

--- a/test/README.md
+++ b/test/README.md
@@ -146,7 +146,7 @@ and `setInterval`).
 ## Common module API
 
 The common.js module is used by tests for consistency across repeated
-tasks. It has a number of helpful functions and properties to help with 
+tasks. It has a number of helpful functions and properties to help with
 writing tests.
 
 ### allowGlobals(...whitelist)
@@ -177,7 +177,7 @@ Check if there is more than 1gb of total memory.
 * `name` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
 * `expected` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) | [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
 
-Tests whether `name` and `expected` are part of a raised warning. 
+Tests whether `name` and `expected` are part of a raised warning.
 
 ### hasCrypto
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc, tools


##### Description of change

tools: disallow trailing whitespace for markdown

markdown had a dispensation because 2 or more trailing spaces triggers a
new paragraph. There are no examples of that usage in Node, all trailing
whitespace found were mistakes, and the dispensation is now removed.

See: https://github.com/nodejs/node/pull/9620