### PR TITLE
v4.x backport silent logs in addons tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,10 @@ test/addons/.buildstamp: config.gypi \
 	$(ADDONS_BINDING_GYPS) test/addons/.docbuildstamp
 	# Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 	# embedded addons have been generated from the documentation.
-	for dirname in test/addons/*/; do \
-		echo "\nRunning addons test $$PWD/$$dirname" ; \
-		$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp --loglevel=$(LOGLEVEL) rebuild \
+	@for dirname in test/addons/*/; do \
+		echo "\nBuilding addon $$PWD/$$dirname" ; \
+		env MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
+		        --loglevel=$(LOGLEVEL) rebuild \
 			--python="$(PYTHON)" \
 			--directory="$$PWD/$$dirname" \
 			--nodedir="$$PWD"; \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PREFIX ?= /usr/local
 FLAKY_TESTS ?= run
 TEST_CI_ARGS ?=
 STAGINGSERVER ?= node-www
+LOGLEVEL ?= silent
 
 OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
 
@@ -150,7 +151,8 @@ test/addons/.buildstamp: config.gypi \
 	# Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 	# embedded addons have been generated from the documentation.
 	for dirname in test/addons/*/; do \
-		$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
+		echo "\nRunning addons test $$PWD/$$dirname" ; \
+		$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp --loglevel=$(LOGLEVEL) rebuild \
 			--python="$(PYTHON)" \
 			--directory="$$PWD/$$dirname" \
 			--nodedir="$$PWD"; \
@@ -180,6 +182,7 @@ CI_NATIVE_SUITES := addons
 CI_JS_SUITES := doctool message parallel pseudo-tty sequential
 
 # Build and test addons without building anything else
+test-ci-native: LOGLEVEL := info
 test-ci-native: | test/addons/.buildstamp
 	$(PYTHON) tools/test.py -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
@@ -191,6 +194,7 @@ test-ci-js:
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
 
+test-ci: LOGLEVEL := info
 test-ci: | build-addons
 	out/Release/cctest --gtest_output=tap:cctest.tap
 	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release --flaky-tests=$(FLAKY_TESTS) \


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

build v4.x

##### Description of change

Backport of https://github.com/nodejs/node/pull/8990 and https://github.com/nodejs/node/pull/9450

---

cc @TheAlphaNerd @danbev 
