### PR TITLE
build: revert to pretty-print by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ BUILD_DOWNLOAD_FLAGS ?= --download=all
 BUILD_INTL_FLAGS ?= --with-intl=small-icu
 BUILD_RELEASE_FLAGS ?= $(BUILD_DOWNLOAD_FLAGS) $(BUILD_INTL_FLAGS)
 
-# Default to verbose builds.
-# To do quiet/pretty builds, run `make V=` to set V to an empty string,
-# or set the V environment variable to an empty string.
-V ?= 1
+# Default to quiet builds.
+# To do verbose builds, run `make V=1` or set the V environment variable to a
+# non-empty string.
+V ?=
 
 # BUILDTYPE=Debug builds both release and debug builds. If you want to compile
 # just the debug build, run `make -C out BUILDTYPE=Debug` instead.


### PR DESCRIPTION
This essentially reverts 8656c2654 which arose as a result of https://github.com/nodejs/node-v0.x-archive/issues/3761, which says:

> The practice of hiding command execution during the build process frustrates debugging and provides no meaningful benefit. A quick survey of existing GH issues shows several incidents in which submitters who provided build output were asked to take another lap with V=1. We should save everyone a lot of time -- including people who are debugging the build themselves in development or automated build environments -- and just make that behavior the default. If for some reason there is someone relying on not having any usable information about the build and wants the existing behavior, it could be preserved if a similar make variable is set (e.g., SILENT_BUILD=1 or similar).

This is what you get when you're not running verbose:

```
  CXX(target) /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/logging.o
  CXX(target) /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/once.o
  CXX(target) /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/time.o
  CXX(target) /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/condition-variable.o
```

And this is what you get when you run verbose as we do now:

```
  g++ '-DV8_TARGET_ARCH_X64' '-DENABLE_DISASSEMBLER' '-DV8_I18N_SUPPORT' -I../deps/v8  -pthread -Wall -Wextra -Wno-unused-parameter -m64 -fno-strict-aliasing -m64 -fdata-sections -ffunction-sections -O3 -O3 -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++0x -MMD -MF /home/rvagg/git/iojs/io.js/out/Release/.deps//home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/logging.o.d.raw   -c -o /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/logging.o ../deps/v8/src/base/logging.cc
  g++ '-DV8_TARGET_ARCH_X64' '-DENABLE_DISASSEMBLER' '-DV8_I18N_SUPPORT' -I../deps/v8  -pthread -Wall -Wextra -Wno-unused-parameter -m64 -fno-strict-aliasing -m64 -fdata-sections -ffunction-sections -O3 -O3 -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++0x -MMD -MF /home/rvagg/git/iojs/io.js/out/Release/.deps//home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/once.o.d.raw   -c -o /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/once.o ../deps/v8/src/base/once.cc
  g++ '-DV8_TARGET_ARCH_X64' '-DENABLE_DISASSEMBLER' '-DV8_I18N_SUPPORT' -I../deps/v8  -pthread -Wall -Wextra -Wno-unused-parameter -m64 -fno-strict-aliasing -m64 -fdata-sections -ffunction-sections -O3 -O3 -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++0x -MMD -MF /home/rvagg/git/iojs/io.js/out/Release/.deps//home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/time.o.d.raw   -c -o /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/time.o ../deps/v8/src/base/platform/time.cc
  g++ '-DV8_TARGET_ARCH_X64' '-DENABLE_DISASSEMBLER' '-DV8_I18N_SUPPORT' -I../deps/v8  -pthread -Wall -Wextra -Wno-unused-parameter -m64 -fno-strict-aliasing -m64 -fdata-sections -ffunction-sections -O3 -O3 -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++0x -MMD -MF /home/rvagg/git/iojs/io.js/out/Release/.deps//home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/condition-variable.o.d.raw   -c -o /home/rvagg/git/iojs/io.js/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/condition-variable.o ../deps/v8/src/base/platform/condition-variable.cc
```

I take the point of the original issue poster and I wasn't around in core before we turned `V=1` on so I can't speak to the experience of having to go back and ask people to turn it on in order to get bug reports so I'd be happy to hear from more experienced folks, like @bnoordhuis and @indutny.

Here's the case for going back to a cleaner build though:

1. Our builds have double the number of steps than they did when they were first made silent (833 then vs 1798 now), they have become extremely noisy for everyone
2. I don't see people being asked to provide snippets of their build output these days, I suspect that we've reached a new level of maturity where our problems are elsewhere
3. Further to point 2, we have _very_ broad CI support, our CI system covers all of our primary targets and most of our secondary, it's really only the exotic cases where we're likely to run into problems where compiler options that _users_ are using are interesting.
4. It's slowing down Jenkins (I _believe_), all of this output gets stored for each run and it's rarely looked it. It's at least slowing down loading of console output from Jenkins (I'm regularly doing this and the majority is this compile output, not even the test output!).
5. It's hiding compiler warnings, they get hidden in the output and we mostly ignore them.
6. It's pretty and shiny, and who doesn't love a bit of pretty and shiny?