### PR TITLE
test: const/let, strictEqual in symlink-dir-junct

### DIFF
--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
 
 // test creating and reading symbolic link
-var linkData = path.join(common.fixturesDir, 'cycles/');
-var linkPath = path.join(common.tmpDir, 'cycles_link');
+const linkData = path.join(common.fixturesDir, 'cycles/');
+const linkPath = path.join(common.tmpDir, 'cycles_link');
 
 common.refreshTmpDir();
 
@@ -22,7 +22,7 @@ fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
 
     fs.readlink(linkPath, common.mustCall(function(err, destination) {
       if (err) throw err;
-      assert.equal(destination, linkData);
+      assert.strictEqual(destination, linkData);
 
       fs.unlink(linkPath, common.mustCall(function(err) {
         if (err) throw err;


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
- change `var` to `const`/`let`
- change `assert.equal` to `asset.strictEqual`

