### PR TITLE
doc: fix <code> inside stability boxes

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -267,7 +267,7 @@ pre, tt, code {
 pre {
   padding: 1em;
   vertical-align: top;
-  background: rgba(128, 128, 128, .1);
+  background: #f2f2f2;
   margin: 1em;
   overflow-x: auto;
 }
@@ -357,8 +357,13 @@ hr {
 tt, code {
   font-size: .9em;
   color: #040404;
-  background-color: rgba(128, 128, 128, .1);
+  background-color: #f2f2f2;
   border-radius: 2px;
+  padding: .1em .3em;
+}
+
+.api_stability code {
+  background: rgba(0, 0, 0, .1);
   padding: .1em .3em;
 }
 

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -267,7 +267,7 @@ pre, tt, code {
 pre {
   padding: 1em;
   vertical-align: top;
-  background: #f2f2f2;
+  background: rgba(128, 128, 128, .1);
   margin: 1em;
   overflow-x: auto;
 }
@@ -357,7 +357,7 @@ hr {
 tt, code {
   font-size: .9em;
   color: #040404;
-  background-color: #f2f2f2;
+  background-color: rgba(128, 128, 128, .1);
   border-radius: 2px;
   padding: .1em .3em;
 }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tools, doc

##### Description of change
Mades `<code>` backgrounds semi-transparent so they work on all backgrounds. The inline blocks are rendered as `#f2f2f2` before and after this change.

### Before
<img width="929" src="https://cloud.githubusercontent.com/assets/115237/20495205/617e288a-b020-11e6-84c6-84eef5549328.png">

### After
<img width="926" src="https://cloud.githubusercontent.com/assets/115237/20495239/84121956-b020-11e6-880b-634e599abebe.png">


Fixes: https://github.com/nodejs/node/issues/9714