### PR TITLE
url: check MaybeLocal return value

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -618,7 +618,7 @@ namespace url {
     }
   }
 
-  static void Parse(Environment* env,
+  static bool Parse(Environment* env,
                     Local<Value> recv,
                     const char* input,
                     const size_t len,
@@ -1294,7 +1294,7 @@ namespace url {
         argv[ARG_PATH] = Copy(isolate, url.path);
     }
 
-    cb->Call(context, recv, 9, argv);
+    return cb->Call(context, recv, 9, argv).IsEmpty();
   }
 
   static void Parse(const FunctionCallbackInfo<Value>& args) {
@@ -1313,6 +1313,9 @@ namespace url {
     if (args[1]->IsNumber())
       override = (enum url_parse_state)(args[1]->Uint32Value());
 
+    // The return value is a bool that indicates whether v8::Function::Call()
+    // threw or not. Though not sure what we're supposed to do with that vlaue
+    // at the moment, but v8::MaybeLocal requires us to check anyway.
     Parse(env, args.This(),
           *input, input.length(),
           override,


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`url`


##### Description of change

Always check the return value for V8 APIs that return a `v8::MaybeLocal`.

Fixes: 4b31238 "url: adding WHATWG URL support"

CI: https://ci.nodejs.org/job/node-test-commit/6785/

**NOTE**: Not a fan of simply ignoring whether the callback threw or not, but if we're going to use the `MaybeLocal` API then we shouldn't be using it in a way that creates a compiler warning. So I'm up for suggestions on how we should check it.