### PR TITLE
meta: modify pull request template for prepending

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 <!--
-Thank you for your pull request. Please review below requirements.
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
 
 Bug fixes and new features should include tests and possibly benchmarks.
 
@@ -16,7 +17,3 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 
 ##### Affected core subsystem(s)
 <!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
-
-
-##### Description of change
-<!-- Provide a description of the change below this comment. -->


### PR DESCRIPTION
The GitHub interface for new pull requests has started prepending
commit messages for single-commit pull requests. It had previously
been appending them. Modify the GitHub template to accommodate the new
behavior.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

meta