### PR TITLE
v4.x: backport util.inspect.custom

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -234,18 +234,19 @@ Predefined color codes are: `white`, `grey`, `black`, `blue`, `cyan`,
 `green`, `magenta`, `red` and `yellow`.
 There are also `bold`, `italic`, `underline` and `inverse` codes.
 
-### Custom `inspect()` function on Objects
+### Custom inspection functions on Objects
 
 <!-- type=misc -->
 
-Objects also may define their own `inspect(depth)` function which `util.inspect()`
-will invoke and use the result of when inspecting the object:
+Objects may also define their own `[util.inspect.custom](depth, opts)`
+(or, equivalently `inspect(depth, opts)`) function that `util.inspect()` will
+invoke and use the result of when inspecting the object:
 
 ```js
 const util = require('util');
 
-var obj = { name: 'nate' };
-obj.inspect = function(depth) {
+const obj = { name: 'nate' };
+obj[util.inspect.custom] = function(depth) {
   return `{${this.name}}`;
 };
 
@@ -253,12 +254,29 @@ util.inspect(obj);
   // "{nate}"
 ```
 
-You may also return another Object entirely, and the returned String will be
-formatted according to the returned Object. This is similar to how
-`JSON.stringify()` works:
+Custom `[util.inspect.custom](depth, opts)` functions typically return a string
+but may return a value of any type that will be formatted accordingly by
+`util.inspect()`.
 
 ```js
-var obj = { foo: 'this will not show up in the inspect() output' };
+const util = require('util');
+
+const obj = { foo: 'this will not show up in the inspect() output' };
+obj[util.inspect.custom] = function(depth) {
+  return { bar: 'baz' };
+};
+
+util.inspect(obj);
+  // "{ bar: 'baz' }"
+```
+
+A custom inspection method can alternatively be provided by exposing
+an `inspect(depth, opts)` method on the object:
+
+```js
+const util = require('util');
+
+const obj = { foo: 'this will not show up in the inspect() output' };
 obj.inspect = function(depth) {
   return { bar: 'baz' };
 };
@@ -266,6 +284,14 @@ obj.inspect = function(depth) {
 util.inspect(obj);
   // "{ bar: 'baz' }"
 ```
+
+### util.inspect.custom
+<!-- YAML
+added: REPLACEME
+-->
+
+A Symbol that can be used to declare custom inspect functions, see
+[Custom inspection functions on Objects][].
 
 ## util.isArray(object)
 <!-- YAML
@@ -656,6 +682,7 @@ Deprecated predecessor of `console.log`.
 [constructor]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
 [here]: #util_customizing_util_inspect_colors
+[Custom inspection functions on Objects]: #util_custom_inspection_functions_on_objects
 [`Error`]: errors.html#errors_class_error
 [`console.log()`]: console.html#console_console_log_data
 [`console.error()`]: console.html#console_console_error_data

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -469,8 +469,8 @@ Buffer.prototype.equals = function equals(b) {
 };
 
 
