### PR TITLE
test: refactor test-beforeexit-event

### DIFF
--- a/test/parallel/test-beforeexit-event.js
+++ b/test/parallel/test-beforeexit-event.js
@@ -1,42 +1,26 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-var net = require('net');
-var revivals = 0;
-var deaths = 0;
+const common = require('../common');
+const net = require('net');
 
-process.on('beforeExit', function() { deaths++; });
-
-process.once('beforeExit', tryImmediate);
+process.once('beforeExit', common.mustCall(tryImmediate));
 
 function tryImmediate() {
-  console.log('set immediate');
-  setImmediate(function() {
-    revivals++;
-    process.once('beforeExit', tryTimer);
-  });
+  setImmediate(common.mustCall(() => {
+    process.once('beforeExit', common.mustCall(tryTimer));
+  }));
 }
 
 function tryTimer() {
-  console.log('set a timeout');
-  setTimeout(function() {
-    console.log('timeout cb, do another once beforeExit');
-    revivals++;
-    process.once('beforeExit', tryListen);
-  }, 1);
+  setTimeout(common.mustCall(() => {
+    process.once('beforeExit', common.mustCall(tryListen));
+  }), 1);
 }
 
 function tryListen() {
-  console.log('create a server');
   net.createServer()
     .listen(0)
-    .on('listening', function() {
-      revivals++;
+    .on('listening', common.mustCall(function() {
       this.close();
-    });
+      process.on('beforeExit', common.mustCall(() => {}));
+    }));
 }
-
-process.on('exit', function() {
-  assert.strictEqual(4, deaths);
-  assert.strictEqual(3, revivals);
-});


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

- replaced `var` with `const` or `let`.
- removed all `console.log()` statements.
- removed `deaths` and `revivals` vars.
- wrapped `beforexit` listener callbacks with 
  `common.mustCall()`.
- removed `exit` event listener.