### PR TITLE
inspector: /json/version returns object, not array

### DIFF
--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -17,6 +17,12 @@ function checkListResponse(err, response) {
 function checkVersion(err, response) {
   assert.ifError(err);
   assert.ok(response);
+  const expected = {
+    'Browser': 'node.js/' + process.version,
+    'Protocol-Version': '1.1',
+  };
+  assert.strictEqual(JSON.stringify(response),
+                     JSON.stringify(expected));
 }
 
 function checkBadPath(err, response) {


### PR DESCRIPTION
Make /json/version return an object instead of an object wrapped in an
array.

Fixes: #9760 
CI: https://ci.nodejs.org/job/node-test-pull-request/4964/