### PR TITLE
test: stream readable resumeScheduled state

### DIFF
--- a/test/parallel/test-stream-readable-resumeScheduled.js
+++ b/test/parallel/test-stream-readable-resumeScheduled.js
@@ -1,0 +1,65 @@
+'use strict';
+const common = require('../common');
+
+// Testing Readable Stream resumeScheduled state
+
+const assert = require('assert');
+const { Readable, Writable } = require('stream');
+
+{
+  // pipe() test case
+  const r = new Readable({ read() {} });
+  const w = new Writable();
+
+  // resumeScheduled should start = `false`.
+  assert.strictEqual(r._readableState.resumeScheduled, false);
+
+  // calling pipe() should change the state value = true.
+  r.pipe(w);
+  assert.strictEqual(r._readableState.resumeScheduled, true);
+
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(r._readableState.resumeScheduled, false);
+  }));
+}
+
+{
+  // 'data' listener test case
+  const r = new Readable({ read() {} });
+
+  // resumeScheduled should start = `false`.
+  assert.strictEqual(r._readableState.resumeScheduled, false);
+
+  r.push(Buffer.from([1, 2, 3]));
+
+  // adding 'data' listener should change the state value
+  r.on('data', common.mustCall(() => {
+    assert.strictEqual(r._readableState.resumeScheduled, false);
+  }));
+  assert.strictEqual(r._readableState.resumeScheduled, true);
+
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(r._readableState.resumeScheduled, false);
+  }));
+}
+
+{
+  // resume() test case
+  const r = new Readable({ read() {} });
+
+  // resumeScheduled should start = `false`.
+  assert.strictEqual(r._readableState.resumeScheduled, false);
+
+  // Calling resume() should change the state value.
+  r.resume();
+  assert.strictEqual(r._readableState.resumeScheduled, true);
+
+  r.on('resume', common.mustCall(() => {
+    // The state value should be `false` again
+    assert.strictEqual(r._readableState.resumeScheduled, false);
+  }));
+
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(r._readableState.resumeScheduled, false);
+  }));
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test


##### Description of change
Adding test for the `resumeScheduled` state in stream.Readable

Ref: https://github.com/nodejs/node/issues/8683
CI: https://ci.nodejs.org/job/node-test-pull-request/5446/console

cc: @mcollina 