### PR TITLE
Debugger - Filter out the ending of the Module wrapper when using the list command

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1130,7 +1130,9 @@ Interface.prototype.list = function(delta) {
     var lines = res.source.split('\n');
     for (var i = 0; i < lines.length; i++) {
       var lineno = res.fromLine + i + 1;
-      if (lineno < from || lineno > to) continue;
+      // The very last line will be the end of the module wrapper,
+      // and we need to filter that out.
+      if (lineno < from || lineno > to || lineno === lines.length) continue;
 
       const current = lineno === 1 + client.currentSourceLine;
       const breakpoint = client.breakpoints.some(function(bp) {

--- a/test/parallel/test-debugger-list-no-module-wrapper.js
+++ b/test/parallel/test-debugger-list-no-module-wrapper.js
@@ -1,0 +1,60 @@
+'use strict';
+const common = require('../common');
+const path = require('path');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
+const fixture = path.join(
+  common.fixturesDir,
+  'debugger-repeat-last.js'
+);
+
+const args = [
+  'debug',
+  `--port=${common.PORT}`,
+  fixture
+];
+
+const proc = spawn(process.execPath, args, { stdio: 'pipe' });
+proc.stdout.setEncoding('utf8');
+
+let stdout = '';
+
+let sentCommand = false;
+let sentList = false;
+let sentExit = false;
+
+proc.stdout.on('data', (data) => {
+  stdout += data;
+  if (!sentCommand && stdout.includes('> 1')) {
+    sentCommand = true;
+    return;
+  }
+
+  if (!sentList) {
+    setImmediate(() => { proc.stdin.write('list(10)\n'); });
+    sentList = true;
+    return;
+  }
+  if (!sentExit && sentCommand && sentList) {
+    setImmediate(() => { proc.stdin.write('\n\n\n.exit\n\n\n'); });
+    sentExit = true;
+    return;
+  }
+});
+
+proc.on('exit', common.mustCall((exitCode, signal) => {
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signal, null);
+  // No module wrapping at the first line
+  assert.strictEqual(
+    stdout.includes('> 1 var a = 1;'),
+    true,
+    'debugger should not have the module wrapper'
+  );
+  // No module wrapping at the end
+  assert.strictEqual(
+    stdout.includes('9 });'),
+    false,
+    'the last line of the debugger should not have the module wrapping ending'
+  );
+}));

--- a/test/parallel/test-debugger-list-no-module-wrapper.js
+++ b/test/parallel/test-debugger-list-no-module-wrapper.js
@@ -19,26 +19,28 @@ proc.stdout.setEncoding('utf8');
 
 let stdout = '';
 
-let sentCommand = false;
+let hasPrompt = false;
 let sentList = false;
 let sentExit = false;
 
 proc.stdout.on('data', (data) => {
-  stdout += data;
-  if (!sentCommand && stdout.includes('> 1')) {
-    sentCommand = true;
-    return;
+  if (!hasPrompt && data.startsWith('> 1')) {
+    hasPrompt = true;
   }
 
-  if (!sentList) {
-    setImmediate(() => { proc.stdin.write('list(10)\n'); });
-    sentList = true;
-    return;
-  }
-  if (!sentExit && sentCommand && sentList) {
-    setImmediate(() => { proc.stdin.write('\n\n\n.exit\n\n\n'); });
-    sentExit = true;
-    return;
+  if (hasPrompt) {
+    stdout += data;
+    if (!sentList) {
+      setImmediate(() => { proc.stdin.write('list(10)\n'); });
+      sentList = true;
+      return;
+    }
+
+    if (!sentExit && sentList) {
+      setImmediate(() => { proc.stdin.write('\n\n\n.exit\n\n\n'); });
+      sentExit = true;
+      return;
+    }
   }
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Debbuger

##### Description of change
<!-- Provide a description of the change below this comment. -->

PR for https://github.com/nodejs/node/issues/9768.  

When inside the debugger, doing a `list(10)` on a file with only say 5 lines, would print the end of the module wrapper on the last line.

There is code currently to make sure that the first part of the Module wrapper is filtered out.  that is located here:   https://github.com/nodejs/node/blob/master/lib/_debugger.js#L1107

The code added filters out the very last line of the lines array, which is the ending of the module wrapper.

I did not add a test for this.  I don't believe there was one that tests List anyways.  If there needs to be one,  i will try and look at the other debugger tests as an example