### PR TITLE
doc: add note to parallelize make

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
-- [ ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
+- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
 - [ ] tests and/or benchmarks are included
 - [ ] documentation is changed or added
 - [ ] commit message follows commit guidelines

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,8 +31,16 @@ To build Node.js:
 
 ```console
 $ ./configure
-$ make
+$ make -j4
 ```
+
+Running `make` with the `-j4` flag will cause it to run 4 compilation jobs
+concurrently which may significantly reduce build time. The number after `-j`
+can be changed to best suit the number of processor cores on your machine. If
+you run into problems running `make` with concurrency, try running it without
+the `-j4` flag. See the
+[GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html)
+for more information.
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7 and not a newer version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ to see how they should be structured can also help.
 To run the tests on Unix / OS X:
 
 ```text
-$ ./configure && make -j8 test
+$ ./configure && make -j4 test
 ```
 
 Windows:
@@ -189,7 +189,7 @@ You can run tests directly with node:
 $ ./node ./test/parallel/test-stream2-transform.js
 ```
 
-Remember to recompile with `make -j8` in between test runs if you change
+Remember to recompile with `make -j4` in between test runs if you change
 core modules.
 
 ### Step 6: Push

--- a/doc/guides/building-node-with-ninja.md
+++ b/doc/guides/building-node-with-ninja.md
@@ -16,7 +16,7 @@ ninja: Entering directory `out/Release`
 
 The bottom line will change while building, showing the progress as `[finished/total]` build steps.
 This is useful output that `make` does not produce and is one of the benefits of using Ninja.
-Also, Ninja will likely compile much faster than even `make -j8` (or `-j<number of processor threads on your machine>`).
+Also, Ninja will likely compile much faster than even `make -j4` (or `-j<number of processor threads on your machine>`).
 
 ## Considerations
 

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -71,7 +71,7 @@ Please use these when possible / appropriate
   * major vs. everything else: run last versions tests against this version, if they pass, **probably** minor or patch
   * A breaking change helper ([full source](https://gist.github.com/chrisdickinson/ba532fa0e4e243fb7b44)):
   ```sh
-  git checkout $(git show -s --pretty='%T' $(git show-ref -d $(git describe --abbrev=0) | tail -n1 | awk '{print $1}')) -- test; make -j8 test
+  git checkout $(git show -s --pretty='%T' $(git show-ref -d $(git describe --abbrev=0) | tail -n1 | awk '{print $1}')) -- test; make -j4 test
   ```
 
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
Adds a note to the BUILDING doc to encourage parallelizing make. When I
first built node I didn't know this trick and thought that the build was
just stuck in an infinite loop after waiting for 10 minutes.