### PR TITLE
doc: typo in util.inherits documentation for ES6 example

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -180,7 +180,6 @@ stream.write('It works!'); // Received data: "It works!"
 ES6 example using `class` and `extends`
 
 ```js
-const util = require('util');
 const EventEmitter = require('events');
 
 class MyStream extends EventEmitter {


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
there is no need for "util" in the ES6 example

