### PR TITLE
test: increase test coverage for cancelling timers

### DIFF
--- a/test/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -5,14 +5,14 @@ const assert = require('assert');
 // This test makes sure clearing timers with
 // 'null' or no input does not throw error
 
-assert.doesNotThrow(() => { clearInterval(null);});
+assert.doesNotThrow(() => clearInterval(null));
 
-assert.doesNotThrow(() => { clearInterval();});
+assert.doesNotThrow(() => clearInterval());
 
-assert.doesNotThrow(() => { clearTimeout(null);});
+assert.doesNotThrow(() => clearTimeout(null));
 
-assert.doesNotThrow(() => { clearTimeout();});
+assert.doesNotThrow(() => clearTimeout());
 
-assert.doesNotThrow(() => { clearInterval(null);});
+assert.doesNotThrow(() => clearInterval(null));
 
-assert.doesNotThrow(() => { clearInterval();});
+assert.doesNotThrow(() => clearInterval());

--- a/test/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -5,14 +5,14 @@ const assert = require('assert');
 // This test makes sure clearing timers with
 // 'null' or no input does not throw error
 
-assert.doesNotThrow(() => { clearInterval(null)});
+assert.doesNotThrow(() => { clearInterval(null);});
 
-assert.doesNotThrow(() => { clearInterval() });
+assert.doesNotThrow(() => { clearInterval();});
 
-assert.doesNotThrow(() => { clearTimeout(null) });
+assert.doesNotThrow(() => { clearTimeout(null);});
 
-assert.doesNotThrow(() => { clearTimeout() });
+assert.doesNotThrow(() => { clearTimeout();});
 
-assert.doesNotThrow(() => { clearInterval(null) });
+assert.doesNotThrow(() => { clearInterval(null);});
 
-assert.doesNotThrow(() => { clearInterval() });
+assert.doesNotThrow(() => { clearInterval();});

--- a/test/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// This test makes sure clearing timers with
+// 'null' or no input does not throw error
+
+assert.doesNotThrow(() => { clearInterval(null)});
+
+assert.doesNotThrow(() => { clearInterval() });
+
+assert.doesNotThrow(() => { clearTimeout(null) });
+
+assert.doesNotThrow(() => { clearTimeout() });
+
+assert.doesNotThrow(() => { clearInterval(null) });
+
+assert.doesNotThrow(() => { clearInterval() });

--- a/test/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -13,6 +13,6 @@ assert.doesNotThrow(() => clearTimeout(null));
 
 assert.doesNotThrow(() => clearTimeout());
 
-assert.doesNotThrow(() => clearInterval(null));
+assert.doesNotThrow(() => clearImmediate(null));
 
-assert.doesNotThrow(() => clearInterval());
+assert.doesNotThrow(() => clearImmediate());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tests

##### Description of change
<!-- Provide a description of the change below this comment. -->
This PR tests cancelling timers with `null`, or no arguments do not throw an error. 