### PR TITLE
tools: refactor json.js

### DIFF
--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -102,7 +102,7 @@ function doJSON(input, filename, cb) {
         current.list.push(tok);
         current.list.level = 1;
       } else if (type === 'html' && common.isYAMLBlock(tok.text)) {
-        current.meta = parseYAML(tok.text);
+        current.meta = common.extractAndParseYAML(tok.text);
       } else {
         current.desc = current.desc || [];
         if (!Array.isArray(current.desc)) {
@@ -302,10 +302,6 @@ function processList(section) {
   delete section.list;
 }
 
-function parseYAML(text) {
-  return common.extractAndParseYAML(text);
-}
-
 // textRaw = "someobject.someMethod(a[, b=100][, c])"
 function parseSignature(text, sig) {
   var params = text.match(paramExpr);
@@ -314,7 +310,7 @@ function parseSignature(text, sig) {
   params = params.split(/,/);
   var optionalLevel = 0;
   var optionalCharDict = {'[': 1, ' ': 0, ']': -1};
-  params.forEach(function(p, i, _) {
+  params.forEach(function(p, i) {
     p = p.trim();
     if (!p) return;
     var param = sig.params[i];
@@ -544,14 +540,12 @@ function deepCopy_(src) {
 
 // these parse out the contents of an H# tag
 var eventExpr = /^Event(?::|\s)+['"]?([^"']+).*$/i;
-var classExpr = /^Class:\s*([^ ]+).*?$/i;
-var propExpr = /^(?:property:?\s*)?[^.]+\.([^ .()]+)\s*?$/i;
-var braceExpr = /^(?:property:?\s*)?[^.\[]+(\[[^\]]+\])\s*?$/i;
-var classMethExpr =
-  /^class\s*method\s*:?[^.]+\.([^ .()]+)\([^)]*\)\s*?$/i;
-var methExpr =
-  /^(?:method:?\s*)?(?:[^.]+\.)?([^ .()]+)\([^)]*\)\s*?$/i;
-var newExpr = /^new ([A-Z][a-zA-Z]+)\([^)]*\)\s*?$/;
+var classExpr = /^Class:\s*([^ ]+).*$/i;
+var propExpr = /^[^.]+\.([^ .()]+)\s*$/;
+var braceExpr = /^[^.[]+(\[[^\]]+\])\s*$/;
+var classMethExpr = /^class\s*method\s*:?[^.]+\.([^ .()]+)\([^)]*\)\s*$/i;
+var methExpr = /^(?:[^.]+\.)?([^ .()]+)\([^)]*\)\s*$/;
+var newExpr = /^new ([A-Z][a-zA-Z]+)\([^)]*\)\s*$/;
 var paramExpr = /\((.*)\);?$/;
 
 function newSection(tok) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

##### Description of change
<!-- Provide a description of the change below this comment. -->
    * Simplify regular expressions (see below)
    * Remove unneeded `parseYAML()` wrapper
    * Remove unused callback argument
    
    Regular expression simplifications include:
    
    * Changing trailing `*?$/` to `*$/` because non-greedy matching to the
      end of a line will not change behavior
    * Change regexp beginnings eike `/^(?:property:?\s*)?[^.\[]+` to the
      equivalent `/[^.\]]+`
    * For regular expressions changed per the above, remove
      case-insensitivity if it no longer affects the regexp

`make docclean && make doc` results in identical files with these changes.