### PR TITLE
test: fix Coverity warning in inspector test

### DIFF
--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -70,7 +70,7 @@ class Timeout {
 class InspectorSocketServerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    uv_loop_init(&loop);
+    EXPECT_EQ(0, uv_loop_init(&loop));
   }
 
   void TearDown() override {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Minor fix in tests


##### Description of change
Coverity complains the return value is not checked.
