### PR TITLE
Symbol key props visible in inspection by default

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -373,7 +373,7 @@ function formatValue(ctx, value, recurseTimes) {
   var visibleKeys = arrayToHash(keys);
   const symbolKeys = Object.getOwnPropertySymbols(value);
   const enumSymbolKeys = symbolKeys
-    .filter((key) => value.propertyIsEnumerable(key));
+      .filter((key) => value.propertyIsEnumerable(key));
   keys = keys.concat(enumSymbolKeys);
 
   if (ctx.showHidden) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -372,7 +372,9 @@ function formatValue(ctx, value, recurseTimes) {
   var keys = Object.keys(value);
   var visibleKeys = arrayToHash(keys);
   var symbolKeys = Object.getOwnPropertySymbols(value);
-  keys = keys.concat(symbolKeys);
+  var enumSymbolKeys = symbolKeys
+    .filter((key) => value.propertyIsEnumerable(key));
+  keys = keys.concat(enumSymbolKeys);
 
   if (ctx.showHidden) {
     keys = Object.getOwnPropertyNames(value).concat(symbolKeys);

--- a/lib/util.js
+++ b/lib/util.js
@@ -371,10 +371,11 @@ function formatValue(ctx, value, recurseTimes) {
   // Look up the keys of the object.
   var keys = Object.keys(value);
   var visibleKeys = arrayToHash(keys);
+  var symbolKeys = Object.getOwnPropertySymbols(value);
+  keys = keys.concat(symbolKeys);
 
   if (ctx.showHidden) {
-    keys = Object.getOwnPropertyNames(value);
-    keys = keys.concat(Object.getOwnPropertySymbols(value));
+    keys = Object.getOwnPropertyNames(value).concat(symbolKeys);
   }
 
   // This could be a boxed primitive (new String(), etc.), check valueOf()

--- a/lib/util.js
+++ b/lib/util.js
@@ -371,8 +371,8 @@ function formatValue(ctx, value, recurseTimes) {
   // Look up the keys of the object.
   var keys = Object.keys(value);
   var visibleKeys = arrayToHash(keys);
-  var symbolKeys = Object.getOwnPropertySymbols(value);
-  var enumSymbolKeys = symbolKeys
+  const symbolKeys = Object.getOwnPropertySymbols(value);
+  const enumSymbolKeys = symbolKeys
     .filter((key) => value.propertyIsEnumerable(key));
   keys = keys.concat(enumSymbolKeys);
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -588,9 +588,9 @@ assert.doesNotThrow(function() {
                      '{ a: 123, inspect: [Function: inspect] }');
 
   const subject = { a: 123, [util.inspect.custom]() { return this; } };
-  const UTC = 'util.inspect.custom';
+  const UIC = 'util.inspect.custom';
   assert.strictEqual(util.inspect(subject),
-                     `{ a: 123,\n  [Symbol(${UTC})]: [Function: [${UTC}]] }`);
+                     `{ a: 123,\n  [Symbol(${UIC})]: [Function: [${UIC}]] }`);
 }
 
 // util.inspect with "colors" option should produce as many lines as without it

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -666,6 +666,16 @@ if (typeof Symbol !== 'undefined') {
     '{ [Symbol(symbol)]: 42 }'
   );
 
+  Object.defineProperty(
+    subject,
+    Symbol(),
+    {enumerable: false, value: 'non-enum'});
+  assert.strictEqual(util.inspect(subject), '{ [Symbol(symbol)]: 42 }');
+  assert.strictEqual(
+    util.inspect(subject, options),
+    '{ [Symbol(symbol)]: 42, [Symbol()]: \'non-enum\' }'
+  );
+
   subject = [1, 2, 3];
   subject[Symbol('symbol')] = 42;
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -588,8 +588,9 @@ assert.doesNotThrow(function() {
                      '{ a: 123, inspect: [Function: inspect] }');
 
   const subject = { a: 123, [util.inspect.custom]() { return this; } };
+  const UTC = 'util.inspect.custom';
   assert.strictEqual(util.inspect(subject),
-                     '{ a: 123 }');
+                     `{ a: 123,\n  [Symbol(${UTC})]: [Function: [${UTC}]] }`);
 }
 
 // util.inspect with "colors" option should produce as many lines as without it
@@ -659,7 +660,7 @@ if (typeof Symbol !== 'undefined') {
 
   subject[Symbol('symbol')] = 42;
 
-  assert.strictEqual(util.inspect(subject), '{}');
+  assert.strictEqual(util.inspect(subject), '{ [Symbol(symbol)]: 42 }');
   assert.strictEqual(
     util.inspect(subject, options),
     '{ [Symbol(symbol)]: 42 }'
@@ -668,9 +669,8 @@ if (typeof Symbol !== 'undefined') {
   subject = [1, 2, 3];
   subject[Symbol('symbol')] = 42;
 
-  assert.strictEqual(util.inspect(subject), '[ 1, 2, 3 ]');
-  assert.strictEqual(util.inspect(subject, options),
-                     '[ 1, 2, 3, [length]: 3, [Symbol(symbol)]: 42 ]');
+  assert.strictEqual(util.inspect(subject),
+                     '[ 1, 2, 3, [Symbol(symbol)]: 42 ]');
 }
 
 // test Set


### PR DESCRIPTION
I use symbol key properties. And I find it awful that they do
not show up in inspection. I can alter
`util.inspect.defaultOptions.showHidden` each time I debug. Does
that sound like fun to you? Isn't fun a core principle life?

The way I see it, it is not about the spec or about what is
enumerable/hidden, etc. When inspecting, it is about ease of
access to the information. That's how I see it. Does anyone have
any other thoughts?

Fixes #9709 (which should not have been closed so fast)