### PR TITLE
url, test: fix typo in inspect output, add test

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -449,7 +449,7 @@ class URL {
       ret += `  hash: ${this.hash}\n`;
     if (opts.showHidden) {
       ret += `  cannot-be-base: ${this[cannotBeBase]}\n`;
-      ret += `  special: ${this[special]}\n;`;
+      ret += `  special: ${this[special]}\n`;
     }
     ret += '}';
     return ret;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

In the string returned from URL.inspect there was an extra semicolon
at the end when showHidden === true. The semicolon has been
removed and a test for the inspect function has been added. The test
parses the returned string, validates all of the contained keys/values
and tests logic related to the showHidden option.