### PR TITLE
test: fix flaky test-dgram-exclusive-implicit-bind

### DIFF
--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -84,10 +84,10 @@ if (cluster.isMaster) {
 }
 
 const source = dgram.createSocket('udp4');
-var timer;
+var interval;
 
 source.on('close', function() {
-  clearTimeout(timer);
+  clearTimeout(interval);
 });
 
 if (process.env.BOUND === 'y') {
@@ -99,12 +99,7 @@ if (process.env.BOUND === 'y') {
   source.unref();
 }
 
-function send() {
-  const buf = Buffer.from(process.pid.toString());
-  timer = setTimeout(function() {
-    source.send(buf, common.PORT, '127.0.0.1', send);
-  }, 1);
-  timer.unref();
-}
-
-send();
+const buf = Buffer.from(process.pid.toString());
+interval = setInterval(() => {
+  source.send(buf, common.PORT, '127.0.0.1');
+}, 1).unref();

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -87,7 +87,7 @@ const source = dgram.createSocket('udp4');
 var interval;
 
 source.on('close', function() {
-  clearTimeout(interval);
+  clearInterval(interval);
 });
 
 if (process.env.BOUND === 'y') {

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -20,10 +20,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var common = require('../common');
-var assert = require('assert');
-var cluster = require('cluster');
-var dgram = require('dgram');
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const dgram = require('dgram');
 
 // Without an explicit bind, send() causes an implicit bind, which always
 // generate a unique per-socket ephemeral port. An explicit bind to a port
@@ -40,17 +40,21 @@ var dgram = require('dgram');
 // with ENOTSUP.
 
 if (cluster.isMaster) {
-  var pass;
   var messages = 0;
-  var ports = {};
-
-  process.on('exit', function() {
-    assert.strictEqual(pass, true);
-  });
+  const ports = {};
+  const pids = [];
 
   var target = dgram.createSocket('udp4');
 
+  const done = common.mustCall(function() {
+    cluster.disconnect();
+    target.close();
+  });
+
   target.on('message', function(buf, rinfo) {
+    if (pids.includes(buf.toString()))
+      return;
+    pids.push(buf.toString());
     messages++;
     ports[rinfo.port] = true;
 
@@ -62,12 +66,6 @@ if (cluster.isMaster) {
     if (!common.isWindows && messages === 4) {
       assert.strictEqual(Object.keys(ports).length, 3);
       done();
-    }
-
-    function done() {
-      pass = true;
-      cluster.disconnect();
-      target.close();
     }
   });
 
@@ -85,7 +83,12 @@ if (cluster.isMaster) {
   return;
 }
 
-var source = dgram.createSocket('udp4');
+const source = dgram.createSocket('udp4');
+var timer;
+
+source.on('close', function() {
+  clearTimeout(timer);
+});
 
 if (process.env.BOUND === 'y') {
   source.bind(0);
@@ -96,4 +99,12 @@ if (process.env.BOUND === 'y') {
   source.unref();
 }
 
-source.send(Buffer.from('abc'), 0, 3, common.PORT, '127.0.0.1');
+function send() {
+  const buf = Buffer.from(process.pid.toString());
+  timer = setTimeout(function() {
+    source.send(buf, common.PORT, '127.0.0.1', send);
+  }, 1);
+  timer.unref();
+}
+
+send();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram

##### Description of change
<!-- Provide a description of the change below this comment. -->

test-dgram-exclusive-implicit-bind is written assuming that dgram
messages are received with 100% reliability. While missing a dgram
message sent to localhost is rare, we do see it as evidenced by CI
failures from time to time.

The test has been rewritten to send dgram messages over and over until
the test requirements have been met.

Additional incidental refactoring includes:

* var -> const
* use of common.mustCall() instead of exit listener + boolean