### PR TITLE
test: change assert.equal to assert.strictEqual in parallel/test-cluster-setup-argv.js

### DIFF
--- a/test/parallel/test-cluster-setup-master-argv.js
+++ b/test/parallel/test-cluster-setup-master-argv.js
@@ -8,8 +8,8 @@ setTimeout(common.fail.bind(assert, 'setup not emitted'), 1000).unref();
 cluster.on('setup', function() {
   var clusterArgs = cluster.settings.args;
   var realArgs = process.argv;
-  assert.equal(clusterArgs[clusterArgs.length - 1],
-               realArgs[realArgs.length - 1]);
+  assert.strictEqual(clusterArgs[clusterArgs.length - 1],
+                     realArgs[realArgs.length - 1]);
 });
 
 assert.notStrictEqual(process.argv[process.argv.length - 1], 'OMG,OMG');


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Test

##### Description of change
Update equal assertion in parallel/test-cluster-setup-master-argv.js to strict equal.