### PR TITLE
Recommend make with good parallel build setting for laptop running 

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ To build Node.js:
 
 ```console
 $ ./configure
-$ make
+$ make -j4
 ```
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7 and not a newer version.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

Added a good default setting in building doc to execute a parallel build on OS/Linux. This should help users get going, and build/test their changes faster.
…X or linux