### PR TITLE
test: replace assert.equal to assert.strictEqual, var to const/let

### DIFF
--- a/test/parallel/test-dgram-bind-default-address.js
+++ b/test/parallel/test-dgram-bind-default-address.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var dgram = require('dgram');
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
 
 // skip test in FreeBSD jails since 0.0.0.0 will resolve to default interface
 if (common.inFreeBSDJail) {
@@ -13,7 +13,7 @@ dgram.createSocket('udp4').bind(0, common.mustCall(function() {
   assert.strictEqual(typeof this.address().port, 'number');
   assert.ok(isFinite(this.address().port));
   assert.ok(this.address().port > 0);
-  assert.equal(this.address().address, '0.0.0.0');
+  assert.strictEqual(this.address().address, '0.0.0.0');
   this.close();
 }));
 
@@ -26,9 +26,9 @@ dgram.createSocket('udp6').bind(0, common.mustCall(function() {
   assert.strictEqual(typeof this.address().port, 'number');
   assert.ok(isFinite(this.address().port));
   assert.ok(this.address().port > 0);
-  var address = this.address().address;
+  let address = this.address().address;
   if (address === '::ffff:0.0.0.0')
     address = '::';
-  assert.equal(address, '::');
+  assert.strictEqual(address, '::');
   this.close();
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

##### Description of change
<!-- Provide a description of the change below this comment. -->

- Replaced `var` keywords to `const` / `let`
- Replaced `assert.equal` assertions to use `assert.strictEqual`