### PR TITLE
test: add ES6 and improve test-fs-truncate

### DIFF
--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -1,43 +1,43 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
-var tmp = common.tmpDir;
-var filename = path.resolve(tmp, 'truncate-file.txt');
-var data = Buffer.alloc(1024 * 16, 'x');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const tmp = common.tmpDir;
+const filename = path.resolve(tmp, 'truncate-file.txt');
+const data = Buffer.alloc(1024 * 16, 'x');
 
 common.refreshTmpDir();
 
-var stat;
+let stat;
 
 // truncateSync
 fs.writeFileSync(filename, data);
 stat = fs.statSync(filename);
-assert.equal(stat.size, 1024 * 16);
+assert.strictEqual(stat.size, 1024 * 16);
 
 fs.truncateSync(filename, 1024);
 stat = fs.statSync(filename);
-assert.equal(stat.size, 1024);
+assert.strictEqual(stat.size, 1024);
 
 fs.truncateSync(filename);
 stat = fs.statSync(filename);
-assert.equal(stat.size, 0);
+assert.strictEqual(stat.size, 0);
 
 // ftruncateSync
 fs.writeFileSync(filename, data);
-var fd = fs.openSync(filename, 'r+');
+const fd = fs.openSync(filename, 'r+');
 
 stat = fs.statSync(filename);
-assert.equal(stat.size, 1024 * 16);
+assert.strictEqual(stat.size, 1024 * 16);
 
 fs.ftruncateSync(fd, 1024);
 stat = fs.statSync(filename);
-assert.equal(stat.size, 1024);
+assert.strictEqual(stat.size, 1024);
 
 fs.ftruncateSync(fd);
 stat = fs.statSync(filename);
-assert.equal(stat.size, 0);
+assert.strictEqual(stat.size, 0);
 
 fs.closeSync(fd);
 
@@ -54,19 +54,19 @@ function testTruncate(cb) {
     if (er) return cb(er);
     fs.stat(filename, function(er, stat) {
       if (er) return cb(er);
-      assert.equal(stat.size, 1024 * 16);
+      assert.strictEqual(stat.size, 1024 * 16);
 
       fs.truncate(filename, 1024, function(er) {
         if (er) return cb(er);
         fs.stat(filename, function(er, stat) {
           if (er) return cb(er);
-          assert.equal(stat.size, 1024);
+          assert.strictEqual(stat.size, 1024);
 
           fs.truncate(filename, function(er) {
             if (er) return cb(er);
             fs.stat(filename, function(er, stat) {
               if (er) return cb(er);
-              assert.equal(stat.size, 0);
+              assert.strictEqual(stat.size, 0);
               cb();
             });
           });
@@ -82,7 +82,7 @@ function testFtruncate(cb) {
     if (er) return cb(er);
     fs.stat(filename, function(er, stat) {
       if (er) return cb(er);
-      assert.equal(stat.size, 1024 * 16);
+      assert.strictEqual(stat.size, 1024 * 16);
 
       fs.open(filename, 'w', function(er, fd) {
         if (er) return cb(er);
@@ -90,13 +90,13 @@ function testFtruncate(cb) {
           if (er) return cb(er);
           fs.stat(filename, function(er, stat) {
             if (er) return cb(er);
-            assert.equal(stat.size, 1024);
+            assert.strictEqual(stat.size, 1024);
 
             fs.ftruncate(fd, function(er) {
               if (er) return cb(er);
               fs.stat(filename, function(er, stat) {
                 if (er) return cb(er);
-                assert.equal(stat.size, 0);
+                assert.strictEqual(stat.size, 0);
                 fs.close(fd, cb);
               });
             });


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

use const and let for variables
replace assert.equal with assert.strictEqual