### PR TITLE
update test/parallel/test-fs-read-stream-inherit.js to use ES6 variable declarations and assert.strictEqual

### DIFF
--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var path = require('path');
-var fs = require('fs');
-var fn = path.join(common.fixturesDir, 'elipses.txt');
-var rangeFile = path.join(common.fixturesDir, 'x.txt');
+const path = require('path');
+const fs = require('fs');
+const fn = path.join(common.fixturesDir, 'elipses.txt');
+const rangeFile = path.join(common.fixturesDir, 'x.txt');
 
-var callbacks = { open: 0, end: 0, close: 0 };
+const callbacks = { open: 0, end: 0, close: 0 };
 
-var paused = false;
+let paused = false;
 
-var file = fs.ReadStream(fn);
+const file = fs.ReadStream(fn);
 
 file.on('open', function(fd) {
   file.length = 0;
@@ -52,13 +52,13 @@ file.on('close', function() {
   //assert.equal(fs.readFileSync(fn), fileContent);
 });
 
-var file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
+const file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
 file3.length = 0;
 file3.on('data', function(data) {
   assert.equal('string', typeof data);
   file3.length += data.length;
 
-  for (var i = 0; i < data.length; i++) {
+  for (let i = 0; i < data.length; i++) {
     // http://www.fileformat.info/info/unicode/char/2026/index.htm
     assert.equal('\u2026', data[i]);
   }
@@ -77,11 +77,11 @@ process.on('exit', function() {
   console.error('ok');
 });
 
-var file4 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
+const file4 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
                                 start: 1, end: 2}));
 assert.equal(file4.start, 1);
 assert.equal(file4.end, 2);
-var contentRead = '';
+let contentRead = '';
 file4.on('data', function(data) {
   contentRead += data.toString('utf-8');
 });
@@ -89,7 +89,7 @@ file4.on('end', function(data) {
   assert.equal(contentRead, 'yz');
 });
 
-var file5 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
+const file5 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
                                 start: 1}));
 assert.equal(file5.start, 1);
 file5.data = '';
@@ -101,7 +101,7 @@ file5.on('end', function() {
 });
 
 // https://github.com/joyent/node/issues/2320
-var file6 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1.23,
+const file6 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1.23,
                                 start: 1}));
 assert.equal(file6.start, 1);
 file6.data = '';
@@ -116,7 +116,7 @@ assert.throws(function() {
   fs.createReadStream(rangeFile, Object.create({start: 10, end: 2}));
 }, /"start" option must be <= "end" option/);
 
-var stream = fs.createReadStream(rangeFile, Object.create({ start: 0,
+const stream = fs.createReadStream(rangeFile, Object.create({ start: 0,
                                  end: 0 }));
 assert.equal(stream.start, 0);
 assert.equal(stream.end, 0);
@@ -131,11 +131,11 @@ stream.on('end', function() {
 });
 
 // pause and then resume immediately.
-var pauseRes = fs.createReadStream(rangeFile);
+const pauseRes = fs.createReadStream(rangeFile);
 pauseRes.pause();
 pauseRes.resume();
 
-var file7 = fs.createReadStream(rangeFile, Object.create({autoClose: false }));
+let file7 = fs.createReadStream(rangeFile, Object.create({autoClose: false }));
 assert.equal(file7.autoClose, false);
 file7.on('data', function() {});
 file7.on('end', function() {
@@ -159,13 +159,13 @@ function file7Next() {
 }
 
 // Just to make sure autoClose won't close the stream because of error.
-var file8 = fs.createReadStream(null, Object.create({fd: 13337,
+const file8 = fs.createReadStream(null, Object.create({fd: 13337,
                                 autoClose: false }));
 file8.on('data', function() {});
 file8.on('error', common.mustCall(function() {}));
 
 // Make sure stream is destroyed when file does not exist.
-var file9 = fs.createReadStream('/path/to/file/that/does/not/exist');
+const file9 = fs.createReadStream('/path/to/file/that/does/not/exist');
 file9.on('data', function() {});
 file9.on('error', common.mustCall(function() {}));
 

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -76,7 +76,7 @@ process.on('exit', function() {
 });
 
 const file4 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
-                                start: 1, end: 2}));
+                                  start: 1, end: 2}));
 assert.strictEqual(file4.start, 1);
 assert.strictEqual(file4.end, 2);
 let contentRead = '';
@@ -88,7 +88,7 @@ file4.on('end', function(data) {
 });
 
 const file5 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
-                                start: 1}));
+                                  start: 1}));
 assert.strictEqual(file5.start, 1);
 file5.data = '';
 file5.on('data', function(data) {
@@ -100,7 +100,7 @@ file5.on('end', function() {
 
 // https://github.com/joyent/node/issues/2320
 const file6 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1.23,
-                                start: 1}));
+                                  start: 1}));
 assert.strictEqual(file6.start, 1);
 file6.data = '';
 file6.on('data', function(data) {
@@ -115,7 +115,7 @@ assert.throws(function() {
 }, /"start" option must be <= "end" option/);
 
 const stream = fs.createReadStream(rangeFile, Object.create({ start: 0,
-                                 end: 0 }));
+                                   end: 0 }));
 assert.strictEqual(stream.start, 0);
 assert.strictEqual(stream.end, 0);
 stream.data = '';
