### PR TITLE
tty: remove NODE_TTY_UNSAFE_ASYNC

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -319,16 +319,6 @@ Path to the file used to store the persistent REPL history. The default path is
 to an empty string (`""` or `" "`) disables persistent REPL history.
 
 
-### `NODE_TTY_UNSAFE_ASYNC=1`
-<!-- YAML
-added: 6.4.0
--->
-
-When set to `1`, writes to `stdout` and `stderr` will be non-blocking and
-asynchronous when outputting to a TTY on platforms which support async stdio.
-Setting this will void any guarantee that stdio will not be interleaved or
-dropped at program exit. **Use of this mode is not recommended.**
-
 ### `NODE_EXTRA_CA_CERTS=file`
 
 When set, the well known "root" CAs (like VeriSign) will be extended with the

--- a/doc/node.1
+++ b/doc/node.1
@@ -200,13 +200,6 @@ Path to the file used to store the persistent REPL history. The default path
 is ~/.node_repl_history, which is overridden by this variable. Setting the
 value to an empty string ("" or " ") disables persistent REPL history.
 
-.TP
-.BR NODE_TTY_UNSAFE_ASYNC=1
-When set to 1, writes to stdout and stderr will be non-blocking and asynchronous
-when outputting to a TTY on platforms which support async stdio.
-Setting this will void any guarantee that stdio will not be interleaved or
-dropped at program exit. \fBAvoid use.\fR
-
 
 .SH BUGS
 Bugs are tracked in GitHub Issues:

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -53,7 +53,7 @@ function WriteStream(fd) {
   // this behaviour has become expected due historical functionality on OS X,
   // even though it was originally intended to change in v1.0.2 (Libuv 1.2.1).
   // Ref: https://github.com/nodejs/node/pull/1771#issuecomment-119351671
-  this._handle.setBlocking(process.env.NODE_TTY_UNSAFE_ASYNC !== '1');
+  this._handle.setBlocking(true);
 
   var winSize = [];
   var err = this._handle.getWindowSize(winSize);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tty

##### Description of change
<!-- Provide a description of the change below this comment. -->

Nothing but trouble can ever come from it.

Refs: https://github.com/nodejs/node/pull/10157#issuecomment-267774090

_Edit: I should mention that anyone can still use `setBlocking(false)` to get this behavior back if they **really** desire._