### PR TITLE
test: refactor test-fs-non-number-arguments-throw

### DIFF
--- a/test/parallel/test-fs-non-number-arguments-throw.js
+++ b/test/parallel/test-fs-non-number-arguments-throw.js
@@ -15,17 +15,20 @@ const saneEmitter = fs.createReadStream(tempFile, { start: 4, end: 6 });
 
 assert.throws(function() {
   fs.createReadStream(tempFile, { start: '4', end: 6 });
-}, "start as string didn't throw an error for createReadStream");
+}, /^TypeError: "start" option must be a Number$/,
+   "start as string didn't throw an error for createReadStream");
 
 assert.throws(function() {
   fs.createReadStream(tempFile, { start: 4, end: '6' });
-}, "end as string didn't throw an error");
+}, /^TypeError: "end" option must be a Number$/,
+   "end as string didn't throw an error");
 
 assert.throws(function() {
   fs.createWriteStream(tempFile, { start: '4' });
-}, "start as string didn't throw an error for createWriteStream");
+}, /^TypeError: "start" option must be a Number$/,
+   "start as string didn't throw an error for createWriteStream");
 
-saneEmitter.on('data', function(data) {
+saneEmitter.on('data', common.mustCall(function(data) {
   assert.strictEqual(sanity, data.toString('utf8'), 'read ' +
                      data.toString('utf8') + ' instead of ' + sanity);
-});
+}));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

* Add RegExp arguments to throws assertions.
* Use common.mustCall for emitter callback.

CI: https://ci.nodejs.org/job/node-test-pull-request/5024/