### PR TITLE
test: polish test-net-better-error-messages-listen

### DIFF
--- a/test/parallel/test-net-better-error-messages-listen.js
+++ b/test/parallel/test-net-better-error-messages-listen.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var net = require('net');
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
 
-var server = net.createServer(common.fail);
+const server = net.createServer(common.fail);
 server.listen(1, '1.1.1.1', common.fail);
 server.on('error', common.mustCall(function(e) {
-  assert.equal(e.address, '1.1.1.1');
-  assert.equal(e.port, 1);
-  assert.equal(e.syscall, 'listen');
+  assert.strictEqual(e.address, '1.1.1.1');
+  assert.strictEqual(e.port, 1);
+  assert.strictEqual(e.syscall, 'listen');
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Cleans up test-net-better-error-messages-list.js with following:
- var -> cons
- assert.equal -> assert.strictEqual