### PR TITLE
v8: make ObjectMirror handle proxy objects

### DIFF
--- a/deps/v8/src/runtime/runtime-debug.cc
+++ b/deps/v8/src/runtime/runtime-debug.cc
@@ -331,7 +331,7 @@ RUNTIME_FUNCTION(Runtime_DebugGetInternalProperties) {
 RUNTIME_FUNCTION(Runtime_DebugGetPropertyDetails) {
   HandleScope scope(isolate);
   DCHECK_EQ(2, args.length());
-  CONVERT_ARG_HANDLE_CHECKED(JSObject, obj, 0);
+  CONVERT_ARG_HANDLE_CHECKED(JSReceiver, obj, 0);
   CONVERT_ARG_HANDLE_CHECKED(Object, name_obj, 1);
 
   // Convert the {name_obj} to a Name.
@@ -1330,6 +1330,7 @@ static bool HasInPrototypeChainIgnoringProxies(Isolate* isolate,
 RUNTIME_FUNCTION(Runtime_DebugReferencedBy) {
   HandleScope scope(isolate);
   DCHECK(args.length() == 3);
+  if (!args[0]->IsJSObject()) return *isolate->factory()->NewJSArray(0);
   CONVERT_ARG_HANDLE_CHECKED(JSObject, target, 0);
   CONVERT_ARG_HANDLE_CHECKED(Object, filter, 1);
   CHECK(filter->IsUndefined(isolate) || filter->IsJSObject());
@@ -1420,7 +1421,7 @@ RUNTIME_FUNCTION(Runtime_DebugConstructedBy) {
 RUNTIME_FUNCTION(Runtime_DebugGetPrototype) {
   HandleScope shs(isolate);
   DCHECK(args.length() == 1);
-  CONVERT_ARG_HANDLE_CHECKED(JSObject, obj, 0);
+  CONVERT_ARG_HANDLE_CHECKED(JSReceiver, obj, 0);
   // TODO(1543): Come up with a solution for clients to handle potential errors
   // thrown by an intermediate proxy.
   RETURN_RESULT_OR_FAILURE(isolate, JSReceiver::GetPrototype(isolate, obj));

--- a/test/parallel/test-debug-mirror-proxy.js
+++ b/test/parallel/test-debug-mirror-proxy.js
@@ -1,0 +1,33 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const { MakeMirror } = vm.runInDebugContext('Debug');
+const proxy = new Proxy({ x: 1, y: 2 }, { get: Reflect.get });
+const mirror = MakeMirror(proxy);
+
+assert.ok(mirror.protoObject().value());
+assert.strictEqual(mirror.className(), 'Object');
+assert.strictEqual(mirror.constructorFunction().value(), undefined);
+assert.strictEqual(mirror.prototypeObject().value(), undefined);
+assert.strictEqual(mirror.hasNamedInterceptor(), false);
+assert.strictEqual(mirror.hasIndexedInterceptor(), false);
+assert.strictEqual(mirror.referencedBy(1).length, 0);
+assert.strictEqual(mirror.toText(), '#<Object>');
+
+const propertyNames = mirror.propertyNames();
+const ThatArray = propertyNames.constructor;
+assert.deepStrictEqual(propertyNames, ThatArray.from(['x', 'y']));
+
+const properties = mirror.properties();
+assert.strictEqual(properties.length, 2);
+assert.strictEqual(properties[0].name(), 'x');
+// |undefined| is not quite right but V8 cannot retrieve the correct values
+// without invoking the handler and that wouldn't be safe when the script is
+// currently being debugged.  Yes, it's odd that it does return property names
+// but it retrieves them without calling the handler.
+assert.strictEqual(properties[0].value().value(), undefined);
+assert.strictEqual(properties[1].name(), 'y');
+assert.strictEqual(properties[1].value().value(), undefined);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/10406

@eugeneo @ofrobots Should I send this upstream?  IIUC, mirrors are being phased out?

CI: https://ci.nodejs.org/job/node-test-pull-request/5531/
CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/476/