### PR TITLE
http: make the expression test more faster

### DIFF
--- a/benchmark/misc/fixed-regexp.js
+++ b/benchmark/misc/fixed-regexp.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../common.js');
+const _makeStrTest = require('_http_outgoing')._makeStrTest;
+const upgradeExpression = /^Upgrade$/i;
+const upgradeExpressionTest = _makeStrTest(upgradeExpression);
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  type: ['regexp', 'faster'],
+  field: ['Upgrade', 'Upgrade!', 'Connectionbalalalalala'],
+  n: [10e5]
+});
+
+function directTest(input) {
+  return upgradeExpression.test(input);
+}
+
+function fasterTest(input) {
+  return upgradeExpressionTest(input);
+}
+
+function main(conf) {
+  let fn;
+  const n = conf.n | 0;
+  const field = conf.field;
+  let v8command;
+
+  if (conf.type === 'regexp') {
+    fn = directTest;
+    v8command = '%OptimizeFunctionOnNextCall(directTest)';
+  } else if (conf.type === 'faster') {
+    fn = fasterTest;
+    v8command = '%OptimizeFunctionOnNextCall(fasterTest)';
+  }
+
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval(v8command);
+
+  bench.start();
+  for (var j = 0; j < n; j += 1)
+    fn(field);
+  bench.end(n);
+}

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -12,13 +12,28 @@ const CRLF = common.CRLF;
 const trfrEncChunkExpression = common.chunkExpression;
 const debug = common.debug;
 
-const upgradeExpression = /^Upgrade$/i;
-const transferEncodingExpression = /^Transfer-Encoding$/i;
-const contentLengthExpression = /^Content-Length$/i;
-const dateExpression = /^Date$/i;
-const expectExpression = /^Expect$/i;
-const trailerExpression = /^Trailer$/i;
-const connectionExpression = /^Connection$/i;
+function makeStrTest(expression) {
+  assert(expression.source.startsWith('^'));
+  assert(expression.source.endsWith('$'));
+
+  var length = expression.source.length - 2;
+
+  return function(field) {
+    if (field.length !== length) return false;
+
+    return expression.test(field);
+  };
+}
+
+exports._makeStrTest = makeStrTest;
+
+const upgradeExpressionTest = makeStrTest(/^Upgrade$/i);
+const transferEncodingExpressionTest = makeStrTest(/^Transfer-Encoding$/i);
+const contentLengthExpressionTest = makeStrTest(/^Content-Length$/i);
+const dateExpressionTest = makeStrTest(/^Date$/i);
+const expectExpressionTest = makeStrTest(/^Expect$/i);
+const trailerExpressionTest = makeStrTest(/^Trailer$/i);
+const connectionExpressionTest = makeStrTest(/^Connection$/i);
 const connCloseExpression = /(^|\W)close(\W|$)/i;
 const connUpgradeExpression = /(^|\W)upgrade(\W|$)/i;
 
@@ -322,7 +337,7 @@ function storeHeader(self, state, field, value) {
   }
   state.messageHeader += field + ': ' + escapeHeaderValue(value) + CRLF;
 
-  if (connectionExpression.test(field)) {
+  if (connectionExpressionTest(field)) {
     state.sentConnectionHeader = true;
     if (connCloseExpression.test(value)) {
       self._last = true;
@@ -331,19 +346,19 @@ function storeHeader(self, state, field, value) {
     }
     if (connUpgradeExpression.test(value))
       state.sentConnectionUpgrade = true;
-  } else if (transferEncodingExpression.test(field)) {
+  } else if (transferEncodingExpressionTest(field)) {
     state.sentTransferEncodingHeader = true;
     if (trfrEncChunkExpression.test(value)) self.chunkedEncoding = true;
 
-  } else if (contentLengthExpression.test(field)) {
+  } else if (contentLengthExpressionTest(field)) {
     state.sentContentLengthHeader = true;
-  } else if (dateExpression.test(field)) {
+  } else if (dateExpressionTest(field)) {
     state.sentDateHeader = true;
-  } else if (expectExpression.test(field)) {
+  } else if (expectExpressionTest(field)) {
     state.sentExpect = true;
-  } else if (trailerExpression.test(field)) {
+  } else if (trailerExpressionTest(field)) {
     state.sentTrailer = true;
-  } else if (upgradeExpression.test(field)) {
+  } else if (upgradeExpressionTest(field)) {
     state.sentUpgrade = true;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http


##### Description of change
<!-- Provide a description of the change below this comment. -->

When a regular expression starts with ^, ends with $, and don't
contains +?*, it's fixed length. e.g., /^Date$/.

If the regular expression explain is fixed length, we can compare
string length for fast failure.

In the bad case, it 5x speed faster than direct regular expression
test.