### PR TITLE
buffer: allow Uint8Array input to methods

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -635,8 +635,8 @@ actual byte length is returned.
 added: v0.11.13
 -->
 
-* `buf1` {Buffer}
-* `buf2` {Buffer}
+* `buf1` {Buffer|Uint8Array}
+* `buf2` {Buffer|Uint8Array}
 * Returns: {Integer}
 
 Compares `buf1` to `buf2` typically for the purpose of sorting arrays of
@@ -660,7 +660,7 @@ console.log(arr.sort(Buffer.compare));
 added: v0.7.11
 -->
 
-* `list` {Array} List of `Buffer` instances to concat
+* `list` {Array} List of `Buffer` or [`Uint8Array`] instances to concat
 * `totalLength` {Integer} Total length of the `Buffer` instances in `list`
   when concatenated
 * Returns: {Buffer}
@@ -882,7 +882,7 @@ console.log(buf.toString('ascii'));
 added: v0.11.13
 -->
 
-* `target` {Buffer} A `Buffer` to compare to
+* `target` {Buffer|Uint8Array} A `Buffer` or [`Uint8Array`] to compare to
 * `targetStart` {Integer} The offset within `target` at which to begin
   comparison. **Default:** `0`
 * `targetEnd` {Integer} The offset with `target` at which to end comparison
