### PR TITLE
doc: add some info on `tty#setRawMode()`

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -50,6 +50,13 @@ raw device. Defaults to `false`.
 added: v0.7.7
 -->
 
+Allows configuration of `tty.ReadStream` so that it operates as a raw device.
+
+When in raw mode, input is always available character-by-character, not
+including modifiers. Additionally, all special processing of characters by the
+terminal is disabled, including echoing input characters.
+Note that `CTRL`+`C` will no longer cause a `SIGINT` when in this mode.
+
 * `mode` {boolean} If `true`, configures the `tty.ReadStream` to operate as a
   raw device. If `false`, configures the `tty.ReadStream` to operate in its
   default mode. The `readStream.isRaw` property will be set to the resulting


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, tty

##### Description of change
<!-- Provide a description of the change below this comment. -->

Partially taken from https://linux.die.net/man/3/cfmakeraw

A very simple test script:

```
if (process.argv[2] === 'raw')
  process.stdin.setRawMode(true)

process.stdin.on('data', (chunk) => {
  console.log(chunk)
  console.log(chunk.toString())
})
```

Related to https://github.com/nodejs/node/pull/10037
Refs(?): http://docs.libuv.org/en/v1.x/tty.html#c.uv_tty_mode_t