### PR TITLE
test: known issue url.parse() does not return an empty string

### DIFF
--- a/test/known_issues/test-url-parse-return-empty-string.js
+++ b/test/known_issues/test-url-parse-return-empty-string.js
@@ -1,0 +1,80 @@
+'use strict';
+
+// Refs: https://github.com/nodejs/node/issues/9600
+
+const url = require('url');
+const assert = require('assert');
+
+var attempted = 0;
+var failed = 0;
+
+var emptyParseTests = {
+
+  'http:\\\\empty-auth:80?foobar': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'empty-auth',
+    hostname: 'empty-auth',
+    search: 'foobar',
+    auth: null,
+    port: 80
+  },
+
+  'http:\\\\empty-port#bar': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'empty-port',
+    hostname: 'empty-port',
+    port: null,
+    hash: 'bar'
+  },
+
+  'http:\\\\empty-hash?foo=bar': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'empty-hash',
+    hostname: 'empty-hash',
+    hash: null,
+    search: '?foo=@bar',
+    query: 'foo=@bar',
+    href: 'http://empty-hash'
+  },
+
+  'http:\\\\empty-search\\foo.html': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'empty-search',
+    hostname: 'empty-search',
+    pathname: 'foo.html',
+    path: 'foo.html',
+    search: null,
+    query: {},
+    href: 'http://empty-search/foo.html'
+  },
+
+  'http:\\\\empty-query\\': {
+    protocol: 'http:',
+    slashes: true,
+    host: 'empty-query',
+    hostname: 'empty-query',
+    search: '',
+    query: {},
+    href: 'http://empty-query/'
+  }
+};
+
+for (var instance in emptyParseTests) {
+
+  const parsed = url.parse(instance);
+  const prop = parsed.hostname.split('-')[1];
+
+  try {
+    attempted++;
+    assert.strictEqual(parsed[prop], '');
+  } catch (e) {
+    console.error(`expected ${prop} === ${parsed[prop]} to be an empty string`);
+    failed++;
+  }
+}
+
+assert.ok(failed === 0, `${failed} failed tests (out of ${attempted})`);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

url

##### Description of change
<!-- Provide a description of the change below this comment. -->

This creates a test for a known issue for url.parse().

Should there be empty keys set for search, query, hash, port, or auth,
url.parse() willl return a nulltype instead of an empty string.

Refs: https://github.com/nodejs/node/issues/9600