### PR TITLE
Experimental: Symlinks Just Work

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,6 +11,7 @@ const path = require('path');
 const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;
+const adjacentNodeModules = !!process.binding('config').adjacentNodeModules;
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -120,7 +121,7 @@ const realpathCache = new Map();
 // absolute realpath.
 function tryFile(requestPath, isMain) {
   const rc = stat(requestPath);
-  if (preserveSymlinks && !isMain) {
+  if (preserveSymlinks && !isMain || adjacentNodeModules) {
     return rc === 0 && path.resolve(requestPath);
   }
   return rc === 0 && toRealPath(requestPath);
@@ -172,7 +173,7 @@ Module._findPath = function(request, paths, isMain) {
     const rc = stat(basePath);
     if (!trailingSlash) {
       if (rc === 0) {  // File.
-        if (preserveSymlinks && !isMain) {
+        if (preserveSymlinks && !isMain || adjacentNodeModules) {
           filename = path.resolve(basePath);
         } else {
           filename = toRealPath(basePath);
@@ -253,9 +254,22 @@ if (process.platform === 'win32') {
       // Use colon as an extra condition since we can get node_modules
       // path for dirver root like 'C:\node_modules' and don't need to
       // parse driver name.
-      if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/) {
-        if (p !== nmLen)
-          paths.push(from.slice(0, last) + '\\node_modules');
+      if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/
+        || (adjacentNodeModules && code === 46/*.*/)) {
+        if (p !== nmLen) {
+          var parent = from.slice(0, last);
+          paths.push(parent + '\\node_modules');
+
+          if (adjacentNodeModules) {
+            paths.push(parent + '.node_modules');
+            if (code === 46/*.*/)
+              while (i > 1) {
+                const code = from.charCodeAt(--i);
+                if (code === 92/*\*/ || code === 47/*/*/ || code === 58/*:*/)
+                  break;
+              }
+          }
+        }
         last = i;
         p = 0;
       } else if (p !== -1) {
@@ -266,6 +280,9 @@ if (process.platform === 'win32') {
         }
       }
     }
+
+    // superfluous "/.node_modules"
+    if (adjacentNodeModules) paths.pop();
 
     return paths;
   };
@@ -287,9 +304,17 @@ if (process.platform === 'win32') {
     var last = from.length;
     for (var i = from.length - 1; i >= 0; --i) {
       const code = from.charCodeAt(i);
-      if (code === 47/*/*/) {
-        if (p !== nmLen)
-          paths.push(from.slice(0, last) + '/node_modules');
+      if (code === 47/*/*/ || (adjacentNodeModules && code === 46/*.*/)) {
+        if (p !== nmLen) {
+          var parent = from.slice(0, last);
+          paths.push(parent + '/node_modules');
+
+          if (adjacentNodeModules) {
+            paths.push(parent + '.node_modules');
+            if (code === 46/*.*/)
+              while (i > 1 && from.charCodeAt(--i) !== 47/*/*/);
+          }
+        }
         last = i;
         p = 0;
       } else if (p !== -1) {
@@ -300,6 +325,9 @@ if (process.platform === 'win32') {
         }
       }
     }
+
+    // superfluous "/.node_modules"
+    if (adjacentNodeModules) paths.pop();
 
     // Append /node_modules to handle root paths.
     paths.push('/node_modules');
@@ -416,13 +444,16 @@ Module._load = function(request, parent, isMain) {
   }
 
   var filename = Module._resolveFilename(request, parent, isMain);
+  var doesNonInternalExist = NativeModule.nonInternalExists(filename);
+  var cachePath = adjacentNodeModules && !doesNonInternalExist
+    ? toRealPath(filename) : filename;
 
-  var cachedModule = Module._cache[filename];
+  var cachedModule = Module._cache[cachePath];
   if (cachedModule) {
     return cachedModule.exports;
   }
 
-  if (NativeModule.nonInternalExists(filename)) {
+  if (doesNonInternalExist) {
     debug('load native module %s', request);
     return NativeModule.require(filename);
   }
@@ -434,21 +465,21 @@ Module._load = function(request, parent, isMain) {
     module.id = '.';
   }
 
-  Module._cache[filename] = module;
+  Module._cache[cachePath] = module;
 
-  tryModuleLoad(module, filename);
+  tryModuleLoad(module, filename, cachePath);
 
   return module.exports;
 };
 
-function tryModuleLoad(module, filename) {
+function tryModuleLoad(module, filename, cachePath) {
   var threw = true;
   try {
     module.load(filename);
     threw = false;
   } finally {
     if (threw) {
-      delete Module._cache[filename];
+      delete Module._cache[cachePath];
     }
   }
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -186,7 +186,7 @@ bool trace_warnings = false;
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/module.js
 bool config_preserve_symlinks = false;
-
+bool config_adjacent_node_modules = false;
 bool v8_initialized = false;
 
 // process-relative uptime base, initialized at start-up
@@ -3702,6 +3702,8 @@ static void ParseArgs(int* argc,
       Revert(cve);
     } else if (strcmp(arg, "--preserve-symlinks") == 0) {
       config_preserve_symlinks = true;
+    } else if (strcmp(arg, "--adjacent-node-modules") == 0) {
+      config_adjacent_node_modules = true;
     } else if (strcmp(arg, "--prof-process") == 0) {
       prof_process = true;
       short_circuit = true;
@@ -4211,6 +4213,12 @@ void Init(int* argc,
   // Allow for environment set preserving symlinks.
   if (auto preserve_symlinks = secure_getenv("NODE_PRESERVE_SYMLINKS")) {
     config_preserve_symlinks = (*preserve_symlinks == '1');
+  }
+
+  if (auto adjacent_node_modules
+    = secure_getenv("NODE_ADJACENT_NODE_MODULES")) {
+
+    config_adjacent_node_modules = (*adjacent_node_modules == '1');
   }
 
   // Parse a few arguments which are specific to Node.

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -44,6 +44,9 @@ void InitConfig(Local<Object> target,
 
   if (config_preserve_symlinks)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinks");
+
+  if (config_adjacent_node_modules)
+    READONLY_BOOLEAN_PROPERTY("adjacentNodeModules");
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -40,6 +40,7 @@ extern const char* openssl_config;
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/module.js
 extern bool config_preserve_symlinks;
+extern bool config_adjacent_node_modules;
 
 // Tells whether it is safe to call v8::Isolate::GetCurrent().
 extern bool v8_initialized;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
The same tests pass/fail with and without the change
- [x] tests and/or benchmarks are included
At the end of the comment
- [ ] documentation is changed or added
This is an intentionally undocumented, experimental opt-in switch
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Modules

# Symlinks that Just Work
The request to merge this PR also comes with a request that for the time being, the opt-in command line switch that activates the change in behavior be left undocumented and considered experimental. 

To fully realize what the switch enables will require changes to package managers, and will then need to be used and vetted by some representative portion of the ecosystem to uncover and address any potential issues, all of which will take some time. 
 
This is ultimately to determine if the solution should be announced and broadly publicized because it works great, or removed from `node` because it fundamentally does not solve the problem in a way that can be reliably used on a daily basis, or it in any way breaks the current ecosystem.

## What I've Experienced
I'm a professional software engineer of 35+ years who in some way uses `node` on a daily basis, and has been doing so for about 2 years.

I have 150+ projects on just one of my development machines, spanning front-end, back-end, and library type projects, from developing my own modules, modules as part of teams, and open source modules I've git cloned and have contributed to or used for learning.

I enjoy developing with `node`, except whenever I need to install or update or change module dependencies for a project, as the time it takes to always copy modules, or sometimes delete the `node_modules` directory and reinstall everything, is quite frustrating. It feels like torture by a thousand paper cuts. 

I know that in many cases I've already used many of the module@versions being copied during an install, and they're already on my machine. I know symlinking exists, and from past experiences outside `node` know that if it could be used correctly, installs and `node_modules` directory deletion would go from taking a couple minutes to a couple of seconds. It's like pouring rubbing alcohol all over the paper cuts.

I can also see by looking at the average size of the `node_modules` directory in my projects, and the size of `npm`'s module cache, even factoring in a 90% compression ratio on the tarballs, that all those copies are taking several orders more space than would be needed if `node` and `npm` could exploit symlinking to its fullest; I could get many Gigabytes of storage back.

I understand several attempts have been made to use symlinks, but they have often just not worked in ways that can be generally relied on, and have caused show-stopping issues with memory consumption, module dependency-version resolution, addon loading, filesystem cycles, and tooling failure. Because of this, practically speaking, symlinking just shouldn't be used during development, and the general perception is that it will never quite work.

## What I'd Like
I'd like `node` and `npm` (or any package manager) to exploit symlinks to optimize in all possible ways how modules are stored on my machine. In other words, for a given module@version there should be only one physical copy on my machine, and it should be symlinked to from anywhere else it may happen to be used on my machine.

Other than telling `node` and `npm` its ok to maximally exploit symlinking, I'd like to never have to do something different in how I'm using development tooling, or how I author a module and its module dependencies, just because modules may have been symlinked vs having been copied. In other words, module behavior and tooling behavior should always work the same, like they have no idea nor care if the module's directory was a symlink or an actual copy.

I'd like all the current show-stopping issues with using symlinks to just disappear.

I'd like it to be easy to point a symlink away from the central copy to somewhere else in my development root folder, to support those situations where I'm concurrently developing dependent modules at the same time. 

I'd require a means to alter a particular symlink within a given project, by replacing it with a copy, so in those rare cases I want to temporarily muck with dependencies source in order to understand some behavior or find a bug, I can do so without affecting the centrally stored copy.

I'd require this all to be done without breaking anything in any way with how `node` and `npm` work today.
 
I'd require that if there were a solution that I began to use, and then some issue arose, I could always very quickly and easily just go back to not using symlinks for the particular project, simply by deleting `node_modules` and telling `npm` to copy-install everything.

While it would be nice if this would work in other contexts, such as on production servers, I only require that it work this way during development on a development machine.

## How it can be done
This PR enables `node`, when explicitly opted-into, and working in conjunction with sufficiently enhanced package managers conforming to a normalized use of symlinks, to leverage symlinks in a way that _**Just Works**_. Additionally, when deploying modules, package managers can easily ring every last drop of value out of symlinks to fully optimize the use and consumption of a given machine's filesystem, regardless of how many places a given module may be redundantly used across the entire machine.

It enables this while also addressing all know issues within `node` when using symlinks to module directories, and would not require developers alter the way in which they currently specify, author, and consume modules, or expect modules to behave. In other words, the only things that would need to be aware of symlinks would be `node` and package managers (and bundlers like webpack and their brethren); developers and tooling would not.

Because the behavior is opt-in, merging the PR will not change `node`'s default behavior. When opted-into, except for one edge case, the behavior should be fully backwards compatible with respect to `node`'s behavior during link-time dependency-version resolution.

The behavior-effecting changes in this PR (ie those absent `housekeeping`, like reading the command line switch) are about 10 lines within the locked Modules subsystem.

I fully appreciate how preserving `node`'s `node_modules` based elegant mechanic is fundamental to the entire ecosystem, even when not directly being used by `node`, but by bundlers such as webpack. It is currently the de-facto mechanism for dealing with link-time dependency-version resolution for the javascript ecosystem, and ES6 Modules wont change that as they don't address the problem of versioning.

I believe this PR not only preserves that, but enhances it just as elegantly while allowing us to get symlinks that just work.

### Adjacent Node Modules
In order to precisely control what dependencies get resolved for a given module, they must be stored in a subdirectory, `node_modules`, of the dependent module's directory. `node`'s resolution logic does allow for shared modules to be stored in a common ancestor `node_modules` directory, but this is merely an optimization. If a shared module has more than one of its versions used anywhere in a given dependency tree, the package manager can only bubble one of the versions to some common ancestor, with the remaining most likely needing to be copied into each dependent module's `node_modules` subdirectory.

The `node_modules` subdirectory constraint, while extremely elegant in fundamentally dealing with link-time dependency-version resolution in those cases where several versions of a common module are used in a single tree, is the core reason modules cannot be centrally stored on a machine and then symlinked to from anywhere else used on the machine. It is also the core reason filesystem cycles can appear when using symlinks. (Note: The `ied` package manager is a little more clever in how it ensures modules resolve their dependencies, but it is also prevented from using centrally stored copies for the same fundamental reason)

Understanding why it's the cause of cycles should be straight forward, but some don't at first understand why it prevents centrally storing. It basically comes down to the fact that module dependencies specified in a package.json usually come with a version specifier that is a range of valid versions, and based on simply when a module is installed and what version of it's dependencies happen to be most recently released, the actual dependency versions used can change from install to install; i.e. from project to project. This is one reason `npm` implements a "shrinkwrap" option, and why `yarn` has a "lock file". If a module was centrally stored with it's dependents underneath it in its `node_modules` subdirectory, not matter if they be copies or symlinks, it would not be possible to honor the shrinkwrap or lock files between projects, or for the same project between developer machines.

The solution is to offer an additional, equivalently scoping directory as the `node_modules` directory, that is located _adjacent_ to the dependent module's directory rather than _underneath_ it. This solves both the cycle problem when using symlinks, rendering them physically impossible, and the problems with symlinking to a central copy, all in one fell swoop.

With this approach, the central copy of a module would never have a `node_modules` subdirectory. Instead, an adjacent equivalently scoping directory would be an actual directory within a given project, itself containing symlinks to the particular modules dependencies@version, thereby keeping them specific to their inclusion _in that specific project_, which then enables shrinkwrap and lock files to work as expected, and directory cycles to never occur.

#### Implementation
Implementing Adjacent Node Modules is incredibly simple to do and understand. When `node` processes a `require()` call whose request path is neither relative nor absolute (i.e. doesn't start with '..', '.', or '/'), the first thing it does is create an ordered list of directory paths to search, starting from the directory location of the `.js` that made the `require()` call, ensuring or suffixing `'/node_modes'` as necessary. A list of directories could look something like this:

```
src/projectA/node_modules/mod-A/node_modules/mod-B/node_modules
src/projectA/node_modules/mod-A/node_modules
src/projectA/node_modules
```

Making an ordered list of equivalently scoping adjacent node_modules directories, is as simple as changing `'/node_modules'` to `'.node_modules'` (the `/` becomes a `.`), so the list would now look like this:
```
src/projectA.node_modules/mod-A.node_modules/mod-B.node_modules
src/projectA.node_modules/mod-A.node_modules
src/projectA.node_modules
```

`node` would still mechanically implement link-time dependency-version resolution, practically speaking, in exactly the same way it currently does. But of course if this PR only did that, activating the new behavior would obviously break running node against trees deployed using `'/node_modules'`. The solution for _that_ is also very simple; we interleave both paths in the search, giving priority to `'/node_modules'`, and so now the search list looks something like this for deployments using `'/node_modules'` based tree structure:

```
src/projectA/node_modules/mod-A/node_modules/mod-B/node_modules
src/projectA/node_modules/mod-A/node_modules/mod-B.node_modules
src/projectA/node_modules/mod-A/node_modules
src/projectA/node_modules/mod-A.node_modules
src/projectA/node_modules
src/projectA.node_modules
```

and then like this for new deployments using the `'.node_modules'` based tree structure:
```
src/projectA.node_modules/mod-A.node_modules/mod-B/node_modules
src/projectA.node_modules/mod-A.node_modules/mod-B.node_modules
src/projectA.node_modules/mod-A/node_modules
src/projectA.node_modules/mod-A.node_modules
src/projectA/node_modules
src/projectA.node_modules
```

The actual implementation merely creates an additional search path by suffixing `'.node_modules'`, right after `node` decides it needs to make a search path suffixing `'/node_modules'`, where the same parent folder is used in each case; super simple. This means with the new behavior active, its not only backwards compatible, but both structures are interoperable, giving precedence to `'/node_modules'`.

I earlier alluded to one edge case that could be a problem, and that would be if someone named their module something like `'myModule.node_modules'`; i.e. `'.node_modules'` was actually part of the modules full name. While not impossible, I would opinion a highly improbable thing to occur. Package managers could easily check for such a thing when installing, and prevent with a warning, and the developer could then decide to simply not use the new behavior.

### Simultaneously Preserving and Following Symlinks
By default, `node` will always 'follow' symlinks, meaning it will get the 'real' path of a symlink, and use that to identify the module. In other words the `__dirname` of a module is always the 'real' path of where the module physically exists. The 'real' path is also the path used inside `node` to cache/map a path to a module instance. This ensures `node` never creates multiple instances of the same logical module, which prevents memory from being consumed unnecessarily, and prevents `node` from possibly crashing when trying to load the same `addon` twice. However, its at the expense that other kinds of resolutions relative to the module's `__dirname` now occur outside the symlink, which is often not what is wanted and prevents many uses of symlinks.

When `node` is told to `--preserve-symlinks`, it uses the symlink path for both the `__dirname` and its internal cache/mapping, and while it does let symlinks work a bit more like one would expect (kinda, as the directory of the entry.js passed on the command line is not preserved), the above problems can then occur regarding memory consumption and crashing from multiply loading the same addon.

The fix for this is also incredibly simple, but first lets understand how a module's path is, and is not, significant.

When following symlinks, if there are multiple symlinks to the same module, no matter what, the module will always have the same `__dirname`; it's 'real' path. In fact, from execution to execution, one could change the physical location, i.e. the 'real' path, update all the symlinks, and the program would still operate exactly like it did on the previous executions, even though at no time where any of the symlink paths used as the `__dirname`.

This makes it quite obvious the actual `__dirname` of a module isn't important to the modules behavior, but only to resolutions that are relative to it's `__dirname`. And this is what lets us fundamentally simultaneously preserve and follow symlinks. This is accomplished by no longer coupling the path we use to cache/map a module or addon instance, to the path we use to initialize its `__dirname`.

#### Implementation
With the new behavior active, the path we use to cache/map will always be the 'real' path of a module, but the path we use as the modules `'__dirname'` will always be the first symlink path that was used to initially load the module (or the real path if it wasn't a symlink to begin with). This means that the next symlink to that module that gets `required()`, will still get the first instance that was created, but that instance would still have its `__dirname` set to the symlink that it was first loadeded through. But going back to our previous thought experiment regarding changing the real path from run to run, it won't matter. However, because the `__dirname` is in fact still a symlink, things will work exactly as one would expect.

Also, unlike the `--preserve-symlinks` switch, this behavior is applied to the directory of the `entry.js` file passed to `node` on its command line, so that tooling and scripts that launch `node` with `entry.js` files somewhere down in the `node_modules` tree also still behave as expected when they're coming from a symlinked directory.

This does place and additional responsibility on package managers to ensure that in each case the symlinked modules will resolve their dependencies exactly the same, but that's an easy thing, and not part of `node`'s behavior.
 
### All Together
By implementing Adjacent Node Modules and Simultaneous Preservation and Resolution of symlinks, `node` can very easily and efficiently use symlinks all the time in all cases, without tooling and developers having to do anything different than they otherwise would.

However, there are going to be some issues with package managers and tooling. For example, package managers run preinstall, install, and postinstall lifecycle scripts. How and when those run would need to change. Also, some scripts simply launch `node` to run some module that was actually installed somewhere in the tree, and package managers will need to know to set the environment variable that activates the new behavior before spawning a process to run the `node` script.

There are also others things that might be issues, but I'm already working on a first POC fork/branch of yarn, and this is also why, for now, it would be nice to merge this PR, but keep it as a hidden and undocumented switch.

## Lastly
I'm looking foward to answering any questions in more detail, and responding to any concerns. However, if you decide to comment or question, please, please, please don't say something like 'This will break things with ES6 Modules', or 'This will still likely break vast amounts of the ecosystem'. I can't respond to those types of comments, they're not at all helpful in bringing about technical awareness, and I will simply ignore them. Please reply with actionable, technically descriptive responses.


# Test Results

```
[----------] Global test environment tear-down
[==========] 26 tests from 2 test cases ran. (211 ms total)
[  PASSED  ] 26 tests.
running 'python tools\test.py --mode=release  sequential parallel message gc inspector internet pummel'
=== release test-http-chunk-problem ===
Path: parallel/test-http-chunk-problem
Command: C:\src\node\Release\node.exe C:\src\node\test\parallel\test-http-chunk-problem.js
--- TIMEOUT ---
=== release test-process-kill-null ===
Path: parallel/test-process-kill-null
Command: C:\src\node\Release\node.exe C:\src\node\test\parallel\test-process-kill-null.js
--- TIMEOUT ---
=== release test-net-timeout ===
Path: gc/test-net-timeout
We should do 500 requests
Done: 22/500
Collected: 11/33
Done: 44/500
Collected: 33/55
Done: 66/500
Collected: 66/88
Done: 88/500
Collected: 77/99
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: connect EADDRNOTAVAIL :::26086
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1090:14)
Command: C:\src\node\Release\node.exe --expose-gc C:\src\node\test\gc\test-net-timeout.js
=== release test-crypto-timing-safe-equal-benchmarks ===
Path: pummel/test-crypto-timing-safe-equal-benchmarks
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-crypto-timing-safe-equal-benchmarks.js
--- TIMEOUT ---
=== release test-dh-regr ===
Path: pummel/test-dh-regr
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-dh-regr.js
--- TIMEOUT ---
=== release test-fs-watch-file ===
Path: pummel/test-fs-watch-file
assert.js:355
    throw actual;
    ^

Error: "watchFile()" requires a listener function
    at Object.fs.watchFile (fs.js:1409:11)
    at C:\src\node\test\pummel\test-fs-watch-file.js:41:10
    at _tryBlock (assert.js:314:5)
    at _throws (assert.js:333:12)
    at Function.throws (assert.js:363:3)
    at Object.<anonymous> (C:\src\node\test\pummel\test-fs-watch-file.js:39:8)
    at Module._compile (module.js:602:32)
    at Object.Module._extensions..js (module.js:611:10)
    at Module.load (module.js:519:32)
    at tryModuleLoad (module.js:478:12)
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-fs-watch-file.js
=== release test-http-client-reconnect-bug ===
Path: pummel/test-http-client-reconnect-bug
C:\src\node\test\pummel\test-http-client-reconnect-bug.js:11
  var client = http.createClient(common.PORT);
                    ^

TypeError: http.createClient is not a function
    at Server.<anonymous> (C:\src\node\test\pummel\test-http-client-reconnect-bug.js:11:21)
    at Server.<anonymous> (C:\src\node\test\common.js:422:15)
    at emitNone (events.js:86:13)
    at Server.emit (events.js:185:7)
    at emitListeningNT (net.js:1288:10)
    at _combinedTickCallback (internal/process/next_tick.js:71:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:638:11)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-http-client-reconnect-bug.js
=== release test-https-ci-reneg-attack ===
Path: pummel/test-https-ci-reneg-attack
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-https-ci-reneg-attack.js
--- TIMEOUT ---
=== release test-net-connect-memleak ===
Path: pummel/test-net-connect-memleak
C:\src\node\test\pummel\test-net-connect-memleak.js:20
  for (let i = 0; i < 26; ++i) junk = junk.concat(junk);
                                           ^

RangeError: Invalid array length
    at Array.concat (<anonymous>)
    at Object.<anonymous> (C:\src\node\test\pummel\test-net-connect-memleak.js:20:44)
    at Module._compile (module.js:602:32)
    at Object.Module._extensions..js (module.js:611:10)
    at Module.load (module.js:519:32)
    at tryModuleLoad (module.js:478:12)
    at Function.Module._load (module.js:470:3)
    at Module.runMain (module.js:636:10)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
Command: C:\src\node\Release\node.exe --expose-gc C:\src\node\test\pummel\test-net-connect-memleak.js
=== release test-tls-ci-reneg-attack ===
Path: pummel/test-tls-ci-reneg-attack
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-tls-ci-reneg-attack.js
--- TIMEOUT ---
=== release test-tls-connect-memleak ===
Path: pummel/test-tls-connect-memleak
C:\src\node\test\pummel\test-tls-connect-memleak.js:30
  for (let i = 0; i < 26; ++i) junk = junk.concat(junk);
                                           ^

RangeError: Invalid array length
    at Array.concat (<anonymous>)
    at Object.<anonymous> (C:\src\node\test\pummel\test-tls-connect-memleak.js:30:44)
    at Module._compile (module.js:602:32)
    at Object.Module._extensions..js (module.js:611:10)
    at Module.load (module.js:519:32)
    at tryModuleLoad (module.js:478:12)
    at Function.Module._load (module.js:470:3)
    at Module.runMain (module.js:636:10)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
Command: C:\src\node\Release\node.exe --expose-gc C:\src\node\test\pummel\test-tls-connect-memleak.js
=== release test-tls-securepair-client ===
Path: pummel/test-tls-securepair-client
Loading 'screen' into random state -Using default temp DH parameters
ACCEPT
client connected
client: connected+secure!
client pair.cleartext.getPeerCertificate(): {"subject":{"C":"AU","ST":"Some-State","O":"Internet Widgits Pty Ltd"},"issuer":{"C":"AU","ST":"Some-State","O":"Internet Widgits Pty Ltd"},"modulus":"CFE2D764E8DC40226ADFE64A50569B8FBD68A3F7B1FD7B01705AAD0538638D3C3D095115C1F3D0429E17C2D3E2076D38BE7617C10D7F47635D4D0A8266EE3B97BF4BB2C2FFBB66B963DFB43445379D0039A9DB7ED45004D1CE687B13E29973AB4771967CACFB3E66763B4D75EC87825145CF1B953CBA68437BFE260C5E1934988A738D385AD86AB93AA04BBACB4191E167A0F41271A73A4CE59B124C60F34748E635FFA8AF74D514702F3B6B03440379607E1CB6E48C812B740973E69828D4DBB7BD0B7ABCB76EEDB058B146B663621A54134B826CC48991B0409323BDBB39B4BBFC558042CA96F8238BD126B906E305AC52298CFAC47B48A1EEF4516DD99747","exponent":"0x10001","valid_from":"Nov 16 09:32:49 2010 GMT","valid_to":"Nov 15 09:32:49 2013 GMT","fingerprint":"FF:91:92:D1:18:5D:21:9B:E2:7D:C7:9E:63:F2:51:73:A9:61:77:CA","serialNumber":"C5123AF95A7B2407","raw":{"type":"Buffer","data":[48,130,3,93,48,130,2,69,160,3,2,1,2,2,9,0,197,18,58,249,90,123,36,7,48,13,6,9,42,134,72,134,247,13,1,1,5,5,0,48,69,49,11,48,9,6,3,85,4,6,19,2,65,85,49,19,48,17,6,3,85,4,8,12,10,83,111,109,101,45,83,116,97,116,101,49,33,48,31,6,3,85,4,10,12,24,73,110,116,101,114,110,101,116,32,87,105,100,103,105,116,115,32,80,116,121,32,76,116,100,48,30,23,13,49,48,49,49,49,54,48,57,51,50,52,57,90,23,13,49,51,49,49,49,53,48,57,51,50,52,57,90,48,69,49,11,48,9,6,3,85,4,6,19,2,65,85,49,19,48,17,6,3,85,4,8,12,10,83,111,109,101,45,83,116,97,116,101,49,33,48,31,6,3,85,4,10,12,24,73,110,116,101,114,110,101,116,32,87,105,100,103,105,116,115,32,80,116,121,32,76,116,100,48,130,1,34,48,13,6,9,42,134,72,134,247,13,1,1,1,5,0,3,130,1,15,0,48,130,1,10,2,130,1,1,0,207,226,215,100,232,220,64,34,106,223,230,74,80,86,155,143,189,104,163,247,177,253,123,1,112,90,173,5,56,99,141,60,61,9,81,21,193,243,208,66,158,23,194,211,226,7,109,56,190,118,23,193,13,127,71,99,93,77,10,130,102,238,59,151,191,75,178,194,255,187,102,185,99,223,180,52,69,55,157,0,57,169,219,126,212,80,4,209,206,104,123,19,226,153,115,171,71,113,150,124,172,251,62,102,118,59,77,117,236,135,130,81,69,207,27,149,60,186,104,67,123,254,38,12,94,25,52,152,138,115,141,56,90,216,106,185,58,160,75,186,203,65,145,225,103,160,244,18,113,167,58,76,229,155,18,76,96,243,71,72,230,53,255,168,175,116,213,20,112,47,59,107,3,68,3,121,96,126,28,182,228,140,129,43,116,9,115,230,152,40,212,219,183,189,11,122,188,183,110,237,176,88,177,70,182,99,98,26,84,19,75,130,108,196,137,145,176,64,147,35,189,187,57,180,187,252,85,128,66,202,150,248,35,139,209,38,185,6,227,5,172,82,41,140,250,196,123,72,161,238,244,81,109,217,151,71,2,3,1,0,1,163,80,48,78,48,29,6,3,85,29,14,4,22,4,20,14,117,120,119,169,131,180,233,229,184,186,2,142,69,7,77,127,231,225,168,48,31,6,3,85,29,35,4,24,48,22,128,20,14,117,120,119,169,131,180,233,229,184,186,2,142,69,7,77,127,231,225,168,48,12,6,3,85,29,19,4,5,48,3,1,1,255,48,13,6,9,42,134,72,134,247,13,1,1,5,5,0,3,130,1,1,0,23,5,120,49,7,211,163,234,140,191,210,76,139,41,232,32,72,170,124,236,248,70,11,102,6,164,103,93,71,223,114,52,182,118,23,59,255,63,133,61,153,204,239,210,158,143,199,139,30,133,95,196,44,150,68,113,101,206,111,119,188,71,111,195,19,130,172,61,119,16,51,162,211,195,142,101,252,86,200,137,66,107,160,96,241,195,0,42,164,51,119,99,175,64,229,170,149,21,129,77,56,65,36,136,86,126,85,55,222,44,215,66,126,70,118,102,42,133,250,92,251,214,71,28,104,111,92,220,157,181,20,36,119,21,74,217,214,77,204,176,111,6,82,229,70,107,104,10,85,59,198,109,192,251,254,93,117,215,143,1,1,196,62,220,133,149,76,56,245,86,45,103,122,238,232,170,143,154,206,204,42,247,17,133,130,236,203,218,240,73,251,174,158,35,37,199,135,116,108,52,123,76,233,48,209,4,18,3,67,124,48,100,17,66,156,229,226,108,56,140,188,242,51,151,121,66,219,134,6,29,143,234,19,198,107,70,16,198,210,55,68,244,255,167,161,13,207,48,98,0,165,226,73,252,232,199]}}
client pair.cleartext.getCipher(): {"name":"RC4-SHA","version":"TLSv1/SSLv3"}
hello
WAIT-ACCEPT
WAIT-HELLO

assert.js:85
  throw new assert.AssertionError({
  ^
AssertionError: 0 == -1
    at process.<anonymous> (C:\src\node\test\pummel\test-tls-securepair-client.js:161:12)
    at emitOne (events.js:101:20)
    at process.emit (events.js:188:7)
    at process.exit (internal/process.js:147:15)
    at Timeout._onTimeout (C:\src\node\test\pummel\test-tls-securepair-client.js:91:13)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
Command: C:\src\node\Release\node.exe C:\src\node\test\pummel\test-tls-securepair-client.js
[19:50|% 100|+ 1283|-  12]: Done
running jslint
```