### PR TITLE
subsystem: fix error in test-cluster-worker-death.js

### DIFF
--- a/test/parallel/test-cluster-worker-death.js
+++ b/test/parallel/test-cluster-worker-death.js
@@ -8,10 +8,10 @@ if (!cluster.isMaster) {
 } else {
   var worker = cluster.fork();
   worker.on('exit', common.mustCall(function(exitCode, signalCode) {
-    assert.equal(exitCode, 42);
-    assert.equal(signalCode, null);
+    assert.strictEqual(exitCode, 42);
+    assert.strictEqual(signalCode, null);
   }));
   cluster.on('exit', common.mustCall(function(worker_) {
-    assert.equal(worker_, worker);
+    assert.strictEqual(worker_, worker);
   }));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Replaced calls to assert.equal with assert.strictEqual in order
to fix the following error:
"Please use assert.strictEqual() instead of assert.strictEqual()"