### PR TITLE
test: Use strictEqual in cwd-enoent

### DIFF
--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -21,6 +21,6 @@ proc.stdout.pipe(process.stdout);
 proc.stderr.pipe(process.stderr);
 
 proc.once('exit', common.mustCall(function(exitCode, signalCode) {
-  assert.equal(exitCode, 0);
-  assert.equal(signalCode, null);
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signalCode, null);
 }));


### PR DESCRIPTION
test: Use strictEqual in cwd-enoent

Changed all references from assert.Equal() to assert.strictEqual().