### PR TITLE
cluster: return worker reference from disconnect()

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -257,6 +257,8 @@ It is not emitted in the worker.
 added: v0.7.7
 -->
 
+* Returns: {Worker} A reference to worker
+
 In a worker, this function will close all servers, wait for the `'close'` event on
 those servers, and then disconnect the IPC channel.
 

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -257,7 +257,7 @@ It is not emitted in the worker.
 added: v0.7.7
 -->
 
-* Returns: {Worker} A reference to worker
+* Returns: {Worker} A reference to `worker`.
 
 In a worker, this function will close all servers, wait for the `'close'` event on
 those servers, and then disconnect the IPC channel.

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -430,6 +430,7 @@ function masterInit() {
     send(this, { act: 'disconnect' });
     removeHandlesForWorker(this);
     removeWorker(this);
+    return this;
   };
 
   Worker.prototype.destroy = function(signo) {
@@ -687,6 +688,7 @@ function workerInit() {
 
   Worker.prototype.disconnect = function() {
     _disconnect.call(this);
+    return this;
   };
 
   Worker.prototype.destroy = function() {

--- a/test/parallel/test-cluster-worker-destroy.js
+++ b/test/parallel/test-cluster-worker-destroy.js
@@ -8,6 +8,7 @@
  */
 
 const common = require('../common');
+const assert = require('assert');
 var cluster = require('cluster');
 var worker1, worker2;
 
@@ -26,7 +27,8 @@ if (cluster.isMaster) {
       cluster.worker.destroy();
     });
 
-    cluster.worker.disconnect();
+    const w = cluster.worker.disconnect();
+    assert.strictEqual(w, cluster.worker, 'did not return a reference');
   } else {
     // Call destroy when worker is not disconnected yet
     cluster.worker.destroy();

--- a/test/parallel/test-cluster-worker-disconnect.js
+++ b/test/parallel/test-cluster-worker-disconnect.js
@@ -40,7 +40,8 @@ if (cluster.isWorker) {
 
   // Disconnect worker when it is ready
   worker.once('listening', common.mustCall(() => {
-    worker.disconnect();
+    const w = worker.disconnect();
+    assert.strictEqual(worker, w, 'did not return a reference');
   }));
 
   // Check cluster events

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -13,7 +13,8 @@ if (cluster.isMaster) {
 
   worker.on('message', common.mustCall((message) => {
     assert.strictEqual(message, true, 'did not receive expected message');
-    worker.disconnect();
+    const w = worker.disconnect();
+    assert.strictEqual(worker, w, 'did not return a reference');
   }));
 
   worker.on('online', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
cluster

##### Description of change
<!-- Provide a description of the change below this comment. -->

Changes disconnect() to return a refererence to the worker.
This will enable method chaining such as
`worker.disconnect().once('disconnect', doThis);`