### PR TITLE
build: --without-profiler option, add Windows build options

### DIFF
--- a/configure
+++ b/configure
@@ -458,6 +458,11 @@ parser.add_option('--without-bundled-v8',
     help='do not use V8 includes from the bundled deps folder. ' +
          '(This mode is not officially supported for regular applications)')
 
+parser.add_option('--without-profiler',
+    action='store_true',
+    dest='without_profiler',
+    help='disable V8 profiler usage')
+
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -877,6 +882,8 @@ def configure_node(o):
     o['variables']['coverage'] = 'true'
   else:
     o['variables']['coverage'] = 'false'
+
+  o['variables']['node_use_profiler'] = b(not options.without_profiler)
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/node.gyp
+++ b/node.gyp
@@ -275,6 +275,15 @@
             'NODE_USE_V8_PLATFORM=0',
           ],
         }],
+        [ 'node_use_v8_platform=="true"' and 'node_use_profiler=="true"', {
+          'defines': [
+            'NODE_USE_PROFILER=1',
+          ],
+        }, {
+          'defines': [
+            'NODE_USE_PROFILER=0',
+          ],
+        }],
         [ 'node_tag!=""', {
           'defines': [ 'NODE_TAG="<(node_tag)"' ],
         }],

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -6,8 +6,11 @@
 #include "util-inl.h"
 
 #include "uv.h"
+
 #include "v8.h"
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
 #include "v8-profiler.h"
+#endif
 
 using v8::Boolean;
 using v8::Context;
