### PR TITLE
test: refactor test-tls-server-verify

### DIFF
--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -1,5 +1,5 @@
 'use strict';
-var common = require('../common');
+const common = require('../common');
 
 if (!common.opensslCli) {
   common.skip('node compiled without OpenSSL CLI.');
@@ -14,7 +14,7 @@ if (!common.opensslCli) {
 // - accepted and "unauthorized", or
 // - accepted and "authorized".
 
-var testCases =
+const testCases =
     [{ title: 'Do not request certs. Everyone is unauthorized.',
       requestCert: false,
       rejectUnauthorized: false,
@@ -102,14 +102,14 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const tls = require('tls');
 
 const SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION =
   require('crypto').constants.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
 
-var assert = require('assert');
-var fs = require('fs');
-var spawn = require('child_process').spawn;
+const assert = require('assert');
+const fs = require('fs');
+const spawn = require('child_process').spawn;
 
 
 function filenamePEM(n) {
@@ -122,8 +122,8 @@ function loadPEM(n) {
 }
 
 
-var serverKey = loadPEM('agent2-key');
-var serverCert = loadPEM('agent2-cert');
+const serverKey = loadPEM('agent2-key');
+const serverCert = loadPEM('agent2-cert');
 
 
 function runClient(prefix, port, options, cb) {
@@ -133,7 +133,7 @@ function runClient(prefix, port, options, cb) {
   // - Certificate, but not signed by CA.
   // - Certificate signed by CA.
 
-  var args = ['s_client', '-connect', '127.0.0.1:' + port];
+  const args = ['s_client', '-connect', '127.0.0.1:' + port];
 
   // for the performance issue in s_client on Windows
   if (common.isWindows)
@@ -184,13 +184,13 @@ function runClient(prefix, port, options, cb) {
   }
 
   // To test use: openssl s_client -connect localhost:8000
-  var client = spawn(common.opensslCli, args);
+  const client = spawn(common.opensslCli, args);
 
-  var out = '';
+  let out = '';
 
-  var rejected = true;
-  var authed = false;
-  var goodbye = false;
+  let rejected = true;
+  let authed = false;
+  let goodbye = false;
 
   client.stdout.setEncoding('utf8');
   client.stdout.on('data', function(d) {
@@ -219,12 +219,12 @@ function runClient(prefix, port, options, cb) {
     //assert.equal(0, code, prefix + options.name +
     //      ": s_client exited with error code " + code);
     if (options.shouldReject) {
-      assert.equal(true, rejected, prefix + options.name +
+      assert.strictEqual(true, rejected, prefix + options.name +
           ' NOT rejected, but should have been');
     } else {
-      assert.equal(false, rejected, prefix + options.name +
+      assert.strictEqual(false, rejected, prefix + options.name +
           ' rejected, but should NOT have been');
-      assert.equal(options.shouldAuth, authed, prefix +
+      assert.strictEqual(options.shouldAuth, authed, prefix +
           options.name + ' authed is ' + authed +
           ' but should have been ' + options.shouldAuth);
     }
@@ -235,19 +235,19 @@ function runClient(prefix, port, options, cb) {
 
 
 // Run the tests
-var successfulTests = 0;
+let successfulTests = 0;
 function runTest(port, testIndex) {
-  var prefix = testIndex + ' ';
-  var tcase = testCases[testIndex];
+  const prefix = testIndex + ' ';
+  const tcase = testCases[testIndex];
   if (!tcase) return;
 
   console.error(prefix + "Running '%s'", tcase.title);
 
-  var cas = tcase.CAs.map(loadPEM);
+  const cas = tcase.CAs.map(loadPEM);
 
-  var crl = tcase.crl ? loadPEM(tcase.crl) : null;
+  const crl = tcase.crl ? loadPEM(tcase.crl) : null;
 
-  var serverOptions = {
+  const serverOptions = {
     key: serverKey,
     cert: serverCert,
     ca: cas,
@@ -265,8 +265,8 @@ function runTest(port, testIndex) {
         SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
   }
 
-  var renegotiated = false;
-  var server = tls.Server(serverOptions, function handleConnection(c) {
+  let renegotiated = false;
+  const server = tls.Server(serverOptions, function handleConnection(c) {
     c.on('error', function(e) {
       // child.kill() leads ECONNRESET errro in the TLS connection of
       // openssl s_client via spawn(). A Test result is already
@@ -301,7 +301,7 @@ function runTest(port, testIndex) {
   });
 
   function runNextClient(clientIndex) {
-    var options = tcase.clients[clientIndex];
+    const options = tcase.clients[clientIndex];
     if (options) {
       runClient(prefix + clientIndex + ' ', port, options, function() {
         runNextClient(clientIndex + 1);
@@ -321,8 +321,8 @@ function runTest(port, testIndex) {
       if (tcase.renegotiate) {
         runNextClient(0);
       } else {
-        var clientsCompleted = 0;
-        for (var i = 0; i < tcase.clients.length; i++) {
+        let clientsCompleted = 0;
+        for (let i = 0; i < tcase.clients.length; i++) {
           runClient(prefix + i + ' ', port, tcase.clients[i], function() {
             clientsCompleted++;
             if (clientsCompleted === tcase.clients.length) {
@@ -338,11 +338,11 @@ function runTest(port, testIndex) {
 }
 
 
-var nextTest = 0;
+let nextTest = 0;
 runTest(0, nextTest++);
 runTest(0, nextTest++);
 
 
 process.on('exit', function() {
-  assert.equal(successfulTests, testCases.length);
+  assert.strictEqual(successfulTests, testCases.length);
 });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Refactored `test-tls-server-verify.js` to replace uses of `var` with `const` and `let`. Also replaced uses of `assert.equal` with `assert.strictEqual`.
