### PR TITLE
test: const, let and strictEqual in test-tls-0

### DIFF
--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -1,16 +1,16 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
-var fs = require('fs');
+const fs = require('fs');
 
-var server = tls.createServer({
+const server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/0-dns-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/0-dns-cert.pem')
 }, function(c) {
@@ -19,16 +19,16 @@ var server = tls.createServer({
     server.close();
   });
 }).listen(0, common.mustCall(function() {
-  var c = tls.connect(this.address().port, {
+  const c = tls.connect(this.address().port, {
     rejectUnauthorized: false
   }, common.mustCall(function() {
-    var cert = c.getPeerCertificate();
-    assert.equal(cert.subjectaltname,
-                 'DNS:google.com\0.evil.com, ' +
-                     'DNS:just-another.com, ' +
-                     'IP Address:8.8.8.8, ' +
-                     'IP Address:8.8.4.4, ' +
-                     'DNS:last.com');
+    const cert = c.getPeerCertificate();
+    assert.strictEqual(cert.subjectaltname,
+                       'DNS:google.com\0.evil.com, ' +
+                           'DNS:just-another.com, ' +
+                           'IP Address:8.8.8.8, ' +
+                           'IP Address:8.8.4.4, ' +
+                           'DNS:last.com');
     c.write('ok');
   }));
 }));


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Just a fix for a test

##### Description of change
Using const instead of var and strictEqual instead of equal in test/parallel/test-tls-0-dns-altname.js

