### PR TITLE
buffer: fix single-character string filling

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -672,23 +672,27 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
       encoding = end;
       end = this.length;
     }
-    if (val.length === 1) {
-      var code = val.charCodeAt(0);
-      if (code < 256)
-        val = code;
+
+    if (encoding !== undefined && typeof encoding !== 'string') {
+      throw new TypeError('encoding must be a string');
     }
+    var normalizedEncoding = internalUtil.normalizeEncoding(encoding);
+    if (normalizedEncoding === undefined) {
+      throw new TypeError('Unknown encoding: ' + encoding);
+    }
+
     if (val.length === 0) {
       // Previously, if val === '', the Buffer would not fill,
       // which is rather surprising.
       val = 0;
+    } else if (val.length === 1) {
+      var code = val.charCodeAt(0);
+      if ((normalizedEncoding === 'utf8' && code < 128) ||
+          normalizedEncoding === 'latin1') {
+        // Fast path: If `val` fits into a single byte, use that numeric value.
+        val = code;
+      }
     }
-    if (encoding !== undefined && typeof encoding !== 'string') {
-      throw new TypeError('encoding must be a string');
-    }
-    if (typeof encoding === 'string' && !Buffer.isEncoding(encoding)) {
-      throw new TypeError('Unknown encoding: ' + encoding);
-    }
-
   } else if (typeof val === 'number') {
     val = val & 255;
   }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -606,6 +606,9 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
 
   } else if (enc == UCS2) {
     node::TwoByteValue str(env->isolate(), args[1]);
+    if (IsBigEndian())
+      SwapBytes16(reinterpret_cast<char*>(&str[0]), str_length);
+
     memcpy(ts_obj_data + start, *str, MIN(str_length, fill_length));
 
   } else {

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -395,7 +395,6 @@ assert.throws(() => {
   buf.fill('');
 }, /^RangeError: out of range index$/);
 
-
 assert.deepStrictEqual(
     Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
     Buffer.from('61006200610062006100620061006200', 'hex'));
@@ -403,3 +402,30 @@ assert.deepStrictEqual(
 assert.deepStrictEqual(
     Buffer.allocUnsafeSlow(15).fill('ab', 'utf16le'),
     Buffer.from('610062006100620061006200610062', 'hex'));
+
+assert.deepStrictEqual(
+    Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
+    Buffer.from('61006200610062006100620061006200', 'hex'));
+assert.deepStrictEqual(
+    Buffer.allocUnsafeSlow(16).fill('a', 'utf16le'),
+    Buffer.from('61006100610061006100610061006100', 'hex'));
+
+assert.strictEqual(
+    Buffer.allocUnsafeSlow(16).fill('a', 'utf16le').toString('utf16le'),
+    'a'.repeat(8));
+assert.strictEqual(
+    Buffer.allocUnsafeSlow(16).fill('a', 'latin1').toString('latin1'),
+    'a'.repeat(16));
+assert.strictEqual(
+    Buffer.allocUnsafeSlow(16).fill('a', 'utf8').toString('utf8'),
+    'a'.repeat(16));
+
+assert.strictEqual(
+    Buffer.allocUnsafeSlow(16).fill('Љ', 'utf16le').toString('utf16le'),
+    'Љ'.repeat(8));
+assert.strictEqual(
+    Buffer.allocUnsafeSlow(16).fill('Љ', 'latin1').toString('latin1'),
+    '\t'.repeat(16));
+assert.strictEqual(
+    Buffer.allocUnsafeSlow(16).fill('Љ', 'utf8').toString('utf8'),
+    'Љ'.repeat(8));

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -2,12 +2,10 @@
 
 require('../common');
 const assert = require('assert');
-const os = require('os');
 const SIZE = 28;
 
 const buf1 = Buffer.allocUnsafe(SIZE);
 const buf2 = Buffer.allocUnsafe(SIZE);
-
 
 // Default encoding
 testBufs('abc');
@@ -112,8 +110,7 @@ testBufs('\u0222aa', 8, 1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 4, -1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 4, 1, 'ucs2');
 testBufs('a\u0234b\u0235c\u0236', 12, 1, 'ucs2');
-assert.strictEqual(Buffer.allocUnsafe(1).fill('\u0222', 'ucs2')[0],
-                   os.endianness() === 'LE' ? 0x22 : 0x02);
+assert.strictEqual(Buffer.allocUnsafe(1).fill('\u0222', 'ucs2')[0], 0x22);
 
 
 // HEX
@@ -259,15 +256,6 @@ function writeToFill(string, offset, end, encoding) {
     }
   } while (offset < buf2.length);
 
-  // Correction for UCS2 operations.
-  if (os.endianness() === 'BE' && encoding === 'ucs2') {
-    for (var i = 0; i < buf2.length; i += 2) {
-      var tmp = buf2[i];
-      buf2[i] = buf2[i + 1];
-      buf2[i + 1] = tmp;
-    }
-  }
-
   return buf2;
 }
 
@@ -406,3 +394,12 @@ assert.throws(() => {
   });
   buf.fill('');
 }, /^RangeError: out of range index$/);
+
+
+assert.deepStrictEqual(
+    Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
+    Buffer.from('61006200610062006100620061006200', 'hex'));
+
+assert.deepStrictEqual(
+    Buffer.allocUnsafeSlow(15).fill('ab', 'utf16le'),
+    Buffer.from('610062006100620061006200610062', 'hex'));


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Fix the fast path for `buffer.fill()` with a single-character string.

The fast path only works for strings that are equivalent to a
single-byte buffer, but that condition was not checked properly
for the `utf8` or `utf16le` encodings and is always true for the
`latin1` encoding.

This change fixes these problems.

Fixes: https://github.com/nodejs/node/issues/9836

/cc @nodejs/buffer 
~~CI: https://ci.nodejs.org/job/node-test-commit/6222/~~
~~CI: https://ci.nodejs.org/job/node-test-commit/6224/~~
CI: https://ci.nodejs.org/job/node-test-commit/6600/