### PR TITLE
test: refactor the code in test-fs-watch.js

### DIFF
--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -1,25 +1,25 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var path = require('path');
-var fs = require('fs');
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
 
-var expectFilePath = common.isWindows ||
-                     common.isLinux ||
-                     common.isOSX;
+const expectFilePath = common.isWindows ||
+                       common.isLinux ||
+                       common.isOSX;
 
-var watchSeenOne = 0;
-var watchSeenTwo = 0;
-var watchSeenThree = 0;
+let watchSeenOne = 0;
+let watchSeenTwo = 0;
+let watchSeenThree = 0;
 
-var testDir = common.tmpDir;
+const testDir = common.tmpDir;
 
-var filenameOne = 'watch.txt';
-var filepathOne = path.join(testDir, filenameOne);
+const filenameOne = 'watch.txt';
+const filepathOne = path.join(testDir, filenameOne);
 
-var filenameTwo = 'hasOwnProperty';
-var filepathTwo = filenameTwo;
-var filepathTwoAbs = path.join(testDir, filenameTwo);
+const filenameTwo = 'hasOwnProperty';
+const filepathTwo = filenameTwo;
+const filepathTwoAbs = path.join(testDir, filenameTwo);
 
 process.on('exit', function() {
   assert.ok(watchSeenOne > 0);
@@ -33,12 +33,12 @@ fs.writeFileSync(filepathOne, 'hello');
 
 assert.doesNotThrow(
     function() {
-      var watcher = fs.watch(filepathOne);
+      const watcher = fs.watch(filepathOne);
       watcher.on('change', function(event, filename) {
-        assert.equal('change', event);
+        assert.strictEqual('change', event);
 
         if (expectFilePath) {
-          assert.equal('watch.txt', filename);
+          assert.strictEqual('watch.txt', filename);
         }
         watcher.close();
         ++watchSeenOne;
@@ -57,11 +57,11 @@ fs.writeFileSync(filepathTwoAbs, 'howdy');
 
 assert.doesNotThrow(
     function() {
-      var watcher = fs.watch(filepathTwo, function(event, filename) {
-        assert.equal('change', event);
+      const watcher = fs.watch(filepathTwo, function(event, filename) {
+        assert.strictEqual('change', event);
 
         if (expectFilePath) {
-          assert.equal('hasOwnProperty', filename);
+          assert.strictEqual('hasOwnProperty', filename);
         }
         watcher.close();
         ++watchSeenTwo;
@@ -79,13 +79,13 @@ const filepathThree = path.join(testsubdir, filenameThree);
 
 assert.doesNotThrow(
     function() {
-      var watcher = fs.watch(testsubdir, function(event, filename) {
-        var renameEv = common.isSunOS ? 'change' : 'rename';
-        assert.equal(renameEv, event);
+      const watcher = fs.watch(testsubdir, function(event, filename) {
+        const renameEv = common.isSunOS ? 'change' : 'rename';
+        assert.strictEqual(renameEv, event);
         if (expectFilePath) {
-          assert.equal('newfile.txt', filename);
+          assert.strictEqual('newfile.txt', filename);
         } else {
-          assert.equal(null, filename);
+          assert.strictEqual(null, filename);
         }
         watcher.close();
         ++watchSeenThree;
@@ -94,7 +94,7 @@ assert.doesNotThrow(
 );
 
 setImmediate(function() {
-  var fd = fs.openSync(filepathThree, 'w');
+  const fd = fs.openSync(filepathThree, 'w');
   fs.closeSync(fd);
 });
 
@@ -106,9 +106,9 @@ fs.watch(__filename, {persistent: false}, function() {
 
 // whitebox test to ensure that wrapped FSEvent is safe
 // https://github.com/joyent/node/issues/6690
-var oldhandle;
+let oldhandle;
 assert.throws(function() {
-  var w = fs.watch(__filename, function(event, filename) { });
+  const w = fs.watch(__filename, function(event, filename) { });
   oldhandle = w._handle;
   w._handle = { close: w._handle.close };
   w.close();
@@ -116,7 +116,7 @@ assert.throws(function() {
 oldhandle.close(); // clean up
 
 assert.throws(function() {
-  var w = fs.watchFile(__filename, {persistent: false}, function() {});
+  const w = fs.watchFile(__filename, {persistent: false}, function() {});
   oldhandle = w._handle;
   w._handle = { stop: w._handle.stop };
   w.stop();


### PR DESCRIPTION
* used let and const instead of var
* used assert.strictEqual instead assert.equal

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
used let and const instead of var
used assert.strictEqual instead of assert.equal