### PR TITLE
deps: define missing operator delete functions

### DIFF
--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -598,6 +598,11 @@ HandleScope::~HandleScope() {
 }
 
 
+void HandleScope::operator delete(void*, size_t) {
+  base::OS::Abort();
+}
+
+
 int HandleScope::NumberOfHandles(Isolate* isolate) {
   return i::HandleScope::NumberOfHandles(
       reinterpret_cast<i::Isolate*>(isolate));
@@ -620,6 +625,11 @@ EscapableHandleScope::EscapableHandleScope(Isolate* v8_isolate) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
   escape_slot_ = CreateHandle(isolate, isolate->heap()->the_hole_value());
   Initialize(v8_isolate);
+}
+
+
+void EscapableHandleScope::operator delete(void*, size_t) {
+  base::OS::Abort();
 }
 
 
@@ -655,6 +665,11 @@ SealHandleScope::~SealHandleScope() {
   current->level = prev_level_;
   DCHECK_EQ(current->next, current->limit);
   current->limit = prev_limit_;
+}
+
+
+void SealHandleScope::operator delete(void*, size_t) {
+  base::OS::Abort();
 }
 
 
@@ -1881,6 +1896,11 @@ v8::TryCatch::~TryCatch() {
     isolate_->UnregisterTryCatchHandler(this);
     v8::internal::SimulatorStack::UnregisterCTryCatch();
   }
+}
+
+
+void v8::TryCatch::operator delete(void*, size_t) {
+  base::OS::Abort();
 }
 
 
@@ -6446,6 +6466,11 @@ void Isolate::AddGCEpilogueCallback(GCEpilogueCallback callback,
 void Isolate::RemoveGCEpilogueCallback(GCEpilogueCallback callback) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(this);
   isolate->heap()->RemoveGCEpilogueCallback(callback);
+}
+
+
+void Isolate::operator delete(void*, size_t) {
+  base::OS::Abort();
 }
 
 

--- a/deps/v8/src/version.cc
+++ b/deps/v8/src/version.cc
@@ -35,7 +35,7 @@
 #define MAJOR_VERSION     3
 #define MINOR_VERSION     28
 #define BUILD_NUMBER      71
-#define PATCH_LEVEL 19
+#define PATCH_LEVEL 20
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)
 #define IS_CANDIDATE_VERSION 0


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/10173, includes the changes to Isolate and SealHandleScope.

Section 3.2 of the C++ standard states that destructor definitions
implicitly "use" operator delete functions. Therefore, these operator
delete functions must be defined even if they are never called by
user code explicitly.
http://www.open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#261

gcc allows them to remain as empty definitions. However, not all
compilers allow this.

This pull request creates definitions which if ever called, result
in an abort.

@jBarz I've used your ca.ibm.com email address as the author email.

CI: https://ci.nodejs.org/job/node-test-pull-request/5487/