### PR TITLE
test: fix flaky test-inspector

### DIFF
--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -286,7 +286,7 @@ TestSession.prototype.disconnect = function(childDone) {
     this.expectClose_ = true;
     this.harness_.childInstanceDone =
         this.harness_.childInstanceDone || childDone;
-    this.socket_.end();
+    this.socket_.destroy();
     console.log('[test]', 'Connection terminated');
     callback();
   });

--- a/test/inspector/inspector.status
+++ b/test/inspector/inspector.status
@@ -7,4 +7,3 @@ prefix inspector
 [true] # This section applies to all platforms
 
 [$system==win32]
-test-inspector  : PASS,FLAKY


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test V8_inspector

##### Description of change
<!-- Provide a description of the change below this comment. -->

Using `socket.destroy()` instead of `socket.end()` fixes
more-than-intermittent ECONNRESET issues on Windows.

Fixes: https://github.com/nodejs/node/issues/8804

/cc @eugeneo @gibfahn 

Stress test on master showing 93 failures in 100 runs on Windows 10: https://ci.nodejs.org/job/node-stress-single-test/1063/nodes=win10/console

Stress test with this change showing 0 failures in 100 runs on Windows 10:
https://ci.nodejs.org/job/node-stress-single-test/1066/nodes=win10/console