### PR TITLE
inspector: do not rely on debug context

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -499,8 +499,10 @@
     return NativeModule._source[id];
   };
 
-  NativeModule.wrap = function(script) {
-    return NativeModule.wrapper[0] + script + NativeModule.wrapper[1];
+  NativeModule.wrap = function(script, breakOnStart) {
+    const debug = breakOnStart ? 'debugger;' : '';
+    return NativeModule.wrapper[0] + debug + script +
+           NativeModule.wrapper[1];
   };
 
   NativeModule.wrapper = [

--- a/lib/module.js
+++ b/lib/module.js
@@ -536,17 +536,12 @@ Module.prototype._compile = function(content, filename) {
       }
     }
   }
+  var isScript = process._eval == null;
+  var debugWait = isScript && process._debugWaitConnect;
+  var inspectorWait = isScript && process._inspectorWaitConnect;
+  var isMainFile = false;
 
-  // create wrapper function
-  var wrapper = Module.wrap(content);
-
-  var compiledWrapper = vm.runInThisContext(wrapper, {
-    filename: filename,
-    lineOffset: 0,
-    displayErrors: true
-  });
-
-  if (process._debugWaitConnect && process._eval == null) {
+  if (debugWait || inspectorWait) {
     if (!resolvedArgv) {
       // we enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
@@ -555,13 +550,26 @@ Module.prototype._compile = function(content, filename) {
         resolvedArgv = 'repl';
       }
     }
+    isMainFile = filename === resolvedArgv;
+  }
 
-    // Set breakpoint on module start
-    if (filename === resolvedArgv) {
-      delete process._debugWaitConnect;
-      const Debug = vm.runInDebugContext('Debug');
-      Debug.setBreakPoint(compiledWrapper, 0, 0);
-    }
+  // create wrapper function
+  var wrapper = Module.wrap(content, inspectorWait && isMainFile);
+
+  var compiledWrapper = vm.runInThisContext(wrapper, {
+    filename: filename,
+    lineOffset: 0,
+    displayErrors: true
+  });
+
+  // Set breakpoint on module start
+  if (debugWait && isMainFile) {
+    delete process._debugWaitConnect;
+    const Debug = vm.runInDebugContext('Debug');
+    Debug.setBreakPoint(compiledWrapper, 0, 0);
+  }
+  if (inspectorWait && isMainFile) {
+    delete process._inspectorWaitConnect;
   }
   var dirname = path.dirname(filename);
   var require = internalModule.makeRequireFunction.call(this);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3265,7 +3265,11 @@ void SetupProcessObject(Environment* env,
 
   // --debug-brk
   if (debug_options.wait_for_connect()) {
-    READONLY_PROPERTY(process, "_debugWaitConnect", True(env->isolate()));
+    if (debug_options.inspector_enabled()) {
+      READONLY_PROPERTY(process, "_inspectorWaitConnect", True(env->isolate()));
+    } else {
+      READONLY_PROPERTY(process, "_debugWaitConnect", True(env->isolate()));
+    }
   }
 
   // --security-revert flags


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
inspector: switched to setting the breakpoint by adding a statement
debug: code refactored


##### Description of change
This change removes a need for the V8 debug context for setting up
initial breakpoint. The new approach to setting the breakpoint is to add
'debugger;' statement to the script wrapper.
