### PR TITLE
timers: use consistent checks for canceled timers

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -384,6 +384,9 @@ function ontimeout(timer) {
 
 
 function rearm(timer) {
+  // // Do not re-arm unenroll'd or closed timers.
+  if (timer._idleTimeout === -1) return;
+
   // If timer is unref'd (or was - it's permanently removed from the list.)
   if (timer._handle && timer instanceof Timeout) {
     timer._handle.start(timer._repeat);
@@ -463,9 +466,17 @@ function Timeout(after, callback, args) {
 
 
 function unrefdHandle() {
-  ontimeout(this.owner);
-  if (!this.owner._repeat)
+  // Don't attempt to call the callback if it is not a function.
+  if (typeof this.owner._onTimeout === 'function') {
+    ontimeout(this.owner);
+  }
+
+  // Make sure we clean up if the callback is no longer a function
+  // even if the timer is an interval.
+  if (!this.owner._repeat
+      || typeof this.owner._onTimeout !== 'function') {
     this.owner.close();
+  }
 }
 
 
@@ -505,6 +516,7 @@ Timeout.prototype.ref = function() {
 Timeout.prototype.close = function() {
   this._onTimeout = null;
   if (this._handle) {
+    this._idleTimeout = -1;
     this._handle[kOnTimeout] = null;
     this._handle.close();
   } else {

--- a/test/parallel/test-timers-unenroll-unref-interval.js
+++ b/test/parallel/test-timers-unenroll-unref-interval.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+const timers = require('timers');
+
+{
+  const interval = setInterval(common.mustCall(() => {
+    clearTimeout(interval);
+  }), 1).unref();
+}
+
+{
+  const interval = setInterval(common.mustCall(() => {
+    interval.close();
+  }), 1).unref();
+}
+
+{
+  const interval = setInterval(common.mustCall(() => {
+    timers.unenroll(interval);
+  }), 1).unref();
+}
+
+{
+  const interval = setInterval(common.mustCall(() => {
+    interval._idleTimeout = -1;
+  }), 1).unref();
+}
+
+{
+  const interval = setInterval(common.mustCall(() => {
+    interval._onTimeout = null;
+  }), 1).unref();
+}
+
+// Use timers' intrinsic behavior to keep this open
+// exactly long enough for the problem to manifest.
+//
+// See https://github.com/nodejs/node/issues/9561
+//
+// Since this is added after it will always fire later
+// than the previous timeouts, unrefed or not.
+//
+// Keep the event loop alive for one timeout and then
+// another. Any problems will occur when the second
+// should be called but before it is able to be.
+setTimeout(common.mustCall(() => {
+  setTimeout(common.mustCall(() => {}), 1);
+}), 1);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously not all codepaths set `timer._idleTimeout = -1` for canceled
or closed timers, and not all codepaths checked it either.

Unenroll uses this to say that a timer is indeed closed and it is the
closest thing there is to an authoritative source for this.

Refs: https://github.com/nodejs/node/pull/9606
Fixes: https://github.com/nodejs/node/issues/9561

I think the problem originated from or became more apparent after https://github.com/nodejs/node/commit/c8c2544cd9c339cdde881fc9a7f0851971b94d72

CI: https://ci.nodejs.org/job/node-test-pull-request/4898/

cc @cjihrig, @misterdjules, @watson 

_(This patch was made live during https://www.twitch.tv/nodesource/v/101846332 if you'd like to see me working on this in retrospect. :P)_