### PR TITLE
lib,src: make constants not inherit from Object

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1004,7 +1004,7 @@ fs.fchmodSync = function(fd, mode) {
   return binding.fchmod(fd, modeNum(mode));
 };
 
-if (constants.hasOwnProperty('O_SYMLINK')) {
+if (constants.O_SYMLINK !== undefined) {
   fs.lchmod = function(path, mode, callback) {
     callback = maybeCallback(callback);
     fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {
@@ -1059,7 +1059,7 @@ fs.chmodSync = function(path, mode) {
   return binding.chmod(pathModule._makeLong(path), modeNum(mode));
 };
 
-if (constants.hasOwnProperty('O_SYMLINK')) {
+if (constants.O_SYMLINK !== undefined) {
   fs.lchown = function(path, uid, gid, callback) {
     callback = maybeCallback(callback);
     fs.open(path, constants.O_WRONLY | constants.O_SYMLINK, function(err, fd) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -184,8 +184,7 @@ function setupSignalHandlers() {
   const signalWraps = {};
 
   function isSignal(event) {
-    return typeof event === 'string' &&
-           lazyConstants().hasOwnProperty(event);
+    return typeof event === 'string' && lazyConstants()[event] !== undefined;
   }
 
   // Detect presence of a listener for the special signal types

--- a/src/node.cc
+++ b/src/node.cc
@@ -2621,6 +2621,8 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
     cache->Set(module, exports);
   } else if (!strcmp(*module_v, "constants")) {
     exports = Object::New(env->isolate());
+    CHECK(exports->SetPrototype(env->context(),
+                                Null(env->isolate())).FromJust());
     DefineConstants(env->isolate(), exports);
     cache->Set(module, exports);
   } else if (!strcmp(*module_v, "natives")) {

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1224,12 +1224,31 @@ void DefineZlibConstants(Local<Object> target) {
 }
 
 void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
+  Environment* env = Environment::GetCurrent(isolate);
+
   Local<Object> os_constants = Object::New(isolate);
+  CHECK(os_constants->SetPrototype(env->context(),
+                                   Null(env->isolate())).FromJust());
+
   Local<Object> err_constants = Object::New(isolate);
+  CHECK(err_constants->SetPrototype(env->context(),
+                                    Null(env->isolate())).FromJust());
+
   Local<Object> sig_constants = Object::New(isolate);
+  CHECK(sig_constants->SetPrototype(env->context(),
+                                    Null(env->isolate())).FromJust());
+
   Local<Object> fs_constants = Object::New(isolate);
+  CHECK(fs_constants->SetPrototype(env->context(),
+                                   Null(env->isolate())).FromJust());
+
   Local<Object> crypto_constants = Object::New(isolate);
+  CHECK(crypto_constants->SetPrototype(env->context(),
+                                       Null(env->isolate())).FromJust());
+
   Local<Object> zlib_constants = Object::New(isolate);
+  CHECK(zlib_constants->SetPrototype(env->context(),
+                                     Null(env->isolate())).FromJust());
 
   DefineErrnoConstants(err_constants);
   DefineWindowsErrorConstants(err_constants);

--- a/test/parallel/test-binding-constants.js
+++ b/test/parallel/test-binding-constants.js
@@ -1,0 +1,30 @@
+'use strict';
+
+require('../common');
+const constants = process.binding('constants');
+const assert = require('assert');
+
+assert.deepStrictEqual(
+  Object.keys(constants).sort(), ['crypto', 'fs', 'os', 'zlib']
+);
+
+assert.deepStrictEqual(
+  Object.keys(constants.os).sort(), ['UV_UDP_REUSEADDR', 'errno', 'signals']
+);
+
+// Make sure all the constants objects don't inherit from Object.prototype
+const inheritedProperties = Object.getOwnPropertyNames(Object.prototype);
+function test(obj) {
+  assert(obj);
+  assert.strictEqual(Object.prototype.toString.call(obj), '[object Object]');
+  assert.strictEqual(Object.getPrototypeOf(obj), null);
+
+  inheritedProperties.forEach((property) => {
+    assert.strictEqual(property in obj, false);
+  });
+}
+
+[
+  constants, constants.crypto, constants.fs, constants.os, constants.zlib,
+  constants.os.errno, constants.os.signals
+].forEach(test);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

lib src test

##### Description of change

Make sure `constants` object and all the nested objects don't inherit
from `Object.prototype` but from `null`.