### PR TITLE
test: replace equal with strictEqual

### DIFF
--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -227,7 +227,7 @@ if (process.argv[2] === 'child') {
   tests[testIndex]();
 
   process.on('exit', function onExit() {
-    assert.equal(errorHandlerCalled, true);
+    assert.strictEqual(errorHandlerCalled, true);
   });
 } else {
 
@@ -248,7 +248,7 @@ if (process.argv[2] === 'child') {
     var child = child_process.exec(testCmd);
 
     child.on('exit', function onExit(code, signal) {
-      assert.equal(code, 0, 'Test at index ' + testIndex +
+      assert.strictEqual(code, 0, 'Test at index ' + testIndex +
         ' should have exited with exit code 0 but instead exited with code ' +
         code + ' and signal ' + signal);
     });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
Replaces assert.equal() with assert.strictEqual where appropriate.
