### PR TITLE
test: improve code in test-vm-symbols

### DIFF
--- a/test/parallel/test-vm-symbols.js
+++ b/test/parallel/test-vm-symbols.js
@@ -1,11 +1,11 @@
 'use strict';
 
 require('../common');
-var assert = require('assert');
+const assert = require('assert');
 
-var vm = require('vm');
+const vm = require('vm');
 
-var symbol = Symbol();
+const symbol = Symbol();
 
 function Document() {
   this[symbol] = 'foo';
@@ -15,11 +15,11 @@ Document.prototype.getSymbolValue = function() {
   return this[symbol];
 };
 
-var context = new Document();
+const context = new Document();
 vm.createContext(context);
 
-assert.equal(context.getSymbolValue(), 'foo',
-             'should return symbol-keyed value from the outside');
+assert.strictEqual(context.getSymbolValue(), 'foo',
+                   'should return symbol-keyed value from the outside');
 
-assert.equal(vm.runInContext('this.getSymbolValue()', context), 'foo',
-             'should return symbol-keyed value from the inside');
+assert.strictEqual(vm.runInContext('this.getSymbolValue()', context), 'foo',
+                   'should return symbol-keyed value from the inside');


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use const instead of var
* use assert.strictEqual instead of assert.equal