### PR TITLE
Use assert.strictEqual instead of assert.equal

### DIFF
--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -23,6 +23,6 @@ proc.stdin.write('require("path");\n');
 proc.stdin.write('process.exit(42);\n');
 
 proc.once('exit', common.mustCall(function(exitCode, signalCode) {
-  assert.equal(exitCode, 42);
-  assert.equal(signalCode, null);
+  assert.strictEqual(exitCode, 42);
+  assert.strictEqual(signalCode, null);
 }));


### PR DESCRIPTION
## Checklist
- [x] make -j8 test (UNIX), or vcbuild test nosign (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

## Affected core subsystem(s)
Test

## Description of change
convert assert.equal to assert.strictEqual
