### PR TITLE
test: change the equal() by strictEqual()

### DIFF
--- a/test/parallel/test-event-emitter-method-names.js
+++ b/test/parallel/test-event-emitter-method-names.js
@@ -4,10 +4,10 @@ var assert = require('assert');
 var events = require('events');
 
 var E = events.EventEmitter.prototype;
-assert.equal(E.constructor.name, 'EventEmitter');
-assert.equal(E.on, E.addListener);  // Same method.
+assert.strictEqual(E.constructor.name, 'EventEmitter');
+assert.strictEqual(E.on, E.addListener);  // Same method.
 Object.getOwnPropertyNames(E).forEach(function(name) {
   if (name === 'constructor' || name === 'on') return;
   if (typeof E[name] !== 'function') return;
-  assert.equal(E[name].name, name);
+  assert.strictEqual(E[name].name, name);
 });


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Improved test by using strictEqual instead of equal