-// Inspect
-Buffer.prototype.inspect = function inspect() {
+// Override how buffers are presented by util.inspect().
+Buffer.prototype[internalUtil.inspectSymbol] = function inspect() {
   var str = '';
   var max = exports.INSPECT_MAX_BYTES;
   if (this.length > 0) {
@@ -480,6 +480,7 @@ Buffer.prototype.inspect = function inspect() {
   }
   return '<' + this.constructor.name + ' ' + str + '>';
 };
+Buffer.prototype.inspect = Buffer.prototype[internalUtil.inspectSymbol];
 
 
 Buffer.prototype.compare = function compare(b) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -470,7 +470,7 @@ Buffer.prototype.equals = function equals(b) {
 
 
 // Override how buffers are presented by util.inspect().
-Buffer.prototype[internalUtil.inspectSymbol] = function inspect() {
+Buffer.prototype[internalUtil.customInspectSymbol] = function inspect() {
   var str = '';
   var max = exports.INSPECT_MAX_BYTES;
   if (this.length > 0) {
@@ -480,7 +480,7 @@ Buffer.prototype[internalUtil.inspectSymbol] = function inspect() {
   }
   return '<' + this.constructor.name + ' ' + str + '>';
 };
-Buffer.prototype.inspect = Buffer.prototype[internalUtil.inspectSymbol];
+Buffer.prototype.inspect = Buffer.prototype[internalUtil.customInspectSymbol];
 
 
 Buffer.prototype.compare = function compare(b) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -5,6 +5,10 @@ const prefix = '(node) ';
 
 exports.getHiddenValue = binding.getHiddenValue;
 
+// The `buffer` module uses this. Defining it here instead of in the public
+// `util` module makes it accessible without having to `require('util')` there.
+exports.customInspectSymbol = Symbol('util.inspect.custom');
+
 // All the internal deprecations have to use this function only, as this will
 // prepend the prefix to the actual message.
 exports.deprecate = function(fn, msg) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -255,10 +255,15 @@ function formatValue(ctx, value, recurseTimes) {
         // Also filter out any prototype objects using the circular check.
         !(value.constructor && value.constructor.prototype === value)) {
       let ret = maybeCustomInspect.call(value, recurseTimes, ctx);
-      if (typeof ret !== 'string') {
-        ret = formatValue(ctx, ret, recurseTimes);
+
+      // If the custom inspection method returned `this`, don't go into
+      // infinite recursion.
+      if (ret !== value) {
+        if (typeof ret !== 'string') {
+          ret = formatValue(ctx, ret, recurseTimes);
+        }
+        return ret;
       }
-      return ret;
     }
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -142,7 +142,6 @@ function inspect(obj, opts) {
   if (ctx.colors) ctx.stylize = stylizeWithColor;
   return formatValue(ctx, obj, ctx.depth);
 }
-exports.inspect = inspect;
 
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
@@ -176,6 +175,10 @@ inspect.styles = {
   'regexp': 'red'
 };
 
+const customInspectSymbol = internalUtil.customInspectSymbol;
+
+exports.inspect = inspect;
+exports.inspect.custom = customInspectSymbol;
 
 function stylizeWithColor(str, styleType) {
   var style = inspect.styles[styleType];
@@ -243,18 +246,20 @@ function inspectPromise(p) {
 function formatValue(ctx, value, recurseTimes) {
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it
-  if (ctx.customInspect &&
-      value &&
-      typeof value.inspect === 'function' &&
-      // Filter out the util module, it's inspect function is special
-      value.inspect !== exports.inspect &&
-      // Also filter out any prototype objects using the circular check.
-      !(value.constructor && value.constructor.prototype === value)) {
-    var ret = value.inspect(recurseTimes, ctx);
-    if (typeof ret !== 'string') {
-      ret = formatValue(ctx, ret, recurseTimes);
+  if (ctx.customInspect && value) {
+    const maybeCustomInspect = value[customInspectSymbol] || value.inspect;
+
+    if (typeof maybeCustomInspect === 'function' &&
+        // Filter out the util module, its inspect function is special
+        maybeCustomInspect !== exports.inspect &&
+        // Also filter out any prototype objects using the circular check.
+        !(value.constructor && value.constructor.prototype === value)) {
+      let ret = maybeCustomInspect.call(value, recurseTimes, ctx);
+      if (typeof ret !== 'string') {
+        ret = formatValue(ctx, ret, recurseTimes);
+      }
+      return ret;
     }
-    return ret;
   }
 
   // Primitive types cannot have properties

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -36,3 +36,6 @@ assert.doesNotThrow(function() {
   assert.strictEqual(util.inspect(b), expected);
   assert.strictEqual(util.inspect(s), expected);
 });
+
+b.inspect = undefined;
+assert.strictEqual(util.inspect(b), expected);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -387,6 +387,16 @@ assert.doesNotThrow(function() {
   );
 }
 
+{
+  // Returning `this` from a custom inspection function works.
+  assert.strictEqual(util.inspect({ a: 123, inspect() { return this; } }),
+                     '{ a: 123, inspect: [Function: inspect] }');
+
+  const subject = { a: 123, [util.inspect.custom]() { return this; } };
+  assert.strictEqual(util.inspect(subject),
+                     '{ a: 123 }');
+}
+
 // util.inspect with "colors" option should produce as many lines as without it
 function test_lines(input) {
   var count_lines = function(str) {


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util

##### Description of change

Backport of #8174 (2 **semver-minor** commits) and #9289 to v4.x.

/cc @TheAlphaNerd @nodejs/lts