### PR TITLE
test: assert.throws() should include a RegExp

### DIFF
--- a/test/parallel/test-child-process-detached.js
+++ b/test/parallel/test-child-process-detached.js
@@ -18,7 +18,7 @@ process.on('exit', function() {
   assert.notStrictEqual(persistentPid, -1);
   assert.throws(function() {
     process.kill(child.pid);
-  });
+  }, /^Error: kill ESRCH$/);
   assert.doesNotThrow(function() {
     process.kill(persistentPid);
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Test
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
Assert.throws() in /test/parallel/test-child-process-detached.js should include a RegExp as the second argument.
Added RegExp to match on error.
<!-- Provide a description of the change below this comment. -->