### PR TITLE
test: refactor the code in test-http-keep-alive

### DIFF
--- a/test/parallel/test-http-keep-alive.js
+++ b/test/parallel/test-http-keep-alive.js
@@ -1,51 +1,51 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-var http = require('http');
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
 
-var body = 'hello world\n';
+const server = http.createServer(common.mustCall((req, res) => {
+  const body = 'hello world\n';
 
-var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Length': body.length});
   res.write(body);
   res.end();
-});
+}, 3));
 
-var agent = new http.Agent({maxSockets: 1});
-var headers = {'connection': 'keep-alive'};
-var name;
+const agent = new http.Agent({maxSockets: 1});
+const headers = {'connection': 'keep-alive'};
+let name;
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   name = agent.getName({ port: this.address().port });
   http.get({
     path: '/', headers: headers, port: this.address().port, agent: agent
-  }, function(response) {
-    assert.equal(agent.sockets[name].length, 1);
-    assert.equal(agent.requests[name].length, 2);
+  }, common.mustCall((response) => {
+    assert.strictEqual(agent.sockets[name].length, 1);
+    assert.strictEqual(agent.requests[name].length, 2);
     response.resume();
-  });
+  }));
 
   http.get({
     path: '/', headers: headers, port: this.address().port, agent: agent
-  }, function(response) {
-    assert.equal(agent.sockets[name].length, 1);
-    assert.equal(agent.requests[name].length, 1);
+  }, common.mustCall((response) => {
+    assert.strictEqual(agent.sockets[name].length, 1);
+    assert.strictEqual(agent.requests[name].length, 1);
     response.resume();
-  });
+  }));
 
   http.get({
     path: '/', headers: headers, port: this.address().port, agent: agent
-  }, function(response) {
-    response.on('end', function() {
-      assert.equal(agent.sockets[name].length, 1);
+  }, common.mustCall((response) => {
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(agent.sockets[name].length, 1);
       assert(!agent.requests.hasOwnProperty(name));
       server.close();
-    });
+    }));
     response.resume();
-  });
-});
+  }));
+}));
 
-process.on('exit', function() {
+process.on('exit', () => {
   assert(!agent.sockets.hasOwnProperty(name));
   assert(!agent.requests.hasOwnProperty(name));
 });


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use common.mustCall to control the functions execution automatically
* use let and const instead of var
* use assert.strictEqual instead assert.equal
