### PR TITLE
test: improve code in test-child-process-kill

### DIFF
--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var spawn = require('child_process').spawn;
-var cat = spawn(common.isWindows ? 'cmd' : 'cat');
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+const cat = spawn(common.isWindows ? 'cmd' : 'cat');
 
 cat.stdout.on('end', common.mustCall(function() {}));
 cat.stderr.on('data', common.fail);
@@ -13,6 +13,6 @@ cat.on('exit', common.mustCall(function(code, signal) {
   assert.strictEqual(signal, 'SIGTERM');
 }));
 
-assert.equal(cat.killed, false);
+assert.strictEqual(cat.killed, false);
 cat.kill();
-assert.equal(cat.killed, true);
+assert.strictEqual(cat.killed, true);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

improve code in test-child-process-kill

* use const instead of var for includes
* replace assert.equal with assert.strictEqual