### PR TITLE
http: remove stale timeout listeners

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -562,7 +562,7 @@ function tickOnSocket(req, socket) {
   socket.on('close', socketCloseListener);
 
   if (req.timeout) {
-    socket.once('timeout', () => req.emit('timeout'));
+    req.setTimeout(req.timeout);
   }
   req.emit('socket', socket);
 }
@@ -620,27 +620,20 @@ ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
     self.emit('timeout');
   }
 
-  if (this.socket && this.socket.writable) {
-    if (this.timeoutCb)
-      this.socket.setTimeout(0, this.timeoutCb);
-    this.timeoutCb = emitTimeout;
-    this.socket.setTimeout(msecs, emitTimeout);
-    return this;
-  }
+  // Remove any existing timeout listener
+  if (this.timeoutCb)
+    this.socket.setTimeout(0, this.timeoutCb);
 
   // Set timeoutCb so that it'll get cleaned up on request end
   this.timeoutCb = emitTimeout;
+
   if (this.socket) {
-    var sock = this.socket;
-    this.socket.once('connect', function() {
+    this.socket.setTimeout(msecs, emitTimeout);
+  } else {
+    this.once('socket', function(sock) {
       sock.setTimeout(msecs, emitTimeout);
     });
-    return this;
   }
-
-  this.once('socket', function(sock) {
-    sock.setTimeout(msecs, emitTimeout);
-  });
 
   return this;
 };

--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -1,0 +1,44 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const agent = new http.Agent({ keepAlive: true });
+
+const server = http.createServer((req, res) => {
+  res.end('');
+});
+
+const options = {
+  agent,
+  method: 'GET',
+  port: undefined,
+  host: common.localhostIPv4,
+  path: '/',
+  timeout: common.platformTimeout(100)
+};
+
+server.listen(0, options.host, common.mustCall(() => {
+  options.port = server.address().port;
+  doRequest(common.mustCall((numListeners) => {
+    assert.strictEqual(numListeners, 1);
+    doRequest(common.mustCall((numListeners) => {
+      assert.strictEqual(numListeners, 1);
+      server.close();
+      agent.destroy();
+    }));
+  }));
+}));
+
+function doRequest(cb) {
+  http.request(options, common.mustCall((response) => {
+    const sockets = agent.sockets[`${options.host}:${options.port}:`];
+    assert.strictEqual(sockets.length, 1);
+    const socket = sockets[0];
+    const numListeners = socket.listeners('timeout').length;
+    response.resume();
+    response.once('end', common.mustCall(() => {
+      process.nextTick(cb, numListeners);
+    }));
+  })).end();
+}


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

http

##### Description of change

Fix memory leak #9268 introduced by https://github.com/nodejs/node/commit/ee7af01

Unifies handling of timeout set via http#request (i.e. prior to socket connect) with explicit `ClientRequest.prototype.setTimeout`.  Previously, `setTimeout` would only apply if socket was writeable.  Now, the timeout is applied regardless of whether socket is writeable, i.e. it applies to connect + write + read response combined.

Alternative solution to #9440