### PR TITLE
buffer: removed unused variable conf from buffer-base64-decode & buffer-base64-encode

### DIFF
--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  len: [32],
+  n: [32],
 });
 
 function main(conf) {

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -2,15 +2,18 @@
 const assert = require('assert');
 const common = require('../common.js');
 
-const bench = common.createBenchmark(main, {});
+const bench = common.createBenchmark(main, {
+  n: [32],
+});
 
 function main(conf) {
+  const n = conf.n;
   const s = 'abcd'.repeat(8 << 20);
   s.match(/./);  // Flatten string.
   assert.strictEqual(s.length % 4, 0);
   const b = Buffer.allocUnsafe(s.length / 4 * 3);
   b.write(s, 0, s.length, 'base64');
   bench.start();
-  for (var i = 0; i < 32; i += 1) b.base64Write(s, 0, s.length);
-  bench.end(32);
+  for (var i = 0; i < n; i += 1) b.base64Write(s, 0, s.length);
+  bench.end(n);
 }

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -3,11 +3,11 @@ const assert = require('assert');
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  n: [32],
+  len: [32],
 });
 
 function main(conf) {
-  const n = conf.n;
+  const n = +conf.len;
   const s = 'abcd'.repeat(8 << 20);
   s.match(/./);  // Flatten string.
   assert.strictEqual(s.length % 4, 0);

--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  const n = +conf.len;
+  const n = +conf.n;
   const s = 'abcd'.repeat(8 << 20);
   s.match(/./);  // Flatten string.
   assert.strictEqual(s.length % 4, 0);

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -1,16 +1,20 @@
 'use strict';
 var common = require('../common.js');
 
-var bench = common.createBenchmark(main, {});
+const bench = common.createBenchmark(main, {
+  N: [64 * 1024 * 1024],
+  n: [32]
+});
 
 function main(conf) {
-  var N = 64 * 1024 * 1024;
+  var n = conf.n;
+  var N = conf.N;
   var b = Buffer.allocUnsafe(N);
   var s = '';
   var i;
   for (i = 0; i < 256; ++i) s += String.fromCharCode(i);
   for (i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
   bench.start();
-  for (i = 0; i < 32; ++i) b.toString('base64');
-  bench.end(64);
+  for (i = 0; i < n; ++i) b.toString('base64');
+  bench.end(n);
 }

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -2,8 +2,8 @@
 var common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  N: [64 * 1024 * 1024],
-  len: [32]
+  len: [64 * 1024 * 1024],
+  n: [32]
 });
 
 function main(conf) {

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -7,13 +7,13 @@ const bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  const n = +conf.len;
-  const N = +conf.N;
-  const b = Buffer.allocUnsafe(N);
+  const n = +conf.n;
+  const len = +conf.len;
+  const b = Buffer.allocUnsafe(len);
   let s = '';
   let i;
   for (i = 0; i < 256; ++i) s += String.fromCharCode(i);
-  for (i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
+  for (i = 0; i < len; i += 256) b.write(s, i, 256, 'ascii');
   bench.start();
   for (i = 0; i < n; ++i) b.toString('base64');
   bench.end(n);

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -3,15 +3,15 @@ var common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   N: [64 * 1024 * 1024],
-  n: [32]
+  len: [32]
 });
 
 function main(conf) {
-  var n = conf.n;
-  var N = conf.N;
-  var b = Buffer.allocUnsafe(N);
-  var s = '';
-  var i;
+  const n = +conf.len;
+  const N = +conf.N;
+  const b = Buffer.allocUnsafe(N);
+  let s = '';
+  let i;
   for (i = 0; i < 256; ++i) s += String.fromCharCode(i);
   for (i = 0; i < N; i += 256) b.write(s, i, 256, 'ascii');
   bench.start();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Removed unused variable `conf` from buffer-base64-decode.js and buffer-based64-encode.js
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Buffer

##### Description of change
<!-- Provide a description of the change below this comment. -->
Deleted variable that wasn't used which was `conf`