### PR TITLE
test: test for http.request() invalid method error

### DIFF
--- a/test/parallel/test-http-request-invalid-method-error.js
+++ b/test/parallel/test-http-request-invalid-method-error.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const http = require('http');
+
+assert.throws(
+  () => { http.request({method: '\0'}); },
+  (error) => {
+    return (error instanceof TypeError) &&
+      /Method must be a valid HTTP token/.test(error);
+  }
+);


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

##### Description of change
Adds a test for when an invalid http method is passed into
http.request() to verify an error is thrown, that the
error is the correct type, and the error message is correct.