### PR TITLE
doc: add link to `net.Server` in tls.md

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -402,7 +402,7 @@ connections on the specified `port` and `hostname`.
 This function operates asynchronously. If the `callback` is given, it will be
 called when the server has started listening.
 
-See `net.Server` for more information.
+See [`net.Server`][] for more information.
 
 ### server.setTicketKeys(keys)
 <!-- YAML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

I was looking through the `tls` docs and it referenced the `net` docs without linking it. This change adds the link.

I also did a quick grep through the other docs for similar phrases, and didn't find any instances to fix similar to this one.
