### PR TITLE
test: basic functionalities of readInt8

### DIFF
--- a/test/parallel/test-buffer-readint8.js
+++ b/test/parallel/test-buffer-readint8.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// testing basic functionality of readInt8()
+
+const buf = Buffer.from([42, 84, 168, 127]);
+const result = buf.readInt8(1);
+
+assert.strictEqual(result, 84);
+
+assert.throws(
+  () => {
+    buf.readInt8(5);
+  },
+  /Index out of range/
+);
+
+assert.doesNotThrow(
+  () => {
+    buf.readInt8(5, true);
+  },
+  'readInt8() should not throw if noAssert is true'
+);

--- a/test/parallel/test-buffer-readintbe.js
+++ b/test/parallel/test-buffer-readintbe.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// testing basic functionality of readIntBE()
+
+const buf = Buffer.from([42, 84, 167, 127]);
+const result = buf.readIntBE(1);
+
+assert.strictEqual(result, 42);
+
+assert.throws(
+  () => {
+    buf.readIntBE(5);
+  },
+  /Index out of range/
+);
+
+assert.doesNotThrow(
+  () => {
+    buf.readIntBE(5, 0, true);
+  },
+  'readIntBE() should not throw if noAssert is true'
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test
##### Description of change
<!-- Provide a description of the change below this comment. -->
- Testing readInt8() in `lib/buffer.js`
- Testing when `noAssert` is both `true` and `false`