### PR TITLE
test: use const and strictEqual in child-process-spawn-error

### DIFF
--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common');
-var spawn = require('child_process').spawn;
-var assert = require('assert');
+const common = require('../common');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
 
-var enoentPath = 'foo123';
-var spawnargs = ['bar'];
+const enoentPath = 'foo123';
+const spawnargs = ['bar'];
 assert.equal(common.fileExists(enoentPath), false);
 
-var enoentChild = spawn(enoentPath, spawnargs);
+const enoentChild = spawn(enoentPath, spawnargs);
 enoentChild.on('error', common.mustCall(function(err) {
-  assert.equal(err.code, 'ENOENT');
-  assert.equal(err.errno, 'ENOENT');
-  assert.equal(err.syscall, 'spawn ' + enoentPath);
-  assert.equal(err.path, enoentPath);
+  assert.strictEqual(err.code, 'ENOENT');
+  assert.strictEqual(err.errno, 'ENOENT');
+  assert.strictEqual(err.syscall, 'spawn ' + enoentPath);
+  assert.strictEqual(err.path, enoentPath);
   assert.deepStrictEqual(err.spawnargs, spawnargs);
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
<!-- Provide a description of the change below this comment. -->

- Using const instead of var for assignments.
- let is not used since there are no reassignments or block scopes.
- assert.equals was changed to assert.strictEquals