### PR TITLE
doc: clarify macosx-firewall suggestion BUILDING

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,7 +24,7 @@ On OS X, you will also need:
     this under the menu `Xcode -> Preferences -> Downloads`
   * This step will install `gcc` and the related toolchain containing `make`
 
-* You may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid
+* After building, you may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid
 popups asking to accept incoming network connections when running tests:
 
 ```console

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,8 +24,8 @@ On OS X, you will also need:
     this under the menu `Xcode -> Preferences -> Downloads`
   * This step will install `gcc` and the related toolchain containing `make`
 
-* After building, you may want to setup [firewall rules](tools/macosx-firewall.sh) to avoid
-popups asking to accept incoming network connections when running tests:
+* After building, you may want to setup [firewall rules](tools/macosx-firewall.sh)
+to avoid popups asking to accept incoming network connections when running tests:
 
 ```console
 $ sudo ./tools/macosx-firewall.sh


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->

`./tools/macosx-firewall.sh` fails if run before build step. Since the
suggestion comes before the build steps in the document, this change
clarifies that the script should be run after building.