### PR TITLE
test: fix linter error in whatwg-url-parsing

### DIFF
--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -136,9 +136,7 @@ for (const test of tests) {
 }
 
 for (const test of allTests) {
-  const url = test.url
-    ? new URL(test.url)
-    : new URL(test.input, test.base);
+  const url = test.url ? new URL(test.url) : new URL(test.input, test.base);
 
   for (const showHidden of [true, false]) {
     const res = url.inspect(null, {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

test-whatwg-url-parsing file violates the linter rule changes in
966e5cfb8169a35bf3a99d0272256b0976681a70. This patch makes the linter
happy.

