### PR TITLE
doc: document R CRAN mirror process

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -50,6 +50,21 @@ install.packages("ggplot2")
 install.packages("plyr")
 ```
 
+### CRAN Mirror Issues
+In the event you get a message that you need to select a CRAN mirror first.
+
+You can specify a mirror by adding in the repo parameter.
+
+If we used the "http://cran.us.r-project.org" mirror, it could look somehting like
+this:
+
+```R
+install.packages("ggplot2", repo="http://cran.us.r-project.org")
+```
+
+Of course, use the mirror that suits your location.
+A list of mirrors is [located here](https://cran.r-project.org/mirrors.html).
+
 ## Running benchmarks
 
 ### Running individual benchmarks


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] documentation is changed or added
- [ x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

The current benchmark docs showing how to install R packages
doesn't go into how to specify a CRAN mirror.

This PR adds 3 options on how to install the needed packages
when a CRAN mirror is asked for.

fixes: #10204