### PR TITLE
v4.x: backport test: use mustCall() for simple flow tracking

### DIFF
--- a/test/addons/async-hello-world/test.js
+++ b/test/addons/async-hello-world/test.js
@@ -1,17 +1,10 @@
 'use strict';
-var common = require('../../common');
+const common = require('../../common');
 var assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
-var called = false;
 
-process.on('exit', function() {
-  assert(called);
-});
-
-binding(5, function(err, val) {
+binding(5, common.mustCall(function(err, val) {
   assert.equal(null, err);
   assert.equal(10, val);
-  process.nextTick(function() {
-    called = true;
-  });
-});
+  process.nextTick(common.mustCall(function() {}));
+}));

--- a/test/internet/test-http-dns-fail.js
+++ b/test/internet/test-http-dns-fail.js
@@ -4,11 +4,10 @@
  * should trigger the error event after each attempt.
  */
 
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var resDespiteError = false;
 var hadError = 0;
 
 function httpreq(count) {
@@ -19,9 +18,7 @@ function httpreq(count) {
     port: 80,
     path: '/',
     method: 'GET'
-  }, function(res) {
-    resDespiteError = true;
-  });
+  }, common.fail);
 
   req.on('error', function(e) {
     console.log(e.message);
@@ -37,6 +34,5 @@ httpreq(0);
 
 
 process.on('exit', function() {
-  assert.equal(false, resDespiteError);
   assert.equal(2, hadError);
 });

--- a/test/internet/test-http-https-default-ports.js
+++ b/test/internet/test-http-https-default-ports.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -9,21 +8,11 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 var http = require('http');
-var gotHttpsResp = false;
-var gotHttpResp = false;
 
-process.on('exit', function() {
-  assert(gotHttpsResp);
-  assert(gotHttpResp);
-  console.log('ok');
-});
-
-https.get('https://www.google.com/', function(res) {
-  gotHttpsResp = true;
+https.get('https://www.google.com/', common.mustCall(function(res) {
   res.resume();
-});
+}));
 
-http.get('http://www.google.com/', function(res) {
-  gotHttpResp = true;
+http.get('http://www.google.com/', common.mustCall(function(res) {
   res.resume();
-});
+}));

--- a/test/internet/test-net-connect-timeout.js
+++ b/test/internet/test-net-connect-timeout.js
@@ -3,15 +3,11 @@
 // https://groups.google.com/forum/#!topic/nodejs/UE0ZbfLt6t8
 // https://groups.google.com/forum/#!topic/nodejs-dev/jR7-5UDqXkw
 
-require('../common');
+const common = require('../common');
 var net = require('net');
 var assert = require('assert');
 
 var start = new Date();
-
-var gotTimeout = false;
-
-var gotConnect = false;
 
 var T = 100;
 
@@ -23,22 +19,11 @@ var socket = net.createConnection(9999, '192.0.2.1');
 
 socket.setTimeout(T);
 
-socket.on('timeout', function() {
+socket.on('timeout', common.mustCall(function() {
   console.error('timeout');
-  gotTimeout = true;
   var now = new Date();
   assert.ok(now - start < T + 500);
   socket.destroy();
-});
+}));
 
-socket.on('connect', function() {
-  console.error('connect');
-  gotConnect = true;
-  socket.destroy();
-});
-
-
-process.on('exit', function() {
-  assert.ok(gotTimeout);
-  assert.ok(!gotConnect);
-});
+socket.on('connect', common.fail);

--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -1,25 +1,14 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var net = require('net');
 
-var client, killed = false, ended = false;
+var client;
 var TIMEOUT = 10 * 1000;
 
 client = net.createConnection(53, '8.8.8.8', function() {
   client.unref();
 });
 
-client.on('close', function() {
-  ended = true;
-});
+client.on('close', common.fail);
 
-setTimeout(function() {
-  killed = true;
-  client.end();
-}, TIMEOUT).unref();
-
-process.on('exit', function() {
-  assert.strictEqual(killed, false, 'A client should have connected');
-  assert.strictEqual(ended, false, 'A client should stay connected');
-});
+setTimeout(common.fail, TIMEOUT).unref();

--- a/test/parallel/test-child-process-buffering.js
+++ b/test/parallel/test-child-process-buffering.js
@@ -2,10 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-var pwd_called = false;
-var childClosed = false;
-var childExited = false;
-
 function pwd(callback) {
   var output = '';
   var child = common.spawnPwd();
@@ -16,17 +12,14 @@ function pwd(callback) {
     output += s;
   });
 
-  child.on('exit', function(c) {
+  child.on('exit', common.mustCall(function(c) {
     console.log('exit: ' + c);
     assert.equal(0, c);
-    childExited = true;
-  });
+  }));
 
-  child.on('close', function() {
+  child.on('close', common.mustCall(function() {
     callback(output);
-    pwd_called = true;
-    childClosed = true;
-  });
+  }));
 }
 
 
@@ -34,10 +27,4 @@ pwd(function(result) {
   console.dir(result);
   assert.equal(true, result.length > 1);
   assert.equal('\n', result[result.length - 1]);
-});
-
-process.on('exit', function() {
-  assert.equal(true, pwd_called);
-  assert.equal(true, childExited);
-  assert.equal(true, childClosed);
 });

--- a/test/parallel/test-child-process-disconnect.js
+++ b/test/parallel/test-child-process-disconnect.js
@@ -48,21 +48,16 @@ if (process.argv[2] === 'child') {
   var child = fork(process.argv[1], ['child']);
 
   var childFlag = false;
-  var childSelfTerminate = false;
-  var parentEmit = false;
   var parentFlag = false;
 
   // when calling .disconnect the event should emit
   // and the disconnected flag should be true.
-  child.on('disconnect', function() {
-    parentEmit = true;
+  child.on('disconnect', common.mustCall(function() {
     parentFlag = child.connected;
-  });
+  }));
 
   // the process should also self terminate without using signals
-  child.on('exit', function() {
-    childSelfTerminate = true;
-  });
+  child.on('exit', common.mustCall(function() {}));
 
   // when child is listening
   child.on('message', function(obj) {
@@ -91,8 +86,5 @@ if (process.argv[2] === 'child') {
   process.on('exit', function() {
     assert.equal(childFlag, false);
     assert.equal(parentFlag, false);
-
-    assert.ok(childSelfTerminate);
-    assert.ok(parentEmit);
   });
 }

--- a/test/parallel/test-child-process-exec-buffer.js
+++ b/test/parallel/test-child-process-exec-buffer.js
@@ -1,33 +1,22 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 var os = require('os');
-
-var success_count = 0;
-
 var str = 'hello';
 
 // default encoding
-exec('echo ' + str, function(err, stdout, stderr) {
+exec('echo ' + str, common.mustCall(function(err, stdout, stderr) {
   assert.ok('string', typeof stdout, 'Expected stdout to be a string');
   assert.ok('string', typeof stderr, 'Expected stderr to be a string');
   assert.equal(str + os.EOL, stdout);
-
-  success_count++;
-});
+}));
 
 // no encoding (Buffers expected)
 exec('echo ' + str, {
   encoding: null
-}, function(err, stdout, stderr) {
+}, common.mustCall(function(err, stdout, stderr) {
   assert.ok(stdout instanceof Buffer, 'Expected stdout to be a Buffer');
   assert.ok(stderr instanceof Buffer, 'Expected stderr to be a Buffer');
   assert.equal(str + os.EOL, stdout.toString());
-
-  success_count++;
-});
-
-process.on('exit', function() {
-  assert.equal(2, success_count);
-});
+}));

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -3,9 +3,6 @@ const common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 
-var success_count = 0;
-var error_count = 0;
-
 var pwdcommand, dir;
 
 if (common.isWindows) {
@@ -16,21 +13,7 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-exec(pwdcommand, {cwd: dir}, function(err, stdout, stderr) {
-  if (err) {
-    error_count++;
-    console.log('error!: ' + err.code);
-    console.log('stdout: ' + JSON.stringify(stdout));
-    console.log('stderr: ' + JSON.stringify(stderr));
-    assert.equal(false, err.killed);
-  } else {
-    success_count++;
-    console.log(stdout);
-    assert.ok(stdout.indexOf(dir) == 0);
-  }
-});
-
-process.on('exit', function() {
-  assert.equal(1, success_count);
-  assert.equal(0, error_count);
-});
+exec(pwdcommand, {cwd: dir}, common.mustCall(function(err, stdout, stderr) {
+  assert.ifError(err);
+  assert.ok(stdout.indexOf(dir) == 0);
+}));

--- a/test/parallel/test-child-process-exec-error.js
+++ b/test/parallel/test-child-process-exec-error.js
@@ -4,17 +4,10 @@ var assert = require('assert');
 var child_process = require('child_process');
 
 function test(fun, code) {
-  var errors = 0;
-
-  fun('does-not-exist', function(err) {
+  fun('does-not-exist', common.mustCall(function(err) {
     assert.equal(err.code, code);
     assert(/does\-not\-exist/.test(err.cmd));
-    errors++;
-  });
-
-  process.on('exit', function() {
-    assert.equal(errors, 1);
-  });
+  }));
 }
 
 if (common.isWindows) {

--- a/test/parallel/test-child-process-exit-code.js
+++ b/test/parallel/test-child-process-exit-code.js
@@ -4,29 +4,18 @@ var assert = require('assert');
 var spawn = require('child_process').spawn;
 var path = require('path');
 
-var exits = 0;
-
 var exitScript = path.join(common.fixturesDir, 'exit.js');
 var exitChild = spawn(process.argv[0], [exitScript, 23]);
-exitChild.on('exit', function(code, signal) {
+exitChild.on('exit', common.mustCall(function(code, signal) {
   assert.strictEqual(code, 23);
   assert.strictEqual(signal, null);
-
-  exits++;
-});
+}));
 
 
 var errorScript = path.join(common.fixturesDir,
                             'child_process_should_emit_error.js');
 var errorChild = spawn(process.argv[0], [errorScript]);
-errorChild.on('exit', function(code, signal) {
+errorChild.on('exit', common.mustCall(function(code, signal) {
   assert.ok(code !== 0);
   assert.strictEqual(signal, null);
-
-  exits++;
-});
-
-
-process.on('exit', function() {
-  assert.equal(2, exits);
-});
+}));

--- a/test/parallel/test-child-process-fork-and-spawn.js
+++ b/test/parallel/test-child-process-fork-and-spawn.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var fork = require('child_process').fork;
@@ -7,12 +7,11 @@ var fork = require('child_process').fork;
 // Fork, then spawn. The spawned process should not hang.
 switch (process.argv[2] || '') {
   case '':
-    fork(__filename, ['fork']).on('exit', checkExit);
-    process.on('exit', haveExit);
+    fork(__filename, ['fork']).on('exit', common.mustCall(checkExit));
     break;
   case 'fork':
-    spawn(process.execPath, [__filename, 'spawn']).on('exit', checkExit);
-    process.on('exit', haveExit);
+    spawn(process.execPath, [__filename, 'spawn'])
+      .on('exit', common.mustCall(checkExit));
     break;
   case 'spawn':
     break;
@@ -20,14 +19,7 @@ switch (process.argv[2] || '') {
     assert(0);
 }
 
-var seenExit = false;
-
 function checkExit(statusCode) {
-  seenExit = true;
   assert.equal(statusCode, 0);
   process.nextTick(process.exit);
-}
-
-function haveExit() {
-  assert.equal(seenExit, true);
 }

--- a/test/parallel/test-child-process-fork-close.js
+++ b/test/parallel/test-child-process-fork-close.js
@@ -9,28 +9,22 @@ let gotMessage = false;
 let gotExit = false;
 let gotClose = false;
 
-cp.on('message', function(message) {
+cp.on('message', common.mustCall(function(message) {
   assert(!gotMessage);
   assert(!gotClose);
   assert.strictEqual(message, 'hello');
   gotMessage = true;
-});
+}));
 
-cp.on('exit', function() {
+cp.on('exit', common.mustCall(function() {
   assert(!gotExit);
   assert(!gotClose);
   gotExit = true;
-});
+}));
 
-cp.on('close', function() {
+cp.on('close', common.mustCall(function() {
   assert(gotMessage);
   assert(gotExit);
   assert(!gotClose);
   gotClose = true;
-});
-
-process.on('exit', function() {
-  assert(gotMessage);
-  assert(gotExit);
-  assert(gotClose);
-});
+}));

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -1,6 +1,6 @@
 'use strict';
+const common = require('../common');
 var assert = require('assert');
-var common = require('../common');
 var fork = require('child_process').fork;
 var args = ['foo', 'bar'];
 
@@ -19,11 +19,6 @@ assert.throws(function() { n.send(); }, TypeError);
 
 n.send({ hello: 'world' });
 
-var childExitCode = -1;
-n.on('exit', function(c) {
-  childExitCode = c;
-});
-
-process.on('exit', function() {
-  assert.ok(childExitCode == 0);
-});
+n.on('exit', common.mustCall(function(c) {
+  assert.strictEqual(c, 0);
+}));

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 //messages
@@ -21,18 +21,11 @@ if (process.argv[2] === 'child') {
   var fork = require('child_process').fork;
   var child = fork(process.argv[1], ['child']);
 
-  var gotNormal;
-  child.once('message', function(data) {
-    gotNormal = data;
-  });
+  child.once('message', common.mustCall(function(data) {
+    assert.deepStrictEqual(data, normal);
+  }));
 
-  var gotInternal;
-  child.once('internalMessage', function(data) {
-    gotInternal = data;
-  });
-
-  process.on('exit', function() {
-    assert.deepEqual(gotNormal, normal);
-    assert.deepEqual(gotInternal, internal);
-  });
+  child.once('internalMessage', common.mustCall(function(data) {
+    assert.deepStrictEqual(data, internal);
+  }));
 }

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -1,41 +1,18 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-
 var spawn = require('child_process').spawn;
-
-var exitCode;
-var termSignal;
-var gotStdoutEOF = false;
-var gotStderrEOF = false;
-
 var cat = spawn(common.isWindows ? 'cmd' : 'cat');
 
+cat.stdout.on('end', common.mustCall(function() {}));
+cat.stderr.on('data', common.fail);
+cat.stderr.on('end', common.mustCall(function() {}));
 
-cat.stdout.on('end', function() {
-  gotStdoutEOF = true;
-});
-
-cat.stderr.on('data', function(chunk) {
-  assert.ok(false);
-});
-
-cat.stderr.on('end', function() {
-  gotStderrEOF = true;
-});
-
-cat.on('exit', function(code, signal) {
-  exitCode = code;
-  termSignal = signal;
-});
+cat.on('exit', common.mustCall(function(code, signal) {
+  assert.strictEqual(code, null);
+  assert.strictEqual(signal, 'SIGTERM');
+}));
 
 assert.equal(cat.killed, false);
 cat.kill();
 assert.equal(cat.killed, true);
-
-process.on('exit', function() {
-  assert.strictEqual(exitCode, null);
-  assert.strictEqual(termSignal, 'SIGTERM');
-  assert.ok(gotStdoutEOF);
-  assert.ok(gotStderrEOF);
-});

--- a/test/parallel/test-child-process-set-blocking.js
+++ b/test/parallel/test-child-process-set-blocking.js
@@ -1,20 +1,14 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var ch = require('child_process');
 
 var SIZE = 100000;
-var childGone = false;
 
 var cp = ch.spawn('python', ['-c', 'print ' + SIZE + ' * "C"'], {
   stdio: 'inherit'
 });
 
-cp.on('exit', function(code) {
-  childGone = true;
+cp.on('exit', common.mustCall(function(code) {
   assert.equal(0, code);
-});
-
-process.on('exit', function() {
-  assert.ok(childGone);
-});
+}));

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -3,22 +3,15 @@ var common = require('../common');
 var spawn = require('child_process').spawn;
 var assert = require('assert');
 
-var errors = 0;
-
 var enoentPath = 'foo123';
 var spawnargs = ['bar'];
 assert.equal(common.fileExists(enoentPath), false);
 
 var enoentChild = spawn(enoentPath, spawnargs);
-enoentChild.on('error', function(err) {
+enoentChild.on('error', common.mustCall(function(err) {
   assert.equal(err.code, 'ENOENT');
   assert.equal(err.errno, 'ENOENT');
   assert.equal(err.syscall, 'spawn ' + enoentPath);
   assert.equal(err.path, enoentPath);
   assert.deepEqual(err.spawnargs, spawnargs);
-  errors++;
-});
-
-process.on('exit', function() {
-  assert.equal(1, errors);
-});
+}));

--- a/test/parallel/test-child-process-stdin-ipc.js
+++ b/test/parallel/test-child-process-stdin-ipc.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var spawn = require('child_process').spawn;
@@ -14,11 +14,6 @@ var proc = spawn(process.execPath, [__filename, 'child'], {
   stdio: ['ipc', 'inherit', 'inherit']
 });
 
-var childCode = -1;
-proc.on('exit', function(code) {
-  childCode = code;
-});
-
-process.on('exit', function() {
-  assert.equal(childCode, 0);
-});
+proc.on('exit', common.mustCall(function(code) {
+  assert.strictEqual(code, 0);
+}));

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -15,8 +15,6 @@ assert.ok(!cat.stdin.readable);
 cat.stdin.end();
 
 var response = '';
-var exitStatus = -1;
-var closed = false;
 
 cat.stdout.setEncoding('utf8');
 cat.stdout.on('data', function(chunk) {
@@ -26,33 +24,18 @@ cat.stdout.on('data', function(chunk) {
 
 cat.stdout.on('end', common.mustCall(function() {}));
 
-cat.stderr.on('data', function(chunk) {
-  // shouldn't get any stderr output
-  assert.ok(false);
-});
+cat.stderr.on('data', common.fail);
 
 cat.stderr.on('end', common.mustCall(function() {}));
 
-cat.on('exit', function(status) {
-  console.log('exit event');
-  exitStatus = status;
-});
+cat.on('exit', common.mustCall(function(status) {
+  assert.strictEqual(0, status);
+}));
 
-cat.on('close', function() {
-  closed = true;
+cat.on('close', common.mustCall(function() {
   if (common.isWindows) {
     assert.equal('hello world\r\n', response);
   } else {
     assert.equal('hello world', response);
   }
-});
-
-process.on('exit', function() {
-  assert.equal(0, exitStatus);
-  assert(closed);
-  if (common.isWindows) {
-    assert.equal('hello world\r\n', response);
-  } else {
-    assert.equal('hello world', response);
-  }
-});
+}));

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -13,17 +13,12 @@ if (common.isWindows) {
 
 if (cluster.isMaster) {
   common.refreshTmpDir();
-  var ok = false;
   var worker = cluster.fork();
-  worker.on('message', function(msg) {
+  worker.on('message', common.mustCall(function(msg) {
     assert.equal(msg, 'DONE');
-    ok = true;
-  });
+  }));
   worker.on('exit', function() {
     process.exit();
-  });
-  process.on('exit', function() {
-    assert(ok);
   });
   return;
 }

--- a/test/parallel/test-cluster-listening-port.js
+++ b/test/parallel/test-cluster-listening-port.js
@@ -5,20 +5,15 @@ var cluster = require('cluster');
 var net = require('net');
 
 if (cluster.isMaster) {
-  var port = null;
   cluster.fork();
-  cluster.on('listening', function(worker, address) {
-    port = address.port;
+  cluster.on('listening', common.mustCall(function(worker, address) {
+    const port = address.port;
     // ensure that the port is not 0 or null
     assert(port);
     // ensure that the port is numerical
     assert.strictEqual(typeof port, 'number');
     worker.kill();
-  });
-  process.on('exit', function() {
-    // ensure that the 'listening' handler has been called
-    assert(port);
-  });
+  }));
 } else {
   net.createServer(common.fail).listen(0);
 }

--- a/test/parallel/test-cluster-net-listen.js
+++ b/test/parallel/test-cluster-net-listen.js
@@ -6,14 +6,9 @@ var net = require('net');
 
 if (cluster.isMaster) {
   // ensure that the worker exits peacefully
-  var worker = cluster.fork();
-  worker.on('exit', function(statusCode) {
+  cluster.fork().on('exit', common.mustCall(function(statusCode) {
     assert.equal(statusCode, 0);
-    worker = null;
-  });
-  process.on('exit', function() {
-    assert.equal(worker, null);
-  });
+  }));
 } else {
   // listen() without port should not trigger a libuv assert
   net.createServer(common.fail).listen(process.exit);

--- a/test/parallel/test-cluster-setup-master-emit.js
+++ b/test/parallel/test-cluster-setup-master-emit.js
@@ -1,39 +1,26 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 
 assert(cluster.isMaster);
 
-var assertsRun = 0;
-
 function emitAndCatch(next) {
-  cluster.once('setup', function(settings) {
+  cluster.once('setup', common.mustCall(function(settings) {
     assert.strictEqual(settings.exec, 'new-exec');
-    console.log('ok "setup" emitted with options set');
-    assertsRun += 1;
     setImmediate(next);
-  });
+  }));
   cluster.setupMaster({ exec: 'new-exec' });
 }
 
 function emitAndCatch2(next) {
-  cluster.once('setup', function(settings) {
+  cluster.once('setup', common.mustCall(function(settings) {
     assert('exec' in settings);
-    console.log('ok "setup" emitted without options set');
-    assertsRun += 1;
     setImmediate(next);
-  });
+  }));
   cluster.setupMaster();
 }
 
-process.on('exit', function() {
-  assert.strictEqual(assertsRun, 2);
-  console.log('ok correct number of assertions');
-});
-
-emitAndCatch(function() {
-  emitAndCatch2(function() {
-    console.log('ok emitted and caught');
-  });
-});
+emitAndCatch(common.mustCall(function() {
+  emitAndCatch2(common.mustCall(function() {}));
+}));

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -3,7 +3,7 @@
 // one that the cluster module installs.
 // https://github.com/joyent/node/issues/2556
 
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 var fork = require('child_process').fork;
@@ -13,16 +13,10 @@ var MAGIC_EXIT_CODE = 42;
 var isTestRunner = process.argv[2] != 'child';
 
 if (isTestRunner) {
-  var exitCode = -1;
-
-  process.on('exit', function() {
-    assert.equal(exitCode, MAGIC_EXIT_CODE);
-  });
-
   var master = fork(__filename, ['child']);
-  master.on('exit', function(code) {
-    exitCode = code;
-  });
+  master.on('exit', common.mustCall(function(code) {
+    assert.strictEqual(code, MAGIC_EXIT_CODE);
+  }));
 } else if (cluster.isMaster) {
   process.on('uncaughtException', function() {
     process.nextTick(function() {

--- a/test/parallel/test-cluster-worker-death.js
+++ b/test/parallel/test-cluster-worker-death.js
@@ -1,25 +1,17 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 
 if (!cluster.isMaster) {
   process.exit(42);
 } else {
-  var seenExit = 0;
-  var seenDeath = 0;
   var worker = cluster.fork();
-  worker.on('exit', function(exitCode, signalCode) {
+  worker.on('exit', common.mustCall(function(exitCode, signalCode) {
     assert.equal(exitCode, 42);
     assert.equal(signalCode, null);
-    seenExit++;
-  });
-  cluster.on('exit', function(worker_) {
+  }));
+  cluster.on('exit', common.mustCall(function(worker_) {
     assert.equal(worker_, worker);
-    seenDeath++;
-  });
-  process.on('exit', function() {
-    assert.equal(seenExit, 1);
-    assert.equal(seenDeath, 1);
-  });
+  }));
 }

--- a/test/parallel/test-cluster-worker-destroy.js
+++ b/test/parallel/test-cluster-worker-destroy.js
@@ -7,26 +7,18 @@
  * both code paths.
  */
 
-require('../common');
+const common = require('../common');
 var cluster = require('cluster');
-var assert = require('assert');
-
-var worker1, worker2, workerExited, workerDisconnected;
+var worker1, worker2;
 
 if (cluster.isMaster) {
   worker1 = cluster.fork();
   worker2 = cluster.fork();
 
-  workerExited = 0;
-  workerDisconnected = 0;
-
   [worker1, worker2].forEach(function(worker) {
-    worker.on('disconnect', ondisconnect);
-    worker.on('exit', onexit);
+    worker.on('disconnect', common.mustCall(function() {}));
+    worker.on('exit', common.mustCall(function() {}));
   });
-
-  process.on('exit', onProcessExit);
-
 } else {
   if (cluster.worker.id === 1) {
     // Call destroy when worker is disconnected
@@ -39,21 +31,4 @@ if (cluster.isMaster) {
     // Call destroy when worker is not disconnected yet
     cluster.worker.destroy();
   }
-}
-
-function onProcessExit() {
-  assert.equal(workerExited,
-               2,
-               'When master exits, all workers should have exited too');
-  assert.equal(workerDisconnected,
-               2,
-               'When master exits, all workers should have disconnected');
-}
-
-function ondisconnect() {
-  ++workerDisconnected;
-}
-
-function onexit() {
-  ++workerExited;
 }

--- a/test/parallel/test-cluster-worker-forced-exit.js
+++ b/test/parallel/test-cluster-worker-forced-exit.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var cluster = require('cluster');
 
@@ -24,14 +24,6 @@ if (cluster.isWorker) {
   return;
 }
 
-var unforcedOk;
-var forcedOk;
-
-process.on('exit', function() {
-  assert(forcedOk);
-  assert(unforcedOk);
-});
-
 checkUnforced();
 checkForced();
 
@@ -40,10 +32,9 @@ function checkUnforced() {
   .on('online', function() {
     this.disconnect();
   })
-  .on('exit', function(status) {
+  .on('exit', common.mustCall(function(status) {
     assert.equal(status, SENTINEL);
-    unforcedOk = true;
-  });
+  }));
 }
 
 function checkForced() {
@@ -51,8 +42,7 @@ function checkForced() {
   .on('online', function() {
     this.process.disconnect();
   })
-  .on('exit', function(status) {
+  .on('exit', common.mustCall(function(status) {
     assert.equal(status, 0);
-    forcedOk = true;
-  });
+  }));
 }

--- a/test/parallel/test-crypto-domains.js
+++ b/test/parallel/test-crypto-domains.js
@@ -4,7 +4,6 @@ var domain = require('domain');
 var assert = require('assert');
 var d = domain.create();
 var expect = ['pbkdf2', 'randomBytes', 'pseudoRandomBytes'];
-var errors = 0;
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -12,14 +11,9 @@ if (!common.hasCrypto) {
 }
 var crypto = require('crypto');
 
-process.on('exit', function() {
-  assert.equal(errors, 3);
-});
-
-d.on('error', function(e) {
+d.on('error', common.mustCall(function(e) {
   assert.equal(e.message, expect.shift());
-  errors += 1;
-});
+}, 3));
 
 d.run(function() {
   one();

--- a/test/parallel/test-crypto-hash-stream-pipe.js
+++ b/test/parallel/test-crypto-hash-stream-pipe.js
@@ -12,16 +12,9 @@ var stream = require('stream');
 var s = new stream.PassThrough();
 var h = crypto.createHash('sha1');
 var expect = '15987e60950cf22655b9323bc1e281f9c4aff47e';
-var gotData = false;
 
-process.on('exit', function() {
-  assert(gotData);
-  console.log('ok');
-});
-
-s.pipe(h).on('data', function(c) {
+s.pipe(h).on('data', common.mustCall(function(c) {
   assert.equal(c, expect);
-  gotData = true;
-}).setEncoding('hex');
+})).setEncoding('hex');
 
 s.end('aoeu');

--- a/test/parallel/test-delayed-require.js
+++ b/test/parallel/test-delayed-require.js
@@ -1,14 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
-var a;
-setTimeout(function() {
-  a = require('../fixtures/a');
-}, 50);
-
-process.on('exit', function() {
-  assert.equal(true, 'A' in a);
-  assert.equal('A', a.A());
-  assert.equal('D', a.D());
-});
+setTimeout(common.mustCall(function() {
+  const a = require('../fixtures/a');
+  assert.strictEqual(true, 'A' in a);
+  assert.strictEqual('A', a.A());
+  assert.strictEqual('D', a.D());
+}), 50);

--- a/test/parallel/test-dgram-close-is-not-callback.js
+++ b/test/parallel/test-dgram-close-is-not-callback.js
@@ -1,5 +1,4 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 var dgram = require('dgram');
 
@@ -7,16 +6,10 @@ var buf = new Buffer(1024);
 buf.fill(42);
 
 var socket = dgram.createSocket('udp4');
-var closeEvents = 0;
+
 socket.send(buf, 0, buf.length, common.PORT, 'localhost');
 
 // if close callback is not function, ignore the argument.
 socket.close('bad argument');
 
-socket.on('close', function() {
-  ++closeEvents;
-});
-
-process.on('exit', function() {
-  assert.equal(closeEvents, 1);
-});
+socket.on('close', common.mustCall(function() {}));

--- a/test/parallel/test-dgram-close.js
+++ b/test/parallel/test-dgram-close.js
@@ -2,8 +2,8 @@
 // Ensure that if a dgram socket is closed before the DNS lookup completes, it
 // won't crash.
 
-const assert = require('assert');
 const common = require('../common');
+const assert = require('assert');
 const dgram = require('dgram');
 
 var buf = new Buffer(1024);
@@ -11,16 +11,10 @@ buf.fill(42);
 
 var socket = dgram.createSocket('udp4');
 var handle = socket._handle;
-var closeEvents = 0;
-var closeCallbacks = 0;
+
 socket.send(buf, 0, buf.length, common.PORT, 'localhost');
-assert.strictEqual(socket.close(function() {
-  ++closeCallbacks;
-}), socket);
-socket.on('close', function() {
-  assert.equal(closeCallbacks, 1);
-  ++closeEvents;
-});
+assert.strictEqual(socket.close(common.mustCall(function() {})), socket);
+socket.on('close', common.mustCall(function() {}));
 socket = null;
 
 // Verify that accessing handle after closure doesn't throw
@@ -28,9 +22,4 @@ setImmediate(function() {
   setImmediate(function() {
     console.log('Handle fd is: ', handle.fd);
   });
-});
-
-process.on('exit', function() {
-  assert.equal(closeEvents, 1);
-  assert.equal(closeCallbacks, 1);
 });

--- a/test/parallel/test-dgram-implicit-bind.js
+++ b/test/parallel/test-dgram-implicit-bind.js
@@ -1,24 +1,19 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var dgram = require('dgram');
 
 var source = dgram.createSocket('udp4');
 var target = dgram.createSocket('udp4');
 var messages = 0;
 
-process.on('exit', function() {
-  assert.equal(messages, 2);
-});
-
-target.on('message', function(buf) {
+target.on('message', common.mustCall(function(buf) {
   if (buf.toString() === 'abc') ++messages;
   if (buf.toString() === 'def') ++messages;
   if (messages === 2) {
     source.close();
     target.close();
   }
-});
+}, 2));
 
 target.on('listening', function() {
   // Second .send() call should not throw a bind error.

--- a/test/parallel/test-dgram-unref.js
+++ b/test/parallel/test-dgram-unref.js
@@ -1,19 +1,9 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-
+const common = require('../common');
 var dgram = require('dgram');
-var closed = false;
 
 var s = dgram.createSocket('udp4');
 s.bind();
 s.unref();
 
-setTimeout(function() {
-  closed = true;
-  s.close();
-}, 1000).unref();
-
-process.on('exit', function() {
-  assert.strictEqual(closed, false, 'Unrefd socket should not hold loop open');
-});
+setTimeout(common.fail, 1000).unref();

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -1,15 +1,13 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
-var caught = 0;
-var expectCaught = 1;
 
 var d = new domain.Domain();
 
-d.on('error', function(er) {
+d.on('error', common.mustCall(function(er) {
   console.error('caught', er);
 
   assert.strictEqual(er.domain, d);
@@ -18,15 +16,7 @@ d.on('error', function(er) {
   assert.strictEqual(er.code, 'ENOENT');
   assert.ok(/\bthis file does not exist\b/i.test(er.path));
   assert.strictEqual(typeof er.errno, 'number');
-
-  caught++;
-});
-
-process.on('exit', function() {
-  console.error('exit');
-  assert.equal(caught, expectCaught);
-  console.log('ok');
-});
+}));
 
 
 // implicit handling of thrown errors while in a domain, via the

--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -1,16 +1,16 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var domain = require('domain');
 var assert = require('assert');
 
-var timeout_err, timeout, immediate_err;
+var timeout;
 
 var timeoutd = domain.create();
 
-timeoutd.on('error', function(e) {
-  timeout_err = e;
+timeoutd.on('error', common.mustCall(function(e) {
+  assert.equal(e.message, 'Timeout UNREFd', 'Domain should catch timer error');
   clearTimeout(timeout);
-});
+}));
 
 timeoutd.run(function() {
   setTimeout(function() {
@@ -20,9 +20,10 @@ timeoutd.run(function() {
 
 var immediated = domain.create();
 
-immediated.on('error', function(e) {
-  immediate_err = e;
-});
+immediated.on('error', common.mustCall(function(e) {
+  assert.equal(e.message, 'Immediate Error',
+               'Domain should catch immediate error');
+}));
 
 immediated.run(function() {
   setImmediate(function() {
@@ -31,10 +32,3 @@ immediated.run(function() {
 });
 
 timeout = setTimeout(function() {}, 10 * 1000);
-
-process.on('exit', function() {
-  assert.equal(timeout_err.message, 'Timeout UNREFd',
-               'Domain should catch timer error');
-  assert.equal(immediate_err.message, 'Immediate Error',
-               'Domain should catch immediate error');
-});

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -4,8 +4,6 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 var path = require('path');
 
-var exits = 0;
-
 function errExec(script, callback) {
   var cmd = '"' + process.argv[0] + '" "' +
             path.join(common.fixturesDir, script) + '"';
@@ -21,52 +19,45 @@ function errExec(script, callback) {
 
     // Proxy the args for more tests.
     callback(err, stdout, stderr);
-
-    // Count the tests
-    exits++;
   });
 }
 
 
 // Simple throw error
-errExec('throws_error.js', function(err, stdout, stderr) {
+errExec('throws_error.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/blah/.test(stderr));
-});
+}));
 
 
 // Trying to JSON.parse(undefined)
-errExec('throws_error2.js', function(err, stdout, stderr) {
+errExec('throws_error2.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/SyntaxError/.test(stderr));
-});
+}));
 
 
 // Trying to JSON.parse(undefined) in nextTick
-errExec('throws_error3.js', function(err, stdout, stderr) {
+errExec('throws_error3.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/SyntaxError/.test(stderr));
-});
+}));
 
 
 // throw ILLEGAL error
-errExec('throws_error4.js', function(err, stdout, stderr) {
+errExec('throws_error4.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/\/\*\*/.test(stderr));
   assert.ok(/SyntaxError/.test(stderr));
-});
+}));
 
 // Specific long exception line doesn't result in stack overflow
-errExec('throws_error5.js', function(err, stdout, stderr) {
+errExec('throws_error5.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/SyntaxError/.test(stderr));
-});
+}));
 
 // Long exception line with length > errorBuffer doesn't result in assertion
-errExec('throws_error6.js', function(err, stdout, stderr) {
+errExec('throws_error6.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/SyntaxError/.test(stderr));
-});
+}));
 
 // Object that throws in toString() doesn't print garbage
-errExec('throws_error7.js', function(err, stdout, stderr) {
+errExec('throws_error7.js', common.mustCall(function(err, stdout, stderr) {
   assert.ok(/<toString\(\) threw exception/.test(stderr));
-});
-
-process.on('exit', function() {
-  assert.equal(7, exits);
-});
+}));

--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -1,27 +1,13 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var util = require('util');
 var assert = require('assert');
 var exec = require('child_process').exec;
 
-var success_count = 0;
-var error_count = 0;
-
 var cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
            'foo', 'bar'].join(' ');
 var expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
-exec(cmd, function(err, stdout, stderr) {
-  if (err) {
-    console.log(err.toString());
-    ++error_count;
-    return;
-  }
+exec(cmd, common.mustCall(function(err, stdout, stderr) {
+  assert.ifError(err);
   assert.equal(stderr, expected);
-  ++success_count;
-});
-
-process.on('exit', function() {
-  assert.equal(1, success_count);
-  assert.equal(0, error_count);
-});
-
+}));

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -1,19 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var events = require('events');
-
-var gotEvent = false;
-
-process.on('exit', function() {
-  assert(gotEvent);
-});
-
 var e = new events.EventEmitter();
 
-e.on('maxListeners', function() {
-  gotEvent = true;
-});
+e.on('maxListeners', common.mustCall(function() {}));
 
 // Should not corrupt the 'maxListeners' queue.
 e.setMaxListeners(42);

--- a/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
+++ b/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
@@ -1,22 +1,14 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var events = require('events');
 var domain = require('domain');
-
-var errorCatched = false;
-
 var e = new events.EventEmitter();
 
 var d = domain.create();
 d.add(e);
-d.on('error', function(er) {
+d.on('error', common.mustCall(function(er) {
   assert(er instanceof Error, 'error created');
-  errorCatched = true;
-});
+}));
 
 e.emit('error');
-
-process.on('exit', function() {
-  assert(errorCatched, 'error got caught');
-});

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -1,14 +1,10 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
 var events = require('events');
 
 var e = new events.EventEmitter();
-var times_hello_emited = 0;
 
-e.once('hello', function(a, b) {
-  times_hello_emited++;
-});
+e.once('hello', common.mustCall(function(a, b) {}));
 
 e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
@@ -23,23 +19,10 @@ e.once('foo', remove);
 e.removeListener('foo', remove);
 e.emit('foo');
 
-process.on('exit', function() {
-  assert.equal(1, times_hello_emited);
-});
-
-var times_recurse_emitted = 0;
-
-e.once('e', function() {
+e.once('e', common.mustCall(function() {
   e.emit('e');
-  times_recurse_emitted++;
-});
+}));
 
-e.once('e', function() {
-  times_recurse_emitted++;
-});
+e.once('e', common.mustCall(function() {}));
 
 e.emit('e');
-
-process.on('exit', function() {
-  assert.equal(2, times_recurse_emitted);
-});

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
@@ -13,10 +13,7 @@ function MyEE(cb) {
   EventEmitter.call(this);
 }
 
-var called = false;
-var myee = new MyEE(function() {
-  called = true;
-});
+var myee = new MyEE(common.mustCall(function() {}));
 
 
 util.inherits(ErrorEE, EventEmitter);
@@ -29,7 +26,6 @@ assert.throws(function() {
 }, /blerg/);
 
 process.on('exit', function() {
-  assert(called);
   assert.deepEqual(myee._events, {});
   console.log('ok');
 });

--- a/test/parallel/test-exception-handler.js
+++ b/test/parallel/test-exception-handler.js
@@ -1,27 +1,19 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var MESSAGE = 'catch me if you can';
-var caughtException = false;
 
-process.on('uncaughtException', function(e) {
+process.on('uncaughtException', common.mustCall(function(e) {
   console.log('uncaught exception! 1');
   assert.equal(MESSAGE, e.message);
-  caughtException = true;
-});
+}));
 
-process.on('uncaughtException', function(e) {
+process.on('uncaughtException', common.mustCall(function(e) {
   console.log('uncaught exception! 2');
   assert.equal(MESSAGE, e.message);
-  caughtException = true;
-});
+}));
 
 setTimeout(function() {
   throw new Error(MESSAGE);
 }, 10);
-
-process.on('exit', function() {
-  console.log('exit');
-  assert.equal(true, caughtException);
-});

--- a/test/parallel/test-file-read-noexist.js
+++ b/test/parallel/test-file-read-noexist.js
@@ -3,20 +3,8 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
-var got_error = false;
 
 var filename = path.join(common.fixturesDir, 'does_not_exist.txt');
-fs.readFile(filename, 'raw', function(err, content) {
-  if (err) {
-    got_error = true;
-  } else {
-    console.error('cat returned some content: ' + content);
-    console.error('this shouldn\'t happen as the file doesn\'t exist...');
-    assert.equal(true, false);
-  }
-});
-
-process.on('exit', function() {
-  console.log('done');
-  assert.equal(true, got_error);
-});
+fs.readFile(filename, 'raw', common.mustCall(function(err, content) {
+  assert.ok(err);
+}));

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -1,23 +1,16 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var f = __filename;
-var exists;
-var doesNotExist;
 
-fs.exists(f, function(y) {
-  exists = y;
-});
+fs.exists(f, common.mustCall(function(y) {
+  assert.strictEqual(y, true);
+}));
 
-fs.exists(f + '-NO', function(y) {
-  doesNotExist = y;
-});
+fs.exists(f + '-NO', common.mustCall(function(y) {
+  assert.strictEqual(y, false);
+}));
 
 assert(fs.existsSync(f));
 assert(!fs.existsSync(f + '-NO'));
-
-process.on('exit', function() {
-  assert.strictEqual(exists, true);
-  assert.strictEqual(doesNotExist, false);
-});

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -2,14 +2,11 @@
 var common = require('../common');
 var fs = require('fs');
 var path = require('path');
-var assert = require('assert');
 
 if (!common.isWindows) {
   common.skip('this test is Windows-specific.');
   return;
 }
-
-var successes = 0;
 
 // make a path that will be at least 260 chars long.
 var fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
@@ -23,17 +20,14 @@ console.log({
   fullPathLength: fullPath.length
 });
 
-fs.writeFile(fullPath, 'ok', function(err) {
+fs.writeFile(fullPath, 'ok', common.mustCall(function(err) {
   if (err) throw err;
-  successes++;
 
-  fs.stat(fullPath, function(err, stats) {
+  fs.stat(fullPath, common.mustCall(function(err, stats) {
     if (err) throw err;
-    successes++;
-  });
-});
+  }));
+}));
 
 process.on('exit', function() {
   fs.unlinkSync(fullPath);
-  assert.equal(2, successes);
 });

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 
@@ -14,24 +14,14 @@ try {
 }
 assert.ok(caughtException);
 
-var openFd;
-fs.open(__filename, 'r', function(err, fd) {
+fs.open(__filename, 'r', common.mustCall(function(err, fd) {
   if (err) {
     throw err;
   }
-  openFd = fd;
-});
+}));
 
-var openFd2;
-fs.open(__filename, 'rs', function(err, fd) {
+fs.open(__filename, 'rs', common.mustCall(function(err, fd) {
   if (err) {
     throw err;
   }
-  openFd2 = fd;
-});
-
-process.on('exit', function() {
-  assert.ok(openFd);
-  assert.ok(openFd2);
-});
-
+}));

--- a/test/parallel/test-fs-read-buffer.js
+++ b/test/parallel/test-fs-read-buffer.js
@@ -7,21 +7,19 @@ const fs = require('fs');
 const filepath = path.join(common.fixturesDir, 'x.txt');
 const fd = fs.openSync(filepath, 'r');
 const expected = 'xyz\n';
-const bufferAsync = new Buffer(expected.length);
-const bufferSync = new Buffer(expected.length);
-let readCalled = 0;
+const bufferAsync = Buffer.allocUnsafe(expected.length);
+const bufferSync = Buffer.allocUnsafe(expected.length);
 
-fs.read(fd, bufferAsync, 0, expected.length, 0, function(err, bytesRead) {
-  readCalled++;
-
-  assert.equal(bytesRead, expected.length);
-  assert.deepEqual(bufferAsync, new Buffer(expected));
-});
+fs.read(fd,
+        bufferAsync,
+        0,
+        expected.length,
+        0,
+        common.mustCall(function(err, bytesRead) {
+          assert.equal(bytesRead, expected.length);
+          assert.deepStrictEqual(bufferAsync, Buffer.from(expected));
+        }));
 
 var r = fs.readSync(fd, bufferSync, 0, expected.length, 0);
 assert.deepEqual(bufferSync, new Buffer(expected));
 assert.equal(r, expected.length);
-
-process.on('exit', function() {
-  assert.equal(readCalled, 1);
-});

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -6,20 +6,17 @@ const fs = require('fs');
 const filepath = path.join(common.fixturesDir, 'x.txt');
 const fd = fs.openSync(filepath, 'r');
 const expected = 'xyz\n';
-let readCalled = 0;
 
-fs.read(fd, expected.length, 0, 'utf-8', function(err, str, bytesRead) {
-  readCalled++;
-
-  assert.ok(!err);
-  assert.equal(str, expected);
-  assert.equal(bytesRead, expected.length);
-});
+fs.read(fd,
+        expected.length,
+        0,
+        'utf-8',
+        common.mustCall(function(err, str, bytesRead) {
+          assert.ok(!err);
+          assert.equal(str, expected);
+          assert.equal(bytesRead, expected.length);
+        }));
 
 var r = fs.readSync(fd, expected.length, 0, 'utf-8');
 assert.equal(r[0], expected);
 assert.equal(r[1], expected.length);
-
-process.on('exit', function() {
-  assert.equal(readCalled, 1);
-});

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -11,8 +11,6 @@ if (process.platform === 'freebsd') {
   return;
 }
 
-var callbacks = 0;
-
 function test(env, cb) {
   var filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
   var execPath = '"' + process.execPath + '" "' + filename + '"';
@@ -25,18 +23,12 @@ function test(env, cb) {
   });
 }
 
-test({ NODE_DEBUG: '' }, function(data) {
+test({ NODE_DEBUG: '' }, common.mustCall(function(data) {
   assert(/EISDIR/.test(data));
   assert(!/test-fs-readfile-error/.test(data));
-  callbacks++;
-});
+}));
 
-test({ NODE_DEBUG: 'fs' }, function(data) {
+test({ NODE_DEBUG: 'fs' }, common.mustCall(function(data) {
   assert(/EISDIR/.test(data));
   assert(/test-fs-readfile-error/.test(data));
-  callbacks++;
-});
-
-process.on('exit', function() {
-  assert.equal(callbacks, 2);
-});
+}));

--- a/test/parallel/test-fs-readfile-zero-byte-liar.js
+++ b/test/parallel/test-fs-readfile-zero-byte-liar.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 
@@ -26,13 +26,6 @@ fs.fstatSync = function(fd) {
 var d = fs.readFileSync(__filename, 'utf8');
 assert.equal(d, dataExpected);
 
-var called = false;
-fs.readFile(__filename, 'utf8', function(er, d) {
+fs.readFile(__filename, 'utf8', common.mustCall(function(er, d) {
   assert.equal(d, dataExpected);
-  called = true;
-});
-
-process.on('exit', function() {
-  assert(called);
-  console.log('ok');
-});
+}));

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -64,18 +64,11 @@ function asynctest(testBlock, args, callback, assertBlock) {
 
 // sub-tests:
 function test_simple_error_callback(cb) {
-  var ncalls = 0;
-
-  fs.realpath('/this/path/does/not/exist', function(err, s) {
+  fs.realpath('/this/path/does/not/exist', common.mustCall(function(err, s) {
     assert(err);
     assert(!s);
-    ncalls++;
     cb();
-  });
-
-  process.on('exit', function() {
-    assert.equal(ncalls, 1);
-  });
+  }));
 }
 
 function test_simple_relative_symlink(callback) {

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -1,108 +1,81 @@
 /* eslint-disable strict */
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
-var got_error = false;
-var success_count = 0;
 
-fs.stat('.', function(err, stats) {
-  if (err) {
-    got_error = true;
-  } else {
-    console.dir(stats);
-    assert.ok(stats.mtime instanceof Date);
-    success_count++;
-  }
+fs.stat('.', common.mustCall(function(err, stats) {
+  assert.ifError(err);
+  assert.ok(stats.mtime instanceof Date);
   assert(this === global);
-});
+}));
 
-fs.stat('.', function(err, stats) {
+fs.stat('.', common.mustCall(function(err, stats) {
   assert.ok(stats.hasOwnProperty('blksize'));
   assert.ok(stats.hasOwnProperty('blocks'));
-});
+}));
 
-fs.lstat('.', function(err, stats) {
-  if (err) {
-    got_error = true;
-  } else {
-    console.dir(stats);
-    assert.ok(stats.mtime instanceof Date);
-    success_count++;
-  }
+fs.lstat('.', common.mustCall(function(err, stats) {
+  assert.ifError(err);
+  assert.ok(stats.mtime instanceof Date);
   assert(this === global);
-});
+}));
 
 // fstat
-fs.open('.', 'r', undefined, function(err, fd) {
+fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   assert.ok(!err);
   assert.ok(fd);
 
-  fs.fstat(fd, function(err, stats) {
-    if (err) {
-      got_error = true;
-    } else {
-      console.dir(stats);
-      assert.ok(stats.mtime instanceof Date);
-      success_count++;
-      fs.close(fd);
-    }
+  fs.fstat(fd, common.mustCall(function(err, stats) {
+    assert.ifError(err);
+    assert.ok(stats.mtime instanceof Date);
+    fs.close(fd);
     assert(this === global);
-  });
+  }));
 
   assert(this === global);
-});
+}));
 
 // fstatSync
-fs.open('.', 'r', undefined, function(err, fd) {
+fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   var stats;
   try {
     stats = fs.fstatSync(fd);
   } catch (err) {
-    got_error = true;
+    common.fail(err);
   }
   if (stats) {
     console.dir(stats);
     assert.ok(stats.mtime instanceof Date);
-    success_count++;
   }
   fs.close(fd);
-});
+}));
 
 console.log(`stating:  ${__filename}`);
-fs.stat(__filename, function(err, s) {
-  if (err) {
-    got_error = true;
-  } else {
-    console.dir(s);
-    success_count++;
+fs.stat(__filename, common.mustCall(function(err, s) {
+  assert.ifError(err);
 
-    console.log('isDirectory: ' + JSON.stringify(s.isDirectory()));
-    assert.equal(false, s.isDirectory());
+  console.dir(s);
 
-    console.log('isFile: ' + JSON.stringify(s.isFile()));
-    assert.equal(true, s.isFile());
+  console.log('isDirectory: ' + JSON.stringify(s.isDirectory()));
+  assert.equal(false, s.isDirectory());
 
-    console.log('isSocket: ' + JSON.stringify(s.isSocket()));
-    assert.equal(false, s.isSocket());
+  console.log('isFile: ' + JSON.stringify(s.isFile()));
+  assert.equal(true, s.isFile());
 
-    console.log('isBlockDevice: ' + JSON.stringify(s.isBlockDevice()));
-    assert.equal(false, s.isBlockDevice());
+  console.log('isSocket: ' + JSON.stringify(s.isSocket()));
+  assert.equal(false, s.isSocket());
 
-    console.log('isCharacterDevice: ' + JSON.stringify(s.isCharacterDevice()));
-    assert.equal(false, s.isCharacterDevice());
+  console.log('isBlockDevice: ' + JSON.stringify(s.isBlockDevice()));
+  assert.equal(false, s.isBlockDevice());
 
-    console.log('isFIFO: ' + JSON.stringify(s.isFIFO()));
-    assert.equal(false, s.isFIFO());
+  console.log('isCharacterDevice: ' + JSON.stringify(s.isCharacterDevice()));
+  assert.equal(false, s.isCharacterDevice());
 
-    console.log('isSymbolicLink: ' + JSON.stringify(s.isSymbolicLink()));
-    assert.equal(false, s.isSymbolicLink());
+  console.log('isFIFO: ' + JSON.stringify(s.isFIFO()));
+  assert.equal(false, s.isFIFO());
 
-    assert.ok(s.mtime instanceof Date);
-  }
-});
+  console.log('isSymbolicLink: ' + JSON.stringify(s.isSymbolicLink()));
+  assert.equal(false, s.isSymbolicLink());
 
-process.on('exit', function() {
-  assert.equal(5, success_count);
-  assert.equal(false, got_error);
-});
-
+  assert.ok(s.mtime instanceof Date);
+}));

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var fs = require('fs');
 
 common.refreshTmpDir();
@@ -20,24 +19,14 @@ function test1(stream) {
 
 function test2(stream) {
   stream.destroy();
-  stream.on('open', function(fd) {
+  stream.on('open', common.mustCall(function(fd) {
     stream.destroy();
-    open_cb_called++;
-  });
-  process.on('exit', function() {
-    assert.equal(open_cb_called, 1);
-  });
-  var open_cb_called = 0;
+  }));
 }
 
 function test3(stream) {
-  stream.on('open', function(fd) {
+  stream.on('open', common.mustCall(function(fd) {
     stream.destroy();
     stream.destroy();
-    open_cb_called++;
-  });
-  process.on('exit', function() {
-    assert.equal(open_cb_called, 1);
-  });
-  var open_cb_called = 0;
+  }));
 }

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -5,8 +5,6 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
-var completed = 0;
-var expected_tests = 2;
 
 var linkPath1 = path.join(common.tmpDir, 'junction1');
 var linkPath2 = path.join(common.tmpDir, 'junction2');
@@ -16,10 +14,10 @@ var linkData = path.join(common.fixturesDir);
 common.refreshTmpDir();
 
 // Test fs.symlink()
-fs.symlink(linkData, linkPath1, 'junction', function(err) {
+fs.symlink(linkData, linkPath1, 'junction', common.mustCall(function(err) {
   if (err) throw err;
   verifyLink(linkPath1);
-});
+}));
 
 // Test fs.symlinkSync()
 fs.symlinkSync(linkData, linkPath2, 'junction');
@@ -35,10 +33,4 @@ function verifyLink(linkPath) {
 
   // Clean up.
   fs.unlinkSync(linkPath);
-
-  completed++;
 }
-
-process.on('exit', function() {
-  assert.equal(completed, expected_tests);
-});

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -3,8 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
-var completed = 0;
-var expected_tests = 4;
 
 // test creating and reading symbolic link
 var linkData = path.join(common.fixturesDir, 'cycles/');
@@ -15,31 +13,22 @@ common.refreshTmpDir();
 console.log('linkData: ' + linkData);
 console.log('linkPath: ' + linkPath);
 
-fs.symlink(linkData, linkPath, 'junction', function(err) {
+fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
   if (err) throw err;
-  completed++;
 
-  fs.lstat(linkPath, function(err, stats) {
+  fs.lstat(linkPath, common.mustCall(function(err, stats) {
     if (err) throw err;
     assert.ok(stats.isSymbolicLink());
-    completed++;
 
-    fs.readlink(linkPath, function(err, destination) {
+    fs.readlink(linkPath, common.mustCall(function(err, destination) {
       if (err) throw err;
       assert.equal(destination, linkData);
-      completed++;
 
-      fs.unlink(linkPath, function(err) {
+      fs.unlink(linkPath, common.mustCall(function(err) {
         if (err) throw err;
         assert(!common.fileExists(linkPath));
         assert(common.fileExists(linkData));
-        completed++;
-      });
-    });
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(completed, expected_tests);
-});
-
+      }));
+    }));
+  }));
+}));

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -7,19 +7,15 @@ var tmp = common.tmpDir;
 common.refreshTmpDir();
 var filename = path.resolve(tmp, 'truncate-file.txt');
 
-var success = 0;
-
 fs.writeFileSync(filename, 'hello world', 'utf8');
 var fd = fs.openSync(filename, 'r+');
-fs.truncate(fd, 5, function(err) {
+fs.truncate(fd, 5, common.mustCall(function(err) {
   assert.ok(!err);
   assert.equal(fs.readFileSync(filename, 'utf8'), 'hello');
-  success++;
-});
+}));
 
 process.on('exit', function() {
   fs.closeSync(fd);
   fs.unlinkSync(filename);
-  assert.equal(success, 1);
   console.log('ok');
 });

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -43,20 +43,12 @@ assert.equal(stat.size, 0);
 fs.closeSync(fd);
 
 // async tests
-var success = 0;
-testTruncate(function(er) {
+testTruncate(common.mustCall(function(er) {
   if (er) throw er;
-  success++;
-  testFtruncate(function(er) {
+  testFtruncate(common.mustCall(function(er) {
     if (er) throw er;
-    success++;
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(success, 2);
-  console.log('ok');
-});
+  }));
+}));
 
 function testTruncate(cb) {
   fs.writeFile(filename, data, function(er) {

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -5,32 +5,26 @@ const path = require('path');
 const Buffer = require('buffer').Buffer;
 const fs = require('fs');
 const filename = path.join(common.tmpDir, 'write.txt');
-const expected = new Buffer('hello');
-let openCalled = 0;
-let writeCalled = 0;
-
+const expected = Buffer.from('hello');
 
 common.refreshTmpDir();
 
-fs.open(filename, 'w', 0o644, function(err, fd) {
-  openCalled++;
+fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
   if (err) throw err;
 
-  fs.write(fd, expected, 0, expected.length, null, function(err, written) {
-    writeCalled++;
-    if (err) throw err;
+  fs.write(fd,
+           expected,
+           0,
+           expected.length,
+           null,
+           common.mustCall(function(err, written) {
+             if (err) throw err;
 
-    assert.equal(expected.length, written);
-    fs.closeSync(fd);
+             assert.equal(expected.length, written);
+             fs.closeSync(fd);
 
-    var found = fs.readFileSync(filename, 'utf8');
-    assert.deepEqual(expected.toString(), found);
-    fs.unlinkSync(filename);
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(1, openCalled);
-  assert.equal(1, writeCalled);
-});
-
+             var found = fs.readFileSync(filename, 'utf8');
+             assert.deepStrictEqual(expected.toString(), found);
+             fs.unlinkSync(filename);
+           }));
+}));

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -17,41 +17,34 @@ var s = '南越国是前203年至前111年存在于岭南地区的一个国家�
         '历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，' +
         '它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
 
-var ncallbacks = 0;
-
-fs.writeFile(filename, s, function(e) {
+fs.writeFile(filename, s, common.mustCall(function(e) {
   if (e) throw e;
 
-  ncallbacks++;
-
-  fs.readFile(filename, function(e, buffer) {
+  fs.readFile(filename, common.mustCall(function(e, buffer) {
     if (e) throw e;
-    ncallbacks++;
     assert.equal(Buffer.byteLength(s), buffer.length);
-  });
-});
+  }));
+}));
 
 // test that writeFile accepts buffers
 var filename2 = join(common.tmpDir, 'test2.txt');
 var buf = new Buffer(s, 'utf8');
 
-fs.writeFile(filename2, buf, function(e) {
+fs.writeFile(filename2, buf, common.mustCall(function(e) {
   if (e) throw e;
 
-  ncallbacks++;
-
-  fs.readFile(filename2, function(e, buffer) {
+  fs.readFile(filename2, common.mustCall(function(e, buffer) {
     if (e) throw e;
-    ncallbacks++;
+
     assert.equal(buf.length, buffer.length);
-  });
-});
+  }));
+}));
 
 // test that writeFile accepts numbers.
 var filename3 = join(common.tmpDir, 'test3.txt');
 
 var m = 0o600;
-fs.writeFile(filename3, n, { mode: m }, function(e) {
+fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
   if (e) throw e;
 
   // windows permissions aren't unix
@@ -60,19 +53,14 @@ fs.writeFile(filename3, n, { mode: m }, function(e) {
     assert.equal(st.mode & 0o700, m);
   }
 
-  ncallbacks++;
-
-  fs.readFile(filename3, function(e, buffer) {
+  fs.readFile(filename3, common.mustCall(function(e, buffer) {
     if (e) throw e;
-    ncallbacks++;
-    assert.equal(Buffer.byteLength('' + n), buffer.length);
-  });
-});
 
+    assert.equal(Buffer.byteLength('' + n), buffer.length);
+  }));
+}));
 
 process.on('exit', function() {
-  assert.equal(6, ncallbacks);
-
   fs.unlinkSync(filename);
   fs.unlinkSync(filename2);
   fs.unlinkSync(filename3);

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -10,24 +10,19 @@ common.refreshTmpDir();
 var fn = path.join(common.tmpDir, 'write-string-coerce.txt');
 var data = true;
 var expected = data + '';
-var found;
 
-fs.open(fn, 'w', 0o644, function(err, fd) {
+fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   if (err) throw err;
   console.log('open done');
-  fs.write(fd, data, 0, 'utf8', function(err, written) {
+  fs.write(fd, data, 0, 'utf8', common.mustCall(function(err, written) {
     console.log('write done');
     if (err) throw err;
     assert.equal(Buffer.byteLength(expected), written);
     fs.closeSync(fd);
-    found = fs.readFileSync(fn, 'utf8');
+    const found = fs.readFileSync(fn, 'utf8');
     console.log('expected: "%s"', expected);
     console.log('found: "%s"', found);
     fs.unlinkSync(fn);
-  });
-});
-
-
-process.on('exit', function() {
-  assert.equal(expected, found);
-});
+    assert.strictEqual(expected, found);
+  }));
+}));

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -8,51 +8,45 @@ var fn = path.join(common.tmpDir, 'write.txt');
 var fn2 = path.join(common.tmpDir, 'write2.txt');
 var expected = 'ümlaut.';
 var constants = require('constants');
-var found, found2;
 
 common.refreshTmpDir();
 
-fs.open(fn, 'w', 0o644, function(err, fd) {
+fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   if (err) throw err;
   console.log('open done');
   fs.write(fd, '', 0, 'utf8', function(err, written) {
     assert.equal(0, written);
   });
-  fs.write(fd, expected, 0, 'utf8', function(err, written) {
+  fs.write(fd, expected, 0, 'utf8', common.mustCall(function(err, written) {
     console.log('write done');
     if (err) throw err;
     assert.equal(Buffer.byteLength(expected), written);
     fs.closeSync(fd);
-    found = fs.readFileSync(fn, 'utf8');
+    const found = fs.readFileSync(fn, 'utf8');
     console.log('expected: "%s"', expected);
     console.log('found: "%s"', found);
     fs.unlinkSync(fn);
-  });
-});
+    assert.strictEqual(expected, found);
+  }));
+}));
 
 
 fs.open(fn2, constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC, 0o644,
-    function(err, fd) {
+    common.mustCall(function(err, fd) {
       if (err) throw err;
       console.log('open done');
       fs.write(fd, '', 0, 'utf8', function(err, written) {
         assert.equal(0, written);
       });
-      fs.write(fd, expected, 0, 'utf8', function(err, written) {
+      fs.write(fd, expected, 0, 'utf8', common.mustCall(function(err, written) {
         console.log('write done');
         if (err) throw err;
         assert.equal(Buffer.byteLength(expected), written);
         fs.closeSync(fd);
-        found2 = fs.readFileSync(fn2, 'utf8');
+        const found = fs.readFileSync(fn2, 'utf8');
         console.log('expected: "%s"', expected);
-        console.log('found: "%s"', found2);
+        console.log('found: "%s"', found);
         fs.unlinkSync(fn2);
-      });
-    });
-
-
-process.on('exit', function() {
-  assert.equal(expected, found);
-  assert.equal(expected, found2);
-});
-
+        assert.strictEqual(expected, found);
+      }));
+    }));

--- a/test/parallel/test-http-abort-before-end.js
+++ b/test/parallel/test-http-abort-before-end.js
@@ -1,11 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var http = require('http');
 var assert = require('assert');
 
-var server = http.createServer(function(req, res) {
-  assert(false); // should not be called
-});
+var server = http.createServer(common.fail);
 
 server.listen(0, function() {
   var req = http.request({

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -1,7 +1,6 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var http = require('http');
-var assert = require('assert');
 
 var server = http.Server(function(req, res) {
   console.log('Server accepted request.');
@@ -11,13 +10,11 @@ var server = http.Server(function(req, res) {
   res.destroy();
 });
 
-var responseClose = false;
-
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   http.get({
     port: this.address().port,
     headers: { connection: 'keep-alive' }
-  }, function(res) {
+  }, common.mustCall(function(res) {
     server.close();
 
     console.log('Got res: ' + res.statusCode);
@@ -41,14 +38,6 @@ server.listen(0, function() {
     });
 
     // it would be nice if this worked:
-    res.on('close', function() {
-      console.log('Response aborted');
-      responseClose = true;
-    });
-  });
-});
-
-
-process.on('exit', function() {
-  assert.ok(responseClose);
-});
+    res.on('close', common.mustCall(function() {}));
+  }));
+}));

--- a/test/parallel/test-http-agent-no-protocol.js
+++ b/test/parallel/test-http-agent-no-protocol.js
@@ -1,20 +1,11 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 var url = require('url');
 
-var request = 0;
-var response = 0;
-process.on('exit', function() {
-  assert.equal(1, request, 'http server "request" callback was not called');
-  assert.equal(1, response, 'http client "response" callback was not called');
-});
-
-var server = http.createServer(function(req, res) {
+var server = http.createServer(common.mustCall(function(req, res) {
   res.end();
-  request++;
-}).listen(0, '127.0.0.1', function() {
+})).listen(0, '127.0.0.1', common.mustCall(function() {
   var opts = url.parse(`http://127.0.0.1:${this.address().port}/`);
 
   // remove the `protocol` field… the `http` module should fall back
@@ -22,9 +13,8 @@ var server = http.createServer(function(req, res) {
   opts.agent = new http.Agent();
   opts.agent.protocol = null;
 
-  http.get(opts, function(res) {
-    response++;
+  http.get(opts, common.mustCall(function(res) {
     res.resume();
     server.close();
-  });
-});
+  }));
+}));

--- a/test/parallel/test-http-agent-null.js
+++ b/test/parallel/test-http-agent-null.js
@@ -1,26 +1,16 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 
-var request = 0;
-var response = 0;
-process.on('exit', function() {
-  assert.equal(request, 1, 'http server "request" callback was not called');
-  assert.equal(response, 1, 'http request "response" callback was not called');
-});
-
-var server = http.createServer(function(req, res) {
-  request++;
+var server = http.createServer(common.mustCall(function(req, res) {
   res.end();
-}).listen(0, function() {
+})).listen(0, common.mustCall(function() {
   var options = {
     agent: null,
     port: this.address().port
   };
-  http.get(options, function(res) {
-    response++;
+  http.get(options, common.mustCall(function(res) {
     res.resume();
     server.close();
-  });
-});
+  }));
+}));

--- a/test/parallel/test-http-bind-twice.js
+++ b/test/parallel/test-http-bind-twice.js
@@ -1,26 +1,15 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var gotError = false;
+var server1 = http.createServer(common.fail);
+server1.listen(0, '127.0.0.1', common.mustCall(function() {
+  var server2 = http.createServer(common.fail);
+  server2.listen(this.address().port, '127.0.0.1', common.fail);
 
-process.on('exit', function() {
-  assert(gotError);
-});
-
-function dontCall() {
-  assert(false);
-}
-
-var server1 = http.createServer(dontCall);
-server1.listen(0, '127.0.0.1', function() {
-  var server2 = http.createServer(dontCall);
-  server2.listen(this.address().port, '127.0.0.1', dontCall);
-
-  server2.on('error', function(e) {
+  server2.on('error', common.mustCall(function(e) {
     assert.equal(e.code, 'EADDRINUSE');
     server1.close();
-    gotError = true;
-  });
-});
+  }));
+}));

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -1,13 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
 
-var gotReq = false;
-
-var server = http.createServer(function(req, res) {
-  gotReq = true;
+var server = http.createServer(common.mustCall(function(req, res) {
   assert.equal('GET', req.method);
   assert.equal('/blah', req.url);
   assert.deepEqual({
@@ -15,7 +12,7 @@ var server = http.createServer(function(req, res) {
     origin: 'http://mapdevel.trolologames.ru',
     cookie: ''
   }, req.headers);
-});
+}));
 
 
 server.listen(0, function() {
@@ -37,9 +34,4 @@ server.listen(0, function() {
   c.on('close', function() {
     server.close();
   });
-});
-
-
-process.on('exit', function() {
-  assert.ok(gotReq);
 });

--- a/test/parallel/test-http-buffer-sanity.js
+++ b/test/parallel/test-http-buffer-sanity.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
@@ -42,9 +42,7 @@ var web = http.Server(function(req, res) {
   });
 });
 
-var gotThanks = false;
-
-web.listen(0, function() {
+web.listen(0, common.mustCall(function() {
   console.log('Making request');
 
   var req = http.request({
@@ -52,19 +50,17 @@ web.listen(0, function() {
     method: 'GET',
     path: '/',
     headers: { 'content-length': buffer.length }
-  }, function(res) {
+  }, common.mustCall(function(res) {
     console.log('Got response');
     res.setEncoding('utf8');
-    res.on('data', function(string) {
+    res.on('data', common.mustCall(function(string) {
       assert.equal('thanks', string);
-      gotThanks = true;
-    });
-  });
+    }));
+  }));
   req.end(buffer);
-});
+}));
 
 
 process.on('exit', function() {
   assert.equal(bufferSize, measuredSize);
-  assert.ok(gotThanks);
 });

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -1,24 +1,17 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
 var body = 'hello world\n';
 
-var sawFinish = false;
-process.on('exit', function() {
-  assert(sawFinish);
-  console.log('ok');
-});
-
-var httpServer = http.createServer(function(req, res) {
+var httpServer = http.createServer(common.mustCall(function(req, res) {
   httpServer.close();
 
-  res.on('finish', function() {
-    sawFinish = true;
+  res.on('finish', common.mustCall(function() {
     assert(typeof req.connection.bytesWritten === 'number');
     assert(req.connection.bytesWritten > 0);
-  });
+  }));
   res.writeHead(200, { 'Content-Type': 'text/plain' });
 
   // Write 1.5mb to cause some requests to buffer
@@ -34,7 +27,7 @@ var httpServer = http.createServer(function(req, res) {
   assert(res.connection.bytesWritten > 0);
 
   res.end(body);
-});
+}));
 
 httpServer.listen(0, function() {
   http.get({ port: this.address().port });

--- a/test/parallel/test-http-client-abort-event.js
+++ b/test/parallel/test-http-client-abort-event.js
@@ -1,29 +1,20 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 var server = http.createServer(function(req, res) {
   res.end();
 });
-var count = 0;
-server.listen(0, function() {
+
+server.listen(0, common.mustCall(function() {
   var req = http.request({
     port: this.address().port
-  }, function() {
-    assert(false, 'should not receive data');
-  });
+  }, common.fail);
 
-  req.on('abort', function() {
-    // should only be emitted once
-    count++;
+  req.on('abort', common.mustCall(function() {
     server.close();
-  });
+  }));
 
   req.end();
   req.abort();
   req.abort();
-});
-
-process.on('exit', function() {
-  assert.equal(count, 1);
-});
+}));

--- a/test/parallel/test-http-client-get-url.js
+++ b/test/parallel/test-http-client-get-url.js
@@ -1,24 +1,17 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var seen_req = false;
-
-var server = http.createServer(function(req, res) {
+var server = http.createServer(common.mustCall(function(req, res) {
   assert.equal('GET', req.method);
   assert.equal('/foo?bar', req.url);
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('hello\n');
   res.end();
   server.close();
-  seen_req = true;
-});
+}));
 
 server.listen(0, function() {
   http.get(`http://127.0.0.1:${this.address().port}/foo?bar`);
-});
-
-process.on('exit', function() {
-  assert(seen_req);
 });

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var util = require('util');
@@ -39,22 +39,18 @@ FakeAgent.prototype.createConnection = function createConnection() {
 };
 
 var received = '';
-var ended = 0;
 
 var req = http.request({
   agent: new FakeAgent()
-}, function(res) {
+}, common.mustCall(function(res) {
   res.on('data', function(chunk) {
     received += chunk;
   });
 
-  res.on('end', function() {
-    ended++;
-  });
-});
+  res.on('end', common.mustCall(function() {}));
+}));
 req.end();
 
 process.on('exit', function() {
   assert.equal(received, 'hello world');
-  assert.equal(ended, 1);
 });

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -4,12 +4,7 @@ const assert = require('assert');
 const http = require('http');
 const domain = require('domain');
 
-var gotDomainError = false;
 var d;
-
-process.on('exit', function() {
-  assert(gotDomainError);
-});
 
 common.refreshTmpDir();
 
@@ -22,15 +17,14 @@ var server = http.createServer(function(req, res) {
 server.listen(common.PIPE, function() {
   // create a domain
   d = domain.create();
-  d.run(test);
+  d.run(common.mustCall(test));
 });
 
 function test() {
 
-  d.on('error', function(err) {
-    gotDomainError = true;
+  d.on('error', common.mustCall(function(err) {
     assert.equal('should be caught by domain', err.message);
-  });
+  }));
 
   var req = http.get({
     socketPath: common.PIPE,

--- a/test/parallel/test-http-client-upload-buf.js
+++ b/test/parallel/test-http-client-upload-buf.js
@@ -1,52 +1,44 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
 var N = 1024;
-var bytesReceived = 0;
-var server_req_complete = false;
-var client_res_complete = false;
 
-var server = http.createServer(function(req, res) {
+var server = http.createServer(common.mustCall(function(req, res) {
   assert.equal('POST', req.method);
+
+  var bytesReceived = 0;
 
   req.on('data', function(chunk) {
     bytesReceived += chunk.length;
   });
 
-  req.on('end', function() {
-    server_req_complete = true;
+  req.on('end', common.mustCall(function() {
+    assert.strictEqual(N, bytesReceived);
     console.log('request complete from server');
     res.writeHead(200, {'Content-Type': 'text/plain'});
     res.write('hello\n');
     res.end();
-  });
-});
+  }));
+}));
 server.listen(0);
 
-server.on('listening', function() {
+server.on('listening', common.mustCall(function() {
   var req = http.request({
     port: this.address().port,
     method: 'POST',
     path: '/'
-  }, function(res) {
+  }, common.mustCall(function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       console.log(chunk);
     });
-    res.on('end', function() {
-      client_res_complete = true;
+    res.on('end', common.mustCall(function() {
       server.close();
-    });
-  });
+    }));
+  }));
 
   req.write(new Buffer(N));
   req.end();
-});
-
-process.on('exit', function() {
-  assert.equal(N, bytesReceived);
-  assert.equal(true, server_req_complete);
-  assert.equal(true, client_res_complete);
-});
+}));

--- a/test/parallel/test-http-client-upload.js
+++ b/test/parallel/test-http-client-upload.js
@@ -1,55 +1,46 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var sent_body = '';
-var server_req_complete = false;
-var client_res_complete = false;
-
-var server = http.createServer(function(req, res) {
+var server = http.createServer(common.mustCall(function(req, res) {
   assert.equal('POST', req.method);
   req.setEncoding('utf8');
+
+  var sent_body = '';
 
   req.on('data', function(chunk) {
     console.log('server got: ' + JSON.stringify(chunk));
     sent_body += chunk;
   });
 
-  req.on('end', function() {
-    server_req_complete = true;
+  req.on('end', common.mustCall(function() {
+    assert.strictEqual('1\n2\n3\n', sent_body);
     console.log('request complete from server');
     res.writeHead(200, {'Content-Type': 'text/plain'});
     res.write('hello\n');
     res.end();
-  });
-});
+  }));
+}));
 server.listen(0);
 
-server.on('listening', function() {
+server.on('listening', common.mustCall(function() {
   var req = http.request({
     port: this.address().port,
     method: 'POST',
     path: '/'
-  }, function(res) {
+  }, common.mustCall(function(res) {
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       console.log(chunk);
     });
-    res.on('end', function() {
-      client_res_complete = true;
+    res.on('end', common.mustCall(function() {
       server.close();
-    });
-  });
+    }));
+  }));
 
   req.write('1\n');
   req.write('2\n');
   req.write('3\n');
   req.end();
-});
-
-process.on('exit', function() {
-  assert.equal('1\n2\n3\n', sent_body);
-  assert.equal(true, server_req_complete);
-  assert.equal(true, client_res_complete);
-});
+}));

--- a/test/parallel/test-http-conn-reset.js
+++ b/test/parallel/test-http-conn-reset.js
@@ -1,10 +1,8 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
-
-var caughtError = false;
 
 var options = {
   host: '127.0.0.1',
@@ -16,7 +14,7 @@ var server = net.createServer(function(client) {
   client.destroy();
   server.close();
 });
-server.listen(0, options.host, onListen);
+server.listen(0, options.host, common.mustCall(onListen));
 
 // do a GET request, expect it to fail
 function onListen() {
@@ -24,14 +22,8 @@ function onListen() {
   var req = http.request(options, function(res) {
     assert.ok(false, 'this should never run');
   });
-  req.on('error', function(err) {
+  req.on('error', common.mustCall(function(err) {
     assert.equal(err.code, 'ECONNRESET');
-    caughtError = true;
-  });
+  }));
   req.end();
 }
-
-process.on('exit', function() {
-  assert.equal(caughtError, true);
-});
-

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -3,9 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-const server = http.createServer(function(req, res) {
-  assert(false);
-});
+const server = http.createServer(common.fail);
 server.on('connect', common.mustCall(function(req, socket, firstBodyChunk) {
   assert.equal(req.method, 'CONNECT');
   assert.equal(req.url, 'example.com:443');
@@ -33,9 +31,7 @@ server.listen(0, common.mustCall(function() {
     port: this.address().port,
     method: 'CONNECT',
     path: 'example.com:443'
-  }, function(res) {
-    assert(false);
-  });
+  }, common.fail);
 
   req.on('close', common.mustCall(function() { }));
 

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -1,14 +1,12 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
 var serverGotConnect = false;
 var clientGotConnect = false;
 
-var server = http.createServer(function(req, res) {
-  assert(false);
-});
+var server = http.createServer(common.fail);
 server.on('connect', function(req, socket, firstBodyChunk) {
   assert.equal(req.method, 'CONNECT');
   assert.equal(req.url, 'google.com:443');
@@ -30,9 +28,7 @@ server.listen(0, function() {
     port: this.address().port,
     method: 'CONNECT',
     path: 'google.com:443'
-  }, function(res) {
-    assert(false);
-  });
+  }, common.fail);
 
   var clientRequestClosed = false;
   req.on('close', function() {

--- a/test/parallel/test-http-end-throw-socket-handling.js
+++ b/test/parallel/test-http-end-throw-socket-handling.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 // Make sure that throwing in 'end' handler doesn't lock
 // up the socket forever.
@@ -29,11 +28,4 @@ server.listen(0, common.mustCall(() => {
   }
 }));
 
-let errors = 0;
-process.on('uncaughtException', () => {
-  errors++;
-});
-
-process.on('exit', () => {
-  assert.equal(errors, 10);
-});
+process.on('uncaughtException', common.mustCall(() => {}, 10));

--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -19,9 +19,6 @@ var fullResponse =
     'Server: badly broken/0.1 (OS NAME)\r\n' +
     '\r\n' +
     body;
-
-var gotResponse = false;
-
 
 var server = net.createServer(function(socket) {
   var postBody = '';
@@ -44,8 +41,8 @@ var server = net.createServer(function(socket) {
 });
 
 
-server.listen(0, function() {
-  http.get({ port: this.address().port }, function(res) {
+server.listen(0, common.mustCall(function() {
+  http.get({ port: this.address().port }, common.mustCall(function(res) {
     var buffer = '';
     console.log('Got res code: ' + res.statusCode);
 
@@ -54,17 +51,10 @@ server.listen(0, function() {
       buffer += chunk;
     });
 
-    res.on('end', function() {
+    res.on('end', common.mustCall(function() {
       console.log('Response ended, read ' + buffer.length + ' bytes');
       assert.equal(body, buffer);
       server.close();
-      gotResponse = true;
-    });
-  });
-});
-
-
-process.on('exit', function() {
-  assert.ok(gotResponse);
-});
-
+    }));
+  }));
+}));

--- a/test/parallel/test-http-full-response.js
+++ b/test/parallel/test-http-full-response.js
@@ -17,8 +17,6 @@ var server = http.createServer(function(req, res) {
   res.end(body);
 });
 
-var runs = 0;
-
 function runAb(opts, callback) {
   var command = `ab ${opts} http://127.0.0.1:${server.address().port}/`;
   exec(command, function(err, stdout, stderr) {
@@ -43,28 +41,21 @@ function runAb(opts, callback) {
     assert.equal(bodyLength, documentLength);
     assert.equal(completeRequests * documentLength, htmlTransfered);
 
-    runs++;
-
     if (callback) callback();
   });
 }
 
-server.listen(0, function() {
-  runAb('-c 1 -n 10', function() {
+server.listen(0, common.mustCall(function() {
+  runAb('-c 1 -n 10', common.mustCall(function() {
     console.log('-c 1 -n 10 okay');
 
-    runAb('-c 1 -n 100', function() {
+    runAb('-c 1 -n 100', common.mustCall(function() {
       console.log('-c 1 -n 100 okay');
 
-      runAb('-c 1 -n 1000', function() {
+      runAb('-c 1 -n 1000', common.mustCall(function() {
         console.log('-c 1 -n 1000 okay');
         server.close();
-      });
-    });
-  });
-
-});
-
-process.on('exit', function() {
-  assert.equal(3, runs);
-});
+      }));
+    }));
+  }));
+}));

--- a/test/parallel/test-http-head-request.js
+++ b/test/parallel/test-http-head-request.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 
 var body = 'hello world\n';
@@ -13,27 +12,20 @@ function test(headers) {
     server.close();
   });
 
-  var gotEnd = false;
-
-  server.listen(0, function() {
+  server.listen(0, common.mustCall(function() {
     var request = http.request({
       port: this.address().port,
       method: 'HEAD',
       path: '/'
-    }, function(response) {
+    }, common.mustCall(function(response) {
       console.error('response start');
-      response.on('end', function() {
+      response.on('end', common.mustCall(function() {
         console.error('response end');
-        gotEnd = true;
-      });
+      }));
       response.resume();
-    });
+    }));
     request.end();
-  });
-
-  process.on('exit', function() {
-    assert.ok(gotEnd);
-  });
+  }));
 }
 
 test({

--- a/test/parallel/test-http-head-response-has-no-body-end.js
+++ b/test/parallel/test-http-head-response-has-no-body-end.js
@@ -1,7 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-
+const common = require('../common');
 var http = require('http');
 
 // This test is to make sure that when the HTTP server
@@ -14,23 +12,16 @@ var server = http.createServer(function(req, res) {
 });
 server.listen(0);
 
-var responseComplete = false;
-
-server.on('listening', function() {
+server.on('listening', common.mustCall(function() {
   var req = http.request({
     port: this.address().port,
     method: 'HEAD',
     path: '/'
-  }, function(res) {
-    res.on('end', function() {
+  }, common.mustCall(function(res) {
+    res.on('end', common.mustCall(function() {
       server.close();
-      responseComplete = true;
-    });
+    }));
     res.resume();
-  });
+  }));
   req.end();
-});
-
-process.on('exit', function() {
-  assert.ok(responseComplete);
-});
+}));

--- a/test/parallel/test-http-head-response-has-no-body.js
+++ b/test/parallel/test-http-head-response-has-no-body.js
@@ -1,7 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-
+const common = require('../common');
 var http = require('http');
 
 // This test is to make sure that when the HTTP server
@@ -14,23 +12,16 @@ var server = http.createServer(function(req, res) {
 });
 server.listen(0);
 
-var responseComplete = false;
-
-server.on('listening', function() {
+server.on('listening', common.mustCall(function() {
   var req = http.request({
     port: this.address().port,
     method: 'HEAD',
     path: '/'
-  }, function(res) {
-    res.on('end', function() {
+  }, common.mustCall(function(res) {
+    res.on('end', common.mustCall(function() {
       server.close();
-      responseComplete = true;
-    });
+    }));
     res.resume();
-  });
+  }));
   req.end();
-});
-
-process.on('exit', function() {
-  assert.ok(responseComplete);
-});
+}));

--- a/test/parallel/test-http-hex-write.js
+++ b/test/parallel/test-http-hex-write.js
@@ -1,18 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var http = require('http');
 
 var expect = 'hex\nutf8\n';
-var data = '';
-var ended = false;
-
-process.on('exit', function() {
-  assert(ended);
-  assert.equal(data, expect);
-  console.log('ok');
-});
 
 http.createServer(function(q, s) {
   s.setHeader('content-length', expect.length);
@@ -20,14 +12,17 @@ http.createServer(function(q, s) {
   s.write('utf8\n');
   s.end();
   this.close();
-}).listen(0, function() {
-  http.request({ port: this.address().port }).on('response', function(res) {
-    res.setEncoding('ascii');
-    res.on('data', function(c) {
-      data += c;
-    });
-    res.on('end', function() {
-      ended = true;
-    });
-  }).end();
-});
+}).listen(0, common.mustCall(function() {
+  http.request({ port: this.address().port })
+    .on('response', common.mustCall(function(res) {
+      var data = '';
+
+      res.setEncoding('ascii');
+      res.on('data', function(c) {
+        data += c;
+      });
+      res.on('end', common.mustCall(function() {
+        assert.strictEqual(data, expect);
+      }));
+    })).end();
+}));

--- a/test/parallel/test-http-legacy.js
+++ b/test/parallel/test-http-legacy.js
@@ -1,11 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var url = require('url');
 
 var responses_sent = 0;
-var responses_recvd = 0;
 var body0 = '';
 var body1 = '';
 
@@ -37,37 +36,32 @@ var server = http.createServer(function(req, res) {
   req.resume();
 });
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var client = http.createClient(this.address().port);
   var req = client.request('/hello', {'Accept': '*/*', 'Foo': 'bar'});
   setTimeout(function() {
     req.end();
   }, 100);
-  req.on('response', function(res) {
+  req.on('response', common.mustCall(function(res) {
     assert.equal(200, res.statusCode);
-    responses_recvd += 1;
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body0 += chunk; });
     console.error('Got /hello response');
-  });
+  }));
 
-  setTimeout(function() {
+  setTimeout(common.mustCall(function() {
     var req = client.request('POST', '/world');
     req.end();
-    req.on('response', function(res) {
+    req.on('response', common.mustCall(function(res) {
       assert.equal(200, res.statusCode);
-      responses_recvd += 1;
       res.setEncoding('utf8');
       res.on('data', function(chunk) { body1 += chunk; });
       console.error('Got /world response');
-    });
-  }, 1);
-});
+    }));
+  }), 1);
+}));
 
 process.on('exit', function() {
-  console.error('responses_recvd: ' + responses_recvd);
-  assert.equal(2, responses_recvd);
-
   console.error('responses_sent: ' + responses_sent);
   assert.equal(2, responses_sent);
 

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -1,10 +1,8 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 var invalidLocalAddress = '1.2.3.4';
-var gotError = false;
 
 var server = http.createServer(function(req, res) {
   console.log('Connect from: ' + req.connection.remoteAddress);
@@ -16,7 +14,7 @@ var server = http.createServer(function(req, res) {
   req.resume();
 });
 
-server.listen(0, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', common.mustCall(function() {
   http.request({
     host: 'localhost',
     port: this.address().port,
@@ -25,13 +23,8 @@ server.listen(0, '127.0.0.1', function() {
     localAddress: invalidLocalAddress
   }, function(res) {
     common.fail('unexpectedly got response from server');
-  }).on('error', function(e) {
+  }).on('error', common.mustCall(function(e) {
     console.log('client got error: ' + e.message);
-    gotError = true;
     server.close();
-  }).end();
-});
-
-process.on('exit', function() {
-  assert.ok(gotError);
-});
+  })).end();
+}));

--- a/test/parallel/test-http-multi-line-headers.js
+++ b/test/parallel/test-http-multi-line-headers.js
@@ -1,11 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var http = require('http');
 var net = require('net');
-
-var gotResponse = false;
 
 var server = net.createServer(function(conn) {
   var body = 'Yet another node.js server.';
@@ -24,15 +22,13 @@ var server = net.createServer(function(conn) {
   server.close();
 });
 
-server.listen(0, function() {
-  http.get({host: '127.0.0.1', port: this.address().port}, function(res) {
+server.listen(0, common.mustCall(function() {
+  http.get({
+    host: '127.0.0.1',
+    port: this.address().port
+  }, common.mustCall(function(res) {
     assert.equal(res.headers['content-type'],
                  'text/plain; x-unix-mode=0600; name="hello.txt"');
-    gotResponse = true;
     res.destroy();
-  });
-});
-
-process.on('exit', function() {
-  assert.ok(gotResponse);
-});
+  }));
+}));

--- a/test/parallel/test-http-no-content-length.js
+++ b/test/parallel/test-http-no-content-length.js
@@ -1,26 +1,23 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
 
-var body = '';
-
 var server = net.createServer(function(socket) {
   // Neither Content-Length nor Connection
   socket.end('HTTP/1.1 200 ok\r\n\r\nHello');
-}).listen(0, function() {
-  http.get({port: this.address().port}, function(res) {
+}).listen(0, common.mustCall(function() {
+  http.get({port: this.address().port}, common.mustCall(function(res) {
+    var body = '';
+
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
       body += chunk;
     });
-    res.on('end', function() {
+    res.on('end', common.mustCall(function() {
+      assert.strictEqual(body, 'Hello');
       server.close();
-    });
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(body, 'Hello');
-});
+    }));
+  }));
+}));

--- a/test/parallel/test-http-pause-resume-one-end.js
+++ b/test/parallel/test-http-pause-resume-one-end.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 
 var server = http.Server(function(req, res) {
@@ -9,32 +8,20 @@ var server = http.Server(function(req, res) {
   server.close();
 });
 
-
-var dataCount = 0, endCount = 0;
-
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var opts = {
     port: this.address().port,
     headers: { connection: 'close' }
   };
 
-  http.get(opts, function(res) {
-    res.on('data', function(chunk) {
-      dataCount++;
+  http.get(opts, common.mustCall(function(res) {
+    res.on('data', common.mustCall(function(chunk) {
       res.pause();
       setTimeout(function() {
         res.resume();
       });
-    });
+    }));
 
-    res.on('end', function() {
-      endCount++;
-    });
-  });
-});
-
-
-process.on('exit', function() {
-  assert.equal(1, dataCount);
-  assert.equal(1, endCount);
-});
+    res.on('end', common.mustCall(function() {}));
+  }));
+}));

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var fs = require('fs');
 var path = require('path');
@@ -8,17 +7,15 @@ var path = require('path');
 common.refreshTmpDir();
 
 var file = path.join(common.tmpDir, 'http-pipe-fs-test.txt');
-var requests = 0;
 
-var server = http.createServer(function(req, res) {
-  ++requests;
+var server = http.createServer(common.mustCall(function(req, res) {
   var stream = fs.createWriteStream(file);
   req.pipe(stream);
   stream.on('close', function() {
     res.writeHead(200);
     res.end();
   });
-}).listen(0, function() {
+}, 2)).listen(0, function() {
   http.globalAgent.maxSockets = 1;
 
   for (var i = 0; i < 2; ++i) {
@@ -44,8 +41,4 @@ var server = http.createServer(function(req, res) {
       req.end('12345');
     }(i + 1));
   }
-});
-
-process.on('exit', function() {
-  assert.equal(requests, 2);
 });

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 // Here we are testing the HTTP server module's flood prevention mechanism.
 // When writeable.write returns false (ie the underlying send() indicated the
@@ -26,8 +25,7 @@ switch (process.argv[2]) {
 
 function parent() {
   const http = require('http');
-  const bigResponse = new Buffer(10240).fill('x');
-  var connections = 0;
+  const bigResponse = Buffer.alloc(10240, 'x');
   var backloggedReqs = 0;
 
   const server = http.createServer(function(req, res) {
@@ -48,9 +46,7 @@ function parent() {
     res.end();
   });
 
-  server.on('connection', function(conn) {
-    connections++;
-  });
+  server.on('connection', common.mustCall(function(conn) {}));
 
   server.listen(0, function() {
     const spawn = require('child_process').spawn;
@@ -63,10 +59,6 @@ function parent() {
     server.setTimeout(200, common.mustCall(function() {
       child.kill();
     }));
-  });
-
-  process.on('exit', function() {
-    assert.equal(connections, 1);
   });
 }
 

--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -4,15 +4,17 @@ var assert = require('assert');
 var http = require('http');
 
 var expected = 'Post Body For Test';
-var result = '';
 
 var server = http.Server(function(req, res) {
+  var result = '';
+
   req.setEncoding('utf8');
   req.on('data', function(chunk) {
     result += chunk;
   });
 
   req.on('end', function() {
+    assert.strictEqual(expected, result);
     server.close();
     res.writeHead(200);
     res.end('hello world\n');
@@ -32,8 +34,4 @@ server.listen(0, function() {
     console.log(e.message);
     process.exit(1);
   }).end(expected);
-});
-
-process.on('exit', function() {
-  assert.equal(expected, result);
 });

--- a/test/parallel/test-http-request-methods.js
+++ b/test/parallel/test-http-request-methods.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -7,20 +7,18 @@ var http = require('http');
 // Test that the DELETE, PATCH and PURGE verbs get passed through correctly
 
 ['DELETE', 'PATCH', 'PURGE'].forEach(function(method, index) {
-  var server_response = '';
-  var received_method = null;
-
-  var server = http.createServer(function(req, res) {
-    received_method = req.method;
+  var server = http.createServer(common.mustCall(function(req, res) {
+    assert.strictEqual(req.method, method);
     res.writeHead(200, {'Content-Type': 'text/plain'});
     res.write('hello ');
     res.write('world\n');
     res.end();
-  });
+  }));
   server.listen(0);
 
-  server.on('listening', function() {
+  server.on('listening', common.mustCall(function() {
     var c = net.createConnection(this.address().port);
+    var server_response = '';
 
     c.setEncoding('utf8');
 
@@ -33,18 +31,14 @@ var http = require('http');
       server_response += chunk;
     });
 
-    c.on('end', function() {
+    c.on('end', common.mustCall(function() {
+      const m = server_response.split('\r\n\r\n');
+      assert.strictEqual(m[1], 'hello world\n');
       c.end();
-    });
+    }));
 
     c.on('close', function() {
       server.close();
     });
-  });
-
-  process.on('exit', function() {
-    var m = server_response.split('\r\n\r\n');
-    assert.equal(m[1], 'hello world\n');
-    assert.equal(received_method, method);
-  });
+  }));
 });

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -1,29 +1,22 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var responseError;
-
-var server = http.Server(function(req, res) {
-  res.on('error', function onResError(err) {
-    responseError = err;
-  });
+var server = http.Server(common.mustCall(function(req, res) {
+  res.on('error', common.mustCall(function onResError(err) {
+    assert.strictEqual(err.message, 'write after end');
+  }));
 
   res.write('This should write.');
   res.end();
 
   var r = res.write('This should raise an error.');
   assert.equal(r, true, 'write after end should return true');
-});
+}));
 
 server.listen(0, function() {
   http.get({port: this.address().port}, function(res) {
     server.close();
   });
-});
-
-process.on('exit', function onProcessExit(code) {
-  assert(responseError, 'response should have emitted error');
-  assert.equal(responseError.message, 'write after end');
 });

--- a/test/parallel/test-http-response-close.js
+++ b/test/parallel/test-http-response-close.js
@@ -1,24 +1,18 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 
-var requestGotEnd = false;
-var responseGotEnd = false;
-
-var server = http.createServer(function(req, res) {
+var server = http.createServer(common.mustCall(function(req, res) {
   res.writeHead(200);
   res.write('a');
 
-  req.on('close', function() {
+  req.on('close', common.mustCall(function() {
     console.error('request aborted');
-    requestGotEnd = true;
-  });
-  res.on('close', function() {
+  }));
+  res.on('close', common.mustCall(function() {
     console.error('response aborted');
-    responseGotEnd = true;
-  });
-});
+  }));
+}));
 server.listen(0);
 
 server.on('listening', function() {
@@ -33,9 +27,4 @@ server.on('listening', function() {
       server.close();
     });
   });
-});
-
-process.on('exit', function() {
-  assert.ok(requestGotEnd);
-  assert.ok(responseGotEnd);
 });

--- a/test/parallel/test-http-response-no-headers.js
+++ b/test/parallel/test-http-response-no-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -10,13 +10,7 @@ var expected = {
   '1.1': ''
 };
 
-var gotExpected = false;
-
 function test(httpVersion, callback) {
-  process.on('exit', function() {
-    assert(gotExpected);
-  });
-
   var server = net.createServer(function(conn) {
     var reply = 'HTTP/' + httpVersion + ' 200 OK\r\n\r\n' +
                 expected[httpVersion];
@@ -24,31 +18,30 @@ function test(httpVersion, callback) {
     conn.end(reply);
   });
 
-  server.listen(0, '127.0.0.1', function() {
+  server.listen(0, '127.0.0.1', common.mustCall(function() {
     var options = {
       host: '127.0.0.1',
       port: this.address().port
     };
 
-    var req = http.get(options, function(res) {
+    var req = http.get(options, common.mustCall(function(res) {
       var body = '';
 
       res.on('data', function(data) {
         body += data;
       });
 
-      res.on('end', function() {
+      res.on('end', common.mustCall(function() {
         assert.equal(body, expected[httpVersion]);
-        gotExpected = true;
         server.close();
         if (callback) process.nextTick(callback);
-      });
-    });
+      }));
+    }));
 
     req.on('error', function(err) {
       throw err;
     });
-  });
+  }));
 }
 
 test('0.9', function() {

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -3,10 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 
-var status_ok = false; // status code == 200?
-var headers_ok = false;
-var body_ok = false;
-
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {
     'Content-Type': 'text/plain',
@@ -19,19 +15,16 @@ var server = http.createServer(function(req, res) {
 
 common.refreshTmpDir();
 
-server.listen(common.PIPE, function() {
+server.listen(common.PIPE, common.mustCall(function() {
 
   var options = {
     socketPath: common.PIPE,
     path: '/'
   };
 
-  var req = http.get(options, function(res) {
+  var req = http.get(options, common.mustCall(function(res) {
     assert.equal(res.statusCode, 200);
-    status_ok = true;
-
     assert.equal(res.headers['content-type'], 'text/plain');
-    headers_ok = true;
 
     res.body = '';
     res.setEncoding('utf8');
@@ -40,17 +33,16 @@ server.listen(common.PIPE, function() {
       res.body += chunk;
     });
 
-    res.on('end', function() {
+    res.on('end', common.mustCall(function() {
       assert.equal(res.body, 'hello world\n');
-      body_ok = true;
       server.close(function(error) {
         assert.equal(error, undefined);
         server.close(function(error) {
           assert.equal(error && error.message, 'Not running');
         });
       });
-    });
-  });
+    }));
+  }));
 
   req.on('error', function(e) {
     console.log(e.stack);
@@ -59,10 +51,4 @@ server.listen(common.PIPE, function() {
 
   req.end();
 
-});
-
-process.on('exit', function() {
-  assert.ok(status_ok);
-  assert.ok(headers_ok);
-  assert.ok(body_ok);
-});
+}));

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -25,9 +25,7 @@ var srv = net.createServer(function(c) {
   });
 });
 
-var gotUpgrade = false;
-
-srv.listen(0, '127.0.0.1', function() {
+srv.listen(0, '127.0.0.1', common.mustCall(function() {
 
   var options = {
     port: this.address().port,
@@ -42,7 +40,7 @@ srv.listen(0, '127.0.0.1', function() {
   var req = http.request(options);
   req.end();
 
-  req.on('upgrade', function(res, socket, upgradeHead) {
+  req.on('upgrade', common.mustCall(function(res, socket, upgradeHead) {
     var recvData = upgradeHead;
     socket.on('data', function(d) {
       recvData += d;
@@ -61,16 +59,9 @@ srv.listen(0, '127.0.0.1', function() {
     // Make sure this request got removed from the pool.
     assert(!http.globalAgent.sockets.hasOwnProperty(name));
 
-    req.on('close', function() {
+    req.on('close', common.mustCall(function() {
       socket.end();
       srv.close();
-
-      gotUpgrade = true;
-    });
-  });
-
-});
-
-process.on('exit', function() {
-  assert.ok(gotUpgrade);
-});
+    }));
+  }));
+}));

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 
 var CRLF = '\r\n';
@@ -15,9 +14,7 @@ server.on('upgrade', function(req, socket, head) {
   });
 });
 
-var successCount = 0;
-
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
 
   function upgradeRequest(fn) {
     console.log('req');
@@ -52,18 +49,11 @@ server.listen(0, function() {
 
   }
 
-  upgradeRequest(function() {
-    successCount++;
-    upgradeRequest(function() {
-      successCount++;
+  upgradeRequest(common.mustCall(function() {
+    upgradeRequest(common.mustCall(function() {
       // Test pass
       console.log('Pass!');
       server.close();
-    });
-  });
-
-});
-
-process.on('exit', function() {
-  assert.equal(2, successCount);
-});
+    }));
+  }));
+}));

--- a/test/parallel/test-http-upgrade-server2.js
+++ b/test/parallel/test-http-upgrade-server2.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');
@@ -14,13 +14,10 @@ server.on('upgrade', function(req, socket, upgradeHead) {
   throw new Error('upgrade error');
 });
 
-var gotError = false;
-
-process.on('uncaughtException', function(e) {
+process.on('uncaughtException', common.mustCall(function(e) {
   assert.equal('upgrade error', e.message);
-  gotError = true;
   process.exit(0);
-});
+}));
 
 
 server.listen(0, function() {
@@ -40,8 +37,4 @@ server.listen(0, function() {
   c.on('close', function() {
     server.close();
   });
-});
-
-process.on('exit', function() {
-  assert.ok(gotError);
 });

--- a/test/parallel/test-http-wget.js
+++ b/test/parallel/test-http-wget.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 var http = require('http');
@@ -19,10 +19,6 @@ var http = require('http');
 // content-length is not provided, that the connection is in fact
 // closed.
 
-var server_response = '';
-var client_got_eof = false;
-var connection_was_closed = false;
-
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('hello ');
@@ -31,8 +27,9 @@ var server = http.createServer(function(req, res) {
 });
 server.listen(0);
 
-server.on('listening', function() {
+server.on('listening', common.mustCall(function() {
   var c = net.createConnection(this.address().port);
+  var server_response = '';
 
   c.setEncoding('utf8');
 
@@ -46,22 +43,15 @@ server.on('listening', function() {
     server_response += chunk;
   });
 
-  c.on('end', function() {
-    client_got_eof = true;
+  c.on('end', common.mustCall(function() {
+    const m = server_response.split('\r\n\r\n');
+    assert.strictEqual(m[1], 'hello world\n');
     console.log('got end');
     c.end();
-  });
+  }));
 
-  c.on('close', function() {
-    connection_was_closed = true;
+  c.on('close', common.mustCall(function() {
     console.log('got close');
     server.close();
-  });
-});
-
-process.on('exit', function() {
-  var m = server_response.split('\r\n\r\n');
-  assert.equal(m[1], 'hello world\n');
-  assert.ok(client_got_eof);
-  assert.ok(connection_was_closed);
-});
+  }));
+}));

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var http = require('http');
@@ -17,20 +17,17 @@ var server = http.createServer(function(request, response) {
   this.close();
 });
 
-var response = '';
+server.listen(0, common.mustCall(function() {
+  http.get({ port: this.address().port }, common.mustCall(function(res) {
+    var response = '';
 
-process.on('exit', function() {
-  assert.equal('1\n2\n3\n', response);
-});
-
-
-server.listen(0, function() {
-  http.get({ port: this.address().port }, function(res) {
     assert.equal(200, res.statusCode);
     res.setEncoding('ascii');
     res.on('data', function(chunk) {
       response += chunk;
     });
-  });
-});
-
+    res.on('end', common.mustCall(function() {
+      assert.strictEqual('1\n2\n3\n', response);
+    }));
+  }));
+}));

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -81,9 +81,6 @@ function third(server) {
     assert(!req.socket.isSessionReused());
     server.close();
   });
-  req.on('error', function(err) {
-    // never called
-    assert(false);
-  });
+  req.on('error', common.fail);
   req.end();
 }

--- a/test/parallel/test-https-client-checkServerIdentity.js
+++ b/test/parallel/test-https-client-checkServerIdentity.js
@@ -16,14 +16,11 @@ var options = {
   cert: fs.readFileSync(path.join(common.fixturesDir, 'keys/agent3-cert.pem'))
 };
 
-var reqCount = 0;
-
-var server = https.createServer(options, function(req, res) {
-  ++reqCount;
+var server = https.createServer(options, common.mustCall(function(req, res) {
   res.writeHead(200);
   res.end();
   req.resume();
-}).listen(0, function() {
+})).listen(0, function() {
   authorized();
 });
 
@@ -32,9 +29,7 @@ function authorized() {
     port: server.address().port,
     rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))]
-  }, function(res) {
-    assert(false);
-  });
+  }, common.fail);
   req.on('error', function(err) {
     override();
   });
@@ -60,7 +55,3 @@ function override() {
   });
   req.end();
 }
-
-process.on('exit', function() {
-  assert.equal(reqCount, 1);
-});

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -13,27 +13,20 @@ var https = require('https');
 
 var fs = require('fs');
 
-var seen_req = false;
-
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var server = https.createServer(options, function(req, res) {
+var server = https.createServer(options, common.mustCall(function(req, res) {
   assert.equal('GET', req.method);
   assert.equal('/foo?bar', req.url);
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('hello\n');
   res.end();
   server.close();
-  seen_req = true;
-});
+}));
 
 server.listen(0, function() {
   https.get(`https://127.0.0.1:${this.address().port}/foo?bar`);
-});
-
-process.on('exit', function() {
-  assert(seen_req);
 });

--- a/test/parallel/test-https-client-reject.js
+++ b/test/parallel/test-https-client-reject.js
@@ -16,14 +16,11 @@ var options = {
   cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
 };
 
-var reqCount = 0;
-
-var server = https.createServer(options, function(req, res) {
-  ++reqCount;
+var server = https.createServer(options, common.mustCall(function(req, res) {
   res.writeHead(200);
   res.end();
   req.resume();
-}).listen(0, function() {
+}, 2)).listen(0, function() {
   unauthorized();
 });
 
@@ -47,9 +44,7 @@ function rejectUnauthorized() {
     port: server.address().port
   };
   options.agent = new https.Agent(options);
-  var req = https.request(options, function(res) {
-    assert(false);
-  });
+  var req = https.request(options, common.fail);
   req.on('error', function(err) {
     authorized();
   });
@@ -67,12 +62,6 @@ function authorized() {
     assert(req.socket.authorized);
     server.close();
   });
-  req.on('error', function(err) {
-    assert(false);
-  });
+  req.on('error', common.fail);
   req.end();
 }
-
-process.on('exit', function() {
-  assert.equal(reqCount, 2);
-});

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -19,13 +19,10 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-var connections = 0;
-
 // create server
-var server = https.createServer(options, function(req, res) {
+var server = https.createServer(options, common.mustCall(function(req, res) {
   res.end('Goodbye');
-  connections++;
-});
+}, 2));
 
 // start listening
 server.listen(0, function() {
@@ -65,8 +62,4 @@ server.listen(0, function() {
       server.close();
     });
   });
-});
-
-process.on('exit', function() {
-  assert.equal(2, connections);
 });

--- a/test/parallel/test-https-connecting-to-http.js
+++ b/test/parallel/test-https-connecting-to-http.js
@@ -2,7 +2,6 @@
 // This tests the situation where you try to connect a https client
 // to an http server. You should get an error and exit.
 var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 
 if (!common.hasCrypto) {
@@ -11,35 +10,13 @@ if (!common.hasCrypto) {
 }
 var https = require('https');
 
-var reqCount = 0;
-var resCount = 0;
-var reqErrorCount = 0;
-var body = 'hello world\n';
+var server = http.createServer(common.fail);
 
+server.listen(0, common.mustCall(function() {
+  var req = https.get({ port: this.address().port }, common.fail);
 
-var server = http.createServer(function(req, res) {
-  reqCount++;
-  console.log('got request');
-  res.writeHead(200, { 'content-type': 'text/plain' });
-  res.end(body);
-});
-
-
-server.listen(0, function() {
-  var req = https.get({ port: this.address().port }, function(res) {
-    resCount++;
-  });
-
-  req.on('error', function(e) {
+  req.on('error', common.mustCall(function(e) {
     console.log('Got expected error: ', e.message);
     server.close();
-    reqErrorCount++;
-  });
-});
-
-
-process.on('exit', function() {
-  assert.equal(0, reqCount);
-  assert.equal(0, resCount);
-  assert.equal(1, reqErrorCount);
-});
+  }));
+}));

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -46,37 +46,27 @@ var server = tls.Server(options, function(socket) {
   }, 100);
 });
 
-
-var gotHeaders = false;
-var gotEnd = false;
-var bodyBuffer = '';
-
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   console.log('1) Making Request');
   https.get({
     port: this.address().port,
     rejectUnauthorized: false
-  }, function(res) {
+  }, common.mustCall(function(res) {
+    var bodyBuffer = '';
+
     server.close();
     console.log('3) Client got response headers.');
 
     assert.equal('gws', res.headers.server);
-    gotHeaders = true;
 
     res.setEncoding('utf8');
     res.on('data', function(s) {
       bodyBuffer += s;
     });
 
-    res.on('end', function() {
+    res.on('end', common.mustCall(function() {
       console.log('5) Client got "end" event.');
-      gotEnd = true;
-    });
-  });
-});
-
-process.on('exit', function() {
-  assert.ok(gotHeaders);
-  assert.ok(gotEnd);
-  assert.equal('hello world\nhello world\n', bodyBuffer);
-});
+      assert.strictEqual('hello world\nhello world\n', bodyBuffer);
+    }));
+  }));
+}));

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -24,25 +24,31 @@ var options = {
   requestCert: true
 };
 
+const modulus = 'A6F44A9C25791431214F5C87AF9E040177A8BB89AC803F7E09BBC3A5519F' +
+                '349CD9B9C40BE436D0AA823A94147E26C89248ADA2BE3DD4D34E8C289646' +
+                '94B2047D217B4F1299371EA93A83C89AB9440724131E65F2B0161DE9560C' +
+                'DE9C13455552B2F49CF0FB00D8D77532324913F6F80FF29D0A131D29DB06' +
+                'AFF8BE191B7920DC2DAE1C26EA82A47847A10391EF3BF6AABB3CC40FF821' +
+                '00B03A4F0FF1809278E4DDFDA7DE954ED56DC7AD9A47EEBC37D771A366FC' +
+                '60A5BCB72373BEC180649B3EFA0E9092707210B41B90032BB18BC91F2046' +
+                'EBDAF1191F4A4E26D71879C4C7867B62FCD508E8CE66E82D128A71E91580' +
+                '9FCF44E8DE774067F1DE5D70B9C03687';
+
 var CRLF = '\r\n';
 var body = 'hello world\n';
 var cert;
-var subjectaltname;
-var modulus;
-var exponent;
 
-var server = https.createServer(options, function(req, res) {
+var server = https.createServer(options, common.mustCall(function(req, res) {
   console.log('got request');
 
   cert = req.connection.getPeerCertificate();
 
-  subjectaltname = cert.subjectaltname;
-  modulus = cert.modulus;
-  exponent = cert.exponent;
-
+  assert.strictEqual(cert.subjectaltname, 'URI:http://example.com/#me');
+  assert.strictEqual(cert.exponent, '0x10001');
+  assert.strictEqual(cert.modulus, modulus);
   res.writeHead(200, { 'content-type': 'text/plain' });
   res.end(body);
-});
+}));
 
 server.listen(0, function() {
   var args = ['s_client',
@@ -69,17 +75,4 @@ server.listen(0, function() {
   client.on('error', function(error) {
     throw error;
   });
-});
-
-process.on('exit', function() {
-  assert.equal(subjectaltname, 'URI:http://example.com/#me');
-  assert.equal(modulus, 'A6F44A9C25791431214F5C87AF9E040177A8BB89AC803F7E09' +
-      'BBC3A5519F349CD9B9C40BE436D0AA823A94147E26C89248ADA2BE3DD4D34E8C2896' +
-      '4694B2047D217B4F1299371EA93A83C89AB9440724131E65F2B0161DE9560CDE9C13' +
-      '455552B2F49CF0FB00D8D77532324913F6F80FF29D0A131D29DB06AFF8BE191B7920' +
-      'DC2DAE1C26EA82A47847A10391EF3BF6AABB3CC40FF82100B03A4F0FF1809278E4DD' +
-      'FDA7DE954ED56DC7AD9A47EEBC37D771A366FC60A5BCB72373BEC180649B3EFA0E90' +
-      '92707210B41B90032BB18BC91F2046EBDAF1191F4A4E26D71879C4C7867B62FCD508' +
-      'E8CE66E82D128A71E915809FCF44E8DE774067F1DE5D70B9C03687');
-  assert.equal(exponent, '0x10001');
 });

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var fs = require('fs');
 
 if (!common.hasCrypto) {
@@ -15,7 +14,6 @@ var options = {
 };
 
 var invalidLocalAddress = '1.2.3.4';
-var gotError = false;
 
 var server = https.createServer(options, function(req, res) {
   console.log('Connect from: ' + req.connection.remoteAddress);
@@ -27,7 +25,7 @@ var server = https.createServer(options, function(req, res) {
   req.resume();
 });
 
-server.listen(0, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', common.mustCall(function() {
   https.request({
     host: 'localhost',
     port: this.address().port,
@@ -36,13 +34,8 @@ server.listen(0, '127.0.0.1', function() {
     localAddress: invalidLocalAddress
   }, function(res) {
     common.fail('unexpectedly got response from server');
-  }).on('error', function(e) {
+  }).on('error', common.mustCall(function(e) {
     console.log('client got error: ' + e.message);
-    gotError = true;
     server.close();
-  }).end();
-});
-
-process.on('exit', function() {
-  assert.ok(gotError);
-});
+  })).end();
+}));

--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -28,16 +28,16 @@ var server = https.createServer(options, function(req, res) {
   res.end('OK');
 });
 
-server.listen(0, options.host, function() {
+server.listen(0, options.host, common.mustCall(function() {
   options.port = this.address().port;
-  var data = '';
 
-  https.get(options, function(res) {
+  https.get(options, common.mustCall(function(res) {
+    var data = '';
+
     res.on('data', function(data_) { data += data_; });
-    res.on('end', function() { server.close(); });
-  });
-
-  process.on('exit', function() {
-    assert.equal(data, 'OK');
-  });
-});
+    res.on('end', common.mustCall(function() {
+      assert.strictEqual(data, 'OK');
+      server.close();
+    }));
+  }));
+}));

--- a/test/parallel/test-https-req-split.js
+++ b/test/parallel/test-https-req-split.js
@@ -3,7 +3,6 @@
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -14,8 +13,6 @@ var https = require('https');
 var tls = require('tls');
 var fs = require('fs');
 
-var seen_req = false;
-
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
@@ -25,13 +22,12 @@ var options = {
 tls.SLAB_BUFFER_SIZE = 1;
 
 var server = https.createServer(options);
-server.on('upgrade', function(req, socket, upgrade) {
+server.on('upgrade', common.mustCall(function(req, socket, upgrade) {
   socket.on('data', function(data) {
     throw new Error('Unexpected data: ' + data);
   });
   socket.end('HTTP/1.1 200 Ok\r\n\r\n');
-  seen_req = true;
-});
+}));
 
 server.listen(0, function() {
   var req = https.request({
@@ -48,9 +44,4 @@ server.listen(0, function() {
   });
 
   req.end();
-});
-
-process.on('exit', function() {
-  assert(seen_req);
-  console.log('ok');
 });

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -11,12 +11,6 @@ var https = require('https');
 var net = require('net');
 var fs = require('fs');
 
-var clientErrors = 0;
-
-process.on('exit', function() {
-  assert.equal(clientErrors, 1);
-});
-
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
@@ -25,14 +19,13 @@ var options = {
 
 var server = https.createServer(options, common.fail);
 
-server.on('clientError', function(err, conn) {
+server.on('clientError', common.mustCall(function(err, conn) {
   // Don't hesitate to update the asserts if the internal structure of
   // the cleartext object ever changes. We're checking that the https.Server
   // has closed the client connection.
   assert.equal(conn._secureEstablished, false);
   server.close();
-  clientErrors++;
-});
+}));
 
 server.listen(0, function() {
   net.connect({ host: '127.0.0.1', port: this.address().port });

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -3,16 +3,11 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var gotError = 0;
-
-process.on('exit', function() {
-  assert.equal(gotError, 2);
-});
-
-net.createServer(common.fail).listen({fd: 2}).on('error', onError);
-net.createServer(common.fail).listen({fd: 42}).on('error', onError);
+net.createServer(common.fail).listen({fd: 2})
+  .on('error', common.mustCall(onError));
+net.createServer(common.fail).listen({fd: 42})
+  .on('error', common.mustCall(onError));
 
 function onError(ex) {
   assert.equal(ex.code, 'EINVAL');
-  gotError++;
 }

--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -1,20 +1,18 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var closed = false;
 
 var server = net.createServer(function(s) {
   console.error('SERVER: got connection');
   s.end();
 });
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var c = net.createConnection(this.address().port);
-  c.on('close', function() {
+  c.on('close', common.mustCall(function() {
     console.error('connection closed');
     assert.strictEqual(c._handle, null);
-    closed = true;
     assert.doesNotThrow(function() {
       c.setNoDelay();
       c.setKeepAlive();
@@ -26,9 +24,5 @@ server.listen(0, function() {
       c.remotePort;
     });
     server.close();
-  });
-});
-
-process.on('exit', function() {
-  assert(closed);
-});
+  }));
+}));

--- a/test/parallel/test-net-bind-twice.js
+++ b/test/parallel/test-net-bind-twice.js
@@ -1,26 +1,15 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var gotError = false;
+var server1 = net.createServer(common.fail);
+server1.listen(0, '127.0.0.1', common.mustCall(function() {
+  var server2 = net.createServer(common.fail);
+  server2.listen(this.address().port, '127.0.0.1', common.fail);
 
-process.on('exit', function() {
-  assert(gotError);
-});
-
-function dontCall() {
-  assert(false);
-}
-
-var server1 = net.createServer(dontCall);
-server1.listen(0, '127.0.0.1', function() {
-  var server2 = net.createServer(dontCall);
-  server2.listen(this.address().port, '127.0.0.1', dontCall);
-
-  server2.on('error', function(e) {
+  server2.on('error', common.mustCall(function(e) {
     assert.equal(e.code, 'EADDRINUSE');
     server1.close();
-    gotError = true;
-  });
-});
+  }));
+}));

--- a/test/parallel/test-net-can-reset-timeout.js
+++ b/test/parallel/test-net-can-reset-timeout.js
@@ -1,29 +1,23 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var net = require('net');
-var assert = require('assert');
 
-var timeoutCount = 0;
-
-var server = net.createServer(function(stream) {
+var server = net.createServer(common.mustCall(function(stream) {
   stream.setTimeout(100);
 
   stream.resume();
 
-  stream.on('timeout', function() {
+  stream.on('timeout', common.mustCall(function() {
     console.log('timeout');
     // try to reset the timeout.
     stream.write('WHAT.');
-    // don't worry, the socket didn't *really* time out, we're just thinking
-    // it did.
-    timeoutCount += 1;
-  });
+  }));
 
   stream.on('end', function() {
     console.log('server side end');
     stream.end();
   });
-});
+}));
 
 server.listen(0, function() {
   var c = net.createConnection(this.address().port);
@@ -36,9 +30,4 @@ server.listen(0, function() {
     console.log('client side end');
     server.close();
   });
-});
-
-
-process.on('exit', function() {
-  assert.equal(1, timeoutCount);
 });

--- a/test/parallel/test-net-connect-handle-econnrefused.js
+++ b/test/parallel/test-net-connect-handle-econnrefused.js
@@ -12,14 +12,7 @@ c.on('connect', function() {
   assert.ok(false);
 });
 
-var gotError = false;
-c.on('error', function(e) {
+c.on('error', common.mustCall(function(e) {
   console.error('couldn\'t connect.');
-  gotError = true;
   assert.equal('ECONNREFUSED', e.code);
-});
-
-
-process.on('exit', function() {
-  assert.ok(gotError);
-});
+}));

--- a/test/parallel/test-net-connect-options.js
+++ b/test/parallel/test-net-connect-options.js
@@ -1,42 +1,32 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var serverGotEnd = false;
-var clientGotEnd = false;
-
-var server = net.createServer({allowHalfOpen: true}, function(socket) {
+var server = net.createServer({
+  allowHalfOpen: true
+}, common.mustCall(function(socket) {
   socket.resume();
-  socket.on('end', function() {
-    serverGotEnd = true;
-  });
+  socket.on('end', common.mustCall(function() {}));
   socket.end();
-});
+}));
 
 server.listen(0, function() {
   var client = net.connect({
     host: '127.0.0.1',
     port: this.address().port,
     allowHalfOpen: true
-  }, function() {
+  }, common.mustCall(function() {
     console.error('client connect cb');
     client.resume();
-    client.on('end', function() {
-      clientGotEnd = true;
+    client.on('end', common.mustCall(function() {
       setTimeout(function() {
         assert(client.writable);
         client.end();
       }, 10);
-    });
+    }));
     client.on('close', function() {
       server.close();
     });
-  });
-});
-
-process.on('exit', function() {
-  console.error('exit', serverGotEnd, clientGotEnd);
-  assert(serverGotEnd);
-  assert(clientGotEnd);
+  }));
 });

--- a/test/parallel/test-net-dns-custom-lookup.js
+++ b/test/parallel/test-net-dns-custom-lookup.js
@@ -2,7 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var ok = false;
 
 function check(addressType, cb) {
   var server = net.createServer(function(client) {
@@ -12,19 +11,18 @@ function check(addressType, cb) {
   });
 
   var address = addressType === 4 ? common.localhostIPv4 : '::1';
-  server.listen(0, address, function() {
+  server.listen(0, address, common.mustCall(function() {
     net.connect({
       port: this.address().port,
       host: 'localhost',
       family: addressType,
       lookup: lookup
-    }).on('lookup', function(err, ip, type) {
+    }).on('lookup', common.mustCall(function(err, ip, type) {
       assert.equal(err, null);
       assert.equal(address, ip);
       assert.equal(type, addressType);
-      ok = true;
-    });
-  });
+    }));
+  }));
 
   function lookup(host, dnsopts, cb) {
     dnsopts.family = addressType;
@@ -42,8 +40,4 @@ function check(addressType, cb) {
 
 check(4, function() {
   common.hasIPv6 && check(6);
-});
-
-process.on('exit', function() {
-  assert.ok(ok);
 });

--- a/test/parallel/test-net-dns-error.js
+++ b/test/parallel/test-net-dns-error.js
@@ -1,11 +1,8 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var net = require('net');
-
-var expected_bad_connections = 1;
-var actual_bad_connections = 0;
 
 var host = '*'.repeat(256);
 
@@ -14,17 +11,12 @@ function do_not_call() {
 }
 
 var socket = net.connect(42, host, do_not_call);
-socket.on('error', function(err) {
+socket.on('error', common.mustCall(function(err) {
   assert.equal(err.code, 'ENOTFOUND');
-  actual_bad_connections++;
-});
+}));
 socket.on('lookup', function(err, ip, type) {
   assert(err instanceof Error);
   assert.equal(err.code, 'ENOTFOUND');
   assert.equal(ip, undefined);
   assert.equal(type, undefined);
-});
-
-process.on('exit', function() {
-  assert.equal(actual_bad_connections, expected_bad_connections);
 });

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -1,24 +1,18 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var ok = false;
 
 var server = net.createServer(function(client) {
   client.end();
   server.close();
 });
 
-server.listen(0, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', common.mustCall(function() {
   net.connect(this.address().port, 'localhost')
-    .on('lookup', function(err, ip, type) {
+    .on('lookup', common.mustCall(function(err, ip, type) {
       assert.equal(err, null);
       assert.equal(ip, '127.0.0.1');
       assert.equal(type, '4');
-      ok = true;
-    });
-});
-
-process.on('exit', function() {
-  assert(ok);
-});
+    }));
+}));

--- a/test/parallel/test-net-during-close.js
+++ b/test/parallel/test-net-during-close.js
@@ -1,14 +1,13 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var accessedProperties = false;
 
 var server = net.createServer(function(socket) {
   socket.end();
 });
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var client = net.createConnection(this.address().port);
   server.close();
   // server connection event has not yet fired
@@ -18,11 +17,6 @@ server.listen(0, function() {
     client.remoteFamily;
     client.remotePort;
   });
-  accessedProperties = true;
   // exit now, do not wait for the client error event
   process.exit(0);
-});
-
-process.on('exit', function() {
-  assert(accessedProperties);
-});
+}));

