### PR TITLE
v4.x backport for #9113: test,lib,benchmark: match function names

### DIFF
--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -159,7 +159,7 @@ function QueueItem(type, req) {
   this.next = this;
 }
 
-StreamWrap.prototype._enqueue = function enqueue(type, req) {
+StreamWrap.prototype._enqueue = function _enqueue(type, req) {
   const item = new QueueItem(type, req);
   if (this._list === null) {
     this._list = item;
@@ -174,7 +174,7 @@ StreamWrap.prototype._enqueue = function enqueue(type, req) {
   return item;
 };
 
-StreamWrap.prototype._dequeue = function dequeue(item) {
+StreamWrap.prototype._dequeue = function _dequeue(item) {
   assert(item instanceof QueueItem);
 
   var next = item.next;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -118,7 +118,7 @@ function WritableState(options, stream) {
   this.corkedRequestsFree = new CorkedRequest(this);
 }
 
-WritableState.prototype.getBuffer = function writableStateGetBuffer() {
+WritableState.prototype.getBuffer = function getBuffer() {
   var current = this.bufferedRequest;
   var out = [];
   while (current) {

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -142,7 +142,7 @@ CryptoStream.prototype.init = function init() {
 };
 
 
-CryptoStream.prototype._write = function write(data, encoding, cb) {
+CryptoStream.prototype._write = function _write(data, encoding, cb) {
   assert(this._pending === null);
 
   // Black-hole data
@@ -223,7 +223,7 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
 };
 
 
-CryptoStream.prototype._writePending = function writePending() {
+CryptoStream.prototype._writePending = function _writePending() {
   const data = this._pending;
   const encoding = this._pendingEncoding;
   const cb = this._pendingCallback;
@@ -235,7 +235,7 @@ CryptoStream.prototype._writePending = function writePending() {
 };
 
 
-CryptoStream.prototype._read = function read(size) {
+CryptoStream.prototype._read = function _read(size) {
   // XXX: EOF?!
   if (!this.pair.ssl) return this.push(null);
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -316,7 +316,7 @@ proxiedMethods.forEach(function(name) {
   };
 });
 
-tls_wrap.TLSWrap.prototype.close = function closeProxy(cb) {
+tls_wrap.TLSWrap.prototype.close = function close(cb) {
   let ssl;
   if (this.owner) {
     ssl = this.owner.ssl;
@@ -369,10 +369,10 @@ TLSSocket.prototype._wrapHandle = function(wrap) {
   res._secureContext = context;
   res.reading = handle.reading;
   Object.defineProperty(handle, 'reading', {
-    get: function readingGetter() {
+    get: function get() {
       return res.reading;
     },
-    set: function readingSetter(value) {
+    set: function set(value) {
       res.reading = value;
     }
   });

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -58,7 +58,7 @@ Domain.prototype._disposed = undefined;
 
 
 // Called by process._fatalException in case an error was thrown.
-Domain.prototype._errorHandler = function errorHandler(er) {
+Domain.prototype._errorHandler = function _errorHandler(er) {
   var caught = false;
   var self = this;
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -697,7 +697,7 @@ fs.truncate = function(path, len, callback) {
   fs.open(path, 'r+', function(er, fd) {
     if (er) return callback(er);
     var req = new FSReqWrap();
-    req.oncomplete = function ftruncateCb(er) {
+    req.oncomplete = function oncomplete(er) {
       fs.close(fd, function(er2) {
         callback(er || er2);
       });

--- a/lib/net.js
+++ b/lib/net.js
@@ -189,7 +189,7 @@ function Socket(options) {
 }
 util.inherits(Socket, stream.Duplex);
 
-Socket.prototype._unrefTimer = function unrefTimer() {
+Socket.prototype._unrefTimer = function _unrefTimer() {
   for (var s = this; s !== null; s = s._parent)
     timers._unrefActive(s);
 };

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -57,7 +57,7 @@ assert.throws(function() {
 // Argument types for combinatorics
 const a = [];
 const o = {};
-const c = function callback() {};
+const c = function c() {};
 const s = 'string';
 const u = undefined;
 const n = null;

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -15,7 +15,7 @@ FakeAgent.prototype.createConnection = function createConnection() {
   var s = new Duplex();
   var once = false;
 
-  s._read = function read() {
+  s._read = function _read() {
     if (once)
       return this.push(null);
     once = true;
@@ -27,7 +27,7 @@ FakeAgent.prototype.createConnection = function createConnection() {
   };
 
   // Blackhole
-  s._write = function write(data, enc, cb) {
+  s._write = function _write(data, enc, cb) {
     cb();
   };
 

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -176,7 +176,7 @@ const tests = [
     expected: [prompt, replFailedRead, prompt, replDisabled, prompt]
   },
   { // Make sure this is always the last test, since we change os.homedir()
-    before: function mockHomedirFailure() {
+    before: function before() {
       // Mock os.homedir() failure
       os.homedir = function() {
         throw new Error('os.homedir() failure');

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -27,7 +27,7 @@ function Mediator() {
 }
 util.inherits(Mediator, stream.Writable);
 
-Mediator.prototype._write = function write(data, enc, cb) {
+Mediator.prototype._write = function _write(data, enc, cb) {
   this.buf += data;
   setTimeout(cb, 0);
 


### PR DESCRIPTION
In most cases, named functions match the variable or property to which
they are being assigned. That also seems to be the practice in a series
of PRs currently being evaluated that name currently-anonymous
functions.

This change applies that rule to instances in the code base that don't
comply with that practice.

This will be enforceable with a lint rule once we upgrade to ESLint
3.8.0.

PR-URL: https://github.com/nodejs/node/pull/9113
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Franziska Hinkelmann <franziska.hinkelmann@gmail.com>

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test lib benchmark

##### Description of change
<!-- Provide a description of the change below this comment. -->
