### PR TITLE
benchmark: use commas in non-csv rate output

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -185,7 +185,9 @@ function formatResult(data) {
     conf += ' ' + key + '=' + JSON.stringify(data.conf[key]);
   }
 
-  return `${data.name}${conf}: ${data.rate}`;
+  const rate = Math.floor(data.rate)
+                   .toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+  return `${data.name}${conf}: ${rate}`;
 }
 
 function sendResult(data) {

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -56,7 +56,9 @@ if (format === 'csv') {
       conf = conf.replace(/"/g, '""');
       console.log(`"${data.name}", "${conf}", ${data.rate}, ${data.time}`);
     } else {
-      console.log(`${data.name} ${conf}: ${data.rate}`);
+      const rate = Math.floor(data.rate)
+                       .toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+      console.log(`${data.name} ${conf}: ${rate}`);
     }
   });
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

* benchmark


##### Description of change

This just adds commas as separators in the (non-csv) rate output to make it easier to read when dealing with larger numbers.

/cc @nodejs/benchmarking ?