### PR TITLE
test: Modernize test-fs-truncate-fd

### DIFF
--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
-var tmp = common.tmpDir;
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const tmp = common.tmpDir;
 common.refreshTmpDir();
-var filename = path.resolve(tmp, 'truncate-file.txt');
+const filename = path.resolve(tmp, 'truncate-file.txt');
 
 fs.writeFileSync(filename, 'hello world', 'utf8');
-var fd = fs.openSync(filename, 'r+');
+const fd = fs.openSync(filename, 'r+');
 fs.truncate(fd, 5, common.mustCall(function(err) {
   assert.ok(!err);
-  assert.equal(fs.readFileSync(filename, 'utf8'), 'hello');
+  assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'hello');
 }));
 
 process.on('exit', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
- changed `var` to `const` where variables were not reassigned.
- changed `assert.equal` to `assert.strictEqual` because there was no
downside to being more rigorous.