### PR TITLE
deps: define missing operator delete functions

### DIFF
--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -598,6 +598,11 @@ HandleScope::~HandleScope() {
 }
 
 
+void HandleScope::operator delete(void*, size_t) {
+  base::OS::Abort();
+}
+
+
 int HandleScope::NumberOfHandles(Isolate* isolate) {
   return i::HandleScope::NumberOfHandles(
       reinterpret_cast<i::Isolate*>(isolate));
@@ -620,6 +625,11 @@ EscapableHandleScope::EscapableHandleScope(Isolate* v8_isolate) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
   escape_slot_ = CreateHandle(isolate, isolate->heap()->the_hole_value());
   Initialize(v8_isolate);
+}
+
+
+void EscapableHandleScope::operator delete(void*, size_t) {
+  base::OS::Abort();
 }
 
 
@@ -1881,6 +1891,11 @@ v8::TryCatch::~TryCatch() {
     isolate_->UnregisterTryCatchHandler(this);
     v8::internal::SimulatorStack::UnregisterCTryCatch();
   }
+}
+
+
+void v8::TryCatch::operator delete(void*, size_t) {
+  base::OS::Abort();
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
v8

##### Description of change
<!-- Provide a description of the change below this comment. -->

Section 3.2 of the C++ standard states that destructor definitions
implicitly "use" operator delete functions. Therefore, these operator
delete functions must be defined even if they are never called by
user code explicitly.
http://www.open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#261

gcc allows them to remain as empty definitions. However, not all
compilers allow this.

This pull request creates definitions which if ever called, result
in an abort.