### PR TITLE
url: move originFor, domainToAscii and domainToUnicode

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -69,7 +69,7 @@ class TupleOrigin {
   toString(unicode = false) {
     var result = this[kScheme];
     result += '://';
-    result += unicode ? URL.domainToUnicode(this[kHost]) : this[kHost];
+    result += unicode ? domainToUnicode(this[kHost]) : this[kHost];
     if (this[kPort] !== undefined && this[kPort] !== null)
       result += `:${this[kPort]}`;
     return result;
@@ -898,13 +898,16 @@ function originFor(url, base) {
   return origin;
 }
 
-URL.originFor = originFor;
-URL.domainToASCII = function(domain) {
+function domainToASCII(domain) {
   return binding.domainToASCII(String(domain));
-};
-URL.domainToUnicode = function(domain) {
+}
+
+function domainToUnicode(domain) {
   return binding.domainToUnicode(String(domain));
-};
+}
 
 exports.URL = URL;
+exports.originFor = originFor;
+exports.domainToASCII = domainToASCII;
+exports.domainToUnicode = domainToUnicode;
 exports.encodeAuth = encodeAuth;

--- a/lib/url.js
+++ b/lib/url.js
@@ -17,6 +17,9 @@ exports.resolve = urlResolve;
 exports.resolveObject = urlResolveObject;
 exports.format = urlFormat;
 exports.URL = internalUrl.URL;
+exports.originFor = internalUrl.originFor;
+exports.domainToASCII = internalUrl.domainToASCII;
+exports.domainToUnicode = internalUrl.domainToUnicode;
 
 
 exports.Url = Url;

--- a/test/parallel/test-url-domain-ascii-unicode.js
+++ b/test/parallel/test-url-domain-ascii-unicode.js
@@ -4,8 +4,8 @@ require('../common');
 const strictEqual = require('assert').strictEqual;
 const url = require('url');
 
-const domainToASCII = url.URL.domainToASCII;
-const domainToUnicode = url.URL.domainToUnicode;
+const domainToASCII = url.domainToASCII;
+const domainToUnicode = url.domainToUnicode;
 
 const domainWithASCII = [
   ['ıídيٴ', 'xn--d-iga7ro0q9f'],

--- a/test/parallel/test-util-inspect-tuple-origin.js
+++ b/test/parallel/test-util-inspect-tuple-origin.js
@@ -3,10 +3,10 @@
 require('../common');
 const assert = require('assert');
 const inspect = require('util').inspect;
-const URL = require('url').URL;
+const originFor = require('url').originFor;
 
 assert.strictEqual(
-    inspect(URL.originFor('http://test.com:8000')),
+    inspect(originFor('http://test.com:8000')),
     `TupleOrigin {
       scheme: http,
       host: test.com,
@@ -16,7 +16,7 @@ assert.strictEqual(
   );
 
 assert.strictEqual(
-    inspect(URL.originFor('http://test.com')),
+    inspect(originFor('http://test.com')),
     `TupleOrigin {
       scheme: http,
       host: test.com,
@@ -27,7 +27,7 @@ assert.strictEqual(
 
 
 assert.strictEqual(
-    inspect(URL.originFor('https://test.com')),
+    inspect(originFor('https://test.com')),
     `TupleOrigin {
       scheme: https,
       host: test.com,

--- a/test/parallel/test-whatwg-url-origin-for.js
+++ b/test/parallel/test-whatwg-url-origin-for.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-const URL = require('url').URL;
+const originFor = require('url').originFor;
 const path = require('path');
 const assert = require('assert');
 const tests = require(path.join(common.fixturesDir, 'url-tests.json'));
@@ -12,7 +12,7 @@ for (const test of tests) {
     continue;
 
   if (test.origin) {
-    const origin = URL.originFor(test.input, test.base);
+    const origin = originFor(test.input, test.base);
     // Pass true to origin.toString() to enable unicode serialization.
     assert.strictEqual(origin.toString(true), test.origin);
   }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

url

##### Description of change
Move non-standard methods from the new experimental `URL` implementation
to `url` module instead of exposing as static methods on the `URL` object.