### PR TITLE
benchmark: reformat code for clarity

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -15,8 +15,13 @@ function AutocannonBenchmarker() {
 }
 
 AutocannonBenchmarker.prototype.create = function(options) {
-  const args = ['-d', options.duration, '-c', options.connections, '-j', '-n',
-                `http://127.0.0.1:${options.port}${options.path}` ];
+  const args = [
+    '-d', options.duration,
+    '-c', options.connections,
+    '-j',
+    '-n',
+    `http://127.0.0.1:${options.port}${options.path}`
+  ];
   const child = child_process.spawn(this.autocannon_exe, args);
   return child;
 };
@@ -43,8 +48,12 @@ function WrkBenchmarker() {
 }
 
 WrkBenchmarker.prototype.create = function(options) {
-  const args = ['-d', options.duration, '-c', options.connections, '-t', 8,
-                `http://127.0.0.1:${options.port}${options.path}` ];
+  const args = [
+    '-d', options.duration,
+    '-c', options.connections,
+    '-t', 8,
+    `http://127.0.0.1:${options.port}${options.path}`
+  ];
   const child = child_process.spawn('wrk', args);
   return child;
 };
@@ -59,8 +68,7 @@ WrkBenchmarker.prototype.processResults = function(output) {
   }
 };
 
-const http_benchmarkers = [ new WrkBenchmarker(),
-                            new AutocannonBenchmarker() ];
+const http_benchmarkers = [new WrkBenchmarker(), new AutocannonBenchmarker()];
 
 const benchmarkers = {};
 

--- a/benchmark/arrays/var-int.js
+++ b/benchmark/arrays/var-int.js
@@ -1,9 +1,21 @@
 'use strict';
 var common = require('../common.js');
+
+var types = [
+  'Array',
+  'Buffer',
+  'Int8Array',
+  'Uint8Array',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array'
+];
+
 var bench = common.createBenchmark(main, {
-  type: ['Array', 'Buffer', 'Int8Array', 'Uint8Array', 'Int16Array',
-         'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
-         'Float64Array'],
+  type: types,
   n: [25]
 });
 

--- a/benchmark/arrays/zero-float.js
+++ b/benchmark/arrays/zero-float.js
@@ -1,9 +1,21 @@
 'use strict';
 var common = require('../common.js');
+
+var types = [
+  'Array',
+  'Buffer',
+  'Int8Array',
+  'Uint8Array',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array'
+];
+
 var bench = common.createBenchmark(main, {
-  type: ['Array', 'Buffer', 'Int8Array', 'Uint8Array', 'Int16Array',
-         'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
-         'Float64Array'],
+  type: types,
   n: [25]
 });
 

--- a/benchmark/arrays/zero-int.js
+++ b/benchmark/arrays/zero-int.js
@@ -1,9 +1,21 @@
 'use strict';
 var common = require('../common.js');
