### PR TITLE
test: make gh-2847 regression test stricter

### DIFF
--- a/test/parallel/test-child-process-fork-regr-gh-2847.js
+++ b/test/parallel/test-child-process-fork-regr-gh-2847.js
@@ -56,8 +56,8 @@ var server = net.createServer(function(s) {
         // Ignore errors when sending the second handle because the worker
         // may already have exited.
         if (err) {
-          if ((err.message !== 'channel closed') &&
-             (err.code !== 'ECONNREFUSED')) {
+          if ((err.message !== 'channel closed') ||
+              (err.code !== 'ECONNREFUSED')) {
             throw err;
           }
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process

##### Description of change
<!-- Provide a description of the change below this comment. -->

Throw an error if either `err.message` or `err.code` is wrong.
Previously, it was only throwing an error if one or the other was
happening.