### PR TITLE
tools: remove unneeded escaping in generate.js

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -13,14 +13,14 @@ let inputFile = null;
 let nodeVersion = null;
 
 args.forEach(function(arg) {
-  if (!arg.match(/^\-\-/)) {
+  if (!arg.match(/^--/)) {
     inputFile = arg;
-  } else if (arg.match(/^\-\-format=/)) {
-    format = arg.replace(/^\-\-format=/, '');
-  } else if (arg.match(/^\-\-template=/)) {
-    template = arg.replace(/^\-\-template=/, '');
-  } else if (arg.match(/^\-\-node\-version=/)) {
-    nodeVersion = arg.replace(/^\-\-node\-version=/, '');
+  } else if (arg.match(/^--format=/)) {
+    format = arg.replace(/^--format=/, '');
+  } else if (arg.match(/^--template=/)) {
+    template = arg.replace(/^--template=/, '');
+  } else if (arg.match(/^--node-version=/)) {
+    nodeVersion = arg.replace(/^--node-version=/, '');
   }
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

`-` does not need to be escaped in a regular expression outside of
character classes.