### PR TITLE
stream: bugfix for test-child-process-stdio-big-write-end.js

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -302,7 +302,7 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
 
   state.length += len;
 
-  var ret = state.length < state.highWaterMark;
+  var ret = state.length < state.highWaterMark && state.pendingcb < state.highWaterMark;
   // we must ensure that previous needDrain will not be reset to false.
   if (!ret)
     state.needDrain = true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

In this testcase, if the parent and child process entering balanced state
(both processes never sleep), the event loop of Node.js will never be
scheduled. Eventually, thousands of callbacks (_stream_writable.js:
afterWrite) on event queue cause memory leak.