### PR TITLE
test: Refactors variables to ES6 compatible and newer assertions 

### DIFF
--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -1,29 +1,29 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
-var cluster = require('cluster');
-var fs = require('fs');
-var join = require('path').join;
+const cluster = require('cluster');
+const fs = require('fs');
+const join = require('path').join;
 
-var workerCount = 4;
-var expectedReqCount = 16;
+const workerCount = 4;
+const expectedReqCount = 16;
 
 if (cluster.isMaster) {
-  var reusedCount = 0;
-  var reqCount = 0;
-  var lastSession = null;
-  var shootOnce = false;
+  let reusedCount = 0;
+  let reqCount = 0;
+  let lastSession = null;
+  let shootOnce = false;
 
   function shoot() {
     console.error('[master] connecting');
-    var c = tls.connect(common.PORT, {
+    const c = tls.connect(common.PORT, {
       session: lastSession,
       rejectUnauthorized: false
     }, function() {
@@ -41,7 +41,7 @@ if (cluster.isMaster) {
   }
 
   function fork() {
-    var worker = cluster.fork();
+    const worker = cluster.fork();
     worker.on('message', function(msg) {
       console.error('[master] got %j', msg);
       if (msg === 'reused') {
@@ -56,27 +56,27 @@ if (cluster.isMaster) {
       console.error('[master] worker died');
     });
   }
-  for (var i = 0; i < workerCount; i++) {
+  for (let i = 0; i < workerCount; i++) {
     fork();
   }
 
   process.on('exit', function() {
-    assert.equal(reqCount, expectedReqCount);
-    assert.equal(reusedCount + 1, reqCount);
+    assert.strictEqual(reqCount, expectedReqCount);
+    assert.strictEqual(reusedCount + 1, reqCount);
   });
   return;
 }
 
-var keyFile = join(common.fixturesDir, 'agent.key');
-var certFile = join(common.fixturesDir, 'agent.crt');
-var key = fs.readFileSync(keyFile);
-var cert = fs.readFileSync(certFile);
-var options = {
+const keyFile = join(common.fixturesDir, 'agent.key');
+const certFile = join(common.fixturesDir, 'agent.crt');
+const key = fs.readFileSync(keyFile);
+const cert = fs.readFileSync(certFile);
+const options = {
   key: key,
   cert: cert
 };
 
-var server = tls.createServer(options, function(c) {
+const server = tls.createServer(options, function(c) {
   if (c.isSessionReused()) {
     process.send('reused');
   } else {

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -89,11 +89,11 @@ function start(callback) {
 process.on('exit', function() {
   assert.strictEqual(ticketLog.length, serverLog.length);
   for (let i = 0; i < naturalServers.length - 1; i++) {
-    assert.notEqual(serverLog[i], serverLog[i + 1]);
+    assert.notStrictEqual(serverLog[i], serverLog[i + 1]);
     assert.strictEqual(ticketLog[i], ticketLog[i + 1]);
 
     // 2nd connection should have different ticket
-    assert.notEqual(ticketLog[i], ticketLog[i + naturalServers.length]);
+    assert.notStrictEqual(ticketLog[i], ticketLog[i + naturalServers.length]);
 
     // 3rd connection should have the same ticket
     assert.strictEqual(ticketLog[i], ticketLog[i + naturalServers.length * 2]);

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -1,29 +1,29 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
-var fs = require('fs');
-var net = require('net');
-var crypto = require('crypto');
+const fs = require('fs');
+const net = require('net');
+const crypto = require('crypto');
 
-var keys = crypto.randomBytes(48);
-var serverLog = [];
-var ticketLog = [];
+const keys = crypto.randomBytes(48);
+const serverLog = [];
+const ticketLog = [];
 
-var serverCount = 0;
+let serverCount = 0;
 function createServer() {
-  var id = serverCount++;
+  const id = serverCount++;
 
-  var counter = 0;
-  var previousKey = null;
+  let counter = 0;
+  let previousKey = null;
 
-  var server = tls.createServer({
+  const server = tls.createServer({
     key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
     cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
     ticketKeys: keys
@@ -49,13 +49,13 @@ function createServer() {
   return server;
 }
 
-var naturalServers = [ createServer(), createServer(), createServer() ];
+const naturalServers = [ createServer(), createServer(), createServer() ];
 
 // 3x servers
-var servers = naturalServers.concat(naturalServers).concat(naturalServers);
+const servers = naturalServers.concat(naturalServers).concat(naturalServers);
 
 // Create one TCP server and balance sockets to multiple TLS server instances
-var shared = net.createServer(function(c) {
+const shared = net.createServer(function(c) {
   servers.shift().emit('connection', c);
 }).listen(0, function() {
   start(function() {
@@ -64,11 +64,11 @@ var shared = net.createServer(function(c) {
 });
 
 function start(callback) {
-  var sess = null;
-  var left = servers.length;
+  let sess = null;
+  let left = servers.length;
 
   function connect() {
-    var s = tls.connect(shared.address().port, {
+    const s = tls.connect(shared.address().port, {
       session: sess,
       rejectUnauthorized: false
     }, function() {
@@ -87,15 +87,15 @@ function start(callback) {
 }
 
 process.on('exit', function() {
-  assert.equal(ticketLog.length, serverLog.length);
-  for (var i = 0; i < naturalServers.length - 1; i++) {
+  assert.strictEqual(ticketLog.length, serverLog.length);
+  for (let i = 0; i < naturalServers.length - 1; i++) {
     assert.notEqual(serverLog[i], serverLog[i + 1]);
-    assert.equal(ticketLog[i], ticketLog[i + 1]);
+    assert.strictEqual(ticketLog[i], ticketLog[i + 1]);
 
     // 2nd connection should have different ticket
     assert.notEqual(ticketLog[i], ticketLog[i + naturalServers.length]);
 
     // 3rd connection should have the same ticket
-    assert.equal(ticketLog[i], ticketLog[i + naturalServers.length * 2]);
+    assert.strictEqual(ticketLog[i], ticketLog[i + naturalServers.length * 2]);
   }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
- Changes `var` to either `const` or `let` where applicable
- Changes `assert.equal` to `assert.strictEqual` for more "strict" check

_Note:- even though ticket was asking to change `process.on('exit')` handler to `common.mustCall` - this was omitted as this kept breaking the test (my guess and from discussion with others was that it's because `common.mustCall` has `process.on('exit')` internally which never fires `process.on('exit')` in the test_
