### PR TITLE
test: add test for process.stdin.setRawMode()

### DIFF
--- a/test/pseudo-tty/stdin-setrawmode.js
+++ b/test/pseudo-tty/stdin-setrawmode.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+process.stdin.setRawMode(true);
+assert(process.stdin.isRaw);
+
+process.stdin.setRawMode(false);
+assert(!process.stdin.isRaw);

--- a/test/pseudo-tty/stdin-setrawmode.js
+++ b/test/pseudo-tty/stdin-setrawmode.js
@@ -3,7 +3,7 @@ require('../common');
 const assert = require('assert');
 
 process.stdin.setRawMode(true);
-assert(process.stdin.isRaw);
+assert.strictEqual(process.stdin.isRaw, true);
 
 process.stdin.setRawMode(false);
-assert(!process.stdin.isRaw);
+assert.strictEqual(process.stdin.isRaw, false);


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
adds a basic test for process.stdin.setRawMode to ensure that the isRaw
property is properly changed