### PR TITLE
Updated test-crypto-ecb.js to change assert.equal to assert.strictEqual

### DIFF
--- a/test/parallel/test-crypto-ecb.js
+++ b/test/parallel/test-crypto-ecb.js
@@ -21,7 +21,7 @@ crypto.DEFAULT_ENCODING = 'buffer';
   var encrypt = crypto.createCipheriv('BF-ECB', 'SomeRandomBlahz0c5GZVnR', '');
   var hex = encrypt.update('Hello World!', 'ascii', 'hex');
   hex += encrypt.final('hex');
-  assert.equal(hex.toUpperCase(), '6D385F424AAB0CFBF0BB86E07FFB7D71');
+  assert.strictEqual(hex.toUpperCase(), '6D385F424AAB0CFBF0BB86E07FFB7D71');
 }());
 
 (function() {
@@ -29,5 +29,5 @@ crypto.DEFAULT_ENCODING = 'buffer';
       '');
   var msg = decrypt.update('6D385F424AAB0CFBF0BB86E07FFB7D71', 'hex', 'ascii');
   msg += decrypt.final('ascii');
-  assert.equal(msg, 'Hello World!');
+  assert.strictEqual(msg, 'Hello World!');
 }());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tests

##### Description of change
<!-- Provide a description of the change below this comment. -->
Updated test-crypto-ecb.js to change assert.equal to assert.strictEqual