### PR TITLE
Backport: assert: Fix deepEqual/deepStrictEqual on equivalent typed arrays

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -176,8 +176,13 @@ function _deepEqual(actual, expected, strict, memos) {
              pToString(actual) === pToString(expected) &&
              !(actual instanceof Float32Array ||
                actual instanceof Float64Array)) {
-    return compare(new Buffer(actual.buffer),
-                   new Buffer(expected.buffer)) === 0;
+    return compare(
+      new Buffer(actual.buffer).slice(actual.byteOffset,
+                                      actual.byteOffset +
+                                      actual.byteLength),
+      new Buffer(expected.buffer).slice(expected.byteOffset,
+                                        expected.byteOffset +
+                                        expected.byteLength)) === 0;
 
   // 7.5 For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -25,7 +25,10 @@ const equalArrayPairs = [
   [new Int16Array([256]), new Uint16Array([256])],
   [new Float32Array([+0.0]), new Float32Array([-0.0])],
   [new Float64Array([+0.0]), new Float32Array([-0.0])],
-  [new Float64Array([+0.0]), new Float64Array([-0.0])]
+  [new Float64Array([+0.0]), new Float64Array([-0.0])],
+  [new Uint8Array([1, 2, 3, 4]).subarray(1), new Uint8Array([2, 3, 4])],
+  [new Uint16Array([1, 2, 3, 4]).subarray(1), new Uint16Array([2, 3, 4])],
+  [new Uint32Array([1, 2, 3, 4]).subarray(1, 3), new Uint32Array([2, 3])]
 ];
 
 const notEqualArrayPairs = [


### PR DESCRIPTION
This is a backport of #8002 to v4.

Note, the exact API used to implement this doesn't seem to exist in v4, so I combined `new Buffer()` and `slice()`.

R= @TheAlphaNerd @feross 