### PR TITLE
 doc: fix broken link in COLLABORATOR_GUIDE.md

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -36,7 +36,7 @@ Collaborators or additional evidence that the issue has relevance, the
 issue may be closed. Remember that issues can always be re-opened if
 necessary.
 
-[**See "Who to CC in issues"**](./onboarding-extras.md#who-to-cc-in-issues)
+[**See "Who to CC in issues"**](./docs/onboarding-extras.md#who-to-cc-in-issues)
 
 ## Accepting Modifications
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -36,7 +36,7 @@ Collaborators or additional evidence that the issue has relevance, the
 issue may be closed. Remember that issues can always be re-opened if
 necessary.
 
-[**See "Who to CC in issues"**](./docs/onboarding-extras.md#who-to-cc-in-issues)
+[**See "Who to CC in issues"**](./doc/onboarding-extras.md#who-to-cc-in-issues)
 
 ## Accepting Modifications
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

##### Description of change
<!-- Provide a description of the change below this comment. -->
The link to the onboarding-extras.md document is broken and can not be called in COLLABORATOR_GUIDE.md as it is now located in the folder docs. I've changed the link that it points to the document.