### PR TITLE
test: add known_issues test for #5350

### DIFF
--- a/test/known_issues/test-vm-inherited_properties.js
+++ b/test/known_issues/test-vm-inherited_properties.js
@@ -1,0 +1,20 @@
+'use strict';
+// Ref: https://github.com/nodejs/node/issues/5350
+
+require('../common');
+const vm = require('vm');
+const assert = require('assert');
+
+const base = {
+  propBase: 1
+};
+
+const sandbox = Object.create(base, {
+  propSandbox: {value: 3}
+});
+
+const context = vm.createContext(sandbox);
+
+const result = vm.runInContext('this.hasOwnProperty("propBase");', context);
+
+assert.strictEqual(result, false);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tests

##### Description of change
<!-- Provide a description of the change below this comment. -->
A test addressing subproblem of #5350 
`inherited properties flattened in the vm.runInNewContext`
is added to the known_issues directory.
It will be fixed with the 5.5 V8 API changes

#5350 is a consequence of the above as flattening of sandbox 
inherited properties happens first inside the vm context 
and is subsequently translated onto the outer sandbox.
```assert.strictEqual(sandbox.hasOwnProperty('propBase'), false); ```
