### PR TITLE
test: updated var and assert.equal in net-local-address-port

### DIFF
--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -1,11 +1,11 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
 var server = net.createServer(common.mustCall(function(socket) {
-  assert.equal(socket.localAddress, common.localhostIPv4);
-  assert.equal(socket.localPort, this.address().port);
+  assert.strictEqual(socket.localAddress, common.localhostIPv4);
+  assert.strictEqual(socket.localPort, this.address().port);
   socket.on('end', function() {
     server.close();
   });


### PR DESCRIPTION
##### Checklist
- [x ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x ] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
- changed var to const
- changed assert.equal to assert.strictEqual