### PR TITLE
gitignore: add osx .DS_STORE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_g
 /.cproject
 icu_config.gypi
 .eslintcache
+.DS_Store
 
 /out
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
project gitignore

##### Description of change
<!-- Provide a description of the change below this comment. -->
Obviously, people can and should add `.DS_STORE` files to their global gitignore, but I don't think it'll hurt anyone to have it in the project file.
