### PR TITLE
doc: fix typo for `decipher.final`.

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -317,7 +317,7 @@ added: v0.1.94
 -->
 
 Returns any remaining deciphered contents. If `output_encoding`
-parameter is one of `'latin1'`, `'base64'` or `'hex'`, a string is returned.
+parameter is one of `'latin1'`, `'ascii'` or `'utf8'`, a string is returned.
 If an `output_encoding` is not provided, a [`Buffer`][] is returned.
 
 Once the `decipher.final()` method has been called, the `Decipher` object can


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
The `output_encoding` parameter of `decipher.final` should be as the same as `decipher.update`.
So `output_encoding: 'latin1'|'base64'|'hex'` to `output_encoding: 'latin1'|'ascii'|'utf8'`.