### PR TITLE
child_process: name anonymous functions

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -70,10 +70,10 @@ exports._forkChild = function(fd) {
   p.open(fd);
   p.unref();
   const control = setupChannel(process, p);
-  process.on('newListener', function(name) {
+  process.on('newListener', function onNewListener(name) {
     if (name === 'message' || name === 'disconnect') control.ref();
   });
-  process.on('removeListener', function(name) {
+  process.on('removeListener', function onRemoveListener(name) {
     if (name === 'message' || name === 'disconnect') control.unref();
   });
 };
@@ -247,7 +247,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (options.timeout > 0) {
-    timeoutId = setTimeout(function() {
+    timeoutId = setTimeout(function delayedKill() {
       kill();
       timeoutId = null;
     }, options.timeout);
@@ -257,7 +257,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     if (encoding)
       child.stdout.setEncoding(encoding);
 
-    child.stdout.addListener('data', function(chunk) {
+    child.stdout.on('data', function onChildStdout(chunk) {
       stdoutLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
 
       if (stdoutLen > options.maxBuffer) {
@@ -276,7 +276,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     if (encoding)
       child.stderr.setEncoding(encoding);
 
-    child.stderr.addListener('data', function(chunk) {
+    child.stderr.on('data', function onChildStderr(chunk) {
       stderrLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
 
       if (stderrLen > options.maxBuffer) {
@@ -297,12 +297,14 @@ exports.execFile = function(file /*, args, options, callback*/) {
   return child;
 };
 
-var _deprecatedCustomFds = internalUtil.deprecate(function(options) {
-  options.stdio = options.customFds.map(function(fd) {
-    return fd === -1 ? 'pipe' : fd;
-  });
-}, 'child_process: options.customFds option is deprecated. ' +
-   'Use options.stdio instead.');
+const _deprecatedCustomFds = internalUtil.deprecate(
+  function deprecateCustomFds(options) {
+    options.stdio = options.customFds.map(function mapCustomFds(fd) {
+      return fd === -1 ? 'pipe' : fd;
+    });
+  }, 'child_process: options.customFds option is deprecated. ' +
+     'Use options.stdio instead.'
+);
 
 function _convertCustomFds(options) {
   if (options.customFds && !options.stdio) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process

##### Description of change
Per #8913 i've named anonymous callback handlers.

I have some mixed styling in here because i'm still going over the message log from #8913 and trying to determine best practices. Is the correct implementation of current anonymous functions just to apply a name to those functions without lifting them out of the function call and using arrow functions?

In particular this file has no arrow functions in it yet, so i would assume we'd want to stick to using:

```js
setTimeout(function name() {}, options.timeout);
```
over
```js
const name = () => {};
setTimeout(name, options.timeout);
```

if that's the case is there a preferred naming schema for things like setTimeout? The names on some of these seem to be moving towards the verbose, ex:

```js
child.stderr.addListener('data', function stderrAddListenerCallback(){});
```

Definitely ready to make changes to this to make it compliant. 
