### PR TITLE
test: refactor test for crypto cipher/decipher iv

### DIFF
--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -10,51 +10,51 @@ var crypto = require('crypto');
 
 function testCipher1(key, iv) {
   // Test encyrption and decryption with explicit key and iv
-  var plaintext =
+  var plain =
       '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
       'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
       'jAfaFg**';
   var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
-  var ciph = cipher.update(plaintext, 'utf8', 'hex');
+  var ciph = cipher.update(plain, 'utf8', 'hex');
   ciph += cipher.final('hex');
 
   var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
   var txt = decipher.update(ciph, 'hex', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+  assert.strictEqual(txt, plain, 'encryption and decryption with key and iv');
 
   // streaming cipher interface
   // NB: In real life, it's not guaranteed that you can get all of it
   // in a single read() like this.  But in this case, we know it's
   // quite small, so there's no harm.
   var cStream = crypto.createCipheriv('des-ede3-cbc', key, iv);
-  cStream.end(plaintext);
+  cStream.end(plain);
   ciph = cStream.read();
 
   var dStream = crypto.createDecipheriv('des-ede3-cbc', key, iv);
   dStream.end(ciph);
   txt = dStream.read().toString('utf8');
 
-  assert.equal(txt, plaintext, 'streaming cipher iv');
+  assert.strictEqual(txt, plain, 'streaming cipher iv');
 }
 
 
 function testCipher2(key, iv) {
   // Test encyrption and decryption with explicit key and iv
-  var plaintext =
+  var plain =
       '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
       'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
       'jAfaFg**';
   var cipher = crypto.createCipheriv('des-ede3-cbc', key, iv);
-  var ciph = cipher.update(plaintext, 'utf8', 'buffer');
+  var ciph = cipher.update(plain, 'utf8', 'buffer');
   ciph = Buffer.concat([ciph, cipher.final('buffer')]);
 
   var decipher = crypto.createDecipheriv('des-ede3-cbc', key, iv);
   var txt = decipher.update(ciph, 'buffer', 'utf8');
   txt += decipher.final('utf8');
 
-  assert.equal(txt, plaintext, 'encryption and decryption with key and iv');
+  assert.strictEqual(txt, plain, 'encryption and decryption with key and iv');
 }
 
 testCipher1('0123456789abcd0123456789', '12345678');


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test, crypto

##### Description of change

Replace assert.equal with assert.strictEqual, renamed plaintext to plain
to reduce line length