### PR TITLE
test: refactor the code in test-http-connect

### DIFF
--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -1,85 +1,73 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var http = require('http');
+const assert = require('assert');
+const http = require('http');
 
-var serverGotConnect = false;
-var clientGotConnect = false;
+const server = http.createServer(common.fail);
 
-var server = http.createServer(common.fail);
-server.on('connect', function(req, socket, firstBodyChunk) {
-  assert.equal(req.method, 'CONNECT');
-  assert.equal(req.url, 'google.com:443');
-  console.error('Server got CONNECT request');
-  serverGotConnect = true;
+server.on('connect', common.mustCall((req, socket, firstBodyChunk) => {
+  assert.strictEqual(req.method, 'CONNECT');
+  assert.strictEqual(req.url, 'google.com:443');
 
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');
 
-  var data = firstBodyChunk.toString();
-  socket.on('data', function(buf) {
+  let data = firstBodyChunk.toString();
+  socket.on('data', (buf) => {
     data += buf.toString();
   });
-  socket.on('end', function() {
+
+  socket.on('end', common.mustCall(() => {
     socket.end(data);
-  });
-});
-server.listen(0, function() {
-  var req = http.request({
+  }));
+}));
+
+server.listen(0, common.mustCall(function() {
+  const req = http.request({
     port: this.address().port,
     method: 'CONNECT',
     path: 'google.com:443'
   }, common.fail);
 
-  var clientRequestClosed = false;
-  req.on('close', function() {
-    clientRequestClosed = true;
-  });
+  req.on('close', common.mustCall(() => {}));
 
-  req.on('connect', function(res, socket, firstBodyChunk) {
-    console.error('Client got CONNECT request');
-    clientGotConnect = true;
-
+  req.on('connect', common.mustCall((res, socket, firstBodyChunk) => {
     // Make sure this request got removed from the pool.
-    var name = 'localhost:' + server.address().port;
+    const name = 'localhost:' + server.address().port;
     assert(!http.globalAgent.sockets.hasOwnProperty(name));
     assert(!http.globalAgent.requests.hasOwnProperty(name));
 
     // Make sure this socket has detached.
     assert(!socket.ondata);
     assert(!socket.onend);
-    assert.equal(socket.listeners('connect').length, 0);
-    assert.equal(socket.listeners('data').length, 0);
+    assert.strictEqual(socket.listeners('connect').length, 0);
+    assert.strictEqual(socket.listeners('data').length, 0);
 
     // the stream.Duplex onend listener
     // allow 0 here, so that i can run the same test on streams1 impl
     assert(socket.listeners('end').length <= 1);
 
-    assert.equal(socket.listeners('free').length, 0);
-    assert.equal(socket.listeners('close').length, 0);
-    assert.equal(socket.listeners('error').length, 0);
-    assert.equal(socket.listeners('agentRemove').length, 0);
+    assert.strictEqual(socket.listeners('free').length, 0);
+    assert.strictEqual(socket.listeners('close').length, 0);
+    assert.strictEqual(socket.listeners('error').length, 0);
+    assert.strictEqual(socket.listeners('agentRemove').length, 0);
 
-    var data = firstBodyChunk.toString();
-    socket.on('data', function(buf) {
+    let data = firstBodyChunk.toString();
+    socket.on('data', (buf) => {
       data += buf.toString();
     });
-    socket.on('end', function() {
-      assert.equal(data, 'HeadBody');
-      assert(clientRequestClosed);
+
+    socket.on('end', common.mustCall(() => {
+      assert.strictEqual(data, 'HeadBody');
       server.close();
-    });
+    }));
+
     socket.write('Body');
     socket.end();
-  });
+  }));
 
   // It is legal for the client to send some data intended for the server
   // before the "200 Connection established" (or any other success or
   // error code) is received.
   req.write('Head');
   req.end();
-});
-
-process.on('exit', function() {
-  assert.ok(serverGotConnect);
-  assert.ok(clientGotConnect);
-});
+}));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use common.mustCall to control the functions execution automatically
* use let and const instead of var
* use assert.strictEqual instead of assert.equal
* use assert.strictEqual instead of assert.ok
* use arrow functions
