### PR TITLE
test: replace var with const and use strictEqual

### DIFF
--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-var http = require('http');
+const http = require('http');
 
 if (common.hasCrypto) {
   var https = require('https');
@@ -10,7 +10,7 @@ if (common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-var host = '*'.repeat(256);
+const host = '*'.repeat(256);
 
 function do_not_call() {
   throw new Error('This function should not have been called.');
@@ -20,15 +20,15 @@ function test(mod) {
 
   // Bad host name should not throw an uncatchable exception.
   // Ensure that there is time to attach an error listener.
-  var req1 = mod.get({host: host, port: 42}, do_not_call);
+  const req1 = mod.get({host: host, port: 42}, do_not_call);
   req1.on('error', common.mustCall(function(err) {
-    assert.equal(err.code, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
   }));
   // http.get() called req1.end() for us
 
-  var req2 = mod.request({method: 'GET', host: host, port: 42}, do_not_call);
+  const req2 = mod.request({method: 'GET', host: host, port: 42}, do_not_call);
   req2.on('error', common.mustCall(function(err) {
-    assert.equal(err.code, 'ENOTFOUND');
+    assert.strictEqual(err.code, 'ENOTFOUND');
   }));
   req2.end();
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
replace `var` with `const` and use `assert.strictEqual` instead `assert.equal`