### PR TITLE
Using assert.strictEqual instead of equal

### DIFF
--- a/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -48,8 +48,8 @@ if (process.argv[2] === 'child') {
       var expectedExitCode = 7;
       var expectedSignal = null;
 
-      assert.equal(exitCode, expectedExitCode);
-      assert.equal(signal, expectedSignal);
+      assert.strictEqual(exitCode, expectedExitCode);
+      assert.strictEqual(signal, expectedSignal);
     });
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
