### PR TITLE
[tests]Changed var -> const, assert.equal -> assert.strictEqual

### DIFF
--- a/test/parallel/test-net-better-error-messages-port.js
+++ b/test/parallel/test-net-better-error-messages-port.js
@@ -1,14 +1,15 @@
 'use strict';
-var common = require('../common');
-var net = require('net');
-var assert = require('assert');
 
-var c = net.createConnection(common.PORT);
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+
+const c = net.createConnection(common.PORT);
 
 c.on('connect', common.fail);
 
 c.on('error', common.mustCall(function(e) {
-  assert.equal(e.code, 'ECONNREFUSED');
-  assert.equal(e.port, common.PORT);
-  assert.equal(e.address, '127.0.0.1');
+  assert.strictEqual(e.code, 'ECONNREFUSED');
+  assert.strictEqual(e.port, common.PORT);
+  assert.strictEqual(e.address, '127.0.0.1');
 }));


### PR DESCRIPTION


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Tests 


##### Description of change
* Changed `var` to `const`
* Changed `assert.equal` to `assert.strictEqual`

