### PR TITLE
Backport: test: refactor large event emitter tests

### DIFF
--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -1,32 +1,38 @@
 'use strict';
 
 require('../common');
-var assert = require('assert');
-var events = require('events');
+const assert = require('assert');
+const events = require('events');
 
 function listener() {}
 function listener2() {}
 
-var e1 = new events.EventEmitter();
-e1.on('foo', listener);
-var fooListeners = e1.listeners('foo');
-assert.deepEqual(e1.listeners('foo'), [listener]);
-e1.removeAllListeners('foo');
-assert.deepEqual(e1.listeners('foo'), []);
-assert.deepEqual(fooListeners, [listener]);
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  const fooListeners = ee.listeners('foo');
+  assert.deepStrictEqual(ee.listeners('foo'), [listener]);
+  ee.removeAllListeners('foo');
+  assert.deepStrictEqual(ee.listeners('foo'), []);
+  assert.deepStrictEqual(fooListeners, [listener]);
+}
 
-var e2 = new events.EventEmitter();
-e2.on('foo', listener);
-var e2ListenersCopy = e2.listeners('foo');
-assert.deepEqual(e2ListenersCopy, [listener]);
-assert.deepEqual(e2.listeners('foo'), [listener]);
-e2ListenersCopy.push(listener2);
-assert.deepEqual(e2.listeners('foo'), [listener]);
-assert.deepEqual(e2ListenersCopy, [listener, listener2]);
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  const eeListenersCopy = ee.listeners('foo');
+  assert.deepStrictEqual(eeListenersCopy, [listener]);
+  assert.deepStrictEqual(ee.listeners('foo'), [listener]);
+  eeListenersCopy.push(listener2);
+  assert.deepStrictEqual(ee.listeners('foo'), [listener]);
+  assert.deepStrictEqual(eeListenersCopy, [listener, listener2]);
+}
 
