### PR TITLE
test: changed equal to strictEqual in dgram-send-multi-buffer-copy.js

### DIFF
--- a/test/parallel/test-dgram-send-multi-buffer-copy.js
+++ b/test/parallel/test-dgram-send-multi-buffer-copy.js
@@ -7,7 +7,7 @@ const dgram = require('dgram');
 const client = dgram.createSocket('udp4');
 
 const onMessage = common.mustCall(function(err, bytes) {
-  assert.equal(bytes, buf1.length + buf2.length);
+  assert.strictEqual(bytes, buf1.length + buf2.length);
 });
 
 const buf1 = Buffer.alloc(256, 'x');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Changed assert.equal() to assert.strictEqual() in test/parallel/test-dgram-send-multi-buffer-copy.js
