### PR TITLE
events: update and clarify error message

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -177,7 +177,7 @@ EventEmitter.prototype.emit = function emit(type) {
       er = arguments[1];
     if (domain) {
       if (!er)
-        er = new Error('Uncaught, unspecified "error" event');
+        er = new Error('Unhandled "error" event');
       if (typeof er === 'object' && er !== null) {
         er.domainEmitter = this;
         er.domain = domain;
@@ -188,7 +188,7 @@ EventEmitter.prototype.emit = function emit(type) {
       throw er; // Unhandled 'error' event
     } else {
       // At least give some kind of context to the user
-      var err = new Error('Uncaught, unspecified "error" event. (' + er + ')');
+      const err = new Error('Unhandled "error" event. (' + er + ')');
       err.context = er;
       throw err;
     }

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -5,6 +5,10 @@ const assert = require('assert');
 
 const EE = new EventEmitter();
 
-assert.throws(function() {
+assert.throws(() => {
   EE.emit('error', 'Accepts a string');
-}, /Accepts a string/);
+}, /^Error: Unhandled "error" event\. \(Accepts a string\)$/);
+
+assert.throws(() => {
+  EE.emit('error', {message: 'Error!'});
+}, /^Error: Unhandled "error" event\. \(\[object Object\]\)$/);


### PR DESCRIPTION
eventemitter: clarify error message

Update error message that's thrown when no error listeners are attached to an emitter. This would have been trivial to debug if I had understood what 'unspecified error' was supposed to mean. Once I went looking at the source, and saw the comment on 149, it was easy to fix.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
eventemitter

##### Description of change
Update error message that's thrown when no error listeners are attached to an emitter. This would have been trivial to debug if I had understood what 'unspecified error' was supposed to mean. Once I went looking at the source, and saw the comment on 149, it was easy to fix.
