### PR TITLE
test: refactor test-net-pingpong

### DIFF
--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -1,87 +1,87 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-
-var net = require('net');
-
-var tests_run = 0;
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
 function pingPongTest(port, host) {
-  var N = 1000;
+  const N = 1000;
   var count = 0;
   var sentPongs = 0;
   var sent_final_ping = false;
 
-  var server = net.createServer({ allowHalfOpen: true }, function(socket) {
-    console.log('connection: ' + socket.remoteAddress);
-    assert.equal(server, socket.server);
-    assert.equal(1, server.connections);
+  const server = net.createServer(
+    { allowHalfOpen: true },
+    common.mustCall(onSocket)
+  );
+
+  function onSocket(socket) {
+    assert.strictEqual(socket.server, server);
+    server.getConnections(common.mustCall(function(err, connections) {
+      assert.ifError(err);
+      assert.strictEqual(connections, 1);
+    }));
 
     socket.setNoDelay();
     socket.timeout = 0;
 
     socket.setEncoding('utf8');
-    socket.on('data', function(data) {
+    socket.on('data', common.mustCall(function(data) {
       // Since we never queue data (we're always waiting for the PING
       // before sending a pong) the writeQueueSize should always be less
       // than one message.
       assert.ok(0 <= socket.bufferSize && socket.bufferSize <= 4);
 
-      assert.equal(true, socket.writable);
-      assert.equal(true, socket.readable);
-      assert.equal(true, count <= N);
-      assert.equal(data, 'PING');
+      assert.strictEqual(socket.writable, true);
+      assert.strictEqual(socket.readable, true);
+      assert.ok(count <= N);
+      assert.strictEqual(data, 'PING');
 
-      socket.write('PONG', function() {
+      socket.write('PONG', common.mustCall(function() {
         sentPongs++;
-      });
-    });
+      }));
+    }, N + 1));
 
-    socket.on('end', function() {
-      assert.equal(true, socket.allowHalfOpen);
-      assert.equal(true, socket.writable); // because allowHalfOpen
-      assert.equal(false, socket.readable);
+    socket.on('end', common.mustCall(function() {
+      assert.strictEqual(socket.allowHalfOpen, true);
+      assert.strictEqual(socket.writable, true); // because allowHalfOpen
+      assert.strictEqual(socket.readable, false);
       socket.end();
-    });
+    }));
 
-    socket.on('error', function(e) {
-      throw e;
-    });
+    socket.on('error', common.fail);
 
-    socket.on('close', function() {
-      console.log('server socket.end');
-      assert.equal(false, socket.writable);
-      assert.equal(false, socket.readable);
+    socket.on('close', common.mustCall(function() {
+      assert.strictEqual(socket.writable, false);
+      assert.strictEqual(socket.readable, false);
       socket.server.close();
-    });
-  });
+    }));
+  }
 
 
-  server.listen(port, host, function() {
+  server.listen(port, host, common.mustCall(function() {
     if (this.address().port)
       port = this.address().port;
-    console.log(`server listening on ${port} ${host}`);
 
-    var client = net.createConnection(port, host);
+    const client = net.createConnection(port, host);
 
     client.setEncoding('ascii');
-    client.on('connect', function() {
-      assert.equal(true, client.readable);
-      assert.equal(true, client.writable);
+    client.on('connect', common.mustCall(function() {
+      assert.strictEqual(client.readable, true);
+      assert.strictEqual(client.writable, true);
       client.write('PING');
-    });
+    }));
 
-    client.on('data', function(data) {
-      assert.equal('PONG', data);
+    client.on('data', common.mustCall(function(data) {
+      assert.strictEqual(data, 'PONG');
       count += 1;
 
       if (sent_final_ping) {
-        assert.equal(false, client.writable);
-        assert.equal(true, client.readable);
+        assert.strictEqual(client.writable, false);
+        assert.strictEqual(client.readable, true);
         return;
       } else {
-        assert.equal(true, client.writable);
-        assert.equal(true, client.readable);
+        assert.strictEqual(client.writable, true);
+        assert.strictEqual(client.readable, true);
       }
 
       if (count < N) {
@@ -91,20 +91,16 @@ function pingPongTest(port, host) {
         client.write('PING');
         client.end();
       }
-    });
+    }, N + 1));
 
-    client.on('close', function() {
-      console.log('client.end');
-      assert.equal(N + 1, count);
-      assert.equal(N + 1, sentPongs);
-      assert.equal(true, sent_final_ping);
-      tests_run += 1;
-    });
+    client.on('close', common.mustCall(function() {
+      assert.strictEqual(count, N + 1);
+      assert.strictEqual(sentPongs, N + 1);
+      assert.strictEqual(sent_final_ping, true);
+    }));
 
-    client.on('error', function(e) {
-      throw e;
-    });
-  });
+    client.on('error', common.fail);
+  }));
 }
 
 /* All are run at once, so run on different ports */
@@ -114,11 +110,3 @@ pingPongTest(0);
 pingPongTest(0, 'localhost');
 if (common.hasIPv6)
   pingPongTest(0, '::1');
-
-process.on('exit', function() {
-  if (common.hasIPv6)
-    assert.equal(4, tests_run);
-  else
-    assert.equal(3, tests_run);
-  console.log('done');
-});


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, net

##### Description of change
<!-- Provide a description of the change below this comment. -->

* var -> const.
* Verify that callbacks are called with common.mustCall.
* Replace usage of deprecated `server.connections`.
* Use common.fail instead of rethrowing errors.
* Remove console.log statements.
* assert.equal -> assert.strictEqual.
* Correct order of arguments in assert.strictEqual.