### PR TITLE
test fix: Use assert.strictEqual instead of assert.equal and assert.ok

### DIFF
--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -9,8 +9,8 @@ cat.stdin.write('hello');
 cat.stdin.write(' ');
 cat.stdin.write('world');
 
-assert.ok(cat.stdin.writable);
-assert.ok(!cat.stdin.readable);
+assert.strictEqual(true, cat.stdin.writable);
+assert.strictEqual(false, cat.stdin.readable);
 
 cat.stdin.end();
 
@@ -34,8 +34,8 @@ cat.on('exit', common.mustCall(function(status) {
 
 cat.on('close', common.mustCall(function() {
   if (common.isWindows) {
-    assert.equal('hello world\r\n', response);
+    assert.strictEqual('hello world\r\n', response);
   } else {
-    assert.equal('hello world', response);
+    assert.strictEqual('hello world', response);
   }
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
