### PR TITLE
Test: Updated test/parallel/test-fs-write-file.js.

### DIFF
--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -1,34 +1,34 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
-var join = require('path').join;
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const join = require('path').join;
 
 common.refreshTmpDir();
 
-var filename = join(common.tmpDir, 'test.txt');
+const filename = join(common.tmpDir, 'test.txt');
 
-var n = 220;
-var s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
-        '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +
-        '南越国是秦朝灭亡后，由南海郡尉赵佗于前203年起兵兼并桂林郡和象郡后建立。' +
-        '前196年和前179年，南越国曾先后两次名义上臣属于西汉，成为西汉的“外臣”。前112年，' +
-        '南越国末代君主赵建德与西汉发生战争，被汉武帝于前111年所灭。南越国共存在93年，' +
-        '历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，' +
-        '它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
+const n = 220;
+const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、\
+        广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。\
+        南越国是秦朝灭亡后，由南海郡尉赵佗于前203年起兵兼并桂林郡和象郡后建立。\
+        前196年和前179年，南越国曾先后两次名义上臣属于西汉，成为西汉的“外臣”。前112年，\
+        南越国末代君主赵建德与西汉发生战争，被汉武帝于前111年所灭。南越国共存在93年，\
+        历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，\
+        它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
 
 fs.writeFile(filename, s, common.mustCall(function(e) {
   if (e) throw e;
 
   fs.readFile(filename, common.mustCall(function(e, buffer) {
     if (e) throw e;
-    assert.equal(Buffer.byteLength(s), buffer.length);
+    assert.strictEqual(Buffer.byteLength(s), buffer.length);
   }));
 }));
 
 // test that writeFile accepts buffers
-var filename2 = join(common.tmpDir, 'test2.txt');
-var buf = Buffer.from(s, 'utf8');
+const filename2 = join(common.tmpDir, 'test2.txt');
+const buf = Buffer.from(s, 'utf8');
 
 fs.writeFile(filename2, buf, common.mustCall(function(e) {
   if (e) throw e;
@@ -36,32 +36,32 @@ fs.writeFile(filename2, buf, common.mustCall(function(e) {
   fs.readFile(filename2, common.mustCall(function(e, buffer) {
     if (e) throw e;
 
-    assert.equal(buf.length, buffer.length);
+    assert.strictEqual(buf.length, buffer.length);
   }));
 }));
 
 // test that writeFile accepts numbers.
-var filename3 = join(common.tmpDir, 'test3.txt');
+const filename3 = join(common.tmpDir, 'test3.txt');
 
-var m = 0o600;
+const m = 0o600;
 fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
   if (e) throw e;
 
   // windows permissions aren't unix
   if (!common.isWindows) {
-    var st = fs.statSync(filename3);
-    assert.equal(st.mode & 0o700, m);
+    const st = fs.statSync(filename3);
+    assert.strictEqual(st.mode & 0o700, m);
   }
 
   fs.readFile(filename3, common.mustCall(function(e, buffer) {
     if (e) throw e;
 
-    assert.equal(Buffer.byteLength('' + n), buffer.length);
+    assert.strictEqual(Buffer.byteLength('' + n), buffer.length);
   }));
 }));
 
 // test that writeFile accepts file descriptors
-var filename4 = join(common.tmpDir, 'test4.txt');
+const filename4 = join(common.tmpDir, 'test4.txt');
 
 fs.open(filename4, 'w+', common.mustCall(function(e, fd) {
   if (e) throw e;
@@ -75,7 +75,7 @@ fs.open(filename4, 'w+', common.mustCall(function(e, fd) {
       fs.readFile(filename4, common.mustCall(function(e, buffer) {
         if (e) throw e;
 
-        assert.equal(Buffer.byteLength(s), buffer.length);
+        assert.strictEqual(Buffer.byteLength(s), buffer.length);
       }));
     }));
   }));


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
- Updated references of var to const
- Updated assert.equal to assert.strictEqual
- Fixed eslint error for multiline string on line 12