### PR TITLE
events: improve once() performance

### DIFF
--- a/benchmark/events/ee-once.js
+++ b/benchmark/events/ee-once.js
@@ -1,0 +1,20 @@
+'use strict';
+var common = require('../common.js');
+var EventEmitter = require('events').EventEmitter;
+
+var bench = common.createBenchmark(main, {n: [2e7]});
+
+function main(conf) {
+  var n = conf.n | 0;
+
+  var ee = new EventEmitter();
+
+  function listener() {}
+
+  bench.start();
+  for (var i = 0; i < n; i += 1) {
+    ee.once('dummy', listener);
+    ee.emit('dummy');
+  }
+  bench.end(n);
+}

--- a/lib/events.js
+++ b/lib/events.js
@@ -283,17 +283,20 @@ EventEmitter.prototype.prependListener =
       return _addListener(this, type, listener, true);
     };
 
-function _onceWrap(target, type, listener) {
-  var fired = false;
-  function g() {
-    target.removeListener(type, g);
-    if (!fired) {
-      fired = true;
-      listener.apply(target, arguments);
-    }
+function onceWrapper() {
+  this.target.removeListener(this.type, this.wrapFn);
+  if (!this.fired) {
+    this.fired = true;
+    this.listener.apply(this.target, arguments);
   }
-  g.listener = listener;
-  return g;
+}
+
+function _onceWrap(target, type, listener) {
+  var state = { fired: false, wrapFn: undefined, target, type, listener };
+  var wrapped = onceWrapper.bind(state);
+  wrapped.listener = listener;
+  state.wrapFn = wrapped;
+  return wrapped;
 }
 
 EventEmitter.prototype.once = function once(type, listener) {


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* events


##### Description of change

This commit takes advantage of the performance improvements V8 has made to `function.bind()` in V8 5.4 and uses it to avoid constant recompilation/reoptimization of the wrapper closure used in `once()`. This change results in ~27% performance increase for `once()`.

Example results with included benchmark:

```
                             improvement significant      p.value
events/ee-once.js n=20000000     27.17 %         *** 2.322255e-10
```

CI: https://ci.nodejs.org/job/node-test-pull-request/5581/