### PR TITLE
util: add %i and %f formatting specifiers

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -103,7 +103,8 @@ Each placeholder token is replaced with the converted value from the
 corresponding argument. Supported placeholders are:
 
 * `%s` - String.
-* `%d` - Number (both integer and float).
+* `%d` or `%i` - Integer.
+* `%f` - Floating point value.
 * `%j` - JSON.  Replaced with the string `'[Circular]'` if the argument
 contains circular references.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -103,7 +103,8 @@ Each placeholder token is replaced with the converted value from the
 corresponding argument. Supported placeholders are:
 
 * `%s` - String.
-* `%d` or `%i` - Integer.
+* `%d` - Number (integer or floating point value).
+* `%i` - Integer.
 * `%f` - Floating point value.
 * `%j` - JSON.  Replaced with the string `'[Circular]'` if the argument
 contains circular references.

--- a/lib/util.js
+++ b/lib/util.js
@@ -79,6 +79,13 @@ exports.format = function(f) {
     if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
       switch (f.charCodeAt(i + 1)) {
         case 100: // 'd'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += Number(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
         case 105: // 'i'
           if (a >= argLen)
             break;

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,6 +38,14 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
+const formatters = {
+  d: Number,
+  i: parseInt,
+  f: parseFloat,
+  j: tryStringify,
+  s: String
+};
+
 var CIRCULAR_ERROR_MESSAGE;
 var Debug;
 
@@ -75,55 +83,23 @@ exports.format = function(f) {
   var str = '';
   var a = 1;
   var lastPos = 0;
+
   for (var i = 0; i < f.length;) {
-    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
-      switch (f.charCodeAt(i + 1)) {
-        case 100: // 'd'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += Number(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 105: // 'i'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += parseInt(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 102: // 'f'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += parseFloat(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 106: // 'j'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += tryStringify(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 115: // 's'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += String(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 37: // '%'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += '%';
-          lastPos = i = i + 2;
-          continue;
+    if (f[i] === '%' && i + 1 < f.length) {
+      if (formatters[f[i + 1]]) {
+        if (a >= argLen)
+          break;
+        if (lastPos < i)
+          str += f.slice(lastPos, i);
+        str += formatters[f[i + 1]](arguments[a++]);
+        lastPos = i = i + 2;
+        continue;
+      } else if (f[i + 1] === '%') {
+        if (lastPos < i)
+          str += f.slice(lastPos, i);
+        str += '%';
+        lastPos = i = i + 2;
+        continue;
       }
     }
     ++i;

--- a/lib/util.js
+++ b/lib/util.js
@@ -79,11 +79,20 @@ exports.format = function(f) {
     if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
       switch (f.charCodeAt(i + 1)) {
         case 100: // 'd'
+        case 105: // 'i'
           if (a >= argLen)
             break;
           if (lastPos < i)
             str += f.slice(lastPos, i);
-          str += Number(arguments[a++]);
+          str += parseInt(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 102: // 'f'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += parseFloat(arguments[a++]);
           lastPos = i = i + 2;
           continue;
         case 106: // 'j'

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,14 +38,6 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
-const formatters = {
-  d: Number,
-  i: parseInt,
-  f: parseFloat,
-  j: tryStringify,
-  s: String
-};
-
 var CIRCULAR_ERROR_MESSAGE;
 var Debug;
 
@@ -83,23 +75,55 @@ exports.format = function(f) {
   var str = '';
   var a = 1;
   var lastPos = 0;
-
   for (var i = 0; i < f.length;) {
-    if (f[i] === '%' && i + 1 < f.length) {
-      if (formatters[f[i + 1]]) {
-        if (a >= argLen)
-          break;
-        if (lastPos < i)
-          str += f.slice(lastPos, i);
-        str += formatters[f[i + 1]](arguments[a++]);
-        lastPos = i = i + 2;
-        continue;
-      } else if (f[i + 1] === '%') {
-        if (lastPos < i)
-          str += f.slice(lastPos, i);
-        str += '%';
-        lastPos = i = i + 2;
-        continue;
+    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
+      switch (f.charCodeAt(i + 1)) {
+        case 100: // 'd'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += Number(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 105: // 'i'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += parseInt(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 102: // 'f'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += parseFloat(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 106: // 'j'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += tryStringify(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 115: // 's'
+          if (a >= argLen)
+            break;
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += String(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        case 37: // '%'
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += '%';
+          lastPos = i = i + 2;
+          continue;
       }
     }
     ++i;

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -48,15 +48,17 @@ assert.throws(function() {
   util.format('%d', symbol);
 }, TypeError);
 
-// Integer format specifier
+// Number format specifier
 assert.strictEqual(util.format('%d'), '%d');
 assert.strictEqual(util.format('%d', 42.0), '42');
 assert.strictEqual(util.format('%d', 42), '42');
 assert.strictEqual(util.format('%d', '42'), '42');
 assert.strictEqual(util.format('%d', '42.0'), '42');
-assert.strictEqual(util.format('%d', 1.5), '1');
-assert.strictEqual(util.format('%d', -0.5), '0');
-assert.strictEqual(util.format('%d', ''), 'NaN');
+assert.strictEqual(util.format('%d', 1.5), '1.5');
+assert.strictEqual(util.format('%d', -0.5), '-0.5');
+assert.strictEqual(util.format('%d', ''), '0');
+
+// Integer format specifier
 assert.strictEqual(util.format('%i'), '%i');
 assert.strictEqual(util.format('%i', 42.0), '42');
 assert.strictEqual(util.format('%i', 42), '42');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -48,21 +48,49 @@ assert.throws(function() {
   util.format('%d', symbol);
 }, TypeError);
 
+// Integer format specifier
+assert.strictEqual(util.format('%d'), '%d');
 assert.strictEqual(util.format('%d', 42.0), '42');
 assert.strictEqual(util.format('%d', 42), '42');
-assert.strictEqual(util.format('%s', 42), '42');
-assert.strictEqual(util.format('%j', 42), '42');
-
-assert.strictEqual(util.format('%d', '42.0'), '42');
 assert.strictEqual(util.format('%d', '42'), '42');
-assert.strictEqual(util.format('%s', '42'), '42');
-assert.strictEqual(util.format('%j', '42'), '"42"');
+assert.strictEqual(util.format('%d', '42.0'), '42');
+assert.strictEqual(util.format('%d', 1.5), '1');
+assert.strictEqual(util.format('%d', -0.5), '0');
+assert.strictEqual(util.format('%d', ''), 'NaN');
+assert.strictEqual(util.format('%i'), '%i');
+assert.strictEqual(util.format('%i', 42.0), '42');
+assert.strictEqual(util.format('%i', 42), '42');
+assert.strictEqual(util.format('%i', '42'), '42');
+assert.strictEqual(util.format('%i', '42.0'), '42');
+assert.strictEqual(util.format('%i', 1.5), '1');
+assert.strictEqual(util.format('%i', -0.5), '0');
+assert.strictEqual(util.format('%i', ''), 'NaN');
 
-assert.strictEqual(util.format('%%s%s', 'foo'), '%sfoo');
+// Float format specifier
+assert.strictEqual(util.format('%f'), '%f');
+assert.strictEqual(util.format('%f', 42.0), '42');
+assert.strictEqual(util.format('%f', 42), '42');
+assert.strictEqual(util.format('%f', '42'), '42');
+assert.strictEqual(util.format('%f', '42.0'), '42');
+assert.strictEqual(util.format('%f', 1.5), '1.5');
+assert.strictEqual(util.format('%f', -0.5), '-0.5');
+assert.strictEqual(util.format('%f', Math.PI), '3.141592653589793');
+assert.strictEqual(util.format('%f', ''), 'NaN');
 
+// String format specifier
 assert.strictEqual(util.format('%s'), '%s');
 assert.strictEqual(util.format('%s', undefined), 'undefined');
 assert.strictEqual(util.format('%s', 'foo'), 'foo');
+assert.strictEqual(util.format('%s', 42), '42');
+assert.strictEqual(util.format('%s', '42'), '42');
+
+// JSON format specifier
+assert.strictEqual(util.format('%j'), '%j');
+assert.strictEqual(util.format('%j', 42), '42');
+assert.strictEqual(util.format('%j', '42'), '"42"');
+
+// Various format specifiers
+assert.strictEqual(util.format('%%s%s', 'foo'), '%sfoo');
 assert.strictEqual(util.format('%s:%s'), '%s:%s');
 assert.strictEqual(util.format('%s:%s', undefined), 'undefined:%s');
 assert.strictEqual(util.format('%s:%s', 'foo'), 'foo:%s');
@@ -71,11 +99,9 @@ assert.strictEqual(util.format('%s:%s', 'foo', 'bar', 'baz'), 'foo:bar baz');
 assert.strictEqual(util.format('%%%s%%', 'hi'), '%hi%');
 assert.strictEqual(util.format('%%%s%%%%', 'hi'), '%hi%%');
 assert.strictEqual(util.format('%sbc%%def', 'a'), 'abc%def');
-
 assert.strictEqual(util.format('%d:%d', 12, 30), '12:30');
 assert.strictEqual(util.format('%d:%d', 12), '12:%d');
 assert.strictEqual(util.format('%d:%d'), '%d:%d');
-
 assert.strictEqual(util.format('o: %j, a: %j', {}, []), 'o: {}, a: []');
 assert.strictEqual(util.format('o: %j, a: %j', {}), 'o: {}, a: %j');
 assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
util

##### Description of change
This change brings formatting specifiers available in `util.format` and consequently, `console.*` closer to what is supported in all major browsers. There is a breaking change with the `%d` specifier which previously served a double purpose of formatting both integer and floats. With this change, it will format only as integer.

- `%d` is being changed to format only as integer.
- `%i` is introduced as an alias to `%d`.
- `%f` is introduced to format floating point values.

When updating code, all instances of `%d` format strings that were supplied with floats should be changed to the `%f` format string.

Fixes: https://github.com/nodejs/node/issues/10292