### PR TITLE
doc: small fixes in the buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2293,7 +2293,7 @@ Returns the maximum number of bytes that will be returned when
 `buf.inspect()` is called. This can be overridden by user modules. See
 [`util.inspect()`] for more details on `buf.inspect()` behavior.
 
-Note that this is a property on the `buffer` module as returned by
+Note that this is a property on the `buffer` module returned by
 `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
 
 ## buffer.kMaxLength
@@ -2306,7 +2306,7 @@ added: v3.0.0
 On 32-bit architectures, this value is `(2^30)-1` (~1GB).
 On 64-bit architectures, this value is `(2^31)-1` (~2GB).
 
-Note that this is a property on the `buffer` module as returned by
+Note that this is a property on the `buffer` module returned by
 `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
 
 ## buffer.transcode(source, fromEnc, toEnc)
@@ -2338,7 +2338,7 @@ console.log(newBuf.toString('ascii'));
 Because the Euro (`€`) sign is not representable in US-ASCII, it is replaced
 with `?` in the transcoded `Buffer`.
 
-Note that this is a property on the `buffer` module as returned by
+Note that this is a property on the `buffer` module returned by
 `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
 
 ## Class: SlowBuffer

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,4 +1,4 @@
-# Buffer
+﻿# Buffer
 
 > Stability: 2 - Stable
 
@@ -282,7 +282,7 @@ const buf = Buffer.from([1, 2, 3]);
 //   1
 //   2
 //   3
-for (var b of buf) {
+for (const b of buf) {
   console.log(b);
 }
 ```
@@ -995,7 +995,7 @@ overlapping region within the same `Buffer`
 ```js
 const buf = Buffer.allocUnsafe(26);
 
-for (var i = 0 ; i < 26 ; i++) {
+for (let i = 0 ; i < 26 ; i++) {
   // 97 is the decimal ASCII value for 'a'
   buf[i] = i + 97;
 }
@@ -1028,7 +1028,7 @@ const buf = Buffer.from('buffer');
 //   [3, 102]
 //   [4, 101]
 //   [5, 114]
-for (var pair of buf.entries()) {
+for (const pair of buf.entries()) {
   console.log(pair);
 }
 ```
@@ -1212,7 +1212,7 @@ const buf = Buffer.from('buffer');
 //   3
 //   4
 //   5
