### PR TITLE
dgram: improve "address" parameter behavior in Socket.prototype.send

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -225,7 +225,7 @@ never have reason to call this.
 If `multicastInterface` is not specified, the operating system will attempt to
 drop membership on all valid interfaces.
 
-### socket.send(msg, [offset, length,] port, address[, callback])
+### socket.send(msg, [offset, length,] port [, address] [, callback])
 <!-- YAML
 added: v0.1.99
 -->
@@ -234,7 +234,7 @@ added: v0.1.99
 * `offset` {Number} Integer. Optional. Offset in the buffer where the message starts.
 * `length` {Number} Integer. Optional. Number of bytes in the message.
 * `port` {Number} Integer. Destination port.
-* `address` {String} Destination hostname or IP address.
+* `address` {String} Destination hostname or IP address. Optional.
 * `callback` {Function} Called when the message has been sent. Optional.
 
 Broadcasts a datagram on the socket. The destination `port` and `address` must
@@ -251,8 +251,9 @@ respect to [byte length][] and not the character position.
 If `msg` is an array, `offset` and `length` must not be specified.
 
 The `address` argument is a string. If the value of `address` is a host name,
-DNS will be used to resolve the address of the host. If the `address` is not
-specified or is an empty string, `'127.0.0.1'` or `'::1'` will be used instead.
+DNS will be used to resolve the address of the host.  If `address` is not
+provided or otherwise falsy, `'127.0.0.1'` (for `udp4` sockets) or `'::1'`
+(for `udp6` sockets) will be used by default.
 
 If the socket has not been previously bound with a call to `bind`, the socket
 is assigned a random port number and is bound to the "all interfaces" address
@@ -283,14 +284,15 @@ client.send(message, 41234, 'localhost', (err) => {
 });
 ```
 
-Example of sending a UDP packet composed of multiple buffers to a random port on `localhost`;
+Example of sending a UDP packet composed of multiple buffers to a random port
+on `127.0.0.1`;
 
 ```js
 const dgram = require('dgram');
 const buf1 = Buffer.from('Some ');
 const buf2 = Buffer.from('bytes');
 const client = dgram.createSocket('udp4');