--- a/test/parallel/test-net-large-string.js
+++ b/test/parallel/test-net-large-string.js
@@ -1,22 +1,24 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
 var kPoolSize = 40 * 1024;
 var data = 'あ'.repeat(kPoolSize);
-var receivedSize = 0;
 var encoding = 'UTF-8';
 
-var server = net.createServer(function(socket) {
+var server = net.createServer(common.mustCall(function(socket) {
+  var receivedSize = 0;
+
   socket.setEncoding(encoding);
   socket.on('data', function(data) {
     receivedSize += data.length;
   });
-  socket.on('end', function() {
+  socket.on('end', common.mustCall(function() {
+    assert.strictEqual(receivedSize, kPoolSize);
     socket.end();
-  });
-});
+  }));
+}));
 
 server.listen(0, function() {
   var client = net.createConnection(this.address().port);
@@ -25,8 +27,4 @@ server.listen(0, function() {
   });
   client.write(data, encoding);
   client.end();
-});
-
-process.on('exit', function() {
-  assert.equal(receivedSize, kPoolSize);
 });

--- a/test/parallel/test-net-listen-close-server-callback-is-not-function.js
+++ b/test/parallel/test-net-listen-close-server-callback-is-not-function.js
@@ -1,19 +1,11 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
 var net = require('net');
 
 var server = net.createServer(common.fail);
