### PR TITLE
repl:null check when invoked from cmdline with throw null

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -322,7 +322,7 @@ function REPLServer(prompt,
         }
       } catch (e) {
         err = e;
-        if (err.message === 'Script execution interrupted.') {
+        if (err && err.message === 'Script execution interrupted.') {
           // The stack trace for this case is not very useful anyway.
           Object.defineProperty(err, 'stack', { value: '' });
         }

--- a/test/parallel/test-repl-throw-null.js
+++ b/test/parallel/test-repl-throw-null.js
@@ -1,0 +1,11 @@
+'use strict';
+require('../common');
+const repl = require('repl');
+const assert = require('assert');
+
+var replserver = new repl.REPLServer();
+
+// Check when throw null is sent to stream behavior is expected. Stream null is checked before accessing the err
+assert.strictEqual( replserver.emit('line', 'throw null'), true );
+
+replserver.emit('line', '.exit');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl

##### Description of change
<!-- Provide a description of the change below this comment. -->
Null check added for flow executed from command line.
Test case: test/parallel/test-repl-throw-null.js
