### PR TITLE
tools: enable ESLint arrow-body-style rule (no braces or `return` if not needed)

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -115,6 +115,7 @@ rules:
 
   # ECMAScript 6
   # http://eslint.org/docs/rules/#ecmascript-6
+  arrow-body-style: 2
   arrow-parens: [2, always]
   arrow-spacing: [2, {before: true, after: true}]
   constructor-super: 2

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -70,7 +70,7 @@ cluster.setupMaster = function(options) {
   assert(schedulingPolicy === SCHED_NONE || schedulingPolicy === SCHED_RR,
          `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
 
-  const hasDebugArg = process.execArgv.some((argv) => {
+  const hasDebugArg = process.execArgv.some(function(argv) {
     return /^(--debug|--debug-brk)(=\d+)?$/.test(argv);
   });
 

--- a/test/common.js
+++ b/test/common.js
@@ -614,7 +614,7 @@ exports.WPT = {
   assert_true: (value, message) => assert.strictEqual(value, true, message),
   assert_false: (value, message) => assert.strictEqual(value, false, message),
   assert_throws: (code, func, desc) => {
-    assert.throws(func, (err) => {
+    assert.throws(func, function(err) {
       return typeof err === 'object' && 'name' in err && err.name === code.name;
     }, desc);
   },

--- a/tools/eslint-rules/prefer-assert-iferror.js
+++ b/tools/eslint-rules/prefer-assert-iferror.js
@@ -14,7 +14,7 @@ module.exports = {
       const bTokens = sourceCode.getTokens(nodeB);
 
       return aTokens.length === bTokens.length &&
-        aTokens.every((token, index) => {
+        aTokens.every(function(token, index) {
           return token.type === bTokens[index].type &&
             token.value === bTokens[index].value;
         });


### PR DESCRIPTION
tools: enable ESLint arrow-body-style rule
    
    This codifies the prevalent practice in the code base of not surrounding
    arrow function bodies that consist of a single expression in their own
    block.
       
    Arrow functions that are a single expression do not need to be their own
    blocks. Remove instances of single expressions as blocks in arrow
    functions in the code base.

    The "use or do not use blocks" discussion came up in a pull request.
    This change will codify the prevalent practice in the code base in a
    lint rule.

    Refs: https://github.com/nodejs/node/pull/10504#discussion_r94066593

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test lib tools

