### PR TITLE
test: fix assert.equal to strictEq

### DIFF
--- a/test/parallel/test-dgram-send-callback-multi-buffer.js
+++ b/test/parallel/test-dgram-send-callback-multi-buffer.js
@@ -7,7 +7,7 @@ const dgram = require('dgram');
 const client = dgram.createSocket('udp4');
 
 const messageSent = common.mustCall(function messageSent(err, bytes) {
-  assert.equal(bytes, buf1.length + buf2.length);
+  assert.strictEqual(bytes, buf1.length + buf2.length);
 });
 
 const buf1 = Buffer.alloc(256, 'x');


### PR DESCRIPTION
- [x] `make -j4 test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
Affected core subsystem: test
On line 10: changed assert.equal to "assert.strictEqual(bytes, buf1.length + buf2.length);"
