### PR TITLE
url: fix URL query update if searchParams changes

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -593,7 +593,15 @@ function update(url, params) {
   if (!url)
     return;
 
-  url[context].query = params.toString();
+  const ctx = url[context];
+  const serializedParams = params.toString();
+  if (serializedParams) {
+    ctx.query = serializedParams;
+    ctx.flags |= binding.URL_FLAGS_HAS_QUERY;
+  } else {
+    ctx.query = null;
+    ctx.flags &= ~binding.URL_FLAGS_HAS_QUERY;
+  }
 }
 
 function getSearchParamPairs(target) {

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -42,3 +42,15 @@ params.append('first', 10);
 params.delete('first');
 assert.strictEqual(false, params.has('first'),
                    'Search params object has no "first" name');
+
+// https://github.com/nodejs/node/issues/10480
+// Emptying searchParams should correctly update url's query
+{
+  const url = new URL('http://domain?var=1&var=2&var=3');
+  for (const param of url.searchParams.keys()) {
+    url.searchParams.delete(param);
+  }
+  assert.strictEqual(url.searchParams.toString(), '');
+  assert.strictEqual(url.search, '');
+  assert.strictEqual(url.href, 'http://domain/');
+}


### PR DESCRIPTION
If searchParams becomes empty, query must be set to null.
Add missing update of context flags.

Fixes: https://github.com/nodejs/node/issues/10480

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

url
