### PR TITLE
tools: add macosx-firewall script to avoid popups

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,7 +30,8 @@ popups asking to accept incoming network connections when running tests:
 ```console
 $ sudo ./tools/macosx-firewall.sh
 ```
-Running this script will add rules for the executable `node` in the out directory and the symbolic `node` link in the projects root directory.
+Running this script will add rules for the executable `node` in the out
+directory and the symbolic `node` link in the projects root directory.
 
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,6 +23,7 @@ On OS X, you will also need:
   * You also need to install the `Command Line Tools` via Xcode. You can find
     this under the menu `Xcode -> Preferences -> Downloads`
   * This step will install `gcc` and the related toolchain containing `make`
+  * You may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid popups asking to accept incoming network connections when running tests.
 
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,8 +23,14 @@ On OS X, you will also need:
   * You also need to install the `Command Line Tools` via Xcode. You can find
     this under the menu `Xcode -> Preferences -> Downloads`
   * This step will install `gcc` and the related toolchain containing `make`
-  * You may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid
-    popups asking to accept incoming network connections when running tests.
+
+* You may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid
+popups asking to accept incoming network connections when running tests:
+
+```console
+$ sudo ./tools/macosx-firewall.sh
+```
+Running this script will add rules for the executable `node` in the out directory and the symbolic `node` link in the projects root directory.
 
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,7 +23,8 @@ On OS X, you will also need:
   * You also need to install the `Command Line Tools` via Xcode. You can find
     this under the menu `Xcode -> Preferences -> Downloads`
   * This step will install `gcc` and the related toolchain containing `make`
-  * You may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid popups asking to accept incoming network connections when running tests.
+  * You may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid
+    popups asking to accept incoming network connections when running tests.
 
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo

--- a/tools/macosx-firewall.sh
+++ b/tools/macosx-firewall.sh
@@ -16,6 +16,8 @@ OUTDIR="`( cd \"$OUTDIR\" && pwd) `"
 NODE_RELEASE="$OUTDIR/Release/node"
 NODE_DEBUG="$OUTDIR/Debug/node"
 NODE_LINK="$ROOTDIR/node"
+CCTEST_RELEASE="$OUTDIR/Release/cctest"
+CCTEST_DEBUG="$OUTDIR/Debug/cctest"
 
 if [ -f $SFW ];
 then
@@ -27,14 +29,20 @@ then
   $SFW --remove "$NODE_RELEASE"
   $SFW --remove "$NODE_RELEASE"
   $SFW --remove "$NODE_LINK"
+  $SFW --remove "$CCTEST_DEBUG"
+  $SFW --remove "$CCTEST_RELEASE"
 
   $SFW --add "$NODE_DEBUG"
   $SFW --add "$NODE_RELEASE"
   $SFW --add "$NODE_LINK"
+  $SFW --add "$CCTEST_DEBUG"
+  $SFW --add "$CCTEST_RELEASE"
 
   $SFW --unblock "$NODE_DEBUG"
   $SFW --unblock "$NODE_RELEASE"
   $SFW --unblock "$NODE_LINK"
+  $SFW --unblock "$CCTEST_DEBUG"
+  $SFW --unblock "$CCTEST_RELEASE"
 else
   echo "SocketFirewall not found in location: $SFW"
 fi

--- a/tools/macosx-firewall.sh
+++ b/tools/macosx-firewall.sh
@@ -7,6 +7,11 @@ TOOLSDIR="`dirname \"$0\"`"
 TOOLSDIR="`( cd \"$TOOLSDIR\" && pwd) `"
 ROOTDIR="`( cd \"$TOOLSDIR/..\" && pwd) `"
 OUTDIR="$TOOLSDIR/../out"
+# Using cd and pwd here so that the path used for socketfilterfw does not
+# contain a '..', which seems to cause the rules to be incorrectly added
+# and they are not removed when this script is re-run. Instead the new
+# rules are simply appended. By using pwd we can get the full path
+# without '..' and things work as expected.
 OUTDIR="`( cd \"$OUTDIR\" && pwd) `"
 NODE_RELEASE="$OUTDIR/Release/node"
 NODE_DEBUG="$OUTDIR/Debug/node"

