### PR TITLE
buffer: improve allocation and from(arrayLike) performance

### DIFF
--- a/benchmark/buffers/buffer-from.js
+++ b/benchmark/buffers/buffer-from.js
@@ -10,7 +10,8 @@ const bench = common.createBenchmark(main, {
     'buffer',
     'uint8array',
     'string',
-    'string-base64'
+    'string-base64',
+    'object'
   ],
   len: [10, 2048],
   n: [1024]
@@ -25,6 +26,7 @@ function main(conf) {
   const str = 'a'.repeat(len);
   const buffer = Buffer.allocUnsafe(len);
   const uint8array = new Uint8Array(len);
+  const obj = { length: null }; // Results in a new, empty Buffer
 
   var i;
 
@@ -77,6 +79,13 @@ function main(conf) {
       bench.start();
       for (i = 0; i < n * 1024; i++) {
         Buffer.from(str, 'base64');
+      }
+      bench.end(n);
+      break;
+    case 'object':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(obj);
       }
       bench.end(n);
       break;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -263,7 +263,7 @@ function fromObject(obj) {
   }
 
   if (obj) {
-    if ('length' in obj || isArrayBuffer(obj.buffer) ||
+    if (obj.length !== undefined || isArrayBuffer(obj.buffer) ||
         isSharedArrayBuffer(obj.buffer)) {
       if (typeof obj.length !== 'number' || obj.length !== obj.length) {
         return new FastBuffer();

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -109,6 +109,9 @@ Buffer.from = function(value, encodingOrOffset, length) {
 
 Object.setPrototypeOf(Buffer, Uint8Array);
 
+// The 'assertSize' method will remove itself from the callstack when an error
+// occurs. This is done simply to keep the internal details of the
+// implementation from bleeding out to users.
 function assertSize(size) {
   let err = null;
 
@@ -121,9 +124,6 @@ function assertSize(size) {
                          'than ' + binding.kMaxLength);
 
   if (err) {
-    // The following hides the 'assertSize' method from the
-    // callstack. This is done simply to hide the internal
-    // details of the implementation from bleeding out to users.
     Error.captureStackTrace(err, assertSize);
     throw err;
   }


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* buffer


##### Description of change

Improve Buffer allocation performance (up to ~11%) by making `assertSize()` inlineable and improve `Buffer.from(arrayLike)` performance (~50%) by replacing the usage of the `in` operator when checking for a `length` property.

Relevant benchmark results:

Buffer allocation:

```
                                                                   improvement significant      p.value
buffers/buffer-creation.js n=1024 len=10 type="buffer()"                3.67 %         *** 1.907380e-31
buffers/buffer-creation.js n=1024 len=10 type="fast-alloc-fill"         4.34 %         *** 3.497544e-11
buffers/buffer-creation.js n=1024 len=10 type="fast-alloc"              9.94 %         *** 7.596522e-44
buffers/buffer-creation.js n=1024 len=10 type="fast-allocUnsafe"        5.05 %         *** 2.696345e-51
buffers/buffer-creation.js n=1024 len=10 type="slow-allocUnsafe"        3.49 %         *** 1.076653e-07
buffers/buffer-creation.js n=1024 len=10 type="slow"                   11.22 %         *** 5.188153e-61
buffers/buffer-creation.js n=1024 len=1024 type="buffer()"              1.42 %          ** 1.348395e-03
buffers/buffer-creation.js n=1024 len=1024 type="fast-alloc-fill"       2.52 %         *** 1.446582e-06
buffers/buffer-creation.js n=1024 len=1024 type="fast-alloc"            5.38 %         *** 1.283277e-27
buffers/buffer-creation.js n=1024 len=1024 type="fast-allocUnsafe"      2.18 %         *** 2.896226e-06
buffers/buffer-creation.js n=1024 len=1024 type="slow-allocUnsafe"      3.41 %         *** 6.929603e-10
buffers/buffer-creation.js n=1024 len=1024 type="slow"                  9.38 %         *** 1.607505e-56
buffers/buffer-creation.js n=1024 len=2048 type="buffer()"              2.13 %         *** 2.849077e-05
buffers/buffer-creation.js n=1024 len=2048 type="fast-alloc-fill"       2.39 %         *** 1.291052e-07
buffers/buffer-creation.js n=1024 len=2048 type="fast-alloc"            3.96 %         *** 2.701098e-22
buffers/buffer-creation.js n=1024 len=2048 type="fast-allocUnsafe"      1.57 %         *** 5.975363e-04
buffers/buffer-creation.js n=1024 len=2048 type="slow-allocUnsafe"      4.54 %         *** 3.838296e-15
buffers/buffer-creation.js n=1024 len=2048 type="slow"                  8.52 %         *** 6.733714e-46
buffers/buffer-creation.js n=1024 len=4096 type="buffer()"              3.62 %         *** 1.399411e-10
buffers/buffer-creation.js n=1024 len=4096 type="fast-alloc-fill"       1.85 %         *** 2.706257e-05
buffers/buffer-creation.js n=1024 len=4096 type="fast-alloc"            1.30 %         *** 1.625928e-04
buffers/buffer-creation.js n=1024 len=4096 type="fast-allocUnsafe"      4.14 %         *** 4.122709e-15
buffers/buffer-creation.js n=1024 len=4096 type="slow-allocUnsafe"      3.78 %         *** 5.601502e-13
buffers/buffer-creation.js n=1024 len=4096 type="slow"                  8.09 %         *** 6.466906e-46
buffers/buffer-creation.js n=1024 len=8192 type="buffer()"              2.54 %         *** 1.426874e-05
buffers/buffer-creation.js n=1024 len=8192 type="fast-alloc-fill"       1.16 %          ** 1.392665e-03
buffers/buffer-creation.js n=1024 len=8192 type="fast-alloc"            0.83 %          ** 2.391328e-03
buffers/buffer-creation.js n=1024 len=8192 type="fast-allocUnsafe"      5.33 %         *** 1.811794e-19
buffers/buffer-creation.js n=1024 len=8192 type="slow-allocUnsafe"      4.85 %         *** 1.764478e-16
buffers/buffer-creation.js n=1024 len=8192 type="slow"                  8.18 %         *** 1.006915e-42
```

`Buffer.from(arrayLike)`:

```
                                                       improvement significant      p.value
buffers/buffer-from.js n=10024 len=10 source="object"       48.85 %         *** 4.055606e-41
buffers/buffer-from.js n=10024 len=2048 source="object"     49.44 %         *** 2.809991e-51
```

/cc @nodejs/buffer 
CI: https://ci.nodejs.org/job/node-test-pull-request/5580/