### PR TITLE
test: update test-stdout-to-file

### DIFF
--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -1,13 +1,14 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var childProcess = require('child_process');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const childProcess = require('child_process');
+const fs = require('fs');
 
-var scriptString = path.join(common.fixturesDir, 'print-chars.js');
-var scriptBuffer = path.join(common.fixturesDir, 'print-chars-from-buffer.js');
-var tmpFile = path.join(common.tmpDir, 'stdout.txt');
+const scriptString = path.join(common.fixturesDir, 'print-chars.js');
+const scriptBuffer = path.join(common.fixturesDir,
+                               'print-chars-from-buffer.js');
+const tmpFile = path.join(common.tmpDir, 'stdout.txt');
 
 common.refreshTmpDir();
 
@@ -24,22 +25,22 @@ function test(size, useBuffer, cb) {
     fs.unlinkSync(tmpFile);
   } catch (e) {}
 
-  console.log(size + ' chars to ' + tmpFile + '...');
+  console.log(`${size} chars to ${tmpFile}...`);
 
-  childProcess.exec(cmd, function(err) {
+  childProcess.exec(cmd, common.mustCall(function(err) {
     if (err) throw err;
 
     console.log('done!');
 
     var stat = fs.statSync(tmpFile);
 
-    console.log(tmpFile + ' has ' + stat.size + ' bytes');
+    console.log(`${tmpFile} has ${stat.size} bytes`);
 
-    assert.equal(size, stat.size);
+    assert.strictEqual(size, stat.size);
     fs.unlinkSync(tmpFile);
 
     cb();
-  });
+  }));
 }
 
 test(1024 * 1024, false, common.mustCall(function() {


### PR DESCRIPTION
##### Checklist
- [x ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x ] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
- changed vars to const
- changed assert.equal to assert.strictEqual
- added a common.mustCall in the childProcess.exec callback
- replaced 2 console.log strings with template strings for readability
- broke up line 9 as it was causing a line max length (80) listing err