### PR TITLE
repl: avoid parsing division operator as regex

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -93,6 +93,7 @@ class LineParser {
     this.shouldFail = false;
     this.blockComment = false;
     this.regExpLiteral = false;
+    this.prevTokenChar = null;
   }
 
   parseLine(line) {
@@ -132,7 +133,11 @@ class LineParser {
         if (previous === '/') {
           if (current === '*') {
             this.blockComment = true;
-          } else {
+          } else if (
+            // Distinguish between a division operator and the start of a regex
+            // by examining the non-whitespace character that precedes the /
+            [null, '(', '[', '{', '}', ';'].includes(this.prevTokenChar)
+          ) {
             this.regExpLiteral = true;
           }
           previous = null;
@@ -146,6 +151,8 @@ class LineParser {
       } else if (current === '\'' || current === '"') {
         this._literal = this._literal || current;
       }
+
+      if (current.trim() && current !== '/') this.prevTokenChar = current;
 
       previous = current;
     }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -352,6 +352,16 @@ function error_test() {
 
     { client: client_unix, send: 'function * foo() {}; foo().next()',
       expect: '{ value: undefined, done: true }' },
+
+    // https://github.com/nodejs/node/issues/9300
+    { client: client_unix, send: 'function foo() {\nvar bar = 1 / 1; // "/"\n}',
+      expect: prompt_multiline + prompt_multiline + 'undefined\n' + prompt_unix },
+
+    { client: client_unix, send: '(function() {\nreturn /foo/ / /bar/;\n}())',
+      expect: prompt_multiline + prompt_multiline + 'NaN\n' + prompt_unix },
+
+    { client: client_unix, send: '(function() {\nif (false) {} /bar"/;\n}())',
+      expect: prompt_multiline + prompt_multiline + 'undefined\n' + prompt_unix }
   ]);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

repl

##### Description of change
<!-- Provide a description of the change below this comment. -->

This improves the heuristic used in multiline-prompt mode to determine
whether a given slash character is at the beginning of a regular
expression.

Fixes: https://github.com/nodejs/node/issues/9300