### PR TITLE
doc: clarifying variables in fs.write()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1827,7 +1827,8 @@ added: v0.0.2
 
 Write `buffer` to the file specified by `fd`.
 
-`offset` and `length` determine the part of the buffer to be written.
+`offset` determines the part of the buffer to be written, and `length` is
+an integer specifying the number of bytes to write.
 
 `position` refers to the offset from the beginning of the file where this data
 should be written. If `typeof position !== 'number'`, the data will be written


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] documentation is changed or added
- [ x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

This commit clarifies variables in the Filesystem docs.
Prior, the documentation for fs.write() had an ambiguous
remark on the parameters of offset and length.

Therefore, this commit makes explicit that the length parameter
in fs.write() is used to denote the number of bytes, which is
a clearer reference for its usage.

Ref: #7868