### PR TITLE
test: fix flaky test-https-timeout

### DIFF
--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -1,24 +1,24 @@
 'use strict';
-var common = require('../common');
+const common = require('../common');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var https = require('https');
+const https = require('https');
 
-var fs = require('fs');
+const fs = require('fs');
 
-var options = {
+const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
 // a server that never replies
-var server = https.createServer(options, function() {
+const server = https.createServer(options, function() {
   console.log('Got request.  Doing nothing.');
-}).listen(0, function() {
-  var req = https.request({
+}).listen(0, common.mustCall(function() {
+  const req = https.request({
     host: 'localhost',
     port: this.address().port,
     path: '/',
@@ -28,26 +28,14 @@ var server = https.createServer(options, function() {
   req.setTimeout(10);
   req.end();
 
-  req.on('response', function(res) {
+  req.on('response', function() {
     console.log('got response');
   });
 
-  req.on('socket', function() {
-    console.log('got a socket');
-
-    req.socket.on('connect', function() {
-      console.log('socket connected');
-    });
-
-    setTimeout(function() {
-      throw new Error('Did not get timeout event');
-    }, 200);
-  });
-
-  req.on('timeout', function() {
+  req.on('timeout', common.mustCall(function() {
     console.log('timeout occurred outside');
     req.destroy();
     server.close();
     process.exit(0);
-  });
-});
+  }));
+}));


### PR DESCRIPTION
Remove `setTimeout()` in test and instead rely on `common.mustCall()` on
a `timeout` event handler.

The test was flaky on CI. The flakiness was replicable by running the
test under load. This version, in contrast, is robust under load.

Took the opportunity to do some `var` -> `const` while refactoring.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test https

##### Description of change
<!-- Provide a description of the change below this comment. -->
