### PR TITLE
test: strictEqual in test-cli-eval-event test

### DIFF
--- a/test/parallel/test-cli-eval-event.js
+++ b/test/parallel/test-cli-eval-event.js
@@ -10,6 +10,6 @@ const child = spawn(process.execPath, ['-e', `
 `]);
 
 child.once('exit', common.mustCall(function(exitCode, signalCode) {
-  assert.equal(exitCode, 0);
-  assert.equal(signalCode, null);
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signalCode, null);
 }));


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
N/A

##### Description of change
Using strictEqual instead of equal in test/parallel/test-cli-eval-event.js