-var closeEvents = 0;
 
-server.on('close', function() {
-  ++closeEvents;
-});
+server.on('close', common.mustCall(function() {}));
 
 server.listen(0, common.fail);
 
 server.close('bad argument');
-
-process.on('exit', function() {
-  assert.equal(closeEvents, 1);
-});

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -1,15 +1,9 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var net = require('net');
 
 var server = net.createServer(function(socket) {
 });
-server.listen(0, function() {
-  assert(false);
-});
-server.on('error', function(error) {
-  console.error(error);
-  assert(false);
-});
+server.listen(0, common.fail);
+server.on('error', common.fail);
 server.close();

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -1,19 +1,8 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var net = require('net');
-var gotError = false;
 
 var server = net.createServer(function(socket) {
 });
-server.listen(1, '1.1.1.1', function() { // EACCESS or EADDRNOTAVAIL
-  assert(false);
-});
-server.on('error', function(error) {
-  console.error(error);
-  gotError = true;
-});
-
-process.on('exit', function() {
-  assert(gotError);
-});
+server.listen(1, '1.1.1.1', common.fail); // EACCESS or EADDRNOTAVAIL
+server.on('error', common.mustCall(function(error) {}));

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -3,25 +3,18 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var conns = 0;
-
-var server = net.createServer(function(socket) {
-  conns++;
+var server = net.createServer(common.mustCall(function(socket) {
   assert.equal(socket.localAddress, common.localhostIPv4);
   assert.equal(socket.localPort, this.address().port);
   socket.on('end', function() {
     server.close();
   });
   socket.resume();
-});
+}));
 
 server.listen(0, common.localhostIPv4, function() {
   var client = net.createConnection(this.address().port, common.localhostIPv4);
   client.on('connect', function() {
     client.end();
   });
-});
-
-process.on('exit', function() {
-  assert.equal(1, conns);
 });

