### PR TITLE
test: fix test-child-process-stdin.js

### DIFF
--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -34,8 +34,8 @@ cat.on('exit', common.mustCall(function(status) {
 
 cat.on('close', common.mustCall(function() {
   if (common.isWindows) {
-    assert.equal('hello world\r\n', response);
+    assert.strictEqual('hello world\r\n', response);
   } else {
-    assert.equal('hello world', response);
+    assert.strictEqual('hello world', response);
   }
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

37:5 error please use assert.strictEqual() instead of assert.equal()
39:5 error please use assert.strictEqual() instead of assert.equal()