### PR TITLE
test: replace equal with strictEqual in test-freelist.js

### DIFF
--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -6,8 +6,8 @@ require('../common');
 const assert = require('assert');
 const freelist = require('internal/freelist');
 
-assert.equal(typeof freelist, 'object');
-assert.equal(typeof freelist.FreeList, 'function');
+assert.strictEqual(typeof freelist, 'object');
+assert.strictEqual(typeof freelist.FreeList, 'function');
 
 const flist1 = new freelist.FreeList('flist1', 3, String);
 


### PR DESCRIPTION
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change

Improving asserts in test-freelist.js