--- a/test/parallel/test-net-pause-resume-connecting.js
+++ b/test/parallel/test-net-pause-resume-connecting.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -34,7 +34,7 @@ server.listen(0, function() {
   // Client 3
   conn = require('net').createConnection(this.address().port, 'localhost');
   conn.pause();
-  conn.on('data', onDataError);
+  conn.on('data', common.fail);
   scheduleTearDown(conn);
 
 
@@ -51,14 +51,8 @@ server.listen(0, function() {
   conn.resume();
   conn.resume();
   conn.pause();
-  conn.on('data', onDataError);
+  conn.on('data', common.fail);
   scheduleTearDown(conn);
-
-
-  // Client helper functions
-  function onDataError() {
-    assert(false);
-  }
 
   function onDataOk() {
     dataEvents++;

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -1,12 +1,10 @@
 'use strict';
+var common = require('../common');
 var fs = require('fs');
 var net = require('net');
 var path = require('path');
 var assert = require('assert');
-var common = require('../common');
 
-var notSocketErrorFired = false;
-var noEntErrorFired = false;
 var accessErrorFired = false;
 
 // Test if ENOTSOCK is fired when trying to connect to a file which is not
@@ -43,11 +41,10 @@ var notSocketClient = net.createConnection(emptyTxt, function() {
   assert.ok(false);
 });
 
-notSocketClient.on('error', function(err) {
+notSocketClient.on('error', common.mustCall(function(err) {
   assert(err.code === 'ENOTSOCK' || err.code === 'ECONNREFUSED',
-    `received ${err.code} instead of ENOTSOCK or ECONNREFUSED`);
-  notSocketErrorFired = true;
-});
+         `received ${err.code} instead of ENOTSOCK or ECONNREFUSED`);
+}));
 
 
 // Trying to connect to not-existing socket should result in ENOENT error
@@ -55,10 +52,9 @@ var noEntSocketClient = net.createConnection('no-ent-file', function() {
   assert.ok(false);
 });
 
-noEntSocketClient.on('error', function(err) {
+noEntSocketClient.on('error', common.mustCall(function(err) {
   assert.equal(err.code, 'ENOENT');
-  noEntErrorFired = true;
-});
+}));
 
 
 // On Windows or when running as root, a chmod has no effect on named pipes
@@ -85,10 +81,7 @@ if (!common.isWindows && process.getuid() !== 0) {
 
 // Assert that all error events were fired
 process.on('exit', function() {
-  assert.ok(notSocketErrorFired);
-  assert.ok(noEntErrorFired);
   if (!common.isWindows && process.getuid() !== 0) {
     assert.ok(accessErrorFired);
   }
 });
-

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const net = require('net');
 
-var conns = 0, conns_closed = 0;
+var conns_closed = 0;
 
 var remoteAddrCandidates = [ common.localhostIPv4 ];
 if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
@@ -12,8 +12,7 @@ if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
 var remoteFamilyCandidates = ['IPv4'];
 if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
 
-var server = net.createServer(function(socket) {
-  conns++;
+var server = net.createServer(common.mustCall(function(socket) {
   assert.notEqual(-1, remoteAddrCandidates.indexOf(socket.remoteAddress));
   assert.notEqual(-1, remoteFamilyCandidates.indexOf(socket.remoteFamily));
   assert.ok(socket.remotePort);
@@ -26,7 +25,7 @@ var server = net.createServer(function(socket) {
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(socket.remoteFamily));
   });
   socket.resume();
-});
+}, 2));
 
 server.listen(0, 'localhost', function() {
   var client = net.createConnection(this.address().port, 'localhost');
@@ -51,8 +50,4 @@ server.listen(0, 'localhost', function() {
     assert.notEqual(-1, remoteAddrCandidates.indexOf(client2.remoteAddress));
     assert.notEqual(-1, remoteFamilyCandidates.indexOf(client2.remoteFamily));
   });
-});
-
-process.on('exit', function() {
-  assert.equal(2, conns);
 });

--- a/test/parallel/test-net-server-unref-persistent.js
+++ b/test/parallel/test-net-server-unref-persistent.js
@@ -1,8 +1,6 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var net = require('net');
-var closed = false;
 var server = net.createServer();
 
 // unref before listening
@@ -11,11 +9,4 @@ server.listen();
 
 // If the timeout fires, that means the server held the event loop open
 // and the unref() was not persistent. Close the server and fail the test.
-setTimeout(function() {
-  closed = true;
-  server.close();
-}, 1000).unref();
-
-process.on('exit', function() {
-  assert.strictEqual(closed, false, 'server should not hold loop open');
-});
+setTimeout(common.fail, 1000).unref();

--- a/test/parallel/test-net-server-unref.js
+++ b/test/parallel/test-net-server-unref.js
@@ -1,19 +1,9 @@
 'use strict';
-require('../common');
-var assert = require('assert');
-
+const common = require('../common');
 var net = require('net');
-var closed = false;
 
 var s = net.createServer();
 s.listen(0);
 s.unref();
 
-setTimeout(function() {
-  closed = true;
-  s.close();
-}, 1000).unref();
-
-process.on('exit', function() {
-  assert.strictEqual(closed, false, 'Unrefd socket should not hold loop open');
-});
+setTimeout(common.fail, 1000).unref();

--- a/test/parallel/test-net-socket-destroy-twice.js
+++ b/test/parallel/test-net-socket-destroy-twice.js
@@ -1,23 +1,11 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 var net = require('net');
-
-var nerrors = 0;
-var ncloses = 0;
-
-process.on('exit', function() {
-  assert.equal(nerrors, 1);
-  assert.equal(ncloses, 1);
-});
 
 var conn = net.createConnection(common.PORT);
 
-conn.on('error', function() {
-  nerrors++;
+conn.on('error', common.mustCall(function() {
   conn.destroy();
-});
+}));
 
-conn.on('close', function() {
-  ncloses++;
-});
+conn.on('close', common.mustCall(function() {}));

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -28,22 +28,15 @@ for (let i = 0; i < validDelays.length; i++) {
   });
 }
 
-var timedout = false;
-
 var server = net.Server();
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var socket = net.createConnection(this.address().port);
-  socket.setTimeout(100, function() {
-    timedout = true;
+  socket.setTimeout(100, common.mustCall(function() {
     socket.destroy();
     server.close();
     clearTimeout(timer);
-  });
+  }));
   var timer = setTimeout(function() {
     process.exit(1);
   }, common.platformTimeout(200));
-});
-
-process.on('exit', function() {
-  assert.ok(timedout);
-});
+}));

