### PR TITLE
test: basic functionalities of readInt32BE()

### DIFF
--- a/test/parallel/test-buffer-readint32be.js
+++ b/test/parallel/test-buffer-readint32be.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// testing basic functionality of readInt32BE()
+
+const buf = Buffer.from([42, 84, 168, 127, 130]);
+const result = buf.readInt32BE(1);
+
+assert.strictEqual(result, 1420328834);
+
+assert.throws(
+  () => {
+    buf.readInt32BE(2);
+  },
+  /Index out of range/
+);
+
+assert.doesNotThrow(
+  () => {
+    buf.readInt32BE(2, true);
+  },
+  'readInt32BE() should not throw if noAssert is true'
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->



- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
- Testing readInt32BE() in `lib/buffer.js`
- Testing when `noAssert` is both `true` and `false`