### PR TITLE
test: exclude no_interleaved_stdio test for AIX

### DIFF
--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -3,3 +3,4 @@ prefix pseudo-tty
 [$system==aix]
 # test issue only, covered under https://github.com/nodejs/node/issues/7973
 no_dropped_stdio           : SKIP
+no_interleaved_stdio       : SKIP


### PR DESCRIPTION
- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
pseudo-tty/no_interleaved_stdio has hung a few times
in the last couple of days on AIX.  We believe
it is not a Node.js issue but an issue with python
on AIX. Its being investigated under:
https://github.com/nodejs/node/issues/7973.
Excluding this additional test until we can
resolve the python issue.

Fixes: https://github.com/nodejs/node/issues/9765