### PR TITLE
tools: enforce linebreak after ternary operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -93,7 +93,7 @@ rules:
   no-multiple-empty-lines: [2, {max: 2, maxEOF: 0, maxBOF: 0}]
   no-tabs: 2
   no-trailing-spaces: 2
-  operator-linebreak: [2, after, {overrides: {'?': ignore, ':': ignore}}]
+  operator-linebreak: [2, after]
   quotes: [2, single, avoid-escape]
   semi: 2
   semi-spacing: 2

--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -7,9 +7,9 @@ exports.PORT = process.env.PORT || 12346;
 
 function AutocannonBenchmarker() {
   this.name = 'autocannon';
-  this.autocannon_exe = process.platform === 'win32'
-                      ? 'autocannon.cmd'
-                      : 'autocannon';
+  this.autocannon_exe = process.platform === 'win32' ?
+                        'autocannon.cmd' :
+                        'autocannon';
   const result = child_process.spawnSync(this.autocannon_exe, ['-h']);
   this.present = !(result.error && result.error.code === 'ENOENT');
 }

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -876,9 +876,9 @@ function fromListPartial(n, list, hasStrings) {
     ret = list.shift();
   } else {
     // result spans more than one buffer
-    ret = (hasStrings
-           ? copyFromBufferString(n, list)
-           : copyFromBuffer(n, list));
+    ret = (hasStrings ?
+           copyFromBufferString(n, list) :
+           copyFromBuffer(n, list));
   }
   return ret;
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -426,13 +426,12 @@ function REPLServer(prompt,
   self.lines.level = [];
 
   // Figure out which "complete" function to use.
-  self.completer = (typeof options.completer === 'function')
-    ? options.completer
-    : completer;
+  self.completer = (typeof options.completer === 'function') ?
+    options.completer : completer;
 
   function completer(text, cb) {
-    complete.call(self, text, self.editorMode
-      ? self.completeOnEditorMode(cb) : cb);
+    complete.call(self, text, self.editorMode ?
+      self.completeOnEditorMode(cb) : cb);
   }
 
   Interface.call(this, {

--- a/lib/url.js
+++ b/lib/url.js
@@ -381,9 +381,9 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   }
 
   var firstIdx = (questionIdx !== -1 &&
-                  (hashIdx === -1 || questionIdx < hashIdx)
-                  ? questionIdx
-                  : hashIdx);
+                  (hashIdx === -1 || questionIdx < hashIdx) ?
+                  questionIdx :
+                  hashIdx);
   if (firstIdx === -1) {
     if (rest.length > 0)
       this.pathname = rest;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -775,9 +775,9 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
   assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}');
 
   assert.deepStrictEqual(buffer, JSON.parse(string, (key, value) => {
-    return value && value.type === 'Buffer'
-      ? Buffer.from(value.data)
-      : value;
+    return value && value.type === 'Buffer' ?
+      Buffer.from(value.data) :
+      value;
   }));
 }
 

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -39,9 +39,9 @@ function assertWrongList(value) {
   });
 }
 
-const random10 = common.hasCrypto
-    ? require('crypto').randomBytes(10)
-    : Buffer.alloc(10, 1);
+const random10 = common.hasCrypto ?
+  require('crypto').randomBytes(10) :
+  Buffer.alloc(10, 1);
 const empty = Buffer.alloc(0);
 
 assert.notDeepStrictEqual(random10, empty);

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -127,10 +127,10 @@ function makeReq(path, port, error, host, ca) {
   }
   var req = https.get(options);
   expectResponseCount++;
-  var server = port === server1.address().port ? server1
-      : port === server2.address().port ? server2
-      : port === server3.address().port ? server3
-      : null;
+  var server = port === server1.address().port ? server1 :
+      port === server2.address().port ? server2 :
+      port === server3.address().port ? server3 :
+      null;
 
   if (!server) throw new Error('invalid port: ' + port);
   server.expectCount++;

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -11,9 +11,9 @@ var asyncTest = (function() {
   var currentTest = null;
 
   function fail(error) {
-    var stack = currentTest
-          ? error.stack + '\nFrom previous event:\n' + currentTest.stack
-          : error.stack;
+    var stack = currentTest ?
+      error.stack + '\nFrom previous event:\n' + currentTest.stack :
+      error.stack;
 
     if (currentTest)
       process.stderr.write('\'' + currentTest.description + '\' failed\n\n');

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -182,19 +182,19 @@ const testBattery = {
   ),
   toASCII: (test) => assert.strictEqual(
     punycode.toASCII(test.decoded),
-    regexNonASCII.test(test.decoded)
-      ? `xn--${test.encoded}`
-      : test.decoded
+    regexNonASCII.test(test.decoded) ?
+      `xn--${test.encoded}` :
+      test.decoded
   ),
   toUnicode: (test) => assert.strictEqual(
     punycode.toUnicode(
-      regexNonASCII.test(test.decoded)
-        ? `xn--${test.encoded}`
-        : test.decoded
+      regexNonASCII.test(test.decoded) ?
+        `xn--${test.encoded}` :
+        test.decoded
     ),
-    regexNonASCII.test(test.decoded)
-      ? test.decoded.toLowerCase()
-      : test.decoded
+    regexNonASCII.test(test.decoded) ?
+      test.decoded.toLowerCase() :
+      test.decoded
   )
 };
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -463,9 +463,9 @@ function isWarned(emitter) {
   });
 
   {
-    const expected = terminal
-      ? ['\u001b[1G', '\u001b[0J', '$ ', '\u001b[3G']
-      : ['$ '];
+    const expected = terminal ?
+      ['\u001b[1G', '\u001b[0J', '$ ', '\u001b[3G'] :
+      ['$ '];
 
     let counter = 0;
     const output = new Writable({

--- a/tools/eslint-rules/no-useless-regex-char-class-escape.js
+++ b/tools/eslint-rules/no-useless-regex-char-class-escape.js
@@ -108,9 +108,9 @@ module.exports = {
   },
 
   create(context) {
-    const overrideSet = new Set(context.options.length
-                                  ? context.options[0].override || []
-                                  : []);
+    const overrideSet = new Set(context.options.length ?
+                                context.options[0].override || [] :
+                                []);
 
     /**
      * Reports a node


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

This is to be consistent with the other operators and helps
understanding the context when the code is grepped.
