### PR TITLE
test: change assert.equal to assert.strictEqual

### DIFF
--- a/test/parallel/test-cluster-worker-constructor.js
+++ b/test/parallel/test-cluster-worker-constructor.js
@@ -8,21 +8,21 @@ var cluster = require('cluster');
 var worker;
 
 worker = new cluster.Worker();
-assert.equal(worker.suicide, undefined);
-assert.equal(worker.state, 'none');
-assert.equal(worker.id, 0);
-assert.equal(worker.process, undefined);
+assert.strictEqual(worker.suicide, undefined);
+assert.strictEqual(worker.state, 'none');
+assert.strictEqual(worker.id, 0);
+assert.strictEqual(worker.process, undefined);
 
 worker = new cluster.Worker({
   id: 3,
   state: 'online',
   process: process
 });
-assert.equal(worker.suicide, undefined);
-assert.equal(worker.state, 'online');
-assert.equal(worker.id, 3);
-assert.equal(worker.process, process);
+assert.strictEqual(worker.suicide, undefined);
+assert.strictEqual(worker.state, 'online');
+assert.strictEqual(worker.id, 3);
+assert.strictEqual(worker.process, process);
 
 worker = cluster.Worker.call({}, {id: 5});
 assert(worker instanceof cluster.Worker);
-assert.equal(worker.id, 5);
+assert.strictEqual(worker.id, 5);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Use assert.strictEqual() instead of assert.equal() for lines 11, 12, 13, 14, 21, 22, 23, 24, 28
