### PR TITLE
fs: re-enable watch facility in AIX

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1750,6 +1750,13 @@ a new inode. The watch will emit an event for the delete but will continue
 watching the *original* inode. Events for the new inode will not be emitted.
 This is expected behavior.
 
+In AIX, save and close of a file being watched causes two notifications -
+one for adding new content, and one for truncation. Moreover, save and 
+close operations on some platforms cause inode changes that force watch 
+operations to become invalid and ineffective. AIX retains inode for the 
+lifetime of a file, that way though this is different from Linux / OS X, 
+this improves the usability of file watching. This is expected behavior.
+
 #### Filename Argument
 
 <!--type=misc-->

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -18,10 +18,3 @@ prefix parallel
 
 [$system==freebsd]
 
-# fs-watch currently needs special configuration on AIX and we
-# want to improve under https://github.com/nodejs/node/issues/5085.
-# Tests are disabled so CI can be green and we can spot other
-# regressions until this work is complete
-[$system==aix]
-test-fs-watch-enoent                 : FAIL, PASS
-test-fs-watch-encoding               : FAIL, PASS

--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -14,6 +14,15 @@ const common = require('../common');
 const fs = require('fs');
 const path = require('path');
 
+// fs-watch on folders have limited capability in AIX.
+// The testcase makes use of folder watching, and causes
+// hang. This behavior is documented. Skip this for AIX.
+
+if (common.isAix) {
+  common.skip('folder watch capability is limited in AIX.');
+  return;
+}
+
 common.refreshTmpDir();
 
 const fn = '新建文夹件.txt';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

##### Description of change
<!-- Provide a description of the change below this comment. -->

Please refer to [5085](https://github.com/nodejs/node/issues/5085) for a full description of the background, need for this PR, and the changes.

On AIX, watch feature depends on AHAFS based Event infrastructure.
While in principle the watch use case is same across platforms, there
are subtle differences in the way AIX deals with this, with few
behavioral changes (external).

This commit addresses an assertion failure on folder watch, enabling the
AIX code for watch feature which was masked under a macro, open up
relevant test cases, skip tests which comes under the AIX limitation,
and make the document changes as appropriate.