### PR TITLE
http: verify method is a string

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -72,7 +72,7 @@ function ClientRequest(options, cb) {
   if (_method != null && typeof _method !== 'string') {
     throw new TypeError('Method must be a string');
   }
-  var method = self.method = (options.method || 'GET').toUpperCase();
+  var method = self.method = (_method || 'GET').toUpperCase();
   if (!common._checkIsHttpToken(method)) {
     throw new TypeError('Method must be a valid HTTP token');
   }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -68,11 +68,11 @@ function ClientRequest(options, cb) {
   self.socketPath = options.socketPath;
   self.timeout = options.timeout;
 
-  const _method = options.method;
-  if (_method != null && typeof _method !== 'string') {
+  let method = options.method;
+  if (method != null && typeof method !== 'string') {
     throw new TypeError('Method must be a string');
   }
-  var method = self.method = (_method || 'GET').toUpperCase();
+  method = self.method = (method || 'GET').toUpperCase();
   if (!common._checkIsHttpToken(method)) {
     throw new TypeError('Method must be a valid HTTP token');
   }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -68,7 +68,7 @@ function ClientRequest(options, cb) {
   self.socketPath = options.socketPath;
   self.timeout = options.timeout;
 
-  let method = options.method;
+  var method = options.method;
   if (method != null && typeof method !== 'string') {
     throw new TypeError('Method must be a string');
   }

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -69,8 +69,7 @@ function ClientRequest(options, cb) {
   self.timeout = options.timeout;
 
   const _method = options.method;
-  if (_method !== undefined && _method !== null
-    && typeof _method !== 'string') {
+  if (_method != null && typeof _method !== 'string') {
     throw new TypeError('Method must be a string');
   }
   var method = self.method = (options.method || 'GET').toUpperCase();

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -68,6 +68,11 @@ function ClientRequest(options, cb) {
   self.socketPath = options.socketPath;
   self.timeout = options.timeout;
 
+  const _method = options.method;
+  if (_method !== undefined && _method !== null
+    && typeof _method !== 'string') {
+    throw new TypeError('Method must be a string');
+  }
   var method = self.method = (options.method || 'GET').toUpperCase();
   if (!common._checkIsHttpToken(method)) {
     throw new TypeError('Method must be a valid HTTP token');

--- a/test/parallel/test-http-client-check-http-token.js
+++ b/test/parallel/test-http-client-check-http-token.js
@@ -3,21 +3,14 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-const expectedSuccesses = {
-  undefined: 'GET',
-  null: 'GET',
-  'get': 'GET',
-  'post': 'POST'
-};
-
-const methods = Object.keys(expectedSuccesses);
+const expectedSuccesses = [undefined, null, 'GET', 'post'];
 let requestCount = 0;
 
 const server = http.createServer((req, res) => {
   requestCount++;
   res.end();
 
-  if (methods.length === requestCount) {
+  if (expectedSuccesses.length === requestCount) {
     server.close();
   }
 }).listen(0, test);
@@ -26,7 +19,7 @@ function test() {
   function fail(input) {
     assert.throws(() => {
       http.request({ method: input, path: '/' }, common.fail);
-    }, /Method must be a string/);
+    }, /^TypeError: Method must be a string$/);
   }
 
   fail(-1);
@@ -41,8 +34,7 @@ function test() {
     http.request({ method: method, port: server.address().port }).end();
   }
 
-  ok(undefined);
-  ok(null);
-  ok('get');
-  ok('post');
+  expectedSuccesses.forEach((method) => {
+    ok(method);
+  });
 }

--- a/test/parallel/test-http-client-check-http-token.js
+++ b/test/parallel/test-http-client-check-http-token.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const expectedSuccesses = {
+  undefined: 'GET',
+  null: 'GET',
+  'get': 'GET',
+  'post': 'POST'
+};
+
+const methods = Object.keys(expectedSuccesses);
+let requestCount = 0;
+
+const server = http.createServer((req, res) => {
+  requestCount++;
+  res.end();
+
+  if (methods.length === requestCount) {
+    server.close();
+  }
+}).listen(0, test);
+
+function test() {
+  function fail(input) {
+    assert.throws(() => {
+      http.request({ method: input, path: '/' }, common.fail);
+    }, /Method must be a string/);
+  }
+
+  fail(-1);
+  fail(1);
+  fail(0);
+  fail({});
+  fail(true);
+  fail(false);
+  fail([]);
+
+  function ok(method) {
+    http.request({ method: method, port: server.address().port }).end();
+  }
+
+  ok(undefined);
+  ok(null);
+  ok('get');
+  ok('post');
+}


### PR DESCRIPTION
##### Checklist

- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http


##### Description of change
Added strict check for http request `method` to be a `string`. If `method` is not a string (or `undefined` or `null`) a `TypeError` exceptions is thrown. 
The `method` value is still defaulted to `GET` in the following cases:
- `method` is `undefined`
- `method` is `null`
This fixes the `http-client` to crash if `options.method` in `http.request` was set to a number not equal to 0.

