### PR TITLE
test: refactor test for net listen on fd0

### DIFF
--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -1,20 +1,12 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
-var gotError = false;
-
-process.on('exit', function() {
-  assert(gotError instanceof Error);
-});
-
-// this should fail with an async EINVAL error, not throw an exception
-net.createServer(common.fail).listen({fd: 0}).on('error', function(e) {
-  switch (e.code) {
-    case 'EINVAL':
-    case 'ENOTSOCK':
-      gotError = e;
-      break;
-  }
-});
+// This should fail with an async EINVAL error, not throw an exception
+net.createServer(common.fail)
+  .listen({fd: 0})
+  .on('error', common.mustCall(function(e) {
+    assert(e instanceof Error);
+    assert(['EINVAL', 'ENOTSOCK'].includes(e.code));
+  }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test, net

##### Description of change

Replace var to const/let, use common.mustCall on callbacks and move
process.on('exit') to the .on('error') handler