### PR TITLE
test: refactor test-crypto-binary-default

### DIFF
--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -3,30 +3,30 @@
 // to use buffers by default.
 
 
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var crypto = require('crypto');
-var tls = require('tls');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const tls = require('tls');
 const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
 
 crypto.DEFAULT_ENCODING = 'latin1';
 
-var fs = require('fs');
-var path = require('path');
-
 // Test Certificates
-var certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
-var certPfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
-var keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
-var rsaPubPem = fs.readFileSync(common.fixturesDir + '/test_rsa_pubkey.pem',
-    'ascii');
-var rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
-    'ascii');
+const certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
+const certPfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
+const keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
+const rsaPubPem = fs.readFileSync(common.fixturesDir + '/test_rsa_pubkey.pem',
+                                  'ascii');
+const rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
+                                  'ascii');
 
 // PFX tests
 assert.doesNotThrow(function() {
@@ -35,22 +35,22 @@ assert.doesNotThrow(function() {
 
 assert.throws(function() {
   tls.createSecureContext({pfx: certPfx});
-}, 'mac verify failure');
+}, /^Error: mac verify failure$/);
 
 assert.throws(function() {
   tls.createSecureContext({pfx: certPfx, passphrase: 'test'});
-}, 'mac verify failure');
+}, /^Error: mac verify failure$/);
 
 assert.throws(function() {
   tls.createSecureContext({pfx: 'sample', passphrase: 'test'});
-}, 'not enough data');
+}, /^Error: not enough data$/);
 
 // Test HMAC
 const hmacHash = crypto.createHmac('sha1', 'Node')
                        .update('some data')
                        .update('to hmac')
                        .digest('hex');
-assert.equal(hmacHash, '19fd6e1ba73d9ed2224dd5094a71babe85d9a892', 'test HMAC');
+assert.strictEqual(hmacHash, '19fd6e1ba73d9ed2224dd5094a71babe85d9a892');
 
 // Test HMAC-SHA-* (rfc 4231 Test Cases)
 var rfc4231 = [
@@ -74,7 +74,7 @@ var rfc4231 = [
   {
     key: Buffer.from('4a656665', 'hex'), // 'Jefe'
     data: Buffer.from('7768617420646f2079612077616e7420666f72206e6f74686' +
-                     '96e673f', 'hex'), // 'what do ya want for nothing?'
+                      '96e673f', 'hex'), // 'what do ya want for nothing?'
     hmac: {
       sha224: 'a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44',
       sha256:
@@ -92,8 +92,8 @@ var rfc4231 = [
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'hex'),
     data: Buffer.from('ddddddddddddddddddddddddddddddddddddddddddddddddd' +
-                     'ddddddddddddddddddddddddddddddddddddddddddddddddddd',
-                     'hex'),
+                      'ddddddddddddddddddddddddddddddddddddddddddddddddddd',
+                      'hex'),
     hmac: {
       sha224: '7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea',
       sha256:
@@ -110,10 +110,10 @@ var rfc4231 = [
   },
   {
     key: Buffer.from('0102030405060708090a0b0c0d0e0f10111213141516171819',
-                    'hex'),
-    data: Buffer.from('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc' +
-                     'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd',
                      'hex'),
+    data: Buffer.from('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc' +
+                      'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd',
+                      'hex'),
     hmac: {
       sha224: '6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a',
       sha256:
@@ -143,15 +143,15 @@ var rfc4231 = [
   },
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaa', 'hex'),
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaa', 'hex'),
     // 'Test Using Larger Than Block-Size Key - Hash Key First'
     data: Buffer.from('54657374205573696e67204c6172676572205468616e20426' +
-                     'c6f636b2d53697a65204b6579202d2048617368204b657920' +
-                     '4669727374', 'hex'),
+                      'c6f636b2d53697a65204b6579202d2048617368204b657920' +
+                      '4669727374', 'hex'),
     hmac: {
       sha224: '95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e',
       sha256:
@@ -168,21 +168,21 @@ var rfc4231 = [
   },
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaa', 'hex'),
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaa', 'hex'),
     // 'This is a test using a larger than block-size key and a larger ' +
     // 'than block-size data. The key needs to be hashed before being ' +
     // 'used by the HMAC algorithm.'
     data: Buffer.from('5468697320697320612074657374207573696e672061206c6' +
-                     '172676572207468616e20626c6f636b2d73697a65206b6579' +
-                     '20616e642061206c6172676572207468616e20626c6f636b2' +
-                     'd73697a6520646174612e20546865206b6579206e65656473' +
-                     '20746f20626520686173686564206265666f7265206265696' +
-                     'e6720757365642062792074686520484d414320616c676f72' +
-                     '6974686d2e', 'hex'),
+                      '172676572207468616e20626c6f636b2d73697a65206b6579' +
+                      '20616e642061206c6172676572207468616e20626c6f636b2' +
+                      'd73697a6520646174612e20546865206b6579206e65656473' +
+                      '20746f20626520686173686564206265666f7265206265696' +
+                      'e6720757365642062792074686520484d414320616c676f72' +
+                      '6974686d2e', 'hex'),
     hmac: {
       sha224: '3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1',
       sha256:
@@ -207,9 +207,11 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
     if (rfc4231[i]['truncate']) {
       result = result.substr(0, 32); // first 128 bits == 32 hex chars
     }
-    assert.equal(rfc4231[i]['hmac'][hash],
-                 result,
-                 'Test HMAC-' + hash + ': Test case ' + (i + 1) + ' rfc 4231');
+    assert.strictEqual(
+      rfc4231[i]['hmac'][hash],
+      result,
+      `Test HMAC-${hash}: Test case ${i + 1} rfc 4231`
+    );
   }
 }
 
@@ -228,17 +230,17 @@ var rfc2202_md5 = [
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'hex'),
     data: Buffer.from('ddddddddddddddddddddddddddddddddddddddddddddddddd' +
-                     'ddddddddddddddddddddddddddddddddddddddddddddddddddd',
-                     'hex'),
+                      'ddddddddddddddddddddddddddddddddddddddddddddddddddd',
+                      'hex'),
     hmac: '56be34521d144c88dbb8c733f0e8b3f6'
   },
   {
     key: Buffer.from('0102030405060708090a0b0c0d0e0f10111213141516171819',
-                    'hex'),
-    data: Buffer.from('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc' +
-                     'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd' +
-                     'cdcdcdcdcd',
                      'hex'),
+    data: Buffer.from('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc' +
+                      'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd' +
+                      'cdcdcdcdcd',
+                      'hex'),
     hmac: '697eaf0aca3a3aea3a75164746ffaa79'
   },
   {
@@ -248,19 +250,19 @@ var rfc2202_md5 = [
   },
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaa',
-                    'hex'),
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaa',
+                     'hex'),
     data: 'Test Using Larger Than Block-Size Key - Hash Key First',
     hmac: '6b1ab7fe4bd7bf8f0b62e6ce61b9d0cd'
   },
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaa',
-                    'hex'),
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaa',
+                     'hex'),
     data:
         'Test Using Larger Than Block-Size Key and Larger Than One ' +
         'Block-Size Data',
