### PR TITLE
doc: fix trivial mistakes in stream document.

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1503,9 +1503,9 @@ Implementers, and only from within the `readable._read()` method.
 It is recommended that errors occurring during the processing of the
 `readable._read()` method are emitted using the `'error'` event rather than
 being thrown. Throwing an Error from within `readable._read()` can result in
-expected and inconsistent behavior depending on whether the stream is operating
-in flowing or paused mode. Using the `'error'` event ensures consistent and
-predictable handling of errors.
+unexpected and inconsistent behavior depending on whether the stream is
+operating in flowing or paused mode. Using the `'error'` event ensures
+consistent and predictable handling of errors.
 
 ```js
 const Readable = require('stream').Readable;

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1273,8 +1273,8 @@ If the `decodeStrings` property is set in the constructor options, then
 indicate the character encoding of the string. This is to support
 implementations that have an optimized handling for certain string
 data encodings. If the `decodeStrings` property is explicitly set to `false`,
-the `encoding` argument can be safely ignored, and `chunk` will always be a
-`Buffer`.
+the `encoding` argument can be safely ignored, and `chunk` will remain the same
+object that is passed to `.write()`.
 
 The `writable._write()` method is prefixed with an underscore because it is
 internal to the class that defines it, and should never be called directly by


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

##### Description of change
1st commit: 
In stream.Writable, when decodeStrings option is false, the chunk `_write()` function received is **not** always be `Buffer`, it depends types of the sources.
```
const {Writable} = require('stream');
class MyWritable extends Writable {
  _write(chunk, enc, cb) {
    console.log(chunk);
    console.log('typeof chunk : ' + typeof chunk);
    cb();
  }
}

const w = new MyWritable({decodeStrings: false});
w.write('abc');
w.write(Buffer.from('abc'));

// => abc
// => typeof chunk : string
// => <Buffer 61 62 63>
// => typeof chunk : object
```

2nd commit:
This is a trivial fix, 'unexpected' fits this context.