### PR TITLE
src: improve hex encoding performance

### DIFF
--- a/benchmark/buffers/buffer-hex.js
+++ b/benchmark/buffers/buffer-hex.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  len: [0, 1, 64, 1024],
+  len: [0, 1, 4, 8, 16, 64, 1024],
   mode: ['enc', 'dec'],
   n: [1e7]
 });

--- a/benchmark/buffers/buffer-hex.js
+++ b/benchmark/buffers/buffer-hex.js
@@ -4,6 +4,7 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   len: [0, 1, 64, 1024],
+  mode: ['enc', 'dec'],
   n: [1e7]
 });
 
@@ -11,16 +12,24 @@ function main(conf) {
   const len = conf.len | 0;
   const n = conf.n | 0;
   const buf = Buffer.alloc(len);
+  const mode = conf.mode;
+  var hex;
+  var i;
 
-  for (let i = 0; i < buf.length; i++)
+  for (i = 0; i < buf.length; i++)
     buf[i] = i & 0xff;
 
-  const hex = buf.toString('hex');
+  if (mode === 'enc') {
+    bench.start();
+    for (i = 0; i < n; i += 1)
+      buf.toString('hex');
+    bench.end(n);
+  } else {
+    hex = buf.toString('hex');
 
-  bench.start();
-
-  for (let i = 0; i < n; i += 1)
-    Buffer.from(hex, 'hex');
-
-  bench.end(n);
+    bench.start();
+    for (i = 0; i < n; i += 1)
+      Buffer.from(hex, 'hex');
+    bench.end(n);
+  }
 }


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* buffer


##### Description of change

This commit improves hex encoding performance by converting more than one byte at a time and by avoiding the use of a lookup table.

Encoding benchmark results:

```
 buffers/buffer-hex.js n=10000000 mode="enc" len=1024    181.03 %         *** 1.144588e-22
 buffers/buffer-hex.js n=10000000 mode="enc" len=64       31.83 %         *** 2.142052e-05
```

For fun I tested it on arm64 too, although I had to lower `n` to get it to finish in a reasonable amount of time:

```
 buffers/buffer-hex.js n=100000 mode="enc" len=1024     85.52 %         *** 4.753473e-33
 buffers/buffer-hex.js n=100000 mode="enc" len=64       10.60 %         *** 1.176254e-15
```

<s>CI: https://ci.nodejs.org/job/node-test-pull-request/5414/</s>
<s>CI: https://ci.nodejs.org/job/node-test-pull-request/5431/</s>
CI: https://ci.nodejs.org/job/node-test-pull-request/5436/