@@ -281,18 +283,18 @@ var rfc2202_sha1 = [
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'hex'),
     data: Buffer.from('ddddddddddddddddddddddddddddddddddddddddddddd' +
-                     'ddddddddddddddddddddddddddddddddddddddddddddd' +
-                     'dddddddddd',
-                     'hex'),
+                      'ddddddddddddddddddddddddddddddddddddddddddddd' +
+                      'dddddddddd',
+                      'hex'),
     hmac: '125d7342b9ac11cd91a39af48aa17b4f63f175d3'
   },
   {
     key: Buffer.from('0102030405060708090a0b0c0d0e0f10111213141516171819',
-                    'hex'),
-    data: Buffer.from('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc' +
-                     'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd' +
-                     'cdcdcdcdcd',
                      'hex'),
+    data: Buffer.from('cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc' +
+                      'dcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd' +
+                      'cdcdcdcdcd',
+                      'hex'),
     hmac: '4c9007f4026250c6bc8414f9bf50c86c2d7235da'
   },
   {
@@ -302,19 +304,19 @@ var rfc2202_sha1 = [
   },
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaa',
-                    'hex'),
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaa',
+                     'hex'),
     data: 'Test Using Larger Than Block-Size Key - Hash Key First',
     hmac: 'aa4ae5e15272d00e95705637ce8a3b55ed402112'
   },
   {
     key: Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
-                    'aaaaaaaaaaaaaaaaaaaaaa',
-                    'hex'),
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' +
+                     'aaaaaaaaaaaaaaaaaaaaaa',
+                     'hex'),
     data:
         'Test Using Larger Than Block-Size Key and Larger Than One ' +
         'Block-Size Data',
@@ -329,7 +331,7 @@ for (let i = 0, l = rfc2202_md5.length; i < l; i++) {
       crypto.createHmac('md5', rfc2202_md5[i]['key'])
         .update(rfc2202_md5[i]['data'])
         .digest('hex'),
-      'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202'
+      `Test HMAC-MD5 : Test case ${i + 1} rfc 2202`
     );
   }
 }
@@ -339,7 +341,7 @@ for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
     crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
       .update(rfc2202_sha1[i]['data'])
       .digest('hex'),
