### PR TITLE
core: properly skip tick_callback_function call

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1263,6 +1263,7 @@ Local<Value> MakeCallback(Environment* env,
 
   if (tick_info->length() == 0) {
     tick_info->set_index(0);
+    return ret;
   }
 
   if (env->tick_callback_function()->Call(process, 0, nullptr).IsEmpty()) {


### PR DESCRIPTION
This improves MakeCallback peformance a lot. See #10101 for a very tedious conversation with @trevnorris