@@ -28,7 +31,8 @@ using v8::Value;
 
 namespace node {
 
-static const char* const provider_names[] = {
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
+static const char* const retained_async_provider_names[] = {
 #define V(PROVIDER)                                                           \
   #PROVIDER,
   NODE_ASYNC_PROVIDER_TYPES(V)
@@ -54,7 +58,7 @@ class RetainedAsyncInfo: public RetainedObjectInfo {
 
 
 RetainedAsyncInfo::RetainedAsyncInfo(uint16_t class_id, AsyncWrap* wrap)
-    : label_(provider_names[class_id - NODE_ASYNC_ID_OFFSET]),
+    : label_(retained_async_provider_names[class_id - NODE_ASYNC_ID_OFFSET]),
       wrap_(wrap),
       length_(wrap->self_size()) {
 }
@@ -100,6 +104,7 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
 
   return new RetainedAsyncInfo(class_id, wrap);
 }
+#endif
 
 
 // end RetainedAsyncInfo
@@ -215,6 +220,7 @@ void AsyncWrap::DestroyIdsCb(uv_idle_t* handle) {
 }
 
 
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
 void LoadAsyncWrapperInfo(Environment* env) {
   HeapProfiler* heap_profiler = env->isolate()->GetHeapProfiler();
 #define V(PROVIDER)                                                           \
@@ -223,6 +229,7 @@ void LoadAsyncWrapperInfo(Environment* env) {
   NODE_ASYNC_PROVIDER_TYPES(V)
 #undef V
 }
+#endif
 
 
 AsyncWrap::AsyncWrap(Environment* env,

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -91,7 +91,9 @@ class AsyncWrap : public BaseObject {
   const int64_t uid_;
 };
 
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
 void LoadAsyncWrapperInfo(Environment* env);
+#endif
 
 }  // namespace node
 

--- a/src/env.h
+++ b/src/env.h
@@ -422,8 +422,10 @@ class Environment {
              bool start_profiler_idle_notifier);
   void AssignToContext(v8::Local<v8::Context> context);
 
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
   void StartProfilerIdleNotifier();
   void StopProfilerIdleNotifier();
+#endif
 
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;

--- a/src/node.cc
+++ b/src/node.cc
@@ -38,12 +38,18 @@
 #include "req-wrap-inl.h"
 #include "string_bytes.h"
 #include "util.h"
+
 #include "uv.h"
+
 #if NODE_USE_V8_PLATFORM
 #include "libplatform/libplatform.h"
 #endif  // NODE_USE_V8_PLATFORM
+
 #include "v8-debug.h"
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
 #include "v8-profiler.h"
+#endif
+
 #include "zlib.h"
 
 #ifdef NODE_ENABLE_VTUNE_PROFILING
@@ -2979,6 +2985,7 @@ static void NeedImmediateCallbackSetter(
 }
 
 
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
 void StartProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   env->StartProfilerIdleNotifier();
@@ -2989,6 +2996,7 @@ void StopProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   env->StopProfilerIdleNotifier();
 }
+#endif
 
 
 #define READONLY_PROPERTY(obj, str, var)                                      \
@@ -3314,12 +3322,16 @@ void SetupProcessObject(Environment* env,
                              env->as_external()).FromJust());
 
   // define various internal methods
+
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
   env->SetMethod(process,
                  "_startProfilerIdleNotifier",
                  StartProfilerIdleNotifier);
   env->SetMethod(process,
                  "_stopProfilerIdleNotifier",
                  StopProfilerIdleNotifier);
+#endif
+
   env->SetMethod(process, "_getActiveRequests", GetActiveRequests);
   env->SetMethod(process, "_getActiveHandles", GetActiveHandles);
   env->SetMethod(process, "reallyExit", Exit);
@@ -4490,9 +4502,11 @@ inline int Start(uv_loop_t* event_loop,
   isolate->SetAutorunMicrotasks(false);
   isolate->SetFatalErrorHandler(OnFatalError);
 
+#if defined(NODE_USE_PROFILER) && NODE_USE_PROFILER
   if (track_heap_objects) {
     isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
   }
+#endif
 
   {
     Mutex::ScopedLock scoped_lock(node_isolate_mutex);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -7,7 +7,7 @@
 #include "string_search.h"
 #include "util.h"
 #include "util-inl.h"
-#include "v8-profiler.h"
+
 #include "v8.h"
 
 #include <string.h>

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -39,6 +39,8 @@ set enable_vtune_arg=
 set configure_flags=
 set build_addons=
 set dll=
+set noinspector=
+set noprofiler=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -77,11 +79,13 @@ if /i "%1"=="upload"        set upload=1&goto arg-ok
 if /i "%1"=="small-icu"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
 if /i "%1"=="intl-none"     set i18n_arg=%1&goto arg-ok
-if /i "%1"=="without-intl"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
 if /i "%1"=="dll"           set dll=1&goto arg-ok
+if /i "%1"=="without-intl"      set i18n_arg=%1&goto arg-ok
+if /i "%1"=="without-inspector" set noinspector=1&goto arg-ok
+if /i "%1"=="without-profiler"  set noprofiler=1&goto arg-ok
 
 echo Error: invalid command line option `%1`.
 exit /b 1
@@ -118,6 +122,9 @@ if "%i18n_arg%"=="full-icu" set configure_flags=%configure_flags% --with-intl=fu
 if "%i18n_arg%"=="small-icu" set configure_flags=%configure_flags% --with-intl=small-icu
 if "%i18n_arg%"=="intl-none" set configure_flags=%configure_flags% --with-intl=none
 if "%i18n_arg%"=="without-intl" set configure_flags=%configure_flags% --without-intl
+
+if defined noinspector set configure_flags=%configure_flags% --without-inspector
+if defined noprofiler set configure_flags=%configure_flags% --without-profiler
 
 if defined config_flags set configure_flags=%configure_flags% %config_flags%
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX [macOS]; Linux i386 & amd64) **and** `vcbuild test nosign` (`.\vcbuild.bat nosign` then ` .\vcbuild.bat test nosign nobuild` as Administrator on Windows) PASS OK
- [x] commit message follows commit guidelines

###### Additional item

- [x] I hereby certify the statements in [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

build

##### Description of change
<!-- Provide a description of the change below this comment. -->

- `--without-profiler` option to build with code related to `v8-profiler.h` disabled
- `vcbuild.bat` add `without-inspector` & `without-profiler` options

These options can be used to silence some ugly build warnings ref: PR #10139