### PR TITLE
test: crypto-hash-stream-pipe use strict equal

### DIFF
--- a/test/parallel/test-crypto-hash-stream-pipe.js
+++ b/test/parallel/test-crypto-hash-stream-pipe.js
@@ -14,7 +14,7 @@ var h = crypto.createHash('sha1');
 var expect = '15987e60950cf22655b9323bc1e281f9c4aff47e';
 
 s.pipe(h).on('data', common.mustCall(function(c) {
-  assert.equal(c, expect);
+  assert.strictEqual(c, expect);
 })).setEncoding('hex');
 
 s.end('aoeu');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Replaces the use of assert.equal() with assert.strictEqual in test
code.