### PR TITLE
test: test-http-unix-socket.js - var -> const, assert.equal -> assert.strictEqual

### DIFF
--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var http = require('http');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
 
-var server = http.createServer(function(req, res) {
+const server = http.createServer(function(req, res) {
   res.writeHead(200, {
     'Content-Type': 'text/plain',
     'Connection': 'close'
@@ -23,8 +23,8 @@ server.listen(common.PIPE, common.mustCall(function() {
   };
 
   var req = http.get(options, common.mustCall(function(res) {
-    assert.equal(res.statusCode, 200);
-    assert.equal(res.headers['content-type'], 'text/plain');
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers['content-type'], 'text/plain');
 
     res.body = '';
     res.setEncoding('utf8');
@@ -34,19 +34,18 @@ server.listen(common.PIPE, common.mustCall(function() {
     });
 
     res.on('end', common.mustCall(function() {
-      assert.equal(res.body, 'hello world\n');
-      server.close(function(error) {
-        assert.equal(error, undefined);
-        server.close(function(error) {
-          assert.equal(error && error.message, 'Not running');
-        });
-      });
+      assert.strictEqual(res.body, 'hello world\n');
+      server.close(common.mustCall(function(error) {
+        assert.strictEqual(error, undefined);
+        server.close(common.mustCall(function(error) {
+          assert.strictEqual(error && error.message, 'Not running');
+        }));
+      }));
     }));
   }));
 
   req.on('error', function(e) {
-    console.log(e.stack);
-    process.exit(1);
+    common.fail(e.stack);
   });
 
   req.end();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

changes `assert.equal` to `assert.strictEqual` to ensure specificity

changes var declarations to const to take advantage of es6 immutable bindings


---
edit: correct subsystem

---