### PR TITLE
fs: 'O_SYMLINK' property on constant variable

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1021,24 +1021,6 @@ fs.chmodSync = function(path, mode) {
   return binding.chmod(pathModule._makeLong(path), modeNum(mode));
 };
 
-if (constants.hasOwnProperty('O_SYMLINK')) {
-  fs.lchown = function(path, uid, gid, callback) {
-    callback = maybeCallback(callback);
-    fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
-      if (err) {
-        callback(err);
-        return;
-      }
-      fs.fchown(fd, uid, gid, callback);
-    });
-  };
-
-  fs.lchownSync = function(path, uid, gid) {
-    var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
-    return fs.fchownSync(fd, uid, gid);
-  };
-}
-
 fs.fchown = function(fd, uid, gid, callback) {
   var req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1006,46 +1006,6 @@ fs.fchmodSync = function(fd, mode) {
   return binding.fchmod(fd, modeNum(mode));
 };
 
-if (constants.hasOwnProperty('O_SYMLINK')) {
-  fs.lchmod = function(path, mode, callback) {
-    callback = maybeCallback(callback);
-    fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
-      if (err) {
-        callback(err);
-        return;
-      }
-      // prefer to return the chmod error, if one occurs,
-      // but still try to close, and report closing errors if they occur.
-      fs.fchmod(fd, mode, function(err) {
-        fs.close(fd, function(err2) {
-          callback(err || err2);
-        });
-      });
-    });
-  };
-
-  fs.lchmodSync = function(path, mode) {
-    var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
-
-    // prefer to return the chmod error, if one occurs,
-    // but still try to close, and report closing errors if they occur.
-    var err, err2, ret;
-    try {
-      ret = fs.fchmodSync(fd, mode);
-    } catch (er) {
-      err = er;
-    }
-    try {
-      fs.closeSync(fd);
-    } catch (er) {
-      err2 = er;
-    }
-    if (err || err2) throw (err || err2);
-    return ret;
-  };
-}
-
-
 fs.chmod = function(path, mode, callback) {
   callback = makeCallback(callback);
   if (!nullCheck(path, callback)) return;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

##### Description of change
<!-- Provide a description of the change below this comment. -->
fs: 'O_SYMLINK' property on constant variable
The 'O_SYMLINK' property is never defined on the constant
variable (line 6). On lines 1009 and 1064, an if statement
is called with the condition:
constants.hasOwnProperty('O_SYMLINK')

Removing the two if statements removes a combined total of
51 unused lines of code.