### PR TITLE
crypto: use CHECK_NE instead of ABORT or abort

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -701,11 +701,8 @@ static X509_STORE* NewRootCertStore() {
       X509 *x509 = PEM_read_bio_X509(bp, nullptr, CryptoPemCallback, nullptr);
       BIO_free(bp);
 
-      if (x509 == nullptr) {
-        // Parse errors from the built-in roots are fatal.
-        ABORT();
-        return nullptr;
-      }
+      // Parse errors from the built-in roots are fatal.
+      CHECK_NE(x509, nullptr);
 
       root_certs_vector->push_back(x509);
     }


### PR DESCRIPTION
Use of abort() was added in 34febfbf4, and changed to ABORT()
in 21826ef21ad, but conditional+ABORT() is better expressesed
using a CHECK_xxx() macro.

See: https://github.com/nodejs/node/pull/9409#discussion_r93575328

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src,crypto,tls

##### Description of change
