### PR TITLE
test: replace equal with strictEqual in crypto

### DIFF
--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -27,7 +27,7 @@ function testCipher1(key) {
   var txt = decipher.update(ciph, 'hex', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption');
+  assert.strictEqual(txt, plaintext, 'encryption and decryption');
 
   // streaming cipher interface
   // NB: In real life, it's not guaranteed that you can get all of it
@@ -41,7 +41,7 @@ function testCipher1(key) {
   dStream.end(ciph);
   txt = dStream.read().toString('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with streams');
+  assert.strictEqual(txt, plaintext, 'encryption and decryption with streams');
 }
 
 
@@ -63,7 +63,7 @@ function testCipher2(key) {
   var txt = decipher.update(ciph, 'base64', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with Base64');
+  assert.strictEqual(txt, plaintext, 'encryption and decryption with Base64');
 }
 
 testCipher1('MySecretKey123');


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Replace assert.equal with assert.strictEqual in crypto cipher-decipher test