### PR TITLE
deps: backport fix to v8 bug in toUpper('ç')

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 4
 #define V8_BUILD_NUMBER 500
-#define V8_PATCH_LEVEL 45
+#define V8_PATCH_LEVEL 46
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/runtime/runtime-i18n.cc
+++ b/deps/v8/src/runtime/runtime-i18n.cc
@@ -931,7 +931,7 @@ inline uint16_t ToASCIIUpper(uint16_t ch) {
 inline uint16_t ToLatin1Upper(uint16_t ch) {
   DCHECK(ch != 0xDF && ch != 0xB5 && ch != 0xFF);
   return ch &
-         ~(((ch >= 'a' && ch <= 'z') || (((ch & 0xE0) == 0xE0) && ch != 0xE7))
+         ~(((ch >= 'a' && ch <= 'z') || (((ch & 0xE0) == 0xE0) && ch != 0xF7))
            << 5);
 }
 

--- a/deps/v8/test/intl/general/case-mapping.js
+++ b/deps/v8/test/intl/general/case-mapping.js
@@ -136,3 +136,29 @@ assertEquals("\u{10CC0}", "\u{10C80}".toLocaleLowerCase());
 assertEquals("\u{10C80}", "\u{10CC0}".toLocaleUpperCase(["tr"]));
 assertEquals("\u{10C80}", "\u{10CC0}".toLocaleUpperCase(["tr"]));
 assertEquals("\u{10CC0}", "\u{10C80}".toLocaleLowerCase());
+
+// check fast path for Latin-1 supplement (U+00A0 ~ U+00FF)
+var latin1Suppl = "\u00A0¡¢£¤¥¦§¨©ª«¬\u00AD®°±²³´µ¶·¸¹º»¼½¾¿" +
+    "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ";
+var latin1SupplLowercased = "\u00A0¡¢£¤¥¦§¨©ª«¬\u00AD®°±²³´µ¶·¸¹º»¼½¾¿" +
+    "àáâãäåæçèéêëìíîïðñòóôõö×øùúûüýþßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ";
+var latin1SupplUppercased = "\u00A0¡¢£¤¥¦§¨©ª«¬\u00AD®°±²³´\u039C¶·¸¹º»¼½¾¿" +
+    "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞSSÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ÷ØÙÚÛÜÝÞ\u0178";
+
+assertEquals(latin1SupplLowercased, latin1Suppl.toLowerCase());
+assertEquals(latin1SupplUppercased, latin1Suppl.toUpperCase());
+assertEquals(latin1SupplLowercased, latin1Suppl.toLocaleLowerCase("de"));
+assertEquals(latin1SupplUppercased, latin1Suppl.toLocaleUpperCase("de"));
+assertEquals(latin1SupplLowercased, latin1Suppl.toLocaleLowerCase("el"));
+assertEquals(latin1SupplUppercased, latin1Suppl.toLocaleUpperCase("el"));
+assertEquals(latin1SupplUppercased, latin1Suppl.toLocaleUpperCase("tr"));
+assertEquals(latin1SupplLowercased, latin1Suppl.toLocaleLowerCase("tr"));
+assertEquals(latin1SupplUppercased, latin1Suppl.toLocaleUpperCase("az"));
+assertEquals(latin1SupplLowercased, latin1Suppl.toLocaleLowerCase("az"));
+assertEquals(latin1SupplUppercased, latin1Suppl.toLocaleUpperCase("lt"));
+// Lithuanian need to have a dot-above for U+00CC(Ì) and U+00CD(Í) when
+// lowercasing.
+assertEquals("\u00A0¡¢£¤¥¦§¨©ª«¬\u00AD®°±²³´µ¶·¸¹º»¼½¾¿" +
+    "àáâãäåæçèéêëi\u0307\u0300i\u0307\u0301îïðñòóôõö×øùúûüýþß" +
+    "àáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ",
+    latin1Suppl.toLocaleLowerCase("lt"));

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -16,6 +16,16 @@ function haveLocale(loc) {
   return locs.indexOf(loc) !== -1;
 }
 
+// Always run these. They should always pass, even if the locale
+// param is ignored.
+assert.strictEqual('Ç'.toLocaleLowerCase('el'), 'ç');
+assert.strictEqual('Ç'.toLocaleLowerCase('tr'), 'ç');
+assert.strictEqual('Ç'.toLowerCase(), 'ç');
+
+assert.strictEqual('ç'.toLocaleUpperCase('el'), 'Ç');
+assert.strictEqual('ç'.toLocaleUpperCase('tr'), 'Ç');
+assert.strictEqual('ç'.toUpperCase(), 'Ç');
+
 if (!common.hasIntl) {
   const erMsg =
       '"Intl" object is NOT present but v8_enable_i18n_support is ' +


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
deps - v8 floating patch

##### Description of change

* add test for ç/Ç in various locales
* work around v8 bug per @jungshik
https://bugs.chromium.org/p/v8/issues/detail?id=5681

Fixes: https://github.com/nodejs/node/issues/9785
