### PR TITLE
test: update test-zlib-truncated to use strictEqual

### DIFF
--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -24,17 +24,18 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli'
   zlib[methods.comp](inputString, function(err, compressed) {
     assert(!err);
     const truncated = compressed.slice(0, compressed.length / 2);
+    const toUTF8 = (buffer) => buffer.toString('utf-8');
 
     // sync sanity
     assert.doesNotThrow(function() {
       const decompressed = zlib[methods.decompSync](compressed);
-      assert.equal(decompressed, inputString);
+      assert.strictEqual(toUTF8(decompressed), inputString);
     });
 
     // async sanity
     zlib[methods.decomp](compressed, function(err, result) {
       assert.ifError(err);
-      assert.equal(result, inputString);
+      assert.strictEqual(toUTF8(result), inputString);
     });
 
     // sync truncated input test
@@ -51,17 +52,15 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli'
 
     // sync truncated input test, finishFlush = Z_SYNC_FLUSH
     assert.doesNotThrow(function() {
-      const result = zlib[methods.decompSync](truncated, syncFlushOpt)
-        .toString();
-      assert.equal(result, inputString.substr(0, result.length));
+      const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
+      assert.strictEqual(result, inputString.substr(0, result.length));
     });
 
     // async truncated input test, finishFlush = Z_SYNC_FLUSH
     zlib[methods.decomp](truncated, syncFlushOpt, function(err, decompressed) {
       assert.ifError(err);
-
-      const result = decompressed.toString();
-      assert.equal(result, inputString.substr(0, result.length));
+      const result = toUTF8(decompressed);
+      assert.strictEqual(result, inputString.substr(0, result.length));
     });
   });
 });


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Only test files updated.


##### Description of change
Updated `test-zlib-truncated` to use `strictEqual`. Added `toUTF8` utility for corresponding tests. 

