### PR TITLE
using strictEquals instead of equals

### DIFF
--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -5,8 +5,8 @@ const assert = require('assert');
 assert.ok(process.stdout.writable);
 assert.ok(process.stderr.writable);
 // Support legacy API
-assert.equal('number', typeof process.stdout.fd);
-assert.equal('number', typeof process.stderr.fd);
+assert.strictEqual('number', typeof process.stdout.fd);
+assert.strictEqual('number', typeof process.stderr.fd);
 
 assert.doesNotThrow(function() {
   process.once('warning', common.mustCall((warning) => {
@@ -35,28 +35,28 @@ global.process.stderr.write = function(string) {
   errStrings.push(string);
 };
 
-// test console.log()
+// test console.log() goes to stdout
 console.log('foo');
 console.log('foo', 'bar');
 console.log('%s %s', 'foo', 'bar', 'hop');
 console.log({slashes: '\\\\'});
 console.log(custom_inspect);
 
-// test console.info()
+// test console.info() goes to stdout
 console.info('foo');
 console.info('foo', 'bar');
 console.info('%s %s', 'foo', 'bar', 'hop');
 console.info({slashes: '\\\\'});
 console.info(custom_inspect);
 
-// test console.error()
+// test console.error() goes to stderr
 console.error('foo');
 console.error('foo', 'bar');
 console.error('%s %s', 'foo', 'bar', 'hop');
 console.error({slashes: '\\\\'});
 console.error(custom_inspect);
 
-// test console.warn()
+// test console.warn() goes to stderr
 console.warn('foo');
 console.warn('foo', 'bar');
 console.warn('%s %s', 'foo', 'bar', 'hop');
@@ -102,29 +102,31 @@ const expectedStrings = [
 ];
 
 for (const expected of expectedStrings) {
-  assert.equal(expected + '\n', strings.shift());      // console.log   (stdout)
-  assert.equal(expected + '\n', errStrings.shift());   // console.error (stderr)
+  assert.strictEqual(expected + '\n', strings.shift());
+  assert.strictEqual(expected + '\n', errStrings.shift());
 }
 
 for (const expected of expectedStrings) {
-  assert.equal(expected + '\n', strings.shift());      // console.info  (stdout)
-  assert.equal(expected + '\n', errStrings.shift());   // console.warn  (stderr)
+  assert.strictEqual(expected + '\n', strings.shift());
+  assert.strictEqual(expected + '\n', errStrings.shift());
 }
 
-assert.equal("{ foo: 'bar', inspect: [Function: inspect] }\n", strings.shift());
-assert.equal("{ foo: 'bar', inspect: [Function: inspect] }\n", strings.shift());
+assert.strictEqual("{ foo: 'bar', inspect: [Function: inspect] }\n",
+                   strings.shift());
+assert.strictEqual("{ foo: 'bar', inspect: [Function: inspect] }\n",
+                   strings.shift());
 assert.notEqual(-1, strings.shift().indexOf('foo: [Object]'));
-assert.equal(-1, strings.shift().indexOf('baz'));
+assert.strictEqual(-1, strings.shift().indexOf('baz'));
 assert.ok(/^label: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^__proto__: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^constructor: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^hasOwnProperty: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 
-assert.equal('Trace: This is a {"formatted":"trace"} 10 foo',
-             errStrings.shift().split('\n').shift());
+assert.strictEqual('Trace: This is a {"formatted":"trace"} 10 foo',
+                   errStrings.shift().split('\n').shift());
 
-assert.equal(strings.length, 0);
-assert.equal(errStrings.length, 0);
+assert.strictEqual(strings.length, 0);
+assert.strictEqual(errStrings.length, 0);
 
 assert.throws(() => {
   console.assert(false, 'should throw');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Update console test to use assert.strictEquals instead of assert.equals