-var e3 = new events.EventEmitter();
-e3.on('foo', listener);
-var e3ListenersCopy = e3.listeners('foo');
-e3.on('foo', listener2);
-assert.deepEqual(e3.listeners('foo'), [listener, listener2]);
-assert.deepEqual(e3ListenersCopy, [listener]);
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  const eeListenersCopy = ee.listeners('foo');
+  ee.on('foo', listener2);
+  assert.deepStrictEqual(ee.listeners('foo'), [listener, listener2]);
+  assert.deepStrictEqual(eeListenersCopy, [listener]);
+}

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var events = require('events');
+const common = require('../common');
+const assert = require('assert');
+const events = require('events');
 
 
 function expect(expected) {
-  var actual = [];
+  const actual = [];
   process.on('exit', function() {
-    assert.deepEqual(actual.sort(), expected.sort());
+    assert.deepStrictEqual(actual.sort(), expected.sort());
   });
   function listener(name) {
     actual.push(name);
@@ -17,56 +17,63 @@ function expect(expected) {
 
 function listener() {}
 
-var e1 = new events.EventEmitter();
-e1.on('foo', listener);
-e1.on('bar', listener);
-e1.on('baz', listener);
-e1.on('baz', listener);
-var fooListeners = e1.listeners('foo');
-var barListeners = e1.listeners('bar');
-var bazListeners = e1.listeners('baz');
-e1.on('removeListener', expect(['bar', 'baz', 'baz']));
-e1.removeAllListeners('bar');
-e1.removeAllListeners('baz');
-assert.deepEqual(e1.listeners('foo'), [listener]);
-assert.deepEqual(e1.listeners('bar'), []);
-assert.deepEqual(e1.listeners('baz'), []);
-// after calling removeAllListeners,
-// the old listeners array should stay unchanged
-assert.deepEqual(fooListeners, [listener]);
-assert.deepEqual(barListeners, [listener]);
-assert.deepEqual(bazListeners, [listener, listener]);
-// after calling removeAllListeners,
-// new listeners arrays are different from the old
-assert.notEqual(e1.listeners('bar'), barListeners);
-assert.notEqual(e1.listeners('baz'), bazListeners);
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  ee.on('bar', listener);
+  ee.on('baz', listener);
+  ee.on('baz', listener);
+  const fooListeners = ee.listeners('foo');
+  const barListeners = ee.listeners('bar');
+  const bazListeners = ee.listeners('baz');
+  ee.on('removeListener', expect(['bar', 'baz', 'baz']));
+  ee.removeAllListeners('bar');
+  ee.removeAllListeners('baz');
+  assert.deepStrictEqual(ee.listeners('foo'), [listener]);
+  assert.deepStrictEqual(ee.listeners('bar'), []);
+  assert.deepStrictEqual(ee.listeners('baz'), []);
+  // After calling removeAllListeners(),
+  // the old listeners array should stay unchanged.
+  assert.deepStrictEqual(fooListeners, [listener]);
+  assert.deepStrictEqual(barListeners, [listener]);
+  assert.deepStrictEqual(bazListeners, [listener, listener]);
+  // After calling removeAllListeners(),
+  // new listeners arrays is different from the old.
+  assert.notEqual(ee.listeners('bar'), barListeners);
+  assert.notEqual(ee.listeners('baz'), bazListeners);
+}
 
-var e2 = new events.EventEmitter();
-e2.on('foo', listener);
-e2.on('bar', listener);
-// expect LIFO order
-e2.on('removeListener', expect(['foo', 'bar', 'removeListener']));
-e2.on('removeListener', expect(['foo', 'bar']));
-e2.removeAllListeners();
-console.error(e2);
-assert.deepEqual([], e2.listeners('foo'));
-assert.deepEqual([], e2.listeners('bar'));
+{
+  const ee = new events.EventEmitter();
+  ee.on('foo', listener);
+  ee.on('bar', listener);
+  // Expect LIFO order
+  ee.on('removeListener', expect(['foo', 'bar', 'removeListener']));
+  ee.on('removeListener', expect(['foo', 'bar']));
+  ee.removeAllListeners();
+  assert.deepStrictEqual([], ee.listeners('foo'));
+  assert.deepStrictEqual([], ee.listeners('bar'));
+}
 
-var e3 = new events.EventEmitter();
-e3.on('removeListener', listener);
-// check for regression where removeAllListeners throws when
-// there exists a removeListener listener, but there exists
-// no listeners for the provided event type
-assert.doesNotThrow(e3.removeAllListeners.bind(e3, 'foo'));
+{
+  const ee = new events.EventEmitter();
+  ee.on('removeListener', listener);
+  // Check for regression where removeAllListeners() throws when
+  // there exists a 'removeListener' listener, but there exists
+  // no listeners for the provided event type.
+  assert.doesNotThrow(ee.removeAllListeners.bind(ee, 'foo'));
+}
 
-var e4 = new events.EventEmitter();
-var expectLength = 2;
-e4.on('removeListener', function(name, listener) {
-  assert.equal(expectLength--, this.listeners('baz').length);
-});
-e4.on('baz', function() {});
-e4.on('baz', function() {});
-e4.on('baz', function() {});
-assert.equal(e4.listeners('baz').length, expectLength + 1);
-e4.removeAllListeners('baz');
-assert.equal(e4.listeners('baz').length, 0);
+{
+  const ee = new events.EventEmitter();
+  var expectLength = 2;
+  ee.on('removeListener', function(name, listener) {
+    assert.strictEqual(expectLength--, this.listeners('baz').length);
+  });
+  ee.on('baz', function() {});
+  ee.on('baz', function() {});
+  ee.on('baz', function() {});
+  assert.strictEqual(ee.listeners('baz').length, expectLength + 1);
+  ee.removeAllListeners('baz');
+  assert.strictEqual(ee.listeners('baz').length, 0);
+}

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -1,111 +1,117 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var events = require('events');
+const common = require('../common');
+const assert = require('assert');
+const EventEmitter = require('events');
 
-function listener1() {
-  console.log('listener1');
-}
+function listener1() {}
+function listener2() {}
 
-function listener2() {
-  console.log('listener2');
-}
-
-function remove1() {
-  assert(0);
-}
-
-function remove2() {
-  assert(0);
-}
-
-var e1 = new events.EventEmitter();
-e1.on('hello', listener1);
-e1.on('removeListener', common.mustCall(function(name, cb) {
-  assert.equal(name, 'hello');
-  assert.equal(cb, listener1);
-}));
-e1.removeListener('hello', listener1);
-assert.deepEqual([], e1.listeners('hello'));
-
-var e2 = new events.EventEmitter();
-e2.on('hello', listener1);
-e2.on('removeListener', common.fail);
-e2.removeListener('hello', listener2);
-assert.deepEqual([listener1], e2.listeners('hello'));
-
-var e3 = new events.EventEmitter();
-e3.on('hello', listener1);
-e3.on('hello', listener2);
-e3.once('removeListener', common.mustCall(function(name, cb) {
-  assert.equal(name, 'hello');
-  assert.equal(cb, listener1);
-  assert.deepEqual([listener2], e3.listeners('hello'));
-}));
-e3.removeListener('hello', listener1);
-assert.deepEqual([listener2], e3.listeners('hello'));
-e3.once('removeListener', common.mustCall(function(name, cb) {
-  assert.equal(name, 'hello');
-  assert.equal(cb, listener2);
-  assert.deepEqual([], e3.listeners('hello'));
-}));
-e3.removeListener('hello', listener2);
-assert.deepEqual([], e3.listeners('hello'));
-
-var e4 = new events.EventEmitter();
-e4.on('removeListener', common.mustCall(function(name, cb) {
-  if (cb !== remove1) return;
-  this.removeListener('quux', remove2);
-  this.emit('quux');
-}, 2));
-e4.on('quux', remove1);
-e4.on('quux', remove2);
-e4.removeListener('quux', remove1);
-
-var e5 = new events.EventEmitter();
-e5.on('hello', listener1);
-e5.on('hello', listener2);
-e5.once('removeListener', common.mustCall(function(name, cb) {
-  assert.equal(name, 'hello');
-  assert.equal(cb, listener1);
-  assert.deepEqual([listener2], e5.listeners('hello'));
-  e5.once('removeListener', common.mustCall(function(name, cb) {
-    assert.equal(name, 'hello');
-    assert.equal(cb, listener2);
-    assert.deepEqual([], e5.listeners('hello'));
+{
+  const ee = new EventEmitter();
+  ee.on('hello', listener1);
+  ee.on('removeListener', common.mustCall((name, cb) => {
+    assert.strictEqual(name, 'hello');
+    assert.strictEqual(cb, listener1);
   }));
-  e5.removeListener('hello', listener2);
-  assert.deepEqual([], e5.listeners('hello'));
-}));
-e5.removeListener('hello', listener1);
-assert.deepEqual([], e5.listeners('hello'));
+  ee.removeListener('hello', listener1);
+  assert.deepStrictEqual([], ee.listeners('hello'));
+}
 
-const e6 = new events.EventEmitter();
+{
+  const ee = new EventEmitter();
+  ee.on('hello', listener1);
+  ee.on('removeListener', common.fail);
+  ee.removeListener('hello', listener2);
+  assert.deepStrictEqual([listener1], ee.listeners('hello'));
+}
 
-const listener3 = common.mustCall(() => {
-  e6.removeListener('hello', listener4);
-}, 2);
+{
+  const ee = new EventEmitter();
+  ee.on('hello', listener1);
+  ee.on('hello', listener2);
+  ee.once('removeListener', common.mustCall((name, cb) => {
+    assert.strictEqual(name, 'hello');
+    assert.strictEqual(cb, listener1);
+    assert.deepStrictEqual([listener2], ee.listeners('hello'));
+  }));
+  ee.removeListener('hello', listener1);
+  assert.deepStrictEqual([listener2], ee.listeners('hello'));
+  ee.once('removeListener', common.mustCall((name, cb) => {
+    assert.strictEqual(name, 'hello');
+    assert.strictEqual(cb, listener2);
+    assert.deepStrictEqual([], ee.listeners('hello'));
+  }));
+  ee.removeListener('hello', listener2);
+  assert.deepStrictEqual([], ee.listeners('hello'));
+}
 
-const listener4 = common.mustCall(() => {}, 1);
+{
+  const ee = new EventEmitter();
 
-e6.on('hello', listener3);
-e6.on('hello', listener4);
+  function remove1() {
+    common.fail('remove1 should not have been called');
+  }
 
-// listener4 will still be called although it is removed by listener 3.
-e6.emit('hello');
-// This is so because the interal listener array at time of emit
-// was [listener3,listener4]
+  function remove2() {
+    common.fail('remove2 should not have been called');
+  }
 
-// Interal listener array [listener3]
-e6.emit('hello');
+  ee.on('removeListener', common.mustCall(function(name, cb) {
+    if (cb !== remove1) return;
+    this.removeListener('quux', remove2);
+    this.emit('quux');
+  }, 2));
+  ee.on('quux', remove1);
+  ee.on('quux', remove2);
+  ee.removeListener('quux', remove1);
+}
 
-const e7 = new events.EventEmitter();
+{
+  const ee = new EventEmitter();
+  ee.on('hello', listener1);
+  ee.on('hello', listener2);
+  ee.once('removeListener', common.mustCall((name, cb) => {
+    assert.strictEqual(name, 'hello');
+    assert.strictEqual(cb, listener1);
+    assert.deepStrictEqual([listener2], ee.listeners('hello'));
+    ee.once('removeListener', common.mustCall((name, cb) => {
+      assert.strictEqual(name, 'hello');
+      assert.strictEqual(cb, listener2);
+      assert.deepStrictEqual([], ee.listeners('hello'));
+    }));
+    ee.removeListener('hello', listener2);
+    assert.deepStrictEqual([], ee.listeners('hello'));
+  }));
+  ee.removeListener('hello', listener1);
+  assert.deepStrictEqual([], ee.listeners('hello'));
+}
 
-const listener5 = () => {};
+{
+  const ee = new EventEmitter();
+  const listener3 = common.mustCall(() => {
+    ee.removeListener('hello', listener4);
+  }, 2);
+  const listener4 = common.mustCall(() => {});
 
-e7.once('hello', listener5);
-e7.on('removeListener', common.mustCall((eventName, listener) => {
-  assert.strictEqual(eventName, 'hello');
-  assert.strictEqual(listener, listener5);
-}));
-e7.emit('hello');
+  ee.on('hello', listener3);
+  ee.on('hello', listener4);
+
+  // listener4 will still be called although it is removed by listener 3.
+  ee.emit('hello');
+  // This is so because the interal listener array at time of emit
+  // was [listener3,listener4]
+
+  // Interal listener array [listener3]
+  ee.emit('hello');
+}
+
+{
+  const ee = new EventEmitter();
+
+  ee.once('hello', listener1);
+  ee.on('removeListener', common.mustCall((eventName, listener) => {
+    assert.strictEqual(eventName, 'hello');
+    assert.strictEqual(listener, listener1);
+  }));
+  ee.emit('hello');
+}


### PR DESCRIPTION
This is a backport of #6446 for v4.

R= @TheAlphaNerd 