@@ -158,7 +158,7 @@ function file7Next() {
 
 // Just to make sure autoClose won't close the stream because of error.
 const file8 = fs.createReadStream(null, Object.create({fd: 13337,
-                                autoClose: false }));
+                                  autoClose: false }));
 file8.on('data', function() {});
 file8.on('error', common.mustCall(function() {}));
 

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -48,8 +48,6 @@ file.on('end', function(chunk) {
 
 file.on('close', function() {
   callbacks.close++;
-
-  //assert.strictEqual(fs.readFileSync(fn), fileContent);
 });
 
 const file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -16,7 +16,7 @@ const file = fs.ReadStream(fn);
 file.on('open', function(fd) {
   file.length = 0;
   callbacks.open++;
-  assert.equal('number', typeof fd);
+  assert.strictEqual('number', typeof fd);
   assert.ok(file.readable);
 
   // GH-535
@@ -49,18 +49,18 @@ file.on('end', function(chunk) {
 file.on('close', function() {
   callbacks.close++;
 
-  //assert.equal(fs.readFileSync(fn), fileContent);
+  //assert.strictEqual(fs.readFileSync(fn), fileContent);
 });
 
 const file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
 file3.length = 0;
 file3.on('data', function(data) {
-  assert.equal('string', typeof data);
+  assert.strictEqual('string', typeof data);
   file3.length += data.length;
 
   for (let i = 0; i < data.length; i++) {
     // http://www.fileformat.info/info/unicode/char/2026/index.htm
-    assert.equal('\u2026', data[i]);
+    assert.strictEqual('\u2026', data[i]);
   }
 });
 
@@ -69,47 +69,47 @@ file3.on('close', function() {
 });
 
 process.on('exit', function() {
-  assert.equal(1, callbacks.open);
-  assert.equal(1, callbacks.end);
-  assert.equal(2, callbacks.close);
-  assert.equal(30000, file.length);
-  assert.equal(10000, file3.length);
+  assert.strictEqual(1, callbacks.open);
+  assert.strictEqual(1, callbacks.end);
+  assert.strictEqual(2, callbacks.close);
+  assert.strictEqual(30000, file.length);
+  assert.strictEqual(10000, file3.length);
   console.error('ok');
 });
 
 const file4 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
                                 start: 1, end: 2}));
-assert.equal(file4.start, 1);
-assert.equal(file4.end, 2);
+assert.strictEqual(file4.start, 1);
+assert.strictEqual(file4.end, 2);
 let contentRead = '';
 file4.on('data', function(data) {
   contentRead += data.toString('utf-8');
 });
 file4.on('end', function(data) {
-  assert.equal(contentRead, 'yz');
+  assert.strictEqual(contentRead, 'yz');
 });
 
 const file5 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1,
                                 start: 1}));
