### PR TITLE
src, lib: deprecate old debug-agent and CLI debugger

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -12,7 +12,7 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const Buffer = require('buffer').Buffer;
 
-exports.start = function(argv, stdin, stdout) {
+exports.start = function start(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));
 
   if (argv.length < 1) {
@@ -27,6 +27,7 @@ exports.start = function(argv, stdin, stdout) {
   stdout = stdout || process.stdout;
 
   const args = [`--debug-brk=${exports.port}`].concat(argv);
+  console.error('`node debug` is deprecated, use `node inspect` instead.\n');
   const interface_ = new Interface(stdin, stdout, args);
 
   stdin.resume();

--- a/src/node.cc
+++ b/src/node.cc
@@ -3460,7 +3460,6 @@ static void PrintHelp() {
   // XXX: If you add an option here, please also add it to doc/node.1 and
   // doc/api/cli.md
   printf("Usage: node [options] [ -e script | script.js ] [arguments] \n"
-         "       node debug script.js [arguments] \n"
          "\n"
          "Options:\n"
          "  -v, --version         print Node.js version\n"

--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -92,6 +92,9 @@ bool DebugOptions::ParseOption(const std::string& option) {
 
   if (option_name == "--debug") {
     debugger_enabled_ = true;
+    fprintf(stderr,
+            "--debug is deprecated and will be removed in "
+            "a future version. Please use --inspect instead.\n\n");
   } else if (option_name == "--debug-brk") {
     debugger_enabled_ = true;
     wait_connect_ = true;

--- a/test/parallel/test-debugger-pid.js
+++ b/test/parallel/test-debugger-pid.js
@@ -19,7 +19,6 @@ var onData = function(data) {
   });
 };
 interfacer.stdout.on('data', onData);
-interfacer.stderr.on('data', onData);
 
 var lineCount = 0;
 interfacer.on('line', function(line) {

--- a/test/parallel/test-debugger-util-regression.js
+++ b/test/parallel/test-debugger-util-regression.js
@@ -9,6 +9,11 @@ const fixture = path.join(
   'debugger-util-regression-fixture.js'
 );
 
+const deprecationWarning = [
+  '`node debug` is deprecated, ',
+  'use `node inspect` instead.\n\n'
+].join('');
+
 const args = [
   'debug',
   `--port=${common.PORT}`,
@@ -49,5 +54,6 @@ process.on('exit', (code) => {
   assert.strictEqual(code, 0, 'the program should exit cleanly');
   assert.strictEqual(stdout.includes('{ a: \'b\' }'), true,
                      'the debugger should print the result of util.inspect');
-  assert.strictEqual(stderr, '', 'stderr should be empty');
+  assert.strictEqual(stderr, deprecationWarning,
+                     'stderr should print deprecation warning');
 });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

src, debugger

##### Description of change
<!-- Provide a description of the change below this comment. -->

Per https://github.com/nodejs/node/issues/9789 the old V8 debugger and its protocol are on their way out 👋 .

This prints a deprecation warning to stderr when node is invoked with `--debug` or `debug`. `--debug` starts the debug-agent within the process; `debug` starts Node's builtin CLI debugger. Both utilize the old V8 debugger protocol.

V8 inspector and `--inspect` replace `--debug`. Work is underway to replace the CLI debugger (i.e. `node debug`), see https://github.com/nodejs/node/pull/10187.

I didn't use `util.deprecate` on the `_debugger.start()` function because it would print within the repl, i.e. prefixed with `debug> `.

/cc @nodejs/diagnostics 