### PR TITLE
src: return early if nextTickQueue is empty

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1268,6 +1268,7 @@ Local<Value> MakeCallback(Environment* env,
 
   if (tick_info->length() == 0) {
     tick_info->set_index(0);
+    return ret;
   }
 
   if (env->tick_callback_function()->Call(process, 0, nullptr).IsEmpty()) {

--- a/test/parallel/test-no-enter-tickcallback.js
+++ b/test/parallel/test-no-enter-tickcallback.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+var allsGood = false;
+var cntr = 0;
+
+process.on('exit', () => {
+  assert.ok(cntr > 0, '_tickDomainCallback was never called');
+});
+
+/**
+ * This test relies upon the following internals to work as specified:
+ *  - require('domain') causes node::Environment::set_tick_callback_function()
+ *    to use process._tickDomainCallback() to process the nextTickQueue;
+ *    replacing process._tickCallback().
+ *  - setImmediate() uses node::MakeCallback() instead of
+ *    node::AsyncWrap::MakeCallback(). Otherwise the test will always pass.
+ *    Have not found a way to verify that node::MakeCallback() is used.
+ */
+process._tickDomainCallback = function _tickDomainCallback() {
+  assert.ok(allsGood, '_tickDomainCallback should not have been called');
+  cntr++;
+};
+
+setImmediate(common.mustCall(() => {
+  require('domain');
+  setImmediate(common.mustCall(() => setImmediate(common.mustCall(() => {
+    allsGood = true;
+    process.nextTick(() => {});
+  }))));
+}));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines


##### Description of change

This brings the `node::MakeCallback` and `node::AsyncWrap::MakeCallback`
implementations into alignment in that they return early if the
`nextTickQueue` is empty after processing the `MicrotaskQueue`.

Include test to make sure early return happens. Test has text explaining
the conditions for the test to pass, since it relies on internal
mechanisms that aren't guaranteed in the future.

R=@bnoordhuis 
R=@addaleax 

CI: https://ci.nodejs.org/job/node-test-commit/6652/