### PR TITLE
test: refactor test-stream-pipe-after-end

### DIFF
--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
@@ -13,7 +13,7 @@ function TestReadable(opt) {
   this._ended = false;
 }
 
-TestReadable.prototype._read = function(n) {
+TestReadable.prototype._read = function() {
   if (this._ended)
     this.emit('error', new Error('_read called twice'));
   this._ended = true;
@@ -35,31 +35,18 @@ TestWritable.prototype._write = function(chunk, encoding, cb) {
 
 // this one should not emit 'end' until we read() from it later.
 const ender = new TestReadable();
-let enderEnded = false;
 
 // what happens when you pipe() a Readable that's already ended?
 const piper = new TestReadable();
 // pushes EOF null, and length=0, so this will trigger 'end'
 piper.read();
 
-setTimeout(function() {
-  ender.on('end', function() {
-    enderEnded = true;
-  });
-  assert(!enderEnded);
+setTimeout(common.mustCall(function() {
+  ender.on('end', common.mustCall(function() {}));
   const c = ender.read();
-  assert.equal(c, null);
+  assert.strictEqual(c, null);
 
   const w = new TestWritable();
-  let writableFinished = false;
-  w.on('finish', function() {
-    writableFinished = true;
-  });
+  w.on('finish', common.mustCall(function() {}));
   piper.pipe(w);
-
-  process.on('exit', function() {
-    assert(enderEnded);
-    assert(writableFinished);
-    console.log('ok');
-  });
-});
+}, 1));


### PR DESCRIPTION
* replace `process.on('exit', ...)` checks with `common.mustCall()`
* assert.equal() -> assert.strictEqual()
* provide duration of 1ms to timer without a duration
* remove unused function argument

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test stream