### PR TITLE
fs: make sure readFile[Sync] reads from the beginning

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -309,7 +309,7 @@ ReadFileContext.prototype.read = function() {
   req.oncomplete = readFileAfterRead;
   req.context = this;
 
-  binding.read(this.fd, buffer, offset, length, -1, req);
+  binding.read(this.fd, buffer, offset, length, this.pos, req);
 };
 
 ReadFileContext.prototype.close = function(err) {
@@ -449,11 +449,11 @@ function tryCreateBuffer(size, fd, isUserFd) {
   return buffer;
 }
 
-function tryReadSync(fd, isUserFd, buffer, pos, len) {
+function tryReadSync(fd, isUserFd, buffer, pos, len, offset) {
   var threw = true;
   var bytesRead;
   try {
-    bytesRead = fs.readSync(fd, buffer, pos, len);
+    bytesRead = fs.readSync(fd, buffer, pos, len, offset);
     threw = false;
   } finally {
     if (threw && !isUserFd) fs.closeSync(fd);
@@ -482,7 +482,7 @@ fs.readFileSync = function(path, options) {
 
   if (size !== 0) {
     do {
-      bytesRead = tryReadSync(fd, isUserFd, buffer, pos, size - pos);
+      bytesRead = tryReadSync(fd, isUserFd, buffer, pos, size - pos, pos);
       pos += bytesRead;
     } while (bytesRead !== 0 && pos < size);
   } else {
@@ -490,7 +490,7 @@ fs.readFileSync = function(path, options) {
       // the kernel lies about many files.
       // Go ahead and try to read some bytes.
       buffer = Buffer.allocUnsafe(8192);
-      bytesRead = tryReadSync(fd, isUserFd, buffer, 0, 8192);
+      bytesRead = tryReadSync(fd, isUserFd, buffer, 0, 8192, pos);
       if (bytesRead !== 0) {
         buffers.push(buffer.slice(0, bytesRead));
       }

--- a/test/parallel/test-fs-readfile-fd-offset.js
+++ b/test/parallel/test-fs-readfile-fd-offset.js
@@ -2,11 +2,15 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 
-const fileLength = fs.statSync(__filename).size;
+const filename = path.join(common.tmpDir, 'readfile.txt');
+const dataExpected = new Array(100).join('a');
+fs.writeFileSync(filename, dataExpected);
+const fileLength = dataExpected.length;
 
 ['r', 'a+'].forEach(mode => {
-  const fd = fs.openSync(__filename, mode);
+  const fd = fs.openSync(filename, mode);
   assert.strictEqual(fileLength, fs.readFileSync(fd).length);
 
   // Reading again should result in the same length.

--- a/test/parallel/test-fs-readfile-fd-offset.js
+++ b/test/parallel/test-fs-readfile-fd-offset.js
@@ -3,9 +3,11 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
+const fileLength = fs.statSync(__filename).size;
+
 ['r', 'a+'].forEach(mode => {
   const fd = fs.openSync(__filename, mode);
-  const fileLength = fs.readFileSync(fd).length;
+  assert.strictEqual(fileLength, fs.readFileSync(fd).length);
 
   // Reading again should result in the same length.
   assert.strictEqual(fileLength, fs.readFileSync(fd).length);

--- a/test/parallel/test-fs-readfile-fd-offset.js
+++ b/test/parallel/test-fs-readfile-fd-offset.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+const fdr = fs.openSync(__filename, 'r');
+const fda = fs.openSync(__filename, 'a+');
+const fileLengthR = fs.readFileSync(fdr).length;
+const fileLengthA = fs.readFileSync(fda).length;
+
+// reading again should result in the same length
+assert.strictEqual(fileLengthR, fs.readFileSync(fdr).length);
+assert.strictEqual(fileLengthA, fs.readFileSync(fda).length);
+
+fs.readFile(fdr, common.mustCall((err, buf) => {
+  if (err) throw err;
+  assert.strictEqual(fileLengthR, buf.length);
+}));
+
+fs.readFile(fda, common.mustCall((err, buf) => {
+  if (err) throw err;
+  assert.strictEqual(fileLengthA, buf.length);
+}));

--- a/test/parallel/test-fs-readfile-fd-offset.js
+++ b/test/parallel/test-fs-readfile-fd-offset.js
@@ -3,21 +3,15 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const fdr = fs.openSync(__filename, 'r');
-const fda = fs.openSync(__filename, 'a+');
-const fileLengthR = fs.readFileSync(fdr).length;
-const fileLengthA = fs.readFileSync(fda).length;
+['r', 'a+'].forEach(mode => {
+  const fd = fs.openSync(__filename, mode);
+  const fileLength = fs.readFileSync(fd).length;
 
-// reading again should result in the same length
-assert.strictEqual(fileLengthR, fs.readFileSync(fdr).length);
-assert.strictEqual(fileLengthA, fs.readFileSync(fda).length);
+  // Reading again should result in the same length.
+  assert.strictEqual(fileLength, fs.readFileSync(fd).length);
 
-fs.readFile(fdr, common.mustCall((err, buf) => {
-  if (err) throw err;
-  assert.strictEqual(fileLengthR, buf.length);
-}));
-
-fs.readFile(fda, common.mustCall((err, buf) => {
-  if (err) throw err;
-  assert.strictEqual(fileLengthA, buf.length);
-}));
+  fs.readFile(fd, common.mustCall((err, buf) => {
+    assert.ifError(err);
+    assert.strictEqual(fileLength, buf.length);
+  }));
+});

--- a/test/parallel/test-fs-readfile-fd-offset.js
+++ b/test/parallel/test-fs-readfile-fd-offset.js
@@ -5,19 +5,19 @@ const fs = require('fs');
 const path = require('path');
 
 const filename = path.join(common.tmpDir, 'readfile.txt');
-const dataExpected = new Array(100).join('a');
+const dataExpected = 'a'.repeat(100);
 fs.writeFileSync(filename, dataExpected);
 const fileLength = dataExpected.length;
 
-['r', 'a+'].forEach(mode => {
+['r', 'a+'].forEach((mode) => {
   const fd = fs.openSync(filename, mode);
-  assert.strictEqual(fileLength, fs.readFileSync(fd).length);
+  assert.strictEqual(fs.readFileSync(fd).length, fileLength);
 
   // Reading again should result in the same length.
-  assert.strictEqual(fileLength, fs.readFileSync(fd).length);
+  assert.strictEqual(fs.readFileSync(fd).length, fileLength);
 
   fs.readFile(fd, common.mustCall((err, buf) => {
     assert.ifError(err);
-    assert.strictEqual(fileLength, buf.length);
+    assert.strictEqual(buf.length, fileLength);
   }));
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently, `fs.readFile[Sync]` starts reading from the current file position, which can be non-zero if the `fd` was previously read or written from/to. This conflicts with the [documentation](https://nodejs.org/api/fs.html#fs_fs_readfile_file_options_callback) which states that it "reads the entire contents of a file".

Fixes: https://github.com/nodejs/node/issues/9671

Provisional testcase for `fs.readFile`:

```js
const assert = require('assert');
const fs = require('fs');

const filleLength = 2;
const path = 'test-read-file';
const fd = fs.openSync(path, 'w+');

fs.writeSync(fd, Buffer.alloc(filleLength, 1), 0, filleLength);

fs.readFile(fd, (err, buf) => {
  if (err) throw err;
  assert.strictEqual(buf.length, filleLength);
});
```

For `fs.readFileSync`:

```js
'use strict';

const assert = require('assert');
const fs = require('fs');

const fileLength = 2;
const path = 'test-read-file';
const fd = fs.openSync(path, 'w+');

fs.writeSync(fd, Buffer.alloc(fileLength, 1), 0, fileLength);

assert.strictEqual(fs.readFileSync(fd).length, fileLength);
```