### PR TITLE
test: increase coverage for lib/events.js

### DIFF
--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -8,6 +8,7 @@ const util = require('util');
 function listener() {}
 function listener2() {}
 class TestStream { constructor() { } }
+util.inherits(TestStream, events.EventEmitter);
 
 {
   const ee = new events.EventEmitter();
@@ -59,7 +60,6 @@ class TestStream { constructor() { } }
 }
 
 {
-  util.inherits(TestStream, events.EventEmitter);
   const s = new TestStream();
   assert.deepStrictEqual(s.listeners('foo'), []);
 }

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -49,3 +49,9 @@ function listener2() {}
   ee.once('foo', listener2);
   assert.deepStrictEqual(ee.listeners('foo'), [listener, listener2]);
 }
+
+{
+  const ee = new events.EventEmitter();
+  ee._events = undefined;
+  assert.deepStrictEqual(ee.listeners('foo'), []);
+}

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -3,9 +3,11 @@
 require('../common');
 const assert = require('assert');
 const events = require('events');
+const util = require('util');
 
 function listener() {}
 function listener2() {}
+class TestStream { constructor() { } }
 
 {
   const ee = new events.EventEmitter();
@@ -54,4 +56,10 @@ function listener2() {}
   const ee = new events.EventEmitter();
   ee._events = undefined;
   assert.deepStrictEqual(ee.listeners('foo'), []);
+}
+
+{
+  util.inherits(TestStream, events.EventEmitter);
+  const s = new TestStream();
+  assert.deepStrictEqual(s.listeners('foo'), []);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, events

##### Description of change
<!-- Provide a description of the change below this comment. -->
This adds a test for the case in which listeners() is invoked on an
EventEmitter with no events.

Note that the EventEmitter does not allow `_events` to ever be
undefined as it is instantiated in the initializer. The only situation in
which it might be undefined is if it is monkey-patched externally.
Because of this, the added tests monkey-patches `this._events` to
mimic this expected behavior.