### PR TITLE
node.h [API] cleanup: remove node_internals.h & extra dependencies from node.h

### DIFF
--- a/src/backtrace_posix.cc
+++ b/src/backtrace_posix.cc
@@ -1,4 +1,4 @@
-#include "node.h"
+#include "node_internals.h"
 
 #if defined(__linux__)
 #include <features.h>

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,6 +1,8 @@
 #include "env.h"
 #include "env-inl.h"
 #include "async-wrap.h"
+#include "node_internals.h"
+
 #include "v8.h"
 #include "v8-profiler.h"
 

--- a/src/node.h
+++ b/src/node.h
@@ -150,33 +150,10 @@ NODE_EXTERN v8::Local<v8::Value> MakeCallback(
     int argc,
     v8::Local<v8::Value>* argv);
 
-}  // namespace node
-
-#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
-#include "node_internals.h"
-#endif
-
-#include <assert.h>
-#include <stdint.h>
-
 #ifndef NODE_STRINGIFY
 #define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)
 #define NODE_STRINGIFY_HELPER(n) #n
 #endif
-
-#ifdef _WIN32
-// TODO(tjfontaine) consider changing the usage of ssize_t to ptrdiff_t
-#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
-typedef intptr_t ssize_t;
-# define _SSIZE_T_
-# define _SSIZE_T_DEFINED
-#endif
-#else  // !_WIN32
-# include <sys/types.h>  // size_t, ssize_t
-#endif  // _WIN32
-
-
-namespace node {
 
 NODE_EXTERN extern bool no_deprecation;
 #if HAVE_OPENSSL && NODE_FIPS_MODE

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1,4 +1,3 @@
-#include "node.h"
 #include "node_buffer.h"
 
 #include "env.h"
@@ -7,6 +6,9 @@
 #include "string_search.h"
 #include "util.h"
 #include "util-inl.h"
+
+#include "node_internals.h"
+
 #include "v8-profiler.h"
 #include "v8.h"
 

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,5 +1,5 @@
-#include "node.h"
 #include "node_i18n.h"
+#include "node_internals.h"
 #include "env.h"
 #include "env-inl.h"
 #include "util.h"

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1,6 +1,7 @@
 #include "node_constants.h"
 #include "env.h"
 #include "env-inl.h"
+#include "node_internals.h"
 
 #include "uv.h"
 #include "zlib.h"

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -27,6 +27,8 @@
 
 #include "util.h"
 
+#include "node_internals.h"
+
 #include <string.h>
 
 namespace node {

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -29,6 +29,8 @@
 #include "env-inl.h"
 #include "util.h"
 #include "util-inl.h"
+#include "node_internals.h"
+
 #include "v8.h"
 
 #include <unicode/utypes.h>

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "node.h"
+#include "util.h"
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -1,8 +1,9 @@
-#include "node.h"
-#include "v8.h"
 #include "env.h"
 #include "env-inl.h"
 #include "string_bytes.h"
+#include "node_internals.h"
+
+#include "v8.h"
 
 #include <errno.h>
 #include <string.h>

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -1,8 +1,9 @@
-#include "node.h"
 #include "node_watchdog.h"
-#include "v8.h"
 #include "env.h"
 #include "env-inl.h"
+#include "node_internals.h"
+
+#include "v8.h"
 
 namespace node {
 namespace util {

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -2,6 +2,7 @@
 #include "env-inl.h"
 #include "string_bytes.h"
 #include "util.h"
+#include "node_internals.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -3,8 +3,9 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "node.h"
 #include "node_buffer.h"
+
+#include "uv.h"
 
 namespace node {
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -3,6 +3,8 @@
 #include "base64.h"
 #include "node.h"
 #include "node_buffer.h"
+#include "node_internals.h"
+
 #include "v8.h"
 
 #include <limits.h>

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -7,8 +7,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "node.h"
-#include <string.h>
+#include "util.h"
 
 namespace node {
 namespace stringsearch {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Node.js API (src)

##### Description of change
<!-- Provide a description of the change below this comment. -->

Removes the following lines from node.h ([node.h#L155-L160](https://github.com/nodejs/node/blob/master/src/node.h#L155-L160)):
```c
#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
#include "node_internals.h"
#endif

#include <assert.h>
#include <stdint.h>
```

_UPDATED: also removes the following from node.h:_
- _mess in [node.h#L167-L176](https://github.com/nodejs/node/blob/master/src/node.h#L167-L176) that defines size_t/ssize_t (https://github.com/nodejs/node/issues/9766#issuecomment-262568948 by @bnoordhuis: "I think we can simply replace that with a `#include <stddef.h>` because it's a workaround for old Visual Studio versions that we no longer support." But `node.h` includes `v8.h` which in turn includes `stddef.h` so I think these lines can simply go away.)_
- break in `namespace node` block

##### For discussion

~~I started the commit message with "api:" since node.h is exported for consumption by both adding and  embedders. In case this is not desired I would be happy to change it to something like "src:", "include:", or perhaps something else.~~

I found that a number of source files unnecessarily include `node.h` and would be happy to fix this (here or in another PR).

~~From #9766: I also hope we can find a nice way rework~~ the following lines in node.h ([node.h#L167-L176](https://github.com/nodejs/node/blob/master/src/node.h#L167-L176)) _are now removed_:
```c
#ifdef _WIN32
// TODO(tjfontaine) consider changing the usage of ssize_t to ptrdiff_t
#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
typedef intptr_t ssize_t;
# define _SSIZE_T_
# define _SSIZE_T_DEFINED
#endif
#else  // !_WIN32
# include <sys/types.h>  // size_t, ssize_t
#endif  // _WIN32
```