### PR TITLE
doc: child_process .stdio accepts a String type

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -626,7 +626,7 @@ added: v0.11.12
   * `cwd` {String} Current working directory of the child process
   * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {String|Array} Child's stdio configuration.
+  * `stdio` {String|Array} Child's stdio configuration. (Default: 'pipe')
   * `env` {Object} Environment key-value pairs
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -551,7 +551,7 @@ added: v0.11.12
   * `cwd` {String} Current working directory of the child process
   * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {Array} Child's stdio configuration. (Default: 'pipe')
+  * `stdio` {String|Array} Child's stdio configuration. (Default: 'pipe')
     - `stderr` by default will be output to the parent process' stderr unless
       `stdio` is specified
   * `env` {Object} Environment key-value pairs
@@ -586,7 +586,7 @@ added: v0.11.12
   * `cwd` {String} Current working directory of the child process
   * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {Array} Child's stdio configuration. (Default: 'pipe')
+  * `stdio` {String|Array} Child's stdio configuration. (Default: 'pipe')
     - `stderr` by default will be output to the parent process' stderr unless
       `stdio` is specified
   * `env` {Object} Environment key-value pairs
@@ -626,7 +626,7 @@ added: v0.11.12
   * `cwd` {String} Current working directory of the child process
   * `input` {String|Buffer} The value which will be passed as stdin to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {Array} Child's stdio configuration.
+  * `stdio` {String|Array} Child's stdio configuration.
   * `env` {Object} Environment key-value pairs
   * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
   * `gid` {Number} Sets the group identity of the process. (See setgid(2).)


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change

Document that `execFileSync`, `execSync` and `spawnSync` also supports `stdio` as an Array for v4.x.

Fixes: #9636

See master branch pull request here https://github.com/nodejs/node/pull/9637 