### PR TITLE
(WIP) lib: fix beforeExit not working with -e

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -591,7 +591,7 @@
     // Defer evaluation for a tick.  This is a workaround for deferred
     // events not firing when evaluating scripts from the command line,
     // see https://github.com/nodejs/node/issues/1600.
-    process.nextTick(function() {
+    setImmediate(function() {
       var result = module._compile(script, `${name}-wrapper`);
       if (process._print_eval) console.log(result);
     });

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -6,9 +6,8 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 42
 42
 [eval]:1
@@ -19,9 +18,8 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 [eval]:1
 throw new Error("hello")
 ^
@@ -30,9 +28,8 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 100
 [eval]:1
 var x = 100; y = x;
@@ -42,9 +39,8 @@ ReferenceError: y is not defined
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 [eval]:1
 var ______________________________________________; throw 10
                                                     ^

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -7,9 +7,8 @@ SyntaxError: Strict mode code may not include a with statement
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 42
 42
 
@@ -21,9 +20,8 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 
 [stdin]:1
 throw new Error("hello")
@@ -33,9 +31,8 @@ Error: hello
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 100
 
 [stdin]:1
@@ -46,9 +43,8 @@ ReferenceError: y is not defined
     at Object.exports.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
-    at node.js:*:*
-    at nextTickCallbackWith0Args (node.js:*:*)
-    at process._tickCallback (node.js:*:*)
+    at Immediate._onImmediate (node.js:*:*)
+    at processImmediate [as _immediateCallback] (timers.js:*:*)
 
 [stdin]:1
 var ______________________________________________; throw 10

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -90,3 +90,18 @@ child.exec(nodejs + ` -e 'require("child_process").fork("${emptyFile}")'`,
       assert.equal(stdout, '');
       assert.equal(stderr, '');
     });
+
+// Regression test for https://github.com/nodejs/node/issues/8534.
+{
+  const script = `
+      // console.log() can revive the event loop so we must be careful
+      // to write from a 'beforeExit' event listener only once.
+      process.once("beforeExit", () => console.log("beforeExit"));
+      process.on("exit", () => console.log("exit"));
+      console.log("start");
+  `;
+  const options = { encoding: 'utf8' };
+  const proc = child.spawnSync(process.execPath, ['-e', script], options);
+  assert.strictEqual(proc.stderr, '');
+  assert.strictEqual(proc.stdout, 'start\nbeforeExit\nexit\n');
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, lib

##### Description of change
<!-- Provide a description of the change below this comment. -->

This is an attempted backport of https://github.com/nodejs/node/commit/c5b07d4ec6de2cb362b887499e44655eaeb26cba to v4.x

It involved manually recreating the entire commit, as `bootstrap_node.js` does not exist in v4.x and the stack traces for the tests are quite different.

Unfortunately when running the tests we are seeing a failure in `test/parallel/test-debug-brk.js`. The node process for that test is not exiting and it is leaving phantom processes running 👻

Please do not run this in CI until we have figured out what is going on with the phantom processes.

@bnoordhuis do you have any idea why this is happening?

/cc @nodejs/lts 

> Commit 93a44d5 ("src: fix deferred events not working with -e") defers
evaluation of the script to the next tick.
>
> A side effect of that change is that 'beforeExit' listeners run before
the actual script.  'beforeExit' is emitted when the event loop is
empty but process.nextTick() does not ref the event loop.
>
> Fix that by using setImmediate().  Because it is implemented in terms
of a uv_check_t handle, it interacts with the event loop properly.
>
> Fixes: https://github.com/nodejs/node/issues/8534
PR-URL: https://github.com/nodejs/node/pull/8821
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>