### PR TITLE
fs: remove needless assignment of null

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1794,7 +1794,6 @@ ReadStream.prototype._read = function(n) {
 
   if (!pool || pool.length - pool.used < kMinPoolSpace) {
     // discard the old pool.
-    pool = null;
     allocNewPool(this._readableState.highWaterMark);
   }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
streams

##### Description of change
This line `pool = null;` isn't needed and has been around since the first iteration of `fs.stream`. I can't find a good reason for it to exist, it's not more readable, nor does it seem to trick the compiler into any optimizations.
