### PR TITLE
nina 2016 code-n-learn, issue: use assert.Equal()

### DIFF
--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -24,7 +24,7 @@ fs.appendFileSync(filename, data);
 
 var fileData = fs.readFileSync(filename);
 
-assert.equal(Buffer.byteLength(data), fileData.length);
+assert.strictEqual(Buffer.byteLength(data), fileData.length);
 
 // test that appends data to a non empty file
 var filename2 = join(common.tmpDir, 'append-sync2.txt');
@@ -34,7 +34,7 @@ fs.appendFileSync(filename2, data);
 
 var fileData2 = fs.readFileSync(filename2);
 
-assert.equal(Buffer.byteLength(data) + currentFileData.length,
+assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
              fileData2.length);
 
 // test that appendFileSync accepts buffers
@@ -46,7 +46,7 @@ fs.appendFileSync(filename3, buf);
 
 var fileData3 = fs.readFileSync(filename3);
 
-assert.equal(buf.length + currentFileData.length, fileData3.length);
+assert.strictEqual(buf.length + currentFileData.length, fileData3.length);
 
 // test that appendFile accepts numbers.
 var filename4 = join(common.tmpDir, 'append-sync4.txt');
@@ -58,12 +58,12 @@ fs.appendFileSync(filename4, num, { mode: m });
 // windows permissions aren't unix
 if (!common.isWindows) {
   var st = fs.statSync(filename4);
-  assert.equal(st.mode & 0o700, m);
+  assert.strictEqual(st.mode & 0o700, m);
 }
 
 var fileData4 = fs.readFileSync(filename4);
 
-assert.equal(Buffer.byteLength('' + num) + currentFileData.length,
+assert.strictEqual(Buffer.byteLength('' + num) + currentFileData.length,
              fileData4.length);
 
 // test that appendFile accepts file descriptors
@@ -76,7 +76,7 @@ fs.closeSync(filename5fd);
 
 var fileData5 = fs.readFileSync(filename5);
 
-assert.equal(Buffer.byteLength(data) + currentFileData.length,
+assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
              fileData5.length);
 
 //exit logic for cleanup

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -35,7 +35,7 @@ fs.appendFileSync(filename2, data);
 var fileData2 = fs.readFileSync(filename2);
 
 assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
-             fileData2.length);
+                   fileData2.length);
 
 // test that appendFileSync accepts buffers
 var filename3 = join(common.tmpDir, 'append-sync3.txt');
@@ -64,7 +64,7 @@ if (!common.isWindows) {
 var fileData4 = fs.readFileSync(filename4);
 
 assert.strictEqual(Buffer.byteLength('' + num) + currentFileData.length,
-             fileData4.length);
+                   fileData4.length);
 
 // test that appendFile accepts file descriptors
 var filename5 = join(common.tmpDir, 'append-sync5.txt');
@@ -77,7 +77,7 @@ fs.closeSync(filename5fd);
 var fileData5 = fs.readFileSync(filename5);
 
 assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
-             fileData5.length);
+                   fileData5.length);
 
 //exit logic for cleanup
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Test

##### Description of change
<!-- Provide a description of the change below this comment. -->
test: change `assert.equal` to `assert.strictEqual`

the following lines have been updated:
```
27:1
37:1
49:1
61:3
66:1
79:1
```
