### PR TITLE
test: replace equal with strictEqual

### DIFF
--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -19,10 +19,10 @@ assert.throws(function() {
 {
   const stdio1 = [];
   const result = _validateStdio(stdio1, false);
-  assert.equal(stdio1.length, 3);
-  assert.equal(result.hasOwnProperty('stdio'), true);
-  assert.equal(result.hasOwnProperty('ipc'), true);
-  assert.equal(result.hasOwnProperty('ipcFd'), true);
+  assert.strictEqual(stdio1.length, 3);
+  assert.strictEqual(result.hasOwnProperty('stdio'), true);
+  assert.strictEqual(result.hasOwnProperty('ipc'), true);
+  assert.strictEqual(result.hasOwnProperty('ipcFd'), true);
 }
 
 // should throw if stdio has ipc and sync is true


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Replace assert.equal with assert.strictEqual