### PR TITLE
test: exclude tests failing on AIX for v4.x

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -35,3 +35,8 @@ test-regress-GH-1899                 : FAIL, PASS
 # localIPv6Hosts list from test/common.js.
 test-https-connect-address-family : PASS,FLAKY
 test-tls-connect-address-family : PASS,FLAKY
+
+# fixed in later releases but not being fixed in 4.x for AIX
+test-async-wrap-post-did-throw           : PASS, FLAKY
+test-async-wrap-throw-from-callback      : PASS, FLAKY
+test-crypto-random                       : PASS, FLAKY


### PR DESCRIPTION
##### Checklist
- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Exclude tests that have been fixed in later versions but that fail in v4.x.  Excluding these will reduce the noise when builds are run for older versions.  The tests were excluded earlier as part of:

  https://github.com/nodejs/node/pull/8065/commits/ecbeeeb1ffd549f3195483bb60f607ff19a2469e

but that never made it back to v6.x and we don't need the full commit just what is included in this PR.

I noticed these as there were quite a few 4.x runs today leading to a lot red in the aix builds.