--- a/tools/macosx-firewall.sh
+++ b/tools/macosx-firewall.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Script that adds rules to Mac OS X Socket Firewall to avoid
+# popups asking to accept incoming network connections when
+# running tests.
+SFW="/usr/libexec/ApplicationFirewall/socketfilterfw"
+TOOLSDIR="`dirname \"$0\"`"
+TOOLSDIR="`( cd \"$TOOLSDIR\" && pwd) `"
+ROOTDIR="`( cd \"$TOOLSDIR/..\" && pwd) `"
+OUTDIR=$TOOLSDIR/../out
+OUTDIR="`( cd \"$OUTDIR\" && pwd) `"
+NODE_RELEASE=$OUTDIR/Release/node
+NODE_DEBUG=$OUTDIR/Debug/node
+NODE_LINK=$ROOTDIR/node
+
+if [ -f $SFW ];
+then
+  # Duplicating these commands on purpose as the symbolic link node might be
+  # linked to either out/Debug/node or out/Release/node depending on the
+  # BUILDTYPE.
+  $SFW --remove $NODE_DEBUG
+  $SFW --remove $NODE_DEBUG
+  $SFW --remove $NODE_RELEASE
+  $SFW --remove $NODE_RELEASE
+  $SFW --remove $NODE_LINK
+
+  $SFW --add $NODE_DEBUG
+  $SFW --add $NODE_RELEASE
+  $SFW --add $NODE_LINK
+
+  $SFW --unblock $NODE_DEBUG
+  $SFW --unblock $NODE_RELEASE
+  $SFW --unblock $NODE_LINK
+else
+  echo "SocketFirewall not found in location: $SFW"
+fi

--- a/tools/macosx-firewall.sh
+++ b/tools/macosx-firewall.sh
@@ -6,30 +6,30 @@ SFW="/usr/libexec/ApplicationFirewall/socketfilterfw"
 TOOLSDIR="`dirname \"$0\"`"
 TOOLSDIR="`( cd \"$TOOLSDIR\" && pwd) `"
 ROOTDIR="`( cd \"$TOOLSDIR/..\" && pwd) `"
-OUTDIR=$TOOLSDIR/../out
+OUTDIR="$TOOLSDIR/../out"
 OUTDIR="`( cd \"$OUTDIR\" && pwd) `"
-NODE_RELEASE=$OUTDIR/Release/node
-NODE_DEBUG=$OUTDIR/Debug/node
-NODE_LINK=$ROOTDIR/node
+NODE_RELEASE="$OUTDIR/Release/node"
+NODE_DEBUG="$OUTDIR/Debug/node"
+NODE_LINK="$ROOTDIR/node"
 
 if [ -f $SFW ];
 then
   # Duplicating these commands on purpose as the symbolic link node might be
   # linked to either out/Debug/node or out/Release/node depending on the
   # BUILDTYPE.
-  $SFW --remove $NODE_DEBUG
-  $SFW --remove $NODE_DEBUG
-  $SFW --remove $NODE_RELEASE
-  $SFW --remove $NODE_RELEASE
-  $SFW --remove $NODE_LINK
+  $SFW --remove "$NODE_DEBUG"
+  $SFW --remove "$NODE_DEBUG"
+  $SFW --remove "$NODE_RELEASE"
+  $SFW --remove "$NODE_RELEASE"
+  $SFW --remove "$NODE_LINK"
 
-  $SFW --add $NODE_DEBUG
-  $SFW --add $NODE_RELEASE
-  $SFW --add $NODE_LINK
+  $SFW --add "$NODE_DEBUG"
+  $SFW --add "$NODE_RELEASE"
+  $SFW --add "$NODE_LINK"
 
-  $SFW --unblock $NODE_DEBUG
-  $SFW --unblock $NODE_RELEASE
-  $SFW --unblock $NODE_LINK
+  $SFW --unblock "$NODE_DEBUG"
+  $SFW --unblock "$NODE_RELEASE"
+  $SFW --unblock "$NODE_LINK"
 else
   echo "SocketFirewall not found in location: $SFW"
 fi


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->

Currently, there are a number of popups that get displayed when running
the tests asking to accept incoming network connections. Rules can be
added manually to the socket firewall on Mac OS X but getting this right
might not be obvious and quite a lot of time can be wasted trying to get
the rules right. This script hopes to simplify things a little so that
it can be re-run when needed.

The script should be runnable from both the projects root directory and
from the tools directory, for example:
$ sudo ./tools/macosx-firewall.sh

Fixes: https://github.com/nodejs/node/issues/8911