### PR TITLE
backport: http: fix connection upgrade checks

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -78,17 +78,11 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
     parser.incoming.statusMessage = statusMessage;
   }
 
-  // The client made non-upgrade request, and server is just advertising
-  // supported protocols.
-  //
-  // See RFC7230 Section 6.7
-  //
-  // NOTE: RegExp below matches `upgrade` in `Connection: abc, upgrade, def`
-  // header.
-  if (upgrade &&
-      parser.outgoing !== null &&
-      (parser.outgoing._headers.upgrade === undefined ||
-       !/(^|\W)upgrade(\W|$)/i.test(parser.outgoing._headers.connection))) {
+  if (upgrade && parser.outgoing !== null && !parser.outgoing.upgrading) {
+    // The client made non-upgrade request, and server is just advertising
+    // supported protocols.
+    //
+    // See RFC7230 Section 6.7
     upgrade = false;
   }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -9,16 +9,18 @@ const Buffer = require('buffer').Buffer;
 const common = require('_http_common');
 
 const CRLF = common.CRLF;
-const chunkExpression = common.chunkExpression;
+const trfrEncChunkExpression = common.chunkExpression;
 const debug = common.debug;
 
-const connectionExpression = /^Connection$/i;
+const upgradeExpression = /^Upgrade$/i;
 const transferEncodingExpression = /^Transfer-Encoding$/i;
-const closeExpression = /close/i;
 const contentLengthExpression = /^Content-Length$/i;
 const dateExpression = /^Date$/i;
 const expectExpression = /^Expect$/i;
 const trailerExpression = /^Trailer$/i;
+const connectionExpression = /^Connection$/i;
+const connCloseExpression = /(^|\W)close(\W|$)/i;
+const connUpgradeExpression = /(^|\W)upgrade(\W|$)/i;
 const lenientHttpHeaders = !!process.REVERT_CVE_2016_2216;
 
 const automaticHeaders = {
@@ -62,6 +64,7 @@ function OutgoingMessage() {
   this.writable = true;
 
   this._last = false;
+  this.upgrading = false;
   this.chunkedEncoding = false;
   this.shouldKeepAlive = true;
   this.useChunkedEncodingByDefault = true;
@@ -191,11 +194,13 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
   // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
   var state = {
     sentConnectionHeader: false,
+    sentConnectionUpgrade: false,
     sentContentLengthHeader: false,
     sentTransferEncodingHeader: false,
     sentDateHeader: false,
     sentExpect: false,
     sentTrailer: false,
+    sentUpgrade: false,
     messageHeader: firstLine
   };
 
@@ -223,6 +228,10 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
       }
     }
   }
+
+  // Are we upgrading the connection?
+  if (state.sentConnectionUpgrade && state.sentUpgrade)
+    this.upgrading = true;
 
   // Date header
   if (this.sendDate === true && state.sentDateHeader === false) {
@@ -313,15 +322,16 @@ function storeHeader(self, state, field, value) {
 
   if (connectionExpression.test(field)) {
     state.sentConnectionHeader = true;
-    if (closeExpression.test(value)) {
+    if (connCloseExpression.test(value)) {
       self._last = true;
     } else {
       self.shouldKeepAlive = true;
     }
-
+    if (connUpgradeExpression.test(value))
+      state.sentConnectionUpgrade = true;
   } else if (transferEncodingExpression.test(field)) {
     state.sentTransferEncodingHeader = true;
-    if (chunkExpression.test(value)) self.chunkedEncoding = true;
+    if (trfrEncChunkExpression.test(value)) self.chunkedEncoding = true;
 
   } else if (contentLengthExpression.test(field)) {
     state.sentContentLengthHeader = true;
@@ -331,6 +341,8 @@ function storeHeader(self, state, field, value) {
     state.sentExpect = true;
   } else if (trailerExpression.test(field)) {
     state.sentTrailer = true;
+  } else if (upgradeExpression.test(field)) {
+    state.sentUpgrade = true;
   }
 }
 


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* http

##### Description of change

This commit fixes connection upgrade checks, specifically when headers are passed as an array instead of a plain object to `http.request()`.

This is a backport of https://github.com/nodejs/node/pull/8238.

CI: https://ci.nodejs.org/job/node-test-pull-request/4894/