### PR TITLE
debugger: call `this.resume()` after `this.run()`

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -829,7 +829,7 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  setImmediate(() => { this.run(); });
+  setImmediate(() => { this.run( () => this.resume() ); });
 }
 
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -829,7 +829,7 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  setImmediate(() => { this.run( () => this.resume() ); });
+  setImmediate(() => { this.run(() => this.resume()); });
 }
 
 

--- a/test/parallel/test-debug-prompt.js
+++ b/test/parallel/test-debug-prompt.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common');
+const spawn = require('child_process').spawn;
+
+const timeoutId = setTimeout(function() {
+  common.fail('test-debug-prompt timeout failure');
+}, common.platformTimeout(5000));
+
+const proc = spawn(process.execPath, ['debug', 'foo']);
+proc.stdout.setEncoding('utf8');
+
+proc.stdout.once('data', common.mustCall((data) => {
+  clearTimeout(timeoutId);
+  assert.strictEqual(data, 'debug> ');
+  proc.kill();
+}));

--- a/test/parallel/test-debug-prompt.js
+++ b/test/parallel/test-debug-prompt.js
@@ -4,15 +4,10 @@ const assert = require('assert');
 const common = require('../common');
 const spawn = require('child_process').spawn;
 
-const timeoutId = setTimeout(function() {
-  common.fail('test-debug-prompt timeout failure');
-}, common.platformTimeout(5000));
-
 const proc = spawn(process.execPath, ['debug', 'foo']);
 proc.stdout.setEncoding('utf8');
 
 proc.stdout.once('data', common.mustCall((data) => {
-  clearTimeout(timeoutId);
   assert.strictEqual(data, 'debug> ');
   proc.kill();
 }));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
debugger


##### Description of change
This addresses https://github.com/nodejs/node/issues/9854

The issue was introduced [here](https://github.com/nodejs/node/commit/068718c91c) and first appeared in 6.2.2.

I haven't figured out the best way to test this yet. Apparently, existing tests didn't catch the regression though.