### PR TITLE
tools: enable block-spacing in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -76,6 +76,7 @@ rules:
 
   # Stylistic Issues
   # http://eslint.org/docs/rules/#stylistic-issues
+  block-spacing: 2
   brace-style: [2, 1tbs, {allowSingleLine: true}]
   comma-spacing: 2
   comma-style: 2

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -358,9 +358,9 @@ try {
 assert.equal(true, threw,
              'a.doesNotThrow is not catching type matching errors');
 
-assert.throws(function() {assert.ifError(new Error('test error'));});
-assert.doesNotThrow(function() {assert.ifError(null);});
-assert.doesNotThrow(function() {assert.ifError();});
+assert.throws(function() { assert.ifError(new Error('test error')); });
+assert.doesNotThrow(function() { assert.ifError(null); });
+assert.doesNotThrow(function() { assert.ifError(); });
 
 assert.throws(() => {
   assert.doesNotThrow(makeBlock(thrower, Error), 'user message');

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -988,7 +988,7 @@ assert.throws(() => Buffer.from('', 'buffer'), TypeError);
 {
   let a = [0];
   for (let i = 0; i < 7; ++i) a = a.concat(a);
-  a = a.map((_, i) => {return i;});
+  a = a.map((_, i) => { return i; });
   const b = Buffer.from(a);
   const c = Buffer.from(b);
   assert.strictEqual(b.length, a.length);

--- a/test/parallel/test-debugger-repeat-last.js
+++ b/test/parallel/test-debugger-repeat-last.js
@@ -26,15 +26,15 @@ var sentExit = false;
 proc.stdout.on('data', (data) => {
   stdout += data;
   if (!sentCommand && stdout.includes('> 1')) {
-    setImmediate(() => {proc.stdin.write('n\n');});
+    setImmediate(() => { proc.stdin.write('n\n'); });
     return sentCommand = true;
   }
   if (!sentEmpty && stdout.includes('> 3')) {
-    setImmediate(() => {proc.stdin.write('\n');});
+    setImmediate(() => { proc.stdin.write('\n'); });
     return sentEmpty = true;
   }
   if (!sentExit && sentCommand && sentEmpty) {
-    setTimeout(() => {proc.stdin.write('\n\n\n.exit\n\n\n');}, 1);
+    setTimeout(() => { proc.stdin.write('\n\n\n.exit\n\n\n'); }, 1);
     return sentExit = true;
   }
 });

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -87,7 +87,7 @@ function test_simple_relative_symlink(callback) {
   [
     [entry, '../' + common.tmpDirName + '/cycles/root.js']
   ].forEach(function(t) {
-    try {fs.unlinkSync(t[0]);} catch (e) {}
+    try { fs.unlinkSync(t[0]); } catch (e) {}
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], t[0], 'file');
     fs.symlinkSync(t[1], t[0], 'file');
     unlink.push(t[0]);
@@ -113,7 +113,7 @@ function test_simple_absolute_symlink(callback) {
   [
     [entry, expected]
   ].forEach(function(t) {
-    try {fs.unlinkSync(t[0]);} catch (e) {}
+    try { fs.unlinkSync(t[0]); } catch (e) {}
     console.error('fs.symlinkSync(%j, %j, %j)', t[1], t[0], type);
     fs.symlinkSync(t[1], t[0], type);
     unlink.push(t[0]);
@@ -138,13 +138,13 @@ function test_deep_relative_file_symlink(callback) {
                                 expected);
   const linkPath1 = path.join(targetsAbsDir,
                             'nested-index', 'one', 'symlink1.js');
-  try {fs.unlinkSync(linkPath1);} catch (e) {}
+  try { fs.unlinkSync(linkPath1); } catch (e) {}
   fs.symlinkSync(linkData1, linkPath1, 'file');
 
   const linkData2 = '../one/symlink1.js';
   const entry = path.join(targetsAbsDir,
                         'nested-index', 'two', 'symlink1-b.js');
-  try {fs.unlinkSync(entry);} catch (e) {}
+  try { fs.unlinkSync(entry); } catch (e) {}
   fs.symlinkSync(linkData2, entry, 'file');
   unlink.push(linkPath1);
   unlink.push(entry);
@@ -165,13 +165,13 @@ function test_deep_relative_dir_symlink(callback) {
   const path1b = path.join(targetsAbsDir, 'nested-index', 'one');
   const linkPath1b = path.join(path1b, 'symlink1-dir');
   const linkData1b = path.relative(path1b, expected);
-  try {fs.unlinkSync(linkPath1b);} catch (e) {}
+  try { fs.unlinkSync(linkPath1b); } catch (e) {}
   fs.symlinkSync(linkData1b, linkPath1b, 'dir');
 
   const linkData2b = '../one/symlink1-dir';
   const entry = path.join(targetsAbsDir,
                         'nested-index', 'two', 'symlink12-dir');
-  try {fs.unlinkSync(entry);} catch (e) {}
+  try { fs.unlinkSync(entry); } catch (e) {}
   fs.symlinkSync(linkData2b, entry, 'dir');
   unlink.push(linkPath1b);
   unlink.push(entry);
@@ -195,7 +195,7 @@ function test_cyclic_link_protection(callback) {
     [common.tmpDir + '/cycles/realpath-3b', '../cycles/realpath-3c'],
     [common.tmpDir + '/cycles/realpath-3c', '../cycles/realpath-3a']
   ].forEach(function(t) {
-    try {fs.unlinkSync(t[0]);} catch (e) {}
+    try { fs.unlinkSync(t[0]); } catch (e) {}
     fs.symlinkSync(t[1], t[0], 'dir');
     unlink.push(t[0]);
   });
@@ -218,7 +218,7 @@ function test_cyclic_link_overprotection(callback) {
   const link = folder + '/cycles';
   var testPath = cycles;
   testPath += '/folder/cycles'.repeat(10);
-  try {fs.unlinkSync(link);} catch (ex) {}
+  try { fs.unlinkSync(link); } catch (ex) {}
   fs.symlinkSync(cycles, link, 'dir');
   unlink.push(link);
   assertEqualPath(fs.realpathSync(testPath), path.resolve(expected));
@@ -246,7 +246,7 @@ function test_relative_input_cwd(callback) {
   ].forEach(function(t) {
     const fn = t[0];
     console.error('fn=%j', fn);
-    try {fs.unlinkSync(fn);} catch (e) {}
+    try { fs.unlinkSync(fn); } catch (e) {}
     const b = path.basename(t[1]);
     const type = (b === 'root.js' ? 'file' : 'dir');
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], fn, type);
@@ -363,7 +363,7 @@ function test_up_multiple(cb) {
     ['a/b',
       'a'
     ].forEach(function(folder) {
-      try {fs.rmdirSync(tmp(folder));} catch (ex) {}
+      try { fs.rmdirSync(tmp(folder)); } catch (ex) {}
     });
   }
   function setup() {
@@ -420,14 +420,14 @@ function test_abs_with_kids(cb) {
     ['/a/b/c/x.txt',
       '/a/link'
     ].forEach(function(file) {
-      try {fs.unlinkSync(root + file);} catch (ex) {}
+      try { fs.unlinkSync(root + file); } catch (ex) {}
     });
     ['/a/b/c',
       '/a/b',
       '/a',
       ''
     ].forEach(function(folder) {
-      try {fs.rmdirSync(root + folder);} catch (ex) {}
+      try { fs.rmdirSync(root + folder); } catch (ex) {}
     });
   }
   function setup() {

--- a/test/parallel/test-http-chunked.js
+++ b/test/parallel/test-http-chunked.js
@@ -25,7 +25,7 @@ server.listen(0, function() {
     port: this.address().port
   }, function(x) {
     x.setEncoding('utf8');
-    x.on('data', function(c) {data += c;});
+    x.on('data', function(c) { data += c; });
     x.on('error', function(e) {
       throw e;
     });
@@ -37,7 +37,7 @@ server.listen(0, function() {
       server.close();
     });
   });
-  get.on('error', function(e) {throw e;});
+  get.on('error', function(e) { throw e; });
   get.end();
 
 });

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -3,5 +3,5 @@ require('../common');
 var assert = require('assert');
 var v8 = require('v8');
 
-assert.throws(function() {v8.setFlagsFromString(1);}, TypeError);
-assert.throws(function() {v8.setFlagsFromString();}, TypeError);
+assert.throws(function() { v8.setFlagsFromString(1); }, TypeError);
+assert.throws(function() { v8.setFlagsFromString(); }, TypeError);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test

##### Description of change
<!-- Provide a description of the change below this comment. -->

Enable rule to enforce consistent use of space between the `{` and `}`
that surround a code block and the code block itself. This enforces via
linting the de facto standard in the code base.

This changes only six files in the code base as block spacing
is consistent throughout the rest of the code base.
    
Before:  
```js
function(c) {data += c;}
```
    
After: 
```js
function(c) { data += c; }
```
