### PR TITLE
test: add new.target add-on regression test

### DIFF
--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -1,0 +1,16 @@
+#include <node.h>
+#include <v8.h>
+
+namespace {
+
+inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>&) {}
+
+inline void Initialize(v8::Local<v8::Object> binding) {
+  auto isolate = binding->GetIsolate();
+  binding->Set(v8::String::NewFromUtf8(isolate, "Class"),
+               v8::FunctionTemplate::New(isolate, NewClass)->GetFunction());
+}
+
+NODE_MODULE(binding, Initialize)
+
+}  // anonymous namespace

--- a/test/addons/new-target/binding.gyp
+++ b/test/addons/new-target/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/new-target/test.js
+++ b/test/addons/new-target/test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const binding = require(`./build/${common.buildType}/binding`);
+
+class Class extends binding.Class {
+  constructor() {
+    super();
+    this.method();
+  }
+  method() {
+    this.ok = true;
+  }
+}
+
+assert.ok(new Class() instanceof binding.Class);
+assert.ok(new Class().ok);


### PR DESCRIPTION
Add a test that checks that new.target inheritance works when inheriting
from a constructor defined in C++.

Refs: #9288
Refs: #9293 

CI: https://ci.nodejs.org/job/node-test-pull-request/4900/