### PR TITLE
test: use assert.strictEqual in test-cli-eval

### DIFF
--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -19,15 +19,15 @@ var filename = __filename.replace(/\\/g, '/');
 // assert that nothing is written to stdout
 child.exec(nodejs + ' --eval 42',
     function(err, stdout, stderr) {
-      assert.equal(stdout, '');
-      assert.equal(stderr, '');
+      assert.strictEqual(stdout, '');
+      assert.strictEqual(stderr, '');
     });
 
 // assert that "42\n" is written to stderr
 child.exec(nodejs + ' --eval "console.error(42)"',
     function(err, stdout, stderr) {
-      assert.equal(stdout, '');
-      assert.equal(stderr, '42\n');
+      assert.strictEqual(stdout, '');
+      assert.strictEqual(stderr, '42\n');
     });
 
 // assert that the expected output is written to stdout
@@ -36,21 +36,21 @@ child.exec(nodejs + ' --eval "console.error(42)"',
 
   child.exec(cmd + '42',
       function(err, stdout, stderr) {
-        assert.equal(stdout, '42\n');
-        assert.equal(stderr, '');
+        assert.strictEqual(stdout, '42\n');
+        assert.strictEqual(stderr, '');
       });
 
   child.exec(cmd + "'[]'", common.mustCall(
       function(err, stdout, stderr) {
-        assert.equal(stdout, '[]\n');
-        assert.equal(stderr, '');
+        assert.strictEqual(stdout, '[]\n');
+        assert.strictEqual(stderr, '');
       }));
 });
 
 // assert that module loading works
 child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
     function(status, stdout, stderr) {
-      assert.equal(status.code, 42);
+      assert.strictEqual(status.code, 42);
     });
 
 // Check that builtin modules are pre-defined.
@@ -63,7 +63,7 @@ child.exec(nodejs + ' --print "os.platform()"',
 // module path resolve bug, regression test
 child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
     function(status, stdout, stderr) {
-      assert.equal(status.code, 42);
+      assert.strictEqual(status.code, 42);
     });
 
 // Missing argument should not crash
@@ -74,28 +74,29 @@ child.exec(nodejs + ' -e', common.mustCall(function(status, stdout, stderr) {
 
 // empty program should do nothing
 child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
-  assert.equal(stdout, '');
-  assert.equal(stderr, '');
+  assert.strictEqual(stdout, '');
+  assert.strictEqual(stderr, '');
 });
 
 // "\\-42" should be interpreted as an escaped expression, not a switch
 child.exec(nodejs + ' -p "\\-42"',
     function(err, stdout, stderr) {
-      assert.equal(stdout, '-42\n');
-      assert.equal(stderr, '');
+      assert.strictEqual(stdout, '-42\n');
+      assert.strictEqual(stderr, '');
     });
 
 child.exec(nodejs + ' --use-strict -p process.execArgv',
     function(status, stdout, stderr) {
-      assert.equal(stdout, "[ '--use-strict', '-p', 'process.execArgv' ]\n");
+      assert.strictEqual(stdout,
+                         "[ '--use-strict', '-p', 'process.execArgv' ]\n");
     });
 
 // Regression test for https://github.com/nodejs/node/issues/3574
 const emptyFile = path.join(common.fixturesDir, 'empty.js');
 child.exec(nodejs + ` -e 'require("child_process").fork("${emptyFile}")'`,
     function(status, stdout, stderr) {
-      assert.equal(stdout, '');
-      assert.equal(stderr, '');
+      assert.strictEqual(stdout, '');
+      assert.strictEqual(stderr, '');
     });
 
 // Regression test for https://github.com/nodejs/node/issues/8534.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x]  tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
<!-- Provide a description of the change below this comment. -->
Being more strict about comparisons here, especially since many comparisons are against an empty string which would equal, but not strictly equal, false.