### PR TITLE
test, win32: fix up symlink tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -163,6 +163,13 @@ A stream to push an array into a REPL
 
 Blocks for `time` amount of time.
 
+### canCreateSymLink
+API to indicate whether the current running process can create
+symlinks. On Windows, this returns false if the process running
+doesn't have privileges to create symlinks (specifically 
+[SeCreateSymbolicLinkPrivilege](https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx)). 
+On non-Windows platforms, this currently returns true.
+
 ### ddCommand(filename, kilobytes)
 * return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -29,7 +29,7 @@ common.refreshTmpDir();
   assert.doesNotThrow(() => fs.readdirSync(__dirname, options));
 }
 
-{
+if (common.canCreateSymLink()) {
   const sourceFile = path.resolve(common.tmpDir, 'test-readlink');
   const linkFile = path.resolve(common.tmpDir, 'test-readlink-link');
 

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -3,20 +3,13 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const exec = require('child_process').exec;
 
 var linkTime;
 var fileTime;
 
-if (common.isWindows) {
-  // On Windows, creating symlinks requires admin privileges.
-  // We'll only try to run symlink test if we have enough privileges.
-  exec('whoami /priv', function(err, o) {
-    if (err || !o.includes('SeCreateSymbolicLinkPrivilege')) {
-      common.skip('insufficient privileges');
-      return;
-    }
-  });
+if (!common.canCreateSymLink()) {
+  common.skip('insufficient privileges');
+  return;
 }
 
 common.refreshTmpDir();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, win32

##### Description of change
<!-- Provide a description of the change below this comment. -->
On Windows, creating a symlink requires admin privileges.
There were two tests which created symlinks which were failing when run
as non-admin.

test-fs-symlink.js already had a check for privileges on Windows
but it had a couple issues:
1. It assumed that whoami was the one that came with windows.
   However, whoami also ships with Win32 Unix utility ports
   like the distribution with git, which can cause this to get check
   tripped up.
2. On failure, the check would just return from the callback instead of
   exiting
3. whoami was executed asynchronously so the test would run regardless
   of privilege state.

test-fs-options-immutable had no check.

As part of this change, I refactored the privilege checking to
a function in common, and changed both above tests to use the
refactored function.
