### PR TITLE
test: Change declaration by var to let.

### DIFF
--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -261,8 +261,8 @@ function writeToFill(string, offset, end, encoding) {
 
   // Correction for UCS2 operations.
   if (os.endianness() === 'BE' && encoding === 'ucs2') {
-    for (var i = 0; i < buf2.length; i += 2) {
-      var tmp = buf2[i];
+    for (let i = 0; i < buf2.length; i += 2) {
+      let tmp = buf2[i];
       buf2[i] = buf2[i + 1];
       buf2[i + 1] = tmp;
     }

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -262,7 +262,7 @@ function writeToFill(string, offset, end, encoding) {
   // Correction for UCS2 operations.
   if (os.endianness() === 'BE' && encoding === 'ucs2') {
     for (let i = 0; i < buf2.length; i += 2) {
-      let tmp = buf2[i];
+      const tmp = buf2[i];
       buf2[i] = buf2[i + 1];
       buf2[i + 1] = tmp;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
none


##### Description of change
<!-- Provide a description of the change below this comment. -->
I narrowed the scope of local variables in `for` on test-buffer-fill.js.
Since `i` and `tmp` are not used outside of `for`, they do not have to be `var` declarations.