### PR TITLE
test: refactor test-https-agent-session-reuse

### DIFF
--- a/test/parallel/test-https-agent-session-reuse.js
+++ b/test/parallel/test-https-agent-session-reuse.js
@@ -1,39 +1,39 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
 
-var https = require('https');
-var crypto = require('crypto');
+const https = require('https');
+const crypto = require('crypto');
 
-var fs = require('fs');
+const fs = require('fs');
 
-var options = {
+const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var ca = fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem');
+const ca = fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem');
 
-var clientSessions = {};
-var serverRequests = 0;
+const clientSessions = {};
+let serverRequests = 0;
 
-var agent = new https.Agent({
+const agent = new https.Agent({
   maxCachedSessions: 1
 });
 
-var server = https.createServer(options, function(req, res) {
+const server = https.createServer(options, function(req, res) {
   if (req.url === '/drop-key')
     server.setTicketKeys(crypto.randomBytes(48));
 
   serverRequests++;
   res.end('ok');
 }).listen(0, function() {
-  var queue = [
+  const queue = [
     {
       name: 'first',
 
@@ -97,7 +97,7 @@ var server = https.createServer(options, function(req, res) {
   ];
 
   function request() {
-    var options = queue.shift();
+    const options = queue.shift();
     options.agent = agent;
     https.request(options, function(res) {
       clientSessions[options.name] = res.socket.getSession();
@@ -114,9 +114,9 @@ var server = https.createServer(options, function(req, res) {
 });
 
 process.on('exit', function() {
-  assert.equal(serverRequests, 6);
-  assert.equal(clientSessions['first'].toString('hex'),
-               clientSessions['first-reuse'].toString('hex'));
+  assert.strictEqual(serverRequests, 6);
+  assert.strictEqual(clientSessions['first'].toString('hex'),
+                     clientSessions['first-reuse'].toString('hex'));
   assert.notEqual(clientSessions['first'].toString('hex'),
                   clientSessions['cipher-change'].toString('hex'));
   assert.notEqual(clientSessions['first'].toString('hex'),
@@ -125,6 +125,6 @@ process.on('exit', function() {
                   clientSessions['before-drop'].toString('hex'));
   assert.notEqual(clientSessions['before-drop'].toString('hex'),
                   clientSessions['after-drop'].toString('hex'));
-  assert.equal(clientSessions['after-drop'].toString('hex'),
-               clientSessions['after-drop-reuse'].toString('hex'));
+  assert.strictEqual(clientSessions['after-drop'].toString('hex'),
+                     clientSessions['after-drop-reuse'].toString('hex'));
 });


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Use const and let instead of var and assert.strictEqual() instead of
assert.equal()