### PR TITLE
test: fix flaky test-cluster-dgram-2

### DIFF
--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -57,6 +57,13 @@ function worker() {
   // send(), explicitly bind them to an ephemeral port.
   socket.bind(0);
 
-  for (var i = 0; i < PACKETS_PER_WORKER; i++)
+  // There is no guarantee that a sent dgram packet will be received so keep
+  // sending until disconnect.
+  const interval = setInterval(() => {
     socket.send(buf, 0, buf.length, common.PORT, '127.0.0.1');
+  }, 1);
+
+  cluster.worker.on('disconnect', () => {
+    clearInterval(interval);
+  });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test cluster

##### Description of change
<!-- Provide a description of the change below this comment. -->

There is no guarantee that a dgram packet will be received. The test is
currently written to only send exactly as many dgram packets as required
assuming they are all received. As a result, failures like this may
occur (from CI):

```
not ok 719 parallel/test-cluster-dgram-2
  ---
  duration_ms: 120.39
  severity: fail
  stack: |-
    timeout
```

This change has the workers send packets continuously until disconnect.

Ref: https://ci.nodejs.org/job/node-test-commit-arm/6044/nodes=armv7-ubuntu1404/console