### PR TITLE
test: add mustCall to setTimeout

### DIFF
--- a/test/parallel/test-net-keepalive.js
+++ b/test/parallel/test-net-keepalive.js
@@ -1,20 +1,20 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+let common = require('../common');
+let assert = require('assert');
+let net = require('net');
 
 var serverConnection;
 var clientConnection;
 var echoServer = net.createServer(function(connection) {
   serverConnection = connection;
-  setTimeout(function() {
+  setTimeout(common.mustCall(function() {
     // make sure both connections are still open
-    assert.equal(serverConnection.readyState, 'open');
-    assert.equal(clientConnection.readyState, 'open');
+    assert.strictEqual(serverConnection.readyState, 'open');
+    assert.strictEqual(clientConnection.readyState, 'open');
     serverConnection.end();
     clientConnection.end();
     echoServer.close();
-  }, common.platformTimeout(100));
+  },1), common.platformTimeout(100));
   connection.setTimeout(0);
   assert.notEqual(connection.setKeepAlive, undefined);
   // send a keepalive packet after 50 ms


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Added mustCall to the setTimout inline function. Changed assert.equal
to assert.strictEqual. Changed var for require modules to let.