-for (var key of buf.keys()) {
+for (const key of buf.keys()) {
   console.log(key);
 }
 ```
@@ -1302,7 +1302,7 @@ use [`buf.slice()`] to create a new `Buffer`.
 Examples:
 
 ```js
-var buf = Buffer.allocUnsafe(10);
+let buf = Buffer.allocUnsafe(10);
 
 buf.write('abcdefghj', 0, 'ascii');
 
@@ -1673,7 +1673,7 @@ one byte from the original `Buffer`
 ```js
 const buf1 = Buffer.allocUnsafe(26);
 
-for (var i = 0 ; i < 26 ; i++) {
+for (let i = 0 ; i < 26 ; i++) {
   // 97 is the decimal ASCII value for 'a'
   buf1[i] = i + 97;
 }
@@ -1822,7 +1822,7 @@ Examples:
 ```js
 const buf1 = Buffer.allocUnsafe(26);
 
-for (var i = 0 ; i < 26 ; i++) {
+for (let i = 0 ; i < 26 ; i++) {
   // 97 is the decimal ASCII value for 'a'
   buf1[i] = i + 97;
 }
@@ -1897,7 +1897,7 @@ const buf = Buffer.from('buffer');
 //   102
 //   101
 //   114
-for (var value of buf.values()) {
+for (const value of buf.values()) {
   console.log(value);
 }
 
@@ -1908,7 +1908,7 @@ for (var value of buf.values()) {
 //   102
 //   101
 //   114
-for (var value of buf) {
+for (const value of buf) {
   console.log(value);
 }
 ```

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1509,10 +1509,10 @@ Examples:
 ```js
 const buf = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
 
-// Prints: 1234567890ab
+// Prints: -546f87a9cbee
 console.log(buf.readIntLE(0, 6).toString(16));
 
-// Prints: -546f87a9cbee
+// Prints: 1234567890ab
 console.log(buf.readIntBE(0, 6).toString(16));
 
 // Throws an exception: RangeError: Index out of range
@@ -1737,7 +1737,7 @@ console.log(buf1);
 const buf2 = Buffer.from([0x1, 0x2, 0x3]);
 
 // Throws an exception: RangeError: Buffer size must be a multiple of 16-bits
-buf2.swap32();
+buf2.swap16();
 ```
 
 ### buf.swap32()

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2328,6 +2328,8 @@ The transcoding process will use substitution characters if a given byte
 sequence cannot be adequately represented in the target encoding. For instance:
 
 ```js
+const buffer = require('buffer');
+
 const newBuf = buffer.transcode(Buffer.from('€'), 'utf8', 'ascii');
 console.log(newBuf.toString('ascii'));
 // Prints: '?'

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1122,7 +1122,7 @@ Examples:
 const buf = Buffer.from('this is a buffer');
 
 // Prints: 0
-console.log(buf.indexOf('this')));
+console.log(buf.indexOf('this'));
 
 // Prints: 2
 console.log(buf.indexOf('is'));

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2306,6 +2306,9 @@ added: v3.0.0
 On 32-bit architectures, this value is `(2^30)-1` (~1GB).
 On 64-bit architectures, this value is `(2^31)-1` (~2GB).
 
+Note that this is a property on the `buffer` module as returned by
+`require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
+
 ## buffer.transcode(source, fromEnc, toEnc)
 <!-- YAML
 added: v7.1.0
@@ -2332,6 +2335,9 @@ console.log(newBuf.toString('ascii'));
 
 Because the Euro (`€`) sign is not representable in US-ASCII, it is replaced
 with `?` in the transcoded `Buffer`.
+
+Note that this is a property on the `buffer` module as returned by
+`require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
 
 ## Class: SlowBuffer
 <!-- YAML

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1223,7 +1223,7 @@ added: v6.0.0
 -->
 
 * `value` {String | Buffer | Integer} What to search for
-* `byteOffset` {Integer} Where to begin searching in `buf` (not inclusive).
+* `byteOffset` {Integer} Where to begin searching in `buf`.
   **Default:** [`buf.length`]
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1264,7 +1264,7 @@ console.log(buf.lastIndexOf('buffer', 4));
 const utf16Buffer = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
 
 // Prints: 6
-console.log(utf16Buffer.lastIndexOf('\u03a3', null, 'ucs2'));
+console.log(utf16Buffer.lastIndexOf('\u03a3', undefined, 'ucs2'));
 
 // Prints: 4
 console.log(utf16Buffer.lastIndexOf('\u03a3', -5, 'ucs2'));
@@ -1446,7 +1446,7 @@ const buf = Buffer.from([0, 5]);
 console.log(buf.readInt16BE());
 
 // Prints: 1280
-console.log(buf.readInt16LE(1));
+console.log(buf.readInt16LE());
 
 // Throws an exception: RangeError: Index out of range
 console.log(buf.readInt16LE(1));

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1224,7 +1224,7 @@ added: v6.0.0
 
 * `value` {String | Buffer | Integer} What to search for
 * `byteOffset` {Integer} Where to begin searching in `buf`.
-  **Default:** [`buf.length`]
+  **Default:** [`buf.length`]` - 1`
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
 * Returns: {Integer} The index of the last occurrence of `value` in `buf` or `-1`

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,4 +1,4 @@
-﻿# Buffer
+# Buffer
 
 > Stability: 2 - Stable
 
@@ -404,14 +404,14 @@ to initialize a `Buffer` to zeroes.
 Example:
 
 ```js
-const buf = new Buffer(5);
+const buf = new Buffer(10);
 
-// Prints: (contents may vary): <Buffer 78 e0 82 02 01>
+// Prints: (contents may vary): <Buffer 48 21 4b 00 00 00 00 00 30 dd>
 console.log(buf);
 
 buf.fill(0);
 
-// Prints: <Buffer 00 00 00 00 00>
+// Prints: <Buffer 00 00 00 00 00 00 00 00 00 00>
 console.log(buf);
 ```
 
@@ -523,14 +523,14 @@ initialized*. The contents of the newly created `Buffer` are unknown and
 Example:
 
 ```js
-const buf = Buffer.allocUnsafe(5);
+const buf = Buffer.allocUnsafe(10);
 
-// Prints: (contents may vary): <Buffer 78 e0 82 02 01>
+// Prints: (contents may vary): <Buffer a0 8b 28 3f 01 00 00 00 50 32>
 console.log(buf);
 
 buf.fill(0);
 
-// Prints: <Buffer 00 00 00 00 00>
+// Prints: <Buffer 00 00 00 00 00 00 00 00 00 00>
 console.log(buf);
 ```
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc, buffer

##### Description of change

1. `var` => `const` / `let`.
2. Fix a syntax error.
3. Fix wrong arguments in function calls*.
4. Fix some copy-paste artifacts.
5. Repeat the remark about buffer module property where it is needed.
6. Add a missing variable declaration.
7. Remove / fix wrong remarks in the buffer.md
8.  Fix examples in buffer.md to avoid confusion (fixes #9786)
9.  Remove an extraneous word in the buffer.md

*As to `null` => `undefined` in point 3, it is a temporary fix untill #9801 is addressed.
