### PR TITLE
test: refactor test-timers-this

### DIFF
--- a/test/parallel/test-timers-this.js
+++ b/test/parallel/test-timers-this.js
@@ -1,45 +1,29 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
-let immediateThis, intervalThis, timeoutThis;
-let immediateArgsThis, intervalArgsThis, timeoutArgsThis;
+const immediateHandler = setImmediate(common.mustCall(function() {
+  assert.strictEqual(this, immediateHandler);
+}));
 
-var immediateHandler = setImmediate(function() {
-  immediateThis = this;
-});
+const immediateArgsHandler = setImmediate(common.mustCall(function() {
+  assert.strictEqual(this, immediateArgsHandler);
+}), 'args ...');
 
-var immediateArgsHandler = setImmediate(function() {
-  immediateArgsThis = this;
-}, 'args ...');
-
-var intervalHandler = setInterval(function() {
+const intervalHandler = setInterval(common.mustCall(function() {
   clearInterval(intervalHandler);
+  assert.strictEqual(this, intervalHandler);
+}), 1);
 
-  intervalThis = this;
-});
-
-var intervalArgsHandler = setInterval(function() {
+const intervalArgsHandler = setInterval(common.mustCall(function() {
   clearInterval(intervalArgsHandler);
+  assert.strictEqual(this, intervalArgsHandler);
+}), 1, 'args ...');
 
-  intervalArgsThis = this;
-}, 0, 'args ...');
+const timeoutHandler = setTimeout(common.mustCall(function() {
+  assert.strictEqual(this, timeoutHandler);
+}), 1);
 
-var timeoutHandler = setTimeout(function() {
-  timeoutThis = this;
-});
-
-var timeoutArgsHandler = setTimeout(function() {
-  timeoutArgsThis = this;
-}, 0, 'args ...');
-
-process.once('exit', function() {
-  assert.strictEqual(immediateThis, immediateHandler);
-  assert.strictEqual(immediateArgsThis, immediateArgsHandler);
-
-  assert.strictEqual(intervalThis, intervalHandler);
-  assert.strictEqual(intervalArgsThis, intervalArgsHandler);
-
-  assert.strictEqual(timeoutThis, timeoutHandler);
-  assert.strictEqual(timeoutArgsThis, timeoutArgsHandler);
-});
+const timeoutArgsHandler = setTimeout(common.mustCall(function() {
+  assert.strictEqual(this, timeoutArgsHandler);
+}), 1, 'args ...');


### PR DESCRIPTION
* use common.mustCall() and eliminate exit handler
* provide timer durtion of 1ms where previously omitted
* var -> const

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
