### PR TITLE
repl: fix generator function preprocessing

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -569,8 +569,10 @@ function REPLServer(prompt,
         self.wrappedCmd = true;
       } else {
         // Mitigate https://github.com/nodejs/node/issues/548
-        cmd = cmd.replace(/^\s*function\s+([^(]+)/,
-                  (_, name) => `var ${name} = function ${name}`);
+        cmd = cmd.replace(
+          /^\s*function(?:\s*(\*)\s*|\s+)([^(]+)/,
+          (_, genStar, name) => `var ${name} = function ${genStar || ''}${name}`
+        );
       }
       // Append a \n so that it will be either
       // terminated, or continued onto the next expression if it's an

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -339,6 +339,19 @@ function error_test() {
     // Avoid emitting stack trace
     { client: client_unix, send: 'a = 3.5e',
       expect: /^(?!\s+at\s)/gm },
+
+    // https://github.com/nodejs/node/issues/9850
+    { client: client_unix, send: 'function* foo() {}; foo().next();',
+      expect: '{ value: undefined, done: true }' },
+
+    { client: client_unix, send: 'function *foo() {}; foo().next();',
+      expect: '{ value: undefined, done: true }' },
+
+    { client: client_unix, send: 'function*foo() {}; foo().next();',
+      expect: '{ value: undefined, done: true }' },
+
+    { client: client_unix, send: 'function * foo() {}; foo().next()',
+      expect: '{ value: undefined, done: true }' },
   ]);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

Function declarations in the REPL are preprocessed into variable
declarations before being evaluated. However, the preprocessing logic
did not account for the star in a generator function declaration, which
caused the preprocessor to output invalid syntax in some circumstances.

Fixes: https://github.com/nodejs/node/issues/9850