### PR TITLE
src: resolve miscellaneous conversion warnings (Windows)

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -203,7 +203,9 @@ void AsyncWrap::DestroyIdsCb(uv_idle_t* handle) {
     // Want each callback to be cleaned up after itself, instead of cleaning
     // them all up after the while() loop completes.
     HandleScope scope(env->isolate());
-    Local<Value> argv = Number::New(env->isolate(), current_id);
+    // TBD POSSIBLE DATA LOSS:
+    Local<Value> argv = Number::New(env->isolate(),
+                                    static_cast<double>(current_id));
     MaybeLocal<Value> ret = fn->Call(
         env->context(), Undefined(env->isolate()), 1, &argv);
 
@@ -252,14 +254,17 @@ AsyncWrap::AsyncWrap(Environment* env,
   HandleScope scope(env->isolate());
 
   Local<Value> argv[] = {
-    Number::New(env->isolate(), get_uid()),
+    // TBD POSSIBLE DATA LOSS:
+    Number::New(env->isolate(), static_cast<double>(get_uid())),
     Int32::New(env->isolate(), provider),
     Null(env->isolate()),
     Null(env->isolate())
   };
 
   if (parent != nullptr) {
-    argv[2] = Number::New(env->isolate(), parent->get_uid());
+    // TBD POSSIBLE DATA LOSS:
+    argv[2] = Number::New(env->isolate(),
+                          static_cast<double>(parent->get_uid()));
     argv[3] = parent->object();
   }
 
@@ -295,7 +300,9 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
   Local<Function> pre_fn = env()->async_hooks_pre_function();
   Local<Function> post_fn = env()->async_hooks_post_function();
-  Local<Value> uid = Number::New(env()->isolate(), get_uid());
+  // TBD POSSIBLE DATA LOSS:
+  Local<Value> uid = Number::New(env()->isolate(),
+    static_cast<double>(get_uid()));
   Local<Object> context = object();
   Local<Object> domain;
   bool has_domain = false;

--- a/src/base64.h
+++ b/src/base64.h
@@ -61,8 +61,8 @@ size_t base64_decode_slow(char* dst, size_t dstlen,
   for (;;) {
 #define V(expr)                                                               \
     while (i < srclen) {                                                      \
-      const uint8_t c = src[i];                                               \
-      lo = unbase64(c);                                                       \
+      const uint8_t c = static_cast<uint8_t>(src[i]);                         \
+      lo = static_cast<uint8_t>(unbase64(c));                                 \
       i += 1;                                                                 \
       if (lo < 64)                                                            \
         break;  /* Legal character. */                                        \
@@ -75,7 +75,7 @@ size_t base64_decode_slow(char* dst, size_t dstlen,
     if (k >= dstlen)                                                          \
       return k;                                                               \
     hi = lo;
-    V(/* Nothing. */);
+    V(; /* Nothing. */);
     V(dst[k++] = ((hi & 0x3F) << 2) | ((lo & 0x30) >> 4));
     V(dst[k++] = ((hi & 0x0F) << 4) | ((lo & 0x3C) >> 2));
     V(dst[k++] = ((hi & 0x03) << 6) | ((lo & 0x3F) >> 0));

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -589,7 +589,9 @@ void AgentImpl::FatalException(v8::Local<v8::Value> error,
   auto env = parent_env_;
   v8::Local<v8::Context> context = env->context();
 
-  int script_id = message->GetScriptOrigin().ScriptID()->Value();
+  // TBD POSSIBLE DATA LOSS:
+  int script_id =
+      static_cast<int>(message->GetScriptOrigin().ScriptID()->Value());
 
   v8::Local<v8::StackTrace> stack_trace = message->GetStackTrace();
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2246,9 +2246,14 @@ void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
       Number::New(env->isolate(), v8_heap_stats.total_heap_size());
   Local<Number> heap_used =
       Number::New(env->isolate(), v8_heap_stats.used_heap_size());
+
+  const int64_t new_external_mem =
+      env->isolate()->AdjustAmountOfExternalAllocatedMemory(0);
+
+  // TBD POSSIBLE DATA LOSS:
   Local<Number> external_mem =
       Number::New(env->isolate(),
-                  env->isolate()->AdjustAmountOfExternalAllocatedMemory(0));
+                  static_cast<double>(new_external_mem));
 
   Local<Object> info = Object::New(env->isolate());
   info->Set(env->rss_string(), Number::New(env->isolate(), rss));

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -789,8 +789,10 @@ void WriteFloatGeneric(const FunctionCallbackInfo<Value>& args) {
   if (ts_obj_length > 0)
     CHECK_NE(ts_obj_data, nullptr);
 
-  T val = args[1]->NumberValue(env->context()).FromMaybe(0);
-  size_t offset = args[2]->IntegerValue(env->context()).FromMaybe(0);
+  // TBD POSSIBLE DATA LOSS:
+  T val = static_cast<T>(args[1]->NumberValue(env->context()).FromMaybe(0));
+  size_t offset =
+      static_cast<size_t>(args[2]->IntegerValue(env->context()).FromMaybe(0));
 
   size_t memcpy_num = sizeof(T);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5543,7 +5543,9 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowRangeError("size is not a valid Smi");
 
   Local<Object> obj = env->NewInternalFieldObject();
-  RandomBytesRequest* req = new RandomBytesRequest(env, obj, size);
+  // TBD POSSIBLE DATA LOSS:
+  RandomBytesRequest* req =
+      new RandomBytesRequest(env, obj, static_cast<int32_t>(size));
 
   if (args[1]->IsFunction()) {
     obj->Set(FIXED_ONE_BYTE_STRING(args.GetIsolate(), "ondone"), args[1]);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -439,8 +439,11 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
   // Unsigned integers. It does not actually seem to be specified whether
   // uid and gid are unsigned or not, but in practice they are unsigned,
   // and Node’s (F)Chown functions do check their arguments for unsignedness.
+  // TBD POSSIBLE DATA LOSS:
 #define X(name)                                                               \
-  Local<Value> name = Integer::NewFromUnsigned(env->isolate(), s->st_##name); \
+  Local<Value> name =                                                         \
+      Integer::NewFromUnsigned(env->isolate(),                                \
+                               static_cast<uint32_t>(s->st_##name));          \
   if (name.IsEmpty())                                                         \
     return Local<Object>();                                                   \
 
@@ -454,8 +457,10 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
 #undef X
 
   // Integers.
+  // TBD POSSIBLE DATA LOSS (Windows)
 #define X(name)                                                               \
-  Local<Value> name = Integer::New(env->isolate(), s->st_##name);             \
+  Local<Value> name = Integer::New(env->isolate(),                            \
+                                   static_cast<int>(s->st_##name));           \
   if (name.IsEmpty())                                                         \
     return Local<Object>();                                                   \
 
@@ -575,11 +580,12 @@ static void InternalModuleReadFile(const FunctionCallbackInfo<Value>& args) {
     start = 3;  // Skip UTF-8 BOM.
   }
 
+  // TBD POSSIBLE DATA LOSS:
   Local<String> chars_string =
       String::NewFromUtf8(env->isolate(),
                           &chars[start],
                           String::kNormalString,
-                          offset - start);
+                          static_cast<int>(offset - start));
   args.GetReturnValue().Set(chars_string);
 }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -294,7 +294,7 @@ class Parser : public AsyncWrap {
       return -1;
     }
 
-    return head_response->IntegerValue();
+    return static_cast<int>(head_response->IntegerValue());
   }
 
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -115,7 +115,8 @@ struct Converter {
     conv = ucnv_open(name, &status);
     CHECK(U_SUCCESS(status));
     if (sub != NULL) {
-      ucnv_setSubstChars(conv, sub, strlen(sub), &status);
+      // TBD POSSIBLE DATA LOSS:
+      ucnv_setSubstChars(conv, sub, static_cast<int8_t>(strlen(sub)), &status);
     }
   }
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -124,16 +124,22 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
     uv_cpu_info_t* ci = cpu_infos + i;
 
     Local<Object> times_info = Object::New(env->isolate());
+    // TBD POSSIBLE DATA LOSS:
     times_info->Set(env->user_string(),
-                    Number::New(env->isolate(), ci->cpu_times.user));
+                    Number::New(env->isolate(),
+                                static_cast<double>(ci->cpu_times.user)));
     times_info->Set(env->nice_string(),
-                    Number::New(env->isolate(), ci->cpu_times.nice));
+                    Number::New(env->isolate(),
+                                static_cast<double>(ci->cpu_times.nice)));
     times_info->Set(env->sys_string(),
-                    Number::New(env->isolate(), ci->cpu_times.sys));
+                    Number::New(env->isolate(),
+                                static_cast<double>(ci->cpu_times.sys)));
     times_info->Set(env->idle_string(),
-                    Number::New(env->isolate(), ci->cpu_times.idle));
+                    Number::New(env->isolate(),
+                                static_cast<double>(ci->cpu_times.idle)));
     times_info->Set(env->irq_string(),
-                    Number::New(env->isolate(), ci->cpu_times.irq));
+                    Number::New(env->isolate(),
+                                static_cast<double>(ci->cpu_times.irq)));
 
     Local<Object> cpu_info = Object::New(env->isolate());
     cpu_info->Set(env->model_string(),
@@ -151,7 +157,8 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetFreeMemory(const FunctionCallbackInfo<Value>& args) {
-  double amount = uv_get_free_memory();
+  // TBD POSSIBLE DATA LOSS:
+  double amount = static_cast<double>(uv_get_free_memory());
   if (amount < 0)
     return;
   args.GetReturnValue().Set(amount);
@@ -159,7 +166,8 @@ static void GetFreeMemory(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetTotalMemory(const FunctionCallbackInfo<Value>& args) {
-  double amount = uv_get_total_memory();
+  // TBD POSSIBLE DATA LOSS:
+  double amount = static_cast<double>(uv_get_total_memory());
   if (amount < 0)
     return;
   args.GetReturnValue().Set(amount);

--- a/src/node_revert.cc
+++ b/src/node_revert.cc
@@ -10,6 +10,11 @@ const char* RevertMessage(const unsigned int cve) {
 #define V(code, label, msg) case REVERT_ ## code: return label ": " msg;
   switch (cve) {
     REVERSIONS(V)
+#ifdef _WIN32
+  // Resolve warning on Windows build:
+  case 0xDEADBEEF:
+    return "deadbeef";
+#endif
     default:
       return "Unknown";
   }

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -341,7 +341,8 @@ namespace url {
       val = numbers[parts - 1];
       for (int n = 0; n < parts - 1; n++) {
         double b = 3-n;
-        val += numbers[n] * pow(256, b);
+        // TBD POSSIBLE DATA LOSS:
+        val += static_cast<uint32_t>(numbers[n] * pow(256, b));
       }
     }
 

--- a/src/string_search.h
+++ b/src/string_search.h
@@ -494,7 +494,7 @@ size_t StringSearch<Char>::BoyerMooreHorspoolSearch(
   const size_t subject_length = subject.length();
   const size_t pattern_length = pattern.length();
   int* char_occurrences = search->bad_char_table();
-  int64_t badness = -pattern_length;
+  int64_t badness = -static_cast<int64_t>(pattern_length);
 
   // How bad we are doing without a good-suffix table.
   Char last_char = pattern[pattern_length - 1];


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX [macOS]; Linux i386 & amd64) **and** `vcbuild test nosign` (`.\vcbuild.bat nosign` then ` .\vcbuild.bat test nosign nobuild` as Administrator on Windows) PASS OK
- [x] commit message follows commit guidelines

###### Additional item

- [x] I hereby certify the statements in [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)

##### Affected core subsystem(s)

src

##### Description of change

Resolve other conversion warnings not covered by #10141/#10142/#10143

This change along with #10140 (build options), #10141 (URL warning fixes), #10142 (crypto warning fixes), and #10143 (dtrace warning fix) resolves all warnings on Windows if vcbuild.bat is called with the following options: noperfctr without-inspector without-profiler

NOTE: This was originally a part of PR #10139 (build, warning, header, and include fixes).

ADDITIONAL NOTE: Some of the changes are marked `// TBD POSSIBLE DATA LOSS:` since I think we should examine these conversions at some point. I would be happy to take some or all of these out if necessary.