### PR TITLE
test: use strictEqual in test fixtures symlinked

### DIFF
--- a/test/fixtures/module-require-symlink/symlinked.js
+++ b/test/fixtures/module-require-symlink/symlinked.js
@@ -1,13 +1,13 @@
 'use strict';
-const assert = require('assert');
 const common = require('../../common');
+const assert = require('assert');
+const foo = require('./foo');
 const path = require('path');
 
 const linkScriptTarget = path.join(common.fixturesDir,
-  '/module-require-symlink/symlinked.js');
+  'module-require-symlink', 'symlinked.js');
 
-var foo = require('./foo');
-assert.equal(foo.dep1.bar.version, 'CORRECT_VERSION');
-assert.equal(foo.dep2.bar.version, 'CORRECT_VERSION');
-assert.equal(__filename, linkScriptTarget);
+assert.strictEqual(foo.dep1.bar.version, 'CORRECT_VERSION');
+assert.strictEqual(foo.dep2.bar.version, 'CORRECT_VERSION');
+assert.strictEqual(__filename, linkScriptTarget);
 assert(__filename in require.cache);


### PR DESCRIPTION
##### Checklist

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

use strictEqual assertions in test fixtures for modules symlinked