### PR TITLE
Test: stdio.js SIGWINCH test coverage

### DIFF
--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 
 // if printing, add to out file
 const originalRefreshSizeWrapperStderr = process.stderr._refreshSize;
@@ -7,12 +7,24 @@ const originalRefreshSizeWrapperStdout = process.stdout._refreshSize;
 
 const refreshSizeWrapperStderr = () => {
   console.log('calling stderr._refreshSize');
-  originalRefreshSizeWrapperStderr.call(process.stderr);
+  try {
+    originalRefreshSizeWrapperStderr.call(process.stderr);
+  } catch (e) {
+    // EINVAL happens on SmartOS if emulation is incomplete
+    if (!common.isSunOS || e.code !== 'EINVAL')
+      throw e;
+  }
 };
 
 const refreshSizeWrapperStdout = () => {
   console.log('calling stdout._refreshSize');
-  originalRefreshSizeWrapperStdout.call(process.stdout);
+  try {
+    originalRefreshSizeWrapperStdout.call(process.stdout);
+  } catch (e) {
+    // EINVAL happens on SmartOS if emulation is incomplete
+    if (!common.isSunOS || e.code !== 'EINVAL')
+      throw e;
+  }
 };
 
 process.stderr._refreshSize = refreshSizeWrapperStderr;

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -1,33 +1,29 @@
 'use strict';
 const common = require('../common');
 
-// if printing, add to out file
-const originalRefreshSizeWrapperStderr = process.stderr._refreshSize;
-const originalRefreshSizeWrapperStdout = process.stdout._refreshSize;
+const originalRefreshSizeStderr = process.stderr._refreshSize;
+const originalRefreshSizeStdout = process.stdout._refreshSize;
 
-const refreshSizeWrapperStderr = () => {
-  console.log('calling stderr._refreshSize');
-  try {
-    originalRefreshSizeWrapperStderr.call(process.stderr);
-  } catch (e) {
-    // EINVAL happens on SmartOS if emulation is incomplete
-    if (!common.isSunOS || e.code !== 'EINVAL')
-      throw e;
-  }
+const wrap = (fn, ioStream, string) => {
+  return () => {
+    // The console.log() call prints a string that is in the .out file. In other
+    // words, the console.log() is part of the test, not extraneous debugging.
+    console.log(string);
+    try {
+      fn.call(ioStream);
+    } catch (e) {
+      // EINVAL happens on SmartOS if emulation is incomplete
+      if (!common.isSunOS || e.code !== 'EINVAL')
+        throw e;
+    }
+  };
 };
 
-const refreshSizeWrapperStdout = () => {
-  console.log('calling stdout._refreshSize');
-  try {
-    originalRefreshSizeWrapperStdout.call(process.stdout);
-  } catch (e) {
-    // EINVAL happens on SmartOS if emulation is incomplete
-    if (!common.isSunOS || e.code !== 'EINVAL')
-      throw e;
-  }
-};
-
-process.stderr._refreshSize = refreshSizeWrapperStderr;
-process.stdout._refreshSize = refreshSizeWrapperStdout;
+process.stderr._refreshSize = wrap(originalRefreshSizeStderr,
+                                   process.stderr,
+                                   'calling stderr._refreshSize');
+process.stdout._refreshSize = wrap(originalRefreshSizeStdout,
+                                   process.stdout,
+                                   'calling stdout._refreshSize');
 
 process.emit('SIGWINCH');

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -1,0 +1,17 @@
+'use strict';
+require('../common');
+
+// if printing, add to out file
+
+const refreshSizeWrapperStderr = () => {
+  console.log('calling stderr._refreshSize');
+};
+
+const refreshSizeWrapperStdout = () => {
+  console.log('calling stdout._refreshSize');
+};
+
+process.stderr._refreshSize = refreshSizeWrapperStderr;
+process.stdout._refreshSize = refreshSizeWrapperStdout;
+
+process.emit('SIGWINCH');

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -2,13 +2,17 @@
 require('../common');
 
 // if printing, add to out file
+const originalRefreshSizeWrapperStderr = process.stderr._refreshSize;
+const originalRefreshSizeWrapperStdout = process.stdout._refreshSize;
 
 const refreshSizeWrapperStderr = () => {
   console.log('calling stderr._refreshSize');
+  originalRefreshSizeWrapperStderr.call(process.stderr);
 };
 
 const refreshSizeWrapperStdout = () => {
   console.log('calling stdout._refreshSize');
+  originalRefreshSizeWrapperStdout.call(process.stdout);
 };
 
 process.stderr._refreshSize = refreshSizeWrapperStderr;

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.out
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.out
@@ -1,0 +1,2 @@
+calling stdout._refreshSize
+calling stderr._refreshSize


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Provides coverage for calling `process._refreshSize` when a `SIGWINCH` is emitted within `stderr` and `stdout` functions in `stdio.js`