### PR TITLE
Cache non-symlinks in realpathSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1531,6 +1531,7 @@ fs.realpathSync = function realpathSync(p, options) {
       var stat = fs.lstatSync(base);
       if (!stat.isSymbolicLink()) {
         knownHard[base] = true;
+        if (cache) cache.set(base, base);
         continue;
       }
 


### PR DESCRIPTION
##### Background

The `fs.realpathSync` function synchronously traverses paths componentwise to resolve symbolic links.

The optional cache argument stores the results of resolution to avoid repeated lookups.  The cache can be used to override resolution and to store the results of calls to `readlinkSync`.

However, the cache only records paths that `lstat` reveals to be symlinks.  Consequently, a call to `fs.realpathSync` for a path without symlinks may result in many calls to `lstat`, even if most parts of the path have been resolved in an earlier call.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

This tiny patch extends `fs.realpathSync` to record the results for paths that are not symlinks.  The code suggests that this was originally the intention, since the cache [is expected to contain entries that resolve to themselves][self-entries]:

```javascript
cache.get(base) === base
```

With this patch a run of `ember build` on a fresh application makes around 6,200 fewer `lstat` calls (out of a total of around 70,000 syscalls).  On a typical native file system the performance difference is negligible, but in situations where a syscall has more significant overhead it can be a worthwhile saving.  For example, with a file system that forwards operations over a socket via FUSE this patch saves around 10% of the build time.

[self-entries]: https://github.com/nodejs/node/blob/3d353c749cdb64b2d018766d05ba0e9b9b0f7ec8/lib/fs.js#L1522
