### PR TITLE
tools: enforce consistent operator linebreak style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -93,6 +93,7 @@ rules:
   no-multiple-empty-lines: [2, {max: 2, maxEOF: 0, maxBOF: 0}]
   no-tabs: 2
   no-trailing-spaces: 2
+  operator-linebreak: [2, after, {overrides: {'?': ignore, ':': ignore}}]
   quotes: [2, single, avoid-escape]
   semi: 2
   semi-spacing: 2

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -473,8 +473,8 @@ function unrefdHandle() {
 
   // Make sure we clean up if the callback is no longer a function
   // even if the timer is an interval.
-  if (!this.owner._repeat
-      || typeof this.owner._onTimeout !== 'function') {
+  if (!this.owner._repeat ||
+      typeof this.owner._onTimeout !== 'function') {
     this.owner.close();
   }
 }

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -32,27 +32,27 @@ const fixtureD = fixture('define-global.js');
 const fixtureThrows = fixture('throws_error4.js');
 
 // test preloading a single module works
-childProcess.exec(nodeBinary + ' '
-  + preloadOption([fixtureA]) + ' '
-  + fixtureB,
+childProcess.exec(nodeBinary + ' ' +
+  preloadOption([fixtureA]) + ' ' +
+  fixtureB,
   function(err, stdout, stderr) {
     if (err) throw err;
     assert.strictEqual(stdout, 'A\nB\n');
   });
 
 // test preloading multiple modules works
-childProcess.exec(nodeBinary + ' '
-  + preloadOption([fixtureA, fixtureB]) + ' '
-  + fixtureC,
+childProcess.exec(nodeBinary + ' ' +
+  preloadOption([fixtureA, fixtureB]) + ' ' +
+  fixtureC,
   function(err, stdout, stderr) {
     if (err) throw err;
     assert.strictEqual(stdout, 'A\nB\nC\n');
   });
 
 // test that preloading a throwing module aborts
-childProcess.exec(nodeBinary + ' '
-  + preloadOption([fixtureA, fixtureThrows]) + ' '
-  + fixtureB,
+childProcess.exec(nodeBinary + ' ' +
+  preloadOption([fixtureA, fixtureThrows]) + ' ' +
+  fixtureB,
   function(err, stdout, stderr) {
     if (err) {
       assert.strictEqual(stdout, 'A\n');
@@ -62,9 +62,9 @@ childProcess.exec(nodeBinary + ' '
   });
 
 // test that preload can be used with --eval
-childProcess.exec(nodeBinary + ' '
-  + preloadOption([fixtureA])
-  + '-e "console.log(\'hello\');"',
+childProcess.exec(nodeBinary + ' ' +
+  preloadOption([fixtureA]) +
+  '-e "console.log(\'hello\');"',
   function(err, stdout, stderr) {
     if (err) throw err;
     assert.strictEqual(stdout, 'A\nhello\n');
@@ -108,19 +108,19 @@ replProc.on('close', function(code) {
 
 // test that preload placement at other points in the cmdline
 // also test that duplicated preload only gets loaded once
-childProcess.exec(nodeBinary + ' '
-  + preloadOption([fixtureA])
-  + '-e "console.log(\'hello\');" '
-  + preloadOption([fixtureA, fixtureB]),
+childProcess.exec(nodeBinary + ' ' +
+  preloadOption([fixtureA]) +
+  '-e "console.log(\'hello\');" ' +
+  preloadOption([fixtureA, fixtureB]),
   function(err, stdout, stderr) {
     if (err) throw err;
     assert.strictEqual(stdout, 'A\nB\nhello\n');
   });
 
 // test that preload works with -i
-const interactive = childProcess.exec(nodeBinary + ' '
-  + preloadOption([fixtureD])
-  + '-i',
+const interactive = childProcess.exec(nodeBinary + ' ' +
+  preloadOption([fixtureD]) +
+  '-i',
   common.mustCall(function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, "> 'test'\n> ");
@@ -129,9 +129,9 @@ const interactive = childProcess.exec(nodeBinary + ' '
 interactive.stdin.write('a\n');
 interactive.stdin.write('process.exit()\n');
 
-childProcess.exec(nodeBinary + ' '
-  + '--require ' + fixture('cluster-preload.js') + ' '
-  + fixture('cluster-preload-test.js'),
+childProcess.exec(nodeBinary + ' ' +
+  '--require ' + fixture('cluster-preload.js') + ' ' +
+  fixture('cluster-preload-test.js'),
   function(err, stdout, stderr) {
     if (err) throw err;
     assert.ok(/worker terminated with code 43/.test(stdout));
@@ -139,10 +139,10 @@ childProcess.exec(nodeBinary + ' '
 
 // https://github.com/nodejs/node/issues/1691
 process.chdir(common.fixturesDir);
-childProcess.exec(nodeBinary + ' '
-  + '--expose_debug_as=v8debug '
-  + '--require ' + fixture('cluster-preload.js') + ' '
-  + 'cluster-preload-test.js',
+childProcess.exec(nodeBinary + ' ' +
+  '--expose_debug_as=v8debug ' +
+  '--require ' + fixture('cluster-preload.js') + ' ' +
+  'cluster-preload-test.js',
   function(err, stdout, stderr) {
     if (err) throw err;
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -18,6 +18,6 @@ putIn.write = function(data) {
 };
 
 putIn.run([
-  'require("domain").create().on("error", function() { console.log("OK") })'
-  + '.run(function() { throw new Error("threw") })'
+  'require("domain").create().on("error", function() { console.log("OK") })' +
+  '.run(function() { throw new Error("threw") })'
 ]);

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -53,8 +53,8 @@ function test(size, err, next) {
     if (err) {
       client.on('error', function(e) {
         nerror++;
-        assert.strictEqual(e.message, 'DH parameter size 1024 is less'
-                           + ' than 2048');
+        assert.strictEqual(e.message, 'DH parameter size 1024 is less' +
+                           ' than 2048');
         server.close();
       });
     }


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

lib, test, tools

##### Description of change

Commit 1:
```
lib,test: use consistent operator linebreak style

We have a tacit rule that for multiline statements, the operator should
be placed before the linebreak. This commit commit fixes the few
violations of this rule in the code base.
This allows us to enable the corresponding ESLint rule.
```

Commit 2:
```
tools: enforce consistent operator linebreak style

Adds the `operator-linebreak` rule to our ESLint config.
```

I disabled the check for the ternary operators because ESLint has a special case for it (rule is inverted) and it's not obvious what we want. There are about 30 violations for each case (linebreak [before](https://github.com/nodejs/node/blob/2d0ce510e8e3d03ad3d45f5ba52dd061e1fd9497/lib/url.js#L581-L583) or [after](https://github.com/nodejs/node/blob/2d0ce510e8e3d03ad3d45f5ba52dd061e1fd9497/test/parallel/test-punycode.js#L183-L199) the operator).
I personally would like it to be after, like everything else.