### PR TITLE
Backport: repl: don't override all internal repl defaults

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -5,7 +5,8 @@ const REPL = require('repl');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const debug = require('util').debuglog('repl');
+const util = require('util');
+const debug = util.debuglog('repl');
 
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
@@ -19,11 +20,11 @@ function createRepl(env, opts, cb) {
     cb = opts;
     opts = null;
   }
-  opts = opts || {
+  opts = util._extend({
     ignoreUndefined: false,
     terminal: process.stdout.isTTY,
     useGlobal: true
-  };
+  }, opts);
 
   if (parseInt(env.NODE_NO_READLINE)) {
     opts.terminal = false;

--- a/test/common.js
+++ b/test/common.js
@@ -336,6 +336,11 @@ if (global.Symbol) {
   knownGlobals.push(Symbol);
 }
 
+function allowGlobals() {
+  knownGlobals = knownGlobals.concat(Array.from(arguments));
+}
+exports.allowGlobals = allowGlobals;
+
 function leakedGlobals() {
   var leaked = [];
 

--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -2,7 +2,7 @@
 
 // Flags: --expose-internals
 
-require('../common');
+const common = require('../common');
 const stream = require('stream');
 const REPL = require('internal/repl');
 const assert = require('assert');
@@ -46,6 +46,10 @@ function run(test) {
 
   REPL.createInternalRepl(env, opts, function(err, repl) {
     if (err) throw err;
+
+    // The REPL registers 'module' and 'require' globals
+    common.allowGlobals(repl.context.module, repl.context.require);
+
     assert.equal(expected.terminal, repl.terminal,
                  'Expected ' + inspect(expected) + ' with ' + inspect(env));
     assert.equal(expected.useColors, repl.useColors,

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -35,6 +35,10 @@ const replHistoryPath = path.join(common.tmpDir, '.node_repl_history');
 const checkResults = common.mustCall(function(err, r) {
   if (err)
     throw err;
+
+  // The REPL registers 'module' and 'require' globals
+  common.allowGlobals(r.context.module, r.context.require);
+
   r.input.end();
   const stat = fs.statSync(replHistoryPath);
   assert.strictEqual(

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -262,6 +262,12 @@ function runTest(assertCleaned) {
       throw err;
     }
 
+    // The REPL registers 'module' and 'require' globals.
+    // This test also registers '_'.
+    common.allowGlobals(repl.context.module,
+                        repl.context.require,
+                        repl.context._);
+
     repl.once('close', () => {
       if (repl._flushing) {
         repl.once('flushHistory', onClose);


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/7826 to v4.

R= @TheAlphaNerd 
