### PR TITLE
test: use strictEqual in test-debug-break

### DIFF
--- a/test/debugger/test-debug-break-on-uncaught.js
+++ b/test/debugger/test-debug-break-on-uncaught.js
@@ -100,10 +100,11 @@ function runScenario(scriptName, throwsOnLine, next) {
 
   function assertHasPaused(client) {
     assert(exceptions.length, 'no exceptions thrown, race condition in test?');
-    assert.equal(exceptions.length, 1, 'debugger did not pause on exception');
-    assert.equal(exceptions[0].uncaught, true);
-    assert.equal(exceptions[0].script.name, testScript);
-    assert.equal(exceptions[0].sourceLine + 1, throwsOnLine);
+    assert.strictEqual(exceptions.length, 1,
+                       'debugger did not pause on exception');
+    assert.strictEqual(exceptions[0].uncaught, true);
+    assert.strictEqual(exceptions[0].script.name, testScript);
+    assert.strictEqual(exceptions[0].sourceLine + 1, throwsOnLine);
     asserted = true;
     client.reqContinue(assert.ifError);
   }


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test


##### Description of change

use strictEqual assertions in test-debug-break-on-uncaught.js