### PR TITLE
test: only check fd 0,1,2 are used and not their access modes

### DIFF
--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const fs = require('fs');
 
 if (common.isWindows) {
   common.skip('platform not supported.');
@@ -9,21 +10,7 @@ if (common.isWindows) {
 }
 
 if (process.argv[2] === 'child') {
-  try {
-    process.stdout.write('stdout', function() {
-      try {
-        process.stderr.write('stderr', function() {
-          process.exit(42);
-        });
-      } catch (e) {
-        process.exit(84);
-      }
-    });
-  } catch (e) {
-    assert.strictEqual(e.code, 'EBADF');
-    assert.strictEqual(e.message, 'EBADF: bad file descriptor, write');
-    process.exit(126);
-  }
+  [0, 1, 2].forEach((i) => assert.doesNotThrow(() => fs.fstatSync(i)));
   return;
 }
 
@@ -32,5 +19,5 @@ const cmd = `"${process.execPath}" "${__filename}" child 1>&- 2>&-`;
 const proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
 
 proc.on('exit', common.mustCall(function(exitCode) {
-  assert.strictEqual(exitCode, common.isAix ? 126 : 42);
+  assert.strictEqual(exitCode, 0);
 }));


### PR DESCRIPTION
Don't do a write on stdout/stderr because that checks for their
writability. But fd=1 could legitimately be opened with read-only access by the user.
What this test needs to only ensure is that they are used at startup.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test


##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes: https://github.com/nodejs/node/issues/10234