### PR TITLE
url, test: WHATWG url originFor should include a base as argument

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -790,9 +790,9 @@ Object.defineProperty(URLSearchParamsIteratorPrototype, Symbol.toStringTag, {
   configurable: true
 });
 
-URL.originFor = function(url) {
+URL.originFor = function(url, base) {
   if (!(url instanceof URL))
-    url = new URL(url);
+    url = new URL(url, base);
   var origin;
   const protocol = url.protocol;
   switch (protocol) {

--- a/test/parallel/test-whatwg-url-origin-for.js
+++ b/test/parallel/test-whatwg-url-origin-for.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+
+const URL = require('url').URL;
+const path = require('path');
+const assert = require('assert');
+const tests = require(path.join(common.fixturesDir, 'url-tests.json'));
+
+for (const test of tests) {
+  if (typeof test === 'string')
+    continue;
+
+  if (test.origin) {
+    const origin = URL.originFor(test.input, test.base);
+    // Pass true to origin.toString() to enable unicode serialization.
+    assert.strictEqual(origin.toString(true), test.origin);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, url

##### Description of change
<!-- Provide a description of the change below this comment. -->

Check if the `originFor` implementation for WHATWG url parsing is correnct.

Right now this test fails because the implementation is still a WIP.

I believe the API for `url.URL.originFor` needs changes too. Right now it only takes the url as the only argument, and pass it to the URL constructor if that's a string, but the constructor actually takes two arguments: the url and the base. I put the base as the second argument here since that would not break the test even if the implementation is correct for urls without bases.

cc @jasnell 

EDIT: I've fixed the implementation too. This indeed need a base as argument. So now this PR:

- Adds tests to check if the `originFor` implementation for WHATWG url parsing is correnct.
- Fixes `originFor` by including a base as argument