### PR TITLE
test: const/strictEqual in test-listen-fd-ebadf

### DIFF
--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
 net.createServer(common.fail).listen({fd: 2})
   .on('error', common.mustCall(onError));
@@ -9,5 +9,5 @@ net.createServer(common.fail).listen({fd: 42})
   .on('error', common.mustCall(onError));
 
 function onError(ex) {
-  assert.equal(ex.code, 'EINVAL');
+  assert.strictEqual(ex.code, 'EINVAL');
 }


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Test refactor only


##### Description of change
Using const and strictEqual in test/parallel/test-listen-fd-ebadf.js

