### PR TITLE
v4 backport: repl: refactor lib/repl.js

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -39,12 +39,12 @@ const parentModule = module;
 const replMap = new WeakMap();
 
 const GLOBAL_OBJECT_PROPERTIES = ['NaN', 'Infinity', 'undefined',
-    'eval', 'parseInt', 'parseFloat', 'isNaN', 'isFinite', 'decodeURI',
-    'decodeURIComponent', 'encodeURI', 'encodeURIComponent',
-    'Object', 'Function', 'Array', 'String', 'Boolean', 'Number',
-    'Date', 'RegExp', 'Error', 'EvalError', 'RangeError',
-    'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
-    'Math', 'JSON'];
+  'eval', 'parseInt', 'parseFloat', 'isNaN', 'isFinite', 'decodeURI',
+  'decodeURIComponent', 'encodeURI', 'encodeURIComponent',
+  'Object', 'Function', 'Array', 'String', 'Boolean', 'Number',
+  'Date', 'RegExp', 'Error', 'EvalError', 'RangeError',
+  'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
+  'Math', 'JSON'];
 const GLOBAL_OBJECT_PROPERTY_MAP = {};
 GLOBAL_OBJECT_PROPERTIES.forEach((p) => GLOBAL_OBJECT_PROPERTY_MAP[p] = p);
 
@@ -622,7 +622,7 @@ ArrayStream.prototype.writable = true;
 ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
-const requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
+const requireRE = /\brequire\s*\(['"](([\w./-]+\/)?([\w./-]*))/;
 const simpleExpressionRE =
     /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
 
@@ -870,7 +870,7 @@ REPLServer.prototype.complete = function(line, callback) {
       var newCompletionGroups = [];
       for (i = 0; i < completionGroups.length; i++) {
         group = completionGroups[i].filter(function(elem) {
-          return elem.indexOf(filter) == 0;
+          return elem.indexOf(filter) === 0;
         });
         if (group.length) {
           newCompletionGroups.push(group);
@@ -1124,8 +1124,8 @@ function regexpEscape(s) {
  * @return {String} The converted command.
  */
 REPLServer.prototype.convertToContext = function(cmd) {
-  const scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m;
-  const scopeFunc = /^\s*function\s*([_\w\$]+)/;
+  const scopeVar = /^\s*var\s*([\w$]+)(.*)$/m;
+  const scopeFunc = /^\s*function\s*([\w$]+)/;
   var matches;
 
   // Replaces: var foo = "bar";  with: self.context.foo = bar;


### PR DESCRIPTION
Backport of #9374 for v4.x-staging.  @TheAlphaNerd 


* remove unnecessary backslash (`\`) escaping in regular expressions
* favor `===` over `==`
* multiline arrays indentation consistent with other indentation

PR-URL: https://github.com/nodejs/node/pull/9374
Reviewed-By: Rod Vagg <rod@vagg.org>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Roman Reiss <me@silverwind.io>