### PR TITLE
test: added validation regex argument to test

### DIFF
--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -46,7 +46,7 @@ file
     assert.throws(function() {
       console.error('write after end should not be allowed');
       file.write('should not work anymore');
-    }, /write/);
+    }, /^Error: write after end$/);
 
     fs.unlinkSync(fn);
   });

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -46,7 +46,7 @@ file
     assert.throws(function() {
       console.error('write after end should not be allowed');
       file.write('should not work anymore');
-    });
+    }, /write/);
 
     fs.unlinkSync(fn);
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test


##### Description of change
<!-- Provide a description of the change below this comment. -->

In this change, I've added the regex pattern to the assert.throws()
in order to provide the validation argument for the call.