+
+var types = [
+  'Array',
+  'Buffer',
+  'Int8Array',
+  'Uint8Array',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array'
+];
+
 var bench = common.createBenchmark(main, {
-  type: ['Array', 'Buffer', 'Int8Array', 'Uint8Array', 'Int16Array',
-         'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
-         'Float64Array'],
+  type: types,
   n: [25]
 });
 

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {});
 function main(conf) {
   const s = 'abcd'.repeat(8 << 20);
   s.match(/./);  // Flatten string.
-  assert.equal(s.length % 4, 0);
+  assert.strictEqual(s.length % 4, 0);
   const b = Buffer.allocUnsafe(s.length / 4 * 3);
   b.write(s, 0, s.length, 'base64');
   bench.start();

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -3,12 +3,26 @@ var common = require('../common.js');
 var fs = require('fs');
 const path = require('path');
 
+const searchStrings = [
+  '@',
+  'SQ',
+  '10x',
+  '--l',
+  'Alice',
+  'Gryphon',
+  'Panther',
+  'Ou est ma chatte?',
+  'found it very',
+  'among mad people',
+  'neighbouring pool',
+  'Soo--oop',
+  'aaaaaaaaaaaaaaaaa',
+  'venture to go near the house till she had brought herself down to',
+  '</i> to the Caterpillar'
+];
+
 var bench = common.createBenchmark(main, {
-  search: ['@', 'SQ', '10x', '--l', 'Alice', 'Gryphon', 'Panther',
-           'Ou est ma chatte?', 'found it very', 'among mad people',
-           'neighbouring pool', 'Soo--oop', 'aaaaaaaaaaaaaaaaa',
-           'venture to go near the house till she had brought herself down to',
-           '</i> to the Caterpillar'],
+  search: searchStrings,
   encoding: ['undefined', 'utf8', 'ucs2', 'binary'],
   type: ['buffer', 'string'],
   iter: [1]

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -1,15 +1,27 @@
 'use strict';
 var common = require('../common.js');
 
+var types = [
+  'UInt8',
+  'UInt16LE',
+  'UInt16BE',
+  'UInt32LE',
+  'UInt32BE',
+  'Int8',
+  'Int16LE',
+  'Int16BE',
+  'Int32LE',
+  'Int32BE',
+  'FloatLE',
+  'FloatBE',
+  'DoubleLE',
+  'DoubleBE'
+];
+
 var bench = common.createBenchmark(main, {
   noAssert: ['false', 'true'],
   buffer: ['fast', 'slow'],
-  type: ['UInt8', 'UInt16LE', 'UInt16BE',
-         'UInt32LE', 'UInt32BE',
-         'Int8', 'Int16LE', 'Int16BE',
-         'Int32LE', 'Int32BE',
-         'FloatLE', 'FloatBE',
-         'DoubleLE', 'DoubleBE'],
+  type: types,
   millions: [1]
 });
 

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -1,14 +1,27 @@
 'use strict';
 var common = require('../common.js');
+
+var types = [
+  'UInt8',
+  'UInt16LE',
+  'UInt16BE',
+  'UInt32LE',
+  'UInt32BE',
+  'Int8',
+  'Int16LE',
+  'Int16BE',
+  'Int32LE',
+  'Int32BE',
+  'FloatLE',
+  'FloatBE',
+  'DoubleLE',
+  'DoubleBE'
+];
+
 var bench = common.createBenchmark(main, {
   noAssert: ['false', 'true'],
   buffer: ['fast', 'slow'],
-  type: ['UInt8', 'UInt16LE', 'UInt16BE',
-         'UInt32LE', 'UInt32BE',
-         'Int8', 'Int16LE', 'Int16BE',
-         'Int32LE', 'Int32BE',
-         'FloatLE', 'FloatBE',
-         'DoubleLE', 'DoubleBE'],
+  type: types,
   millions: [1]
 });
 

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -1,12 +1,25 @@
 'use strict';
 var common = require('../common.js');
+
+var types = [
+  'Uint8',
+  'Uint16LE',
+  'Uint16BE',
+  'Uint32LE',
+  'Uint32BE',
+  'Int8',
+  'Int16LE',
+  'Int16BE',
+  'Int32LE',
+  'Int32BE',
+  'Float32LE',
+  'Float32BE',
+  'Float64LE',
+  'Float64BE'
+];
+
 var bench = common.createBenchmark(main, {
-  type: ['Uint8', 'Uint16LE', 'Uint16BE',
-         'Uint32LE', 'Uint32BE',
-         'Int8', 'Int16LE', 'Int16BE',
-         'Int32LE', 'Int32BE',
-         'Float32LE', 'Float32BE',
-         'Float64LE', 'Float64BE'],
+  type: types,
   millions: [1]
 });
 

--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -15,7 +15,7 @@ function runObject(n) {
   for (; i < n; i++) {
     m['i' + i] = i;
     m['s' + i] = String(i);
-    assert.equal(m['i' + i], m['s' + i]);
+    assert.strictEqual(String(m['i' + i]), m['s' + i]);
     m['i' + i] = undefined;
     m['s' + i] = undefined;
   }
@@ -29,7 +29,7 @@ function runNullProtoObject(n) {
   for (; i < n; i++) {
     m['i' + i] = i;
     m['s' + i] = String(i);
-    assert.equal(m['i' + i], m['s' + i]);
+    assert.strictEqual(String(m['i' + i]), m['s' + i]);
     m['i' + i] = undefined;
     m['s' + i] = undefined;
   }
@@ -53,7 +53,7 @@ function runFakeMap(n) {
   for (; i < n; i++) {
     m.set('i' + i, i);
     m.set('s' + i, String(i));
-    assert.equal(m.get('i' + i), m.get('s' + i));
+    assert.strictEqual(String(m.get('i' + i)), m.get('s' + i));
     m.set('i' + i, undefined);
     m.set('s' + i, undefined);
   }
@@ -67,7 +67,7 @@ function runMap(n) {
   for (; i < n; i++) {
     m.set('i' + i, i);
     m.set('s' + i, String(i));
-    assert.equal(m.get('i' + i), m.get('s' + i));
+    assert.strictEqual(String(m.get('i' + i)), m.get('s' + i));
     m.set('i' + i, undefined);
     m.set('s' + i, undefined);
   }

--- a/benchmark/http/_http_simple.js
+++ b/benchmark/http/_http_simple.js
@@ -75,8 +75,11 @@ var server = module.exports = http.createServer(function(req, res) {
     body = fixed;
 
   } else if (command === 'echo') {
-    res.writeHead(200, { 'Content-Type': 'text/plain',
-                         'Transfer-Encoding': 'chunked' });
+    const headers = {
+      'Content-Type': 'text/plain',
+      'Transfer-Encoding': 'chunked'
+    };
+    res.writeHead(200, headers);
     req.pipe(res);
     return;
 
@@ -88,8 +91,11 @@ var server = module.exports = http.createServer(function(req, res) {
   // example: http://localhost:port/bytes/512/4
   // sends a 512 byte body in 4 chunks of 128 bytes
   if (n_chunks > 0) {
-    res.writeHead(status, { 'Content-Type': 'text/plain',
-                            'Transfer-Encoding': 'chunked' });
+    const headers = {
+      'Content-Type': 'text/plain',
+      'Transfer-Encoding': 'chunked'
+    };
+    res.writeHead(status, headers);
     // send body in chunks
     var len = body.length;
     var step = Math.floor(len / n_chunks) || 1;
@@ -99,10 +105,12 @@ var server = module.exports = http.createServer(function(req, res) {
     }
     res.end(body.slice((n_chunks - 1) * step));
   } else {
-    var content_length = body.length.toString();
+    const headers = {
+      'Content-Type': 'text/plain',
+      'Content-Length': body.length.toString()
+    };
 
-    res.writeHead(status, { 'Content-Type': 'text/plain',
-                            'Content-Length': content_length });
+    res.writeHead(status, headers);
     res.end(body);
   }
 });

--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -21,8 +21,11 @@ try {
 } catch (e) { /* ignore */ }
 
 server = http.createServer(function(req, res) {
-  res.writeHead(200, { 'content-type': 'text/plain',
-                       'content-length': '2' });
+  var headers = {
+    'content-type': 'text/plain',
+    'content-length': '2'
+  };
+  res.writeHead(200, headers);
   res.end('ok');
 });
 

--- a/benchmark/misc/console.js
+++ b/benchmark/misc/console.js
@@ -8,11 +8,15 @@ const v8 = require('v8');
 
 v8.setFlagsFromString('--allow_natives_syntax');
 
+const methods = [
+  'restAndSpread',
+  'argumentsAndApply',
+  'restAndApply',
+  'restAndConcat'
+];
+
 var bench = common.createBenchmark(main, {
-  method: ['restAndSpread',
-           'argumentsAndApply',
-           'restAndApply',
-           'restAndConcat'],
+  method: methods,
   concat: [1, 0],
   n: [1000000]
 });

--- a/benchmark/querystring/querystring-parse.js
+++ b/benchmark/querystring/querystring-parse.js
@@ -3,14 +3,18 @@ var common = require('../common.js');
 var querystring = require('querystring');
 var v8 = require('v8');
 
+var types = [
+  'noencode',
+  'multicharsep',
+  'encodemany',
+  'encodelast',
+  'multivalue',
+  'multivaluemany',
+  'manypairs'
+];
+
 var bench = common.createBenchmark(main, {
-  type: ['noencode',
-         'multicharsep',
-         'encodemany',
-         'encodelast',
-         'multivalue',
-         'multivaluemany',
-         'manypairs'],
+  type: types,
   n: [1e6],
 });
 

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -37,10 +37,12 @@ function main(conf) {
       throw new Error('invalid type');
   }
 
-  options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
-              cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
-              ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
-              ciphers: 'AES256-GCM-SHA384' };
+  options = {
+    key: fs.readFileSync(cert_dir + '/test_key.pem'),
+    cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
+    ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+    ciphers: 'AES256-GCM-SHA384'
+  };
 
   server = tls.createServer(options, onConnection);
   setTimeout(done, dur * 1000);

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -20,11 +20,13 @@ function main(conf) {
   dur = +conf.dur;
   concurrency = +conf.concurrency;
 
-  var cert_dir = path.resolve(__dirname, '../../test/fixtures'),
-    options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
-                cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
-                ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
-                ciphers: 'AES256-GCM-SHA384' };
+  var cert_dir = path.resolve(__dirname, '../../test/fixtures');
+  var options = {
+    key: fs.readFileSync(cert_dir + '/test_key.pem'),
+    cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
+    ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+    ciphers: 'AES256-GCM-SHA384'
+  };
 
   server = tls.createServer(options, onConnection);
   server.listen(common.PORT, onListening);
@@ -42,8 +44,11 @@ function onConnection(conn) {
 }
 
 function makeConnection() {
-  var conn = tls.connect({ port: common.PORT,
-                           rejectUnauthorized: false }, function() {
+  var options = {
+    port: common.PORT,
+    rejectUnauthorized: false
+  };
+  var conn = tls.connect(options, function() {
     clientConn++;
     conn.on('error', function(er) {
       console.error('client error', er);

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -3,13 +3,16 @@
 const util = require('util');
 const common = require('../common');
 const v8 = require('v8');
+const types = [
+  'string',
+  'number',
+  'object',
+  'unknown',
+  'no-replace'
+];
 const bench = common.createBenchmark(main, {
   n: [1e6],
-  type: ['string',
-         'number',
-         'object',
-         'unknown',
-         'no-replace']
+  type: types
 });
 
 const inputs = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark

##### Description of change
<!-- Provide a description of the change below this comment. -->

Some of the benchmark code can be a little dense. Not *very* hard to read
but perhaps harder than it needs to be. 

These changes (many of them whitespace-only) hopefully
improve readability.

There are also a few cases of `assert.equal()` that are changed to `assert.strictEqual()`.