### PR TITLE
aix: fix os.release()

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -87,7 +87,8 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
   }
 # ifdef _AIX
   char release[256];
-  sprintf(release, "%s.%s", info.version, info.release);
+  snprintf(release, sizeof(release),
+           "%s.%s", info.version, info.release);
   rval = release;
 # else
   rval = info.release;

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -85,7 +85,13 @@ static void GetOSRelease(const FunctionCallbackInfo<Value>& args) {
   if (uname(&info) < 0) {
     return env->ThrowErrnoException(errno, "uname");
   }
+# ifdef _AIX
+  char release[256];
+  sprintf(release, "%s.%s", info.version, info.release);
+  rval = release;
+# else
   rval = info.release;
+# endif
 #else  // Windows
   char release[256];
   OSVERSIONINFOW info;

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -77,6 +77,9 @@ const release = os.release();
 console.log('release = ', release);
 is.string(release);
 assert.ok(release.length > 0);
+//TODO: Check format on more than just AIX
+if (common.isAix)
+  assert.ok(/^\d+\.\d+$/.test(release));
 
 const platform = os.platform();
 console.log('platform = ', platform);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)

##### Affected core subsystem(s)
os.release() on aix


##### Description of change
<!-- Provide a description of the change below this comment. -->
On AIX info.release is only a part of OS release version.
 We need to combine info.version and info.release
