### PR TITLE
doc: remove minor contradiction in debugger doc

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -4,10 +4,10 @@
 
 <!-- type=misc -->
 
-Node.js includes a full-featured out-of-process debugging utility accessible
-via a simple [TCP-based protocol][] and built-in debugging client. To use it,
-start Node.js with the `debug` argument followed by the path to the script to
-debug; a prompt will be displayed indicating successful launch of the debugger:
+Node.js includes an out-of-process debugging utility accessible via a
+[TCP-based protocol][] and built-in debugging client. To use it, start Node.js
+with the `debug` argument followed by the path to the script to debug; a prompt
+will be displayed indicating successful launch of the debugger:
 
 ```txt
 $ node debug myscript.js


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc debugger

##### Description of change
<!-- Provide a description of the change below this comment. -->

The doc says the debugger is and also isn't full-featured. Even if the sentences are talking about different things, it's confusing. `full-featured` seems superfluous in the first sentence anyway, so
remove it.