### PR TITLE
test: update test-debugger-client.js to use strictEqual

### DIFF
--- a/test/debugger/test-debugger-client.js
+++ b/test/debugger/test-debugger-client.js
@@ -25,40 +25,40 @@ p.execute('Type: connect\r\n' +
           'Protocol-Version: 1\r\n' +
           'Embedding-Host: node v0.3.3-pre\r\n' +
           'Content-Length: 0\r\n\r\n');
-assert.equal(1, resCount);
+assert.strictEqual(resCount, 1);
 
 // Make sure split messages go in.
 
 var parts = [];
 parts.push('Content-Length: 336\r\n');
-assert.equal(21, parts[0].length);
+assert.strictEqual(parts[0].length, 21);
 parts.push('\r\n');
-assert.equal(2, parts[1].length);
+assert.strictEqual(parts[1].length, 2);
 var bodyLength = 0;
 
 parts.push('{"seq":12,"type":"event","event":"break","body":' +
            '{"invocationText":"#<a Server>');
-assert.equal(78, parts[2].length);
+assert.strictEqual(parts[2].length, 78);
 bodyLength += parts[2].length;
 
 parts.push('.[anonymous](req=#<an IncomingMessage>, ' +
            'res=#<a ServerResponse>)","sourceLine"');
-assert.equal(78, parts[3].length);
+assert.strictEqual(parts[3].length, 78);
 bodyLength += parts[3].length;
 
 parts.push(':45,"sourceColumn":4,"sourceLineText":"    debugger;",' +
            '"script":{"id":24,"name":"/home/ryan/projects/node/' +
            'benchmark/http_simple.js","lineOffset":0,"columnOffset":0,' +
            '"lineCount":98}}}');
-assert.equal(180, parts[4].length);
+assert.strictEqual(parts[4].length, 180);
 bodyLength += parts[4].length;
 
-assert.equal(336, bodyLength);
+assert.strictEqual(bodyLength, 336);
 
 for (var i = 0; i < parts.length; i++) {
   p.execute(parts[i]);
 }
-assert.equal(2, resCount);
+assert.strictEqual(resCount, 2);
 
 
 // Make sure that if we get backed up, we still manage to get all the
@@ -77,7 +77,7 @@ var d = 'Content-Length: 466\r\n\r\n' +
         '{"seq":11,"type":"event","event":"scriptCollected","success":true,' +
         '"body":{"script":{"id":26}},"refs":[],"running":true}';
 p.execute(d);
-assert.equal(4, resCount);
+assert.strictEqual(resCount, 4);
 
 var expectedConnections = 0;
 var tests = [];
@@ -91,7 +91,7 @@ addTest(function(client, done) {
   client.reqVersion(function(err, v) {
     assert.ok(!err);
     console.log('version: %s', v);
-    assert.equal(process.versions.v8, v);
+    assert.strictEqual(process.versions.v8, v);
     done();
   });
 });
@@ -120,8 +120,8 @@ addTest(function(client, done) {
   client.reqEval('2+2', function(err, res) {
     console.error(res);
     assert.ok(!err);
-    assert.equal('4', res.text);
-    assert.equal(4, res.value);
+    assert.strictEqual(res.text, '4');
+    assert.strictEqual(res.value, 4);
     done();
   });
 });
@@ -212,5 +212,5 @@ run();
 
 process.on('exit', function(code) {
   if (!code)
-    assert.equal(expectedConnections, connectCount);
+    assert.strictEqual(connectCount, expectedConnections);
 });


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Only test files have been modified.

##### Description of change
Updated `test-debugger-client.js` to use `strictEqual` instead of `equal` for higher fidelity testing.