--- a/test/parallel/test-net-write-after-close.js
+++ b/test/parallel/test-net-write-after-close.js
@@ -1,32 +1,20 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var net = require('net');
 
-var gotError = false;
-var gotWriteCB = false;
-
-process.on('exit', function() {
-  assert(gotError);
-  assert(gotWriteCB);
-});
-
-var server = net.createServer(function(socket) {
+var server = net.createServer(common.mustCall(function(socket) {
   socket.resume();
 
-  socket.on('error', function(error) {
+  socket.on('error', common.mustCall(function(error) {
     console.error('got error, closing server', error);
     server.close();
-    gotError = true;
-  });
+  }));
 
-  setTimeout(function() {
+  setTimeout(common.mustCall(function() {
     console.error('about to try to write');
-    socket.write('test', function(e) {
-      gotWriteCB = true;
-    });
-  }, 250);
-});
+    socket.write('test', common.mustCall(function(e) {}));
+  }), 250);
+}));
 
 server.listen(0, function() {
   var client = net.connect(this.address().port, function() {

--- a/test/parallel/test-net-write-connect-write.js
+++ b/test/parallel/test-net-write-connect-write.js
@@ -1,14 +1,14 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-var received = '';
-
 var server = net.createServer(function(socket) {
   socket.pipe(socket);
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var conn = net.connect(this.address().port);
+  var received = '';
+
   conn.setEncoding('utf8');
   conn.write('before');
   conn.on('connect', function() {
@@ -18,11 +18,8 @@ var server = net.createServer(function(socket) {
     received += buf;
     conn.end();
   });
-  conn.on('end', function() {
+  conn.on('end', common.mustCall(function() {
     server.close();
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(received, 'before' + 'after');
-});
+    assert.strictEqual(received, 'before' + 'after');
+  }));
+}));

--- a/test/parallel/test-net-write-slow.js
+++ b/test/parallel/test-net-write-slow.js
@@ -27,7 +27,7 @@ var server = net.createServer(function(socket) {
   }
   socket.end();
 
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var conn = net.connect(this.address().port);
   conn.on('data', function(buf) {
     received += buf.length;
@@ -36,11 +36,8 @@ var server = net.createServer(function(socket) {
       conn.resume();
     }, 20);
   });
-  conn.on('end', function() {
+  conn.on('end', common.mustCall(function() {
     server.close();
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(received, SIZE * N);
-});
+    assert.strictEqual(received, SIZE * N);
+  }));
+}));

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -1,28 +1,18 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
-var complete = 0;
+process.nextTick(common.mustCall(function() {
+  process.nextTick(common.mustCall(function() {
+    process.nextTick(common.mustCall(function() {}));
+  }));
+}));
 
-process.nextTick(function() {
-  complete++;
-  process.nextTick(function() {
-    complete++;
-    process.nextTick(function() {
-      complete++;
-    });
-  });
-});
+setTimeout(common.mustCall(function() {
+  process.nextTick(common.mustCall(function() {}));
+}), 50);
 
-setTimeout(function() {
-  process.nextTick(function() {
-    complete++;
-  });
-}, 50);
-
-process.nextTick(function() {
-  complete++;
-});
+process.nextTick(common.mustCall(function() {}));
 
 var obj = {};
 
@@ -32,8 +22,5 @@ process.nextTick(function(a, b) {
 }, 42, obj);
 
 process.on('exit', function() {
-  assert.equal(5, complete);
-  process.nextTick(function() {
-    throw new Error('this should not occur');
-  });
+  process.nextTick(common.fail);
 });

--- a/test/parallel/test-pipe-address.js
+++ b/test/parallel/test-pipe-address.js
@@ -2,20 +2,11 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
-
-var address = null;
-
-var server = net.createServer(function() {
-  assert(false); // should not be called
-});
+var server = net.createServer(common.fail);
 
 common.refreshTmpDir();
 
-server.listen(common.PIPE, function() {
-  address = server.address();
+server.listen(common.PIPE, common.mustCall(function() {
+  assert.strictEqual(server.address(), common.PIPE);
   server.close();
-});
-
-process.on('exit', function() {
-  assert.equal(address, common.PIPE);
-});
+}));

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -10,16 +10,8 @@ var script = join(common.fixturesDir, 'print-10-lines.js');
 
 var cmd = '"' + nodePath + '" "' + script + '" | head -2';
 
-var finished = false;
-
-exec(cmd, function(err, stdout, stderr) {
+exec(cmd, common.mustCall(function(err, stdout, stderr) {
   if (err) throw err;
   var lines = stdout.split('\n');
   assert.equal(3, lines.length);
-  finished = true;
-});
-
-
-process.on('exit', function() {
-  assert.ok(finished);
-});
+}));

--- a/test/parallel/test-pipe-unref.js
+++ b/test/parallel/test-pipe-unref.js
@@ -1,9 +1,6 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
-
 var net = require('net');
-var closed = false;
 
 common.refreshTmpDir();
 
@@ -11,11 +8,4 @@ var s = net.Server();
 s.listen(common.PIPE);
 s.unref();
 
-setTimeout(function() {
-  closed = true;
-  s.close();
-}, 1000).unref();
-
-process.on('exit', function() {
-  assert.strictEqual(closed, false, 'Unrefd socket should not hold loop open');
-});
+setTimeout(common.fail, 1000).unref();

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -1,25 +1,17 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var N = 2;
-var tickCount = 0;
-var exceptionCount = 0;
 
 function cb() {
-  ++tickCount;
   throw new Error();
 }
 
 for (var i = 0; i < N; ++i) {
-  process.nextTick(cb);
+  process.nextTick(common.mustCall(cb));
 }
 
-process.on('uncaughtException', function() {
-  ++exceptionCount;
-});
+process.on('uncaughtException', common.mustCall(function() {}, N));
 
 process.on('exit', function() {
   process.removeAllListeners('uncaughtException');
-  assert.equal(tickCount, N);
-  assert.equal(exceptionCount, N);
 });

--- a/test/parallel/test-process-remove-all-signal-listeners.js
+++ b/test/parallel/test-process-remove-all-signal-listeners.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const common = require('../common');
 
 if (common.isWindows) {
   common.skip('Win32 doesn\'t have signals, just a kind of ' +
@@ -10,22 +10,15 @@ if (common.isWindows) {
   return;
 }
 
-var ok;
-
 if (process.argv[2] !== '--do-test') {
   // We are the master, fork a child so we can verify it exits with correct
   // status.
   process.env.DOTEST = 'y';
   var child = spawn(process.execPath, [__filename, '--do-test']);
 
-  child.once('exit', function(code, signal) {
+  child.once('exit', common.mustCall(function(code, signal) {
     assert.equal(signal, 'SIGINT');
-    ok = true;
-  });
-
-  process.on('exit', function() {
-    assert(ok);
-  });
+  }));
 
   return;
 }

--- a/test/parallel/test-regress-GH-1531.js
+++ b/test/parallel/test-regress-GH-1531.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -15,32 +14,24 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var gotCallback = false;
-
 var server = https.createServer(options, function(req, res) {
   res.writeHead(200);
   res.end('hello world\n');
 });
 
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   console.error('listening');
   https.get({
     agent: false,
     path: '/',
     port: this.address().port,
     rejectUnauthorized: false
-  }, function(res) {
+  }, common.mustCall(function(res) {
     console.error(res.statusCode, res.headers);
-    gotCallback = true;
     res.resume();
     server.close();
-  }).on('error', function(e) {
+  })).on('error', function(e) {
     console.error(e.stack);
     process.exit(1);
   });
-});
-
-process.on('exit', function() {
-  assert.ok(gotCallback);
-  console.log('ok');
-});
+}));

