### PR TITLE
v6 backport: benchmark,lib,test,tools: remove unneeded . escape

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -936,7 +936,7 @@ Server.prototype.addContext = function(servername, context) {
   }
 
   var re = new RegExp('^' +
-                      servername.replace(/([\.^$+?\-\\[\]{}])/g, '\\$1')
+                      servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')
                                 .replace(/\*/g, '[^.]*') +
                       '$');
   this._contexts.push([re, tls.createSecureContext(context).context]);

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -72,7 +72,7 @@ function error_test() {
       if (read_buffer !== client_unix.expect) {
         var expect = client_unix.expect;
         if (expect === prompt_multiline)
-          expect = /[\.]{3} /;
+          expect = /[.]{3} /;
         assert.ok(read_buffer.match(expect));
         console.error('match');
       }

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -545,12 +545,12 @@ function deepCopy_(src) {
 // these parse out the contents of an H# tag
 var eventExpr = /^Event(?::|\s)+['"]?([^"']+).*$/i;
 var classExpr = /^Class:\s*([^ ]+).*?$/i;
-var propExpr = /^(?:property:?\s*)?[^\.]+\.([^ \.\(\)]+)\s*?$/i;
-var braceExpr = /^(?:property:?\s*)?[^\.\[]+(\[[^\]]+\])\s*?$/i;
+var propExpr = /^(?:property:?\s*)?[^.]+\.([^ .()]+)\s*?$/i;
+var braceExpr = /^(?:property:?\s*)?[^.\[]+(\[[^\]]+\])\s*?$/i;
 var classMethExpr =
-  /^class\s*method\s*:?[^\.]+\.([^ \.\(\)]+)\([^\)]*\)\s*?$/i;
+  /^class\s*method\s*:?[^.]+\.([^ .()]+)\([^)]*\)\s*?$/i;
 var methExpr =
-  /^(?:method:?\s*)?(?:[^\.]+\.)?([^ \.\(\)]+)\([^\)]*\)\s*?$/i;
+  /^(?:method:?\s*)?(?:[^.]+\.)?([^ .()]+)\([^)]*\)\s*?$/i;
 var newExpr = /^new ([A-Z][a-zA-Z]+)\([^\)]*\)\s*?$/;
 var paramExpr = /\((.*)\);?$/;
 


### PR DESCRIPTION
Backport of #9449 for v6.x-staging. @TheAlphaNerd 

The `.` character does not need to be escaped when it appears inside a
regular expression character class. This removes instances of
unnecessary escapes of the `.` character.

This also removes a few unnecessary escapes of the `(` and `)`
characters within character classes too.

PR-URL: https://github.com/nodejs/node/pull/9449
Reviewed-By: Roman Reiss <me@silverwind.io>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Minwoo Jung <jmwsoft@gmail.com>
Reviewed-By: James Snell <jasnell@gmail.com>