### PR TITLE
async_wrap: clear destroy_ids vector

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -199,7 +199,9 @@ void AsyncWrap::DestroyIdsCb(uv_idle_t* handle) {
 
   TryCatch try_catch(env->isolate());
 
-  for (auto current_id : *env->destroy_ids_list()) {
+  std::vector<int64_t> destroy_ids_list;
+  destroy_ids_list.swap(*env->destroy_ids_list());
+  for (auto current_id : destroy_ids_list) {
     // Want each callback to be cleaned up after itself, instead of cleaning
     // them all up after the while() loop completes.
     HandleScope scope(env->isolate());
@@ -212,6 +214,8 @@ void AsyncWrap::DestroyIdsCb(uv_idle_t* handle) {
       FatalException(env->isolate(), try_catch);
     }
   }
+
+  env->destroy_ids_list()->clear();
 }
 
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`async_wrap`


##### Description of change

After processing all the callbacks in the destroy_ids vector make sure
to clear() it otherwise the DestroyIdsCb() won't run again.

This patch should land on all releases that have b49b496a92118bf786176bc3c763a292b9bdff5d, or some cherry-pick of it.

CI: https://ci.nodejs.org/job/node-test-commit/6782/