### PR TITLE
backport: debugger: make listen address configurable

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -18,9 +18,10 @@ exports.start = function start() {
     process._rawDebug(err.stack || err);
   });
 
-  agent.listen(process._debugAPI.port, function() {
-    var addr = this.address();
-    process._rawDebug('Debugger listening on port %d', addr.port);
+  agent.listen(process._debugAPI.port, process._debugAPI.host, function() {
+    const addr = this.address();
+    const host = net.isIPv6(addr.address) ? `[${addr.address}]` : addr.address;
+    process._rawDebug('Debugger listening on %s:%d', host, addr.port);
     process._debugAPI.notifyListen();
   });
 

--- a/src/debug-agent.h
+++ b/src/debug-agent.h
@@ -30,6 +30,7 @@
 #include "v8-debug.h"
 
 #include <string.h>
+#include <string>
 
 // Forward declaration to break recursive dependency chain with src/env.h.
 namespace node {
@@ -73,7 +74,7 @@ class Agent {
   typedef void (*DispatchHandler)(node::Environment* env);
 
   // Start the debugger agent thread
-  bool Start(int port, bool wait);
+  bool Start(const std::string& host, int port, bool wait);
   // Listen for debug events
   void Enable();
   // Stop the debugger agent
@@ -112,6 +113,7 @@ class Agent {
 
   State state_;
 
+  std::string host_;
   int port_;
   bool wait_;
 

--- a/test/parallel/test-cluster-disconnect-handles.js
+++ b/test/parallel/test-cluster-disconnect-handles.js
@@ -25,11 +25,8 @@ cluster.schedulingPolicy = cluster.SCHED_RR;
 if (cluster.isMaster) {
   let isKilling = false;
   const handles = require('internal/cluster').handles;
-  // FIXME(bnoordhuis) lib/cluster.js scans the execArgv arguments for
-  // debugger flags and renumbers any port numbers it sees starting
-  // from the default port 5858.  Add a '.' that circumvents the
-  // scanner but is ignored by atoi(3).  Heinous hack.
-  cluster.setupMaster({ execArgv: [`--debug=${common.PORT}.`] });
+  const address = common.hasIPv6 ? '[::1]' : common.localhostIPv4;
+  cluster.setupMaster({ execArgv: [`--debug=${address}:${common.PORT}`] });
   const worker = cluster.fork();
   worker.once('exit', common.mustCall((code, signal) => {
     assert.strictEqual(code, 0, 'worker did not exit normally');

--- a/test/parallel/test-debug-port-cluster.js
+++ b/test/parallel/test-debug-port-cluster.js
@@ -16,7 +16,8 @@ child.stderr.setEncoding('utf8');
 
 const checkMessages = common.mustCall(() => {
   for (let port = PORT_MIN; port <= PORT_MAX; port += 1) {
-    assert(stderr.includes(`Debugger listening on port ${port}`));
+    const re = RegExp(`Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):${port}`);
+    assert(re.test(stderr));
   }
 });
 

--- a/test/parallel/test-debug-port-from-cmdline.js
+++ b/test/parallel/test-debug-port-from-cmdline.js
@@ -39,11 +39,10 @@ function processStderrLine(line) {
 function assertOutputLines() {
   var expectedLines = [
     'Starting debugger agent.',
-    'Debugger listening on port ' + debugPort
+    'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + debugPort,
   ];
 
   assert.equal(outputLines.length, expectedLines.length);
   for (var i = 0; i < expectedLines.length; i++)
-    assert.equal(outputLines[i], expectedLines[i]);
-
+    assert(RegExp(expectedLines[i]).test(outputLines[i]));
 }

--- a/test/parallel/test-debug-port-numbers.js
+++ b/test/parallel/test-debug-port-numbers.js
@@ -52,8 +52,9 @@ function kill(child) {
 
 process.on('exit', function() {
   for (const child of children) {
-    const one = RegExp(`Debugger listening on port ${child.test.port}`);
-    const two = RegExp(`connecting to 127.0.0.1:${child.test.port}`);
+    const port = child.test.port;
+    const one = RegExp(`Debugger listening on (\\[::\\]|0\.0\.0\.0):${port}`);
+    const two = RegExp(`connecting to 127.0.0.1:${port}`);
     assert(one.test(child.test.stdout));
     assert(two.test(child.test.stdout));
   }

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -65,11 +65,11 @@ process.on('exit', function onExit() {
 
 const expectedLines = [
   'Starting debugger agent.',
-  'Debugger listening on port ' + (port + 0),
+  'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + (port + 0),
   'Starting debugger agent.',
-  'Debugger listening on port ' + (port + 1),
+  'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + (port + 1),
   'Starting debugger agent.',
-  'Debugger listening on port ' + (port + 2),
+  'Debugger listening on (\\[::\\]|0\\.0\\.0\\.0):' + (port + 2),
 ];
 
 function assertOutputLines() {
@@ -79,5 +79,7 @@ function assertOutputLines() {
   outputLines.sort();
   expectedLines.sort();
 
-  assert.deepStrictEqual(outputLines, expectedLines);
+  assert.equal(outputLines.length, expectedLines.length);
+  for (var i = 0; i < expectedLines.length; i++)
+    assert(RegExp(expectedLines[i]).test(outputLines[i]));
 }

--- a/test/sequential/test-debug-host-port.js
+++ b/test/sequential/test-debug-host-port.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+let run = () => {};
+function test(args, re) {
+  const next = run;
+  run = () => {
+    const options = {encoding: 'utf8'};
+    const proc = spawn(process.execPath, args.concat(['-e', '0']), options);
+    let stderr = '';
+    proc.stderr.setEncoding('utf8');
+    proc.stderr.on('data', (data) => {
+      stderr += data;
+      if (re.test(stderr)) proc.kill();
+    });
+    proc.on('exit', common.mustCall(() => {
+      assert(re.test(stderr));
+      next();
+    }));
+  };
+}
+
+test(['--debug-brk'], /Debugger listening on (\[::\]|0\.0\.0\.0):5858/);
+test(['--debug-brk=1234'], /Debugger listening on (\[::\]|0\.0\.0\.0):1234/);
+test(['--debug-brk=127.0.0.1'], /Debugger listening on 127\.0\.0\.1:5858/);
+test(['--debug-brk=127.0.0.1:1234'], /Debugger listening on 127\.0\.0\.1:1234/);
+test(['--debug-brk=localhost'],
+     /Debugger listening on (\[::\]|127\.0\.0\.1):5858/);
+test(['--debug-brk=localhost:1234'],
+     /Debugger listening on (\[::\]|127\.0\.0\.1):1234/);
+
+if (common.hasIPv6) {
+  test(['--debug-brk=::'], /Debug port must be in range 1024 to 65535/);
+  test(['--debug-brk=::0'], /Debug port must be in range 1024 to 65535/);
+  test(['--debug-brk=::1'], /Debug port must be in range 1024 to 65535/);
+  test(['--debug-brk=[::]'], /Debugger listening on \[::\]:5858/);
+  test(['--debug-brk=[::0]'], /Debugger listening on \[::\]:5858/);
+  test(['--debug-brk=[::]:1234'], /Debugger listening on \[::\]:1234/);
+  test(['--debug-brk=[::0]:1234'], /Debugger listening on \[::\]:1234/);
+  test(['--debug-brk=[::ffff:127.0.0.1]:1234'],
+       /Debugger listening on \[::ffff:127\.0\.0\.1\]:1234/);
+}
+
+run();  // Runs tests in reverse order.


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* debugger


##### Description of change

This is a backport of:

* https://github.com/nodejs/node/pull/3316

/cc @bnoordhuis @TheAlphaNerd @nodejs/diagnostics 