-    'Test HMAC-SHA1 : Test case ' + (i + 1) + ' rfc 2202'
+    `Test HMAC-SHA1 : Test case ${i + 1} rfc 2202`
   );
 }
 
@@ -351,24 +353,27 @@ var a4 = crypto.createHash('sha1').update('Test123').digest('buffer');
 
 if (!common.hasFipsCrypto) {
   var a0 = crypto.createHash('md5').update('Test123').digest('latin1');
-  assert.equal(
+  assert.strictEqual(
     a0,
     'h\u00ea\u00cb\u0097\u00d8o\fF!\u00fa+\u000e\u0017\u00ca\u00bd\u008c',
     'Test MD5 as latin1'
   );
 }
 
-assert.equal(a1, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
+assert.strictEqual(a1, '8308651804facb7b9af8ffc53a33a22d6a1c8ac2', 'Test SHA1');
 
-assert.equal(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
-             'Test SHA256 as base64');
+assert.strictEqual(a2, '2bX1jws4GYKTlxhloUB09Z66PoJZW+y+hq5R8dnx9l4=',
+                   'Test SHA256 as base64');
 
-assert.equal(a3, '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
-                 '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
-                 '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
-                 '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
-                 '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
-             'Test SHA512 as assumed latin1');
+assert.strictEqual(
+  a3,
+  '\u00c1(4\u00f1\u0003\u001fd\u0097!O\'\u00d4C/&Qz\u00d4' +
+  '\u0094\u0015l\u00b8\u008dQ+\u00db\u001d\u00c4\u00b5}\u00b2' +
+  '\u00d6\u0092\u00a3\u00df\u00a2i\u00a1\u009b\n\n*\u000f' +
+  '\u00d7\u00d6\u00a2\u00a8\u0085\u00e3<\u0083\u009c\u0093' +
+  '\u00c2\u0006\u00da0\u00a1\u00879(G\u00ed\'',
+  'Test SHA512 as assumed latin1'
+);
 
 assert.deepStrictEqual(
   a4,
@@ -379,7 +384,7 @@ assert.deepStrictEqual(
 // Test multiple updates to same hash
 var h1 = crypto.createHash('sha1').update('Test123').digest('hex');
 var h2 = crypto.createHash('sha1').update('Test').update('123').digest('hex');
-assert.equal(h1, h2, 'multipled updates');
+assert.strictEqual(h1, h2, 'multipled updates');
 
 // Test hashing for binary files
 var fn = path.join(common.fixturesDir, 'sample.png');
@@ -388,16 +393,18 @@ var fileStream = fs.createReadStream(fn);
 fileStream.on('data', function(data) {
   sha1Hash.update(data);
 });
-fileStream.on('close', function() {
-  assert.equal(sha1Hash.digest('hex'),
-               '22723e553129a336ad96e10f6aecdf0f45e4149e',
-               'Test SHA1 of sample.png');
-});
+fileStream.on('close', common.mustCall(function() {
+  assert.strictEqual(
+    sha1Hash.digest('hex'),
+    '22723e553129a336ad96e10f6aecdf0f45e4149e',
+    'Test SHA1 of sample.png'
+  );
+}));
 
 // Issue #2227: unknown digest method should throw an error.
 assert.throws(function() {
   crypto.createHash('xyzzy');
-});
+}, /^Error: Digest method not supported$/);
 
 // Test signing and verifying
 var s1 = crypto.createSign('RSA-SHA1')
@@ -443,7 +450,7 @@ function testCipher1(key) {
   var txt = decipher.update(ciph, 'hex', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption');
+  assert.strictEqual(txt, plaintext, 'encryption and decryption');
 }
 
 
@@ -465,7 +472,7 @@ function testCipher2(key) {
   var txt = decipher.update(ciph, 'base64', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with Base64');
+  assert.strictEqual(txt, plaintext, 'encryption and decryption with Base64');
 }
 
 
@@ -483,7 +490,8 @@ function testCipher3(key, iv) {
   var txt = decipher.update(ciph, 'hex', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+  assert.strictEqual(txt, plaintext,
+                     'encryption and decryption with key and iv');
 }
 
 
@@ -501,7 +509,8 @@ function testCipher4(key, iv) {
   var txt = decipher.update(ciph, 'buffer', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+  assert.strictEqual(txt, plaintext,
+                     'encryption and decryption with key and iv');
 }
 
 if (!common.hasFipsCrypto) {
@@ -523,7 +532,7 @@ testCipher4(Buffer.from('0123456789abcd0123456789'), Buffer.from('12345678'));
 // update() should only take buffers / strings
 assert.throws(function() {
   crypto.createHash('sha1').update({foo: 'bar'});
-}, /buffer/);
+}, /^TypeError: Data must be a string or a buffer$/);
 
 
 // Test Diffie-Hellman with two parties sharing a secret,
@@ -536,7 +545,7 @@ var key2 = dh2.generateKeys('hex');
 var secret1 = dh1.computeSecret(key2, 'hex', 'base64');
 var secret2 = dh2.computeSecret(key1, 'latin1', 'buffer');
 
-assert.equal(secret1, secret2.toString('base64'));
+assert.strictEqual(secret1, secret2.toString('base64'));
 
 // Create "another dh1" using generated keys from dh1,
 // and compute secret again
@@ -545,14 +554,14 @@ var privkey1 = dh1.getPrivateKey();
 dh3.setPublicKey(key1);
 dh3.setPrivateKey(privkey1);
 
-assert.equal(dh1.getPrime(), dh3.getPrime());
-assert.equal(dh1.getGenerator(), dh3.getGenerator());
-assert.equal(dh1.getPublicKey(), dh3.getPublicKey());
-assert.equal(dh1.getPrivateKey(), dh3.getPrivateKey());
+assert.strictEqual(dh1.getPrime(), dh3.getPrime());
+assert.strictEqual(dh1.getGenerator(), dh3.getGenerator());
+assert.strictEqual(dh1.getPublicKey(), dh3.getPublicKey());
+assert.strictEqual(dh1.getPrivateKey(), dh3.getPrivateKey());
 
 var secret3 = dh3.computeSecret(key2, 'hex', 'base64');
 
-assert.equal(secret1, secret3);
+assert.strictEqual(secret1, secret3);
 
 // https://github.com/joyent/node/issues/2338
 var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
@@ -560,22 +569,24 @@ var p = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74' +
         '4FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED' +
         'EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFF';
 var d = crypto.createDiffieHellman(p, 'hex');
-assert.equal(d.verifyError, DH_NOT_SUITABLE_GENERATOR);
+assert.strictEqual(d.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 // Test RSA key signing/verification
 var rsaSign = crypto.createSign('RSA-SHA1');
 var rsaVerify = crypto.createVerify('RSA-SHA1');
-assert.ok(rsaSign);
-assert.ok(rsaVerify);
+assert.ok(rsaSign instanceof crypto.Sign);
+assert.ok(rsaVerify instanceof crypto.Verify);
 
 rsaSign.update(rsaPubPem);
 var rsaSignature = rsaSign.sign(rsaKeyPem, 'hex');
-assert.equal(rsaSignature,
-             '5c50e3145c4e2497aadb0eabc83b342d0b0021ece0d4c4a064b7c' +
-             '8f020d7e2688b122bfb54c724ac9ee169f83f66d2fe90abeb95e8' +
-             'e1290e7e177152a4de3d944cf7d4883114a20ed0f78e70e25ef0f' +
-             '60f06b858e6af42a2f276ede95bbc6bc9a9bbdda15bd663186a6f' +
-             '40819a7af19e577bb2efa5e579a1f5ce8a0d4ca8b8f6');
+assert.strictEqual(
+  rsaSignature,
+  '5c50e3145c4e2497aadb0eabc83b342d0b0021ece0d4c4a064b7c' +
+  '8f020d7e2688b122bfb54c724ac9ee169f83f66d2fe90abeb95e8' +
+  'e1290e7e177152a4de3d944cf7d4883114a20ed0f78e70e25ef0f' +
+  '60f06b858e6af42a2f276ede95bbc6bc9a9bbdda15bd663186a6f' +
+  '40819a7af19e577bb2efa5e579a1f5ce8a0d4ca8b8f6'
+);
 
 rsaVerify.update(rsaPubPem);
 assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
@@ -642,12 +653,14 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
 function testPBKDF2(password, salt, iterations, keylen, expected) {
-  var actual = crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha256');
-  assert.equal(actual, expected);
+  const actual = crypto.pbkdf2Sync(password, salt, iterations, keylen,
+                                   'sha256');
+  assert.strictEqual(actual, expected);
 
-  crypto.pbkdf2(password, salt, iterations, keylen, 'sha256', (err, actual) => {
-    assert.equal(actual, expected);
+  const cb = common.mustCall((err, actual) => {
+    assert.strictEqual(actual, expected);
   });
+  crypto.pbkdf2(password, salt, iterations, keylen, 'sha256', cb);
 }
 
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

* var -> const.
* Group and sort imports.
* Correctly align function arguments.
* Fix incorrect use of string instead of RegExp in `throws` assertions.
* assert.equal -> assert.strictEqual.
* Verify that callbacks are called with common.mustCall.