### PR TITLE
util: improve readability of normalizeEncoding

### DIFF
--- a/benchmark/util/normalize-encoding.js
+++ b/benchmark/util/normalize-encoding.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const groupedInputs = {
+  group_common: ['undefined', 'utf8', 'utf-8', 'base64', 'binary', 'latin1'],
+  group_upper: ['UTF-8', 'UTF8', 'UCS2', 'UTF-16LE', 'UTF16LE', 'BASE64'],
+  group_uncommon: [ 'foo', '1', 'false', 'undefined', '[]'],
+  group_misc: ['', 'utf16le', 'usc2', 'hex', 'HEX', 'BINARY']
+};
+
+const inputs = [
+  '', 'utf8', 'utf-8', 'UTF-8',
+  'UTF8', 'Utf8', 'uTf-8', 'utF-8', 'ucs2',
+  'UCS2', 'utf16le', 'utf-16le', 'UTF-16LE', 'UTF16LE',
+  'binary', 'BINARY', 'latin1', 'base64', 'BASE64',
+  'hex', 'HEX', 'foo', '1', 'false', 'undefined', '[]'];
+
+const bench = common.createBenchmark(main, {
+  input: inputs.concat(Object.keys(groupedInputs)),
+  n: [1e5]
+}, {
+  flags: '--expose-internals'
+});
+
+function getInput(input) {
+  switch (input) {
+    case 'group_common':
+      return groupedInputs.group_common;
+    case 'group_upper':
+      return groupedInputs.group_upper;
+    case 'group_uncommon':
+      return groupedInputs.group_uncommon;
+    case 'group_misc':
+      return groupedInputs.group_misc;
+    case '1':
+      return [1];
+    case 'false':
+      return [false];
+    case 'undefined':
+      return [undefined];
+    case '[]':
+      return [[]];
+    default:
+      return [input];
+  }
+}
+
+function main(conf) {
+  const normalizeEncoding = require('internal/util').normalizeEncoding;
+
+  const n = conf.n | 0;
+  const inputs = getInput(conf.input);
+  var noDead = '';
+
+  bench.start();
+  for (var i = 0; i < n; i += 1) {
+    for (var j = 0; j < inputs.length; ++j) {
+      noDead = normalizeEncoding(inputs[j]);
+    }
+  }
+  bench.end(n);
+  assert.ok(noDead === undefined || noDead.length > 0);
+}

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -103,10 +103,16 @@ exports.assertCrypto = function(exports) {
 };
 
 exports.kIsEncodingSymbol = Symbol('node.isEncoding');
+
+// The loop should only run at most twice, retrying with lowercased enc
+// if there is no match in the first pass.
+// We use a loop instead of branching to retry with a helper
+// function in order to avoid the performance hit.
+// Return undefined if there is no match.
 exports.normalizeEncoding = function normalizeEncoding(enc) {
   if (!enc) return 'utf8';
-  var low;
-  for (;;) {
+  var retried;
+  while (true) {
     switch (enc) {
       case 'utf8':
       case 'utf-8':
@@ -124,9 +130,9 @@ exports.normalizeEncoding = function normalizeEncoding(enc) {
       case 'hex':
         return enc;
       default:
-        if (low) return; // undefined
+        if (retried) return; // undefined
         enc = ('' + enc).toLowerCase();
-        low = true;
+        retried = true;
     }
   }
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util

##### Description of change
<!-- Provide a description of the change below this comment. -->

<del>Replace the redundant for loop with if-else.</del>

EDIT: there is a inevitable performance hit if rewrite the loop into if-else with a helper function. Rewrite to use a slightly more readable while loop with comments.

Also add a benchmark for `util.normalizeEncoding`