### PR TITLE
test: add tests for clearBuffer state machine

### DIFF
--- a/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
+++ b/test/parallel/test-stream-writableState-uncorked-bufferedRequestCount.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+const writable = new stream.Writable();
+
+writable._writev = common.mustCall((chunks, cb) => {
+  assert.equal(chunks.length, 2, 'two chunks to write');
+  cb();
+}, 1);
+
+writable._write = common.mustCall((chunk, encoding, cb) => {
+  cb();
+}, 1);
+
+// first cork
+writable.cork();
+assert.strictEqual(writable._writableState.corked, 1);
+assert.strictEqual(writable._writableState.bufferedRequestCount, 0);
+
+// cork again
+writable.cork();
+assert.strictEqual(writable._writableState.corked, 2);
+
+// the first chunk is buffered
+writable.write('first chunk');
+assert.strictEqual(writable._writableState.bufferedRequestCount, 1);
+
+// first uncork does nothing
+writable.uncork();
+assert.strictEqual(writable._writableState.corked, 1);
+assert.strictEqual(writable._writableState.bufferedRequestCount, 1);
+
+process.nextTick(uncork);
+
+// the second chunk is buffered, because we uncork at the end of tick
+writable.write('second chunk');
+assert.strictEqual(writable._writableState.corked, 1);
+assert.strictEqual(writable._writableState.bufferedRequestCount, 2);
+
+function uncork() {
+  // second uncork flushes the buffer
+  writable.uncork();
+  assert.strictEqual(writable._writableState.corked, 0);
+  assert.strictEqual(writable._writableState.bufferedRequestCount, 0);
+
+  // verify that end() uncorks correctly
+  writable.cork();
+  writable.write('third chunk');
+  writable.end();
+
+  // end causes an uncork() as well
+  assert.strictEqual(writable._writableState.corked, 0);
+  assert.strictEqual(writable._writableState.bufferedRequestCount, 0);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

stream, test

##### Description of change
<!-- Provide a description of the change below this comment. -->

This checks to see that clearBuffer appropriately decrements the
correct values in _writableState when clearBuffer is invoked in
end.

Closes #8687.