### PR TITLE
build: change nosign flag to sign and flip the logic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
-- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
+- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
 - [ ] tests and/or benchmarks are included
 - [ ] documentation is changed or added
 - [ ] commit message follows commit guidelines

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -115,7 +115,7 @@ Prerequisites:
   and tools which can be included in the global `PATH`.
 
 ```console
-> .\vcbuild nosign
+> .\vcbuild
 ```
 
 To run the tests:

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -18,7 +18,7 @@ set target_arch=x86
 set target_env=
 set noprojgen=
 set nobuild=
-set nosign=
+set sign=
 set nosnapshot=
 set cctest_args=
 set test_args=
@@ -51,7 +51,8 @@ if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
 if /i "%1"=="vc2015"        set target_env=vc2015&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
-if /i "%1"=="nosign"        set nosign=1&goto arg-ok
+if /i "%1"=="nosign"        set "sign="&goto arg-ok
+if /i "%1"=="sign"          set sign=1&goto arg-ok
 if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
@@ -72,7 +73,7 @@ if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="jslint-ci"     set jslint_ci=1&goto arg-ok
 if /i "%1"=="package"       set package=1&goto arg-ok
 if /i "%1"=="msi"           set msi=1&set licensertf=1&set download_arg="--download=all"&set i18n_arg=small-icu&goto arg-ok
-if /i "%1"=="build-release" set build_release=1&goto arg-ok
+if /i "%1"=="build-release" set build_release=1&set sign=1&goto arg-ok
 if /i "%1"=="upload"        set upload=1&goto arg-ok
 if /i "%1"=="small-icu"     set i18n_arg=%1&goto arg-ok
 if /i "%1"=="full-icu"      set i18n_arg=%1&goto arg-ok
@@ -130,7 +131,7 @@ call :getnodeversion || exit /b 1
 
 if "%target%"=="Clean" rmdir /Q /S "%~dp0%config%\node-v%FULLVERSION%-win-%target_arch%" > nul 2> nul
 
-if defined noprojgen if defined nobuild if defined nosign if not defined msi goto licensertf
+if defined noprojgen if defined nobuild if not defined sign if not defined msi goto licensertf
 
 @rem Set environment for msbuild
 
@@ -189,8 +190,8 @@ if errorlevel 1 goto exit
 if "%target%" == "Clean" goto exit
 
 :sign
-@rem Skip signing if the `nosign` option was specified.
-if defined nosign goto licensertf
+@rem Skip signing unless the `sign` option was specified.
+if not defined sign goto licensertf
 
 call tools\sign.bat Release\node.exe
 if errorlevel 1 echo Failed to sign exe&goto exit
@@ -269,7 +270,7 @@ echo Building node-v%FULLVERSION%-%target_arch%.msi
 msbuild "%~dp0tools\msvs\msi\nodemsi.sln" /m /t:Clean,Build /p:PlatformToolset=%PLATFORM_TOOLSET% /p:GypMsvsVersion=%GYP_MSVS_VERSION% /p:Configuration=%config% /p:Platform=%target_arch% /p:NodeVersion=%NODE_VERSION% /p:FullVersion=%FULLVERSION% /p:DistTypeDir=%DISTTYPEDIR% %noetw_msi_arg% %noperfctr_msi_arg% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 
-if defined nosign goto upload
+if not defined sign goto upload
 call tools\sign.bat node-v%FULLVERSION%-%target_arch%.msi
 if errorlevel 1 echo Failed to sign msi&goto exit
 
@@ -364,7 +365,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [nosign] [x86/x64] [vc2015] [download-all] [enable-vtune]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vc2015] [download-all] [enable-vtune]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

##### Description of change
<!-- Provide a description of the change below this comment. -->

Makes the default build on Windows not try to sign the node.exe
binary after a build. Instead the 'sign' flag now indicates that the
binary should be signed. The 'nosign' flag is left as a noop.

This is a common stumbling block for new users compiling Node on Windows. If the `nosign` flag is left off any `vcbuild.bat` command, they see what appears to be an error with the build. Seeing as the only time node.exe gets signed is for official builds, it makes more sense to default to not trying to sign the binary and to flip the flag to indicate when it should be attempted.

If accepted, this change will require the Windows build process to be adjusted to include the `sign` flag when calling `vcbuild.bat`.