### PR TITLE
build: Add /opt/freeware/... to AIX library path

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -936,6 +936,16 @@
             }, {
               'type': 'executable',
             }],
+            ['target_arch=="ppc64"', {
+              'ldflags': [
+                '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread/ppc64'
+              ],
+            }],
+            ['target_arch=="ppc"', {
+              'ldflags': [
+                '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread'
+              ],
+            }]
           ],
           'dependencies': ['<(node_core_target_name)', 'node_exp'],
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->
At the moment the library search path encoded into the AIX binary has the full path to whether the GNU libstdc++ and libgcc_s were installed on the machine. Unless the user has the exact same package/version as was used on the build machine, the node binary will not be able to pick them up by default, and the user will have to set the LIBPATH variable themselves to the location on their machine.

On the assumption that most people will be picking up their is of libstdc++/libgcc_s from either the Bull Freeware site or the IBM AIX toolbox, this PR adjusts the search path within the node binary to point to /opt/freeware/lib (or lib64) to find this library. The current packages from Bull Freeware/AIX toolbox symlinks those libraries into those locations, so it is far more likely to work out of the box than the current system. For reference, here is the library search path within the current node 7.2.0 binary:

/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/4.8.5/pthread/ppc64:/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/4.8.5/../../../pthread/ppc64:/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/4.8.5:/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/4.8.5/../../..:/usr/lib:/lib  

This change squashes that to be /usr/lib:/lib:/opt/freeware/lib (or lib64).

Considerations for reviewers:

1) I have added /opt/freeware/lib{64} to the end instead of the start of the search path. if someone happens to have a version of the GNU C++ libraries in /usr/lib they will be picked up in preference to any in /opt/freeware/lib64
2) If the user has multiple versions of the GNU C++ runtimes libraries installed (unlikely you'd hope!) and an old one is linked into /opt/freeware/lib64 then it may be too old. This is the only situation in which we might be worse off - if the user has multiple versions, and has the exact version in the same place as the one encoded into the current binaries.
3) We could add /usr/local/lib{64} as well which would be the most common location for anyone that has a self-compiled version of gcc available, but I suspect that to ease support and discourage building their own GNU C++ libraries we should leave it as-is.