### PR TITLE
tools: allow test.py to use full paths of tests

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -298,7 +298,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
 
       if output.HasCrashed():
         self.severity = 'crashed'
-        exit_code = output.output.exit_code 
+        exit_code = output.output.exit_code
         self.traceback = "oh no!\nexit code: " + PrintCrashed(exit_code)
 
       if output.HasTimedOut():
@@ -1461,6 +1461,13 @@ def SplitPath(s):
   stripped = [ c.strip() for c in s.split('/') ]
   return [ Pattern(s) for s in stripped if len(s) > 0 ]
 
+def NormalizePath(path):
+  # strip the extra path information of the specified test
+  if path.startswith('test/'):
+    path = path[5:]
+  if path.endswith('.js'):
+    path = path[:-3]
+  return path
 
 def GetSpecialCommandProcessor(value):
   if (not value) or (value.find('@') == -1):
@@ -1534,7 +1541,7 @@ def Main():
   else:
     paths = [ ]
     for arg in args:
-      path = SplitPath(arg)
+      path = SplitPath(NormalizePath(arg))
       paths.append(path)
 
   # Check for --valgrind option. If enabled, we overwrite the special


### PR DESCRIPTION
##### Checklist
- [x] commit message follows commit guidelines
- [x] ran test suite, no new tests

##### Affected core subsystem(s)
Fixes: https://github.com/nodejs/node/issues/9684
`tools/test.py` can now take paths like 
```bash
$ python tools/test.py test/parallel/test-cluster-worker-init.js
$ python tools/test.py test/parallel/test-cluster-worker-init
$ python tools/test.py parallel/test-cluster-worker-init.js
```

##### Description of change
Slices off the `test/` and the `.js` on input files. Wildcards like `parallel/test-cluster-*` will still work as will defaults.
