### PR TITLE
test: use strictEqual instead of equal

### DIFF
--- a/test/parallel/test-child-process-double-pipe.js
+++ b/test/parallel/test-child-process-double-pipe.js
@@ -91,5 +91,5 @@ sed.stdout.on('data', function(data) {
 });
 
 sed.stdout.on('end', function(code) {
-  assert.equal(result, 'hellO' + os.EOL + 'nOde' + os.EOL + 'wOrld' + os.EOL);
+  assert.strictEqual(result, `hellO${os.EOL}nOde${os.EOL}wOrld${os.EOL}`);
 });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change

Updated test to remove error since expectation is to use strictEquals
for tests.