### PR TITLE
test: improve the code in test-tls-friendly-message.js

### DIFF
--- a/test/parallel/test-tls-friendly-error-message.js
+++ b/test/parallel/test-tls-friendly-error-message.js
@@ -1,26 +1,26 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
-var fs = require('fs');
+const fs = require('fs');
 
-var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
-var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
+const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
 
-tls.createServer({ key: key, cert: cert }, function(conn) {
+tls.createServer({ key: key, cert: cert }, common.mustCall(function(conn) {
   conn.end();
   this.close();
-}).listen(0, function() {
+})).listen(0, common.mustCall(function() {
   var options = { port: this.address().port, rejectUnauthorized: true };
   tls.connect(options).on('error', common.mustCall(function(err) {
-    assert.equal(err.code, 'UNABLE_TO_VERIFY_LEAF_SIGNATURE');
-    assert.equal(err.message, 'unable to verify the first certificate');
+    assert.strictEqual(err.code, 'UNABLE_TO_VERIFY_LEAF_SIGNATURE');
+    assert.strictEqual(err.message, 'unable to verify the first certificate');
     this.destroy();
   }));
-});
+}));


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

code improvements in `/test/parallel/test-tls-friendly-error-message.js`
Replaces var for const and implement some missings common.mustCall