### PR TITLE
test: replace var with const/let and use common.mustCall for cb

### DIFF
--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -1,16 +1,15 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
 
-var tls = require('tls');
-var fs = require('fs');
-var path = require('path');
-var finished = 0;
+const assert = require('assert');
+const tls = require('tls');
+const fs = require('fs');
+const path = require('path');
 
 function filenamePEM(n) {
   return path.join(common.fixturesDir, 'keys', n + '.pem');
@@ -20,7 +19,7 @@ function loadPEM(n) {
   return fs.readFileSync(filenamePEM(n));
 }
 
-var testCases = [
+const testCases = [
   { // Test 0: for the check of a cert not existed in the whitelist.
     // agent7-cert.pem is issued by the fake CNNIC root CA so that its
     // hash is not listed in the whitelist.
@@ -58,27 +57,22 @@ var testCases = [
 ];
 
 function runTest(tindex) {
-  var tcase = testCases[tindex];
+  const tcase = testCases[tindex];
 
   if (!tcase) return;
 
-  var server = tls.createServer(tcase.serverOpts, function(s) {
+  const server = tls.createServer(tcase.serverOpts, (s) => {
     s.resume();
-  }).listen(0, function() {
+  }).listen(0, common.mustCall(function() {
     tcase.clientOpts = this.address().port;
-    var client = tls.connect(tcase.clientOpts);
-    client.on('error', function(e) {
+    const client = tls.connect(tcase.clientOpts);
+    client.on('error', common.mustCall((e) => {
       assert.strictEqual(e.code, tcase.errorCode);
-      server.close(function() {
-        finished++;
+      server.close(common.mustCall(() => {
         runTest(tindex + 1);
-      });
-    });
-  });
+      }));
+    }));
+  }));
 }
 
 runTest(0);
-
-process.on('exit', function() {
-  assert.equal(finished, testCases.length);
-});


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
* replace var with const and let
* use `common.mustCall` for callbacks
* remove `process.on('exit')` because all callbacks are wrapped by `common.mustCall`