### PR TITLE
build: enable debugger tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 CI_NATIVE_SUITES := addons
-CI_JS_SUITES := doctool inspector known_issues message parallel \
+CI_JS_SUITES := debugger doctool inspector known_issues message parallel \
 	pseudo-tty sequential
 
 # Build and test addons without building anything else

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,7 @@ v8:
 test: all
 	$(MAKE) build-addons
 	$(MAKE) cctest
-	$(PYTHON) tools/test.py --mode=release -J \
-		addons doctool inspector known_issues message pseudo-tty parallel sequential
+	$(PYTHON) tools/test.py --mode=release -J $(CI_JS_SUITES) $(CI_NATIVE_SUITES)
 	$(MAKE) lint
 
 test-parallel: all
@@ -200,7 +199,8 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 CI_NATIVE_SUITES := addons
-CI_JS_SUITES := doctool inspector known_issues message parallel pseudo-tty sequential
+CI_JS_SUITES := doctool inspector known_issues message parallel \
+	pseudo-tty sequential
 
 # Build and test addons without building anything else
 test-ci-native: LOGLEVEL := info

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -39,6 +39,7 @@ set enable_vtune_arg=
 set configure_flags=
 set build_addons=
 set dll=
+set ci_test_targets="addons doctool inspector known_issues message parallel sequential"
 
 :next-arg
 if "%1"=="" goto args-done
@@ -57,8 +58,8 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
-if /i "%1"=="test"          set test_args=%test_args% addons doctool known_issues message parallel sequential -J&set jslint=1&set build_addons=1&goto arg-ok
-if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap addons doctool inspector known_issues message sequential parallel&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&set build_addons=1&goto arg-ok
+if /i "%1"=="test"          set test_args=%test_args% %ci_test_targets% -J&set jslint=1&set build_addons=1&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap %ci_test_targets%&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&set build_addons=1&goto arg-ok
 if /i "%1"=="test-addons"   set test_args=%test_args% addons&set build_addons=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -39,7 +39,7 @@ set enable_vtune_arg=
 set configure_flags=
 set build_addons=
 set dll=
-set ci_test_targets="addons doctool inspector known_issues message parallel sequential"
+set ci_test_targets="addons debugger doctool inspector known_issues message parallel sequential"
 
 :next-arg
 if "%1"=="" goto args-done


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

build

##### Description of change

Since https://github.com/nodejs/node/issues/10361 is solved in master
branch, we can enable debugger tests in CI.

---

cc @nodejs/build 
