### PR TITLE
lib: be robust when process global is clobbered

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -504,7 +504,7 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname) { ',
+    '(function (exports, require, module, __filename, process) { ',
     '\n});'
   ];
 
@@ -520,7 +520,7 @@
         lineOffset: 0,
         displayErrors: true
       });
-      fn(this.exports, NativeModule.require, this, this.filename);
+      fn(this.exports, NativeModule.require, this, this.filename, process);
 
       this.loaded = true;
     } finally {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -7,9 +7,13 @@
 
 'use strict';
 
-(function(process) {
+(function(global, process) {
 
-  function startup() {
+  function startup(global, process) {
+    // Expose the global object as a property on itself
+    // (Allows you to set stuff on `global` from anywhere in JavaScript.)
+    global.global = global;
+
     const EventEmitter = NativeModule.require('events');
     process._eventsCount = 0;
 
@@ -196,7 +200,12 @@
       enumerable: false,
       configurable: true
     });
-    global.process = process;
+    Object.defineProperty(global, 'process', {
+      value: process,
+      writable: false,
+      enumerable: true,
+      configurable: true
+    });
     const util = NativeModule.require('util');
 
     // Deprecate GLOBAL and root
@@ -532,5 +541,5 @@
     NativeModule._cache[this.id] = this;
   };
 
-  startup();
+  startup(global, process);
 });

--- a/lib/module.js
+++ b/lib/module.js
@@ -54,8 +54,15 @@ Module._extensions = {};
 var modulePaths = [];
 Module.globalPaths = [];
 
-Module.wrapper = NativeModule.wrapper;
-Module.wrap = NativeModule.wrap;
+Module.wrapper = [
+  '(function (exports, require, module, __filename, __dirname) { ',
+  '\n});'
+];
+
+Module.wrap = function wrap(script) {
+  return Module.wrapper[0] + script + Module.wrapper[1];
+};
+
 Module._debug = util.debuglog('module');
 
 // We use this alias for the preprocessor that filters it out

--- a/src/node.cc
+++ b/src/node.cc
@@ -3441,10 +3441,6 @@ void LoadEnvironment(Environment* env) {
 
   env->SetMethod(env->process_object(), "_rawDebug", RawDebug);
 
-  // Expose the global object as a property on itself
-  // (Allows you to set stuff on `global` from anywhere in JavaScript.)
-  global->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global);
-
   // Now we call 'f' with the 'process' variable that we've built up with
   // all our bindings. Inside bootstrap_node.js and internal/process we'll
   // take care of assigning things to their places.
@@ -3452,8 +3448,8 @@ void LoadEnvironment(Environment* env) {
   // We start the process this way in order to be more modular. Developers
   // who do not like how bootstrap_node.js sets up the module system but do
   // like Node's I/O bindings may want to replace 'f' with their own function.
-  Local<Value> arg = env->process_object();
-  f->Call(Null(env->isolate()), 1, &arg);
+  Local<Value> argv[] = { global, env->process_object() };
+  f->Call(Null(env->isolate()), arraysize(argv), argv);
 }
 
 static void PrintHelp() {

--- a/test/parallel/test-process-clobber.js
+++ b/test/parallel/test-process-clobber.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-global-assign */
+/* eslint-disable required-modules */
+'use strict';
+
+process = null;  // Should not bring down program.

--- a/test/parallel/test-process-clobber.js
+++ b/test/parallel/test-process-clobber.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-global-assign */
-/* eslint-disable required-modules */
 'use strict';
 
-process = null;  // Should not bring down program.
+require('../common');
+const assert = require('assert');
+
+assert.throws(() => process = null, /Cannot assign to read only property/);


### PR DESCRIPTION
Program bugs sometimes happen to overwrite the `process` global object,
leading to unpredictable runtime errors.  The bug is often hard to track
down because the crash usually looks unrelated and happens far away from
the bug point.

Make core mostly immune to such corruption by ensuring that all core
modules close over a direct reference to the process object instead
of a dynamic reference.

CI: https://ci.nodejs.org/job/node-test-pull-request/5234/