### PR TITLE
build: Don't regenerate node->out/*/node symlink if already there

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,18 @@ endif
 # to check for changes.
 .PHONY: $(NODE_EXE) $(NODE_G_EXE)
 
+# The -r/-L check stops it recreating the link if it is already in place,
+# otherwise $(NODE_EXE) being a .PHONY target means it is always re-run. 
+# Without the check there is a race condition between the link being deleted
+# and recreated which can break the addons build when running test-ci
+# See comments on the build-addons target for some more info
 $(NODE_EXE): config.gypi out/Makefile
 	$(MAKE) -C out BUILDTYPE=Release V=$(V)
-	ln -fs out/Release/$(NODE_EXE) $@
+	if [ ! -r $(NODE_EXE) -o ! -L $(NODE_EXE) ]; then ln -fs out/Release/$(NODE_EXE) $@; fi
 
 $(NODE_G_EXE): config.gypi out/Makefile
 	$(MAKE) -C out BUILDTYPE=Debug V=$(V)
-	ln -fs out/Debug/$(NODE_EXE) $@
+	if [ ! -r $(NODE_EXE) -o ! -L $(node_EXE) ]; then ln -fs out/Debug/$(NODE_EXE) $@; fi
 
 out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
               deps/zlib/zlib.gyp deps/v8/gypfiles/toolchain.gypi \


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build


##### Description of change
<!-- Provide a description of the change below this comment. -->
Ref: https://github.com/nodejs/node/issues/9825

This PR will stop the "ln -sf out/Release node node" (and it's Debug equivalent) from occurring if it is already in place. This appears to be causing a problem when it is executed in parallel with the node-gyp execution for the build-addons target as it appears to be triggering a race condition (visible in the AIX CI as per the referenced issue although I haven't replicated it on my own system) whereby the deletion of the symlink (A result of the -f) is leaving a small window before it is recreated where the addons build runs, which requires the node symlink to be in place. I can see no obvious reason why this would have ONLY showed up on the v4 release as the same condition can occur on master as far as I can tell.

The disadvantage of the solution in this PR is that if "node" already existed and wasn't previously a symlink to out/Release node then it won't overwrite it.  I'm open to alternative suggestions on this - checking the output from "diff node out/Release/node" before replacing would work for example. Tagging @bnoordhuis as he has made some comments in Makefile around thisagainst the build-addons target in the makefile. The problem also goes away if the $(NODE_EXE) target is not listed as ".PHONY" but since that was done for sensible reasons I assume we need to leave that in place, and this is really just a "workaround" for the fact it's not a true dependency.