--- a/test/parallel/test-regress-GH-3542.js
+++ b/test/parallel/test-regress-GH-3542.js
@@ -3,7 +3,6 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-let succeeded = 0;
 
 // This test is only relevant on Windows.
 if (!common.isWindows) {
@@ -15,11 +14,10 @@ function test(p) {
   var result = fs.realpathSync(p);
   assert.strictEqual(result, path.resolve(p));
 
-  fs.realpath(p, function(err, result) {
+  fs.realpath(p, common.mustCall(function(err, result) {
     assert.ok(!err);
     assert.strictEqual(result, path.resolve(p));
-    succeeded++;
-  });
+  }));
 }
 
 test('//localhost/c$/windows/system32');
@@ -29,7 +27,3 @@ test('\\\\localhost\\c$');
 test('c:\\');
 test('c:');
 test(process.env.windir);
-
-process.on('exit', function() {
-  assert.strictEqual(succeeded, 7);
-});

--- a/test/parallel/test-regress-GH-746.js
+++ b/test/parallel/test-regress-GH-746.js
@@ -2,28 +2,20 @@
 // Just test that destroying stdin doesn't mess up listening on a server.
 // This is a regression test for GH-746.
 
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var net = require('net');
 
 process.stdin.destroy();
 
-var accepted = null;
-var server = net.createServer(function(socket) {
+var server = net.createServer(common.mustCall(function(socket) {
   console.log('accepted');
-  accepted = socket;
   socket.end();
   server.close();
-});
+}));
 
 
 server.listen(0, function() {
   console.log('listening...');
 
   net.createConnection(this.address().port);
-});
-
-
-process.on('exit', function() {
-  assert.ok(accepted);
 });

--- a/test/parallel/test-sigint-infinite-loop.js
+++ b/test/parallel/test-sigint-infinite-loop.js
@@ -2,7 +2,7 @@
 // This test is to assert that we can SIGINT a script which loops forever.
 // Ref(http):
 // groups.google.com/group/nodejs-dev/browse_thread/thread/e20f2f8df0296d3f
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 
@@ -11,7 +11,6 @@ console.log('start');
 var c = spawn(process.execPath, ['-e', 'while(true) { console.log("hi"); }']);
 
 var sentKill = false;
-var gotChildExit = true;
 
 c.stdout.on('data', function(s) {
   // Prevent race condition:
@@ -25,13 +24,11 @@ c.stdout.on('data', function(s) {
   }
 });
 
-c.on('exit', function(code) {
+c.on('exit', common.mustCall(function(code) {
   assert.ok(code !== 0);
   console.log('killed infinite-loop.js');
-  gotChildExit = true;
-});
+}));
 
 process.on('exit', function() {
   assert.ok(sentKill);
-  assert.ok(gotChildExit);
 });

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 
 if (common.isWindows) {
   common.skip('SIGUSR1 and SIGHUP signals are not supported');
@@ -10,23 +9,14 @@ if (common.isWindows) {
 
 console.log('process.pid: ' + process.pid);
 
-let first = 0;
-let second = 0;
+process.on('SIGUSR1', common.mustCall(function() {}));
 
-var sighup = false;
-
-process.on('SIGUSR1', function() {
-  console.log('Interrupted by SIGUSR1');
-  first += 1;
-});
-
-process.on('SIGUSR1', function() {
-  second += 1;
+process.on('SIGUSR1', common.mustCall(function() {
   setTimeout(function() {
     console.log('End.');
     process.exit(0);
   }, 5);
-});
+}));
 
 var i = 0;
 setInterval(function() {
@@ -41,11 +31,5 @@ setInterval(function() {
 // has been previously registered, and `process.listeners(SIGNAL).length === 1`
 process.on('SIGHUP', function() { common.fail('should not run'); });
 process.removeAllListeners('SIGHUP');
-process.on('SIGHUP', function() { sighup = true; });
+process.on('SIGHUP', common.mustCall(function() {}));
 process.kill(process.pid, 'SIGHUP');
-
-process.on('exit', function() {
-  assert.equal(1, first);
-  assert.equal(1, second);
-  assert.equal(true, sighup);
-});

--- a/test/parallel/test-socket-write-after-fin.js
+++ b/test/parallel/test-socket-write-after-fin.js
@@ -1,44 +1,39 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var net = require('net');
-var serverData = '';
-var gotServerEnd = false;
-var clientData = '';
-var gotClientEnd = false;
+const expected = 'hello1hello2hello3\nTHUNDERMUSCLE!';
 
-var server = net.createServer({ allowHalfOpen: true }, function(sock) {
+var server = net.createServer({
+  allowHalfOpen: true
+}, common.mustCall(function(sock) {
+  var serverData = '';
+
   sock.setEncoding('utf8');
   sock.on('data', function(c) {
     serverData += c;
   });
-  sock.on('end', function() {
-    gotServerEnd = true;
+  sock.on('end', common.mustCall(function() {
+    assert.strictEqual(serverData, expected);
     sock.end(serverData);
     server.close();
-  });
-});
-server.listen(0, function() {
+  }));
+}));
+server.listen(0, common.mustCall(function() {
   var sock = net.connect(this.address().port);
+  var clientData = '';
+
   sock.setEncoding('utf8');
   sock.on('data', function(c) {
     clientData += c;
   });
 
-  sock.on('end', function() {
-    gotClientEnd = true;
-  });
-
-  process.on('exit', function() {
-    assert.equal(serverData, clientData);
-    assert.equal(serverData, 'hello1hello2hello3\nTHUNDERMUSCLE!');
-    assert(gotClientEnd);
-    assert(gotServerEnd);
-    console.log('ok');
-  });
+  sock.on('end', common.mustCall(function() {
+    assert.strictEqual(clientData, expected);
+  }));
 
   sock.write('hello1');
   sock.write('hello2');
   sock.write('hello3\n');
   sock.end('THUNDERMUSCLE!');
-});
+}));

--- a/test/parallel/test-stdout-close-unref.js
+++ b/test/parallel/test-stdout-close-unref.js
@@ -1,21 +1,12 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 if (process.argv[2] === 'child') {
-  var errs = 0;
-
   process.stdin.resume();
   process.stdin._handle.close();
   process.stdin._handle.unref();  // Should not segfault.
-  process.stdin.on('error', function(err) {
-    errs++;
-  });
-
-  process.on('exit', function() {
-    assert.strictEqual(errs, 1);
-  });
+  process.stdin.on('error', common.mustCall(function(err) {}));
   return;
 }
 

--- a/test/parallel/test-stdout-stderr-reading.js
+++ b/test/parallel/test-stdout-stderr-reading.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 // verify that stdout is never read from.
@@ -22,7 +22,6 @@ else
 function parent() {
   var spawn = require('child_process').spawn;
   var node = process.execPath;
-  var closes = 0;
 
   var c1 = spawn(node, [__filename, 'child']);
   var c1out = '';
@@ -34,13 +33,12 @@ function parent() {
   c1.stderr.on('data', function(chunk) {
     console.error('c1err: ' + chunk.split('\n').join('\nc1err: '));
   });
-  c1.on('close', function(code, signal) {
-    closes++;
+  c1.on('close', common.mustCall(function(code, signal) {
     assert(!code);
     assert(!signal);
     assert.equal(c1out, 'ok\n');
     console.log('ok');
-  });
+  }));
 
   var c2 = spawn(node, ['-e', 'console.log("ok")']);
   var c2out = '';
@@ -52,17 +50,12 @@ function parent() {
   c1.stderr.on('data', function(chunk) {
     console.error('c1err: ' + chunk.split('\n').join('\nc1err: '));
   });
-  c2.on('close', function(code, signal) {
-    closes++;
+  c2.on('close', common.mustCall(function(code, signal) {
     assert(!code);
     assert(!signal);
     assert.equal(c2out, 'ok\n');
     console.log('ok');
-  });
-
-  process.on('exit', function() {
-    assert.equal(closes, 2, 'saw both closes');
-  });
+  }));
 }
 
 function child() {

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -43,15 +43,9 @@ function test(size, useBuffer, cb) {
   }));
 }
 
-var finished = false;
-test(1024 * 1024, false, function() {
+test(1024 * 1024, false, common.mustCall(function() {
   console.log('Done printing with string');
-  test(1024 * 1024, true, function() {
+  test(1024 * 1024, true, common.mustCall(function() {
     console.log('Done printing with buffer');
-    finished = true;
-  });
-});
-
-process.on('exit', function() {
-  assert.ok(finished);
-});
+  }));
+}));

--- a/test/parallel/test-stream-end-paused.js
+++ b/test/parallel/test-stream-end-paused.js
@@ -1,7 +1,6 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
-var gotEnd = false;
 
 // Make sure we don't miss the end event for paused 0-length streams
 
@@ -19,15 +18,12 @@ stream.on('data', function() {
 });
 stream.pause();
 
-setTimeout(function() {
-  stream.on('end', function() {
-    gotEnd = true;
-  });
+setTimeout(common.mustCall(function() {
+  stream.on('end', common.mustCall(function() {}));
   stream.resume();
-});
+}));
 
 process.on('exit', function() {
-  assert(gotEnd);
   assert(calledRead);
   console.log('ok');
 });

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var Stream = require('stream').Stream;
 
@@ -51,7 +51,7 @@ var Stream = require('stream').Stream;
     console.log('ok');
   });
 
-  r._read = function() {
+  r._read = common.mustCall(function() {
     setTimeout(function() {
       assert(removed);
       assert.throws(function() {
@@ -59,7 +59,7 @@ var Stream = require('stream').Stream;
       });
       didTest = true;
     });
-  };
+  });
 
   w.on('error', myOnError);
   r.pipe(w);
@@ -86,13 +86,13 @@ var Stream = require('stream').Stream;
     console.log('ok');
   });
 
-  r._read = function() {
+  r._read = common.mustCall(function() {
     setTimeout(function() {
       assert(removed);
       w.emit('error', new Error('fail'));
       didTest = true;
     });
-  };
+  });
 
   w.on('error', myOnError);
   w._write = function() {};

--- a/test/parallel/test-stream-wrap.js
+++ b/test/parallel/test-stream-wrap.js
@@ -1,12 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const StreamWrap = require('_stream_wrap');
 const Duplex = require('stream').Duplex;
 const ShutdownWrap = process.binding('stream_wrap').ShutdownWrap;
-
-var done = false;
 
 function testShutdown(callback) {
   var stream = new Duplex({
@@ -30,10 +28,4 @@ function testShutdown(callback) {
   req.handle.shutdown(req);
 }
 
-testShutdown(function() {
-  done = true;
-});
-
-process.on('exit', function() {
-  assert(done);
-});
+testShutdown(common.mustCall(function() {}));

--- a/test/parallel/test-stream2-httpclient-response-end.js
+++ b/test/parallel/test-stream2-httpclient-response-end.js
@@ -1,31 +1,22 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var msg = 'Hello';
-var readable_event = false;
-var end_event = false;
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end(msg);
 }).listen(0, function() {
   http.get({port: this.address().port}, function(res) {
     var data = '';
-    res.on('readable', function() {
+    res.on('readable', common.mustCall(function() {
       console.log('readable event');
-      readable_event = true;
       data += res.read();
-    });
-    res.on('end', function() {
+    }));
+    res.on('end', common.mustCall(function() {
       console.log('end event');
-      end_event = true;
       assert.strictEqual(msg, data);
       server.close();
-    });
+    }));
   });
-});
-
-process.on('exit', function() {
-  assert(readable_event);
-  assert(end_event);
 });

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 // If everything aligns so that you do a read(n) of exactly the
@@ -32,11 +32,7 @@ r.on('readable', function() {
                 rs.length);
 });
 
-var endEmitted = false;
-r.on('end', function() {
-  endEmitted = true;
-  console.error('end');
-});
+r.on('end', common.mustCall(function() {}));
 
 var pushes = 0;
 function push() {
@@ -55,5 +51,4 @@ function push() {
 
 process.on('exit', function() {
   assert.equal(pushes, PUSHCOUNT + 1);
-  assert(endEmitted);
 });

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var Readable = require('stream').Readable;
 var r = new Readable();
 var N = 256 * 1024;
@@ -21,14 +20,6 @@ r.on('readable', function onReadable() {
   r.read(N * 2);
 });
 
-var ended = false;
-r.on('end', function onEnd() {
-  ended = true;
-});
+r.on('end', common.mustCall(function() {}));
 
 r.read(0);
-
-process.on('exit', function() {
-  assert(ended);
-  console.log('ok');
-});

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var Stream = require('stream');
@@ -12,10 +12,7 @@ r._read = function(n) {
   return r.push(++reads === N ? null : new Buffer(1));
 };
 
-var rended = false;
-r.on('end', function() {
-  rended = true;
-});
+r.on('end', common.mustCall(function() {}));
 
 var w = new Stream();
 w.writable = true;
@@ -32,11 +29,7 @@ function drain() {
   w.emit('drain');
 }
 
-
-var wended = false;
-w.end = function() {
-  wended = true;
-};
+w.end = common.mustCall(function() {});
 
 // Just for kicks, let's mess with the drain count.
 // This verifies that even if it gets negative in the
@@ -46,8 +39,3 @@ r.on('readable', function() {
 });
 
 r.pipe(w);
-process.on('exit', function() {
-  assert(rended);
-  assert(wended);
-  console.error('ok');
-});

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var Readable = require('_stream_readable');
 
@@ -40,14 +40,7 @@ test.read(0);
 function next() {
   // now let's make 'end' happen
   test.removeListener('end', thrower);
-
-  var endEmitted = false;
-  process.on('exit', function() {
-    assert(endEmitted, 'end should be emitted by now');
-  });
-  test.on('end', function() {
-    endEmitted = true;
-  });
+  test.on('end', common.mustCall(function() {}));
 
   // one to get the last byte
   var r = test.read();

--- a/test/parallel/test-stream2-readable-wrap-empty.js
+++ b/test/parallel/test-stream2-readable-wrap-empty.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 
 var Readable = require('_stream_readable');
 var EE = require('events').EventEmitter;
@@ -11,13 +10,8 @@ oldStream.resume = function() {};
 
 var newStream = new Readable().wrap(oldStream);
 
-var ended = false;
 newStream
   .on('readable', function() {})
-  .on('end', function() { ended = true; });
+  .on('end', common.mustCall(function() {}));
 
 oldStream.emit('end');
-
-process.on('exit', function() {
-  assert.ok(ended);
-});

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -10,8 +10,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var requests = 0;
-
 var server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/0-dns-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/0-dns-cert.pem')
@@ -20,11 +18,10 @@ var server = tls.createServer({
     c.destroy();
     server.close();
   });
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
-  }, function() {
-    requests++;
+  }, common.mustCall(function() {
     var cert = c.getPeerCertificate();
     assert.equal(cert.subjectaltname,
                  'DNS:google.com\0.evil.com, ' +
@@ -33,9 +30,5 @@ var server = tls.createServer({
                      'IP Address:8.8.4.4, ' +
                      'DNS:last.com');
     c.write('ok');
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(requests, 1);
-});
+  }));
+}));

--- a/test/parallel/test-tls-cert-regression.js
+++ b/test/parallel/test-tls-cert-regression.js
@@ -1,5 +1,4 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 
 if (!common.hasCrypto) {
@@ -42,13 +41,6 @@ function test(cert, key, cb) {
   });
 }
 
-var completed = false;
-test(cert, key, function() {
-  test(new Buffer(cert), new Buffer(key), function() {
-    completed = true;
-  });
-});
-
-process.on('exit', function() {
-  assert(completed);
-});
+test(cert, key, common.mustCall(function() {
+  test(Buffer.from(cert), Buffer.from(key), common.mustCall(function() {}));
+}));

--- a/test/parallel/test-tls-client-abort2.js
+++ b/test/parallel/test-tls-client-abort2.js
@@ -8,18 +8,9 @@ if (!common.hasCrypto) {
 }
 var tls = require('tls');
 
-var errors = 0;
-
-var conn = tls.connect(common.PORT, function() {
-  assert(false); // callback should never be executed
-});
-conn.on('error', function() {
-  ++errors;
+var conn = tls.connect(common.PORT, common.fail);
+conn.on('error', common.mustCall(function() {
   assert.doesNotThrow(function() {
     conn.destroy();
   });
-});
-
-process.on('exit', function() {
-  assert.equal(errors, 1);
-});
+}));

--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -19,13 +19,10 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-var connections = 0;
-
 // create server
-var server = tls.Server(options, function(socket) {
+var server = tls.Server(options, common.mustCall(function(socket) {
   socket.end('Goodbye');
-  connections++;
-});
+}, 2));
 
 // start listening
 server.listen(0, function() {
@@ -59,8 +56,4 @@ server.listen(0, function() {
       server.close();
     });
   });
-});
-
-process.on('exit', function() {
-  assert.equal(2, connections);
 });

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -11,31 +11,19 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var errorCount = 0;
-var closeCount = 0;
-
 var server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 }, function(c) {
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var c = tls.connect(this.address().port, function() {
     assert(false, 'should not be called');
   });
 
-  c.on('error', function(err) {
-    errorCount++;
-  });
+  c.on('error', common.mustCall(function(err) {}));
 
-  c.on('close', function(err) {
-    if (err)
-      closeCount++;
-
+  c.on('close', common.mustCall(function(err) {
+    assert.ok(err);
     server.close();
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(errorCount, 1);
-  assert.equal(closeCount, 1);
-});
+  }));
+}));

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -1,5 +1,4 @@
 'use strict';
