### PR TITLE
timers: prevent infinite loop when subsequent immediates are cleared

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -580,8 +580,10 @@ function processImmediate() {
   while (immediate) {
     domain = immediate.domain;
 
-    if (!immediate._onImmediate)
+    if (!immediate._onImmediate) {
+      immediate = immediate._idleNext;
       continue;
+    }
 
     if (domain)
       domain.enter();

--- a/test/parallel/test-timers-regress-GH-9765.js
+++ b/test/parallel/test-timers-regress-GH-9765.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that if an Immediate callback clears subsequent
+// immediates we don't get stuck in an infinite loop.
+//
+// If the process does get stuck, it will be timed out by the test
+// runner.
+//
+// Ref: https://github.com/nodejs/node/issues/9756
+
+setImmediate(common.mustCall(function() {
+  clearImmediate(i2);
+  clearImmediate(i3);
+}));
+
+const i2 = setImmediate(function() {
+  common.fail('immediate callback should not have fired');
+});
+
+const i3 = setImmediate(function() {
+  common.fail('immediate callback should not have fired');
+});


### PR DESCRIPTION
PR to go with: https://github.com/nodejs/node/issues/9756

I am not familiar with timers, so the proposed solution could well be wrong. Looking forward to feedback on that!

##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

timers

##### Description of change

Remove the unnecessary `if` branch.

If current `immediate` has no callback, proceed onto the next one in the queue.