### PR TITLE
test: Allow all valid AIX rc in test-stdio-closed

### DIFF
--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -32,5 +32,8 @@ const cmd = `"${process.execPath}" "${__filename}" child 1>&- 2>&-`;
 const proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
 
 proc.on('exit', common.mustCall(function(exitCode) {
-  assert.strictEqual(exitCode, common.isAix ? 126 : 42);
+  if (common.isAix)
+    assert([42, 126].includes(exitCode));
+  else
+    assert.strictEqual(exitCode, 42);
 }));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes: https://github.com/nodejs/node/issues/10234

Allow either of the two possible return codes on AIX to
be considered successful on test-stdio-closed.js. This is likely
an interim solution until we can be sure when AIX returns
one or the other, but I currently have systems that have both
and I don't want this failing on any of them.