### PR TITLE
doc: document argument variant in the repl.md

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -371,7 +371,7 @@ within the action function for commands registered using the
 added: v0.1.91
 -->
 
-* `options` {Object}
+* `options` {Object | String}
   * `prompt` {String} The input prompt to display. Defaults to `> `.
   * `input` {Readable} The Readable stream from which REPL input will be read.
     Defaults to `process.stdin`.
@@ -412,6 +412,15 @@ added: v0.1.91
     with a custom `eval` function. Defaults to `false`.
 
 The `repl.start()` method creates and starts a `repl.REPLServer` instance.
+
+If `options` is a string, then it specifies the input prompt:
+
+```js
+const repl = require('repl');
+
+// a Unix style prompt
+repl.start('$ ');
+```
 
 ## The Node.js REPL
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc, repl

##### Description of change

Document that `options` in the `repl.start([options])` can be a string.

This commit is separated from #10160 on demand for more careful evaluation.

Please, consider these facts:

1. String argument is already used in the doc examples [here](https://github.com/nodejs/node/blame/master/doc/api/repl.md#L101) and [here](https://github.com/nodejs/node/blame/master/doc/api/repl.md#L120).

2. It is also used in the `repl.js` [comment example](https://github.com/nodejs/node/blob/master/lib/repl.js#L6).

3. The chain from string argument to prompt and other options setting is this: [`exports.start`](https://github.com/nodejs/node/blob/master/lib/repl.js#L656) -> [`REPLServer`](https://github.com/nodejs/node/blob/master/lib/repl.js#L184) -> [`Interface` in the `readline.js`](https://github.com/nodejs/node/blob/master/lib/readline.js#L36)

