### PR TITLE
Add regex to text-crypto-random

### DIFF
--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -13,10 +13,11 @@ crypto.DEFAULT_ENCODING = 'buffer';
 // bump, we register a lot of exit listeners
 process.setMaxListeners(256);
 
+const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
 [crypto.randomBytes, crypto.pseudoRandomBytes].forEach(function(f) {
   [-1, undefined, null, false, true, {}, []].forEach(function(value) {
-    assert.throws(function() { f(value); }, TypeError);
-    assert.throws(function() { f(value, function() {}); }, TypeError);
+    assert.throws(function() { f(value); }, expectedErrorRegexp);
+    assert.throws(function() { f(value, function() {}); }, expectedErrorRegexp);
   });
 
   [0, 1, 2, 4, 16, 256, 1024].forEach(function(len) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
test: add RegExp as a second argument to assert.throws()

27:5 and 28:5 error assert.throws() should include RegExp as a second argument
