### PR TITLE
src: remove unused PROTOCOL_JSON array

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -31,10 +31,6 @@ namespace {
 using v8_inspector::StringBuffer;
 using v8_inspector::StringView;
 
-static const uint8_t PROTOCOL_JSON[] = {
-#include "v8_inspector_protocol_json.h"  // NOLINT(build/include_order)
-};
-
 std::string GetProcessTitle() {
   // uv_get_process_title will trim the title if it is too long.
   char title[2048];


### PR DESCRIPTION
Overlooked when moving code around in commit 42da740 ("inspector: split
HTTP/WS server from the inspector".)

CI: https://ci.nodejs.org/job/node-test-pull-request/5530/
