### PR TITLE
Updated test-cluster-send-deadlock.js to use assert.strictEqual

### DIFF
--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -10,7 +10,7 @@ var net = require('net');
 if (cluster.isMaster) {
   var worker = cluster.fork();
   worker.on('exit', function(code, signal) {
-    assert.equal(code, 0, 'Worker exited with an error code');
+    assert.strictEqual(code, 0, 'Worker exited with an error code');
     assert(!signal, 'Worker exited by a signal');
     server.close();
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tests

##### Description of change
<!-- Provide a description of the change below this comment. -->
Updated test-cluster-send-deadlock.js to change assert.equal to assert.strictEqual