### PR TITLE
repl: allow autocompletion for scoped packages

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -788,7 +788,7 @@ ArrayStream.prototype.writable = true;
 ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
-const requireRE = /\brequire\s*\(['"](([\w./-]+\/)?([\w./-]*))/;
+const requireRE = /\brequire\s*\(['"](([\w@./-]+\/)?([\w@./-]*))/;
 const simpleExpressionRE =
     /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
 

--- a/test/fixtures/node_modules/@nodejsscope/index.js
+++ b/test/fixtures/node_modules/@nodejsscope/index.js
@@ -1,0 +1,1 @@
+// Not used

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -1,8 +1,14 @@
 'use strict';
 
-var common = require('../common');
-var assert = require('assert');
-var repl = require('repl');
+const common = require('../common');
+const assert = require('assert');
+
+// We have to change the directory to ../fixtures before requiring repl
+// in order to make the tests for completion of node_modules work properly
+// since repl modifies module.paths.
+process.chdir(common.fixturesDir);
+
+const repl = require('repl');
 
 function getNoResultsFunction() {
   return common.mustCall((err, data) => {
@@ -195,6 +201,15 @@ testMe.complete('require(\'n', common.mustCall(function(error, data) {
       assert(/^n/.test(completion));
   });
 }));
+
+{
+  const expected = ['@nodejsscope', '@nodejsscope/'];
+  putIn.run(['.clear']);
+  testMe.complete('require(\'@nodejs', common.mustCall((err, data) => {
+    assert.strictEqual(err, null);
+    assert.deepStrictEqual(data, [expected, '@nodejs']);
+  }));
+}
 
 // Make sure tab completion works on context properties
 putIn.run(['.clear']);


### PR DESCRIPTION

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
repl


##### Description of change

Previously, autocompletion of scoped packages was not supported by the
repl due to not including the `@` character in the regular expression.