### PR TITLE
test: change equal to strictEqual and var to const

### DIFF
--- a/test/parallel/test-sync-fileread.js
+++ b/test/parallel/test-sync-fileread.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
 
-var fixture = path.join(common.fixturesDir, 'x.txt');
+const fixture = path.join(common.fixturesDir, 'x.txt');
 
-assert.equal('xyz\n', fs.readFileSync(fixture));
+assert.strictEqual(fs.readFileSync(fixture).toString(), 'xyz\n');


### PR DESCRIPTION
- [x] `make -j8 test`
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
- test

##### Description of change
- Change `equal` to `strictEqual` (required addition of `encoding="utf"` parameter for [`readFileSync`](https://nodejs.org/api/fs.html#fs_fs_readfilesync_file_options) call)
- Change `var` to `const`