### PR TITLE
lib: use strict equality in _http_server and _tls_wrap

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -525,7 +525,7 @@ function connectionListener(socket) {
     }
 
     if (req.headers.expect !== undefined &&
-        (req.httpVersionMajor == 1 && req.httpVersionMinor == 1)) {
+        (req.httpVersionMajor === 1 && req.httpVersionMinor === 1)) {
       if (continueExpression.test(req.headers.expect)) {
         res._expect_continue = true;
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -545,7 +545,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
 };
 
 TLSSocket.prototype.setMaxSendFragment = function setMaxSendFragment(size) {
-  return this._handle.setMaxSendFragment(size) == 1;
+  return this._handle.setMaxSendFragment(size) === 1;
 };
 
 TLSSocket.prototype.getTLSTicket = function getTLSTicket() {


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
lib/_http_server
lib/_tls_wrap

##### Description of change
Minor fix to favor strict equality in http_server.js and tls_wrap.js
to ensure accurate comparisons without type coercion.