### PR TITLE
test: change indexOf to includes in ecdh-disable

### DIFF
--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -28,10 +28,10 @@ server.listen(0, '127.0.0.1', function() {
   if (common.isWindows)
     cmd += ' -no_rand_screen';
 
-  exec(cmd, function(err, stdout, stderr) {
+  exec(cmd, common.mustCall(function(err, stdout, stderr) {
     // Old versions of openssl will still exit with 0 so we
     // can't just check if err is not null.
-    assert.notEqual(stderr.indexOf('handshake failure'), -1);
+    assert(stderr.includes('handshake failure'));
     server.close();
-  });
+  }));
 });

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -20,7 +20,7 @@ var options = {
 
 var server = tls.createServer(options, common.fail);
 
-server.listen(0, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', common.mustCall(function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ` -connect 127.0.0.1:${this.address().port}`;
 
@@ -34,4 +34,4 @@ server.listen(0, '127.0.0.1', function() {
     assert(stderr.includes('handshake failure'));
     server.close();
   }));
-});
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Updates test/parallel/test-tls-ecdh-disable.js on line 34 so that
assert.notEqual is changed to just assert. Then in place of indexOf,
includes() is used. The callback on line 31 has been wrapped in
common.mustCall() in order to ensure that this callback is only
made one time.