### PR TITLE
http: Eliminate ClientRequest capture by Agent socket listeners

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -206,34 +206,40 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
     }
     self.sockets[name].push(s);
     debug('sockets', name, self.sockets[name].length);
-
-    function onFree() {
-      self.emit('free', s, options);
-    }
-    s.on('free', onFree);
-
-    function onClose(err) {
-      debug('CLIENT socket onClose');
-      // This is the only place where sockets get removed from the Agent.
-      // If you want to remove a socket from the pool, just close it.
-      // All socket errors end in a close event anyway.
-      self.removeSocket(s, options);
-    }
-    s.on('close', onClose);
-
-    function onRemove() {
-      // We need this function for cases like HTTP 'upgrade'
-      // (defined by WebSockets) where we need to remove a socket from the
-      // pool because it'll be locked up indefinitely
-      debug('CLIENT socket onRemove');
-      self.removeSocket(s, options);
-      s.removeListener('close', onClose);
-      s.removeListener('free', onFree);
-      s.removeListener('agentRemove', onRemove);
-    }
-    s.on('agentRemove', onRemove);
+    self._installListeners(s,options);
     cb(null, s);
   }
+};
+
+Agent.prototype._installListeners = function installListeners(s, options) {
+  var self = this;
+
+  function onFree() {
+    debug('CLIENT socket onFree');
+    self.emit('free', s, options);
+  }
+  s.on('free', onFree);
+
+  function onClose(err) {
+    debug('CLIENT socket onClose');
+    // This is the only place where sockets get removed from the Agent.
+    // If you want to remove a socket from the pool, just close it.
+    // All socket errors end in a close event anyway.
+    self.removeSocket(s, options);
+  }
+  s.on('close', onClose);
+
+  function onRemove() {
+    // We need this function for cases like HTTP 'upgrade'
+    // (defined by WebSockets) where we need to remove a socket from the
+    // pool because it'll be locked up indefinitely
+    debug('CLIENT socket onRemove');
+    self.removeSocket(s, options);
+    s.removeListener('close', onClose);
+    s.removeListener('free', onFree);
+    s.removeListener('agentRemove', onRemove);
+  }
+  s.on('agentRemove', onRemove);
 };
 
 Agent.prototype.removeSocket = function removeSocket(s, options) {

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -212,11 +212,10 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
 };
 
 function installListeners(agent, s, options) {
-  var self = agent;
 
   function onFree() {
     debug('CLIENT socket onFree');
-    self.emit('free', s, options);
+    agent.emit('free', s, options);
   }
   s.on('free', onFree);
 
@@ -225,7 +224,7 @@ function installListeners(agent, s, options) {
     // This is the only place where sockets get removed from the Agent.
     // If you want to remove a socket from the pool, just close it.
     // All socket errors end in a close event anyway.
-    self.removeSocket(s, options);
+    agent.removeSocket(s, options);
   }
   s.on('close', onClose);
 
@@ -234,7 +233,7 @@ function installListeners(agent, s, options) {
     // (defined by WebSockets) where we need to remove a socket from the
     // pool because it'll be locked up indefinitely
     debug('CLIENT socket onRemove');
-    self.removeSocket(s, options);
+    agent.removeSocket(s, options);
     s.removeListener('close', onClose);
     s.removeListener('free', onFree);
     s.removeListener('agentRemove', onRemove);

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -212,7 +212,6 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
 };
 
 function installListeners(agent, s, options) {
-
   function onFree() {
     debug('CLIENT socket onFree');
     agent.emit('free', s, options);
@@ -239,7 +238,7 @@ function installListeners(agent, s, options) {
     s.removeListener('agentRemove', onRemove);
   }
   s.on('agentRemove', onRemove);
-};
+}
 
 Agent.prototype.removeSocket = function removeSocket(s, options) {
   var name = this.getName(options);

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -206,13 +206,13 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
     }
     self.sockets[name].push(s);
     debug('sockets', name, self.sockets[name].length);
-    self._installListeners(s,options);
+    installListeners(self, s, options);
     cb(null, s);
   }
 };
 
-Agent.prototype._installListeners = function installListeners(s, options) {
-  var self = this;
+function installListeners(agent, s, options) {
+  var self = agent;
 
   function onFree() {
     debug('CLIENT socket onFree');


### PR DESCRIPTION
##### Checklist

- [X] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
http

##### Description of change
Eliminate capture of createSocket callback in onFree/onClose/onRemote listeners by moving them to a separate function.

Fixes #10133 

_This reduces the heap usage by eliminating the capture in a prior context of the ClientRequest object associated with the first call that opens a socket.  Let me know the best way to provide tests for this, as it's non-obvious to me how to do so._ 

_I have provided a heapsnapshot screen shot in the accompanying issue (#10133), and will attach a similar heapsnapshot screen shot showing usage after this fix is included._
![heap_noretainer](https://cloud.githubusercontent.com/assets/7834613/20911677/832da02e-bb1e-11e6-8f82-9368e771fa50.png)