@@ -1037,7 +1037,7 @@ for (const pair of buf.entries()) {
 added: v0.11.13
 -->
 
-* `otherBuffer` {Buffer} A `Buffer` to compare to
+* `otherBuffer` {Buffer} A `Buffer` or [`Uint8Array`] to compare to
 * Returns: {Boolean}
 
 Returns `true` if both `buf` and `otherBuffer` have exactly the same bytes,
@@ -1099,7 +1099,7 @@ console.log(Buffer.allocUnsafe(3).fill('\u0222'));
 added: v1.5.0
 -->
 
-* `value` {String | Buffer | Integer} What to search for
+* `value` {String | Buffer | Uint8Array | Integer} What to search for
 * `byteOffset` {Integer} Where to begin searching in `buf`. **Default:** `0`
 * `encoding` {String} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
@@ -1110,8 +1110,8 @@ If `value` is:
 
   * a string, `value` is interpreted according to the character encoding in
     `encoding`.
-  * a `Buffer`, `value` will be used in its entirety. To compare a partial
-  `Buffer` use [`buf.slice()`].
+  * a `Buffer` or [`Uint8Array`], `value` will be used in its entirety.
+    To compare a partial `Buffer`, use [`buf.slice()`].
   * a number, `value` will be interpreted as an unsigned 8-bit integer
   value between `0` and `255`.
 
@@ -1221,7 +1221,7 @@ for (const key of buf.keys()) {
 added: v6.0.0
 -->
 
-* `value` {String | Buffer | Integer} What to search for
+* `value` {String | Buffer | Uint8Array | Integer} What to search for
 * `byteOffset` {Integer} Where to begin searching in `buf`.
   **Default:** [`buf.length`]` - 1`
 * `encoding` {String} If `value` is a string, this is its encoding.
@@ -2313,12 +2313,12 @@ Note that this is a property on the `buffer` module returned by
 added: v7.1.0
 -->
 
-* `source` {Buffer} A `Buffer` instance
+* `source` {Buffer|Uint8Array} A `Buffer` or `Uint8Array` instance
 * `fromEnc` {String} The current encoding
 * `toEnc` {String} To target encoding
 
-Re-encodes the given `Buffer` instance from one character encoding to another.
-Returns a new `Buffer` instance.
+Re-encodes the given `Buffer` or `Uint8Array` instance from one character
+encoding to another. Returns a new `Buffer` instance.
 
 Throws if the `fromEnc` or `toEnc` specify invalid character encodings or if
 conversion from `fromEnc` to `toEnc` is not permitted.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -254,7 +254,7 @@ function fromObject(obj) {
     if (b.length === 0)
       return b;
 
-    Buffer.prototype.copy.call(obj, b, 0, 0, obj.length);
+    binding.copy(obj, b, 0, 0, obj.length);
     return b;
   }
 
@@ -324,7 +324,7 @@ Buffer.concat = function(list, length) {
     var buf = list[i];
     if (!isUint8Array(buf))
       throw new TypeError('"list" argument must be an Array of Buffers');
-    Buffer.prototype.copy.call(buf, buffer, pos);
+    binding.copy(buf, buffer, pos);
     pos += buf.length;
   }
 
@@ -491,6 +491,9 @@ function slowToString(encoding, start, end) {
   }
 }
 
+Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
+  return binding.copy(this, target, targetStart, sourceStart, sourceEnd);
+};
 
 Buffer.prototype.toString = function() {
   let result;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -2,7 +2,8 @@
 'use strict';
 
 const binding = process.binding('buffer');
-const { isArrayBuffer, isSharedArrayBuffer } = process.binding('util');
+const { isArrayBuffer, isSharedArrayBuffer, isUint8Array } =
+    process.binding('util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
@@ -247,13 +248,13 @@ function fromArrayBuffer(obj, byteOffset, length) {
 }
 
 function fromObject(obj) {
-  if (obj instanceof Buffer) {
+  if (isUint8Array(obj)) {
     const b = allocate(obj.length);
 
     if (b.length === 0)
       return b;
 
-    obj.copy(b, 0, 0, obj.length);
+    Buffer.prototype.copy.call(obj, b, 0, 0, obj.length);
     return b;
   }
 
@@ -283,8 +284,7 @@ Buffer.isBuffer = function isBuffer(b) {
 
 
 Buffer.compare = function compare(a, b) {
-  if (!(a instanceof Buffer) ||
-      !(b instanceof Buffer)) {
+  if (!isUint8Array(a) || !isUint8Array(b)) {
     throw new TypeError('Arguments must be Buffers');
   }
 
@@ -322,9 +322,9 @@ Buffer.concat = function(list, length) {
   var pos = 0;
   for (i = 0; i < list.length; i++) {
     var buf = list[i];
-    if (!Buffer.isBuffer(buf))
+    if (!isUint8Array(buf))
       throw new TypeError('"list" argument must be an Array of Buffers');
-    buf.copy(buffer, pos);
+    Buffer.prototype.copy.call(buf, buffer, pos);
     pos += buf.length;
   }
 
@@ -506,7 +506,7 @@ Buffer.prototype.toString = function() {
 
 
 Buffer.prototype.equals = function equals(b) {
-  if (!(b instanceof Buffer))
+  if (!isUint8Array(b))
     throw new TypeError('Argument must be a Buffer');
 
   if (this === b)
@@ -535,7 +535,7 @@ Buffer.prototype.compare = function compare(target,
                                             thisStart,
                                             thisEnd) {
 
-  if (!(target instanceof Buffer))
+  if (!isUint8Array(target))
     throw new TypeError('Argument must be a Buffer');
 
   if (start === undefined)
@@ -600,7 +600,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
       return binding.indexOfString(buffer, val, byteOffset, encoding, dir);
     }
     return slowIndexOf(buffer, val, byteOffset, encoding, dir);
-  } else if (val instanceof Buffer) {
+  } else if (isUint8Array(val)) {
     return binding.indexOfBuffer(buffer, val, byteOffset, encoding, dir);
   } else if (typeof val === 'number') {
     return binding.indexOfNumber(buffer, val, byteOffset, dir);
@@ -1033,7 +1033,7 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
 
 
 function checkInt(buffer, value, offset, ext, max, min) {
-  if (!(buffer instanceof Buffer))
+  if (!isUint8Array(buffer))
     throw new TypeError('"buffer" argument must be a Buffer instance');
   if (value > max || value < min)
     throw new TypeError('"value" argument is out of bounds');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -285,7 +285,7 @@ Buffer.isBuffer = function isBuffer(b) {
 
 Buffer.compare = function compare(a, b) {
   if (!isUint8Array(a) || !isUint8Array(b)) {
-    throw new TypeError('Arguments must be Buffers');
+    throw new TypeError('Arguments must be Buffers or Uint8Arrays');
   }
 
   if (a === b) {
@@ -302,10 +302,13 @@ Buffer.isEncoding = function(encoding) {
 };
 Buffer[internalUtil.kIsEncodingSymbol] = Buffer.isEncoding;
 
+const kConcatErrMsg = '"list" argument must be an Array ' +
+                      'of Buffer or Uint8Array instances';
+
 Buffer.concat = function(list, length) {
   var i;
   if (!Array.isArray(list))
-    throw new TypeError('"list" argument must be an Array of Buffers');
+    throw new TypeError(kConcatErrMsg);
 
   if (list.length === 0)
     return new FastBuffer();
@@ -323,7 +326,7 @@ Buffer.concat = function(list, length) {
   for (i = 0; i < list.length; i++) {
     var buf = list[i];
     if (!isUint8Array(buf))
-      throw new TypeError('"list" argument must be an Array of Buffers');
+      throw new TypeError(kConcatErrMsg);
     binding.copy(buf, buffer, pos);
     pos += buf.length;
   }
@@ -510,7 +513,7 @@ Buffer.prototype.toString = function() {
 
 Buffer.prototype.equals = function equals(b) {
   if (!isUint8Array(b))
-    throw new TypeError('Argument must be a Buffer');
+    throw new TypeError('Argument must be a Buffer or Uint8Array');
 
   if (this === b)
     return true;
@@ -539,7 +542,7 @@ Buffer.prototype.compare = function compare(target,
                                             thisEnd) {
 
   if (!isUint8Array(target))
-    throw new TypeError('Argument must be a Buffer');
+    throw new TypeError('Argument must be a Buffer or Uint8Array');
 
   if (start === undefined)
     start = 0;
@@ -609,7 +612,8 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
     return binding.indexOfNumber(buffer, val, byteOffset, dir);
   }
 
-  throw new TypeError('"val" argument must be string, number or Buffer');
+  throw new TypeError('"val" argument must be string, number, Buffer ' +
+                      'or Uint8Array');
 }
 
 
@@ -1037,7 +1041,7 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
 
 function checkInt(buffer, value, offset, ext, max, min) {
   if (!isUint8Array(buffer))
-    throw new TypeError('"buffer" argument must be a Buffer instance');
+    throw new TypeError('"buffer" argument must be a Buffer or Uint8Array');
   if (value > max || value < min)
     throw new TypeError('"value" argument is out of bounds');
   if (offset + ext > buffer.length)

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -8,18 +8,19 @@ const normalizeEncoding = require('internal/util').normalizeEncoding;
 const Buffer = require('buffer').Buffer;
 
 const icu = process.binding('icu');
+const { isUint8Array } = process.binding('util');
 
 // Transcodes the Buffer from one encoding to another, returning a new
 // Buffer instance.
 exports.transcode = function transcode(source, fromEncoding, toEncoding) {
-  if (!Buffer.isBuffer(source))
+  if (!isUint8Array(source))
     throw new TypeError('"source" argument must be a Buffer');
   if (source.length === 0) return Buffer.alloc(0);
 
   fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;
   toEncoding = normalizeEncoding(toEncoding) || toEncoding;
   const result = icu.transcode(source, fromEncoding, toEncoding);
-  if (Buffer.isBuffer(result))
+  if (typeof result !== 'number')
     return result;
 
   const code = icu.icuErrName(result);

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -14,7 +14,7 @@ const { isUint8Array } = process.binding('util');
 // Buffer instance.
 exports.transcode = function transcode(source, fromEncoding, toEncoding) {
   if (!isUint8Array(source))
-    throw new TypeError('"source" argument must be a Buffer');
+    throw new TypeError('"source" argument must be a Buffer or Uint8Array');
   if (source.length === 0) return Buffer.alloc(0);
 
   fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -519,23 +519,24 @@ void Base64Slice(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-// bytesCopied = buffer.copy(target[, targetStart][, sourceStart][, sourceEnd]);
+// bytesCopied = copy(buffer, target[, targetStart][, sourceStart][, sourceEnd])
 void Copy(const FunctionCallbackInfo<Value> &args) {
   Environment* env = Environment::GetCurrent(args);
 
-  THROW_AND_RETURN_UNLESS_BUFFER(env, args.This());
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
-  Local<Object> target_obj = args[0].As<Object>();
-  SPREAD_BUFFER_ARG(args.This(), ts_obj);
+  THROW_AND_RETURN_UNLESS_BUFFER(env, args[1]);
+  Local<Object> buffer_obj = args[0].As<Object>();
+  Local<Object> target_obj = args[1].As<Object>();
+  SPREAD_BUFFER_ARG(buffer_obj, ts_obj);
   SPREAD_BUFFER_ARG(target_obj, target);
 
   size_t target_start;
   size_t source_start;
   size_t source_end;
 
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[1], 0, &target_start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[2], 0, &source_start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[3], ts_obj_length, &source_end));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[2], 0, &target_start));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[3], 0, &source_start));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(args[4], ts_obj_length, &source_end));
 
   // Copy 0 bytes; we're done
   if (target_start >= target_length || source_start >= source_end)
@@ -1203,8 +1204,6 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
   env->SetMethod(proto, "ucs2Write", Ucs2Write);
   env->SetMethod(proto, "utf8Write", Utf8Write);
 
-  env->SetMethod(proto, "copy", Copy);
-
   if (auto zero_fill_field = env->isolate_data()->zero_fill_field()) {
     CHECK(args[1]->IsObject());
     auto binding_object = args[1].As<Object>();
@@ -1227,6 +1226,7 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "createFromString", CreateFromString);
 
   env->SetMethod(target, "byteLengthUtf8", ByteLengthUtf8);
+  env->SetMethod(target, "copy", Copy);
   env->SetMethod(target, "compare", Compare);
   env->SetMethod(target, "compareOffset", CompareOffset);
   env->SetMethod(target, "fill", Fill);

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -29,7 +29,8 @@ using v8::Value;
   V(isSet, IsSet)                                                             \
   V(isSetIterator, IsSetIterator)                                             \
   V(isSharedArrayBuffer, IsSharedArrayBuffer)                                 \
-  V(isTypedArray, IsTypedArray)
+  V(isTypedArray, IsTypedArray)                                               \
+  V(isUint8Array, IsUint8Array)
 
 
 #define V(_, ucname) \

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -6,10 +6,12 @@ const assert = require('assert');
 const b = Buffer.alloc(1, 'a');
 const c = Buffer.alloc(1, 'c');
 const d = Buffer.alloc(2, 'aa');
+const e = new Uint8Array([ 0x61, 0x61 ]); // ASCII 'aa', same as d
 
 assert.strictEqual(b.compare(c), -1);
 assert.strictEqual(c.compare(d), 1);
 assert.strictEqual(d.compare(b), 1);
+assert.strictEqual(d.compare(e), 0);
 assert.strictEqual(b.compare(d), -1);
 assert.strictEqual(b.compare(b), 0);
 
@@ -18,6 +20,9 @@ assert.strictEqual(Buffer.compare(c, d), 1);
 assert.strictEqual(Buffer.compare(d, b), 1);
 assert.strictEqual(Buffer.compare(b, d), -1);
 assert.strictEqual(Buffer.compare(c, c), 0);
+assert.strictEqual(Buffer.compare(e, e), 0);
+assert.strictEqual(Buffer.compare(d, e), 0);
+assert.strictEqual(Buffer.compare(d, b), 1);
 
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -35,7 +35,8 @@ function assertWrongList(value) {
     Buffer.concat(value);
   }, function(err) {
     return err instanceof TypeError &&
-           err.message === '"list" argument must be an Array of Buffers';
+           err.message === '"list" argument must be an Array of Buffer ' +
+                           'or Uint8Array instances';
   });
 }
 

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -60,3 +60,7 @@ assert.deepStrictEqual(Buffer.concat([empty], 4096), Buffer.alloc(4096));
 assert.deepStrictEqual(
     Buffer.concat([random10], 40),
     Buffer.concat([random10, Buffer.alloc(30)]));
+
+assert.deepStrictEqual(Buffer.concat([new Uint8Array([0x41, 0x42]),
+                                      new Uint8Array([0x43, 0x44])]),
+                       Buffer.from('ABCD'));

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -12,5 +12,6 @@ assert.ok(b.equals(c));
 assert.ok(!c.equals(d));
 assert.ok(!d.equals(e));
 assert.ok(d.equals(d));
+assert.ok(d.equals(new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65])));
 
 assert.throws(() => Buffer.alloc(1).equals('abc'));

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -524,3 +524,11 @@ assert.equal(0, reallyLong.lastIndexOf(pattern));
   assert.strictEqual(buf.indexOf(0xff), -1);
   assert.strictEqual(buf.indexOf(0xffff), -1);
 }
+
+// Test that Uint8Array arguments are okay.
+{
+  const needle = new Uint8Array([ 0x66, 0x6f, 0x6f ]);
+  const haystack = Buffer.from('a foo b foo');
+  assert.strictEqual(haystack.indexOf(needle), 2);
+  assert.strictEqual(haystack.lastIndexOf(needle), haystack.length - 3);
+}

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -40,7 +40,7 @@ for (const test in tests) {
 
 assert.throws(
   () => buffer.transcode(null, 'utf8', 'ascii'),
-  /^TypeError: "source" argument must be a Buffer$/
+  /^TypeError: "source" argument must be a Buffer or Uint8Array$/
 );
 
 assert.throws(

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -62,3 +62,11 @@ assert.deepStrictEqual(
 assert.deepStrictEqual(
     buffer.transcode(Buffer.from('hä', 'latin1'), 'latin1', 'utf16le'),
     Buffer.from('hä', 'utf16le'));
+
+// Test that Uint8Array arguments are okay.
+{
+  const uint8array = new Uint8Array([...Buffer.from('hä', 'latin1')]);
+  assert.deepStrictEqual(
+      buffer.transcode(uint8array, 'latin1', 'utf16le'),
+      Buffer.from('hä', 'utf16le'));
+}


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

##### Description of change

Allow all methods on `buffer` and `Buffer` to take `Uint8Array`
arguments where it makes sense. On the native side, there is
effectively no difference, and as a bonus the `isUint8Array`
check is faster than `instanceof Buffer`.

<details><summary>
Benchmark results @ <a href="https://gist.github.com/addaleax/8544e43f7d28a58d032944137afeabf4">https://gist.github.com/addaleax/8544e43f7d28a58d032944137afeabf4</a>, summary in this fold
</summary>
<pre>
                                                                                                                                                improvement significant      p.value
 buffers/buffer-base64-decode.js                                                                                                                     0.33 %             4.989959e-01
 buffers/buffer-base64-encode.js                                                                                                                    -0.26 %             5.876859e-01
 buffers/buffer-bytelength.js n=5000000 len=16 encoding="base64"                                                                                    -0.20 %             5.174388e-01
 buffers/buffer-bytelength.js n=5000000 len=16 encoding="utf8"                                                                                      -0.18 %             4.589270e-01
 buffers/buffer-bytelength.js n=5000000 len=1 encoding="base64"                                                                                     -0.49 %           * 4.083862e-02
 buffers/buffer-bytelength.js n=5000000 len=1 encoding="utf8"                                                                                       -0.25 %             5.226933e-01
 buffers/buffer-bytelength.js n=5000000 len=256 encoding="base64"                                                                                   -0.15 %             5.624977e-01
 buffers/buffer-bytelength.js n=5000000 len=256 encoding="utf8"                                                                                     -0.35 %             8.081021e-02
 buffers/buffer-bytelength.js n=5000000 len=2 encoding="base64"                                                                                     -0.34 %             1.541680e-01
 buffers/buffer-bytelength.js n=5000000 len=2 encoding="utf8"                                                                                        0.12 %             7.371437e-01
 buffers/buffer-bytelength.js n=5000000 len=4 encoding="base64"                                                                                     -0.05 %             8.371398e-01
 buffers/buffer-bytelength.js n=5000000 len=4 encoding="utf8"                                                                                       -0.07 %             7.692104e-01
 buffers/buffer-bytelength.js n=5000000 len=64 encoding="base64"                                                                                     0.03 %             9.289804e-01
 buffers/buffer-bytelength.js n=5000000 len=64 encoding="utf8"                                                                                      -0.44 %           * 3.595639e-02
 buffers/buffer-compare-instance-method.js millions=1 size=1024                                                                                     38.15 %         *** 1.382193e-32
 buffers/buffer-compare-instance-method.js millions=1 size=16                                                                                       44.75 %         *** 3.403819e-46
 buffers/buffer-compare-instance-method.js millions=1 size=16386                                                                                    12.41 %         *** 1.417884e-39
 buffers/buffer-compare-instance-method.js millions=1 size=4096                                                                                     25.77 %         *** 3.522730e-44
 buffers/buffer-compare-instance-method.js millions=1 size=512                                                                                      40.13 %         *** 5.512553e-39
 buffers/buffer-compare.js millions=1 size=1024                                                                                                    126.83 %         *** 6.571906e-30
 buffers/buffer-compare.js millions=1 size=16                                                                                                      163.95 %         *** 1.334774e-26
 buffers/buffer-compare.js millions=1 size=16386                                                                                                    37.60 %         *** 3.589380e-43
 buffers/buffer-compare.js millions=1 size=4096                                                                                                     72.93 %         *** 5.148946e-28
 buffers/buffer-compare.js millions=1 size=512                                                                                                     141.11 %         *** 2.765525e-29
 buffers/buffer-compare-offset.js millions=1 size=1024 method="offset"                                                                              30.32 %         *** 1.178404e-20
 buffers/buffer-compare-offset.js millions=1 size=1024 method="slice"                                                                               45.20 %         *** 5.328128e-28
 buffers/buffer-compare-offset.js millions=1 size=16386 method="offset"                                                                             29.29 %         *** 1.009668e-20
 buffers/buffer-compare-offset.js millions=1 size=16386 method="slice"                                                                              46.57 %         *** 1.386654e-36
 buffers/buffer-compare-offset.js millions=1 size=16 method="offset"                                                                                28.85 %         *** 1.740339e-20
 buffers/buffer-compare-offset.js millions=1 size=16 method="slice"                                                                                 44.83 %         *** 1.334218e-31
 buffers/buffer-compare-offset.js millions=1 size=4096 method="offset"                                                                              29.05 %         *** 2.917765e-22
 buffers/buffer-compare-offset.js millions=1 size=4096 method="slice"                                                                               46.51 %         *** 7.264692e-30
 buffers/buffer-compare-offset.js millions=1 size=512 method="offset"                                                                               30.08 %         *** 1.155313e-21
 buffers/buffer-compare-offset.js millions=1 size=512 method="slice"                                                                                44.78 %         *** 5.072915e-25
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=1                                                                            49.81 %         *** 5.031896e-22
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=16                                                                          111.19 %         *** 2.691135e-59
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=16 pieces=4                                                                            98.56 %         *** 3.904044e-58
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=1                                                                             51.69 %         *** 1.519463e-20
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=16                                                                            92.09 %         *** 1.172069e-28
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=1 pieces=4                                                                            102.19 %         *** 7.590241e-50
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=1                                                                           62.38 %         *** 7.799720e-58
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=16                                                                          72.91 %         *** 2.967023e-28
 buffers/buffer-concat.js n=1024 withTotalLength=0 pieceSize=256 pieces=4                                                                           70.28 %         *** 1.308737e-57
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=1                                                                            67.29 %         *** 2.724615e-25
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=16                                                                          113.38 %         *** 1.476974e-66
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=16 pieces=4                                                                            88.43 %         *** 2.203940e-73
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=1                                                                             60.37 %         *** 3.169333e-19
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=16                                                                           103.32 %         *** 3.286131e-27
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=1 pieces=4                                                                             97.04 %         *** 1.985550e-37
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=1                                                                           60.69 %         *** 2.728163e-37
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=16                                                                          71.44 %         *** 7.853933e-59
 buffers/buffer-concat.js n=1024 withTotalLength=1 pieceSize=256 pieces=4                                                                           71.37 %         *** 7.135345e-72
 buffers/buffer-creation.js n=1024 len=1024 type="buffer()"                                                                                          0.87 %          ** 6.959919e-03
 buffers/buffer-creation.js n=1024 len=1024 type="fast-alloc"                                                                                        0.47 %             4.485933e-01
 buffers/buffer-creation.js n=1024 len=1024 type="fast-alloc-fill"                                                                                   0.42 %             6.658288e-01
 buffers/buffer-creation.js n=1024 len=1024 type="fast-allocUnsafe"                                                                                 -0.05 %             9.182350e-01
 buffers/buffer-creation.js n=1024 len=1024 type="slow"                                                                                             -1.23 %           * 2.932270e-02
 buffers/buffer-creation.js n=1024 len=1024 type="slow-allocUnsafe"                                                                                  0.23 %             5.926413e-01
 buffers/buffer-creation.js n=1024 len=10 type="buffer()"                                                                                            0.01 %             9.797165e-01
 buffers/buffer-creation.js n=1024 len=10 type="fast-alloc"                                                                                         -4.74 %          ** 5.295541e-03
 buffers/buffer-creation.js n=1024 len=10 type="fast-alloc-fill"                                                                                    -1.58 %             3.609361e-01
 buffers/buffer-creation.js n=1024 len=10 type="fast-allocUnsafe"                                                                                   -0.70 %             5.293258e-01
 buffers/buffer-creation.js n=1024 len=10 type="slow"                                                                                                1.89 %             1.437426e-01
 buffers/buffer-creation.js n=1024 len=10 type="slow-allocUnsafe"                                                                                   -1.37 %             1.110352e-01
 buffers/buffer-creation.js n=1024 len=2048 type="buffer()"                                                                                          0.77 %           * 4.952968e-02
 buffers/buffer-creation.js n=1024 len=2048 type="fast-alloc"                                                                                        0.73 %             1.672748e-01
 buffers/buffer-creation.js n=1024 len=2048 type="fast-alloc-fill"                                                                                   0.10 %             9.052038e-01
 buffers/buffer-creation.js n=1024 len=2048 type="fast-allocUnsafe"                                                                                 -1.41 %          ** 6.444248e-03
 buffers/buffer-creation.js n=1024 len=2048 type="slow"                                                                                             -1.20 %           * 1.895756e-02
 buffers/buffer-creation.js n=1024 len=2048 type="slow-allocUnsafe"                                                                                  3.07 %         *** 2.875319e-06
 buffers/buffer-creation.js n=1024 len=4096 type="buffer()"                                                                                          2.24 %         *** 1.447597e-04
 buffers/buffer-creation.js n=1024 len=4096 type="fast-alloc"                                                                                        0.91 %           * 3.618377e-02
 buffers/buffer-creation.js n=1024 len=4096 type="fast-alloc-fill"                                                                                   0.68 %             3.480161e-01
 buffers/buffer-creation.js n=1024 len=4096 type="fast-allocUnsafe"                                                                                  2.68 %         *** 5.731177e-07
 buffers/buffer-creation.js n=1024 len=4096 type="slow"                                                                                             -2.03 %         *** 4.498264e-05
 buffers/buffer-creation.js n=1024 len=4096 type="slow-allocUnsafe"                                                                                  3.62 %         *** 3.112713e-08
 buffers/buffer-creation.js n=1024 len=8192 type="buffer()"                                                                                          2.31 %         *** 5.904463e-04
 buffers/buffer-creation.js n=1024 len=8192 type="fast-alloc"                                                                                        0.21 %             3.679837e-01
 buffers/buffer-creation.js n=1024 len=8192 type="fast-alloc-fill"                                                                                   0.83 %             1.359332e-01
 buffers/buffer-creation.js n=1024 len=8192 type="fast-allocUnsafe"                                                                                  1.46 %           * 3.465755e-02
 buffers/buffer-creation.js n=1024 len=8192 type="slow"                                                                                             -1.73 %          ** 1.660347e-03
 buffers/buffer-creation.js n=1024 len=8192 type="slow-allocUnsafe"                                                                                  2.00 %          ** 3.660894e-03
 buffers/buffer-from.js n=1024 len=10 source="array"                                                                                                55.19 %         *** 5.065928e-31
 buffers/buffer-from.js n=1024 len=10 source="arraybuffer"                                                                                          -0.48 %             2.372293e-01
 buffers/buffer-from.js n=1024 len=10 source="arraybuffer-middle"                                                                                    1.71 %             6.434012e-02
 buffers/buffer-from.js n=1024 len=10 source="buffer"                                                                                               30.59 %         *** 2.622430e-37
 buffers/buffer-from.js n=1024 len=10 source="string"                                                                                                6.64 %         *** 6.883215e-23
 buffers/buffer-from.js n=1024 len=10 source="string-base64"                                                                                         0.33 %             8.266461e-01
 buffers/buffer-from.js n=1024 len=10 source="uint8array"                                                                                           29.09 %         *** 5.380573e-32
 buffers/buffer-from.js n=1024 len=2048 source="array"                                                                                              15.98 %         *** 3.981186e-44
 buffers/buffer-from.js n=1024 len=2048 source="arraybuffer"                                                                                        -0.94 %           * 1.263886e-02
 buffers/buffer-from.js n=1024 len=2048 source="arraybuffer-middle"                                                                                  2.89 %          ** 9.615152e-03
 buffers/buffer-from.js n=1024 len=2048 source="buffer"                                                                                             11.49 %         *** 9.369552e-20
 buffers/buffer-from.js n=1024 len=2048 source="string"                                                                                              0.45 %             3.291592e-01
 buffers/buffer-from.js n=1024 len=2048 source="string-base64"                                                                                       0.27 %             3.604900e-01
 buffers/buffer-from.js n=1024 len=2048 source="uint8array"                                                                                        342.32 %         *** 1.908472e-47
 buffers/buffer-hex.js n=10000000 len=0                                                                                                              1.05 %             2.726122e-01
 buffers/buffer-hex.js n=10000000 len=1                                                                                                             -9.76 %         *** 2.185367e-13
 buffers/buffer-hex.js n=10000000 len=1024                                                                                                          -2.51 %         *** 2.097545e-08
 buffers/buffer-hex.js n=10000000 len=64                                                                                                           -10.71 %         *** 2.358060e-10
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="@"                                                                        37.20 %         *** 3.542962e-22
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="10x"                                                                      33.68 %         *** 9.223620e-23
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="aaaaaaaaaaaaaaaaa"                                                         0.42 %             1.207794e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="Alice"                                                                    48.93 %         *** 2.565451e-25
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="among mad people"                                                          0.50 %           * 3.892363e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="found it very"                                                             0.85 %           * 2.219407e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="Gryphon"                                                                   3.50 %         *** 8.674603e-04
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="</i> to the Caterpillar"                                                   0.31 %             3.459151e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="--l"                                                                       1.98 %           * 1.021171e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="neighbouring pool"                                                         0.44 %             7.150775e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="Ou est ma chatte?"                                                         1.07 %           * 1.871304e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="Panther"                                                                   2.82 %          ** 2.464515e-03
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="Soo--oop"                                                                 -0.20 %             5.386833e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="SQ"                                                                        8.99 %         *** 1.787493e-07
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="binary" search="venture to go near the house till she had brought herself down to"         0.62 %             2.115197e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="@"                                                                          37.58 %         *** 2.771259e-23
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="10x"                                                                        29.75 %         *** 4.610992e-36
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="aaaaaaaaaaaaaaaaa"                                                           0.77 %           * 2.557371e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="Alice"                                                                      60.62 %         *** 1.165571e-34
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="among mad people"                                                            1.00 %          ** 1.430622e-03
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="found it very"                                                               2.06 %         *** 1.037499e-06
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="Gryphon"                                                                     6.38 %         *** 3.858636e-12
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="</i> to the Caterpillar"                                                     1.52 %         *** 9.562553e-04
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="--l"                                                                         3.35 %         *** 3.924503e-07
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="neighbouring pool"                                                           0.90 %          ** 1.032536e-03
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="Ou est ma chatte?"                                                           1.26 %         *** 1.349364e-04
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="Panther"                                                                     5.16 %         *** 5.009852e-06
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="Soo--oop"                                                                    0.46 %             1.317764e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="SQ"                                                                          5.53 %         *** 8.890122e-09
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="ucs2" search="venture to go near the house till she had brought herself down to"           0.59 %             2.490438e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="@"                                                                     40.38 %         *** 1.063174e-23
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="10x"                                                                   27.50 %         *** 1.220782e-30
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="aaaaaaaaaaaaaaaaa"                                                     -0.11 %             6.967607e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="Alice"                                                                 54.55 %         *** 1.085650e-28
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="among mad people"                                                       0.72 %             6.064134e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="found it very"                                                          0.96 %          ** 3.682646e-03
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="Gryphon"                                                                3.08 %         *** 8.846503e-04
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="</i> to the Caterpillar"                                                0.19 %             5.083242e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="--l"                                                                    1.37 %           * 4.984706e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="neighbouring pool"                                                      0.39 %             1.678855e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="Ou est ma chatte?"                                                      1.86 %         *** 2.286411e-06
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="Panther"                                                                1.95 %         *** 1.392627e-05
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="Soo--oop"                                                               0.11 %             6.461592e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="SQ"                                                                     7.02 %         *** 3.549004e-19
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="undefined" search="venture to go near the house till she had brought herself down to"      0.90 %          ** 3.560083e-03
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="@"                                                                          45.28 %         *** 7.671655e-31
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="10x"                                                                        34.74 %         *** 1.102241e-26
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="aaaaaaaaaaaaaaaaa"                                                           0.17 %             5.713185e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="Alice"                                                                      58.26 %         *** 3.450525e-23
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="among mad people"                                                            0.87 %         *** 2.266250e-04
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="found it very"                                                               0.77 %           * 2.560822e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="Gryphon"                                                                     3.61 %         *** 6.593369e-05
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="</i> to the Caterpillar"                                                     0.15 %             6.481659e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="--l"                                                                         2.77 %         *** 1.076342e-04
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="neighbouring pool"                                                           0.47 %           * 4.559572e-02
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="Ou est ma chatte?"                                                           1.69 %          ** 1.514151e-03
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="Panther"                                                                     1.70 %             1.705668e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="Soo--oop"                                                                    0.22 %             3.613165e-01
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="SQ"                                                                         10.58 %         *** 4.929414e-23
 buffers/buffer-indexof.js iter=1 type="buffer" encoding="utf8" search="venture to go near the house till she had brought herself down to"           0.86 %           * 4.773720e-02
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="@"                                                                         7.79 %         *** 6.007483e-04
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="10x"                                                                       3.96 %           * 2.108940e-02
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="aaaaaaaaaaaaaaaaa"                                                         0.03 %             9.097698e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="Alice"                                                                     6.38 %         *** 5.662132e-04
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="among mad people"                                                          0.24 %             3.256649e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="found it very"                                                             0.26 %             4.113980e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="Gryphon"                                                                   0.44 %             4.888076e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="</i> to the Caterpillar"                                                   0.00 %             9.939394e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="--l"                                                                       1.09 %             1.249109e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="neighbouring pool"                                                         0.03 %             8.908611e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="Ou est ma chatte?"                                                        -0.43 %             3.184906e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="Panther"                                                                   1.35 %             1.549085e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="Soo--oop"                                                                 -0.46 %             1.376180e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="SQ"                                                                        1.31 %             7.418987e-02
 buffers/buffer-indexof.js iter=1 type="string" encoding="binary" search="venture to go near the house till she had brought herself down to"        -0.06 %             8.878934e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="@"                                                                           1.22 %             4.890280e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="10x"                                                                         2.12 %             2.727112e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="aaaaaaaaaaaaaaaaa"                                                          -0.40 %             1.965634e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="Alice"                                                                       4.10 %             6.921701e-02
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="among mad people"                                                           -0.19 %             4.302989e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="found it very"                                                               0.60 %             1.002569e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="Gryphon"                                                                     0.92 %             4.072588e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="</i> to the Caterpillar"                                                    -0.31 %             4.103261e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="--l"                                                                        -0.29 %             7.447259e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="neighbouring pool"                                                          -0.05 %             8.292093e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="Ou est ma chatte?"                                                          -0.08 %             8.313699e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="Panther"                                                                     0.12 %             8.148198e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="Soo--oop"                                                                   -0.22 %             3.934738e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="SQ"                                                                         -0.32 %             6.100616e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="ucs2" search="venture to go near the house till she had brought herself down to"           0.18 %             6.725420e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="@"                                                                     -0.26 %             8.940796e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="10x"                                                                   -0.97 %             1.943054e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="aaaaaaaaaaaaaaaaa"                                                     -0.39 %             1.938172e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="Alice"                                                                 -0.62 %             7.623900e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="among mad people"                                                       0.37 %             2.565950e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="found it very"                                                          0.45 %             1.646049e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="Gryphon"                                                                0.77 %             1.909406e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="</i> to the Caterpillar"                                               -0.38 %             2.535046e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="--l"                                                                    0.21 %             7.001069e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="neighbouring pool"                                                     -0.18 %             5.153790e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="Ou est ma chatte?"                                                      0.31 %             4.755964e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="Panther"                                                                1.53 %             2.057011e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="Soo--oop"                                                              -0.24 %             3.253246e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="SQ"                                                                     1.09 %             3.126744e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="undefined" search="venture to go near the house till she had brought herself down to"     -0.17 %             5.848739e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="@"                                                                           2.78 %             1.453905e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="10x"                                                                         2.09 %          ** 8.082158e-03
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="aaaaaaaaaaaaaaaaa"                                                          -0.47 %             1.367428e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="Alice"                                                                       3.16 %             7.106134e-02
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="among mad people"                                                            0.19 %             4.273365e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="found it very"                                                               0.31 %             3.456479e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="Gryphon"                                                                     1.11 %             1.577975e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="</i> to the Caterpillar"                                                    -0.64 %             6.861593e-02
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="--l"                                                                         0.35 %             6.612087e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="neighbouring pool"                                                          -0.01 %             9.573545e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="Ou est ma chatte?"                                                          -0.45 %             4.094150e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="Panther"                                                                     0.16 %             8.239952e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="Soo--oop"                                                                   -0.19 %             4.129859e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="SQ"                                                                          0.26 %             6.263002e-01
 buffers/buffer-indexof.js iter=1 type="string" encoding="utf8" search="venture to go near the house till she had brought herself down to"           0.05 %             9.158092e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="fast" size=1024                                                                              -0.32 %             5.759045e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="fast" size=16                                                                                 2.91 %             2.662040e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="fast" size=16386                                                                              0.37 %             1.365537e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="fast" size=4096                                                                               0.84 %          ** 7.140241e-03
 buffers/buffer-iterate.js n=1000 method="forOf" type="fast" size=512                                                                                0.84 %             1.557964e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="slow" size=1024                                                                               0.25 %             5.888459e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="slow" size=16                                                                                 1.46 %             5.094230e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="slow" size=16386                                                                              0.30 %             3.086731e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="slow" size=4096                                                                               0.20 %             5.843111e-01
 buffers/buffer-iterate.js n=1000 method="forOf" type="slow" size=512                                                                                0.70 %             2.853516e-01
 buffers/buffer-iterate.js n=1000 method="for" type="fast" size=1024                                                                                -0.79 %             7.844882e-01
 buffers/buffer-iterate.js n=1000 method="for" type="fast" size=16                                                                                   4.70 %             2.226158e-01
 buffers/buffer-iterate.js n=1000 method="for" type="fast" size=16386                                                                                1.01 %             5.769187e-02
 buffers/buffer-iterate.js n=1000 method="for" type="fast" size=4096                                                                                 0.89 %             6.311505e-01
 buffers/buffer-iterate.js n=1000 method="for" type="fast" size=512                                                                                 -3.59 %             2.518263e-01
 buffers/buffer-iterate.js n=1000 method="for" type="slow" size=1024                                                                                 3.17 %             2.904156e-01
 buffers/buffer-iterate.js n=1000 method="for" type="slow" size=16                                                                                   3.27 %             3.286491e-01
 buffers/buffer-iterate.js n=1000 method="for" type="slow" size=16386                                                                                0.90 %             2.002919e-01
 buffers/buffer-iterate.js n=1000 method="for" type="slow" size=4096                                                                                 0.57 %             6.115540e-01
 buffers/buffer-iterate.js n=1000 method="for" type="slow" size=512                                                                                  6.18 %             6.398091e-02
 buffers/buffer-iterate.js n=1000 method="iterator" type="fast" size=1024                                                                           -0.20 %             7.048810e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="fast" size=16                                                                              0.48 %             8.618237e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="fast" size=16386                                                                          -0.04 %             9.079813e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="fast" size=4096                                                                           -0.31 %             4.943081e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="fast" size=512                                                                             1.04 %             3.204352e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="slow" size=1024                                                                            1.17 %             1.901865e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="slow" size=16                                                                              3.42 %             2.490876e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="slow" size=16386                                                                           0.23 %             4.129062e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="slow" size=4096                                                                           -0.03 %             9.316435e-01
 buffers/buffer-iterate.js n=1000 method="iterator" type="slow" size=512                                                                            -0.04 %             9.589368e-01
 buffers/buffer-read.js millions=1 type="DoubleBE" buffer="fast" noAssert="false"                                                                   -0.07 %             9.034292e-01
 buffers/buffer-read.js millions=1 type="DoubleBE" buffer="fast" noAssert="true"                                                                    -0.89 %             5.164235e-02
 buffers/buffer-read.js millions=1 type="DoubleBE" buffer="slow" noAssert="false"                                                                   -0.02 %             9.588723e-01
 buffers/buffer-read.js millions=1 type="DoubleBE" buffer="slow" noAssert="true"                                                                    -0.31 %             5.722770e-01
 buffers/buffer-read.js millions=1 type="DoubleLE" buffer="fast" noAssert="false"                                                                    0.50 %             4.147880e-01
 buffers/buffer-read.js millions=1 type="DoubleLE" buffer="fast" noAssert="true"                                                                     0.48 %             3.999456e-01
 buffers/buffer-read.js millions=1 type="DoubleLE" buffer="slow" noAssert="false"                                                                   -0.29 %             5.647489e-01
 buffers/buffer-read.js millions=1 type="DoubleLE" buffer="slow" noAssert="true"                                                                    -0.96 %             8.664769e-02
 buffers/buffer-read.js millions=1 type="FloatBE" buffer="fast" noAssert="false"                                                                     0.11 %             8.196798e-01
 buffers/buffer-read.js millions=1 type="FloatBE" buffer="fast" noAssert="true"                                                                     -0.00 %             9.962163e-01
 buffers/buffer-read.js millions=1 type="FloatBE" buffer="slow" noAssert="false"                                                                    -0.68 %             1.965449e-01
 buffers/buffer-read.js millions=1 type="FloatBE" buffer="slow" noAssert="true"                                                                      0.55 %             2.704413e-01
 buffers/buffer-read.js millions=1 type="FloatLE" buffer="fast" noAssert="false"                                                                     0.31 %             5.137215e-01
 buffers/buffer-read.js millions=1 type="FloatLE" buffer="fast" noAssert="true"                                                                      0.48 %             3.759505e-01
 buffers/buffer-read.js millions=1 type="FloatLE" buffer="slow" noAssert="false"                                                                    -0.81 %             1.987916e-01
 buffers/buffer-read.js millions=1 type="FloatLE" buffer="slow" noAssert="true"                                                                      0.85 %             8.764929e-02
 buffers/buffer-read.js millions=1 type="Int16BE" buffer="fast" noAssert="false"                                                                     0.04 %             9.809148e-01
 buffers/buffer-read.js millions=1 type="Int16BE" buffer="fast" noAssert="true"                                                                     -0.95 %             7.730131e-01
 buffers/buffer-read.js millions=1 type="Int16BE" buffer="slow" noAssert="false"                                                                     2.04 %             2.846689e-01
 buffers/buffer-read.js millions=1 type="Int16BE" buffer="slow" noAssert="true"                                                                      3.70 %             2.529727e-01
 buffers/buffer-read.js millions=1 type="Int16LE" buffer="fast" noAssert="false"                                                                     0.43 %             8.606788e-01
 buffers/buffer-read.js millions=1 type="Int16LE" buffer="fast" noAssert="true"                                                                     -2.24 %             4.568986e-01
 buffers/buffer-read.js millions=1 type="Int16LE" buffer="slow" noAssert="false"                                                                     0.78 %             6.221753e-01
 buffers/buffer-read.js millions=1 type="Int16LE" buffer="slow" noAssert="true"                                                                      2.88 %             3.171275e-01
 buffers/buffer-read.js millions=1 type="Int32BE" buffer="fast" noAssert="false"                                                                     1.87 %             3.649463e-01
 buffers/buffer-read.js millions=1 type="Int32BE" buffer="fast" noAssert="true"                                                                     -3.02 %             3.445022e-01
 buffers/buffer-read.js millions=1 type="Int32BE" buffer="slow" noAssert="false"                                                                     0.68 %             6.931129e-01
 buffers/buffer-read.js millions=1 type="Int32BE" buffer="slow" noAssert="true"                                                                      1.47 %             6.275251e-01
 buffers/buffer-read.js millions=1 type="Int32LE" buffer="fast" noAssert="false"                                                                    -0.27 %             8.808924e-01
 buffers/buffer-read.js millions=1 type="Int32LE" buffer="fast" noAssert="true"                                                                     -3.66 %             2.600207e-01
 buffers/buffer-read.js millions=1 type="Int32LE" buffer="slow" noAssert="false"                                                                     2.55 %             2.293470e-01
 buffers/buffer-read.js millions=1 type="Int32LE" buffer="slow" noAssert="true"                                                                      1.10 %             7.144814e-01
 buffers/buffer-read.js millions=1 type="Int8" buffer="fast" noAssert="false"                                                                        0.87 %             7.422875e-01
 buffers/buffer-read.js millions=1 type="Int8" buffer="fast" noAssert="true"                                                                        -6.37 %             1.158750e-01
 buffers/buffer-read.js millions=1 type="Int8" buffer="slow" noAssert="false"                                                                        1.54 %             4.284394e-01
 buffers/buffer-read.js millions=1 type="Int8" buffer="slow" noAssert="true"                                                                       -10.09 %          ** 2.968315e-03
 buffers/buffer-read.js millions=1 type="UInt16BE" buffer="fast" noAssert="false"                                                                    7.51 %           * 3.077579e-02
 buffers/buffer-read.js millions=1 type="UInt16BE" buffer="fast" noAssert="true"                                                                     1.31 %             6.516420e-01
 buffers/buffer-read.js millions=1 type="UInt16BE" buffer="slow" noAssert="false"                                                                   -2.47 %             2.759382e-01
 buffers/buffer-read.js millions=1 type="UInt16BE" buffer="slow" noAssert="true"                                                                    -0.66 %             8.439004e-01
 buffers/buffer-read.js millions=1 type="UInt16LE" buffer="fast" noAssert="false"                                                                    2.17 %             5.190179e-01
 buffers/buffer-read.js millions=1 type="UInt16LE" buffer="fast" noAssert="true"                                                                     1.12 %             7.475412e-01
 buffers/buffer-read.js millions=1 type="UInt16LE" buffer="slow" noAssert="false"                                                                    2.44 %             3.112944e-01
 buffers/buffer-read.js millions=1 type="UInt16LE" buffer="slow" noAssert="true"                                                                     0.63 %             8.484462e-01
 buffers/buffer-read.js millions=1 type="UInt32BE" buffer="fast" noAssert="false"                                                                   -0.96 %             7.235121e-01
 buffers/buffer-read.js millions=1 type="UInt32BE" buffer="fast" noAssert="true"                                                                    -1.30 %             7.045360e-01
 buffers/buffer-read.js millions=1 type="UInt32BE" buffer="slow" noAssert="false"                                                                    0.19 %             9.027826e-01
 buffers/buffer-read.js millions=1 type="UInt32BE" buffer="slow" noAssert="true"                                                                    -0.43 %             8.775968e-01
 buffers/buffer-read.js millions=1 type="UInt32LE" buffer="fast" noAssert="false"                                                                   -1.45 %             6.537269e-01
 buffers/buffer-read.js millions=1 type="UInt32LE" buffer="fast" noAssert="true"                                                                     4.22 %             2.660515e-01
 buffers/buffer-read.js millions=1 type="UInt32LE" buffer="slow" noAssert="false"                                                                   -0.45 %             8.419638e-01
 buffers/buffer-read.js millions=1 type="UInt32LE" buffer="slow" noAssert="true"                                                                     2.65 %             4.064618e-01
 buffers/buffer-read.js millions=1 type="UInt8" buffer="fast" noAssert="false"                                                                      -1.76 %             6.157053e-01
 buffers/buffer-read.js millions=1 type="UInt8" buffer="fast" noAssert="true"                                                                        1.79 %             5.589684e-01
 buffers/buffer-read.js millions=1 type="UInt8" buffer="slow" noAssert="false"                                                                       3.39 %             1.290433e-01
 buffers/buffer-read.js millions=1 type="UInt8" buffer="slow" noAssert="true"                                                                        4.25 %             2.632889e-01
 buffers/buffer-slice.js n=1024 type="fast"                                                                                                          0.12 %             9.465963e-01
 buffers/buffer-slice.js n=1024 type="slow"                                                                                                         -0.17 %             8.758580e-01
 buffers/buffer-swap.js n=50000000 len=1024 method="swap16" aligned="false"                                                                          0.72 %             9.809239e-02
 buffers/buffer-swap.js n=50000000 len=1024 method="swap16" aligned="true"                                                                           0.23 %             2.236034e-01
 buffers/buffer-swap.js n=50000000 len=1024 method="swap32" aligned="false"                                                                          1.83 %           * 1.158038e-02
 buffers/buffer-swap.js n=50000000 len=1024 method="swap32" aligned="true"                                                                           0.60 %             3.452454e-01
 buffers/buffer-swap.js n=50000000 len=1024 method="swap64" aligned="false"                                                                         -0.01 %             9.773489e-01
 buffers/buffer-swap.js n=50000000 len=1024 method="swap64" aligned="true"                                                                           0.17 %             5.253134e-01
 buffers/buffer-swap.js n=50000000 len=128 method="swap16" aligned="false"                                                                           8.36 %         *** 5.748127e-04
 buffers/buffer-swap.js n=50000000 len=128 method="swap16" aligned="true"                                                                           -0.20 %             6.428970e-01
 buffers/buffer-swap.js n=50000000 len=128 method="swap32" aligned="false"                                                                           0.21 %             3.703615e-01
 buffers/buffer-swap.js n=50000000 len=128 method="swap32" aligned="true"                                                                            0.66 %             4.632704e-01
 buffers/buffer-swap.js n=50000000 len=128 method="swap64" aligned="false"                                                                           0.25 %             2.096322e-01
 buffers/buffer-swap.js n=50000000 len=128 method="swap64" aligned="true"                                                                            0.03 %             9.127307e-01
 buffers/buffer-swap.js n=50000000 len=1536 method="swap16" aligned="false"                                                                          0.67 %             5.408411e-02
 buffers/buffer-swap.js n=50000000 len=1536 method="swap16" aligned="true"                                                                           0.14 %             4.457590e-01
 buffers/buffer-swap.js n=50000000 len=1536 method="swap32" aligned="false"                                                                          1.34 %           * 1.728387e-02
 buffers/buffer-swap.js n=50000000 len=1536 method="swap32" aligned="true"                                                                           0.84 %             2.382281e-01
 buffers/buffer-swap.js n=50000000 len=1536 method="swap64" aligned="false"                                                                          0.17 %             4.502700e-01
 buffers/buffer-swap.js n=50000000 len=1536 method="swap64" aligned="true"                                                                           0.30 %             2.428025e-01
 buffers/buffer-swap.js n=50000000 len=2056 method="swap16" aligned="false"                                                                          0.56 %             6.208748e-02
 buffers/buffer-swap.js n=50000000 len=2056 method="swap16" aligned="true"                                                                           0.24 %             1.858673e-01
 buffers/buffer-swap.js n=50000000 len=2056 method="swap32" aligned="false"                                                                          1.21 %          ** 3.388105e-03
 buffers/buffer-swap.js n=50000000 len=2056 method="swap32" aligned="true"                                                                           0.70 %             2.989990e-01
 buffers/buffer-swap.js n=50000000 len=2056 method="swap64" aligned="false"                                                                         -0.16 %             4.430901e-01
 buffers/buffer-swap.js n=50000000 len=2056 method="swap64" aligned="true"                                                                           0.28 %             1.697438e-01
 buffers/buffer-swap.js n=50000000 len=256 method="swap16" aligned="false"                                                                           2.56 %           * 3.002227e-02
 buffers/buffer-swap.js n=50000000 len=256 method="swap16" aligned="true"                                                                            0.43 %           * 2.742431e-02
 buffers/buffer-swap.js n=50000000 len=256 method="swap32" aligned="false"                                                                           3.24 %           * 2.630554e-02
 buffers/buffer-swap.js n=50000000 len=256 method="swap32" aligned="true"                                                                            0.89 %             2.818194e-01
 buffers/buffer-swap.js n=50000000 len=256 method="swap64" aligned="false"                                                                           0.19 %             7.137768e-01
 buffers/buffer-swap.js n=50000000 len=256 method="swap64" aligned="true"                                                                            1.79 %         *** 9.228565e-06
 buffers/buffer-swap.js n=50000000 len=4096 method="swap16" aligned="false"                                                                          0.48 %           * 1.620757e-02
 buffers/buffer-swap.js n=50000000 len=4096 method="swap16" aligned="true"                                                                           0.22 %             2.040544e-01
 buffers/buffer-swap.js n=50000000 len=4096 method="swap32" aligned="false"                                                                          0.26 %             3.093509e-01
 buffers/buffer-swap.js n=50000000 len=4096 method="swap32" aligned="true"                                                                           0.43 %             4.942188e-01
 buffers/buffer-swap.js n=50000000 len=4096 method="swap64" aligned="false"                                                                          0.04 %             8.419400e-01
 buffers/buffer-swap.js n=50000000 len=4096 method="swap64" aligned="true"                                                                           0.07 %             7.158100e-01
 buffers/buffer-swap.js n=50000000 len=512 method="swap16" aligned="false"                                                                           1.48 %             5.285946e-02
 buffers/buffer-swap.js n=50000000 len=512 method="swap16" aligned="true"                                                                            0.02 %             9.091293e-01
 buffers/buffer-swap.js n=50000000 len=512 method="swap32" aligned="false"                                                                           2.25 %           * 2.512926e-02
 buffers/buffer-swap.js n=50000000 len=512 method="swap32" aligned="true"                                                                            0.62 %             2.840412e-01
 buffers/buffer-swap.js n=50000000 len=512 method="swap64" aligned="false"                                                                           0.46 %             8.699367e-02
 buffers/buffer-swap.js n=50000000 len=512 method="swap64" aligned="true"                                                                            1.61 %         *** 1.363688e-06
 buffers/buffer-swap.js n=50000000 len=64 method="swap16" aligned="false"                                                                            0.14 %             5.113253e-01
 buffers/buffer-swap.js n=50000000 len=64 method="swap16" aligned="true"                                                                            -0.01 %             9.608600e-01
 buffers/buffer-swap.js n=50000000 len=64 method="swap32" aligned="false"                                                                            0.08 %             7.459225e-01
 buffers/buffer-swap.js n=50000000 len=64 method="swap32" aligned="true"                                                                             0.35 %             3.739231e-01
 buffers/buffer-swap.js n=50000000 len=64 method="swap64" aligned="false"                                                                            0.17 %             4.150318e-01
 buffers/buffer-swap.js n=50000000 len=64 method="swap64" aligned="true"                                                                             0.17 %             5.602302e-01
 buffers/buffer-swap.js n=50000000 len=768 method="swap16" aligned="false"                                                                           1.23 %           * 1.915928e-02
 buffers/buffer-swap.js n=50000000 len=768 method="swap16" aligned="true"                                                                            0.17 %             3.734867e-01
 buffers/buffer-swap.js n=50000000 len=768 method="swap32" aligned="false"                                                                           2.33 %           * 1.078304e-02
 buffers/buffer-swap.js n=50000000 len=768 method="swap32" aligned="true"                                                                            0.54 %             4.597528e-01
 buffers/buffer-swap.js n=50000000 len=768 method="swap64" aligned="false"                                                                          -0.09 %             8.431402e-01
 buffers/buffer-swap.js n=50000000 len=768 method="swap64" aligned="true"                                                                            0.46 %             7.674447e-02
 buffers/buffer-swap.js n=50000000 len=8192 method="swap16" aligned="false"                                                                          0.23 %             2.495725e-01
 buffers/buffer-swap.js n=50000000 len=8192 method="swap16" aligned="true"                                                                           0.20 %             3.363774e-01
 buffers/buffer-swap.js n=50000000 len=8192 method="swap32" aligned="false"                                                                          0.42 %           * 4.265218e-02
 buffers/buffer-swap.js n=50000000 len=8192 method="swap32" aligned="true"                                                                           0.01 %             9.537111e-01
 buffers/buffer-swap.js n=50000000 len=8192 method="swap64" aligned="false"                                                                          0.08 %             6.843852e-01
 buffers/buffer-swap.js n=50000000 len=8192 method="swap64" aligned="true"                                                                           0.12 %             5.495020e-01
 buffers/buffer-swap.js n=50000000 len=8 method="swap16" aligned="false"                                                                            -0.32 %             2.198962e-01
 buffers/buffer-swap.js n=50000000 len=8 method="swap16" aligned="true"                                                                              1.77 %             9.569371e-02
 buffers/buffer-swap.js n=50000000 len=8 method="swap32" aligned="false"                                                                             0.26 %             3.495595e-01
 buffers/buffer-swap.js n=50000000 len=8 method="swap32" aligned="true"                                                                              0.15 %             6.847003e-01
 buffers/buffer-swap.js n=50000000 len=8 method="swap64" aligned="false"                                                                             0.11 %             6.325445e-01
 buffers/buffer-swap.js n=50000000 len=8 method="swap64" aligned="true"                                                                              0.12 %             7.219655e-01
 buffers/buffer-tostring.js n=10000000 len=0 arg="false"                                                                                             0.25 %             5.598026e-01
 buffers/buffer-tostring.js n=10000000 len=0 arg="true"                                                                                              0.47 %             1.151176e-01
 buffers/buffer-tostring.js n=10000000 len=1024 arg="false"                                                                                         -0.17 %             6.426541e-01
 buffers/buffer-tostring.js n=10000000 len=1024 arg="true"                                                                                           2.44 %          ** 3.853967e-03
 buffers/buffer-tostring.js n=10000000 len=1 arg="false"                                                                                             0.64 %             5.148329e-02
 buffers/buffer-tostring.js n=10000000 len=1 arg="true"                                                                                              0.03 %             9.132085e-01
 buffers/buffer-tostring.js n=10000000 len=64 arg="false"                                                                                            0.47 %             1.392449e-01
 buffers/buffer-tostring.js n=10000000 len=64 arg="true"                                                                                            -0.16 %             6.332427e-01
 buffers/buffer-write.js millions=1 type="DoubleBE" buffer="fast" noAssert="false"                                                                  -0.58 %             3.398289e-01
 buffers/buffer-write.js millions=1 type="DoubleBE" buffer="fast" noAssert="true"                                                                   -0.40 %             4.515062e-01
 buffers/buffer-write.js millions=1 type="DoubleBE" buffer="slow" noAssert="false"                                                                   0.10 %             8.833849e-01
 buffers/buffer-write.js millions=1 type="DoubleBE" buffer="slow" noAssert="true"                                                                   -0.25 %             6.332746e-01
 buffers/buffer-write.js millions=1 type="DoubleLE" buffer="fast" noAssert="false"                                                                  -1.02 %             8.618611e-02
 buffers/buffer-write.js millions=1 type="DoubleLE" buffer="fast" noAssert="true"                                                                    0.06 %             9.531467e-01
 buffers/buffer-write.js millions=1 type="DoubleLE" buffer="slow" noAssert="false"                                                                  -0.04 %             9.413074e-01
 buffers/buffer-write.js millions=1 type="DoubleLE" buffer="slow" noAssert="true"                                                                    0.93 %             1.329555e-01
 buffers/buffer-write.js millions=1 type="FloatBE" buffer="fast" noAssert="false"                                                                    1.54 %           * 1.878570e-02
 buffers/buffer-write.js millions=1 type="FloatBE" buffer="fast" noAssert="true"                                                                     1.31 %             7.052881e-02
 buffers/buffer-write.js millions=1 type="FloatBE" buffer="slow" noAssert="false"                                                                    0.88 %             1.889604e-01
 buffers/buffer-write.js millions=1 type="FloatBE" buffer="slow" noAssert="true"                                                                     2.88 %           * 2.500116e-02
 buffers/buffer-write.js millions=1 type="FloatLE" buffer="fast" noAssert="false"                                                                    2.82 %         *** 9.326764e-06
 buffers/buffer-write.js millions=1 type="FloatLE" buffer="fast" noAssert="true"                                                                     3.44 %         *** 1.127102e-06
 buffers/buffer-write.js millions=1 type="FloatLE" buffer="slow" noAssert="false"                                                                    2.29 %         *** 2.142062e-04
 buffers/buffer-write.js millions=1 type="FloatLE" buffer="slow" noAssert="true"                                                                     3.47 %         *** 1.540476e-07
 buffers/buffer-write.js millions=1 type="Int16BE" buffer="fast" noAssert="false"                                                                  373.39 %         *** 5.758374e-45
 buffers/buffer-write.js millions=1 type="Int16BE" buffer="fast" noAssert="true"                                                                     1.08 %             7.279496e-01
 buffers/buffer-write.js millions=1 type="Int16BE" buffer="slow" noAssert="false"                                                                  374.95 %         *** 2.886506e-38
 buffers/buffer-write.js millions=1 type="Int16BE" buffer="slow" noAssert="true"                                                                    -1.31 %             6.932251e-01
 buffers/buffer-write.js millions=1 type="Int16LE" buffer="fast" noAssert="false"                                                                  373.82 %         *** 1.179914e-45
 buffers/buffer-write.js millions=1 type="Int16LE" buffer="fast" noAssert="true"                                                                    -3.79 %             1.997305e-01
 buffers/buffer-write.js millions=1 type="Int16LE" buffer="slow" noAssert="false"                                                                  378.53 %         *** 6.633421e-47
 buffers/buffer-write.js millions=1 type="Int16LE" buffer="slow" noAssert="true"                                                                     1.63 %             6.271788e-01
 buffers/buffer-write.js millions=1 type="Int32BE" buffer="fast" noAssert="false"                                                                  359.81 %         *** 4.468876e-36
 buffers/buffer-write.js millions=1 type="Int32BE" buffer="fast" noAssert="true"                                                                     0.28 %             9.300014e-01
 buffers/buffer-write.js millions=1 type="Int32BE" buffer="slow" noAssert="false"                                                                  365.23 %         *** 3.667399e-46
 buffers/buffer-write.js millions=1 type="Int32BE" buffer="slow" noAssert="true"                                                                    -1.13 %             7.262130e-01
 buffers/buffer-write.js millions=1 type="Int32LE" buffer="fast" noAssert="false"                                                                  363.26 %         *** 3.212750e-40
 buffers/buffer-write.js millions=1 type="Int32LE" buffer="fast" noAssert="true"                                                                     3.54 %             2.226230e-01
 buffers/buffer-write.js millions=1 type="Int32LE" buffer="slow" noAssert="false"                                                                  362.38 %         *** 2.621477e-41
 buffers/buffer-write.js millions=1 type="Int32LE" buffer="slow" noAssert="true"                                                                     0.87 %             7.827498e-01
 buffers/buffer-write.js millions=1 type="Int8" buffer="fast" noAssert="false"                                                                     379.73 %         *** 2.298813e-44
 buffers/buffer-write.js millions=1 type="Int8" buffer="fast" noAssert="true"                                                                       -4.20 %             2.479855e-01
 buffers/buffer-write.js millions=1 type="Int8" buffer="slow" noAssert="false"                                                                     387.10 %         *** 2.288842e-49
 buffers/buffer-write.js millions=1 type="Int8" buffer="slow" noAssert="true"                                                                        0.10 %             9.730214e-01
 buffers/buffer-write.js millions=1 type="UInt16BE" buffer="fast" noAssert="false"                                                                 368.54 %         *** 4.019250e-37
 buffers/buffer-write.js millions=1 type="UInt16BE" buffer="fast" noAssert="true"                                                                    2.32 %             4.378903e-01
 buffers/buffer-write.js millions=1 type="UInt16BE" buffer="slow" noAssert="false"                                                                 375.49 %         *** 6.909551e-47
 buffers/buffer-write.js millions=1 type="UInt16BE" buffer="slow" noAssert="true"                                                                    3.22 %             3.136021e-01
 buffers/buffer-write.js millions=1 type="UInt16LE" buffer="fast" noAssert="false"                                                                 370.98 %         *** 2.698867e-39
 buffers/buffer-write.js millions=1 type="UInt16LE" buffer="fast" noAssert="true"                                                                    0.19 %             9.515645e-01
 buffers/buffer-write.js millions=1 type="UInt16LE" buffer="slow" noAssert="false"                                                                 374.03 %         *** 1.939317e-43
 buffers/buffer-write.js millions=1 type="UInt16LE" buffer="slow" noAssert="true"                                                                    3.73 %             2.493963e-01
 buffers/buffer-write.js millions=1 type="UInt32BE" buffer="fast" noAssert="false"                                                                 348.91 %         *** 1.049299e-44
 buffers/buffer-write.js millions=1 type="UInt32BE" buffer="fast" noAssert="true"                                                                    0.41 %             9.013436e-01
 buffers/buffer-write.js millions=1 type="UInt32BE" buffer="slow" noAssert="false"                                                                 351.56 %         *** 9.156560e-49
 buffers/buffer-write.js millions=1 type="UInt32BE" buffer="slow" noAssert="true"                                                                   -3.30 %             2.827632e-01
 buffers/buffer-write.js millions=1 type="UInt32LE" buffer="fast" noAssert="false"                                                                 344.12 %         *** 1.214096e-31
 buffers/buffer-write.js millions=1 type="UInt32LE" buffer="fast" noAssert="true"                                                                    1.51 %             5.666565e-01
 buffers/buffer-write.js millions=1 type="UInt32LE" buffer="slow" noAssert="false"                                                                 352.90 %         *** 3.244350e-44
 buffers/buffer-write.js millions=1 type="UInt32LE" buffer="slow" noAssert="true"                                                                   -1.84 %             5.294890e-01
 buffers/buffer-write.js millions=1 type="UInt8" buffer="fast" noAssert="false"                                                                    376.14 %         *** 3.505424e-47
 buffers/buffer-write.js millions=1 type="UInt8" buffer="fast" noAssert="true"                                                                       4.61 %             9.893927e-02
 buffers/buffer-write.js millions=1 type="UInt8" buffer="slow" noAssert="false"                                                                    376.86 %         *** 1.417748e-47
 buffers/buffer-write.js millions=1 type="UInt8" buffer="slow" noAssert="true"                                                                      -2.70 %             4.419909e-01
 buffers/buffer_zero.js type="buffer" n=1024                                                                                                        89.70 %         *** 4.644630e-87
 buffers/buffer_zero.js type="string" n=1024                                                                                                        -5.85 %         *** 5.429638e-07
 buffers/dataview-set.js millions=1 type="Float32BE"                                                                                                 0.13 %             7.709391e-01
 buffers/dataview-set.js millions=1 type="Float32LE"                                                                                                -0.01 %             9.800722e-01
 buffers/dataview-set.js millions=1 type="Float64BE"                                                                                                -0.26 %             5.614375e-01
 buffers/dataview-set.js millions=1 type="Float64LE"                                                                                                 0.48 %             3.894129e-01
 buffers/dataview-set.js millions=1 type="Int16BE"                                                                                                   0.09 %             8.604741e-01
 buffers/dataview-set.js millions=1 type="Int16LE"                                                                                                  -0.02 %             9.588750e-01
 buffers/dataview-set.js millions=1 type="Int32BE"                                                                                                   0.27 %             6.324183e-01
 buffers/dataview-set.js millions=1 type="Int32LE"                                                                                                  -0.52 %             4.388504e-01
 buffers/dataview-set.js millions=1 type="Int8"                                                                                                      2.44 %         *** 4.957827e-05
 buffers/dataview-set.js millions=1 type="Uint16BE"                                                                                                  0.59 %             4.320600e-01
 buffers/dataview-set.js millions=1 type="Uint16LE"                                                                                                 -0.98 %             1.570108e-01
 buffers/dataview-set.js millions=1 type="Uint32BE"                                                                                                 -0.16 %             7.642430e-01
 buffers/dataview-set.js millions=1 type="Uint32LE"                                                                                                 -0.66 %             1.920751e-01
 buffers/dataview-set.js millions=1 type="Uint8"                                                                                                     1.46 %             3.819803e-01
</pre>
</details>

/cc @nodejs/buffer 

CI: https://ci.nodejs.org/job/node-test-commit/6602/