### PR TITLE
test: add const/let, mustCall, & === to tls-stream

### DIFF
--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -11,17 +11,11 @@ const stream = require('stream');
 const fs = require('fs');
 const net = require('net');
 
-const connected = {
-  client: 0,
-  server: 0
-};
-
 const server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 }, common.mustCall(function(c) {
   console.log('new client');
-  connected.server++;
   c.end('ohai');
 })).listen(0, common.mustCall(function() {
   const raw = net.connect(this.address().port);
@@ -55,8 +49,6 @@ const server = tls.createServer({
     rejectUnauthorized: false
   }, common.mustCall(function() {
     console.log('client secure');
-
-    connected.client++;
 
     socket.end('hello');
     socket.resume();

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -69,8 +68,3 @@ const server = tls.createServer({
     server.close();
   }));
 }));
-
-process.once('exit', function() {
-  assert.strictEqual(connected.client, 1);
-  assert.strictEqual(connected.server, 1);
-});

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -1,43 +1,43 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
-var stream = require('stream');
-var fs = require('fs');
-var net = require('net');
+const stream = require('stream');
+const fs = require('fs');
+const net = require('net');
 
-var connected = {
+const connected = {
   client: 0,
   server: 0
 };
 
-var server = tls.createServer({
+const server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
-}, function(c) {
+}, common.mustCall(function(c) {
   console.log('new client');
   connected.server++;
   c.end('ohai');
-}).listen(0, function() {
-  var raw = net.connect(this.address().port);
+})).listen(0, common.mustCall(function() {
+  const raw = net.connect(this.address().port);
 
-  var pending = false;
+  let pending = false;
   raw.on('readable', function() {
     if (pending)
       p._read();
   });
 
-  var p = new stream.Duplex({
+  let p = new stream.Duplex({
     read: function read() {
       pending = false;
 
-      var chunk = raw.read();
+      const chunk = raw.read();
       if (chunk) {
         console.log('read', chunk);
         this.push(chunk);
@@ -51,10 +51,10 @@ var server = tls.createServer({
     }
   });
 
-  var socket = tls.connect({
+  const socket = tls.connect({
     socket: p,
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     console.log('client secure');
 
     connected.client++;
@@ -62,15 +62,15 @@ var server = tls.createServer({
     socket.end('hello');
     socket.resume();
     socket.destroy();
-  });
+  }));
 
-  socket.once('close', function() {
+  socket.once('close', common.mustCall(function() {
     console.log('client close');
     server.close();
-  });
-});
+  }));
+}));
 
 process.once('exit', function() {
-  assert.equal(connected.client, 1);
-  assert.equal(connected.server, 1);
+  assert.strictEqual(connected.client, 1);
+  assert.strictEqual(connected.server, 1);
 });


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
- change `var` to `const` and `let` 
- add `common.mustCall` to all functions that need to be called exactly once
- change all `asset.equal` to `asset.strictEqual`

