### PR TITLE
dtrace: resolve conversion warning (Windows)

### DIFF
--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -57,7 +57,7 @@ using v8::Value;
       "expected object for " #obj " to contain integer member " #member); \
   } \
   *valp = obj->Get(OneByteString(env->isolate(), #member)) \
-      ->ToInteger(env->isolate())->Value();
+      ->Int32Value();
 
 #define SLURP_OBJECT(obj, member, valp) \
   if (!(obj)->IsObject()) { \


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX [macOS]; Linux i386 & amd64) **and** `vcbuild test nosign` (`.\vcbuild.bat nosign` then ` .\vcbuild.bat test nosign nobuild` as Administrator on Windows) PASS OK
- [x] commit message follows commit guidelines

###### Additional item

- [x] I hereby certify the statements in [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)

##### Affected core subsystem(s)

dtrace

##### Description of change

static_cast<int32_t> in SLURP_INT macro - resolve conversion warning on Windows

NOTE: This was originally a part of PR #10139 (build, warning, header, and include fixes).

ADDITIONAL NOTE: This and some warnings related to PR #10139 may indicate potential data loss scenarios. For future examination.