### PR TITLE
test: Update to const and use regex for assertions

### DIFF
--- a/test/parallel/test-net-localerror.js
+++ b/test/parallel/test-net-localerror.js
@@ -1,19 +1,19 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
 connect({
   host: 'localhost',
   port: common.PORT,
   localPort: 'foobar',
-}, 'localPort should be a number: foobar');
+}, /^TypeError: "localPort" option should be a number: foobar$/);
 
 connect({
   host: 'localhost',
   port: common.PORT,
   localAddress: 'foobar',
-}, 'localAddress should be a valid IP: foobar');
+}, /^TypeError: "localAddress" option must be a valid IP: foobar$/);
 
 function connect(opts, msg) {
   assert.throws(function() {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Use const over var.

Assert error message with regex.

##### Warning
This PR changes Error message expectation and manipulating test to pass.  Please be advised.