### PR TITLE
fs: remove superfluous type check in `_write()`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1940,8 +1940,7 @@ WriteStream.prototype.open = function() {
 
 
 WriteStream.prototype._write = function(data, encoding, cb) {
-  if (!(data instanceof Buffer))
-    return this.emit('error', new Error('Invalid data'));
+  // `data` is always a Buffer here.
 
   if (typeof this.fd !== 'number')
     return this.once('open', function() {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change

Type checking is already performed on the `streams` level, so this check could never actually fail.

CI: https://ci.nodejs.org/job/node-test-commit/6766/