### PR TITLE
test: crypto-hmac test assert.equal -> assert.strictEqual

### DIFF
--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -69,8 +69,7 @@ for (let i = 0, l = wikipedia.length; i < l; i++) {
                          .digest('hex');
     assert.strictEqual(wikipedia[i]['hmac'][hash],
                        result,
-                       'Test HMAC-' + hash + ': Test case ' + (i + 1)
-                       + ' wikipedia');
+                       `Test HMAC-${hash}: Test case ${i + 1} wikipedia`);
   }
 }
 
@@ -236,8 +235,7 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
     }
     assert.strictEqual(rfc4231[i]['hmac'][hash],
                        result,
-                       'Test HMAC-' + hash + ': Test case ' + (i + 1)
-                       + ' rfc 4231');
+                       `Test HMAC-${hash}: Test case ${i + 1} rfc 4231`);
     assert.strictEqual(strRes, result, 'Should get same result from stream');
   }
 }
@@ -358,7 +356,7 @@ if (!common.hasFipsCrypto) {
       crypto.createHmac('md5', rfc2202_md5[i]['key'])
         .update(rfc2202_md5[i]['data'])
         .digest('hex'),
-      'Test HMAC-MD5 : Test case ' + (i + 1) + ' rfc 2202'
+      `Test HMAC-MD5 : Test case ${i + 1} rfc 2202`
     );
   }
 }
@@ -368,6 +366,6 @@ for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
     crypto.createHmac('sha1', rfc2202_sha1[i]['key'])
       .update(rfc2202_sha1[i]['data'])
       .digest('hex'),
-    'Test HMAC-SHA1 : Test case ' + (i + 1) + ' rfc 2202'
+    `Test HMAC-SHA1 : Test case ${i + 1} rfc 2202`
   );
 }

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -13,7 +13,7 @@ var h1 = crypto.createHmac('sha1', 'Node')
                .update('some data')
                .update('to hmac')
                .digest('hex');
-assert.equal(h1, '19fd6e1ba73d9ed2224dd5094a71babe85d9a892', 'test HMAC');
+assert.strictEqual(h1, '19fd6e1ba73d9ed2224dd5094a71babe85d9a892', 'test HMAC');
 
 // Test HMAC (Wikipedia Test Cases)
 var wikipedia = [
@@ -67,7 +67,7 @@ for (let i = 0, l = wikipedia.length; i < l; i++) {
     const result = crypto.createHmac(hash, wikipedia[i]['key'])
                          .update(wikipedia[i]['data'])
                          .digest('hex');
-    assert.equal(wikipedia[i]['hmac'][hash],
+    assert.strictEqual(wikipedia[i]['hmac'][hash],
                  result,
                  'Test HMAC-' + hash + ': Test case ' + (i + 1) + ' wikipedia');
   }
@@ -233,10 +233,10 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
       result = result.substr(0, 32); // first 128 bits == 32 hex chars
       strRes = strRes.substr(0, 32);
     }
-    assert.equal(rfc4231[i]['hmac'][hash],
+    assert.strictEqual(rfc4231[i]['hmac'][hash],
                  result,
                  'Test HMAC-' + hash + ': Test case ' + (i + 1) + ' rfc 4231');
-    assert.equal(strRes, result, 'Should get same result from stream');
+    assert.strictEqual(strRes, result, 'Should get same result from stream');
   }
 }
 

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -68,8 +68,9 @@ for (let i = 0, l = wikipedia.length; i < l; i++) {
                          .update(wikipedia[i]['data'])
                          .digest('hex');
     assert.strictEqual(wikipedia[i]['hmac'][hash],
-                 result,
-                 'Test HMAC-' + hash + ': Test case ' + (i + 1) + ' wikipedia');
+                       result,
+                       'Test HMAC-' + hash + ': Test case ' + (i + 1)
+                       + ' wikipedia');
   }
 }
 
@@ -234,8 +235,9 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
       strRes = strRes.substr(0, 32);
     }
     assert.strictEqual(rfc4231[i]['hmac'][hash],
-                 result,
-                 'Test HMAC-' + hash + ': Test case ' + (i + 1) + ' rfc 4231');
+                       result,
+                       'Test HMAC-' + hash + ': Test case ' + (i + 1)
+                       + ' rfc 4231');
     assert.strictEqual(strRes, result, 'Should get same result from stream');
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Tests for `crypto.createHmac(..)` affected

##### Description of change
<!-- Provide a description of the change below this comment. -->

For better equals assertions within the `test/parallel/test-crypto-hmac.js` switching from `assert.equals(..)` to `assert.strictEquals(..)`

##### Question for @maintainers
I had to make a 2nd commit to fix the linting errors.
Should I squash them for the PR?
_(the guidelines don't mention this either way)_