### PR TITLE
test: convert assert.equal to assert.strictEqual

### DIFF
--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -35,7 +35,7 @@ try {
   assert.strictEqual(
     SlowBuffer(buffer.kMaxLength).length, buffer.kMaxLength);
 } catch (e) {
-  assert.equal(e.message, 'Array buffer allocation failed');
+  assert.strictEqual(e.message, 'Array buffer allocation failed');
 }
 
 // should work with number-coercible values


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
converts an instance of assert.equal in a file already mostly updated to
use assert.strictEqual