### PR TITLE
stream_base: homogenize req_wrap_obj use

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -82,8 +82,7 @@ void StreamBase::AfterShutdown(ShutdownWrap* req_wrap, int status) {
     req_wrap_obj
   };
 
-  if (req_wrap_obj->Has(env->context(),
-                              env->oncomplete_string()).FromJust()) {
+  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromJust()) {
     req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
   }
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -82,9 +82,8 @@ void StreamBase::AfterShutdown(ShutdownWrap* req_wrap, int status) {
     req_wrap_obj
   };
 
-  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromJust()) {
+  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromJust())
     req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
-  }
 
   delete req_wrap;
 }
@@ -381,10 +380,8 @@ void StreamBase::AfterWrite(WriteWrap* req_wrap, int status) {
     wrap->ClearError();
   }
 
-  if (req_wrap_obj->Has(env->context(),
-                              env->oncomplete_string()).FromJust()) {
+  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromJust())
     req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
-  }
 
   req_wrap->Dispose();
 }

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -174,7 +174,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   req_wrap_obj->Set(env->async(), True(env->isolate()));
   req_wrap_obj->Set(env->bytes_string(),
-                          Number::New(env->isolate(), bytes));
+                    Number::New(env->isolate(), bytes));
   const char* msg = Error();
   if (msg != nullptr) {
     req_wrap_obj->Set(env->error_string(), OneByteString(env->isolate(), msg));

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -173,8 +173,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
   int err = DoWrite(req_wrap, *bufs, count, nullptr);
 
   req_wrap_obj->Set(env->async(), True(env->isolate()));
-  req_wrap_obj->Set(env->bytes_string(),
-                    Number::New(env->isolate(), bytes));
+  req_wrap_obj->Set(env->bytes_string(), Number::New(env->isolate(), bytes));
   const char* msg = Error();
   if (msg != nullptr) {
     req_wrap_obj->Set(env->error_string(), OneByteString(env->isolate(), msg));

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -327,7 +327,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
       // Reference StreamWrap instance to prevent it from being garbage
       // collected before `AfterWrite` is called.
       CHECK_EQ(false, req_wrap->persistent().IsEmpty());
-      req_wrap->object()->Set(env->handle_string(), send_handle_obj);
+      req_wrap_obj->Set(env->handle_string(), send_handle_obj);
     }
 
     err = DoWrite(

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -172,8 +172,8 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   int err = DoWrite(req_wrap, *bufs, count, nullptr);
 
-  req_wrap->object()->Set(env->async(), True(env->isolate()));
-  req_wrap->object()->Set(env->bytes_string(),
+  req_wrap_obj->Set(env->async(), True(env->isolate()));
+  req_wrap_obj->Set(env->bytes_string(),
                           Number::New(env->isolate(), bytes));
   const char* msg = Error();
   if (msg != nullptr) {
@@ -338,7 +338,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
         reinterpret_cast<uv_stream_t*>(send_handle));
   }
 
-  req_wrap->object()->Set(env->async(), True(env->isolate()));
+  req_wrap_obj->Set(env->async(), True(env->isolate()));
 
   if (err)
     req_wrap->Dispose();

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -82,7 +82,7 @@ void StreamBase::AfterShutdown(ShutdownWrap* req_wrap, int status) {
     req_wrap_obj
   };
 
-  if (req_wrap->object()->Has(env->context(),
+  if (req_wrap_obj->Has(env->context(),
                               env->oncomplete_string()).FromJust()) {
     req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
   }
@@ -382,7 +382,7 @@ void StreamBase::AfterWrite(WriteWrap* req_wrap, int status) {
     wrap->ClearError();
   }
 
-  if (req_wrap->object()->Has(env->context(),
+  if (req_wrap_obj->Has(env->context(),
                               env->oncomplete_string()).FromJust()) {
     req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

stream_base

##### Description of change
<!-- Provide a description of the change below this comment. -->

Always use `req_wrap_obj` to allow calling `req->Done()` in stream
implementations.