### PR TITLE
fix: setting timeout propagates to sockets

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -271,7 +271,7 @@ function connectionListener(socket) {
   // If the user has added a listener to the server,
   // request, or response, then it's their responsibility.
   // otherwise, destroy on timeout by default
-  if (this.timeout)
+  if (typeof this.timeout === 'number')
     socket.setTimeout(this.timeout);
   socket.on('timeout', socketOnTimeout.bind(undefined, this, socket));
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -67,7 +67,7 @@ exports.connect = exports.createConnection = function() {
   debug('createConnection', args);
   var s = new Socket(args[0]);
 
-  if (args[0].timeout) {
+  if (typeof args[0].timeout === 'number') {
     s.setTimeout(args[0].timeout);
   }
 


### PR DESCRIPTION
* Allow `server.setTimout` value to be used on incoming sockets in _http_server.js when value is 0
* Allow `net.connect`'s timeout option to work when the value is 0

Will add a couple tests for this when I have a chance just wanted to put it into the queue