### PR TITLE
test: refactor for test-fs-readfile-error

### DIFF
--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
-var exec = require('child_process').exec;
-var path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const exec = require('child_process').exec;
+const path = require('path');
 
 // `fs.readFile('/')` does not fail on FreeBSD, because you can open and read
 // the directory there.
@@ -12,23 +12,23 @@ if (process.platform === 'freebsd') {
 }
 
 function test(env, cb) {
-  var filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
-  var execPath = '"' + process.execPath + '" "' + filename + '"';
-  var options = { env: Object.assign(process.env, env) };
-  exec(execPath, options, function(err, stdout, stderr) {
+  const filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
+  const execPath = '"' + process.execPath + '" "' + filename + '"';
+  const options = { env: Object.assign(process.env, env) };
+  exec(execPath, options, common.mustCall((err, stdout, stderr) => {
     assert(err);
-    assert.equal(stdout, '');
-    assert.notEqual(stderr, '');
+    assert.strictEqual(stdout, '');
+    assert.notStrictEqual(stderr, '');
     cb('' + stderr);
-  });
+  }));
 }
 
-test({ NODE_DEBUG: '' }, common.mustCall(function(data) {
+test({ NODE_DEBUG: '' }, common.mustCall((data) => {
   assert(/EISDIR/.test(data));
   assert(!/test-fs-readfile-error/.test(data));
 }));
 
-test({ NODE_DEBUG: 'fs' }, common.mustCall(function(data) {
+test({ NODE_DEBUG: 'fs' }, common.mustCall((data) => {
   assert(/EISDIR/.test(data));
   assert(/test-fs-readfile-error/.test(data));
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use const instead of var
* use common.mustCall to control the functions execution automatically
* use assert.strictEqual instead assert.equal
* use assert.notStrictEqual instead assert.notEqual
* use arrow functions

