### PR TITLE
test: recommended changes to test-cluster-send-handle-twice.js

### DIFF
--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -1,36 +1,36 @@
 'use strict';
 // Testing to send an handle twice to the parent process.
 
-var common = require('../common');
-var assert = require('assert');
-var cluster = require('cluster');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
 
-var workers = {
+const workers = {
   toStart: 1
 };
 
 if (cluster.isMaster) {
-  for (var i = 0; i < workers.toStart; ++i) {
-    var worker = cluster.fork();
-    worker.on('exit', function(code, signal) {
+  for (let i = 0; i < workers.toStart; ++i) {
+    const worker = cluster.fork();
+    worker.on('exit', common.mustCall(function(code, signal) {
       assert.strictEqual(code, 0, 'Worker exited with an error code');
-      assert(!signal, 'Worker exited by a signal');
-    });
+      assert.strictEqual(signal, null, 'Worker exited by a signal');
+    }));
   }
 } else {
-  var server = net.createServer(function(socket) {
+  const server = net.createServer(function(socket) {
     process.send('send-handle-1', socket);
     process.send('send-handle-2', socket);
   });
 
   server.listen(common.PORT, function() {
-    var client = net.connect({ host: 'localhost', port: common.PORT });
-    client.on('close', function() { cluster.worker.disconnect(); });
+    const client = net.connect({ host: 'localhost', port: common.PORT });
+    client.on('close', common.mustCall(() => { cluster.worker.disconnect(); }));
     setTimeout(function() { client.end(); }, 50);
   }).on('error', function(e) {
     console.error(e);
-    assert(false, 'server.listen failed');
+    common.fail('server.listen failed');
     cluster.worker.disconnect();
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
- `var` --> `const` as applicable
- `assert.equal`  --> `assert.strictEqual`
- `assert(false, ..)` --> `common.fail()`
- `common.mustCall` for functions that need to be called exactly once
- modified an `assert(!signal, 'Worker exited by a signal');` call to `assert.strictEqual(signal, null);` call as that made more sense
