### PR TITLE
cluster:RR - Added public API pausing/unpausing a worker

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -205,7 +205,7 @@ RoundRobinHandle.prototype.handoff = function(worker) {
 RoundRobinHandle.prototype.pause = function(worker) {
   if (worker.id in this.all === false) return false;
   var index = this.free.indexOf(worker);
-  if (index !== -1)  {
+  if (index !== -1) {
     this.free.splice(index, 1);
     return true;
   }
@@ -317,7 +317,7 @@ function masterInit() {
     return false;
   };
 
-  cluster.unpause = function (worker) {
+  cluster.unpause = function(worker) {
     for (var key in handles) {
       var handle = handles[key];
       if (handle.unpause) return handle.unpause(worker);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -202,6 +202,26 @@ RoundRobinHandle.prototype.handoff = function(worker) {
   });
 };
 
+RoundRobinHandle.prototype.pause = function(worker) {
+  if (worker.id in this.all === false) return false;
+  var index = this.free.indexOf(worker);
+  if (index !== -1)  {
+    this.free.splice(index, 1);
+    return true;
+  }
+  return false;
+};
+
+RoundRobinHandle.prototype.unpause = function(worker) {
+  if (worker.id in this.all === false) return false;
+  var index = this.free.indexOf(worker);
+  if (index === -1) {
+    this.free.push(worker);
+    return true;
+  }
+  return false;
+};
+
 
 if (cluster.isMaster)
   masterInit();
@@ -287,6 +307,22 @@ function masterInit() {
         }
       }
     });
+  };
+
+  cluster.pause = function(worker) {
+    for (var key in handles) {
+      var handle = handles[key];
+      if (handle.pause) return handle.pause(worker);
+    }
+    return false;
+  };
+
+  cluster.unpause = function (worker) {
+    for (var key in handles) {
+      var handle = handles[key];
+      if (handle.unpause) return handle.unpause(worker);
+    }
+    return false;
   };
 
   function setupSettingsNT(settings) {

--- a/test/parallel/test-cluster-rr-pause-unpause.js
+++ b/test/parallel/test-cluster-rr-pause-unpause.js
@@ -40,7 +40,6 @@ function runTest(worker1, worker2) {
   getSeveralTimes((result) => {
     assert(result.includes(1));
     assert(result.includes(2));
-    const oldState = worker1.state;
     cluster.pause(worker1);
     getSeveralTimes((result) => {
       assert(!result.includes(1));

--- a/test/parallel/test-cluster-rr-pause-unpause.js
+++ b/test/parallel/test-cluster-rr-pause-unpause.js
@@ -1,0 +1,57 @@
+'use strict';
+const common = require('../common');
+const cluster = require('cluster');
+const http = require('http');
+const assert = require('assert');
+// Want to make sure it's RR on all platforms
+cluster.schedulingPolicy = cluster.SCHED_RR;
+if (cluster.isMaster) {
+  let ready = 0;
+  const worker1 = cluster.fork();
+  const worker2 = cluster.fork();
+  const onMessage = (msg) => {
+    if (msg === 'ready') {
+      ready++;
+      if (ready === 2) runTest(worker1, worker2);
+    }
+  };
+  worker1.on('message', onMessage);
+  worker2.on('message', onMessage);
+} else {
+  http.createServer((req, res) => {
+    res.setHeader('id', cluster.worker.id);
+    res.end();
+  }).listen(common.PORT, () => {
+    process.send('ready');
+  });
+}
+function getSeveralTimes(cb) {
+  const results = [];
+  function getOnce() {
+    http.get('http://localhost:' + common.PORT, (res) => {
+      results.push(parseInt(res.headers.id));
+      if (results.length === 6) cb(results);
+      else getOnce();
+    });
+  }
+  getOnce();
+}
+function runTest(worker1, worker2) {
+  getSeveralTimes((result) => {
+    assert(result.includes(1));
+    assert(result.includes(2));
+    const oldState = worker1.state;
+    cluster.pause(worker1);
+    getSeveralTimes((result) => {
+      assert(!result.includes(1));
+      assert(result.includes(2));
+      cluster.unpause(worker1);
+      getSeveralTimes((result) => {
+        assert(result.includes(1));
+        assert(result.includes(2));
+        worker1.kill();
+        worker2.kill();
+      });
+    });
+  });
+}


### PR DESCRIPTION
cluster:RR - Added public API pausing/unpausing a worker

We have the following two use-cases:
 
   1. Run offline GC, we have a script which coordinates offline GC using pause and unpause API. Basically, the master process is able not to distribute new requests to a paused worker by calling cluster.pause(worker). The paused worker can force full GC after draining all pending requests in its flight. Once it is done the worker can continue to server new request after the master cluster unpauses it by calling cluster.unpause(worker).

   2. Respawn a worker after serving X requests. The master cluster should not distribute requests to the new worker until it prime-cache which may take few seconds. We need to pause it while prime caching the worker. 

This enabled us to reduce long tail latency.

There has been discussion about this on how best to this feature (https://github.com/nodejs/node/pull/7695)