### PR TITLE
doc: fix broken link in COLLABORATOR_GUIDE.md

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -126,7 +126,7 @@ information regarding the change process:
   - Protects against the assumption that GitHub will be around forever.
 
 Review the commit message to ensure that it adheres to the guidelines
-outlined in the [contributing](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit) guide.
+outlined in the [contributing](./CONTRIBUTING.md#step-3-commit) guide.
 
 See the commit log for examples such as
 [this one](https://github.com/nodejs/node/commit/b636ba8186) if unsure
@@ -237,7 +237,8 @@ Save the file and close the editor. You'll be asked to enter a new
 commit message for that commit. This is a good moment to fix incorrect
 commit logs, ensure that they are properly formatted, and add
 `Reviewed-By` lines.
-* The commit message text must conform to the [commit message guidelines](../CONTRIBUTING.md#step-3-commit).
+* The commit message text must conform to the
+[commit message guidelines](./CONTRIBUTING.md#step-3-commit).
 
 Time to push it:
 


### PR DESCRIPTION
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
One of the links to CONTRIBUTING.md was broke in the doc.
Updated broken link to be the same as the other one in the
doc that was working.