### PR TITLE
test: fix http-client-timeout-option-listeners

### DIFF
--- a/test/parallel/test-http-client-timeout-option-listeners.js
+++ b/test/parallel/test-http-client-timeout-option-listeners.js
@@ -9,13 +9,16 @@ const server = http.createServer((req, res) => {
   res.end('');
 });
 
+// Maximum allowed value for timeouts
+const timeout = 2 ** 31 - 1;
+
 const options = {
   agent,
   method: 'GET',
   port: undefined,
   host: common.localhostIPv4,
   path: '/',
-  timeout: common.platformTimeout(100)
+  timeout: timeout
 };
 
 server.listen(0, options.host, common.mustCall(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http

##### Description of change
<!-- Provide a description of the change below this comment. -->

test-http-client-timeout-option-listeners is flaky due to depending on
completing operations before a 100ms socket timeout. The socket timeout
is an integral part of the test. Load on the machine can affect the
test, so move it to sequential.