### PR TITLE
test: use strictEqual in test-child-process-constructor

### DIFF
--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -4,7 +4,7 @@ require('../common');
 var assert = require('assert');
 var child_process = require('child_process');
 var ChildProcess = child_process.ChildProcess;
-assert.equal(typeof ChildProcess, 'function');
+assert.strictEqual(typeof ChildProcess, 'function');
 
 // test that we can call spawn
 var child = new ChildProcess();
@@ -15,11 +15,11 @@ child.spawn({
   stdio: 'pipe'
 });
 
-assert.equal(child.hasOwnProperty('pid'), true);
+assert.strictEqual(child.hasOwnProperty('pid'), true);
 
 // try killing with invalid signal
 assert.throws(function() {
   child.kill('foo');
 }, /Unknown signal: foo/);
 
-assert.equal(child.kill(), true);
+assert.strictEqual(child.kill(), true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x ] tests and/or benchmarks are included
- [x ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

change all assert.equal() to use assert.strictEqual()