### PR TITLE
test: improve code in test-fs-open.js

### DIFF
--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -1,27 +1,24 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
+const assert = require('assert');
+const fs = require('fs');
 
-var caughtException = false;
+let caughtException = false;
+
 try {
   // should throw ENOENT, not EBADF
   // see https://github.com/joyent/node/pull/1228
   fs.openSync('/path/to/file/that/does/not/exist', 'r');
 } catch (e) {
-  assert.equal(e.code, 'ENOENT');
+  assert.strictEqual(e.code, 'ENOENT');
   caughtException = true;
 }
-assert.ok(caughtException);
+assert.strictEqual(caughtException, true);
 
-fs.open(__filename, 'r', common.mustCall(function(err, fd) {
-  if (err) {
-    throw err;
-  }
+fs.open(__filename, 'r', common.mustCall((err) => {
+  assert.ifError(err);
 }));
 
-fs.open(__filename, 'rs', common.mustCall(function(err, fd) {
-  if (err) {
-    throw err;
-  }
+fs.open(__filename, 'rs', common.mustCall((err) => {
+  assert.ifError(err);
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use const instead of var for required modules
* use assert.strictEqual instead of assert.equal
* use assert.strictEqual instead of assert.ok
* use assert.ifError
