### PR TITLE
crypto: build warning fixes

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1536,8 +1536,9 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
                                     String::kNormalString, mem->length));
       (void) BIO_reset(bio);
 
-      BN_ULONG exponent_word = BN_get_word(rsa->e);
-      BIO_printf(bio, "0x%lx", exponent_word);
+      unsigned long exponent =  // NOLINT(runtime/int)
+        static_cast<unsigned long>(BN_get_word(rsa->e));  // NOLINT(runtime/int)
+      BIO_printf(bio, "0x%lx", exponent);
 
       BIO_get_mem_ptr(bio, &mem);
       info->Set(env->exponent_string(),

--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -2,6 +2,9 @@
 #include "node_crypto_clienthello-inl.h"
 #include "node_buffer.h"  // Buffer
 
+// FUTURE TODO export maximum TLS ticket size:
+static const size_t kTLSTicketSizeMask = 0xFFFF;
+
 namespace node {
 
 void ClientHelloParser::Parse(const uint8_t* data, size_t avail) {
@@ -146,7 +149,8 @@ void ClientHelloParser::ParseExtension(const uint16_t type,
       ocsp_request_ = 1;
       break;
     case kTLSSessionTicket:
-      tls_ticket_size_ = len;
+      // TBD POSSIBLE DATA LOSS:
+      tls_ticket_size_ = static_cast<uint16_t>(len & kTLSTicketSizeMask);
       tls_ticket_ = data + len;
       break;
     default:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX [macOS]; Linux i386 & amd64) **and** `vcbuild test nosign` (`.\vcbuild.bat nosign` then ` .\vcbuild.bat test nosign nobuild` as Administrator on Windows) PASS OK
- [x] commit message follows commit guidelines

###### Additional item

- [x] I hereby certify the statements in [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

crypto

##### Description of change
<!-- Provide a description of the change below this comment. -->

- use unsigned long exponent in BIO_printf: resolve warning in Ubuntu Linux i386 build
- use static kTLSTicketSizeMask: resolve conversion warning on Windows

NOTE: This was originally a part of PR #10139 (build, warning, header, and include fixes).

ADDITIONAL NOTE: This and other changes related to _PR #10139_ are marked `// TBD POSSIBLE DATA LOSS:` since I think we should examine these conversions at some point. I would be happy to take some or all of these out if necessary.