### PR TITLE
doc: corrected vcbuild parameters for testing on windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,7 +104,7 @@ Prerequisites:
 To run the tests:
 
 ```console
-> .\vcbuild test
+> .\vcbuild test nosign
 ```
 
 To test if Node.js was built correctly:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ $ ./configure && make -j8 test
 Windows:
 
 ```text
-> vcbuild test
+> vcbuild test nosign
 ```
 
 (See the [BUILDING.md](./BUILDING.md) for more details.)
@@ -170,11 +170,11 @@ Windows:
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-Running `make test`/`vcbuild test` will run the linter as well unless one or
+Running `make test`/`vcbuild test nosign` will run the linter as well unless one or
 more tests fail.
 
 If you want to run the linter without running tests, use
-`make lint`/`vcbuild jslint`.
+`make lint`/`vcbuild jslint nosign`.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
Corrected parameter for running tests on Windows. Without the corrected
parameters, Windows users encounter an error about failing to sign the
build, "Failed to sign exe", which can be discouraging to new Windows
community members.