### PR TITLE
Simplified the test by using common.mustCall(). Use of common.mustCal…

### DIFF
--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -1,32 +1,22 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
 
-var path = require('path');
-var fs = require('fs');
-var successes = 0;
+const path = require('path');
+const fs = require('fs');
 
 var file = path.join(common.fixturesDir, 'a.js');
 
-fs.open(file, 'a', 0o777, function(err, fd) {
+fs.open(file, 'a', 0o777, common.mustCall(function(err, fd) {
   if (err) throw err;
 
   fs.fdatasyncSync(fd);
-  successes++;
 
   fs.fsyncSync(fd);
-  successes++;
 
-  fs.fdatasync(fd, function(err) {
+  fs.fdatasync(fd, common.mustCall(function(err) {
     if (err) throw err;
-    successes++;
-    fs.fsync(fd, function(err) {
+    fs.fsync(fd, common.mustCall(function(err) {
       if (err) throw err;
-      successes++;
-    });
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(4, successes);
-});
+    }));
+  }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Simplified test by using common.mustCall(). This also made assert module and sucesses variable redundant.

…l(), made assert require and use of successes variable redundant