### PR TITLE
src: make `global` non-enumerable

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2983,6 +2983,13 @@ void StopProfilerIdleNotifier(const FunctionCallbackInfo<Value>& args) {
   env->StopProfilerIdleNotifier();
 }
 
+#define NONENUMERABLE_PROPERTY(obj, str, var)                                 \
+  do {                                                                        \
+    obj->DefineOwnProperty(env->context(),                                    \
+                           OneByteString(env->isolate(), str),                \
+                           var,                                               \
+                           v8::DontEnum).FromJust();                          \
+  } while (0)
 
 #define READONLY_PROPERTY(obj, str, var)                                      \
   do {                                                                        \
@@ -3450,9 +3457,9 @@ void LoadEnvironment(Environment* env) {
 
   env->SetMethod(env->process_object(), "_rawDebug", RawDebug);
 
-  // Expose the global object as a property on itself
+  // Expose the global object as a non-enumerable property on itself
   // (Allows you to set stuff on `global` from anywhere in JavaScript.)
-  global->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "global"), global);
+  NONENUMERABLE_PROPERTY(global, "global", global);
 
   // Now we call 'f' with the 'process' variable that we've built up with
   // all our bindings. Inside bootstrap_node.js and internal/process we'll

--- a/test/parallel/test-global-descriptors.js
+++ b/test/parallel/test-global-descriptors.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+
+const assert = require('assert');
+
+const {
+  value,
+  configurable,
+  enumerable,
+  writable
+} = Object.getOwnPropertyDescriptor(global, 'global');
+
+const actualGlobal = Function('return this')();
+assert.strictEqual(value, actualGlobal, 'global should be global object');
+
+assert.strictEqual(configurable, true, 'global should be configurable');
+assert.strictEqual(enumerable, false, 'global should be non-enumerable');
+assert.strictEqual(writable, true, 'global should be writable');


### PR DESCRIPTION
Per https://github.com/tc39/proposal-global

This is my first PR to node core, so I'm putting it up now without a completed checklist. Early feedback is welcome, and I'll be moving through the items as quickly I can.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), ~~or `vcbuild test` (Windows)~~ passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
the JS environment

##### Description of change
<!-- Provide a description of the change below this comment. -->
Per [the stage 3 proposal](https://github.com/tc39/proposal-global), `global` should be non-enumerable (but writable and configurable). This PR alters the property descriptor to be so.

(If there's a better place this should be done, a pointer to it is most welcome)