### PR TITLE
tools: adding osx-uninstall script

### DIFF
--- a/tools/macos-uninstall.sh
+++ b/tools/macos-uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Added to help for removal of node on OSX
+# Remove Node.js installed from tarballs or installer on macOS.
 # Referencing issue: https://github.com/nodejs/node/issues/7371
 # Using gist from rvagg: https://github.com/rvagg/io.js/blob/fhemberger-refactor-mac-installer-rebase/tools/osx-pkg/scripts/uninstall.sh
 

--- a/tools/osx-uninstall.sh
+++ b/tools/osx-uninstall.sh
@@ -16,7 +16,8 @@ rm -f "$DIR_PREFIX/share/man/man1/node.1"
 rm -f "$DIR_PREFIX/share/systemtap/tapset/node.stp"
 rm -f "$DIR_PREFIX/share/doc/node/gdbinit"
 rm -rf "$DIR_PREFIX/lib/node_modules/npm"
+rm -f "$DIR_PREFIX/lib/node_modules/.DS_Store"
 
 if [ ! "$(ls -A "$DIR_PREFIX/lib/node_modules" 2> /dev/null)" ]; then
-    rm -rf "$DIR_PREFIX/lib/node_modules"
+    rm -df "$DIR_PREFIX/lib/node_modules"
 fi

--- a/tools/osx-uninstall.sh
+++ b/tools/osx-uninstall.sh
@@ -8,19 +8,15 @@ if [ -z "$DIR_PREFIX" ]; then
   DIR_PREFIX=/usr/local
 fi
 
-if [ -f /tmp/nodejs-run-uninstall ]; then
-  rm -f $DIR_PREFIX/bin/node
-  rm -f $DIR_PREFIX/bin/npm
-  rm -rf $DIR_PREFIX/include/node
-  rm -f $DIR_PREFIX/lib/dtrace/node.d
-  rm -f $DIR_PREFIX/share/man/man1/node.1
-  rm -f $DIR_PREFIX/share/systemtap/tapset/node.stp
-  rm -f $DIR_PREFIX/share/doc/node/gdbinit
+rm -f "$DIR_PREFIX/bin/node"
+rm -f "$DIR_PREFIX/bin/npm"
+rm -rf "$DIR_PREFIX/include/node"
+rm -f "$DIR_PREFIX/lib/dtrace/node.d"
+rm -f "$DIR_PREFIX/share/man/man1/node.1"
+rm -f "$DIR_PREFIX/share/systemtap/tapset/node.stp"
+rm -f "$DIR_PREFIX/share/doc/node/gdbinit"
+rm -rf "$DIR_PREFIX/lib/node_modules/npm"
 
-  rm -rf $DIR_PREFIX/lib/node_modules/npm
-  if [ ! "$(ls -A $DIR_PREFIX/lib/node_modules 2> /dev/null)" ]; then
-    rm -rf $DIR_PREFIX/lib/node_modules
-  fi
-
-  rm -f /tmp/nodejs-run-uninstall
+if [ ! "$(ls -A "$DIR_PREFIX/lib/node_modules" 2> /dev/null)" ]; then
+    rm -rf "$DIR_PREFIX/lib/node_modules"
 fi

--- a/tools/osx-uninstall.sh
+++ b/tools/osx-uninstall.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Added to help for removal of node on OSX
+# Referencing issue: https://github.com/nodejs/node/issues/7371
+# Using gist from rvagg: https://github.com/rvagg/io.js/blob/fhemberger-refactor-mac-installer-rebase/tools/osx-pkg/scripts/uninstall.sh
+
+if [ -z "$DIR_PREFIX" ]; then
+  DIR_PREFIX=/usr/local
+fi
+
+if [ -f /tmp/nodejs-run-uninstall ]; then
+  rm -f $DIR_PREFIX/bin/node
+  rm -f $DIR_PREFIX/bin/npm
+  rm -rf $DIR_PREFIX/include/node
+  rm -f $DIR_PREFIX/lib/dtrace/node.d
+  rm -f $DIR_PREFIX/share/man/man1/node.1
+  rm -f $DIR_PREFIX/share/systemtap/tapset/node.stp
+  rm -f $DIR_PREFIX/share/doc/node/gdbinit
+
+  rm -rf $DIR_PREFIX/lib/node_modules/npm
+  if [ ! "$(ls -A $DIR_PREFIX/lib/node_modules 2> /dev/null)" ]; then
+    rm -rf $DIR_PREFIX/lib/node_modules
+  fi
+
+  rm -f /tmp/nodejs-run-uninstall
+fi


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

This is the first steps in adding an uninstaller for node and is referencing issue: https://github.com/nodejs/node/issues/7371

As seen in the discussion, 2 ways of going about this were brought up. One is adding an uninstall command to node itself and another is adding documentation to just trigger this bash script. My feeling is if we add the curl / bash script pointing to this file to uninstall to Nodejs.org would be the solution for the time being.

As for the reason this should be in node core: As node changes this file should change to remove any new file references to node. Thus having this in a committed file with history vs a public gist seems like a better way to store it.

If this gets merged i will open a PR on nodejs.org with a short snippet to nodejs.org install page under mac for how to uninstall.

As mentioned in the commit, this is based off @rvagg 's Gist from IO.js's repo:

https://github.com/rvagg/io.js/blob/fhemberger-refactor-mac-installer-rebase/tools/osx-pkg/scripts/uninstall.sh

Discussion/Guidance welcome!