### PR TITLE
src: describe what NODE_MODULE_VERSION is for

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -44,6 +44,9 @@
       (minor) == NODE_MINOR_VERSION && (patch) <= NODE_PATCH_VERSION))
 
 /**
+ * Node.js will refuse to load modules that weren't compiled against its own
+ * module ABI number, exposed as the process.versions.modules property.
+ *
  * When this version number is changed, node.js will refuse
  * to load older modules.  This should be done whenever
  * an API is broken in the C++ side, including in v8 or


### PR DESCRIPTION
Current comment described what to do with it when the ABI changes, but
implied that node would load modules with newere ABI numbers, which it
will not.

##### Checklist

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

##### Description of change
