### PR TITLE
process: Add code to warnings, assign codes to deprecations

### DIFF
--- a/doc/api/_toc.md
+++ b/doc/api/_toc.md
@@ -14,6 +14,7 @@
 * [Console](console.html)
 * [Crypto](crypto.html)
 * [Debugger](debugger.html)
+* [Deprecated APIs](deprecations.html)
 * [DNS](dns.html)
 * [Domain](domain.html)
 * [Errors](errors.html)

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -121,6 +121,16 @@ added: v6.0.0
 
 Print stack traces for process warnings (including deprecations).
 
+### `--redirect-warnings=file`
+<!-- YAML
+added: REPLACEME
+-->
+
+Write process warnings to the given file instead of printing to stderr. The
+file will be created if it does not exist, and will be appended to if it does.
+If an error occurs while attempting to write the warning to the file, the
+warning will be written to stderr instead.
+
 ### `--trace-sync-io`
 <!-- YAML
 added: v2.1.0
@@ -394,6 +404,17 @@ containing trusted certificates.
 Note: Be aware that unless the child environment is explicitly set, this
 evironment variable will be inherited by any child processes, and if they use
 OpenSSL, it may cause them to trust the same CAs as node.
+
+### `NODE_REDIRECT_WARNINGS=file`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set, process warnings will be emitted to the given file instead of
+printing to stderr. The file will be created if it does not exist, and will be
+appended to if it does. If an error occurs while attempting to write the
+warning to the file, the warning will be written to stderr instead. This is
+equivalent to using the `--redirect-warnings=file` command-line flag.
 
 [emit_warning]: process.html#process_process_emitwarning_warning_name_ctor
 [Buffer]: buffer.html#buffer_buffer

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1,0 +1,577 @@
+# Deprecated APIs
+
+Node.js may deprecate APIs when either: (a) use of the API is considered to be
+unsafe, (b) an improved alternative API has been made available, or (c)
+breaking changes to the API are expected in a future major release.
+
+Node.js utilizes three kinds of Deprecations:
+
+* Documentation-only
+* Runtime
+* End-of-Life
+
+A Documentation-only deprecation is one that is expressed only within the
+Node.js API docs. These generate no side-effects while running Node.js.
+
+A Runtime deprecation will, by default, generate a process warning that will
+be printed to `stderr` the first time the deprecated API is used. When the
+`--throw-deprecation` command-line flag is used, a Runtime deprecation will
+cause an error to be thrown.
+
+An End-of-Life deprecation is used to identify code that either has been
+removed or will soon be removed from Node.js.
+
+## Un-deprecation
+
+From time-to-time the deprecation of an API may be reversed. Such action may
+happen in either a semver-minor or semver-major release. In such situations,
+this document will be updated with information relevant to the decision.
+*However, the deprecation identifier will not be modified*.
+
+## List of Deprecated APIs
+
+<a id="DEP0001"></a>
+### DEP0001: http.OutgoingMessage.prototype.flush
+
+Type: Runtime
+
+The `OutgoingMessage.prototype.flush()` method is deprecated. Use
+`OutgoingMessage.prototype.flushHeaders()` instead.
+
+<a id="DEP0002"></a>
+### DEP0002: require('\_linklist')
+
+Type: Runtime
+
+The `_linklist` module is deprecated. Please use a userland alternative.
+
+<a id="DEP0003"></a>
+### DEP0003: \_writableState.buffer
+
+Type: Runtime
+
+The `_writableState.buffer` property is deprecated. Use the
+`_writableState.getBuffer()` method instead.
+
+<a id="DEP0004"></a>
+### DEP0004: CryptoStream.prototype.readyState
+
+Type: Documentation-only
+
+The `CryptoStream.prototype.readyState` property is deprecated and should not
+be used.
+
+<a id="DEP0005"></a>
+### DEP0005: Buffer() constructor
+
+Type: Documentation-only
+
+The `Buffer()` function and `new Buffer()` constructor are deprecated due to
+API usability issues that can potentially lead to accidental security issues.
+
+As an alternative, use of the following methods of constructing `Buffer` objects
+is strongly recommended:
+
+* [`Buffer.alloc(size[, fill[, encoding]])`][alloc] - Create a `Buffer` with
+  *initialized* memory.
+* [`Buffer.allocUnsafe(size)`][alloc_unsafe_size] - Create a `Buffer` with *uninitialized*
+  memory.
+* [`Buffer.allocUnsafeSlow(size)`][] - Create a `Buffer` with *uninitialized*
+   memory.
+* [`Buffer.from(array)`][] - Create a `Buffer` with a copy of `array`
+* [`Buffer.from(arrayBuffer[, byteOffset[, length]])`][from_arraybuffer] - Create a `Buffer`
+  that wraps the given `arrayBuffer`.
+* [`Buffer.from(buffer)`][] - Create a `Buffer` that copies `buffer`.
+* [`Buffer.from(string[, encoding])`][from_string_encoding] - Create a `Buffer` that copies
+  `string`.
+
+<a id="DEP0006"></a>
+### DEP0006: child\_process options.customFds
+
+Type: Runtime
+
+Within the [`child_process`][] module's `spawn()`, `fork()`, and `exec()`
+methods, the `options.customFds` option is deprecated. The `options.stdio`
+option should be used instead.
+
+<a id="DEP0007"></a>
+### DEP0007: cluster worker.suicide
+
+Type: Runtime
+
+Within the `cluster` module, the [`worker.suicide`][] property has been
+deprecated. Please use [`worker.exitedAfterDisconnect`][] instead.
+
+<a id="DEP0008"></a>
+### DEP0008: require('constants')
+
+Type: Documentation-only
+
+The `constants` module has been deprecated. When requiring access to constants
+relevant to specific Node.js builtin modules, developers should instead refer
+to the `constants` property exposed by the relevant module. For instance,
+`require('fs').constants` and `require('os').constants`.
+
+<a id="DEP0009"></a>
+### DEP0009: crypto.pbkdf2 without digest
+
+Type: Runtime
+
+Use of the [`crypto.pbkdf2()`][] API without specifying a digest is deprecated.
+Please specify a digest.
+
+<a id="DEP0010"></a>
+### DEP0010: crypto.createCredentials
+
+Type: Runtime
+
+The [`crypto.createCredentials()`][] API is deprecated. Please use
+[`tls.createSecureContext()`][] instead.
+
+<a id="DEP0011"></a>
+### DEP0011: crypto.Credentials
+
+Type: Runtime
+
+The `crypto.Credentials` class is deprecated. Please use [`tls.SecureContext`][]
+instead.
+
+<a id="DEP0012"></a>
+### DEP0012: Domain.dispose
+
+Type: Runtime
+
+[`Domain.dispose()`][] is deprecated. Recover from failed I/O actions
+explicitly via error event handlers set on the domain instead.
+
+<a id="DEP0013"></a>
+### DEP0013: fs async function without callback
+
+Type: Runtime
+
+Calling an asynchronous function without a callback is deprecated.
+
+<a id="DEP0014"></a>
+### DEP0014: fs.read legacy String interface
+
+Type: End-of-Life
+
+The [`fs.read()`][] legacy String interface is deprecated. Use the Buffer API as
+mentioned in the documentation instead.
+
+<a id="DEP0015"></a>
+### DEP0015: fs.readSync legacy String interface
+
+Type: End-of-Life
+
+The [`fs.readSync()`][] legacy String interface is deprecated. Use the Buffer
+API as mentioned in the documentation instead.
+
+<a id="DEP0016"></a>
+### DEP0016: GLOBAL/root
+
+Type: Runtime
+
+The `GLOBAL` and `root` aliases for the `global` property have been deprecated
+and should no longer be used.
+
+<a id="DEP0017"></a>
+### DEP0017: Intl.v8BreakIterator
+
+Type: Runtime
+
+The `Intl.v8BreakIterator` is deprecated and will be removed or replaced soon.
+
+<a id="DEP0018"></a>
+### DEP0018: Unhandled promise rejections
+
+Type: Runtime
+
+Unhandled promise rejections are deprecated. In the future, promise rejections
+that are not handled will terminate the Node.js process with a non-zero exit
+code.
+
+<a id="DEP0019"></a>
+### DEP0019: require('.') resolved outside directory
+
+Type: Runtime
+
+In certain cases, `require('.')` may resolve outside the package directory.
+This behavior is deprecated and will be removed in a future major Node.js
+release.
+
+<a id="DEP0020"></a>
+### DEP0020: Server.connections
+
+Type: Runtime
+
+The [`Server.connections`][] property is deprecated. Please use the
+[`Server.getConnections()`][] method instead.
+
+<a id="DEP0021"></a>
+### DEP0021: Server.listenFD
+
+Type: Runtime
+
+The `Server.listenFD()` method is deprecated. Please use
+[`Server.listen({fd: <number>})`][] instead.
+
+<a id="DEP0022"></a>
+### DEP0022: os.tmpDir()
+
+Type: Runtime
+
+The `os.tmpDir()` API is deprecated. Please use [`os.tmpdir()`][] instead.
+
+<a id="DEP0023"></a>
+### DEP0023: os.getNetworkInterfaces()
+
+Type: Runtime
+
+The `os.getNetworkInterfaces()` method is deprecated. Please use the
+[`os.networkInterfaces`][] property instead.
+
+<a id="DEP0024"></a>
+### DEP0024: REPLServer.prototype.convertToContext()
+
+Type: Runtime
+
+The `REPLServer.prototype.convertToContext()` API is deprecated and should
+not be used.
+
+<a id="DEP0025"></a>
+### DEP0025: require('sys')
+
+Type: Runtime
+
+The `sys` module is deprecated. Please use the [`util`][] module instead.
+
+<a id="DEP0026"></a>
+### DEP0026: util.print()
+
+Type: Runtime
+
+The [`util.print()`][] API is deprecated. Please use [`console.log()`][]
+instead.
+
+<a id="DEP0027"></a>
+### DEP0027: util.puts()
+
+Type: Runtime
+
+The [`util.puts()`][] API is deprecated. Please use [`console.log()`][] instead.
+
+<a id="DEP0028"></a>
+### DEP0028: util.debug()
+
+Type: Runtime
+
+The [`util.debug()`][] API is deprecated. Please use [`console.error()`][]
+instead.
+
+<a id="DEP0029"></a>
+### DEP0029: util.error()
+
+Type: Runtime
+
+The [`util.error()`][] API is deprecated. Please use [`console.error()`][]
+instead.
+
+<a id="DEP0030"></a>
+### DEP0030: SlowBuffer
+
+Type: Documentation-only
+
+The [`SlowBuffer`][] class has been deprecated. Please use
+[`Buffer.allocUnsafeSlow(size)`][] instead.
+
+<a id="DEP0031"></a>
+### DEP0031: ecdh.setPublicKey()
+
+Type: Documentation-only
+
+The [`ecdh.setPublicKey()`][] method is now deprecated as its inclusion in the
+API is not useful.
+
+<a id="DEP0032"></a>
+### DEP0032: domain module
+
+Type: Documentation-only
+
+The [`domain`][] module is deprecated and should not be used.
+
+<a id="DEP0033"></a>
+### DEP0033: EventEmitter.listenerCount()
+
+Type: Documentation-only
+
+The [`EventEmitter.listenerCount(emitter, eventName)`][] API has been
+deprecated. Please use [`emitter.listenerCount(eventName)`][] instead.
+
+<a id="DEP0034"></a>
+### DEP0034: fs.exists(path, callback)
+
+Type: Documentation-only
+
+The [`fs.exists(path, callback)`][] API has been deprecated. Please use
+[`fs.stat()`][] or [`fs.access()`][] instead.
+
+<a id="DEP0035"></a>
+### DEP0035: fs.lchmod(path, mode, callback)
+
+Type: Documentation-only
+
+The [`fs.lchmod(path, mode, callback)`][] API has been deprecated.
+
+<a id="DEP0036"></a>
+### DEP0036: fs.lchmodSync(path, mode)
+
+Type: Documentation-only
+
+The [`fs.lchmodSync(path, mode)`][] API has been deprecated.
+
+<a id="DEP0037"></a>
+### DEP0037: fs.lchown(path, uid, gid, callback)
+
+Type: Documentation-only
+
+The [`fs.lchown(path, uid, gid, callback)`][] API has been deprecated.
+
+<a id="DEP0038"></a>
+### DEP0038: fs.lchownSync(path, uid, gid)
+
+Type: Documentation-only
+
+The [`fs.lchownSync(path, uid, gid)`][] API has been deprecated.
+
+<a id="DEP0039"></a>
+### DEP0039: require.extensions
+
+Type: Documentation-only
+
+The [`require.extensions`][] property has been deprecated.
+
+<a id="DEP0040"></a>
+### DEP0040: punycode module
+
+Type: Documentation-only
+
+The [`punycode`][] module has been deprecated. Please use a userland alternative
+instead.
+
+<a id="DEP0041"></a>
+### DEP0041: NODE\_REPL\_HISTORY\_FILE environment variable
+
+Type: Documentation-only
+
+The `NODE_REPL_HISTORY_FILE` environment variable has been deprecated.
+
+<a id="DEP0042"></a>
+### DEP0042: tls.CryptoStream
+
+Type: Documentation-only
+
+The [`tls.CryptoStream`][] class has been deprecated. Please use
+[`tls.TLSSocket`][] instead.
+
+<a id="DEP0043"></a>
+### DEP0043: tls.SecurePair
+
+Type: Documentation-only
+
+The [`tls.SecurePair`][] class has been deprecated. Please use
+[`tls.TLSSocket`][] instead.
+
+<a id="DEP0044"></a>
+### DEP0044: util.isArray()
+
+Type: Documentation-only
+
+The [`util.isArray()`][] API has been deprecated. Please use `Array.isArray()`
+instead.
+
+<a id="DEP0045"></a>
+### DEP0045: util.isBoolean()
+
+Type: Documentation-only
+
+The [`util.isBoolean()`][] API has been deprecated.
+
+<a id="DEP0046"></a>
+### DEP0046: util.isBuffer()
+
+Type: Documentation-only
+
+The [`util.isBuffer()`][] API has been deprecated. Please use
+[`Buffer.isBuffer()`][] instead.
+
+<a id="DEP0047"></a>
+### DEP0047: util.isDate()
+
+Type: Documentation-only
+
+The [`util.isDate()`][] API has been deprecated.
+
+<a id="DEP0048"></a>
+### DEP0048: util.isError()
+
+Type: Documentation-only
+
+The [`util.isError()`][] API has been deprecated.
+
+<a id="DEP0049"></a>
+### DEP0049: util.isFunction()
+
+Type: Documentation-only
+
+The [`util.isFunction()`][] API has been deprecated.
+
+<a id="DEP0050"></a>
+### DEP0050: util.isNull()
+
+Type: Documentation-only
+
+The [`util.isNull()`][] API has been deprecated.
+
+<a id="DEP0051"></a>
+### DEP0051: util.isNullOrUndefined()
+
+Type: Documentation-only
+
+The [`util.isNullOrUndefined()`][] API has been deprecated.
+
+<a id="DEP0052"></a>
+### DEP0052: util.isNumber()
+
+Type: Documentation-only
+
+The [`util.isNumber()`][] API has been deprecated.
+
+<a id="DEP0053"></a>
+### DEP0053 util.isObject()
+
+Type: Documentation-only
+
+The [`util.isObject()`][] API has been deprecated.
+
+<a id="DEP0054"></a>
+### DEP0054: util.isPrimitive()
+
+Type: Documentation-only
+
+The [`util.isPrimitive()`][] API has been deprecated.
+
+<a id="DEP0055"></a>
+### DEP0055: util.isRegExp()
+
+Type: Documentation-only
+
+The [`util.isRegExp()`][] API has been deprecated.
+
+<a id="DEP0056"></a>
+### DEP0056: util.isString()
+
+Type: Documentation-only
+
+The [`util.isString()`][] API has been deprecated.
+
+<a id="DEP0057"></a>
+### DEP0057: util.isSymbol()
+
+Type: Documentation-only
+
+The [`util.isSymbol()`][] API has been deprecated.
+
+<a id="DEP0058"></a>
+### DEP0058: util.isUndefined()
+
+Type: Documentation-only
+
+The [`util.isUndefined()`][] API has been deprecated.
+
+<a id="DEP0059"></a>
+### DEP0059: util.log()
+
+Type: Documentation-only
+
+The [`util.log()`][] API has been deprecated.
+
+<a id="DEP0060"></a>
+### DEP0060: util.\_extend()
+
+Type: Documentation-only
+
+The [`util._extend()`][] API has been deprecated.
+
+<a id="DEP0061"></a>
+### DEP0061: fs.SyncWriteStream
+
+Type: Documentation-only
+
+The `fs.SyncWriteStream` class was never intended to be a publicly accessible
+API.
+
+[alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
+[alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
+[`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
+[`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
+[`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
+[from_arraybuffer]: buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length
+[`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
+[from_string_encoding]: buffer.html#buffer_class_method_buffer_from_string_encoding
+[`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
+[`child_process`]: child_process.html
+[`console.error()`]: console.html#console_console_error_data_args
+[`console.log()`]: console.html#console_console_log_data_args
+[`crypto.createCredentials()`]: crypto.html#crypto_crypto_createcredentials_details
+[`crypto.pbkdf2()`]: crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
+[`domain`]: domain.html
+[`Domain.dispose()`]: domain.html#domain_domain_dispose
+[`ecdh.setPublicKey()`]: crypto.html#crypto_ecdh_setpublickey_public_key_encoding
+[`emitter.listenerCount(eventName)`]: events.html#events_emitter_listenercount_eventname
+[`EventEmitter.listenerCount(emitter, eventName)`]: events.html#events_eventemitter_listenercount_emitter_eventname
+[`fs.exists(path, callback)`]: fs.html#fs_fs_exists_path_callback
+[`fs.stat()`]: fs.html#fs_fs_stat_path_callback
+[`fs.access()`]: fs.html#fs_fs_access_path_mode_callback
+[`fs.lchmod(path, mode, callback)`]: fs.html#fs_fs_lchmod_path_mode_callback
+[`fs.lchmodSync(path, mode)`]: fs.html#fs_fs_lchmodsync_path_mode
+[`fs.lchown(path, uid, gid, callback)`]: fs.html#fs_fs_lchown_path_uid_gid_callback
+[`fs.lchownSync(path, uid, gid)`]: fs.html#fs_fs_lchownsync_path_uid_gid
+[`fs.read()`]: fs.html#fs_fs_read_fd_buffer_offset_length_position_callback
+[`fs.readSync()`]: fs.html#fs_fs_readsync_fd_buffer_offset_length_position
+[`Server.connections`]: net.html#net_server_connections
+[`Server.getConnections()`]: net.html#net_server_getconnections_callback
+[`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
+[`os.networkInterfaces`]: os.html#os_os_networkinterfaces
+[`os.tmpdir()`]: os.html#os_os_tmpdir
+[`punycode`]: punycode.html
+[`require.extensions`]: globals.html#globals_require_extensions
+[`tls.TLSSocket`]: tls.html#tls_class_tls_tlssocket
+[`tls.CryptoStream`]: tls.html#tls_class_cryptostream
+[`tls.SecurePair`]: tls.html#tls_class_securepair
+[`tls.SecureContext`]: tls.html#tls_tls_createsecurecontext_options
+[`tls.createSecureContext()`]: tls.html#tls_tls_createsecurecontext_options
+[`util`]: util.html
+[`util.debug()`]: util.html#util_util_debug_string
+[`util.error()`]: util.html#util_util_error_strings
+[`util.puts()`]: util.html#util_util_puts_strings
+[`util.print()`]: util.html#util_util_print_strings
+[`util.isArray()`]: util.html#util_util_isarray_object
+[`util.isBoolean()`]: util.html#util_util_isboolean_object
+[`util.isBuffer()`]: util.html#util_util_isbuffer_object
+[`util.isDate()`]: util.html#util_util_isdate_object
+[`util.isError()`]: util.html#util_util_iserror_object
+[`util.isFunction()`]: util.html#util_util_isfunction_object
+[`util.isNull()`]: util.html#util_util_isnull_object
+[`util.isNullOrUndefined()`]: util.html#util_util_isnullorundefined_object
+[`util.isNumber()`]: util.html#util_util_isnumber_object
+[`util.isObject()`]: util.html#util_util_isobject_object
+[`util.isPrimitive()`]: util.html#util_util_isprimitive_object
+[`util.isRegExp()`]: util.html#util_util_isregexp_object
+[`util.isString()`]: util.html#util_util_isstring_object
+[`util.isSymbol()`]: util.html#util_util_issymbol_object
+[`util.isUndefined()`]: util.html#util_util_isundefined_object
+[`util.log()`]: util.html#util_util_log_string
+[`util._extend()`]: util.html#util_util_extend_target_source
+[`worker.suicide`]: cluster.html#cluster_worker_suicide
+[`worker.exitedAfterDisconnect`]: cluster.html#cluster_worker_exitedafterdisconnect

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -706,14 +706,15 @@ console.log(process.env.test);
 // => 1
 ```
 
-## process.emitWarning(warning[, name][, ctor])
+## process.emitWarning(warning[, type[, code]][, ctor])
 <!-- YAML
 added: v6.0.0
 -->
 
 * `warning` {String | Error} The warning to emit.
-* `name` {String} When `warning` is a String, `name` is the name to use
-  for the warning. Default: `Warning`.
+* `type` {String} When `warning` is a String, `type` is the name to use
+  for the *type* of warning being emitted. Default: `Warning`.
+* `code` {String} A unique identifier for the warning instance being emitted.
 * `ctor` {Function} When `warning` is a String, `ctor` is an optional
   function used to limit the generated stack trace. Default
   `process.emitWarning`
@@ -729,9 +730,14 @@ process.emitWarning('Something happened!');
 ```
 
 ```js
-// Emit a warning using a string and a name...
+// Emit a warning using a string and a type...
 process.emitWarning('Something Happened!', 'CustomWarning');
 // Emits: (node:56338) CustomWarning: Something Happened!
+```
+
+```js
+process.emitWarning('Something happened!', 'CustomWarning', 'WARN001');
+// Emits: (node:56338) CustomWarning [WARN001]: Something Happened!
 ```
 
 In each of the previous examples, an `Error` object is generated internally by
@@ -742,21 +748,24 @@ In each of the previous examples, an `Error` object is generated internally by
 process.on('warning', (warning) => {
   console.warn(warning.name);
   console.warn(warning.message);
+  console.warn(warning.code);
   console.warn(warning.stack);
 });
 ```
 
 If `warning` is passed as an `Error` object, it will be passed through to the
-`process.on('warning')` event handler unmodified (and the optional `name`
-and `ctor` arguments will be ignored):
+`process.on('warning')` event handler unmodified (and the optional `type`,
+`code` and `ctor` arguments will be ignored):
 
 ```js
 // Emit a warning using an Error object...
 const myWarning = new Error('Warning! Something happened!');
+// Use the Error name property to specify the type name
 myWarning.name = 'CustomWarning';
+myWarning.code = 'WARN001';
 
 process.emitWarning(myWarning);
-// Emits: (node:56338) CustomWarning: Warning! Something Happened!
+// Emits: (node:56338) CustomWarning [WARN001]: Warning! Something Happened!
 ```
 
 A `TypeError` is thrown if `warning` is anything other than a string or `Error`
@@ -765,7 +774,7 @@ object.
 Note that while process warnings use `Error` objects, the process warning
 mechanism is **not** a replacement for normal error handling mechanisms.
 
-The following additional handling is implemented if the warning `name` is
+The following additional handling is implemented if the warning `type` is
 `DeprecationWarning`:
 
 * If the `--throw-deprecation` command-line flag is used, the deprecation

--- a/doc/node.1
+++ b/doc/node.1
@@ -113,6 +113,10 @@ Silence all process warnings (including deprecations).
 Print stack traces for process warnings (including deprecations).
 
 .TP
+.BR \-\-redirect\-warnings=\fIfile\fR
+Write process warnings to the given file instead of printing to stderr.
+
+.TP
 .BR \-\-trace\-sync\-io
 Print a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
@@ -261,6 +265,12 @@ containing trusted certificates.
 .BR SSL_CERT_FILE = \fIfile\fR
 If \fB\-\-use\-openssl\-ca\fR is enabled, this overrides and sets OpenSSL's
 file containing trusted certificates.
+
+.TP
+.BR NODE_REDIRECT_WARNINGS=\fIfile\fR
+Write process warnings to the given file instead of printing to stderr.
+(equivalent to using the \-\-redirect\-warnings=\fIfile\fR command-line
+argument).
 
 .SH BUGS
 Bugs are tracked in GitHub Issues:

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -738,4 +738,4 @@ OutgoingMessage.prototype.flushHeaders = function flushHeaders() {
 
 OutgoingMessage.prototype.flush = internalUtil.deprecate(function() {
   this.flushHeaders();
-}, 'OutgoingMessage.flush is deprecated. Use flushHeaders instead.');
+}, 'OutgoingMessage.flush is deprecated. Use flushHeaders instead.', 'DEP0001');

--- a/lib/_linklist.js
+++ b/lib/_linklist.js
@@ -3,4 +3,4 @@
 module.exports = require('internal/linkedlist');
 process.emitWarning(
   '_linklist module is deprecated. Please use a userland alternative.',
-  'DeprecationWarning');
+  'DeprecationWarning', 'DEP0002');

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -125,7 +125,7 @@ Object.defineProperty(WritableState.prototype, 'buffer', {
   get: internalUtil.deprecate(function() {
     return this.getBuffer();
   }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' +
-     'instead.')
+     'instead.', 'DEP0003')
 });
 
 // Test _writableState for inheritance to account for Duplex streams,

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -479,6 +479,7 @@ CryptoStream.prototype._done = function() {
 
 
 // readyState is deprecated. Don't use it.
+// Deprecation Code: DEP0004
 Object.defineProperty(CryptoStream.prototype, 'readyState', {
   get: function() {
     if (this.connecting) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -65,14 +65,14 @@ function alignPool() {
 }
 
 /**
- * The Buffer() construtor is "soft deprecated" ... that is, it is deprecated
- * in the documentation and should not be used moving forward. Rather,
- * developers should use one of the three new factory APIs: Buffer.from(),
- * Buffer.allocUnsafe() or Buffer.alloc() based on their specific needs. There
- * is no hard deprecation because of the extent to which the Buffer constructor
- * is used in the ecosystem currently -- a hard deprecation would introduce too
- * much breakage at this time. It's not likely that the Buffer constructors
- * would ever actually be removed.
+ * The Buffer() construtor is deprecated in documentation and should not be
+ * used moving forward. Rather, developers should use one of the three new
+ * factory APIs: Buffer.from(), Buffer.allocUnsafe() or Buffer.alloc() based on
+ * their specific needs. There is no runtime deprecation because of the extent
+ * to which the Buffer constructor is used in the ecosystem currently -- a
+ * runtime deprecation would introduce too much breakage at this time. It's not
+ * likely that the Buffer constructors would ever actually be removed.
+ * Deprecation Code: DEP0005
  **/
 function Buffer(arg, encodingOrOffset, length) {
   // Common case.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -324,8 +324,7 @@ const _deprecatedCustomFds = internalUtil.deprecate(
       return fd === -1 ? 'pipe' : fd;
     });
   }, 'child_process: options.customFds option is deprecated. ' +
-     'Use options.stdio instead.'
-);
+     'Use options.stdio instead.', 'DEP0006');
 
 function _convertCustomFds(options) {
   if (options.customFds && !options.stdio) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,8 +1,9 @@
 'use strict';
 
-// This module is soft-deprecated. Users should be directed towards using
-// the specific constants exposed by the individual modules on which they
-// are most relevant.
+// This module is deprecated in documentation only. Users should be directed
+// towards using the specific constants exposed by the individual modules on
+// which they are most relevant.
+// Deprecation Code: DEP0008
 const constants = process.binding('constants');
 Object.assign(exports,
               constants.os.errno,

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -539,7 +539,7 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
 
 const pbkdf2DeprecationWarning =
     internalUtil.deprecate(() => {}, 'crypto.pbkdf2 without specifying' +
-      ' a digest is deprecated. Please specify a digest');
+      ' a digest is deprecated. Please specify a digest', 'DEP0009');
 
 
 exports.pbkdf2 = function(password,
@@ -663,7 +663,7 @@ Object.defineProperty(exports, 'createCredentials', {
   get: internalUtil.deprecate(function() {
     return require('tls').createSecureContext;
   }, 'crypto.createCredentials is deprecated. ' +
-     'Use tls.createSecureContext instead.')
+     'Use tls.createSecureContext instead.', 'DEP0010')
 });
 
 Object.defineProperty(exports, 'Credentials', {
@@ -672,5 +672,5 @@ Object.defineProperty(exports, 'Credentials', {
   get: internalUtil.deprecate(function() {
     return require('tls').SecureContext;
   }, 'crypto.Credentials is deprecated. ' +
-     'Use tls.SecureContext instead.')
+     'Use tls.SecureContext instead.', 'DEP0011')
 });

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -315,4 +315,4 @@ Domain.prototype.dispose = util.deprecate(function() {
   // so that it can't be entered or activated.
   this._disposed = true;
 }, 'Domain.dispose is deprecated. Recover from failed I/O actions explicitly ' +
-    'via error event handlers set on the domain instead.');
+    'via error event handlers set on the domain instead.', 'DEP0012');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -68,8 +68,7 @@ function rethrow() {
   // TODO(thefourtheye) Throw error instead of warning in major version > 7
   process.emitWarning(
     'Calling an asynchronous function without callback is deprecated.',
-    'DeprecationWarning',
-    rethrow
+    'DeprecationWarning', 'DEP0013', rethrow
   );
 
   // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
@@ -1943,6 +1942,7 @@ WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 // todo(jasnell): "Docs-only" deprecation for now. This was never documented
 // so there's no documentation to modify. In the future, add a runtime
 // deprecation.
+// Deprecation ID: DEP0061
 Object.defineProperty(fs, 'SyncWriteStream', {
   configurable: true,
   writable: true,

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -204,7 +204,7 @@
       // getter
       const get = util.deprecate(function() {
         return this;
-      }, `'${name}' is deprecated, use 'global'`);
+      }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
       // setter
       const set = util.deprecate(function(value) {
         Object.defineProperty(this, name, {
@@ -213,7 +213,7 @@
           enumerable: true,
           value: value
         });
-      }, `'${name}' is deprecated, use 'global'`);
+      }, `'${name}' is deprecated, use 'global'`, 'DEP0016');
       // define property
       Object.defineProperty(global, name, { get, set, configurable: true });
     });

--- a/lib/internal/cluster/worker.js
+++ b/lib/internal/cluster/worker.js
@@ -23,10 +23,10 @@ function Worker(options) {
   defineProperty(this, 'suicide', {
     get: internalUtil.deprecate(
       () => this.exitedAfterDisconnect,
-      suicideDeprecationMessage),
+      suicideDeprecationMessage, 'DEP0007'),
     set: internalUtil.deprecate(
       (val) => { this.exitedAfterDisconnect = val; },
-      suicideDeprecationMessage),
+      suicideDeprecationMessage, 'DEP0007'),
     enumerable: true
   });
 

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -130,7 +130,8 @@ function setupConfig(_source) {
                         'See https://github.com/nodejs/node/wiki/Intl');
       }
       return Reflect.construct(oldV8BreakIterator, arguments);
-    }, 'Intl.v8BreakIterator is deprecated and will be removed soon.');
+    }, 'Intl.v8BreakIterator is deprecated and will be removed soon.',
+                                                   'DEP0017');
     Object.defineProperty(Intl, 'v8BreakIterator', des);
   }
   // Don’t let icu_data_dir leak through.

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -70,7 +70,7 @@ function setupPromises(scheduleMicrotasks) {
         'Unhandled promise rejections are deprecated. In the future, ' +
         'promise rejections that are not handled will terminate the ' +
         'Node.js process with a non-zero exit code.',
-        'DeprecationWarning');
+        'DeprecationWarning', 'DEP0018');
     }
   }
   var deprecationWarned = false;

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -1,8 +1,79 @@
 'use strict';
 
+const config = process.binding('config');
 const prefix = `(${process.release.name}:${process.pid}) `;
 
 exports.setup = setupProcessWarnings;
+
+var fs;
+var cachedFd;
+var acquiringFd = false;
+function nop() {}
+
+function lazyFs() {
+  if (!fs)
+    fs = require('fs');
+  return fs;
+}
+
+function writeOut(message) {
+  if (console && typeof console.error === 'function')
+    return console.error(message);
+  process._rawDebug(message);
+}
+
+function onClose(fd) {
+  return function() {
+    lazyFs().close(fd, nop);
+  };
+}
+
+function onOpen(cb) {
+  return function(err, fd) {
+    acquiringFd = false;
+    if (fd !== undefined) {
+      cachedFd = fd;
+      process.on('exit', onClose(fd));
+    }
+    cb(err, fd);
+    process.emit('_node_warning_fd_acquired', err, fd);
+  };
+}
+
+function onAcquired(message) {
+  // make a best effort attempt at writing the message
+  // to the fd. Errors are ignored at this point.
+  return function(err, fd) {
+    if (err)
+      return writeOut(message);
+    lazyFs().appendFile(fd, `${message}\n`, nop);
+  };
+}
+
+function acquireFd(cb) {
+  if (cachedFd === undefined && !acquiringFd) {
+    acquiringFd = true;
+    lazyFs().open(config.warningFile, 'a', onOpen(cb));
+  } else if (cachedFd !== undefined && !acquiringFd) {
+    cb(null, cachedFd);
+  } else {
+    process.once('_node_warning_fd_acquired', cb);
+  }
+}
+
+function output(message) {
+  if (typeof config.warningFile === 'string') {
+    acquireFd(onAcquired(message));
+    return;
+  }
+  writeOut(message);
+}
+
+function doEmitWarning(warning) {
+  return function() {
+    process.emit('warning', warning);
+  };
+}
 
 function setupProcessWarnings() {
   if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
@@ -14,19 +85,18 @@ function setupProcessWarnings() {
                     (isDeprecation && process.traceDeprecation);
       if (trace && warning.stack) {
         if (warning.code) {
-          console.error(`${prefix}[${warning.code}] ${warning.stack}`);
+          output(`${prefix}[${warning.code}] ${warning.stack}`);
         } else {
-          console.error(`${prefix}${warning.stack}`);
+          output(`${prefix}${warning.stack}`);
         }
       } else {
         const toString =
           typeof warning.toString === 'function' ?
             warning.toString : Error.prototype.toString;
         if (warning.code) {
-          console.error(
-              `${prefix}[${warning.code}] ${toString.apply(warning)}`);
+          output(`${prefix}[${warning.code}] ${toString.apply(warning)}`);
         } else {
-          console.error(`${prefix}${toString.apply(warning)}`);
+          output(`${prefix}${toString.apply(warning)}`);
         }
       }
     });
@@ -63,6 +133,6 @@ function setupProcessWarnings() {
       if (process.throwDeprecation)
         throw warning;
     }
-    process.nextTick(() => process.emit('warning', warning));
+    process.nextTick(doEmitWarning(warning));
   };
 }

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -13,26 +13,45 @@ function setupProcessWarnings() {
       const trace = process.traceProcessWarnings ||
                     (isDeprecation && process.traceDeprecation);
       if (trace && warning.stack) {
-        console.error(`${prefix}${warning.stack}`);
+        if (warning.code) {
+          console.error(`${prefix}[${warning.code}] ${warning.stack}`);
+        } else {
+          console.error(`${prefix}${warning.stack}`);
+        }
       } else {
-        var toString = warning.toString;
-        if (typeof toString !== 'function')
-          toString = Error.prototype.toString;
-        console.error(`${prefix}${toString.apply(warning)}`);
+        const toString =
+          typeof warning.toString === 'function' ?
+            warning.toString : Error.prototype.toString;
+        if (warning.code) {
+          console.error(
+              `${prefix}[${warning.code}] ${toString.apply(warning)}`);
+        } else {
+          console.error(`${prefix}${toString.apply(warning)}`);
+        }
       }
     });
   }
 
   // process.emitWarning(error)
-  // process.emitWarning(str[, name][, ctor])
-  process.emitWarning = function(warning, name, ctor) {
-    if (typeof name === 'function') {
-      ctor = name;
-      name = 'Warning';
+  // process.emitWarning(str[, type[, code]][, ctor])
+  process.emitWarning = function(warning, type, code, ctor) {
+    if (typeof type === 'function') {
+      ctor = type;
+      code = undefined;
+      type = 'Warning';
     }
+    if (typeof code === 'function') {
+      ctor = code;
+      code = undefined;
+    }
+    if (code !== undefined && typeof code !== 'string')
+      throw new TypeError('\'code\' must be a String');
+    if (type !== undefined && typeof type !== 'string')
+      throw new TypeError('\'type\' must be a String');
     if (warning === undefined || typeof warning === 'string') {
       warning = new Error(warning);
-      warning.name = name || 'Warning';
+      warning.name = String(type || 'Warning');
+      if (code !== undefined) warning.code = code;
       Error.captureStackTrace(warning, ctor || process.emitWarning);
     }
     if (!(warning instanceof Error)) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -15,8 +15,8 @@ exports.customInspectSymbol = Symbol('util.inspect.custom');
 
 // All the internal deprecations have to use this function only, as this will
 // prepend the prefix to the actual message.
-exports.deprecate = function(fn, msg) {
-  return exports._deprecate(fn, msg);
+exports.deprecate = function(fn, msg, code) {
+  return exports._deprecate(fn, msg, code);
 };
 
 exports.error = function(msg) {
@@ -39,7 +39,7 @@ exports.trace = function(msg) {
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
-exports._deprecate = function(fn, msg) {
+exports._deprecate = function(fn, msg, code) {
   // Allow for deprecating things in the process of starting up.
   if (global.process === undefined) {
     return function() {
@@ -51,11 +51,18 @@ exports._deprecate = function(fn, msg) {
     return fn;
   }
 
+  if (code !== undefined && typeof code !== 'string')
+    throw new TypeError('`code` argument must be a string');
+
   var warned = false;
   function deprecated() {
     if (!warned) {
       warned = true;
-      process.emitWarning(msg, 'DeprecationWarning', deprecated);
+      if (code !== undefined) {
+        process.emitWarning(msg, 'DeprecationWarning', code, deprecated);
+      } else {
+        process.emitWarning(msg, 'DeprecationWarning', deprecated);
+      }
     }
     if (new.target) {
       return Reflect.construct(fn, arguments, new.target);

--- a/lib/module.js
+++ b/lib/module.js
@@ -213,7 +213,7 @@ Module._findPath = function(request, paths, isMain) {
             'warning: require(\'.\') resolved outside the package ' +
             'directory. This functionality is deprecated and will be removed ' +
             'soon.',
-            'DeprecationWarning');
+            'DeprecationWarning', 'DEP0019');
         }
       }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1131,9 +1131,10 @@ function Server(options, connectionListener) {
       }
       return this._connections;
     }, 'Server.connections property is deprecated. ' +
-       'Use Server.getConnections method instead.'),
+       'Use Server.getConnections method instead.', 'DEP0020'),
     set: internalUtil.deprecate((val) => (this._connections = val),
-                                'Server.connections property is deprecated.'),
+                                'Server.connections property is deprecated.',
+                                'DEP0020'),
     configurable: true, enumerable: false
   });
 
@@ -1546,7 +1547,8 @@ function emitCloseNT(self) {
 
 Server.prototype.listenFD = internalUtil.deprecate(function(fd, type) {
   return this.listen({ fd: fd });
-}, 'Server.listenFD is deprecated. Use Server.listen({fd: <number>}) instead.');
+}, 'Server.listenFD is deprecated. Use Server.listen({fd: <number>}) instead.',
+                                                   'DEP0021');
 
 Server.prototype._setupSlave = function(socketList) {
   this._usingSlaves = true;

--- a/lib/os.js
+++ b/lib/os.js
@@ -53,12 +53,14 @@ exports.tmpdir = function() {
 
 const tmpDirDeprecationMsg =
   'os.tmpDir() is deprecated. Use os.tmpdir() instead.';
-exports.tmpDir = internalUtil.deprecate(exports.tmpdir, tmpDirDeprecationMsg);
+exports.tmpDir = internalUtil.deprecate(exports.tmpdir,
+                                        tmpDirDeprecationMsg,
+                                        'DEP0022');
 
 exports.getNetworkInterfaces = internalUtil.deprecate(function() {
   return exports.networkInterfaces();
 }, 'os.getNetworkInterfaces is deprecated. ' +
-   'Use os.networkInterfaces instead.');
+   'Use os.networkInterfaces instead.', 'DEP0023');
 
 exports.EOL = isWindows ? '\r\n' : '\n';
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1356,7 +1356,7 @@ REPLServer.prototype.convertToContext = util.deprecate(function(cmd) {
   }
 
   return cmd;
-}, 'replServer.convertToContext() is deprecated');
+}, 'replServer.convertToContext() is deprecated', 'DEP0024');
 
 function bailOnIllegalToken(parser) {
   return parser._literal === null &&

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -6,4 +6,4 @@
 
 module.exports = require('util');
 process.emitWarning('sys is deprecated. Use util instead.',
-                    'DeprecationWarning');
+                    'DeprecationWarning', 'DEP0025');

--- a/lib/util.js
+++ b/lib/util.js
@@ -993,26 +993,26 @@ exports.print = internalUtil.deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(String(arguments[i]));
   }
-}, 'util.print is deprecated. Use console.log instead.');
+}, 'util.print is deprecated. Use console.log instead.', 'DEP0026');
 
 
 exports.puts = internalUtil.deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(arguments[i] + '\n');
   }
-}, 'util.puts is deprecated. Use console.log instead.');
+}, 'util.puts is deprecated. Use console.log instead.', 'DEP0027');
 
 
 exports.debug = internalUtil.deprecate(function(x) {
   process.stderr.write(`DEBUG: ${x}\n`);
-}, 'util.debug is deprecated. Use console.error instead.');
+}, 'util.debug is deprecated. Use console.error instead.', 'DEP0028');
 
 
 exports.error = internalUtil.deprecate(function(x) {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stderr.write(arguments[i] + '\n');
   }
-}, 'util.error is deprecated. Use console.error instead.');
+}, 'util.error is deprecated. Use console.error instead.', 'DEP0029');
 
 
 exports._errnoException = function(err, syscall, original) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -12,6 +12,7 @@ using v8::Context;
 using v8::Local;
 using v8::Object;
 using v8::ReadOnly;
+using v8::String;
 using v8::Value;
 
 // The config binding is used to provide an internal view of compile or runtime
@@ -44,6 +45,15 @@ void InitConfig(Local<Object> target,
 
   if (config_preserve_symlinks)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinks");
+
+  if (config_warning_file != nullptr) {
+    Local<String> name = OneByteString(env->isolate(), "warningFile");
+    Local<String> value = String::NewFromUtf8(env->isolate(),
+                                              config_warning_file,
+                                              v8::NewStringType::kNormal)
+                                                .ToLocalChecked();
+    target->DefineOwnProperty(env->context(), name, value).FromJust();
+  }
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -42,6 +42,11 @@ extern const char* openssl_config;
 // that is used by lib/module.js
 extern bool config_preserve_symlinks;
 
+// Set in node.cc by ParseArgs when --redirect-warnings= is used.
+// Used to redirect warning output to a file rather than sending
+// it to stderr.
+extern const char* config_warning_file;
+
 // Tells whether it is safe to call v8::Isolate::GetCurrent().
 extern bool v8_initialized;
 

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -9,7 +9,7 @@
     at *
     at *
     at *
-(node:*) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
+(node:*) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
     at *
     at *
     at *

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -9,18 +9,21 @@ const util = require('util');
 process.on('warning', common.mustCall((warning) => {
   assert(warning);
   assert(/^(Warning|CustomWarning)/.test(warning.name));
-  assert(warning.message, 'A Warning');
-}, 7));
+  assert.strictEqual(warning.message, 'A Warning');
+  if (warning.code) assert.strictEqual(warning.code, 'CODE001');
+}, 8));
 
 process.emitWarning('A Warning');
 process.emitWarning('A Warning', 'CustomWarning');
 process.emitWarning('A Warning', CustomWarning);
 process.emitWarning('A Warning', 'CustomWarning', CustomWarning);
+process.emitWarning('A Warning', 'CustomWarning', 'CODE001');
 
 function CustomWarning() {
   Error.call(this);
   this.name = 'CustomWarning';
   this.message = 'A Warning';
+  this.code = 'CODE001';
   Error.captureStackTrace(this, CustomWarning);
 }
 util.inherits(CustomWarning, Error);
@@ -36,6 +39,16 @@ warningThrowToString.toString = function() {
 };
 process.emitWarning(warningThrowToString);
 
-// TypeError is thrown on invalid output
+// TypeError is thrown on invalid input
 assert.throws(() => process.emitWarning(1), TypeError);
 assert.throws(() => process.emitWarning({}), TypeError);
+assert.throws(() => process.emitWarning(true), TypeError);
+assert.throws(() => process.emitWarning([]), TypeError);
+assert.throws(() => process.emitWarning('', {}), TypeError);
+assert.throws(() => process.emitWarning('', '', {}), TypeError);
+assert.throws(() => process.emitWarning('', 1), TypeError);
+assert.throws(() => process.emitWarning('', '', 1), TypeError);
+assert.throws(() => process.emitWarning('', true), TypeError);
+assert.throws(() => process.emitWarning('', '', true), TypeError);
+assert.throws(() => process.emitWarning('', []), TypeError);
+assert.throws(() => process.emitWarning('', '', []), TypeError);

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Tests the NODE_REDIRECT_WARNINGS environment variable by spawning
+// a new child node process that emits a warning into a temporary
+// warnings file. Once the process completes, the warning file is
+// opened and the contents are validated
+
+const common = require('../common');
+const fs = require('fs');
+const fork = require('child_process').fork;
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnpath = path.join(common.tmpDir, 'warnings.txt');
+
+fork(warnmod, {env: {NODE_REDIRECT_WARNINGS: warnpath}})
+  .on('exit', common.mustCall(() => {
+    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
+    }));
+  }));

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Tests the --redirect-warnings command line flag by spawning
+// a new child node process that emits a warning into a temporary
+// warnings file. Once the process completes, the warning file is
+// opened and the contents are validated
+
+const common = require('../common');
+const fs = require('fs');
+const fork = require('child_process').fork;
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnpath = path.join(common.tmpDir, 'warnings.txt');
+
+fork(warnmod, {execArgv: [`--redirect-warnings=${warnpath}`]})
+  .on('exit', common.mustCall(() => {
+    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
+    }));
+  }));


### PR DESCRIPTION
##### Checklist
- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

process, lib

##### Description of change

As discussed at the Node.js Interactive Collaboration Summit in Austin last week, this PR adds a few new capabilities that should make it easier to make dealing with runtime deprecation warnings in Node.js easier.

1. A static identifier code can be assigned to all process warnings. These are specified as either a new optional argument to `process.emitWarning()` or as a `code` property on an `Error` object passed into `process.emitWarning()`. Within the `process.on('warning')` event handler, these can be accessed via the `code` property on the `warning` object.

2. A new `--redirect-warnings=file` command line argument and matching `NODE_REDIRECT_WARNINGS=file` environment variable is added to allow process warning output to be printed to the given `file` as opposed to dumping to `stderr`. This will allow, for instance, npm and other applications spawning node process instances to capture warning output with less noise to the console.

3. Every runtime and documentation-only deprecation in Node.js is assigned a static identifier code.

4. A new deprecations.md file is added to the API documentation that lists each of the runtime and documentation-only deprecation codes assigned. For future work (perhaps a good first contribution for new Node.js contributors), it would be helpful to expand the details in deprecations.md to include links to the relevant sections in other parts of the API documentation as well as expanded descriptions of why the APIs are deprecated and what the alternatives are. /cc @nodejs/documentation 

*Note*: This PR is currently semver-major because it adds improved type checking to the input on `process.emitWarning()` to ensure that both the warning name and the identifier code are strings.
If this PR is backported to older Node.js release streams, the backport can be landed as a semver-minor *if and only if* the additional type checking on the `name` argument is removed.

/cc @ashleygwilliams 
