### PR TITLE
buffer: fix transcode for single-byte enc to ucs2

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -179,7 +179,7 @@ MaybeLocal<Object> TranscodeToUcs2(Isolate* isolate,
   MaybeLocal<Object> ret;
   MaybeStackBuffer<UChar> destbuf(source_length);
   Converter from(fromEncoding);
-  const size_t length_in_chars = source_length * sizeof(*destbuf);
+  const size_t length_in_chars = source_length * sizeof(UChar);
   ucnv_toUChars(from.conv, *destbuf, length_in_chars,
                 source, source_length, status);
   if (U_SUCCESS(*status))

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -46,3 +46,13 @@ assert.throws(
   () => buffer.transcode(Buffer.from('a'), 'uf8', 'b'),
   /Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]/
 );
+
+assert.deepStrictEqual(
+    buffer.transcode(Buffer.from('hi', 'ascii'), 'ascii', 'utf16le'),
+    Buffer.from('hi', 'utf16le'));
+assert.deepStrictEqual(
+    buffer.transcode(Buffer.from('hi', 'latin1'), 'latin1', 'utf16le'),
+    Buffer.from('hi', 'utf16le'));
+assert.deepStrictEqual(
+    buffer.transcode(Buffer.from('hä', 'latin1'), 'latin1', 'utf16le'),
+    Buffer.from('hä', 'utf16le'));


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Fix `buffer.transcode()` for transcoding from single-byte character
encodings to UCS2.

These would previously perform out-of-bounds reads due to an
incorrect `sizeof()` expression.

Fixes: https://github.com/nodejs/node/issues/9834

/cc @nodejs/buffer 