### PR TITLE
fix crypto "Verify" typo

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -935,8 +935,8 @@ of two ways:
 - Using the [`verify.update()`][] and [`verify.verify()`][] methods to verify
   the signature.
 
-The [`crypto.createVerify()`][] method is used to create `Verify` instances. `Verify` 
-objects are not to be created directly using the `new` keyword.
+The [`crypto.createVerify()`][] method is used to create `Verify` instances.
+`Verify` objects are not to be created directly using the `new` keyword.
 
 Example: Using `Verify` objects as streams:
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -935,8 +935,8 @@ of two ways:
 - Using the [`verify.update()`][] and [`verify.verify()`][] methods to verify
   the signature.
 
-  The [`crypto.createSign()`][] method is used to create `Sign` instances.
-  `Sign` objects are not to be created directly using the `new` keyword.
+The [`crypto.createVerify()`][] method is used to create `Verify` instances. `Verify` 
+objects are not to be created directly using the `new` keyword.
 
 Example: Using `Verify` objects as streams:
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

fix crypto "Verify" typo
I am currently translating doc into Chinese, but I found this problem in the translation process.