-assert.equal(file5.start, 1);
+assert.strictEqual(file5.start, 1);
 file5.data = '';
 file5.on('data', function(data) {
   file5.data += data.toString('utf-8');
 });
 file5.on('end', function() {
-  assert.equal(file5.data, 'yz\n');
+  assert.strictEqual(file5.data, 'yz\n');
 });
 
 // https://github.com/joyent/node/issues/2320
 const file6 = fs.createReadStream(rangeFile, Object.create({bufferSize: 1.23,
                                 start: 1}));
-assert.equal(file6.start, 1);
+assert.strictEqual(file6.start, 1);
 file6.data = '';
 file6.on('data', function(data) {
   file6.data += data.toString('utf-8');
 });
 file6.on('end', function() {
-  assert.equal(file6.data, 'yz\n');
+  assert.strictEqual(file6.data, 'yz\n');
 });
 
 assert.throws(function() {
@@ -118,8 +118,8 @@ assert.throws(function() {
 
 const stream = fs.createReadStream(rangeFile, Object.create({ start: 0,
                                  end: 0 }));
-assert.equal(stream.start, 0);
-assert.equal(stream.end, 0);
+assert.strictEqual(stream.start, 0);
+assert.strictEqual(stream.end, 0);
 stream.data = '';
 
 stream.on('data', function(chunk) {
@@ -127,7 +127,7 @@ stream.on('data', function(chunk) {
 });
 
 stream.on('end', function() {
-  assert.equal('x', stream.data);
+  assert.strictEqual('x', stream.data);
 });
 
 // pause and then resume immediately.
@@ -136,7 +136,7 @@ pauseRes.pause();
 pauseRes.resume();
 
 let file7 = fs.createReadStream(rangeFile, Object.create({autoClose: false }));
-assert.equal(file7.autoClose, false);
+assert.strictEqual(file7.autoClose, false);
 file7.on('data', function() {});
 file7.on('end', function() {
   process.nextTick(function() {
@@ -154,7 +154,7 @@ function file7Next() {
     file7.data += data;
   });
   file7.on('end', function(err) {
-    assert.equal(file7.data, 'xyz\n');
+    assert.strictEqual(file7.data, 'xyz\n');
   });
 }
 

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -16,7 +16,7 @@ const file = fs.ReadStream(fn);
 file.on('open', function(fd) {
   file.length = 0;
   callbacks.open++;
-  assert.strictEqual('number', typeof fd);
+  assert.strictEqual(typeof fd, 'number');
   assert.ok(file.readable);
 
   // GH-535
@@ -53,12 +53,12 @@ file.on('close', function() {
 const file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
 file3.length = 0;
 file3.on('data', function(data) {
-  assert.strictEqual('string', typeof data);
+  assert.strictEqual(typeof data, 'string');
   file3.length += data.length;
 
   for (let i = 0; i < data.length; i++) {
     // http://www.fileformat.info/info/unicode/char/2026/index.htm
-    assert.strictEqual('\u2026', data[i]);
+    assert.strictEqual(data[i], '\u2026');
   }
 });
 
@@ -67,11 +67,11 @@ file3.on('close', function() {
 });
 
 process.on('exit', function() {
-  assert.strictEqual(1, callbacks.open);
-  assert.strictEqual(1, callbacks.end);
-  assert.strictEqual(2, callbacks.close);
-  assert.strictEqual(30000, file.length);
-  assert.strictEqual(10000, file3.length);
+  assert.strictEqual(callbacks.open, 1);
+  assert.strictEqual(callbacks.end, 1);
+  assert.strictEqual(callbacks.close, 2);
+  assert.strictEqual(file.length, 30000);
+  assert.strictEqual(file3.length, 10000);
   console.error('ok');
 });
 
@@ -125,7 +125,7 @@ stream.on('data', function(chunk) {
 });
 
 stream.on('end', function() {
-  assert.strictEqual('x', stream.data);
+  assert.strictEqual(stream.data, 'x');
 });
 
 // pause and then resume immediately.


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Updates test/parallel/test-fs-read-stream-inherit.js by:
* Converts instances of var to const / let
* Converts instances of asset.equal to assert.strictEqual
