### PR TITLE
test: add second argument to assert.throws()

### DIFF
--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -1,8 +1,8 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var events = require('events');
-var e = new events.EventEmitter();
+const assert = require('assert');
+const events = require('events');
+const e = new events.EventEmitter();
 
 e.on('maxListeners', common.mustCall(function() {}));
 
@@ -11,14 +11,14 @@ e.setMaxListeners(42);
 
 assert.throws(function() {
   e.setMaxListeners(NaN);
-});
+}, /^TypeError: "n" argument must be a positive number$/);
 
 assert.throws(function() {
   e.setMaxListeners(-1);
-});
+}, /^TypeError: "n" argument must be a positive number$/);
 
 assert.throws(function() {
   e.setMaxListeners('and even this');
-});
+}, /^TypeError: "n" argument must be a positive number$/);
 
 e.emit('maxListeners');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

The assert throws() should include a constructor or RegExp as a second
argument.