-client.send([buf1, buf2], 41234, 'localhost', (err) => {
+client.send([buf1, buf2], 41234, (err) => {
   client.close();
 });
 ```

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -314,9 +314,11 @@ function clearQueue() {
 // valid combinations
 // send(buffer, offset, length, port, address, callback)
 // send(buffer, offset, length, port, address)
+// send(buffer, offset, length, port, callback)
 // send(buffer, offset, length, port)
 // send(bufferOrList, port, address, callback)
 // send(bufferOrList, port, address)
+// send(bufferOrList, port, callback)
 // send(bufferOrList, port)
 Socket.prototype.send = function(buffer,
                                  offset,
@@ -354,6 +356,14 @@ Socket.prototype.send = function(buffer,
   // else.
   if (typeof callback !== 'function')
     callback = undefined;
+
+  if (typeof address === 'function') {
+    callback = address;
+    address = undefined;
+  } else if (address && typeof address !== 'string') {
+    throw new TypeError('Invalid arguments: address must be a nonempty ' +
+                        'string or falsy');
+  }
 
   this._healthCheck();
 

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -1,0 +1,56 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const port = common.PORT;
+const host = common.localhostIPv4;
+const buf = Buffer.from('test');
+const client = dgram.createSocket('udp4');
+
+client.bind(0, common.mustCall(() => {
+  const onMessage = common.mustCall((err, bytes) => {
+    assert.ifError(err);
+    assert.strictEqual(bytes, buf.length);
+  }, 5);
+
+  // valid address: false
+  client.send(buf, port, false, onMessage);
+
+  // valid address: empty string
+  client.send(buf, port, '', onMessage);
+
+  // valid address: null
+  client.send(buf, port, null, onMessage);
+
+  // valid address: 0
+  client.send(buf, port, 0, onMessage);
+
+  // valid address: undefined
+  client.send(buf, port, undefined, onMessage);
+
+  // the socket must be bound before these following assertions;
+  // otherwise the exceptions won't be thrown synchronously.
+
+  // invalid address: object
+  assert.throws(() => {
+    client.send(buf, port, []);
+  }, TypeError);
+
+  // invalid address: nonzero number
+  assert.throws(() => {
+    client.send(buf, port, 1);
+  }, TypeError);
+
+  // invalid address: true
+  assert.throws(() => {
+    client.send(buf, port, true);
+  }, TypeError);
+
+  // invalid address: function
+  assert.throws(() => {
+    client.send(buf, port, () => {
+    });
+  }, TypeError);
+}))
+  .unref();

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -4,53 +4,48 @@ const assert = require('assert');
 const dgram = require('dgram');
 
 const port = common.PORT;
-const host = common.localhostIPv4;
 const buf = Buffer.from('test');
 const client = dgram.createSocket('udp4');
 
-client.bind(0, common.mustCall(() => {
-  const onMessage = common.mustCall((err, bytes) => {
-    assert.ifError(err);
-    assert.strictEqual(bytes, buf.length);
-  }, 5);
+const onMessage = common.mustCall((err, bytes) => {
+  assert.ifError(err);
+  assert.strictEqual(bytes, buf.length);
+}, 6);
 
-  // valid address: false
-  client.send(buf, port, false, onMessage);
+// valid address: false
+client.send(buf, port, false, onMessage);
 
-  // valid address: empty string
-  client.send(buf, port, '', onMessage);
+// valid address: empty string
+client.send(buf, port, '', onMessage);
 
-  // valid address: null
-  client.send(buf, port, null, onMessage);
+// valid address: null
+client.send(buf, port, null, onMessage);
 
-  // valid address: 0
-  client.send(buf, port, 0, onMessage);
+// valid address: 0
+client.send(buf, port, 0, onMessage);
 
-  // valid address: undefined
-  client.send(buf, port, undefined, onMessage);
+// valid address: undefined
+client.send(buf, port, undefined, onMessage);
 
-  // the socket must be bound before these following assertions;
-  // otherwise the exceptions won't be thrown synchronously.
+// valid address: not provided
+client.send(buf, port, onMessage);
 
-  // invalid address: object
-  assert.throws(() => {
-    client.send(buf, port, []);
-  }, TypeError);
+const expectedError = new RegExp('^TypeError: Invalid arguments: address ' +
+  'must be a nonempty string or falsy$');
 
-  // invalid address: nonzero number
-  assert.throws(() => {
-    client.send(buf, port, 1);
-  }, TypeError);
+// invalid address: object
+assert.throws(() => {
+  client.send(buf, port, []);
+}, expectedError);
 
-  // invalid address: true
-  assert.throws(() => {
-    client.send(buf, port, true);
-  }, TypeError);
+// invalid address: nonzero number
+assert.throws(() => {
+  client.send(buf, port, 1);
+}, expectedError);
 
-  // invalid address: function
-  assert.throws(() => {
-    client.send(buf, port, () => {
-    });
-  }, TypeError);
-}))
-  .unref();
+// invalid address: true
+assert.throws(() => {
+  client.send(buf, port, true);
+}, expectedError);
+
+client.unref();

--- a/test/parallel/test-dgram-send-callback-buffer-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-buffer-empty-address.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const client = dgram.createSocket('udp4');
+
+const buf = Buffer.alloc(256, 'x');
+
+const onMessage = common.mustCall(function(err, bytes) {
+  assert.ifError(err);
+  assert.strictEqual(bytes, buf.length);
+  client.close();
+});
+
+client.send(buf, common.PORT, onMessage);

--- a/test/parallel/test-dgram-send-callback-buffer-length-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length-empty-address.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const dgram = require('dgram');
+const client = dgram.createSocket('udp4');
+
+const buf = Buffer.alloc(256, 'x');
+const offset = 20;
+const len = buf.length - offset;
+
+const onMessage = common.mustCall(function messageSent(err, bytes) {
+  assert.ifError(err);
+  assert.notStrictEqual(bytes, buf.length);
+  assert.strictEqual(bytes, buf.length - offset);
+  client.close();
+});
+
+client.send(buf, offset, len, common.PORT, onMessage);

--- a/test/parallel/test-dgram-send-callback-multi-buffer-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-multi-buffer-empty-address.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const client = dgram.createSocket('udp4');
+
+const messageSent = common.mustCall(function messageSent(err, bytes) {
+  assert.ifError(err);
+  assert.strictEqual(bytes, buf1.length + buf2.length);
+});
+
+const buf1 = Buffer.alloc(256, 'x');
+const buf2 = Buffer.alloc(256, 'y');
+
+client.on('listening', function() {
+  const port = this.address().port;
+  client.send([buf1, buf2], port, messageSent);
+});
+
+client.on('message', common.mustCall(function onMessage(buf) {
+  const expected = Buffer.concat([buf1, buf2]);
+  assert.ok(buf.equals(expected), 'message was received correctly');
+  client.close();
+}));
+
+client.bind(0);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

dgram

##### Description of change

When using `Socket.prototype.send`, I was confused about when `address` was required, since the docs are ambiguous at best, and conflicting at worst: they claim `address` will default to `127.0.0.1`, *but* this is only in the case where `callback` is not supplied.

My confusion manifest in an exception from the `dns` module, which was unhelpful:

```
dns.js:112
    throw new TypeError('Invalid arguments: ' +
    ^

TypeError: Invalid arguments: hostname must be a string or falsey
    at Object.lookup (dns.js:112:11)
    at lookup (dgram.js:27:14)
    at UDP.lookup4 [as lookup] (dgram.js:32:10)
    at Socket.send (dgram.js:362:16)
```

`dns.lookup` expects a valid `hostname` argument, yet this parameter name ("hostname") is not used in `Socket.prototype.send`.  I thought it better to fail with helpful error messaging *before* getting as far as `dns.lookup`, which prompted this PR. 

~~The signature of `Socket.prototype.send` is a bit awkward, and perhaps the *best* fix here is to change it.  I see this PR as being an *improvement* nonetheless.  Description of changes follow.~~

**UPDATE Jan 8 17**

Upon suggestion by @mscdex, I've modified the changes to make `address` optional in all cases. 

Summary of changes:

- In `Socket.prototype.send`, `address` is now *always* optional; it is no longer required to use `callback`.  The signature has changed from this:
  ```
  socket.send(msg, [offset, length,] port, address [, callback])
  ```
  to this:
  ```
  socket.send(msg, [offset, length,] port, [, address] [, callback])
  ```
- Faster failure and more helpful error messaging in case when `address`  argument is present but invalid; exceptions no longer fall through  to `dns` module.
- Updates docs, adds tests.