### PR TITLE
fs: runtime deprecation for fs.SyncWriteStream

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -506,10 +506,10 @@ The [`util._extend()`][] API has been deprecated.
 <a id="DEP0061"></a>
 ### DEP0061: fs.SyncWriteStream
 
-Type: Documentation-only
+Type: Runtime
 
 The `fs.SyncWriteStream` class was never intended to be a publicly accessible
-API.
+API. No alternative API is available. Please use a userland alternative.
 
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -17,9 +17,9 @@ const FSReqWrap = binding.FSReqWrap;
 const FSEvent = process.binding('fs_event_wrap').FSEvent;
 const internalFS = require('internal/fs');
 const internalURL = require('internal/url');
+const internalUtil = require('internal/util');
 const assertEncoding = internalFS.assertEncoding;
 const stringToFlags = internalFS.stringToFlags;
-const SyncWriteStream = internalFS.SyncWriteStream;
 const getPathFromURL = internalURL.getPathFromURL;
 
 Object.defineProperty(exports, 'constants', {
@@ -2025,12 +2025,14 @@ WriteStream.prototype.close = ReadStream.prototype.close;
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 
 // SyncWriteStream is internal. DO NOT USE.
-// todo(jasnell): "Docs-only" deprecation for now. This was never documented
-// so there's no documentation to modify. In the future, add a runtime
-// deprecation.
-// Deprecation ID: DEP0061
+// This undocumented API was never intended to be made public.
+var SyncWriteStream = internalFS.SyncWriteStream;
 Object.defineProperty(fs, 'SyncWriteStream', {
   configurable: true,
-  writable: true,
-  value: SyncWriteStream
+  get: internalUtil.deprecate(() => {
+    return SyncWriteStream;
+  }, 'fs.SyncWriteStream is deprecated.', 'DEP0061'),
+  set: internalUtil.deprecate((val) => {
+    SyncWriteStream = val;
+  }, 'fs.SyncWriteStream is deprecated.', 'DEP0061')
 });


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

fs

##### Description of change
This API was never intended to be made public and was docs-only
deprecated in Node.js 6.x. This upgrades to a runtime deprecation
for Node.js 8.0.0