### PR TITLE
test: improve code in test-http-bind-twice.js

### DIFF
--- a/test/parallel/test-http-bind-twice.js
+++ b/test/parallel/test-http-bind-twice.js
@@ -1,15 +1,15 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var http = require('http');
+const assert = require('assert');
+const http = require('http');
 
-var server1 = http.createServer(common.fail);
+const server1 = http.createServer(common.fail);
 server1.listen(0, '127.0.0.1', common.mustCall(function() {
-  var server2 = http.createServer(common.fail);
+  const server2 = http.createServer(common.fail);
   server2.listen(this.address().port, '127.0.0.1', common.fail);
 
   server2.on('error', common.mustCall(function(e) {
-    assert.equal(e.code, 'EADDRINUSE');
+    assert.strictEqual(e.code, 'EADDRINUSE');
     server1.close();
   }));
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use const instead of var for required modules
* use assert.strictEqual instead of assert.equal
