### PR TITLE
src: don't overwrite non-writable vm globals

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -383,19 +383,22 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
+    auto attributes = PropertyAttribute::None;
     bool is_declared =
-        ctx->global_proxy()->HasRealNamedProperty(ctx->context(),
-                                                  property).FromJust();
-    bool is_contextual_store = ctx->global_proxy() != args.This();
+        ctx->global_proxy()->GetRealNamedPropertyAttributes(ctx->context(),
+                                                            property)
+        .To(&attributes);
+    bool read_only =
+        static_cast<int>(attributes) &
+        static_cast<int>(PropertyAttribute::ReadOnly);
 
-    bool set_property_will_throw =
-        args.ShouldThrowOnError() &&
-        !is_declared &&
-        is_contextual_store;
+    if (is_declared && read_only)
+      return;
 
-    if (!set_property_will_throw) {
-      ctx->sandbox()->Set(property, value);
-    }
+    if (!is_declared && args.ShouldThrowOnError())
+      return;
+
+    ctx->sandbox()->Set(property, value);
   }
 
 

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -75,3 +75,14 @@ assert.throws(function() {
 // https://github.com/nodejs/node/issues/6158
 ctx = new Proxy({}, {});
 assert.strictEqual(typeof vm.runInNewContext('String', ctx), 'function');
+
+// https://github.com/nodejs/node/issues/10223
+ctx = vm.createContext();
+vm.runInContext('Object.defineProperty(this, "x", { value: 42 })', ctx);
+assert.strictEqual(ctx.x, undefined);  // Not copied out by cloneProperty().
+assert.strictEqual(vm.runInContext('x', ctx), 42);
+vm.runInContext('x = 0', ctx);                      // Does not throw but x...
+assert.strictEqual(vm.runInContext('x', ctx), 42);  // ...should be unaltered.
+assert.throws(() => vm.runInContext('"use strict"; x = 0', ctx),
+              /Cannot assign to read only property 'x'/);
+assert.strictEqual(vm.runInContext('x', ctx), 42);


### PR DESCRIPTION
@fhinkel Can you take a look?  I couldn't figure out what `is_contextual_store` is needed for.  Tests pass without it.

CI: https://ci.nodejs.org/job/node-test-pull-request/5357/