### PR TITLE
test: refactor and fix test-buffer-bytelength

### DIFF
--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -8,13 +8,13 @@ const vm = require('vm');
 
 // coerce values to string
 assert.throws(() => { Buffer.byteLength(32, 'latin1'); },
-              '"string" must be a string, Buffer, or ArrayBuffer');
+              /"string" must be a string, Buffer, or ArrayBuffer/);
 assert.throws(() => { Buffer.byteLength(NaN, 'utf8'); },
-              '"string" must be a string, Buffer, or ArrayBuffer');
+              /"string" must be a string, Buffer, or ArrayBuffer/);
 assert.throws(() => { Buffer.byteLength({}, 'latin1'); },
-              '"string" must be a string, Buffer, or ArrayBuffer');
+              /"string" must be a string, Buffer, or ArrayBuffer/);
 assert.throws(() => { Buffer.byteLength(); },
-              '"string" must be a string, Buffer, or ArrayBuffer');
+              /"string" must be a string, Buffer, or ArrayBuffer/);
 
 assert(ArrayBuffer.isView(new Buffer(10)));
 assert(ArrayBuffer.isView(new SlowBuffer(10)));
@@ -31,7 +31,7 @@ assert.strictEqual(Buffer.byteLength(ascii), 3);
 
 // ArrayBuffer
 var buffer = new ArrayBuffer(8);
-assert.equal(Buffer.byteLength(buffer), 8);
+assert.strictEqual(Buffer.byteLength(buffer), 8);
 
 // TypedArray
 var int8 = new Int8Array(8);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->

* assert.equal -> assert.strictEqual.
* Fix incorrect use of string instead of RegExp in `throws` assertions.