### PR TITLE
test: add known_issues test for #2734

### DIFF
--- a/test/known_issues/test-vm-accessor_properties.js
+++ b/test/known_issues/test-vm-accessor_properties.js
@@ -1,0 +1,25 @@
+'use strict';
+// Ref: https://github.com/nodejs/node/issues/2734
+
+require('../common');
+const vm = require('vm');
+const assert = require('assert');
+
+
+const sandbox = Object.create(null, {
+  prop: {
+    get: function() { return 'foo';}
+  }
+});
+
+const context = vm.createContext(sandbox);
+
+const script = `
+              Object.getOwnPropertyDescriptor(this, 'prop');
+              `;
+
+const result = vm.runInContext(script, context);
+
+// accessor property is flattened to data property with the value
+// returned by the getter and 'writable: true'
+assert.strictEqual(result.value, undefined); // returns 'foo'


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tests

##### Description of change
<!-- Provide a description of the change below this comment. -->

A test addressing #2734
`accessor properties get converted to data properties inside the vm`
is added to the known_issues directory.
It will be fixed with the 5.5 V8 API changes