-var assert = require('assert');
 var common = require('../common');
 
 if (!common.hasCrypto) {
@@ -10,8 +9,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var ended = 0;
-
 var server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
@@ -19,19 +16,14 @@ var server = tls.createServer({
   // Send close-notify without shutting down TCP socket
   if (c._handle.shutdownSSL() !== 1)
     c._handle.shutdownSSL();
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     // Ensure that we receive 'end' event anyway
-    c.on('end', function() {
-      ended++;
+    c.on('end', common.mustCall(function() {
       c.destroy();
       server.close();
-    });
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(ended, 1);
-});
+    }));
+  }));
+}));

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -10,9 +9,6 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var clientConnected = 0;
-var serverConnected = 0;
-
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
@@ -20,19 +16,12 @@ var options = {
 
 common.refreshTmpDir();
 
-var server = tls.Server(options, function(socket) {
-  ++serverConnected;
+var server = tls.Server(options, common.mustCall(function(socket) {
   server.close();
-});
-server.listen(common.PIPE, function() {
+}));
+server.listen(common.PIPE, common.mustCall(function() {
   var options = { rejectUnauthorized: false };
-  var client = tls.connect(common.PIPE, options, function() {
-    ++clientConnected;
+  var client = tls.connect(common.PIPE, options, common.mustCall(function() {
     client.end();
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(clientConnected, 1);
-  assert.equal(serverConnected, 1);
-});
+  }));
+}));

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -17,31 +17,16 @@ var path = require('path');
   var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
   var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-  var errorEmitted = false;
+  var options = {cert: cert, key: key, port: common.PORT};
+  var conn = tls.connect(options, common.fail);
 
-  process.on('exit', function() {
-    assert.ok(errorEmitted);
-  });
-
-  var conn = tls.connect({cert: cert, key: key, port: common.PORT}, function() {
-    assert.ok(false); // callback should never be executed
-  });
-
-  conn.on('error', function() {
-    errorEmitted = true;
-  });
+  conn.on('error', common.mustCall(function() {}));
 })();
 
 // SSL_accept/SSL_connect error handling
 (function() {
   var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
   var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
-
-  var errorEmitted = false;
-
-  process.on('exit', function() {
-    assert.ok(errorEmitted);
-  });
 
   var conn = tls.connect({
     cert: cert,
@@ -52,7 +37,5 @@ var path = require('path');
     assert.ok(false); // callback should never be executed
   });
 
-  conn.on('error', function() {
-    errorEmitted = true;
-  });
+  conn.on('error', common.mustCall(function() {}));
 })();

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -13,34 +12,27 @@ var net = require('net');
 var bonkers = new Buffer(1024);
 bonkers.fill(42);
 
-var receivedError = false;
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var server = net.createServer(function(c) {
-  setTimeout(function() {
+var server = net.createServer(common.mustCall(function(c) {
+  setTimeout(common.mustCall(function() {
     var s = new tls.TLSSocket(c, {
       isServer: true,
       secureContext: tls.createSecureContext(options)
     });
 
-    s.on('_tlsError', function() {
-      receivedError = true;
-    });
+    s.on('_tlsError', common.mustCall(function() {}));
 
     s.on('close', function() {
       server.close();
       s.destroy();
     });
-  }, 200);
-}).listen(0, function() {
+  }), 200);
+})).listen(0, function() {
   var c = net.connect({port: this.address().port}, function() {
     c.write(bonkers);
   });
-});
-
-process.on('exit', function() {
-  assert.ok(receivedError);
 });

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -18,16 +18,7 @@ var options = {
   ecdhCurve: false
 };
 
-var nconns = 0;
-
-process.on('exit', function() {
-  assert.equal(nconns, 0);
-});
-
-var server = tls.createServer(options, function(conn) {
-  conn.end();
-  nconns++;
-});
+var server = tls.createServer(options, common.fail);
 
 server.listen(0, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -19,20 +19,12 @@ var options = {
 };
 
 var reply = 'I AM THE WALRUS'; // something recognizable
-var nconns = 0;
-var response = '';
 
-process.on('exit', function() {
-  assert.equal(nconns, 1);
-  assert.notEqual(response.indexOf(reply), -1);
-});
-
-var server = tls.createServer(options, function(conn) {
+var server = tls.createServer(options, common.mustCall(function(conn) {
   conn.end(reply);
-  nconns++;
-});
+}));
 
-server.listen(0, '127.0.0.1', function() {
+server.listen(0, '127.0.0.1', common.mustCall(function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ` -connect 127.0.0.1:${this.address().port}`;
 
@@ -40,9 +32,9 @@ server.listen(0, '127.0.0.1', function() {
   if (common.isWindows)
     cmd += ' -no_rand_screen';
 
-  exec(cmd, function(err, stdout, stderr) {
+  exec(cmd, common.mustCall(function(err, stdout, stderr) {
     if (err) throw err;
-    response = stdout;
+    assert.notEqual(stdout.indexOf(reply), -1);
     server.close();
-  });
-});
+  }));
+}));

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -18,15 +18,8 @@ var options = {
   honorCipherOrder: true
 };
 
-var nconns = 0;
-
-process.on('exit', function() {
-  assert.equal(nconns, 1);
-});
-
-var server = tls.createServer(options, function(cleartextStream) {
-  nconns++;
-});
+var server = tls.createServer(options,
+                              common.mustCall(function(cleartextStream) {}));
 
 server.listen(0, '127.0.0.1', function() {
   var client = tls.connect({

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -11,15 +11,12 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var errorCount = 0;
-var closeCount = 0;
-
 var server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
   rejectUnauthorized: true
 }, function(c) {
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var c = tls.connect({
     port: this.address().port,
     ciphers: 'RC4'
@@ -27,19 +24,12 @@ var server = tls.createServer({
     assert(false, 'should not be called');
   });
 
-  c.on('error', function(err) {
-    errorCount++;
+  c.on('error', common.mustCall(function(err) {
     assert.notEqual(err.code, 'ECONNRESET');
-  });
+  }));
 
-  c.on('close', function(err) {
-    if (err)
-      closeCount++;
+  c.on('close', common.mustCall(function(err) {
+    assert.ok(err);
     server.close();
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(errorCount, 1);
-  assert.equal(closeCount, 1);
-});
+  }));
+}));

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -12,7 +12,6 @@ var fs = require('fs');
 
 
 var received = '';
-var ended = 0;
 
 var server = tls.createServer({
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
@@ -26,20 +25,15 @@ var server = tls.createServer({
   });
 
   server.close();
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     c.on('data', function(chunk) {
       received += chunk;
     });
-    c.on('end', function() {
-      ended++;
-    });
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(ended, 1);
-  assert.equal(received, 'hello world! gosh');
-});
+    c.on('end', common.mustCall(function() {
+      assert.strictEqual(received, 'hello world! gosh');
+    }));
+  }));
+}));

--- a/test/parallel/test-tls-legacy-onselect.js
+++ b/test/parallel/test-tls-legacy-onselect.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -9,18 +8,15 @@ if (!common.hasCrypto) {
 var tls = require('tls');
 var net = require('net');
 
-var success = false;
-
-var server = net.Server(function(raw) {
+var server = net.Server(common.mustCall(function(raw) {
   var pair = tls.createSecurePair(null, true, false, false);
   pair.on('error', function() {});
-  pair.ssl.setSNICallback(function() {
+  pair.ssl.setSNICallback(common.mustCall(function() {
     raw.destroy();
     server.close();
-    success = true;
-  });
+  }));
   require('_tls_legacy').pipe(pair, raw);
-}).listen(0, function() {
+})).listen(0, function() {
   tls.connect({
     port: this.address().port,
     rejectUnauthorized: false,
@@ -29,7 +25,4 @@ var server = net.Server(function(raw) {
   }).on('error', function() {
     // Just ignore
   });
-});
-process.on('exit', function() {
-  assert(success);
 });

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -15,14 +15,12 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
 };
 
-var cert = null;
-
 var server = tls.createServer(options, function(conn) {
   conn.end('ok');
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var c = tls.connect(this.address().port, {
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     c.on('end', common.mustCall(function() {
       c.end();
       server.close();
@@ -32,11 +30,7 @@ var server = tls.createServer(options, function(conn) {
       assert.equal(data, 'ok');
     });
 
-    cert = c.getPeerCertificate();
-  });
-});
-
-process.on('exit', function() {
-  assert(cert);
-  assert.equal(cert.subject.C, 'US');
-});
+    const cert = c.getPeerCertificate();
+    assert.strictEqual(cert.subject.C, 'US');
+  }));
+}));

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -25,21 +25,18 @@ var server = tls.Server({
   s.end();
 });
 
-var connectCount = 0;
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var c = tls.connect({
     port: this.address().port,
     key: key,
     passphrase: 'passphrase',
     cert: cert,
     rejectUnauthorized: false
-  }, function() {
-    ++connectCount;
-  });
+  }, common.mustCall(function() {}));
   c.on('end', function() {
     server.close();
   });
-});
+}));
 
 assert.throws(function() {
   tls.connect({
@@ -49,8 +46,4 @@ assert.throws(function() {
     cert: cert,
     rejectUnauthorized: false
   });
-});
-
-process.on('exit', function() {
-  assert.equal(connectCount, 1);
 });

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -17,26 +17,20 @@ var options = {
   cert: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent5-cert.pem')),
   ca: [ fs.readFileSync(join(common.fixturesDir, 'keys', 'ca2-cert.pem')) ]
 };
-var verified = false;
 
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var socket = tls.connect({
     port: this.address().port,
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     var peerCert = socket.getPeerCertificate();
 
     console.error(util.inspect(peerCert));
     assert.equal(peerCert.subject.CN, 'Ádám Lippai');
-    verified = true;
     server.close();
-  });
+  }));
   socket.end('Hello');
