### PR TITLE
doc: require() tries first core not native modules

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -368,11 +368,11 @@ example, then `require('./some-library')` would attempt to load:
 
 <!--type=misc-->
 
-If the module identifier passed to `require()` is not a native module,
-and does not begin with `'/'`, `'../'`, or `'./'`, then Node.js starts at the
-parent directory of the current module, and adds `/node_modules`, and
-attempts to load the module from that location. Node will not append
-`node_modules` to a path already ending in `node_modules`.
+If the module identifier passed to `require()` is not a
+[core](#modules_core_modules) module, and does not begin with `'/'`, `'../'`, or
+`'./'`, then Node.js starts at the parent directory of the current module, and
+adds `/node_modules`, and attempts to load the module from that location. Node
+will not append `node_modules` to a path already ending in `node_modules`.
 
 If it is not found there, then it moves to the parent directory, and so
 on, until the root of the file system is reached.


### PR DESCRIPTION
All core modules are native but not all native modules are in core.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->
Change a single word in documentation with a more precise one.