### PR TITLE
fs: copyObject() had unused argument

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -56,8 +56,8 @@ function getOptions(options, defaultOptions) {
   return options;
 }
 
-function copyObject(source, target) {
-  target = arguments.length >= 2 ? target : {};
+function copyObject(source) {
+  const target = {};
   for (const key in source)
     target[key] = source[key];
   return target;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

The fs function copyObject() had two arguments:
source and target. On the first line of the function it
assigned the target variable to:
arguments.length >= 2 ? target : {};

The function copyObject() was not called directly by
any test, but it is called in other fs functions. When it
was called it was only ever called with a single argument,
source. Thus I have removed the target argument and assigned
it to an empty object like it was being assigned to in the
original ternary operator.