### PR TITLE
test: ensure cluster setup callback runs once

### DIFF
--- a/test/parallel/test-cluster-setup-master-argv.js
+++ b/test/parallel/test-cluster-setup-master-argv.js
@@ -1,16 +1,16 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var cluster = require('cluster');
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
 
 setTimeout(common.fail.bind(assert, 'setup not emitted'), 1000).unref();
 
-cluster.on('setup', function() {
+cluster.on('setup', common.mustCall(function() {
   var clusterArgs = cluster.settings.args;
   var realArgs = process.argv;
-  assert.equal(clusterArgs[clusterArgs.length - 1],
-               realArgs[realArgs.length - 1]);
-});
+  assert.strictEqual(clusterArgs[clusterArgs.length - 1],
+                     realArgs[realArgs.length - 1]);
+}));
 
 assert.notStrictEqual(process.argv[process.argv.length - 1], 'OMG,OMG');
 process.argv.push('OMG,OMG');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

- updated vars to const
- strict equal assertion
- add common must call to setup callback