### PR TITLE
crypto: do not use pointers to std::vector

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -121,7 +121,7 @@ const char* const root_certs[] = {
 };
 
 X509_STORE* root_cert_store;
-std::vector<X509*>* root_certs_vector;
+std::vector<X509*> root_certs_vector;
 
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;
@@ -688,9 +688,7 @@ static int X509_up_ref(X509* cert) {
 
 
 static X509_STORE* NewRootCertStore() {
-  if (!root_certs_vector) {
-    root_certs_vector = new std::vector<X509*>;
-
+  if (root_certs_vector.empty()) {
     for (size_t i = 0; i < arraysize(root_certs); i++) {
       BIO* bp = NodeBIO::NewFixed(root_certs[i], strlen(root_certs[i]));
       X509 *x509 = PEM_read_bio_X509(bp, nullptr, CryptoPemCallback, nullptr);
@@ -702,12 +700,12 @@ static X509_STORE* NewRootCertStore() {
         return nullptr;
       }
 
-      root_certs_vector->push_back(x509);
+      root_certs_vector.push_back(x509);
     }
   }
 
   X509_STORE* store = X509_STORE_new();
-  for (auto& cert : *root_certs_vector) {
+  for (X509 *cert : root_certs_vector) {
     X509_up_ref(cert);
     X509_STORE_add_cert(store, cert);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

The pointer to std::vector is unnecessary, so replace it with standard
instance.

Also, make the for() loop more readable by using actual type
instead of inferred - there is no readability benefit here from
obfuscating the type.

These are just pedantic changes.
