### PR TITLE
test: fail for missing output files

### DIFF
--- a/test/message/testcfg.py
+++ b/test/message/testcfg.py
@@ -127,8 +127,7 @@ class MessageTestConfiguration(test.TestConfiguration):
         file_path = file_prefix + ".js"
         output_path = file_prefix + ".out"
         if not exists(output_path):
-          print "Could not find %s" % output_path
-          continue
+          raise Exception("Could not find %s" % output_path)
         result.append(MessageTestCase(test, file_path, output_path,
                                       arch, mode, self.context, self))
     return result

--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -142,8 +142,7 @@ class TTYTestConfiguration(test.TestConfiguration):
         file_path = file_prefix + ".js"
         output_path = file_prefix + ".out"
         if not exists(output_path):
-          print "Could not find %s" % output_path
-          continue
+          raise Exception("Could not find %s" % output_path)
         result.append(TTYTestCase(test, file_path, output_path,
                                       arch, mode, self.context, self))
     return result


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

Instead of ignoring missing `.out` files for message/pseudo-tty tests, raise an error to indicate that something is not quite right.

Ref: https://github.com/nodejs/node/pull/10037

blocked on #10149 for now

/cc @Fishrock123, @thefourtheye 
