### PR TITLE
test: replace assert.equal with assert.strictEqual

### DIFF
--- a/test/addons/async-hello-world/test.js
+++ b/test/addons/async-hello-world/test.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
 
 binding(5, common.mustCall(function(err, val) {
-  assert.equal(null, err);
-  assert.equal(10, val);
+  assert.strictEqual(err, null);
+  assert.strictEqual(val, 10);
   process.nextTick(common.mustCall(function() {}));
 }));

--- a/test/addons/hello-world-function-export/test.js
+++ b/test/addons/hello-world-function-export/test.js
@@ -2,5 +2,5 @@
 const common = require('../../common');
 var assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
-assert.equal('world', binding());
+assert.strictEqual(binding(), 'world');
 console.log('binding.hello() =', binding());

--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -2,5 +2,5 @@
 const common = require('../../common');
 var assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
-assert.equal('world', binding.hello());
+assert.strictEqual(binding.hello(), 'world');
 console.log('binding.hello() =', binding.hello());

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -34,4 +34,4 @@ fs.writeFileSync(addonDestinationPath, contents);
 // Attempt to load at long path destination
 var addon = require(addonDestinationPath);
 assert.notEqual(addon, null);
-assert.equal(addon.hello(), 'world');
+assert.strictEqual(addon.hello(), 'world');

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-at-max.js
@@ -30,4 +30,4 @@ if (!binding.ensureAllocation(2 * kStringMaxLength)) {
 }
 
 const maxString = buf.toString('latin1');
-assert.equal(maxString.length, kStringMaxLength);
+assert.strictEqual(maxString.length, kStringMaxLength);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -34,9 +34,9 @@ assert.throws(function() {
 }, /"toString\(\)" failed/);
 
 var maxString = buf.toString('latin1', 1);
-assert.equal(maxString.length, kStringMaxLength);
+assert.strictEqual(maxString.length, kStringMaxLength);
 // Free the memory early instead of at the end of the next assignment
 maxString = undefined;
 
 maxString = buf.toString('latin1', 0, kStringMaxLength);
-assert.equal(maxString.length, kStringMaxLength);
+assert.strictEqual(maxString.length, kStringMaxLength);

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
@@ -30,4 +30,4 @@ if (!binding.ensureAllocation(2 * kStringMaxLength)) {
 }
 
 const maxString = buf.toString('utf16le');
-assert.equal(maxString.length, (kStringMaxLength + 2) / 2);
+assert.strictEqual(maxString.length, (kStringMaxLength + 2) / 2);


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Using NodeTodo I learned of a need to swap out the .equal function
with .strictEqual in a few test files.
https://twitter.com/NodeTodo/status/803657321993961472
https://gist.github.com/Trott/864401455d4afa2428cd4814e072bd7c

This pull request simply applies those suggested fixes. 