### PR TITLE
win, watchdog: add flag to mark handler as disabled

### DIFF
--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -91,6 +91,7 @@ class SigintWatchdogHelper {
   static void* RunSigintWatchdog(void* arg);
   static void HandleSignal(int signum);
 #else
+  bool watchdog_disabled_;
   static BOOL WINAPI WinCtrlCHandlerRoutine(DWORD dwCtrlType);
 #endif
 };


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
win, watchdog

##### Description of change
When calling `process.exit` from `SIGHUP` handler current code tries to remove CTRL-C handler (`WinCtrlCHandlerRoutine`) by calling `SetConsoleCtrlHandler`. This however leads to deadlock, since `SetConsoleCtrlHandler` blocks util all control handlers exits.

This commit adds flags that marks `WinCtrlCHandlerRoutine` as disabled instead of removing it.

When https://github.com/libuv/libuv/pull/1168 lands, toogether it will fix https://github.com/nodejs/node/issues/10165

cc: @addaleax @bnoordhuis 