-});
-
-process.on('exit', function() {
-  assert.ok(verified);
-});
+}));

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -16,26 +16,20 @@ var options = {
   key: fs.readFileSync(join(common.fixturesDir, 'agent.key')),
   cert: fs.readFileSync(join(common.fixturesDir, 'multi-alice.crt'))
 };
-var verified = false;
 
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var socket = tls.connect({
     port: this.address().port,
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     var peerCert = socket.getPeerCertificate();
     console.error(util.inspect(peerCert));
     assert.deepEqual(peerCert.subject.OU,
                      ['Information Technology', 'Engineering', 'Marketing']);
-    verified = true;
     server.close();
-  });
+  }));
   socket.end('Hello');
-});
-
-process.on('exit', function() {
-  assert.ok(verified);
-});
+}));

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -17,16 +17,15 @@ var options = {
   cert: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent1-cert.pem')),
   ca: [ fs.readFileSync(join(common.fixturesDir, 'keys', 'ca1-cert.pem')) ]
 };
-var verified = false;
 
 var server = tls.createServer(options, function(cleartext) {
   cleartext.end('World');
 });
-server.listen(0, function() {
+server.listen(0, common.mustCall(function() {
   var socket = tls.connect({
     port: this.address().port,
     rejectUnauthorized: false
-  }, function() {
+  }, common.mustCall(function() {
     var peerCert = socket.getPeerCertificate();
     assert.ok(!peerCert.issuerCertificate);
 
@@ -46,12 +45,7 @@ server.listen(0, function() {
     var issuer = peerCert.issuerCertificate;
     assert.ok(issuer.issuerCertificate === issuer);
     assert.equal(issuer.serialNumber, '8DF21C01468AF393');
-    verified = true;
     server.close();
-  });
+  }));
   socket.end('Hello');
-});
-
-process.on('exit', function() {
-  assert.ok(verified);
-});
+}));

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -10,31 +10,24 @@ var tls = require('tls');
 
 var fs = require('fs');
 
-var hadTimeout = false;
-
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var server = tls.Server(options, function(socket) {
+var server = tls.Server(options, common.mustCall(function(socket) {
   var s = socket.setTimeout(100);
   assert.ok(s instanceof tls.TLSSocket);
 
-  socket.on('timeout', function(err) {
-    hadTimeout = true;
+  socket.on('timeout', common.mustCall(function(err) {
     socket.end();
     server.close();
-  });
-});
+  }));
+}));
 
 server.listen(0, function() {
   tls.connect({
     port: this.address().port,
     rejectUnauthorized: false
   });
-});
-
-process.on('exit', function() {
-  assert.ok(hadTimeout);
 });

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -23,18 +23,15 @@ var options = {
 };
 
 var reply = 'I AM THE WALRUS'; // something recognizable
-var nconns = 0;
 var response = '';
 
 process.on('exit', function() {
-  assert.equal(nconns, 1);
   assert.notEqual(response.indexOf(reply), -1);
 });
 
-var server = tls.createServer(options, function(conn) {
+var server = tls.createServer(options, common.mustCall(function(conn) {
   conn.end(reply);
-  nconns++;
-});
+}));
 
 server.listen(0, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -16,14 +16,12 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-var connections = 0;
 var message = 'hello world\n';
 
 
-var server = tls.Server(options, function(socket) {
+var server = tls.Server(options, common.mustCall(function(socket) {
   socket.end(message);
-  connections++;
-});
+}));
 
 
 server.listen(0, function() {
@@ -52,9 +50,4 @@ server.listen(0, function() {
     console.log(message);
     server.close();
   });
-});
-
-
-process.on('exit', function() {
-  assert.equal(1, connections);
 });

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -11,12 +10,6 @@ var tls = require('tls');
 var net = require('net');
 var fs = require('fs');
 
-var clientErrors = 0;
-
-process.on('exit', function() {
-  assert.equal(clientErrors, 1);
-});
-
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
@@ -25,11 +18,10 @@ var options = {
 
 var server = tls.createServer(options, common.fail);
 
-server.on('clientError', function(err, conn) {
+server.on('clientError', common.mustCall(function(err, conn) {
   conn.destroy();
   server.close();
-  clientErrors++;
-});
+}));
 
 server.listen(0, function() {
   net.connect({ host: '127.0.0.1', port: this.address().port });

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -1,6 +1,5 @@
 'use strict';
 var common = require('../common');
-var assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -14,8 +13,6 @@ var path = require('path');
 var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-var errorEmitted = false;
-
 var server = tls.createServer({
   cert: cert,
   key: key
@@ -25,7 +22,7 @@ var server = tls.createServer({
     c.end();
     server.close();
   }, 20);
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   var conn = tls.connect({
     cert: cert,
     key: key,
@@ -41,12 +38,5 @@ var server = tls.createServer({
   // treated as error.
   conn.end('');
 
-  conn.on('error', function(err) {
-    console.log(err);
-    errorEmitted = true;
-  });
-});
-
-process.on('exit', function() {
-  assert.ok(!errorEmitted);
-});
+  conn.on('error', common.fail);
+}));

--- a/test/parallel/test-zerolengthbufferbug.js
+++ b/test/parallel/test-zerolengthbufferbug.js
@@ -1,8 +1,7 @@
 'use strict';
 // Serving up a zero-length buffer should work.
 
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var http = require('http');
 
 var server = http.createServer(function(req, res) {
@@ -13,24 +12,13 @@ var server = http.createServer(function(req, res) {
   res.end(buffer);
 });
 
-var gotResponse = false;
-var resBodySize = 0;
+server.listen(0, common.mustCall(function() {
+  http.get({ port: this.address().port }, common.mustCall(function(res) {
 
-server.listen(0, function() {
-  http.get({ port: this.address().port }, function(res) {
-    gotResponse = true;
-
-    res.on('data', function(d) {
-      resBodySize += d.length;
-    });
+    res.on('data', common.fail);
 
     res.on('end', function(d) {
       server.close();
     });
-  });
-});
-
-process.on('exit', function() {
-  assert.ok(gotResponse);
-  assert.equal(0, resBodySize);
-});
+  }));
+}));

--- a/test/parallel/test-zlib-close-after-write.js
+++ b/test/parallel/test-zlib-close-after-write.js
@@ -1,18 +1,9 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 var zlib = require('zlib');
 
-var closed = false;
-
-zlib.gzip('hello', function(err, out) {
+zlib.gzip('hello', common.mustCall(function(err, out) {
   var unzip = zlib.createGunzip();
   unzip.write(out);
-  unzip.close(function() {
-    closed = true;
-  });
-});
-
-process.on('exit', function() {
-  assert(closed);
-});
+  unzip.close(common.mustCall(function() {}));
+}));

--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -152,13 +152,7 @@ out.on('data', function(c) {
   console.error('out data', c.length);
 });
 
-var didSomething = false;
-out.on('data', function(c) {
-  didSomething = true;
+out.on('data', common.mustCall(function(c) {
   console.error('hash=%s', c);
   assert.equal(c, inp._hash, 'hashes should match');
-});
-
-process.on('exit', function() {
-  assert(didSomething, 'should have done something');
-});
+}));

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -1,20 +1,12 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 
-var closed = false;
-
-zlib.gzip('hello', function(err, out) {
+zlib.gzip('hello', common.mustCall(function(err, out) {
   var unzip = zlib.createGunzip();
-  unzip.close(function() {
-    closed = true;
-  });
+  unzip.close(common.mustCall(function() {}));
   assert.throws(function() {
     unzip.write(out);
   });
-});
-
-process.on('exit', function() {
-  assert(closed);
-});
+}));

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var zlib = require('zlib');
@@ -9,20 +9,10 @@ var received = 0;
 gz.on('data', function(c) {
   received += c.length;
 });
-var ended = false;
-gz.on('end', function() {
-  ended = true;
-});
-var finished = false;
-gz.on('finish', function() {
-  finished = true;
-});
+
+gz.on('end', common.mustCall(function() {
+  assert.strictEqual(received, 20);
+}));
+gz.on('finish', common.mustCall(function() {}));
 gz.write(emptyBuffer);
 gz.end();
-
-process.on('exit', function() {
-  assert.equal(received, 20);
-  assert(ended);
-  assert(finished);
-  console.log('ok');
-});

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -1,47 +1,27 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 const http = require('http');
-
-var errorCount = 0;
-var eofCount = 0;
 
 var server = net.createServer(function(socket) {
   socket.end();
 });
 
-server.on('listening', function() {
+server.on('listening', common.mustCall(function() {
   var client = http.createClient(common.PORT);
 
-  client.on('error', function(err) {
-    // We should receive one error
-    console.log('ERROR! ' + err.message);
-    errorCount++;
-  });
-
-  client.on('end', function() {
-    // When we remove the old Client interface this will most likely have to be
-    // changed.
-    console.log('EOF!');
-    eofCount++;
-  });
+  client.on('error', common.mustCall(function(err) {}));
+  client.on('end', common.mustCall(function() {}));
 
   var request = client.request('GET', '/', {'host': 'localhost'});
   request.end();
   request.on('response', function(response) {
     console.log('STATUS: ' + response.statusCode);
   });
-});
+}));
 
 server.listen(common.PORT);
 
 setTimeout(function() {
   server.close();
 }, 500);
-
-
-process.on('exit', function() {
-  assert.equal(1, errorCount);
-  assert.equal(1, eofCount);
-});

--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -15,28 +15,24 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var reqCount = 0;
-
 process.stdout.write('build body...');
 var body = 'hello world\n'.repeat(1024 * 1024);
 process.stdout.write('done\n');
 
-var server = https.createServer(options, function(req, res) {
-  reqCount++;
+var server = https.createServer(options, common.mustCall(function(req, res) {
   console.log('got request');
   res.writeHead(200, { 'content-type': 'text/plain' });
   res.end(body);
-});
+}));
 
-var count = 0;
-var gotResEnd = false;
-
-server.listen(common.PORT, function() {
+server.listen(common.PORT, common.mustCall(function() {
   https.get({
     port: common.PORT,
     rejectUnauthorized: false
-  }, function(res) {
+  }, common.mustCall(function(res) {
     console.log('response!');
+
+    var count = 0;
 
     res.on('data', function(d) {
       process.stdout.write('.');
@@ -47,19 +43,12 @@ server.listen(common.PORT, function() {
       });
     });
 
-    res.on('end', function(d) {
+    res.on('end', common.mustCall(function(d) {
       process.stdout.write('\n');
       console.log('expected: ', body.length);
       console.log('     got: ', count);
       server.close();
-      gotResEnd = true;
-    });
-  });
-});
-
-
-process.on('exit', function() {
-  assert.equal(1, reqCount);
-  assert.equal(body.length, count);
-  assert.ok(gotResEnd);
-});
+      assert.strictEqual(count, body.length);
+    }));
+  }));
+}));

--- a/test/pummel/test-net-pingpong-delay.js
+++ b/test/pummel/test-net-pingpong-delay.js
@@ -3,9 +3,6 @@ var common = require('../common');
 var assert = require('assert');
 var net = require('net');
 
-
-var tests_run = 0;
-
 function pingPongTest(port, host, on_complete) {
   var N = 100;
   var DELAY = 1;
@@ -45,7 +42,7 @@ function pingPongTest(port, host, on_complete) {
     });
   });
 
-  server.listen(port, host, function() {
+  server.listen(port, host, common.mustCall(function() {
     var client = net.createConnection(port, host);
 
     client.setEncoding('utf8');
@@ -77,18 +74,13 @@ function pingPongTest(port, host, on_complete) {
       assert.equal(false, true);
     });
 
-    client.on('close', function() {
+    client.on('close', common.mustCall(function() {
       console.log('client.end');
       assert.equal(N + 1, count);
       assert.ok(client_ended);
       if (on_complete) on_complete();
-      tests_run += 1;
-    });
-  });
+    }));
+  }));
 }
 
 pingPongTest(common.PORT);
-
-process.on('exit', function() {
-  assert.equal(1, tests_run);
-});

--- a/test/pummel/test-net-timeout2.js
+++ b/test/pummel/test-net-timeout2.js
@@ -3,20 +3,13 @@
 // https://github.com/joyent/node/issues/2002
 
 var common = require('../common');
-var assert = require('assert');
 var net = require('net');
 
 var seconds = 5;
-var gotTimeout = false;
 var counter = 0;
 
 var server = net.createServer(function(socket) {
-  socket.setTimeout((seconds / 2) * 1000, function() {
-    gotTimeout = true;
-    console.log('timeout!!');
-    socket.destroy();
-    process.exit(1);
-  });
+  socket.setTimeout((seconds / 2) * 1000, common.fail);
 
   var interval = setInterval(function() {
     counter++;
@@ -37,9 +30,4 @@ var server = net.createServer(function(socket) {
 server.listen(common.PORT, function() {
   var s = net.connect(common.PORT);
   s.pipe(process.stdout);
-});
-
-
-process.on('exit', function() {
-  assert.equal(false, gotTimeout);
 });

--- a/test/pummel/test-timer-wrap.js
+++ b/test/pummel/test-timer-wrap.js
@@ -1,8 +1,6 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
 
-var timeouts = 0;
 var Timer = process.binding('timer_wrap').Timer;
 var kOnTimeout = Timer.kOnTimeout;
 
@@ -10,12 +8,7 @@ var t = new Timer();
 
 t.start(1000, 0);
 
-t[kOnTimeout] = function() {
-  timeouts++;
+t[kOnTimeout] = common.mustCall(function() {
   console.log('timeout');
   t.close();
-};
-
-process.on('exit', function() {
-  assert.equal(1, timeouts);
 });

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -1,11 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 var WINDOW = 200; // why is does this need to be so big?
 
 var interval_count = 0;
-var setTimeout_called = false;
 
 // check that these don't blow up.
 clearTimeout(null);
@@ -13,7 +12,7 @@ clearInterval(null);
 
 assert.equal(true, setTimeout instanceof Function);
 var starttime = new Date();
-setTimeout(function() {
+setTimeout(common.mustCall(function() {
   var endtime = new Date();
 
   var diff = endtime - starttime;
@@ -21,8 +20,7 @@ setTimeout(function() {
   console.error('diff: ' + diff);
 
   assert.equal(true, 1000 - WINDOW < diff && diff < 1000 + WINDOW);
-  setTimeout_called = true;
-}, 1000);
+}), 1000);
 
 // this timer shouldn't execute
 var id = setTimeout(function() { assert.equal(true, false); }, 500);
@@ -101,7 +99,6 @@ clearTimeout(y);
 
 
 process.on('exit', function() {
-  assert.equal(true, setTimeout_called);
   assert.equal(3, interval_count);
   assert.equal(11, count4);
   assert.equal(0, expectedTimeouts, 'clearTimeout cleared too many timeouts');

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -12,8 +12,6 @@ var fs = require('fs');
 var stream = require('stream');
 var util = require('util');
 
-var clientConnected = 0;
-var serverConnected = 0;
 var request = new Buffer(new Array(1024 * 256).join('ABCD')); // 1mb
 
 var options = {
@@ -39,22 +37,15 @@ Mediator.prototype._write = function write(data, enc, cb) {
 
 var mediator = new Mediator();
 
-var server = tls.Server(options, function(socket) {
+var server = tls.Server(options, common.mustCall(function(socket) {
   socket.pipe(mediator);
-  serverConnected++;
-});
+}));
 
-server.listen(common.PORT, function() {
+server.listen(common.PORT, common.mustCall(function() {
   var client1 = tls.connect({
     port: common.PORT,
     rejectUnauthorized: false
-  }, function() {
-    ++clientConnected;
+  }, common.mustCall(function() {
     client1.end(request);
-  });
-});
-
-process.on('exit', function() {
-  assert.equal(clientConnected, 1);
-  assert.equal(serverConnected, 1);
-});
+  }));
+}));

--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -21,13 +21,9 @@ var options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-var connections = 0;
-
-
-var server = tls.Server(options, function(socket) {
+var server = tls.Server(options, common.mustCall(function(socket) {
   socket.end(body);
-  connections++;
-});
+}));
 
 var recvCount = 0;
 
@@ -67,6 +63,5 @@ var timeout = setTimeout(displayCounts, 10 * 1000);
 
 process.on('exit', function() {
   displayCounts();
-  assert.equal(1, connections);
   assert.equal(body.length, recvCount);
 });

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -48,17 +48,6 @@ function client() {
 function parent() {
   var spawn = require('child_process').spawn;
   var node = process.execPath;
-  var assert = require('assert');
-  var serverExited = false;
-  var clientExited = false;
-  var serverListened = false;
-
-  process.on('exit', function() {
-    assert(serverExited);
-    assert(clientExited);
-    assert(serverListened);
-    console.log('ok');
-  });
 
   setTimeout(function() {
     if (s) s.kill();
@@ -77,21 +66,14 @@ function parent() {
 
   wrap(s.stderr, process.stderr, 'SERVER 2>');
   wrap(s.stdout, process.stdout, 'SERVER 1>');
-  s.on('exit', function(c) {
-    console.error('server exited', c);
-    serverExited = true;
-  });
+  s.on('exit', common.mustCall(function(c) {}));
 
-  s.stdout.once('data', function() {
-    serverListened = true;
+  s.stdout.once('data', common.mustCall(function() {
     c = spawn(node, [__filename, 'client']);
     wrap(c.stderr, process.stderr, 'CLIENT 2>');
     wrap(c.stdout, process.stdout, 'CLIENT 1>');
-    c.on('exit', function(c) {
-      console.error('client exited', c);
-      clientExited = true;
-    });
-  });
+    c.on('exit', common.mustCall(function(c) {}));
+  }));
 
   function wrap(inp, out, w) {
     inp.setEncoding('utf8');

--- a/test/sequential/test-regress-GH-4027.js
+++ b/test/sequential/test-regress-GH-4027.js
@@ -10,14 +10,8 @@ var filename = path.join(common.tmpDir, 'watched');
 fs.writeFileSync(filename, 'quis custodiet ipsos custodes');
 setTimeout(fs.unlinkSync, 100, filename);
 
-var seenEvent = 0;
-process.on('exit', function() {
-  assert.equal(seenEvent, 1);
-});
-
-fs.watchFile(filename, { interval: 50 }, function(curr, prev) {
+fs.watchFile(filename, { interval: 50 }, common.mustCall(function(curr, prev) {
   assert.equal(prev.nlink, 1);
   assert.equal(curr.nlink, 0);
   fs.unwatchFile(filename);
-  seenEvent++;
-});
+}));

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 var assert = require('assert');
 
 if (process.argv[2] === 'child')
@@ -23,7 +23,6 @@ function test(environ, shouldWrite) {
                 'TUD %PID%: number=1234 string=asdf obj={"foo":"bar"}\n';
   }
   var expectOut = 'ok\n';
-  var didTest = false;
 
   var spawn = require('child_process').spawn;
   var child = spawn(process.execPath, [__filename, 'child'], {
@@ -44,17 +43,12 @@ function test(environ, shouldWrite) {
     out += c;
   });
 
-  child.on('close', function(c) {
+  child.on('close', common.mustCall(function(c) {
     assert(!c);
     assert.equal(err, expectErr);
     assert.equal(out, expectOut);
-    didTest = true;
     console.log('ok %j %j', environ, shouldWrite);
-  });
-
-  process.on('exit', function() {
-    assert(didTest);
-  });
+  }));
 }
 
 


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/7753.

I decided to do this because it touches a lot of test files and recent test refactors don't apply cleanly to v4.x because they are based on those changes.

/cc @nodejs/lts 