### PR TITLE
doc: some fixes in console.md

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -135,15 +135,20 @@ the default behavior of `console` in Node.js.
 
 // Creates a simple extension of console with a
 // new impl for assert without monkey-patching.
-const myConsole = Object.setPrototypeOf({
-  assert(assertion, message, ...args) {
-    try {
-      console.assert(assertion, message, ...args);
-    } catch (err) {
-      console.error(err.stack);
-    }
-  }
-}, console);
+const myConsole = Object.create(console, {
+  assert: {
+    value: function assert(assertion, message, ...args) {
+      try {
+        console.assert(assertion, message, ...args);
+      } catch (err) {
+        console.error(err.stack);
+      }
+    },
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  },
+});
 
 module.exports = myConsole;
 ```

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -88,7 +88,7 @@ const errorOutput = fs.createWriteStream('./stderr.log');
 // custom simple logger
 const logger = new Console(output, errorOutput);
 // use it like console
-var count = 5;
+const count = 5;
 logger.log('count: %d', count);
 // in stdout.log: count 5
 ```
@@ -217,7 +217,7 @@ values similar to printf(3) (the arguments are all passed to
 [`util.format()`][]).
 
 ```js
-var count = 5;
+const count = 5;
 console.log('count: %d', count);
 // Prints: count: 5, to stdout
 console.log('count:', count);
@@ -248,7 +248,7 @@ prints the result to `stdout`:
 
 ```js
 console.time('100-elements');
-for (var i = 0; i < 100; i++) {
+for (let i = 0; i < 100; i++) {
   ;
 }
 console.timeEnd('100-elements');


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc, console

##### Description of change
1. `var` -> `const` / `let`

2. `Object.setPrototypeOf()` -> `Object.create()`. The new variant is slightly more verbose, but the former one is warned against as less efficient: see the performance warnings [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) or [here](http://exploringjs.com/es6/ch_oop-besides-classes.html#_objectsetprototypeofobj-proto). The changed example was advised as a way to extend a core lib class in a userland lib, so maybe the doc could use a more careful code here. The verbosity is induced by a wish to get the same property descriptors as the others of the `console` methods.