### PR TITLE
events: remove unneeded safety check code

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -423,17 +423,13 @@ EventEmitter.prototype.listeners = function listeners(type) {
   var ret;
   var events = this._events;
 
-  if (!events)
+  evlistener = events[type];
+  if (!evlistener)
     ret = [];
-  else {
-    evlistener = events[type];
-    if (!evlistener)
-      ret = [];
-    else if (typeof evlistener === 'function')
-      ret = [evlistener.listener || evlistener];
-    else
-      ret = unwrapListeners(evlistener);
-  }
+  else if (typeof evlistener === 'function')
+    ret = [evlistener.listener || evlistener];
+  else
+    ret = unwrapListeners(evlistener);
 
   return ret;
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

events

##### Description of change
<!-- Provide a description of the change below this comment. -->

In the process of creating #9865, it was discovered that the code
checking whether or not events was defined was unnecessary because
the only situation in which events would be undefined is if it is
monkeypatched by an external entity. This should be removed in order
to discourage this. If the test added in #9865 is merged, it will
need to removed on merge of this commit.

Before merging this change we might want to check and see if any
significant usage of monkeypatching `events` in the ecosystem.