### PR TITLE
test: improve test-child-process-exec-buffer

### DIFF
--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -1,22 +1,24 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var exec = require('child_process').exec;
-var os = require('os');
-var str = 'hello';
+const assert = require('assert');
+const exec = require('child_process').exec;
+const os = require('os');
+const str = 'hello';
 
 // default encoding
 exec('echo ' + str, common.mustCall(function(err, stdout, stderr) {
-  assert.ok('string', typeof stdout, 'Expected stdout to be a string');
-  assert.ok('string', typeof stderr, 'Expected stderr to be a string');
-  assert.equal(str + os.EOL, stdout);
+  assert.strictEqual(typeof stdout, 'string', 'Expected stdout to be a string');
+  assert.strictEqual(typeof stderr, 'string', 'Expected stderr to be a string');
+  assert.strictEqual(str + os.EOL, stdout);
 }));
 
 // no encoding (Buffers expected)
 exec('echo ' + str, {
   encoding: null
 }, common.mustCall(function(err, stdout, stderr) {
-  assert.ok(stdout instanceof Buffer, 'Expected stdout to be a Buffer');
-  assert.ok(stderr instanceof Buffer, 'Expected stderr to be a Buffer');
-  assert.equal(str + os.EOL, stdout.toString());
+  assert.strictEqual(stdout instanceof Buffer, true,
+                     'Expected stdout to be a Buffer');
+  assert.strictEqual(stderr instanceof Buffer, true,
+                     'Expected stderr to be a Buffer');
+  assert.strictEqual(str + os.EOL, stdout.toString());
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use const instead of var for required modules
* use assert.strictEqual instead of assert.equal