### PR TITLE
tools: enable ESLint arrow-body-style rule (explicit braces and `return`)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -106,6 +106,7 @@ rules:
 
   # ECMAScript 6
   # http://eslint.org/docs/rules/#ecmascript-6
+  arrow-body-style: [2, always]
   arrow-parens: [2, always]
   arrow-spacing: [2, {before: true, after: true}]
   constructor-super: 2

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -11,7 +11,9 @@ fs.readdirSync(__dirname)
   })
   .forEach(function(category) {
     benchmarks[category] = fs.readdirSync(path.resolve(__dirname, category))
-      .filter((filename) => filename[0] !== '.' && filename[0] !== '_');
+      .filter((filename) => {
+        return filename[0] !== '.' && filename[0] !== '_';
+      });
   });
 
 function CLI(usage, settings) {

--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -112,7 +112,7 @@ exports.run = function(options, callback) {
   child.stderr.pipe(process.stderr);
 
   let stdout = '';
-  child.stdout.on('data', (chunk) => stdout += chunk.toString());
+  child.stdout.on('data', (chunk) => { return stdout += chunk.toString(); });
 
   child.once('close', function(code) {
     const elapsed = process.hrtime(benchmarker_start);

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -21,9 +21,9 @@ function Benchmark(fn, options) {
   // this._run will use fork() to create a new process for each configuration
   // combination.
   if (process.env.hasOwnProperty('NODE_RUN_BENCHMARK_FN')) {
-    process.nextTick(() => fn(this.config));
+    process.nextTick(() => { return fn(this.config); });
   } else {
-    process.nextTick(() => this._run());
+    process.nextTick(() => { return this._run(); });
   }
 }
 

--- a/benchmark/scatter.js
+++ b/benchmark/scatter.js
@@ -53,7 +53,7 @@ function csvEncodeValue(value) {
 
     // print data row
     const confData = Object.keys(data.conf)
-      .map((key) => csvEncodeValue(data.conf[key]))
+      .map((key) => { return csvEncodeValue(data.conf[key]); })
       .join(', ');
 
     console.log(`"${name}", ${confData}, ${data.rate}, ${data.time}`);

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -160,7 +160,7 @@ function Client() {
     protocol.execute(d);
   });
 
-  protocol.onResponse = (res) => this._onResponse(res);
+  protocol.onResponse = (res) => { return this._onResponse(res); };
 }
 inherits(Client, net.Socket);
 exports.Client = Client;
@@ -738,7 +738,9 @@ function Interface(stdin, stdout, args) {
     prompt: 'debug> ',
     input: this.stdin,
     output: this.stdout,
-    eval: (code, ctx, file, cb) => this.controlEval(code, ctx, file, cb),
+    eval: (code, ctx, file, cb) => {
+      return this.controlEval(code, ctx, file, cb);
+    },
     useGlobal: false,
     ignoreUndefined: true
   };
@@ -769,7 +771,7 @@ function Interface(stdin, stdout, args) {
   });
 
   // Handle all possible exits
-  process.on('exit', () => this.killChild());
+  process.on('exit', () => { return this.killChild(); });
   process.once('SIGTERM', process.exit.bind(process, 0));
   process.once('SIGHUP', process.exit.bind(process, 0));
 
@@ -839,7 +841,7 @@ function Interface(stdin, stdout, args) {
   // Run script automatically
   this.pause();
 
-  setImmediate(() => { this.run(() => this.resume()); });
+  setImmediate(() => { this.run(() => { return this.resume(); }); });
 }
 
 
@@ -1589,8 +1591,9 @@ Interface.prototype.repl = function() {
   this.repl.on('exit', exitDebugRepl);
 
   // Set new
-  this.repl.eval = (code, ctx, file, cb) =>
-    this.debugEval(code, ctx, file, cb);
+  this.repl.eval = (code, ctx, file, cb) => {
+    return this.debugEval(code, ctx, file, cb);
+  };
   this.repl.context = {};
 
   // Swap history
@@ -1605,8 +1608,9 @@ Interface.prototype.repl = function() {
 // Exit debug repl
 Interface.prototype.exitRepl = function() {
   // Restore eval
-  this.repl.eval = (code, ctx, file, cb) =>
-    this.controlEval(code, ctx, file, cb);
+  this.repl.eval = (code, ctx, file, cb) => {
+    return this.controlEval(code, ctx, file, cb);
+  };
 
   // Swap history
   this.history.debug = this.repl.rli.history;
@@ -1693,8 +1697,8 @@ Interface.prototype.trySpawn = function(cb) {
     // pipe stream into debugger
     this.child = spawn(process.execPath, childArgs);
 
-    this.child.stdout.on('data', (text) => this.childPrint(text));
-    this.child.stderr.on('data', (text) => this.childPrint(text));
+    this.child.stdout.on('data', (text) => { return this.childPrint(text); });
+    this.child.stderr.on('data', (text) => { return this.childPrint(text); });
   }
 
   this.pause();

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -566,7 +566,7 @@ function tickOnSocket(req, socket) {
   socket.on('close', socketCloseListener);
 
   if (req.timeout) {
-    const emitRequestTimeout = () => req.emit('timeout');
+    const emitRequestTimeout = () => { return req.emit('timeout'); };
     socket.once('timeout', emitRequestTimeout);
     req.once('response', (res) => {
       res.once('end', () => {

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -724,15 +724,17 @@ function SecurePair(context, isServer, requestCert, rejectUnauthorized,
                             this._rejectUnauthorized);
 
   if (this._isServer) {
-    this.ssl.onhandshakestart = () => onhandshakestart.call(this);
-    this.ssl.onhandshakedone = () => onhandshakedone.call(this);
-    this.ssl.onclienthello = (hello) => onclienthello.call(this, hello);
+    this.ssl.onhandshakestart = () => { return onhandshakestart.call(this); };
+    this.ssl.onhandshakedone = () => { return onhandshakedone.call(this); };
+    this.ssl.onclienthello =
+      (hello) => { return onclienthello.call(this, hello); };
     this.ssl.onnewsession =
-        (key, session) => onnewsession.call(this, key, session);
+        (key, session) => { return onnewsession.call(this, key, session); };
     this.ssl.lastHandshakeTime = 0;
     this.ssl.handshakes = 0;
   } else {
-    this.ssl.onocspresponse = (resp) => onocspresponse.call(this, resp);
+    this.ssl.onocspresponse =
+      (resp) => { return onocspresponse.call(this, resp); };
   }
 
   if (process.features.tls_sni) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -412,11 +412,13 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.setVerifyMode(requestCert, rejectUnauthorized);
 
   if (options.isServer) {
-    ssl.onhandshakestart = () => onhandshakestart.call(this);
-    ssl.onhandshakedone = () => onhandshakedone.call(this);
-    ssl.onclienthello = (hello) => onclienthello.call(this, hello);
-    ssl.oncertcb = (info) => oncertcb.call(this, info);
-    ssl.onnewsession = (key, session) => onnewsession.call(this, key, session);
+    ssl.onhandshakestart = () => { return onhandshakestart.call(this); };
+    ssl.onhandshakedone = () => { return onhandshakedone.call(this); };
+    ssl.onclienthello = (hello) => { return onclienthello.call(this, hello); };
+    ssl.oncertcb = (info) => { return oncertcb.call(this, info); };
+    ssl.onnewsession = (key, session) => {
+      return onnewsession.call(this, key, session);
+    };
     ssl.lastHandshakeTime = 0;
     ssl.handshakes = 0;
 
@@ -430,8 +432,8 @@ TLSSocket.prototype._init = function(socket, wrap) {
     }
   } else {
     ssl.onhandshakestart = function() {};
-    ssl.onhandshakedone = () => this._finishInit();
-    ssl.onocspresponse = (resp) => onocspresponse.call(this, resp);
+    ssl.onhandshakedone = () => { return this._finishInit(); };
+    ssl.onocspresponse = (resp) => { return onocspresponse.call(this, resp); };
 
     if (options.session)
       ssl.setSession(options.session);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -28,7 +28,7 @@
 const compare = process.binding('buffer').compare;
 const util = require('util');
 const Buffer = require('buffer').Buffer;
-const pToString = (obj) => Object.prototype.toString.call(obj);
+const pToString = (obj) => { return Object.prototype.toString.call(obj); };
 
 // 1. The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -47,12 +47,12 @@ function Worker(options) {
 
   if (options.process) {
     this.process = options.process;
-    this.process.on('error', (code, signal) =>
-      this.emit('error', code, signal)
-    );
-    this.process.on('message', (message, handle) =>
-      this.emit('message', message, handle)
-    );
+    this.process.on('error', (code, signal) => {
+      return this.emit('error', code, signal);
+    });
+    this.process.on('message', (message, handle) => {
+      return this.emit('message', message, handle);
+    });
   }
 }
 util.inherits(Worker, EventEmitter);
@@ -130,7 +130,8 @@ function RoundRobinHandle(key, address, port, addressType, fd) {
 
   this.server.once('listening', () => {
     this.handle = this.server._handle;
-    this.handle.onconnection = (err, handle) => this.distribute(err, handle);
+    this.handle.onconnection =
+      (err, handle) => { return this.distribute(err, handle); };
     this.server._handle = null;
     this.server = null;
   });
@@ -249,8 +250,9 @@ function masterInit() {
     // Without --logfile=v8-%p.log, everything ends up in a single, unusable
     // file. (Unusable because what V8 logs are memory addresses and each
     // process has its own memory mappings.)
-    if (settings.execArgv.some((s) => s.startsWith('--prof')) &&
-        !settings.execArgv.some((s) => s.startsWith('--logfile='))) {
+    if (settings.execArgv.some((s) => { return s.startsWith('--prof'); }) &&
+        !settings.execArgv.some((s) => { return s.startsWith('--logfile='); })
+    ) {
       settings.execArgv = settings.execArgv.concat(['--logfile=v8-%p.log']);
     }
     cluster.settings = settings;
@@ -414,7 +416,7 @@ function masterInit() {
   cluster.disconnect = function(cb) {
     var workers = Object.keys(cluster.workers);
     if (workers.length === 0) {
-      process.nextTick(() => intercom.emit('disconnect'));
+      process.nextTick(() => { return intercom.emit('disconnect'); });
     } else {
       for (var key in workers) {
         key = workers[key];
@@ -437,7 +439,7 @@ function masterInit() {
     signo = signo || 'SIGTERM';
     var proc = this.process;
     if (this.isConnected()) {
-      this.once('disconnect', () => proc.kill(signo));
+      this.once('disconnect', () => { return proc.kill(signo); });
       this.disconnect();
       return;
     }
@@ -696,8 +698,10 @@ function workerInit() {
     if (!this.isConnected()) {
       process.exit(0);
     } else {
-      send({ act: 'exitedAfterDisconnect' }, () => process.disconnect());
-      process.once('disconnect', () => process.exit(0));
+      send({ act: 'exitedAfterDisconnect' },
+           () => { return process.disconnect(); }
+      );
+      process.once('disconnect', () => { return process.exit(0); });
     }
   };
 
@@ -719,7 +723,9 @@ function workerInit() {
         if (masterInitiated) {
           process.disconnect();
         } else {
-          send({ act: 'exitedAfterDisconnect' }, () => process.disconnect());
+          send({ act: 'exitedAfterDisconnect' },
+               () => { return process.disconnect(); }
+          );
         }
       }
     }

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -213,7 +213,9 @@ exports.lookupService = function lookupService(host, port, callback) {
 
 function onresolve(err, result, ttls) {
   if (ttls && this.ttl)
-    result = result.map((address, index) => ({ address, ttl: ttls[index] }));
+    result = result.map(
+      (address, index) => { return ({ address, ttl: ttls[index] }); }
+    );
 
   if (err)
     this.callback(errnoException(err, this.bindingName, this.hostname));

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1856,7 +1856,7 @@ ReadStream.prototype.close = function(cb) {
       this.once('open', close);
       return;
     }
-    return process.nextTick(() => this.emit('close'));
+    return process.nextTick(() => { return this.emit('close'); });
   }
   this.closed = true;
   close();

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -66,7 +66,7 @@ function SyncWriteStream(fd, options) {
   this.readable = false;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
 
-  this.on('end', () => this._destroy());
+  this.on('end', () => { return this._destroy(); });
 }
 
 util.inherits(SyncWriteStream, Writable);

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -80,7 +80,7 @@ function addBuiltinLibsToObject(object) {
         // non-enumerable property.
         delete object[name];
         Object.defineProperty(object, name, {
-          get: () => lib,
+          get: () => { return lib; },
           set: setReal,
           configurable: true,
           enumerable: false

--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -13,7 +13,7 @@ function setupStdio() {
       stdout.emit('error', er);
     };
     if (stdout.isTTY) {
-      process.on('SIGWINCH', () => stdout._refreshSize());
+      process.on('SIGWINCH', () => { return stdout._refreshSize(); });
     }
     return stdout;
   }
@@ -26,7 +26,7 @@ function setupStdio() {
       stderr.emit('error', er);
     };
     if (stderr.isTTY) {
-      process.on('SIGWINCH', () => stderr._refreshSize());
+      process.on('SIGWINCH', () => { return stderr._refreshSize(); });
     }
     return stderr;
   }

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -44,6 +44,6 @@ function setupProcessWarnings() {
       if (process.throwDeprecation)
         throw warning;
     }
-    process.nextTick(() => process.emit('warning', warning));
+    process.nextTick(() => { return process.emit('warning', warning); });
   };
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -345,8 +345,10 @@ Socket.prototype._onTimeout = function() {
 
 Socket.prototype.setNoDelay = function(enable) {
   if (!this._handle) {
-    this.once('connect',
-              enable ? this.setNoDelay : () => this.setNoDelay(enable));
+    this.once(
+      'connect',
+      enable ? this.setNoDelay : () => { return this.setNoDelay(enable); }
+    );
     return this;
   }
 
@@ -360,7 +362,7 @@ Socket.prototype.setNoDelay = function(enable) {
 
 Socket.prototype.setKeepAlive = function(setting, msecs) {
   if (!this._handle) {
-    this.once('connect', () => this.setKeepAlive(setting, msecs));
+    this.once('connect', () => { return this.setKeepAlive(setting, msecs); });
     return this;
   }
 
@@ -415,7 +417,7 @@ Socket.prototype._read = function(n) {
 
   if (this.connecting || !this._handle) {
     debug('_read wait for connection');
-    this.once('connect', () => this._read(n));
+    this.once('connect', () => { return this._read(n); });
   } else if (!this._handle.reading) {
     // not already reading, start the flow
     debug('Socket._read readStart');

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -959,7 +959,7 @@ function emitKeypressEvents(stream, iface) {
   stream[ESCAPE_DECODER] = emitKeys(stream);
   stream[ESCAPE_DECODER].next();
 
-  const escapeCodeTimeout = () => stream[ESCAPE_DECODER].next('');
+  const escapeCodeTimeout = () => { return stream[ESCAPE_DECODER].next(''); };
   let timeoutId;
 
   function onData(b) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -47,7 +47,9 @@ const GLOBAL_OBJECT_PROPERTIES = ['NaN', 'Infinity', 'undefined',
   'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
   'Math', 'JSON'];
 const GLOBAL_OBJECT_PROPERTY_MAP = {};
-GLOBAL_OBJECT_PROPERTIES.forEach((p) => GLOBAL_OBJECT_PROPERTY_MAP[p] = p);
+GLOBAL_OBJECT_PROPERTIES.forEach(
+  (p) => { return GLOBAL_OBJECT_PROPERTY_MAP[p] = p; }
+);
 
 try {
   // hack for require.resolve("./relative") to work properly.
@@ -258,7 +260,9 @@ function REPLServer(prompt,
       // Mitigate https://github.com/nodejs/node/issues/548
       cmd = cmd.replace(
         /^\s*function(?:\s*(\*)\s*|\s+)([^(]+)/,
-        (_, genStar, name) => `var ${name} = function ${genStar || ''}${name}`
+        (_, genStar, name) => {
+          return `var ${name} = function ${genStar || ''}${name}`;
+        }
       );
     }
     // Append a \n so that it will be either
@@ -391,7 +395,7 @@ function REPLServer(prompt,
                  .replace(/^\s+at\s.*\n?/gm, '');
     } else if (e.stack && self.replMode === exports.REPL_MODE_STRICT) {
       e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
-                                (_, pre, line) => pre + (line - 1));
+                                (_, pre, line) => { return pre + (line - 1); });
     }
     top.outputStream.write((e.stack || e) + '\n');
     top.lineParser.reset();
@@ -672,15 +676,15 @@ exports.start = function(prompt,
 REPLServer.prototype.close = function close() {
   if (this.terminal && this._flushing && !this._closingOnFlush) {
     this._closingOnFlush = true;
-    this.once('flushHistory', () =>
-      Interface.prototype.close.call(this)
-    );
+    this.once('flushHistory', () => {
+      return Interface.prototype.close.call(this);
+    });
 
     return;
   }
-  process.nextTick(() =>
-    Interface.prototype.close.call(this)
-  );
+  process.nextTick(() => {
+    return Interface.prototype.close.call(this);
+  });
 };
 
 REPLServer.prototype.createContext = function() {
@@ -694,7 +698,7 @@ REPLServer.prototype.createContext = function() {
     Object.defineProperty(context, 'console', {
       configurable: true,
       enumerable: true,
-      get: () => _console
+      get: () => { return _console; }
     });
     Object.getOwnPropertyNames(global).filter((name) => {
       if (name === 'console' || name === 'global') return false;
@@ -1095,19 +1099,21 @@ function longestCommonPrefix(arr = []) {
   return first;
 }
 
-REPLServer.prototype.completeOnEditorMode = (callback) => (err, results) => {
-  if (err) return callback(err);
+REPLServer.prototype.completeOnEditorMode = (callback) => {
+  return (err, results) => {
+    if (err) return callback(err);
 
-  const [completions, completeOn = ''] = results;
-  const prefixLength = completeOn.length;
+    const [completions, completeOn = ''] = results;
+    const prefixLength = completeOn.length;
 
-  if (prefixLength === 0) return callback(null, [[], completeOn]);
+    if (prefixLength === 0) return callback(null, [[], completeOn]);
 
-  const isNotEmpty = (v) => v.length > 0;
-  const trimCompleteOnPrefix = (v) => v.substring(prefixLength);
-  const data = completions.filter(isNotEmpty).map(trimCompleteOnPrefix);
+    const isNotEmpty = (v) => { return v.length > 0; };
+    const trimCompleteOnPrefix = (v) => { return v.substring(prefixLength); };
+    const data = completions.filter(isNotEmpty).map(trimCompleteOnPrefix);
 
-  callback(null, [[`${completeOn}${longestCommonPrefix(data)}`], completeOn]);
+    callback(null, [[`${completeOn}${longestCommonPrefix(data)}`], completeOn]);
+  };
 };
 
 /**

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -73,7 +73,7 @@ function unfqdn(host) {
 function splitHost(host) {
   // String#toLowerCase() is locale-sensitive so we use
   // a conservative version that only lowercases A-Z.
-  const replacer = (c) => String.fromCharCode(32 + c.charCodeAt(0));
+  const replacer = (c) => { return String.fromCharCode(32 + c.charCodeAt(0)); };
   return unfqdn(host).replace(/[A-Z]/g, replacer).split('.');
 }
 
@@ -95,7 +95,7 @@ function check(hostParts, pattern, wildcards) {
   // good way to detect their encoding or normalize them so we simply
   // reject them.  Control characters and blanks are rejected as well
   // because nothing good can come from accepting them.
-  const isBad = (s) => /[^\u0021-\u007F]/u.test(s);
+  const isBad = (s) => { return /[^\u0021-\u007F]/u.test(s); };
   if (patternParts.some(isBad))
     return false;
 
@@ -172,8 +172,10 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   } else if (subject) {
     host = unfqdn(host);  // Remove trailing dot for error messages.
     const hostParts = splitHost(host);
-    const wildcard = (pattern) => check(hostParts, pattern, true);
-    const noWildcard = (pattern) => check(hostParts, pattern, false);
+    const wildcard = (pattern) => { return check(hostParts, pattern, true); };
+    const noWildcard = (pattern) => {
+      return check(hostParts, pattern, false);
+    };
 
     // Match against Common Name only if no supported identifiers are present.
     if (dnsNames.length === 0 && ips.length === 0 && uriNames.length === 0) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1052,4 +1052,6 @@ exports._exceptionWithHostPort = function(err,
 
 // process.versions needs a custom function as some values are lazy-evaluated.
 process.versions[exports.inspect.custom] =
-  (depth) => exports.format(JSON.parse(JSON.stringify(process.versions)));
+  (depth) => {
+    return exports.format(JSON.parse(JSON.stringify(process.versions)));
+  };

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -442,7 +442,7 @@ Zlib.prototype.flush = function(kind, callback) {
       this.once('end', callback);
   } else if (ws.needDrain) {
     if (callback) {
-      const drainHandler = () => this.flush(kind, callback);
+      const drainHandler = () => { return this.flush(kind, callback); };
       this.once('drain', drainHandler);
     }
   } else {

--- a/test/abort/test-abort-backtrace.js
+++ b/test/abort/test-abort-backtrace.js
@@ -12,13 +12,21 @@ if (process.argv[2] === 'child') {
   process.abort();
 } else {
   const child = cp.spawnSync(`${process.execPath}`, [`${__filename}`, 'child']);
-  const frames =
-      child.stderr.toString().trimRight().split('\n').map((s) => s.trim());
+  const frames = child.stderr.toString().trimRight().split('\n')
+                   .map((s) => { return s.trim(); });
 
   assert.strictEqual(child.stdout.toString(), '');
   assert.ok(frames.length > 0);
   // All frames should start with a frame number.
-  assert.ok(frames.every((frame, index) => frame.startsWith(`${index + 1}:`)));
+  assert.ok(
+    frames.every(
+      (frame, index) => { return frame.startsWith(`${index + 1}:`); }
+    )
+  );
   // At least some of the frames should include the binary name.
-  assert.ok(frames.some((frame) => frame.includes(`[${process.execPath}]`)));
+  assert.ok(
+    frames.some(
+      (frame) => { return frame.includes(`[${process.execPath}]`); }
+    )
+  );
 }

--- a/test/addons/node-module-version/test.js
+++ b/test/addons/node-module-version/test.js
@@ -8,4 +8,5 @@ const re = new RegExp(
   'NODE_MODULE_VERSION 42. This version of Node.js requires\n' +
   `NODE_MODULE_VERSION ${process.versions.modules}.`);
 
-assert.throws(() => require(`./build/${common.buildType}/binding`), re);
+assert.throws(() => { return require(`./build/${common.buildType}/binding`); },
+              re);

--- a/test/addons/openssl-binding/test.js
+++ b/test/addons/openssl-binding/test.js
@@ -5,4 +5,4 @@ const assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
 const bytes = new Uint8Array(1024);
 assert(binding.randomBytes(bytes));
-assert(bytes.reduce((v, a) => v + a) > 0);
+assert(bytes.reduce((v, a) => { return v + a; }) > 0);

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -30,5 +30,5 @@ const sub = require('./submodule');
   const mod = require(path.join(i, 'binding.node'));
   assert.notStrictEqual(mod, null);
   assert.strictEqual(mod.hello(), 'world');
-  assert.doesNotThrow(() => sub.test(i));
+  assert.doesNotThrow(() => { return sub.test(i); });
 });

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -85,7 +85,7 @@ function checkHttpResponse(port, path, callback) {
     let response = '';
     res.setEncoding('utf8');
     res
-      .on('data', (data) => response += data.toString())
+      .on('data', (data) => { return response += data.toString(); })
       .on('end', () => {
         let err = null;
         let json = undefined;
@@ -116,7 +116,8 @@ function makeBufferingDataCallback(dataCallback) {
 }
 
 function timeout(message, multiplicator) {
-  return setTimeout(() => common.fail(message), TIMEOUT * (multiplicator || 1));
+  return setTimeout(() => { return common.fail(message); },
+                    TIMEOUT * (multiplicator || 1));
 }
 
 const TestSession = function(socket, harness) {
@@ -143,7 +144,10 @@ const TestSession = function(socket, harness) {
       if (consumed)
         buffer = buffer.slice(consumed);
     } while (consumed);
-  }).on('close', () => assert(this.expectClose_, 'Socket closed prematurely'));
+  }).on('close',
+        () => {
+          return assert(this.expectClose_, 'Socket closed prematurely');
+        });
 };
 
 TestSession.prototype.scriptUrlForId = function(id) {
@@ -195,7 +199,7 @@ TestSession.prototype.sendAll_ = function(commands, callback) {
       command = command();
     this.messages_[this.lastId_] = command;
     send(this.socket_, command, this.lastId_,
-         () => this.sendAll_(commands.slice(1), callback));
+         () => { return this.sendAll_(commands.slice(1), callback); });
   }
 };
 
@@ -231,7 +235,7 @@ TestSession.prototype.createCallbackWithTimeout_ = function(message) {
       });
     });
   });
-  return () => promise.then((callback) => callback());
+  return () => { return promise.then((callback) => { return callback(); }); };
 };
 
 TestSession.prototype.expectMessages = function(expects) {
@@ -293,11 +297,12 @@ TestSession.prototype.disconnect = function(childDone) {
 };
 
 TestSession.prototype.testHttpResponse = function(path, check) {
-  return this.enqueue((callback) =>
-      checkHttpResponse(this.harness_.port, path, (err, response) => {
-        check.call(this, err, response);
-        callback();
-      }));
+  return this.enqueue((callback) => {
+    return checkHttpResponse(this.harness_.port, path, (err, response) => {
+      check.call(this, err, response);
+      callback();
+    });
+  });
 };
 
 
@@ -311,7 +316,7 @@ const Harness = function(port, childProcess) {
   this.running_ = true;
 
   childProcess.stdout.on('data', makeBufferingDataCallback(
-      (line) => console.log('[out]', line)));
+      (line) => { return console.log('[out]', line); }));
 
 
   childProcess.stderr.on('data', makeBufferingDataCallback((message) => {
@@ -398,7 +403,7 @@ Harness.prototype.wsHandshake = function(devtoolsUrl, tests, readyCallback) {
       });
     }
     enqueue(tests);
-  }).on('response', () => common.fail('Upgrade was not received'));
+  }).on('response', () => { return common.fail('Upgrade was not received'); });
 };
 
 Harness.prototype.runFrontendSession = function(tests) {

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -129,7 +129,7 @@ function testSetBreakpointAndResume(session) {
     .expectMessages([
       setupExpectConsoleOutput('log', ['A message', 5]),
       setupExpectBreakOnLine(5, session.mainScriptPath,
-                             session, (id) => scopeId = id),
+                             session, (id) => { return scopeId = id; }),
     ]);
 }
 
@@ -165,7 +165,7 @@ function testInspectScope(session) {
         'method': 'Runtime.evaluate', 'params': {
           'expression': '5 * 5'
         }
-      }, (message) => assert.strictEqual(25, message['result']['value'])
+      }, (msg) => { return assert.strictEqual(25, msg['result']['value']); }
     ],
   ]);
 }

--- a/test/known_issues/test-repl-function-redefinition-edge-case.js
+++ b/test/known_issues/test-repl-function-redefinition-edge-case.js
@@ -26,7 +26,7 @@ function initRepl() {
   output.writable = true;
   output.accumulator = [];
 
-  output.write = (data) => output.accumulator.push(data);
+  output.write = (data) => { return output.accumulator.push(data); };
 
   return repl.start({
     input,

--- a/test/known_issues/test-repl-require-context.js
+++ b/test/known_issues/test-repl-require-context.js
@@ -16,7 +16,7 @@ const r = repl.start({
 
 let output = '';
 outputStream.setEncoding('utf8');
-outputStream.on('data', (data) => output += data);
+outputStream.on('data', (data) => { return output += data; });
 
 r.on('exit', common.mustCall(() => {
   const results = output.split('\n').map((line) => {

--- a/test/message/unhandled_promise_trace_warnings.js
+++ b/test/message/unhandled_promise_trace_warnings.js
@@ -2,4 +2,4 @@
 'use strict';
 require('../common');
 const p = Promise.reject(new Error('This was rejected'));
-setImmediate(() => p.catch(() => {}));
+setImmediate(() => { return p.catch(() => {}); });

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -553,8 +553,9 @@ testBlockTypeError(assert.throws, undefined);
 testBlockTypeError(assert.doesNotThrow, undefined);
 
 // https://github.com/nodejs/node/issues/3275
-assert.throws(() => { throw 'error'; }, (err) => err === 'error');
-assert.throws(() => { throw new Error(); }, (err) => err instanceof Error);
+assert.throws(() => { throw 'error'; }, (err) => { return err === 'error'; });
+assert.throws(() => { throw new Error(); },
+              (err) => { return err instanceof Error; });
 
 // Long values should be truncated for display.
 assert.throws(() => {

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -36,7 +36,7 @@ if (common.isAix) {
 }
 
 function init(id, provider) {
-  keyList = keyList.filter((e) => e !== pkeys[provider]);
+  keyList = keyList.filter((e) => { return e !== pkeys[provider]; });
 }
 
 function noop() { }
@@ -91,7 +91,7 @@ dgram.createSocket('udp4').bind(0, function() {
   });
 });
 
-process.on('SIGINT', () => process.exit());
+process.on('SIGINT', () => { return process.exit(); });
 
 // Run from closed net server above.
 function checkTLS() {

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -37,10 +37,11 @@ if (typeof process.argv[2] === 'string') {
   async_wrap.setupHooks({ init, pre, post, destroy });
   async_wrap.enable();
 
-  process.on('uncaughtException', () => assert.ok(0, 'UNREACHABLE'));
+  process.on('uncaughtException',
+             () => { return assert.ok(0, 'UNREACHABLE'); });
 
   const d = domain.create();
-  d.on('error', () => assert.ok(0, 'UNREACHABLE'));
+  d.on('error', () => { return assert.ok(0, 'UNREACHABLE'); });
   d.run(() => {
     // Using randomBytes because timers are not yet supported.
     crypto.randomBytes(0, () => { });

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -54,39 +54,39 @@ assert.strictEqual(0, d.length);
 }
 
 // Test invalid encoding for Buffer.toString
-assert.throws(() => b.toString('invalid'),
+assert.throws(() => { return b.toString('invalid'); },
               /Unknown encoding: invalid/);
 // invalid encoding for Buffer.write
-assert.throws(() => b.write('test string', 0, 5, 'invalid'),
+assert.throws(() => { return b.write('test string', 0, 5, 'invalid'); },
               /Unknown encoding: invalid/);
 // unsupported arguments for Buffer.write
-assert.throws(() => b.write('test', 'utf8', 0),
+assert.throws(() => { return b.write('test', 'utf8', 0); },
               /is no longer supported/);
 
 
 // try to create 0-length buffers
-assert.doesNotThrow(() => Buffer.from(''));
-assert.doesNotThrow(() => Buffer.from('', 'ascii'));
-assert.doesNotThrow(() => Buffer.from('', 'latin1'));
-assert.doesNotThrow(() => Buffer.alloc(0));
-assert.doesNotThrow(() => Buffer.allocUnsafe(0));
-assert.doesNotThrow(() => new Buffer(''));
-assert.doesNotThrow(() => new Buffer('', 'ascii'));
-assert.doesNotThrow(() => new Buffer('', 'latin1'));
-assert.doesNotThrow(() => new Buffer('', 'binary'));
-assert.doesNotThrow(() => Buffer(0));
+assert.doesNotThrow(() => { return Buffer.from(''); });
+assert.doesNotThrow(() => { return Buffer.from('', 'ascii'); });
+assert.doesNotThrow(() => { return Buffer.from('', 'latin1'); });
+assert.doesNotThrow(() => { return Buffer.alloc(0); });
+assert.doesNotThrow(() => { return Buffer.allocUnsafe(0); });
+assert.doesNotThrow(() => { return new Buffer(''); });
+assert.doesNotThrow(() => { return new Buffer('', 'ascii'); });
+assert.doesNotThrow(() => { return new Buffer('', 'latin1'); });
+assert.doesNotThrow(() => { return new Buffer('', 'binary'); });
+assert.doesNotThrow(() => { return Buffer(0); });
 
 // try to write a 0-length string beyond the end of b
-assert.throws(() => b.write('', 2048), RangeError);
+assert.throws(() => { return b.write('', 2048); }, RangeError);
 
 // throw when writing to negative offset
-assert.throws(() => b.write('a', -1), RangeError);
+assert.throws(() => { return b.write('a', -1); }, RangeError);
 
 // throw when writing past bounds from the pool
-assert.throws(() => b.write('a', 2048), RangeError);
+assert.throws(() => { return b.write('a', 2048); }, RangeError);
 
 // throw when writing to negative offset
-assert.throws(() => b.write('a', -1), RangeError);
+assert.throws(() => { return b.write('a', -1); }, RangeError);
 
 // try to copy 0 bytes worth of data into an empty buffer
 b.copy(Buffer.alloc(0), 0, 0, 0);
@@ -111,7 +111,7 @@ b.copy(Buffer.alloc(1), 0, 2048, 2048);
 
 // Offset points to the end of the buffer
 // (see https://github.com/nodejs/node/issues/8127).
-assert.doesNotThrow(() => Buffer.alloc(1).write('', 1, 0));
+assert.doesNotThrow(() => { return Buffer.alloc(1).write('', 1, 0); });
 
 // ASCII slice test
 {
@@ -512,7 +512,7 @@ assert.strictEqual(Buffer.from('=bad'.repeat(1e4), 'base64').length, 0);
 
 // Test single hex character throws TypeError
 // - https://github.com/nodejs/node/issues/6770
-assert.throws(() => Buffer.from('A', 'hex'), TypeError);
+assert.throws(() => { return Buffer.from('A', 'hex'); }, TypeError);
 
 // Test single base64 char encodes as 0
 assert.strictEqual(Buffer.from('A', 'base64').length, 0);
@@ -531,7 +531,7 @@ assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 function buildBuffer(data) {
   if (Array.isArray(data)) {
     const buffer = Buffer.allocUnsafe(data.length);
-    data.forEach((v, k) => buffer[k] = v);
+    data.forEach((v, k) => { return buffer[k] = v; });
     return buffer;
   }
   return null;
@@ -794,32 +794,58 @@ Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 }
 
 // issue GH-5587
-assert.throws(() => Buffer.alloc(8).writeFloatLE(0, 5), RangeError);
-assert.throws(() => Buffer.alloc(16).writeDoubleLE(0, 9), RangeError);
+assert.throws(
+  () => { return Buffer.alloc(8).writeFloatLE(0, 5); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.alloc(16).writeDoubleLE(0, 9); },
+  RangeError
+);
 
 // attempt to overflow buffers, similar to previous bug in array buffers
-assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(0xffffffff),
-              RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
-              RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(0xffffffff),
-              RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff),
-              RangeError);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).readFloatLE(0xffffffff); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).readFloatLE(0xffffffff); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).writeFloatLE(0.0, 0xffffffff); },
+  RangeError
+);
 
 
 // ensure negative values can't get past offset
-assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(-1), RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(-1), RangeError);
-assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).readFloatLE(-1); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).writeFloatLE(0.0, -1); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).readFloatLE(-1); },
+  RangeError
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(8).writeFloatLE(0.0, -1); },
+  RangeError
+);
 
 // offset checks
 {
   const buf = Buffer.allocUnsafe(0);
 
-  assert.throws(() => buf.readUInt8(0), RangeError);
-  assert.throws(() => buf.readInt8(0), RangeError);
+  assert.throws(() => { return buf.readUInt8(0); }, RangeError);
+  assert.throws(() => { return buf.readInt8(0); }, RangeError);
 }
 
 {
@@ -832,19 +858,19 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
 [16, 32].forEach((bits) => {
   const buf = Buffer.allocUnsafe(bits / 8 - 1);
 
-  assert.throws(() => buf[`readUInt${bits}BE`](0),
+  assert.throws(() => { return buf[`readUInt${bits}BE`](0); },
                 RangeError,
                 `readUInt${bits}BE()`);
 
-  assert.throws(() => buf[`readUInt${bits}LE`](0),
+  assert.throws(() => { return buf[`readUInt${bits}LE`](0); },
                 RangeError,
                 `readUInt${bits}LE()`);
 
-  assert.throws(() => buf[`readInt${bits}BE`](0),
+  assert.throws(() => { return buf[`readInt${bits}BE`](0); },
                 RangeError,
                 `readInt${bits}BE()`);
 
-  assert.throws(() => buf[`readInt${bits}LE`](0),
+  assert.throws(() => { return buf[`readInt${bits}LE`](0); },
                 RangeError,
                 `readInt${bits}LE()`);
 });
@@ -981,7 +1007,7 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
 }
 
 // Regression test for #5482: should throw but not assert in C++ land.
-assert.throws(() => Buffer.from('', 'buffer'), TypeError);
+assert.throws(() => { return Buffer.from('', 'buffer'); }, TypeError);
 
 // Regression test for #6111. Constructing a buffer from another buffer
 // should a) work, and b) not corrupt the source buffer.
@@ -1021,14 +1047,14 @@ assert(Buffer.allocUnsafe(1).parent instanceof ArrayBuffer);
 Buffer.poolSize = ps;
 
 // Test Buffer.copy() segfault
-assert.throws(() => Buffer.allocUnsafe(10).copy(),
+assert.throws(() => { return Buffer.allocUnsafe(10).copy(); },
               /TypeError: argument should be a Buffer/);
 
 const regErrorMsg = new RegExp('First argument must be a string, Buffer, ' +
                                'ArrayBuffer, Array, or array-like object.');
 
-assert.throws(() => Buffer.from(), regErrorMsg);
-assert.throws(() => Buffer.from(null), regErrorMsg);
+assert.throws(() => { return Buffer.from(); }, regErrorMsg);
+assert.throws(() => { return Buffer.from(null); }, regErrorMsg);
 
 // Test prototype getters don't throw
 assert.strictEqual(Buffer.prototype.parent, undefined);
@@ -1047,12 +1073,12 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
                          Buffer.from(''));
 
   // Check pool offset after that by trying to write string into the pool.
-  assert.doesNotThrow(() => Buffer.from('abc'));
+  assert.doesNotThrow(() => { return Buffer.from('abc'); });
 }
 
 
 // Test that ParseArrayIndex handles full uint32
-assert.throws(() => Buffer.from(new ArrayBuffer(0), -1 >>> 0),
+assert.throws(() => { return Buffer.from(new ArrayBuffer(0), -1 >>> 0); },
               /RangeError: 'offset' is out of bounds/);
 
 // ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
@@ -1071,16 +1097,16 @@ assert.throws(() => {
 }
 
 // Regression test
-assert.doesNotThrow(() => Buffer.from(new ArrayBuffer()));
+assert.doesNotThrow(() => { return Buffer.from(new ArrayBuffer()); });
 
 // Test that ArrayBuffer from a different context is detected correctly
 const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
-assert.doesNotThrow(() => Buffer.from(arrayBuf));
-assert.doesNotThrow(() => Buffer.from({ buffer: arrayBuf }));
+assert.doesNotThrow(() => { return Buffer.from(arrayBuf); });
+assert.doesNotThrow(() => { return Buffer.from({ buffer: arrayBuf }); });
 
-assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
+assert.throws(() => { return Buffer.alloc({ valueOf: () => { return 1; } }); },
               /"size" argument must be a number/);
-assert.throws(() => Buffer.alloc({ valueOf: () => -1 }),
+assert.throws(() => { return Buffer.alloc({ valueOf: () => { return -1; } }); },
               /"size" argument must be a number/);
 
 assert.strictEqual(Buffer.prototype.toLocaleString, Buffer.prototype.toString);

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -66,12 +66,12 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.strictEqual(ab[1], 9);
 
-  assert.throws(() => Buffer.from(ab.buffer, 6), (err) => {
+  assert.throws(() => { return Buffer.from(ab.buffer, 6); }, (err) => {
     assert(err instanceof RangeError);
     assert(/'offset' is out of bounds/.test(err.message));
     return true;
   });
-  assert.throws(() => Buffer.from(ab.buffer, 3, 6), (err) => {
+  assert.throws(() => { return Buffer.from(ab.buffer, 3, 6); }, (err) => {
     assert(err instanceof RangeError);
     assert(/'length' is out of bounds/.test(err.message));
     return true;
@@ -94,12 +94,12 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.strictEqual(ab[1], 9);
 
-  assert.throws(() => Buffer(ab.buffer, 6), (err) => {
+  assert.throws(() => { return Buffer(ab.buffer, 6); }, (err) => {
     assert(err instanceof RangeError);
     assert(/'offset' is out of bounds/.test(err.message));
     return true;
   });
-  assert.throws(() => Buffer(ab.buffer, 3, 6), (err) => {
+  assert.throws(() => { return Buffer(ab.buffer, 3, 6); }, (err) => {
     assert(err instanceof RangeError);
     assert(/'length' is out of bounds/.test(err.message));
     return true;

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -48,7 +48,7 @@ assert.strictEqual(-1, a.compare(b, 0, 7, 4, 6));
 assert.strictEqual(1, a.compare(b, 0, null));
 
 // coerces to targetEnd == 5
-assert.strictEqual(-1, a.compare(b, 0, {valueOf: () => 5}));
+assert.strictEqual(-1, a.compare(b, 0, {valueOf: () => { return 5; }}));
 
 // zero length target
 assert.strictEqual(1, a.compare(b, Infinity, -Infinity));
@@ -58,10 +58,10 @@ assert.strictEqual(1, a.compare(b, '0xff'));
 
 const oor = /out of range index/;
 
-assert.throws(() => a.compare(b, 0, 100, 0), oor);
-assert.throws(() => a.compare(b, 0, 1, 0, 100), oor);
-assert.throws(() => a.compare(b, -1), oor);
-assert.throws(() => a.compare(b, 0, '0xff'), oor);
-assert.throws(() => a.compare(b, 0, Infinity), oor);
-assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
-assert.throws(() => a.compare(), /Argument must be a Buffer/);
+assert.throws(() => { return a.compare(b, 0, 100, 0); }, oor);
+assert.throws(() => { return a.compare(b, 0, 1, 0, 100); }, oor);
+assert.throws(() => { return a.compare(b, -1); }, oor);
+assert.throws(() => { return a.compare(b, 0, '0xff'); }, oor);
+assert.throws(() => { return a.compare(b, 0, Infinity); }, oor);
+assert.throws(() => { return a.compare(b, -Infinity, Infinity); }, oor);
+assert.throws(() => { return a.compare(); }, /Argument must be a Buffer/);

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -28,8 +28,8 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
 assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
-assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'));
+assert.throws(() => { return Buffer.compare(Buffer.alloc(1), 'abc'); });
 
-assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)));
+assert.throws(() => { return Buffer.compare('abc', Buffer.alloc(1)); });
 
-assert.throws(() => Buffer.alloc(1).compare('abc'));
+assert.throws(() => { return Buffer.alloc(1).compare('abc'); });

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -111,7 +111,7 @@ assert.throws(function() {
 }
 
 // throw with negative sourceEnd
-assert.throws(() => b.copy(c, 0, 0, -1), RangeError);
+assert.throws(() => { return b.copy(c, 0, 0, -1); }, RangeError);
 
 // when sourceStart is greater than sourceEnd, zero copied
 assert.strictEqual(b.copy(c, 0, 100, 10), 0);

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -14,4 +14,4 @@ assert.ok(!d.equals(e));
 assert.ok(d.equals(d));
 assert.ok(d.equals(new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65])));
 
-assert.throws(() => Buffer.alloc(1).equals('abc'));
+assert.throws(() => { return Buffer.alloc(1).equals('abc'); });

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -134,8 +134,8 @@ testBufs('61c8b462c8b563c8b6', 4, 1, 'hex');
 testBufs('61c8b462c8b563c8b6', 12, 1, 'hex');
 // Make sure this operation doesn't go on forever
 buf1.fill('yKJh', 'hex');
-assert.throws(() =>
-      buf1.fill('\u0222', 'hex'), /^TypeError: Invalid hex string$/);
+assert.throws(() => { return buf1.fill('\u0222', 'hex'); },
+              /^TypeError: Invalid hex string$/);
 
 
 // BASE64
@@ -181,25 +181,22 @@ deepStrictEqualValues(genBuffer(4, [hexBufFill, 1, -1]), [0, 0, 0, 0]);
 
 
 // Check exceptions
-assert.throws(() => buf1.fill(0, -1), /^RangeError: Out of range index$/);
-assert.throws(() =>
-             buf1.fill(0, 0, buf1.length + 1),
+assert.throws(() => { return buf1.fill(0, -1); },
+              /^RangeError: Out of range index$/);
+assert.throws(() => { return buf1.fill(0, 0, buf1.length + 1); },
+              /^RangeError: Out of range index$/);
+assert.throws(() => { return buf1.fill('', -1); },
+              /^RangeError: Out of range index$/);
+assert.throws(() => { return buf1.fill('', 0, buf1.length + 1); },
              /^RangeError: Out of range index$/);
-assert.throws(() => buf1.fill('', -1), /^RangeError: Out of range index$/);
-assert.throws(() =>
-             buf1.fill('', 0, buf1.length + 1),
-             /^RangeError: Out of range index$/);
-assert.throws(() =>
-             buf1.fill('a', 0, buf1.length, 'node rocks!'),
+assert.throws(() => { return buf1.fill('a', 0, buf1.length, 'node rocks!'); },
              /^TypeError: Unknown encoding: node rocks!$/);
-assert.throws(() =>
-             buf1.fill('a', 0, 0, NaN),
+assert.throws(() => { return buf1.fill('a', 0, 0, NaN); },
              /^TypeError: encoding must be a string$/);
-assert.throws(() =>
-             buf1.fill('a', 0, 0, null),
+assert.throws(() => { return buf1.fill('a', 0, 0, null); },
              /^TypeError: encoding must be a string$/);
-assert.throws(() =>
-             buf1.fill('a', 0, 0, 'foo'), /^TypeError: Unknown encoding: foo$/);
+assert.throws(() => { return buf1.fill('a', 0, 0, 'foo'); },
+              /^TypeError: Unknown encoding: foo$/);
 
 
 function genBuffer(size, args) {
@@ -269,11 +266,9 @@ function testBufs(string, offset, length, encoding) {
 }
 
 // Make sure these throw.
-assert.throws(() =>
-             Buffer.allocUnsafe(8).fill('a', -1),
+assert.throws(() => { return Buffer.allocUnsafe(8).fill('a', -1); },
              /^RangeError: Out of range index$/);
-assert.throws(() =>
-             Buffer.allocUnsafe(8).fill('a', 0, 9),
+assert.throws(() => { return Buffer.allocUnsafe(8).fill('a', 0, 9); },
              /^RangeError: Out of range index$/);
 
 // Make sure this doesn't hang indefinitely.

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -82,7 +82,10 @@ assert.equal(Buffer.from('ff').indexOf(Buffer.from('f'), 1, 'ucs2'), -1);
 assert.strictEqual(b.indexOf('b', 'utf8'), 1);
 assert.strictEqual(b.indexOf('b', 'UTF8'), 1);
 assert.strictEqual(b.indexOf('62', 'HEX'), 1);
-assert.throws(() => b.indexOf('bad', 'enc'), /Unknown encoding: enc/);
+assert.throws(
+  () => { return b.indexOf('bad', 'enc'); },
+  /Unknown encoding: enc/
+);
 
 // test hex encoding
 assert.strictEqual(

--- a/test/parallel/test-buffer-new.js
+++ b/test/parallel/test-buffer-new.js
@@ -4,4 +4,7 @@ require('../common');
 const assert = require('assert');
 const Buffer = require('buffer').Buffer;
 
-assert.throws(() => new Buffer(42, 'utf8'), /first argument must be a string/);
+assert.throws(
+  () => { return new Buffer(42, 'utf8'); },
+  /first argument must be a string/
+);

--- a/test/parallel/test-buffer-no-negative-allocation.js
+++ b/test/parallel/test-buffer-no-negative-allocation.js
@@ -7,18 +7,18 @@ const msg = /"size" argument must not be negative/;
 
 // Test that negative Buffer length inputs throw errors.
 
-assert.throws(() => Buffer(-Buffer.poolSize), msg);
-assert.throws(() => Buffer(-100), msg);
-assert.throws(() => Buffer(-1), msg);
+assert.throws(() => { return Buffer(-Buffer.poolSize); }, msg);
+assert.throws(() => { return Buffer(-100); }, msg);
+assert.throws(() => { return Buffer(-1); }, msg);
 
-assert.throws(() => Buffer.alloc(-Buffer.poolSize), msg);
-assert.throws(() => Buffer.alloc(-100), msg);
-assert.throws(() => Buffer.alloc(-1), msg);
+assert.throws(() => { return Buffer.alloc(-Buffer.poolSize); }, msg);
+assert.throws(() => { return Buffer.alloc(-100); }, msg);
+assert.throws(() => { return Buffer.alloc(-1); }, msg);
 
-assert.throws(() => Buffer.allocUnsafe(-Buffer.poolSize), msg);
-assert.throws(() => Buffer.allocUnsafe(-100), msg);
-assert.throws(() => Buffer.allocUnsafe(-1), msg);
+assert.throws(() => { return Buffer.allocUnsafe(-Buffer.poolSize); }, msg);
+assert.throws(() => { return Buffer.allocUnsafe(-100); }, msg);
+assert.throws(() => { return Buffer.allocUnsafe(-1); }, msg);
 
-assert.throws(() => Buffer.allocUnsafeSlow(-Buffer.poolSize), msg);
-assert.throws(() => Buffer.allocUnsafeSlow(-100), msg);
-assert.throws(() => Buffer.allocUnsafeSlow(-1), msg);
+assert.throws(() => { return Buffer.allocUnsafeSlow(-Buffer.poolSize); }, msg);
+assert.throws(() => { return Buffer.allocUnsafeSlow(-100); }, msg);
+assert.throws(() => { return Buffer.allocUnsafeSlow(-1); }, msg);

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -9,18 +9,36 @@ const SlowBuffer = buffer.SlowBuffer;
 const kMaxLength = buffer.kMaxLength;
 const bufferMaxSizeMsg = common.bufferMaxSizeMsg;
 
-assert.throws(() => Buffer((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.alloc((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe((-1 >>> 0) + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafeSlow((-1 >>> 0) + 1), bufferMaxSizeMsg);
+assert.throws(() => { return Buffer((-1 >>> 0) + 1); }, bufferMaxSizeMsg);
+assert.throws(() => { return SlowBuffer((-1 >>> 0) + 1); }, bufferMaxSizeMsg);
+assert.throws(() => { return Buffer.alloc((-1 >>> 0) + 1); }, bufferMaxSizeMsg);
+assert.throws(
+  () => { return Buffer.allocUnsafe((-1 >>> 0) + 1); },
+  bufferMaxSizeMsg
+);
+assert.throws(
+  () => { return Buffer.allocUnsafeSlow((-1 >>> 0) + 1); },
+  bufferMaxSizeMsg
+);
 
-assert.throws(() => Buffer(kMaxLength + 1), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer(kMaxLength + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.alloc(kMaxLength + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe(kMaxLength + 1), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);
+assert.throws(() => { return Buffer(kMaxLength + 1); }, bufferMaxSizeMsg);
+assert.throws(() => { return SlowBuffer(kMaxLength + 1); }, bufferMaxSizeMsg);
+assert.throws(() => { return Buffer.alloc(kMaxLength + 1); }, bufferMaxSizeMsg);
+assert.throws(
+  () => { return Buffer.allocUnsafe(kMaxLength + 1); },
+  bufferMaxSizeMsg
+);
+assert.throws(
+  () => { return Buffer.allocUnsafeSlow(kMaxLength + 1); },
+  bufferMaxSizeMsg
+);
 
 // issue GH-4331
-assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFF), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFFF), bufferMaxSizeMsg);
+assert.throws(
+  () => { return Buffer.allocUnsafe(0xFFFFFFFF); },
+  bufferMaxSizeMsg
+);
+assert.throws(
+  () => { return Buffer.allocUnsafe(0xFFFFFFFFF); },
+  bufferMaxSizeMsg
+);

--- a/test/parallel/test-buffer-regression-649.js
+++ b/test/parallel/test-buffer-regression-649.js
@@ -7,8 +7,12 @@ const SlowBuffer = require('buffer').SlowBuffer;
 // Regression test for https://github.com/nodejs/node/issues/649.
 const len = 1422561062959;
 const message = common.bufferMaxSizeMsg;
-assert.throws(() => Buffer(len).toString('utf8'), message);
-assert.throws(() => SlowBuffer(len).toString('utf8'), message);
-assert.throws(() => Buffer.alloc(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafe(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafeSlow(len).toString('utf8'), message);
+assert.throws(() => { return Buffer(len).toString('utf8'); }, message);
+assert.throws(() => { return SlowBuffer(len).toString('utf8'); }, message);
+assert.throws(() => { return Buffer.alloc(len).toString('utf8'); }, message);
+assert.throws(() => {
+  return Buffer.allocUnsafe(len).toString('utf8');
+}, message);
+assert.throws(() => {
+  return Buffer.allocUnsafeSlow(len).toString('utf8');
+}, message);

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -28,4 +28,4 @@ assert.deepStrictEqual(arr_buf, ar_buf, 0);
 
 assert.strictEqual(Buffer.byteLength(sab), sab.byteLength, 0);
 
-assert.doesNotThrow(() => Buffer.from({buffer: sab}));
+assert.doesNotThrow(() => { return Buffer.from({buffer: sab}); });

--- a/test/parallel/test-buffer-slice.js
+++ b/test/parallel/test-buffer-slice.js
@@ -83,7 +83,7 @@ assert.strictEqual(0, Buffer.compare(buf.slice('0', '-111'),
 
 // try to slice a zero length Buffer
 // see https://github.com/joyent/node/issues/5881
-assert.doesNotThrow(() => Buffer.alloc(0).slice(0, 1));
+assert.doesNotThrow(() => { return Buffer.alloc(0).slice(0, 1); });
 assert.strictEqual(Buffer.alloc(0).slice(0, 1).length, 0);
 
 {

--- a/test/parallel/test-buffer-swap.js
+++ b/test/parallel/test-buffer-swap.js
@@ -129,10 +129,10 @@ const re16 = /Buffer size must be a multiple of 16-bits/;
 const re32 = /Buffer size must be a multiple of 32-bits/;
 const re64 = /Buffer size must be a multiple of 64-bits/;
 
-assert.throws(() => Buffer.from(buf3).swap16(), re16);
-assert.throws(() => Buffer.alloc(1025).swap16(), re16);
-assert.throws(() => Buffer.from(buf3).swap32(), re32);
-assert.throws(() => buf3.slice(1, 3).swap32(), re32);
-assert.throws(() => Buffer.alloc(1025).swap32(), re32);
-assert.throws(() => buf3.slice(1, 3).swap64(), re64);
-assert.throws(() => Buffer.alloc(1025).swap64(), re64);
+assert.throws(() => { return Buffer.from(buf3).swap16(); }, re16);
+assert.throws(() => { return Buffer.alloc(1025).swap16(); }, re16);
+assert.throws(() => { return Buffer.from(buf3).swap32(); }, re32);
+assert.throws(() => { return buf3.slice(1, 3).swap32(); }, re32);
+assert.throws(() => { return Buffer.alloc(1025).swap32(); }, re32);
+assert.throws(() => { return buf3.slice(1, 3).swap64(); }, re64);
+assert.throws(() => { return Buffer.alloc(1025).swap64(); }, re64);

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -26,10 +26,14 @@ dns.lookup('::1', common.mustCall((error, result, addressType) => {
 }));
 
 // Try calling resolve with an unsupported type.
-assert.throws(() => dns.resolve('www.google.com', 'HI'), /Unknown type/);
+assert.throws(() => {
+  return dns.resolve('www.google.com', 'HI');
+}, /Unknown type/);
 
 // Try calling resolve with an unsupported type that's an object key
-assert.throws(() => dns.resolve('www.google.com', 'toString'), /Unknown type/);
+assert.throws(() => {
+  return dns.resolve('www.google.com', 'toString');
+}, /Unknown type/);
 
 // Windows doesn't usually have an entry for localhost 127.0.0.1 in
 // C:\Windows\System32\drivers\etc\hosts

--- a/test/parallel/test-child-process-send-keep-open.js
+++ b/test/parallel/test-child-process-send-keep-open.js
@@ -40,13 +40,13 @@ if (process.argv[2] !== 'child') {
   server.listen(0, () => {
     const socket = net.connect(server.address().port, common.localhostIPv4);
     socket.setEncoding('utf8');
-    socket.on('data', (data) => result += data);
+    socket.on('data', (data) => { return result += data; });
   });
 } else {
   // The child process receives the socket from the parent, writes data to
   // the socket, then signals the parent process to write
   process.on('message', common.mustCall((msg, socket) => {
     assert.strictEqual(msg, 'socket');
-    socket.write('child', () => process.send('child_done'));
+    socket.write('child', () => { return process.send('child_done'); });
   }));
 }

--- a/test/parallel/test-cluster-disconnect-handles.js
+++ b/test/parallel/test-cluster-disconnect-handles.js
@@ -41,7 +41,7 @@ if (cluster.isMaster) {
     const debugClient = net.connect({ host, port: common.PORT });
     const protocol = new Protocol();
     debugClient.setEncoding('utf8');
-    debugClient.on('data', (data) => protocol.execute(data));
+    debugClient.on('data', (data) => { return protocol.execute(data); });
     debugClient.once('connect', common.mustCall(() => {
       protocol.onResponse = common.mustCall((res) => {
         protocol.onResponse = (res) => {
@@ -69,7 +69,7 @@ if (cluster.isMaster) {
       });
     }));
   }));
-  process.on('exit', () => assert.deepStrictEqual(handles, {}));
+  process.on('exit', () => { return assert.deepStrictEqual(handles, {}); });
   process.on('uncaughtException', function(ex) {
     // Make sure we clean up so as not to leave a stray worker process running
     // if we encounter a connection or other error
@@ -86,7 +86,7 @@ if (cluster.isMaster) {
     throw ex;
   });
 } else {
-  const server = net.createServer((socket) => socket.pipe(socket));
+  const server = net.createServer((socket) => { return socket.pipe(socket); });
   const cb = () => {
     process.send(['listening', server.address()]);
     debugger;

--- a/test/parallel/test-cluster-master-error.js
+++ b/test/parallel/test-cluster-master-error.js
@@ -83,7 +83,7 @@ if (cluster.isWorker) {
     const pollWorkers = function() {
       // When master is dead all workers should be dead too
       var alive = false;
-      workers.forEach((pid) => alive = common.isAlive(pid));
+      workers.forEach((pid) => { return alive = common.isAlive(pid); });
       if (alive) {
         setTimeout(pollWorkers, 50);
       } else {

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -19,7 +19,7 @@ if (isTestRunner) {
   }));
 } else if (cluster.isMaster) {
   process.on('uncaughtException', common.mustCall(() => {
-    process.nextTick(() => process.exit(MAGIC_EXIT_CODE));
+    process.nextTick(() => { return process.exit(MAGIC_EXIT_CODE); });
   }));
   cluster.fork();
   throw new Error('kill master');

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -66,7 +66,7 @@ if (cluster.isWorker) {
     results.worker_exitedAfterDisconnect = worker.exitedAfterDisconnect;
     results.worker_state = worker.state;
     if (results.worker_emitExit > 0) {
-      process.nextTick(() => finish_test());
+      process.nextTick(() => { return finish_test(); });
     }
   }));
 
@@ -77,7 +77,7 @@ if (cluster.isWorker) {
     results.worker_emitExit += 1;
     results.worker_died = !common.isAlive(worker.process.pid);
     if (results.worker_emitDisconnect > 0) {
-      process.nextTick(() => finish_test());
+      process.nextTick(() => { return finish_test(); });
     }
   }));
 

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -441,6 +441,8 @@ for (const i in TEST_CASES) {
                             '6fKjEjR3Vl30EUYC');
   encrypt.update('blah', 'ascii');
   encrypt.final();
-  assert.throws(() => encrypt.getAuthTag(), / state/);
-  assert.throws(() => encrypt.setAAD(Buffer.from('123', 'ascii')), / state/);
+  assert.throws(() => { return encrypt.getAuthTag(); }, / state/);
+  assert.throws(() => {
+    return encrypt.setAAD(Buffer.from('123', 'ascii'));
+  }, / state/);
 }

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -125,18 +125,24 @@ testCipher2(Buffer.from('0123456789abcdef'));
   let decipher = crypto.createDecipher('aes192', key);
 
   let txt;
-  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'ucs2'));
-  assert.doesNotThrow(() => txt += decipher.final('ucs2'));
+  assert.doesNotThrow(() => {
+    return txt = decipher.update(ciph, 'base64', 'ucs2');
+  });
+  assert.doesNotThrow(() => { return txt += decipher.final('ucs2'); });
   assert.strictEqual(txt, plaintext, 'decrypted result in ucs2');
 
   decipher = crypto.createDecipher('aes192', key);
-  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'ucs-2'));
-  assert.doesNotThrow(() => txt += decipher.final('ucs-2'));
+  assert.doesNotThrow(() => {
+    return txt = decipher.update(ciph, 'base64', 'ucs-2');
+  });
+  assert.doesNotThrow(() => { return txt += decipher.final('ucs-2'); });
   assert.strictEqual(txt, plaintext, 'decrypted result in ucs-2');
 
   decipher = crypto.createDecipher('aes192', key);
-  assert.doesNotThrow(() => txt = decipher.update(ciph, 'base64', 'utf-16le'));
-  assert.doesNotThrow(() => txt += decipher.final('utf-16le'));
+  assert.doesNotThrow(() => {
+    return txt = decipher.update(ciph, 'base64', 'utf-16le');
+  });
+  assert.doesNotThrow(() => { return txt += decipher.final('utf-16le'); });
   assert.strictEqual(txt, plaintext, 'decrypted result in utf-16le');
 }
 

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -69,8 +69,10 @@ crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16), Buffer.alloc(0));
 // But non-empty IVs should be rejected.
 for (let n = 1; n < 256; n += 1) {
   assert.throws(
-      () => crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16),
-                                  Buffer.alloc(n)),
+      () => {
+        return crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16),
+                                     Buffer.alloc(n));
+      },
       /Invalid IV length/);
 }
 
@@ -81,15 +83,19 @@ crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16), Buffer.alloc(16));
 for (let n = 0; n < 256; n += 1) {
   if (n === 16) continue;
   assert.throws(
-      () => crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16),
-                                  Buffer.alloc(n)),
+      () => {
+        return crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16),
+                                     Buffer.alloc(n));
+      },
       /Invalid IV length/);
 }
 
 // Zero-sized IV should be rejected in GCM mode.
 assert.throws(
-    () => crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16),
-                                Buffer.alloc(0)),
+    () => {
+      return crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16),
+                                   Buffer.alloc(0));
+    },
     /Invalid IV length/);
 
 // But all other IV lengths should be accepted.

--- a/test/parallel/test-debug-no-context.js
+++ b/test/parallel/test-debug-no-context.js
@@ -19,7 +19,7 @@ proc.on('exit', common.mustCall((exitCode, signalCode) => {
 }));
 let stdout = '';
 proc.stdout.setEncoding('utf8');
-proc.stdout.on('data', (data) => stdout += data);
+proc.stdout.on('data', (data) => { return stdout += data; });
 process.on('exit', () => {
   assert(stdout.includes('Promise { 42 }'));
   assert(stdout.includes('Promise { 1337 }'));

--- a/test/parallel/test-debugger-util-regression.js
+++ b/test/parallel/test-debugger-util-regression.js
@@ -43,7 +43,7 @@ proc.stdout.on('data', (data) => {
   }
 });
 
-proc.stderr.on('data', (data) => stderr += data);
+proc.stderr.on('data', (data) => { return stderr += data; });
 
 process.on('exit', (code) => {
   assert.strictEqual(code, 0, 'the program should exit cleanly');

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const dns = require('dns');
 
 // Should not raise assertion error. Issue #7070
-assert.throws(() => dns.resolveNs([]), // bad name
+assert.throws(() => { return dns.resolveNs([]); }, // bad name
               /^Error: "name" argument must be a string$/);
-assert.throws(() => dns.resolveNs(''), // bad callback
+assert.throws(() => { return dns.resolveNs(''); }, // bad callback
               /^Error: "callback" argument must be a function$/);

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -40,9 +40,9 @@ const goog = [
   '8.8.8.8',
   '8.8.4.4',
 ];
-assert.doesNotThrow(() => dns.setServers(goog));
+assert.doesNotThrow(() => { return dns.setServers(goog); });
 assert.deepStrictEqual(dns.getServers(), goog);
-assert.throws(() => dns.setServers(['foobar']),
+assert.throws(() => { return dns.setServers(['foobar']); },
               /^Error: IP address is not properly formatted: foobar$/);
 assert.deepStrictEqual(dns.getServers(), goog);
 
@@ -50,7 +50,7 @@ const goog6 = [
   '2001:4860:4860::8888',
   '2001:4860:4860::8844',
 ];
-assert.doesNotThrow(() => dns.setServers(goog6));
+assert.doesNotThrow(() => { return dns.setServers(goog6); });
 assert.deepStrictEqual(dns.getServers(), goog6);
 
 goog6.push('4.4.4.4');
@@ -68,7 +68,7 @@ const portsExpected = [
 dns.setServers(ports);
 assert.deepStrictEqual(dns.getServers(), portsExpected);
 
-assert.doesNotThrow(() => dns.setServers([]));
+assert.doesNotThrow(() => { return dns.setServers([]); });
 assert.deepStrictEqual(dns.getServers(), []);
 
 assert.throws(() => {
@@ -81,25 +81,25 @@ assert.throws(() => {
 const errorReg =
   /^TypeError: Invalid arguments: hostname must be a string or falsey$/;
 
-assert.throws(() => dns.lookup({}, noop), errorReg);
+assert.throws(() => { return dns.lookup({}, noop); }, errorReg);
 
-assert.throws(() => dns.lookup([], noop), errorReg);
+assert.throws(() => { return dns.lookup([], noop); }, errorReg);
 
-assert.throws(() => dns.lookup(true, noop), errorReg);
+assert.throws(() => { return dns.lookup(true, noop); }, errorReg);
 
-assert.throws(() => dns.lookup(1, noop), errorReg);
+assert.throws(() => { return dns.lookup(1, noop); }, errorReg);
 
-assert.throws(() => dns.lookup(noop, noop), errorReg);
+assert.throws(() => { return dns.lookup(noop, noop); }, errorReg);
 
-assert.doesNotThrow(() => dns.lookup('', noop));
+assert.doesNotThrow(() => { return dns.lookup('', noop); });
 
-assert.doesNotThrow(() => dns.lookup(null, noop));
+assert.doesNotThrow(() => { return dns.lookup(null, noop); });
 
-assert.doesNotThrow(() => dns.lookup(undefined, noop));
+assert.doesNotThrow(() => { return dns.lookup(undefined, noop); });
 
-assert.doesNotThrow(() => dns.lookup(0, noop));
+assert.doesNotThrow(() => { return dns.lookup(0, noop); });
 
-assert.doesNotThrow(() => dns.lookup(NaN, noop));
+assert.doesNotThrow(() => { return dns.lookup(NaN, noop); });
 
 /*
  * Make sure that dns.lookup throws if hints does not represent a valid flag.
@@ -115,17 +115,19 @@ assert.throws(() => {
     noop);
 }, /^TypeError: Invalid argument: hints must use valid flags$/);
 
-assert.throws(() => dns.lookup('www.google.com'),
+assert.throws(() => { return dns.lookup('www.google.com'); },
               /^TypeError: Invalid arguments: callback must be passed$/);
 
-assert.throws(() => dns.lookup('www.google.com', 4),
+assert.throws(() => { return dns.lookup('www.google.com', 4); },
               /^TypeError: Invalid arguments: callback must be passed$/);
 
-assert.doesNotThrow(() => dns.lookup('www.google.com', 6, noop));
+assert.doesNotThrow(() => { return dns.lookup('www.google.com', 6, noop); });
 
-assert.doesNotThrow(() => dns.lookup('www.google.com', {}, noop));
+assert.doesNotThrow(() => { return dns.lookup('www.google.com', {}, noop); });
 
-assert.doesNotThrow(() => dns.lookup('', {family: 4, hints: 0}, noop));
+assert.doesNotThrow(() => {
+  return dns.lookup('', {family: 4, hints: 0}, noop);
+});
 
 assert.doesNotThrow(() => {
   dns.lookup('', {
@@ -134,7 +136,9 @@ assert.doesNotThrow(() => {
   }, noop);
 });
 
-assert.doesNotThrow(() => dns.lookup('', {hints: dns.V4MAPPED}, noop));
+assert.doesNotThrow(() => {
+  return dns.lookup('', {hints: dns.V4MAPPED}, noop);
+});
 
 assert.doesNotThrow(() => {
   dns.lookup('', {
@@ -142,29 +146,29 @@ assert.doesNotThrow(() => {
   }, noop);
 });
 
-assert.throws(() => dns.lookupService('0.0.0.0'),
+assert.throws(() => { return dns.lookupService('0.0.0.0'); },
               /^Error: Invalid arguments$/);
 
-assert.throws(() => dns.lookupService('fasdfdsaf', 0, noop),
+assert.throws(() => { return dns.lookupService('fasdfdsaf', 0, noop); },
               /^TypeError: "host" argument needs to be a valid IP address$/);
 
-assert.doesNotThrow(() => dns.lookupService('0.0.0.0', '0', noop));
+assert.doesNotThrow(() => { return dns.lookupService('0.0.0.0', '0', noop); });
 
-assert.doesNotThrow(() => dns.lookupService('0.0.0.0', 0, noop));
+assert.doesNotThrow(() => { return dns.lookupService('0.0.0.0', 0, noop); });
 
-assert.throws(() => dns.lookupService('0.0.0.0', null, noop),
+assert.throws(() => { return dns.lookupService('0.0.0.0', null, noop); },
               /^TypeError: "port" should be >= 0 and < 65536, got "null"$/);
 
 assert.throws(
-  () => dns.lookupService('0.0.0.0', undefined, noop),
+  () => { return dns.lookupService('0.0.0.0', undefined, noop); },
   /^TypeError: "port" should be >= 0 and < 65536, got "undefined"$/
 );
 
-assert.throws(() => dns.lookupService('0.0.0.0', 65538, noop),
+assert.throws(() => { return dns.lookupService('0.0.0.0', 65538, noop); },
               /^TypeError: "port" should be >= 0 and < 65536, got "65538"$/);
 
-assert.throws(() => dns.lookupService('0.0.0.0', 'test', noop),
+assert.throws(() => { return dns.lookupService('0.0.0.0', 'test', noop); },
               /^TypeError: "port" should be >= 0 and < 65536, got "test"$/);
 
-assert.throws(() => dns.lookupService('0.0.0.0', 80, null),
+assert.throws(() => { return dns.lookupService('0.0.0.0', 80, null); },
               /^TypeError: "callback" argument must be a function$/);

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -7,13 +7,17 @@ const assert = require('assert');
 const myEE = new EventEmitter();
 var m = 0;
 // This one comes last.
-myEE.on('foo', common.mustCall(() => assert.equal(m, 2)));
+myEE.on('foo', common.mustCall(() => { return assert.equal(m, 2); }));
 
 // This one comes second.
-myEE.prependListener('foo', common.mustCall(() => assert.equal(m++, 1)));
+myEE.prependListener('foo',
+                     common.mustCall(() => { return assert.equal(m++, 1); })
+);
 
 // This one comes first.
-myEE.prependOnceListener('foo', common.mustCall(() => assert.equal(m++, 0)));
+myEE.prependOnceListener('foo',
+                         common.mustCall(() => { return assert.equal(m++, 0); })
+);
 
 myEE.emit('foo');
 

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -32,5 +32,9 @@ fs.mkdtemp(path.join(common.tmpDir, 'bar.'), {}, common.mustCall(handler));
 
 // Making sure that not passing a callback doesn't crash, as a default function
 // is passed internally.
-assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-')));
-assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-'), {}));
+assert.doesNotThrow(() => {
+  return fs.mkdtemp(path.join(common.tmpDir, 'bar-'));
+});
+assert.doesNotThrow(() => {
+  return fs.mkdtemp(path.join(common.tmpDir, 'bar-'), {});
+});

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -38,16 +38,16 @@ assert.equal(stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
   });
 
 assert.throws(
-  () => stringToFlags({}),
+  () => { return stringToFlags({}); },
   /Unknown file open flag: \[object Object\]/
 );
 
 assert.throws(
-  () => stringToFlags(true),
+  () => { return stringToFlags(true); },
   /Unknown file open flag: true/
 );
 
 assert.throws(
-  () => stringToFlags(null),
+  () => { return stringToFlags(null); },
   /Unknown file open flag: null/
 );

--- a/test/parallel/test-fs-open-numeric-flags.js
+++ b/test/parallel/test-fs-open-numeric-flags.js
@@ -10,6 +10,6 @@ common.refreshTmpDir();
 // O_WRONLY without O_CREAT shall fail with ENOENT
 const pathNE = path.join(common.tmpDir, 'file-should-not-exist');
 assert.throws(
-  () => fs.openSync(pathNE, fs.constants.O_WRONLY),
-  (e) => e.code === 'ENOENT'
+  () => { return fs.openSync(pathNE, fs.constants.O_WRONLY); },
+  (e) => { return e.code === 'ENOENT'; }
 );

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -11,22 +11,22 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const errHandler = (e) => assert.ifError(e);
+const errHandler = (e) => { return assert.ifError(e); };
 const options = Object.freeze({});
 common.refreshTmpDir();
 
 {
-  assert.doesNotThrow(() =>
-    fs.readFile(__filename, options, common.mustCall(errHandler))
-  );
-  assert.doesNotThrow(() => fs.readFileSync(__filename, options));
+  assert.doesNotThrow(() => {
+    return fs.readFile(__filename, options, common.mustCall(errHandler));
+  });
+  assert.doesNotThrow(() => { return fs.readFileSync(__filename, options); });
 }
 
 {
-  assert.doesNotThrow(() =>
-    fs.readdir(__dirname, options, common.mustCall(errHandler))
-  );
-  assert.doesNotThrow(() => fs.readdirSync(__dirname, options));
+  assert.doesNotThrow(() => {
+    return fs.readdir(__dirname, options, common.mustCall(errHandler));
+  });
+  assert.doesNotThrow(() => { return fs.readdirSync(__dirname, options); });
 }
 
 {
@@ -36,26 +36,32 @@ common.refreshTmpDir();
   fs.writeFileSync(sourceFile, '');
   fs.symlinkSync(sourceFile, linkFile);
 
-  assert.doesNotThrow(() =>
-    fs.readlink(linkFile, options, common.mustCall(errHandler))
-  );
-  assert.doesNotThrow(() => fs.readlinkSync(linkFile, options));
+  assert.doesNotThrow(() => {
+    return fs.readlink(linkFile, options, common.mustCall(errHandler));
+  });
+  assert.doesNotThrow(() => { return fs.readlinkSync(linkFile, options); });
 }
 
 {
   const fileName = path.resolve(common.tmpDir, 'writeFile');
-  assert.doesNotThrow(() => fs.writeFileSync(fileName, 'ABCD', options));
-  assert.doesNotThrow(() =>
-    fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler))
-  );
+  assert.doesNotThrow(() => {
+    return fs.writeFileSync(fileName, 'ABCD', options);
+  });
+  assert.doesNotThrow(() => {
+    return fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler));
+  });
 }
 
 {
   const fileName = path.resolve(common.tmpDir, 'appendFile');
-  assert.doesNotThrow(() => fs.appendFileSync(fileName, 'ABCD', options));
-  assert.doesNotThrow(() =>
-    fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler))
-  );
+  assert.doesNotThrow(() => {
+    return fs.appendFileSync(fileName, 'ABCD', options);
+  });
+  assert.doesNotThrow(() => {
+    return fs.appendFile(
+      fileName, 'ABCD', options, common.mustCall(errHandler)
+    );
+  });
 }
 
 if (!common.isAix) {
@@ -63,36 +69,40 @@ if (!common.isAix) {
   // https://github.com/nodejs/node/issues/5085 is fixed
   {
     let watch;
-    assert.doesNotThrow(() => watch = fs.watch(__filename, options, () => {}));
+    assert.doesNotThrow(() => {
+      return watch = fs.watch(__filename, options, () => {});
+    });
     watch.close();
   }
 
   {
-    assert.doesNotThrow(() => fs.watchFile(__filename, options, () => {}));
+    assert.doesNotThrow(() => {
+      return fs.watchFile(__filename, options, () => {});
+    });
     fs.unwatchFile(__filename);
   }
 }
 
 {
-  assert.doesNotThrow(() => fs.realpathSync(__filename, options));
-  assert.doesNotThrow(() =>
-    fs.realpath(__filename, options, common.mustCall(errHandler))
-  );
+  assert.doesNotThrow(() => { return fs.realpathSync(__filename, options); });
+  assert.doesNotThrow(() => {
+    return fs.realpath(__filename, options, common.mustCall(errHandler));
+  });
 }
 
 {
   const tempFileName = path.resolve(common.tmpDir, 'mkdtemp-');
-  assert.doesNotThrow(() => fs.mkdtempSync(tempFileName, options));
-  assert.doesNotThrow(() =>
-    fs.mkdtemp(tempFileName, options, common.mustCall(errHandler))
-  );
+  assert.doesNotThrow(() => { return fs.mkdtempSync(tempFileName, options); });
+  assert.doesNotThrow(() => {
+    return fs.mkdtemp(tempFileName, options, common.mustCall(errHandler));
+  });
 }
 
 {
   const fileName = path.resolve(common.tmpDir, 'streams');
   assert.doesNotThrow(() => {
     fs.WriteStream(fileName, options).once('open', () => {
-      assert.doesNotThrow(() => fs.ReadStream(fileName, options));
+      assert.doesNotThrow(() => { return fs.ReadStream(fileName, options); });
     });
   });
 }

--- a/test/parallel/test-fs-read-stream-err.js
+++ b/test/parallel/test-fs-read-stream-err.js
@@ -38,5 +38,9 @@ fs.read = function() {
 };
 
 stream.on('data', (buf) => {
-  stream.on('data', () => common.fail("no more 'data' events should follow"));
+  stream.on('data',
+            () => {
+              return common.fail("no more 'data' events should follow");
+            }
+  );
 });

--- a/test/parallel/test-fs-syncwritestream.js
+++ b/test/parallel/test-fs-syncwritestream.js
@@ -12,11 +12,17 @@ const path = require('path');
 if (process.argv[2] === 'child') {
   // Note: Calling console.log() is part of this test as it exercises the
   // SyncWriteStream#_write() code path.
-  console.log(JSON.stringify([process.stdout, process.stderr].map((stdio) => ({
-    instance: stdio instanceof stream.Writable,
-    readable: stdio.readable,
-    writable: stdio.writable,
-  }))));
+  console.log(JSON.stringify(
+    [process.stdout, process.stderr].map(
+      (stdio) => {
+        return ({
+          instance: stdio instanceof stream.Writable,
+          readable: stdio.readable,
+          writable: stdio.writable,
+        });
+      }
+    )
+  ));
 
   return;
 }

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -122,7 +122,7 @@ function testFtruncate(cb) {
   const file2 = path.resolve(tmp, 'truncate-file-2.txt');
   fs.writeFileSync(file2, 'Hi');
   const fd = fs.openSync(file2, 'r+');
-  process.on('exit', () => fs.closeSync(fd));
+  process.on('exit', () => { return fs.closeSync(fd); });
   fs.ftruncateSync(fd, 4);
   assert(fs.readFileSync(file2).equals(Buffer.from('Hi\u0000\u0000')));
 }
@@ -140,7 +140,7 @@ function testFtruncate(cb) {
   const file4 = path.resolve(tmp, 'truncate-file-4.txt');
   fs.writeFileSync(file4, 'Hi');
   const fd = fs.openSync(file4, 'r+');
-  process.on('exit', () => fs.closeSync(fd));
+  process.on('exit', () => { return fs.closeSync(fd); });
   fs.ftruncate(fd, 4, common.mustCall(function(err) {
     assert.ifError(err);
     assert(fs.readFileSync(file4).equals(Buffer.from('Hi\u0000\u0000')));

--- a/test/parallel/test-handle-wrap-isrefed-tty.js
+++ b/test/parallel/test-handle-wrap-isrefed-tty.js
@@ -20,7 +20,7 @@ if (process.argv[2] === 'child') {
   tty.unref();
   assert(tty._handle.hasRef(), false);
   tty._handle.close(
-      common.mustCall(() => assert(tty._handle.hasRef(), false)));
+      common.mustCall(() => { return assert(tty._handle.hasRef(), false); }));
   return;
 }
 

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -22,7 +22,9 @@ function makeAssert(message) {
   assert(cp._handle.hasRef(), false);
   cp.ref();
   assert(cp._handle.hasRef(), true);
-  cp._handle.close(common.mustCall(() => assert(cp._handle.hasRef(), false)));
+  cp._handle.close(common.mustCall(
+    () => { return assert(cp._handle.hasRef(), false); }
+  ));
 }
 
 
@@ -39,7 +41,7 @@ function makeAssert(message) {
   sock4.ref();
   assert(sock4._handle.hasRef(), true);
   sock4._handle.close(
-      common.mustCall(() => assert(sock4._handle.hasRef(), false)));
+      common.mustCall(() => { return assert(sock4._handle.hasRef(), false); }));
 
   const sock6 = dgram.createSocket('udp6');
   assert(Object.getPrototypeOf(sock6._handle).hasOwnProperty('hasRef'), true);
@@ -49,7 +51,7 @@ function makeAssert(message) {
   sock6.ref();
   assert(sock6._handle.hasRef(), true);
   sock6._handle.close(
-      common.mustCall(() => assert(sock6._handle.hasRef(), false)));
+      common.mustCall(() => { return assert(sock6._handle.hasRef(), false); }));
 }
 
 
@@ -64,7 +66,9 @@ function makeAssert(message) {
   assert(handle.hasRef(), false);
   handle.ref();
   assert(handle.hasRef(), true);
-  handle.close(common.mustCall(() => assert(handle.hasRef(), false)));
+  handle.close(
+    common.mustCall(() => { return assert(handle.hasRef(), false); })
+  );
 }
 
 
@@ -83,7 +87,8 @@ function makeAssert(message) {
   assert(server._handle.hasRef(), true);
   assert(server._unref, false);
   server._handle.close(
-      common.mustCall(() => assert(server._handle.hasRef(), false)));
+    common.mustCall(() => { return assert(server._handle.hasRef(), false); })
+  );
 }
 
 
@@ -97,5 +102,5 @@ function makeAssert(message) {
   timer.ref();
   assert(timer._handle.hasRef(), true);
   timer._handle.close(
-      common.mustCall(() => assert(timer._handle.hasRef(), false)));
+      common.mustCall(() => { return assert(timer._handle.hasRef(), false); }));
 }

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -77,7 +77,7 @@ cp.exec(ddcmd, function(err, stdout, stderr) {
       res.write(data);
     });
 
-    cat.stdout.on('end', () => res.end());
+    cat.stdout.on('end', () => { return res.end(); });
 
     // End the response on exit (and log errors)
     cat.on('exit', (code) => {
@@ -90,6 +90,6 @@ cp.exec(ddcmd, function(err, stdout, stderr) {
   });
 
   server.listen(0, () => {
-    executeRequest(() => server.close());
+    executeRequest(() => { return server.close(); });
   });
 });

--- a/test/parallel/test-http-client-timeout-event.js
+++ b/test/parallel/test-http-client-timeout-event.js
@@ -17,7 +17,7 @@ server.listen(0, options.host, function() {
   req.on('error', function() {
     // this space is intentionally left blank
   });
-  req.on('close', common.mustCall(() => server.close()));
+  req.on('close', common.mustCall(() => { return server.close(); }));
 
   req.setTimeout(1);
   req.on('timeout', common.mustCall(() => {

--- a/test/parallel/test-http-client-timeout-option.js
+++ b/test/parallel/test-http-client-timeout-option.js
@@ -19,10 +19,10 @@ server.listen(0, options.host, function() {
   req.on('error', function() {
     // this space is intentionally left blank
   });
-  req.on('close', common.mustCall(() => server.close()));
+  req.on('close', common.mustCall(() => { return server.close(); }));
 
   var timeout_events = 0;
-  req.on('timeout', common.mustCall(() => timeout_events += 1));
+  req.on('timeout', common.mustCall(() => { return timeout_events += 1; }));
   setTimeout(function() {
     req.destroy();
     assert.strictEqual(timeout_events, 1);

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -5,6 +5,6 @@ const http = require('http');
 
 for (let i = 0; i <= 32; i += 1) {
   const path = 'bad' + String.fromCharCode(i) + 'path';
-  assert.throws(() => http.get({ path }, common.fail),
+  assert.throws(() => { return http.get({ path }, common.fail); },
                 /contains unescaped characters/);
 }

--- a/test/parallel/test-http-host-header-ipv6-fail.js
+++ b/test/parallel/test-http-host-header-ipv6-fail.js
@@ -36,4 +36,4 @@ const server = http.createServer(common.mustCall(function(req, res) {
   server.close(true);
 }));
 
-server.listen(0, hostname, () => httpreq());
+server.listen(0, hostname, () => { return httpreq(); });

--- a/test/parallel/test-http-invalid-urls.js
+++ b/test/parallel/test-http-invalid-urls.js
@@ -14,9 +14,11 @@ const error = 'Unable to determine the domain name';
 function test(host) {
   ['get', 'request'].forEach((method) => {
     [http, https].forEach((module) => {
-      assert.throws(() => module[method](host, () => {
-        throw new Error(`${module}.${method} should not connect to ${host}`);
-      }), error);
+      assert.throws(() => {
+        return module[method](host, () => {
+          throw new Error(`${module}.${method} should not connect to ${host}`);
+        });
+      }, error);
     });
   });
 }

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -38,7 +38,9 @@ function parent() {
         // may still be asked to process more requests if they were read before
         // the flood-prevention mechanism activated.
         setImmediate(() => {
-          req.socket.on('data', () => common.fail('Unexpected data received'));
+          req.socket.on('data', () => {
+            return common.fail('Unexpected data received');
+          });
         });
       }
       backloggedReqs++;

--- a/test/parallel/test-http-same-map.js
+++ b/test/parallel/test-http-same-map.js
@@ -6,7 +6,8 @@ const assert = require('assert');
 const http = require('http');
 
 const server =
-    http.createServer(onrequest).listen(0, common.localhostIPv4, () => next(0));
+    http.createServer(onrequest)
+      .listen(0, common.localhostIPv4, () => { return next(0); });
 
 function onrequest(req, res) {
   res.end('ok');
@@ -19,14 +20,14 @@ onrequest.responses = [];
 function next(n) {
   const { address: host, port } = server.address();
   const req = http.get({ host, port });
-  req.once('response', (res) => onresponse(n, req, res));
+  req.once('response', (res) => { return onresponse(n, req, res); });
 }
 
 function onresponse(n, req, res) {
   res.resume();
 
   if (n < 3) {
-    res.once('end', () => next(n + 1));
+    res.once('end', () => { return next(n + 1); });
   } else {
     server.close();
   }

--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -44,7 +44,7 @@ dns.lookup('localhost', {family: 6, all: true}, (err, addresses) => {
     throw err;
   }
 
-  if (addresses.some((val) => val.address === '::1'))
+  if (addresses.some((val) => { return val.address === '::1'; }))
     runTest();
   else
     common.skip('localhost does not resolve to ::1');

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -39,17 +39,17 @@ for (const test in tests) {
 }
 
 assert.throws(
-  () => buffer.transcode(null, 'utf8', 'ascii'),
+  () => { return buffer.transcode(null, 'utf8', 'ascii'); },
   /^TypeError: "source" argument must be a Buffer or Uint8Array$/
 );
 
 assert.throws(
-  () => buffer.transcode(Buffer.from('a'), 'b', 'utf8'),
+  () => { return buffer.transcode(Buffer.from('a'), 'b', 'utf8'); },
   /^Error: Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]/
 );
 
 assert.throws(
-  () => buffer.transcode(Buffer.from('a'), 'uf8', 'b'),
+  () => { return buffer.transcode(Buffer.from('a'), 'uf8', 'b'); },
   /^Error: Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]$/
 );
 

--- a/test/parallel/test-intl-v8BreakIterator.js
+++ b/test/parallel/test-intl-v8BreakIterator.js
@@ -14,5 +14,5 @@ try {
   // May succeed if data is available - OK
 } catch (e) {
   // May throw this error if ICU data is not available - OK
-  assert.throws(() => new Intl.v8BreakIterator(), /ICU data/);
+  assert.throws(() => { return new Intl.v8BreakIterator(); }, /ICU data/);
 }

--- a/test/parallel/test-net-end-close.js
+++ b/test/parallel/test-net-end-close.js
@@ -8,9 +8,9 @@ const uv = process.binding('uv');
 const s = new net.Socket({
   handle: {
     readStart: function() {
-      process.nextTick(() => this.onread(uv.UV_EOF, null));
+      process.nextTick(() => { return this.onread(uv.UV_EOF, null); });
     },
-    close: (cb) => process.nextTick(cb)
+    close: (cb) => { return process.nextTick(cb); }
   },
   writable: false
 });
@@ -18,8 +18,8 @@ s.resume();
 
 const events = [];
 
-s.on('end', () => events.push('end'));
-s.on('close', () => events.push('close'));
+s.on('end', () => { return events.push('end'); });
+s.on('close', () => { return events.push('close'); });
 
 process.on('exit', () => {
   assert.deepStrictEqual(events, [ 'end', 'close' ]);

--- a/test/parallel/test-net-internal.js
+++ b/test/parallel/test-net-internal.js
@@ -17,4 +17,4 @@ for (var n = 0; n <= 0xFFFF; n++) {
 const bad = [-1, 'a', {}, [], false, true, 0xFFFF + 1, Infinity,
              -Infinity, NaN, undefined, null, '', ' ', 1.1, '0x',
              '-0x1', '-0o1', '-0b1', '0o', '0b'];
-bad.forEach((i) => assert(!isLegalPort(i)));
+bad.forEach((i) => { return assert(!isLegalPort(i)); });

--- a/test/parallel/test-net-isip.js
+++ b/test/parallel/test-net-isip.js
@@ -35,9 +35,11 @@ assert.equal(net.isIP(null), 0);
 assert.equal(net.isIP(123), 0);
 assert.equal(net.isIP(true), 0);
 assert.equal(net.isIP({}), 0);
-assert.equal(net.isIP({ toString: () => '::2001:252:1:255.255.255.255' }), 6);
-assert.equal(net.isIP({ toString: () => '127.0.0.1' }), 4);
-assert.equal(net.isIP({ toString: () => 'bla' }), 0);
+assert.equal(net.isIP({ toString: () => {
+  return '::2001:252:1:255.255.255.255';
+} }), 6);
+assert.equal(net.isIP({ toString: () => { return '127.0.0.1'; } }), 4);
+assert.equal(net.isIP({ toString: () => { return 'bla'; } }), 0);
 
 assert.equal(net.isIPv4('127.0.0.1'), true);
 assert.equal(net.isIPv4('example.com'), false);
@@ -49,10 +51,10 @@ assert.equal(net.isIPv4(123), false);
 assert.equal(net.isIPv4(true), false);
 assert.equal(net.isIPv4({}), false);
 assert.equal(net.isIPv4({
-  toString: () => '::2001:252:1:255.255.255.255'
+  toString: () => { return '::2001:252:1:255.255.255.255'; }
 }), false);
-assert.equal(net.isIPv4({ toString: () => '127.0.0.1' }), true);
-assert.equal(net.isIPv4({ toString: () => 'bla' }), false);
+assert.equal(net.isIPv4({ toString: () => { return '127.0.0.1'; } }), true);
+assert.equal(net.isIPv4({ toString: () => { return 'bla'; } }), false);
 
 assert.equal(net.isIPv6('127.0.0.1'), false);
 assert.equal(net.isIPv6('example.com'), false);
@@ -64,7 +66,7 @@ assert.equal(net.isIPv6(123), false);
 assert.equal(net.isIPv6(true), false);
 assert.equal(net.isIPv6({}), false);
 assert.equal(net.isIPv6({
-  toString: () => '::2001:252:1:255.255.255.255'
+  toString: () => { return '::2001:252:1:255.255.255.255'; }
 }), true);
-assert.equal(net.isIPv6({ toString: () => '127.0.0.1' }), false);
-assert.equal(net.isIPv6({ toString: () => 'bla' }), false);
+assert.equal(net.isIPv6({ toString: () => { return '127.0.0.1'; } }), false);
+assert.equal(net.isIPv6({ toString: () => { return 'bla'; } }), false);

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -13,8 +13,8 @@ function isPipeName(s) {
 }
 
 const listenVariants = [
-  (port, cb) => net.Server().listen({port}, cb),
-  (port, cb) => net.Server().listen(port, cb)
+  (port, cb) => { return net.Server().listen({port}, cb); },
+  (port, cb) => { return net.Server().listen(port, cb); }
 ];
 
 listenVariants.forEach((listenVariant, i) => {
@@ -35,11 +35,12 @@ listenVariants.forEach((listenVariant, i) => {
       // skip this, because listen(port) can also be listen(path)
       return;
     }
-    assert.throws(() => listenVariant(port, common.fail),
+    assert.throws(() => { return listenVariant(port, common.fail); },
                   /"port" argument must be >= 0 and < 65536/i);
   });
 
-  [null, true, false].forEach((port) =>
-    assert.throws(() => listenVariant(port, common.fail),
-                  /invalid listen argument/i));
+  [null, true, false].forEach((port) => {
+    return assert.throws(() => { return listenVariant(port, common.fail); },
+                         /invalid listen argument/i);
+  });
 });

--- a/test/parallel/test-net-socket-write-error.js
+++ b/test/parallel/test-net-socket-write-error.js
@@ -14,5 +14,5 @@ function connectToServer() {
 
     client.end();
   })
-  .on('end', () => server.close());
+  .on('end', () => { return server.close(); });
 }

--- a/test/parallel/test-no-enter-tickcallback.js
+++ b/test/parallel/test-no-enter-tickcallback.js
@@ -25,8 +25,10 @@ process._tickDomainCallback = function _tickDomainCallback() {
 
 setImmediate(common.mustCall(() => {
   require('domain');
-  setImmediate(common.mustCall(() => setImmediate(common.mustCall(() => {
-    allsGood = true;
-    process.nextTick(() => {});
-  }))));
+  setImmediate(common.mustCall(() => {
+    return setImmediate(common.mustCall(() => {
+      allsGood = true;
+      process.nextTick(() => {});
+    }));
+  }));
 }));

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -37,5 +37,5 @@ warningThrowToString.toString = function() {
 process.emitWarning(warningThrowToString);
 
 // TypeError is thrown on invalid output
-assert.throws(() => process.emitWarning(1), TypeError);
-assert.throws(() => process.emitWarning({}), TypeError);
+assert.throws(() => { return process.emitWarning(1); }, TypeError);
+assert.throws(() => { return process.emitWarning({}); }, TypeError);

--- a/test/parallel/test-process-env-symbols.js
+++ b/test/parallel/test-process-env-symbols.js
@@ -24,4 +24,6 @@ assert.throws(() => {
 }, errRegExp);
 
 // Checks that well-known symbols like `Symbol.toStringTag` won’t throw.
-assert.doesNotThrow(() => Object.prototype.toString.call(process.env));
+assert.doesNotThrow(() => {
+  return Object.prototype.toString.call(process.env);
+});

--- a/test/parallel/test-promises-warning-on-unhandled-rejection.js
+++ b/test/parallel/test-promises-warning-on-unhandled-rejection.js
@@ -26,4 +26,4 @@ process.on('warning', common.mustCall((warning) => {
 }, 3));
 
 const p = Promise.reject('This was rejected');
-setImmediate(common.mustCall(() => p.catch(() => {})));
+setImmediate(common.mustCall(() => { return p.catch(() => {}); }));

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -172,30 +172,38 @@ const handleError = (error, name) => {
 
 const regexNonASCII = /[^\x20-\x7E]/;
 const testBattery = {
-  encode: (test) => assert.strictEqual(
-    punycode.encode(test.decoded),
-    test.encoded
-  ),
-  decode: (test) => assert.strictEqual(
-    punycode.decode(test.encoded),
-    test.decoded
-  ),
-  toASCII: (test) => assert.strictEqual(
-    punycode.toASCII(test.decoded),
-    regexNonASCII.test(test.decoded) ?
-      `xn--${test.encoded}` :
+  encode: (test) => {
+    return assert.strictEqual(
+      punycode.encode(test.decoded),
+      test.encoded
+    );
+  },
+  decode: (test) => {
+    return assert.strictEqual(
+      punycode.decode(test.encoded),
       test.decoded
-  ),
-  toUnicode: (test) => assert.strictEqual(
-    punycode.toUnicode(
+    );
+  },
+  toASCII: (test) => {
+    return assert.strictEqual(
+      punycode.toASCII(test.decoded),
       regexNonASCII.test(test.decoded) ?
         `xn--${test.encoded}` :
         test.decoded
-    ),
-    regexNonASCII.test(test.decoded) ?
-      test.decoded.toLowerCase() :
-      test.decoded
-  )
+    );
+  },
+  toUnicode: (test) => {
+    return assert.strictEqual(
+      punycode.toUnicode(
+        regexNonASCII.test(test.decoded) ?
+          `xn--${test.encoded}` :
+          test.decoded
+      ),
+      regexNonASCII.test(test.decoded) ?
+        test.decoded.toLowerCase() :
+        test.decoded
+    );
+  }
 };
 
 tests.forEach((testCase) => {

--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -11,14 +11,21 @@ assert.deepStrictEqual(qs.escape([5, 10]), '5%2C10');
 
 // using toString for objects
 assert.strictEqual(
-  qs.escape({test: 5, toString: () => 'test', valueOf: () => 10 }),
+  qs.escape({
+    test: 5,
+    toString: () => { return 'test'; },
+    valueOf: () => { return 10; }
+  }),
   'test'
 );
 
 // toString is not callable, must throw an error
-assert.throws(() => qs.escape({toString: 5}));
+assert.throws(() => { return qs.escape({toString: 5}); });
 
 // should use valueOf instead of non-callable toString
-assert.strictEqual(qs.escape({toString: 5, valueOf: () => 'test'}), 'test');
+assert.strictEqual(qs.escape({
+  toString: 5,
+  valueOf: () => { return 'test'; }
+}), 'test');
 
-assert.throws(() => qs.escape(Symbol('test')));
+assert.throws(() => { return qs.escape(Symbol('test')); });

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -55,35 +55,37 @@ function addTest(sequences, expectedKeys) {
 
 const addKeyIntervalTest = (sequences, expectedKeys, interval = 550,
                             assertDelay = 550) => {
-  return (next) => () => {
+  return (next) => {
+    return () => {
 
-    if (!Array.isArray(sequences)) {
-      sequences = [ sequences ];
-    }
-
-    if (!Array.isArray(expectedKeys)) {
-      expectedKeys = [ expectedKeys ];
-    }
-
-    expectedKeys = expectedKeys.map(function(k) {
-      return k ? extend({ ctrl: false, meta: false, shift: false }, k) : k;
-    });
-
-    const keys = [];
-    fi.on('keypress', (s, k) => keys.push(k));
-
-    const emitKeys = ([head, ...tail]) => {
-      if (head) {
-        fi.write(head);
-        setTimeout(() => emitKeys(tail), interval);
-      } else {
-        setTimeout(() => {
-          next();
-          assert.deepStrictEqual(keys, expectedKeys);
-        }, assertDelay);
+      if (!Array.isArray(sequences)) {
+        sequences = [ sequences ];
       }
+
+      if (!Array.isArray(expectedKeys)) {
+        expectedKeys = [ expectedKeys ];
+      }
+
+      expectedKeys = expectedKeys.map(function(k) {
+        return k ? extend({ ctrl: false, meta: false, shift: false }, k) : k;
+      });
+
+      const keys = [];
+      fi.on('keypress', (s, k) => { return keys.push(k); });
+
+      const emitKeys = ([head, ...tail]) => {
+        if (head) {
+          fi.write(head);
+          setTimeout(() => { return emitKeys(tail); }, interval);
+        } else {
+          setTimeout(() => {
+            next();
+            assert.deepStrictEqual(keys, expectedKeys);
+          }, assertDelay);
+        }
+      };
+      emitKeys(sequences);
     };
-    emitKeys(sequences);
   };
 };
 
@@ -207,7 +209,7 @@ const runKeyIntervalTests = [
     { name: 'escape', sequence: '\x1b', meta: true },
     { name: 'escape', sequence: '\x1b', meta: true }
   ])
-].reverse().reduce((acc, fn) => fn(acc), () => {});
+].reverse().reduce((acc, fn) => { return fn(acc); }, () => {});
 
 // run key interval tests one after another
 runKeyIntervalTests();

--- a/test/parallel/test-repl-.editor.js
+++ b/test/parallel/test-repl-.editor.js
@@ -14,7 +14,7 @@ function run({input, output, event, checkTerminalCodes = true}) {
   const stream = new common.ArrayStream();
   let found = '';
 
-  stream.write = (msg) => found += msg.replace('\r', '');
+  stream.write = (msg) => { return found += msg.replace('\r', ''); };
 
   let expected = `${terminalCode}.editor\n` +
                  '// Entering editor mode (^D to finish, ^C to cancel)\n' +
@@ -88,7 +88,7 @@ function testCodeAligment({input, cursor = 0, line = ''}) {
   });
 
   stream.emit('data', '.editor\n');
-  input.split('').forEach((ch) => stream.emit('data', ch));
+  input.split('').forEach((ch) => { return stream.emit('data', ch); });
   // Test the content of current line and the cursor position
   assert.strictEqual(line, replServer.line);
   assert.strictEqual(cursor, replServer.cursor);

--- a/test/parallel/test-repl-console.js
+++ b/test/parallel/test-repl-console.js
@@ -20,4 +20,4 @@ assert(r.context.console);
 assert.notStrictEqual(r.context.console, console);
 
 // ensure that the repl console instance does not have a setter
-assert.throws(() => r.context.console = 'foo', TypeError);
+assert.throws(() => { return r.context.console = 'foo'; }, TypeError);

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -22,5 +22,5 @@ function testContext(repl) {
   assert.strictEqual(context.global, context);
 
   // ensure that the repl console instance does not have a setter
-  assert.throws(() => context.console = 'foo');
+  assert.throws(() => { return context.console = 'foo'; });
 }

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -182,9 +182,9 @@ const numtests = tests.length;
 
 var testsNotRan = tests.length;
 
-process.on('beforeExit', () =>
-  assert.strictEqual(testsNotRan, 0)
-);
+process.on('beforeExit', () => {
+  return assert.strictEqual(testsNotRan, 0);
+});
 
 function cleanupTmpFile() {
   try {
@@ -199,7 +199,8 @@ function cleanupTmpFile() {
 
 // Copy our fixture to the tmp directory
 fs.createReadStream(historyFixturePath)
-  .pipe(fs.createWriteStream(historyPath)).on('unpipe', () => runTest());
+  .pipe(fs.createWriteStream(historyPath))
+  .on('unpipe', () => { return runTest(); });
 
 function runTest(assertCleaned) {
   const opts = tests.shift();

--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -23,7 +23,7 @@ server.listen(options, function() {
   options.port = this.address().port;
   const conn = net.connect(options);
   conn.setEncoding('utf8');
-  conn.on('data', (data) => answer += data);
+  conn.on('data', (data) => { return answer += data; });
   conn.write('require("baz")\nrequire("./baz")\n.exit\n');
 });
 

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -14,20 +14,22 @@ const globalTestCases = [
   [undefined, 'undefined']
 ];
 
-const globalTest = (useGlobal, cb, output) => (err, repl) => {
-  if (err)
-    return cb(err);
+const globalTest = (useGlobal, cb, output) => {
+  return (err, repl) => {
+    if (err)
+      return cb(err);
 
-  // The REPL registers 'module' and 'require' globals
-  common.allowGlobals(repl.context.module, repl.context.require);
+    // The REPL registers 'module' and 'require' globals
+    common.allowGlobals(repl.context.module, repl.context.require);
 
-  let str = '';
-  output.on('data', (data) => (str += data));
-  global.lunch = 'tacos';
-  repl.write('global.lunch;\n');
-  repl.close();
-  delete global.lunch;
-  cb(null, str.trim());
+    let str = '';
+    output.on('data', (data) => { return (str += data); });
+    global.lunch = 'tacos';
+    repl.write('global.lunch;\n');
+    repl.close();
+    delete global.lunch;
+    cb(null, str.trim());
+  };
 };
 
 // Test how the global object behaves in each state for useGlobal
@@ -46,18 +48,20 @@ for (const [option, expected] of globalTestCases) {
 // suite is aware of it, causing a failure to be flagged.
 //
 const processTestCases = [false, undefined];
-const processTest = (useGlobal, cb, output) => (err, repl) => {
-  if (err)
-    return cb(err);
+const processTest = (useGlobal, cb, output) => {
+  return (err, repl) => {
+    if (err)
+      return cb(err);
 
-  let str = '';
-  output.on('data', (data) => (str += data));
+    let str = '';
+    output.on('data', (data) => { return (str += data); });
 
-  // if useGlobal is false, then `let process` should work
-  repl.write('let process;\n');
-  repl.write('21 * 2;\n');
-  repl.close();
-  cb(null, str.trim());
+    // if useGlobal is false, then `let process` should work
+    repl.write('let process;\n');
+    repl.write('21 * 2;\n');
+    repl.close();
+    cb(null, str.trim());
+  };
 };
 
 for (const option of processTestCases) {

--- a/test/parallel/test-require-invalid-package.js
+++ b/test/parallel/test-require-invalid-package.js
@@ -4,6 +4,6 @@ require('../common');
 const assert = require('assert');
 
 // Should be an invalid package path.
-assert.throws(() => require('package.json'), (err) => {
+assert.throws(() => { return require('package.json'); }, (err) => {
   return err && err.code === 'MODULE_NOT_FOUND';
 });

--- a/test/parallel/test-stdin-pipe-large.js
+++ b/test/parallel/test-stdin-pipe-large.js
@@ -17,7 +17,7 @@ let readBytes = 0;
 
 child.stdin.end(Buffer.alloc(expectedBytes));
 
-child.stdout.on('data', (chunk) => readBytes += chunk.length);
+child.stdout.on('data', (chunk) => { return readBytes += chunk.length; });
 child.stdout.on('end', common.mustCall(() => {
   assert.strictEqual(readBytes, expectedBytes);
 }));

--- a/test/parallel/test-stream-base-no-abort.js
+++ b/test/parallel/test-stream-base-no-abort.js
@@ -17,7 +17,7 @@ const providers = Object.keys(async_wrap.Providers);
 var flags = 0;
 
 // Make sure all asserts have run at least once.
-process.on('exit', () => assert.equal(flags, 0b111));
+process.on('exit', () => { return assert.equal(flags, 0b111); });
 
 function init(id, provider) {
   this._external;  // Test will abort if nullptr isn't properly checked.

--- a/test/parallel/test-stream-readable-invalid-chunk.js
+++ b/test/parallel/test-stream-readable-invalid-chunk.js
@@ -7,6 +7,15 @@ const readable = new stream.Readable({
   read: () => {}
 });
 
-assert.throws(() => readable.push([]), /Invalid non-string\/buffer chunk/);
-assert.throws(() => readable.push({}), /Invalid non-string\/buffer chunk/);
-assert.throws(() => readable.push(0), /Invalid non-string\/buffer chunk/);
+assert.throws(
+  () => { return readable.push([]); },
+  /Invalid non-string\/buffer chunk/
+);
+assert.throws(
+  () => { return readable.push({}); },
+  /Invalid non-string\/buffer chunk/
+);
+assert.throws(
+  () => { return readable.push(0); },
+  /Invalid non-string\/buffer chunk/
+);

--- a/test/parallel/test-stream-readable-with-unimplemented-_read.js
+++ b/test/parallel/test-stream-readable-with-unimplemented-_read.js
@@ -5,4 +5,4 @@ const assert = require('assert');
 
 const readable = new stream.Readable();
 
-assert.throws(() => readable.read(), /not implemented/);
+assert.throws(() => { return readable.read(); }, /not implemented/);

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -18,7 +18,7 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
 
 assert.throws(() => {
   var m = new MyWritable({objectMode: true});
-  m.write(null, (err) => assert.ok(err));
+  m.write(null, (err) => { return assert.ok(err); });
 }, TypeError, 'May not write null values to stream');
 assert.doesNotThrow(() => {
   var m = new MyWritable({objectMode: true}).on('error', (e) => {
@@ -31,7 +31,7 @@ assert.doesNotThrow(() => {
 
 assert.throws(() => {
   var m = new MyWritable();
-  m.write(false, (err) => assert.ok(err));
+  m.write(false, (err) => { return assert.ok(err); });
 }, TypeError, 'Invalid non-string/buffer chunk');
 assert.doesNotThrow(() => {
   var m = new MyWritable().on('error', (e) => {
@@ -44,7 +44,7 @@ assert.doesNotThrow(() => {
 
 assert.doesNotThrow(() => {
   var m = new MyWritable({objectMode: true});
-  m.write(false, (err) => assert.ifError(err));
+  m.write(false, (err) => { return assert.ifError(err); });
 });
 assert.doesNotThrow(() => {
   var m = new MyWritable({objectMode: true}).on('error', (e) => {

--- a/test/parallel/test-timers-clear-null-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-null-does-not-throw-error.js
@@ -5,14 +5,14 @@ const assert = require('assert');
 // This test makes sure clearing timers with
 // 'null' or no input does not throw error
 
-assert.doesNotThrow(() => clearInterval(null));
+assert.doesNotThrow(() => { return clearInterval(null); });
 
-assert.doesNotThrow(() => clearInterval());
+assert.doesNotThrow(() => { return clearInterval(); });
 
-assert.doesNotThrow(() => clearTimeout(null));
+assert.doesNotThrow(() => { return clearTimeout(null); });
 
-assert.doesNotThrow(() => clearTimeout());
+assert.doesNotThrow(() => { return clearTimeout(); });
 
-assert.doesNotThrow(() => clearImmediate(null));
+assert.doesNotThrow(() => { return clearImmediate(null); });
 
-assert.doesNotThrow(() => clearImmediate());
+assert.doesNotThrow(() => { return clearImmediate(); });

--- a/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
+++ b/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
@@ -68,5 +68,5 @@ const handle1 = setTimeout(common.mustCall(function() {
 
 function getActiveTimers() {
   const activeHandles = process._getActiveHandles();
-  return activeHandles.filter((handle) => handle instanceof Timer);
+  return activeHandles.filter((handle) => { return handle instanceof Timer; });
 }

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -9,34 +9,38 @@ if (!common.hasCrypto) {
 const assert = require('assert');
 const tls = require('tls');
 
-assert.throws(() => tls.createSecureContext({ciphers: 1}),
+assert.throws(() => { return tls.createSecureContext({ciphers: 1}); },
               /TypeError: Ciphers must be a string/);
 
-assert.throws(() => tls.createServer({ciphers: 1}),
+assert.throws(() => { return tls.createServer({ciphers: 1}); },
               /TypeError: Ciphers must be a string/);
 
-assert.throws(() => tls.createSecureContext({key: 'dummykey', passphrase: 1}),
-              /TypeError: Pass phrase must be a string/);
+assert.throws(
+  () => { return tls.createSecureContext({key: 'dummykey', passphrase: 1}); },
+  /TypeError: Pass phrase must be a string/
+);
 
-assert.throws(() => tls.createServer({key: 'dummykey', passphrase: 1}),
-              /TypeError: Pass phrase must be a string/);
+assert.throws(
+  () => { return tls.createServer({key: 'dummykey', passphrase: 1}); },
+  /TypeError: Pass phrase must be a string/
+);
 
-assert.throws(() => tls.createServer({ecdhCurve: 1}),
+assert.throws(() => { return tls.createServer({ecdhCurve: 1}); },
               /TypeError: ECDH curve name must be a string/);
 
-assert.throws(() => tls.createServer({handshakeTimeout: 'abcd'}),
+assert.throws(() => { return tls.createServer({handshakeTimeout: 'abcd'}); },
               /TypeError: handshakeTimeout must be a number/);
 
-assert.throws(() => tls.createServer({sessionTimeout: 'abcd'}),
+assert.throws(() => { return tls.createServer({sessionTimeout: 'abcd'}); },
               /TypeError: Session timeout must be a 32-bit integer/);
 
-assert.throws(() => tls.createServer({ticketKeys: 'abcd'}),
+assert.throws(() => { return tls.createServer({ticketKeys: 'abcd'}); },
               /TypeError: Ticket keys must be a buffer/);
 
-assert.throws(() => tls.createServer({ticketKeys: new Buffer(0)}),
+assert.throws(() => { return tls.createServer({ticketKeys: new Buffer(0)}); },
               /TypeError: Ticket keys length must be 48 bytes/);
 
-assert.throws(() => tls.createSecurePair({}),
+assert.throws(() => { return tls.createSecurePair({}); },
               /Error: First argument must be a tls module SecureContext/);
 
 {

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -75,16 +75,19 @@ function testDHE2048() {
 
 testDHE1024();
 
-assert.throws(() => test(512, true, common.fail),
+assert.throws(() => { return test(512, true, common.fail); },
               /DH parameter is less than 1024 bits/);
 
 [0, -1, -Infinity, NaN].forEach((minDHSize) => {
-  assert.throws(() => tls.connect({ minDHSize }),
+  assert.throws(() => { return tls.connect({ minDHSize }); },
                 /minDHSize is not a positive number/);
 });
 
 [true, false, null, undefined, {}, [], '', '1'].forEach((minDHSize) => {
-  assert.throws(() => tls.connect({ minDHSize }), /minDHSize is not a number/);
+  assert.throws(
+    () => { return tls.connect({ minDHSize }); },
+    /minDHSize is not a number/
+  );
 });
 
 process.on('exit', function() {

--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -43,7 +43,7 @@ dns.lookup('localhost', {family: 6, all: true}, (err, addresses) => {
     throw err;
   }
 
-  if (addresses.some((val) => val.address === '::1'))
+  if (addresses.some((val) => { return val.address === '::1'; }))
     runTest();
   else
     common.skip('localhost does not resolve to ::1');

--- a/test/parallel/test-tls-external-accessor.js
+++ b/test/parallel/test-tls-external-accessor.js
@@ -13,12 +13,12 @@ const tls = require('tls');
 {
   const pctx = tls.createSecureContext().context;
   const cctx = Object.create(pctx);
-  assert.throws(() => cctx._external, /incompatible receiver/);
+  assert.throws(() => { return cctx._external; }, /incompatible receiver/);
   pctx._external;
 }
 {
   const pctx = tls.createSecurePair().credentials.context;
   const cctx = Object.create(pctx);
-  assert.throws(() => cctx._external, /incompatible receiver/);
+  assert.throws(() => { return cctx._external; }, /incompatible receiver/);
   pctx._external;
 }

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -20,7 +20,10 @@ tls.createServer(assert.fail)
 tls.createServer({})
   .listen(0, common.mustCall(close));
 
-assert.throws(() => tls.createServer('this is not valid'), TypeError);
+assert.throws(
+  () => { return tls.createServer('this is not valid'); },
+  TypeError
+);
 
 tls.createServer()
   .listen(0, common.mustCall(close));

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -36,7 +36,7 @@ server.listen(0, '127.0.0.1', function() {
   client.stdout.pipe(process.stdout);
   client.stderr.pipe(process.stderr);
   client.stderr.setEncoding('utf8');
-  client.stderr.on('data', (data) => stderr += data);
+  client.stderr.on('data', (data) => { return stderr += data; });
 
   client.once('exit', common.mustCall(function(exitCode) {
     assert.strictEqual(exitCode, 1);
@@ -44,7 +44,7 @@ server.listen(0, '127.0.0.1', function() {
   }));
 });
 
-server.on('tlsClientError', (err) => errors.push(err));
+server.on('tlsClientError', (err) => { return errors.push(err); });
 
 process.on('exit', function() {
   if (/unknown option -ssl3/.test(stderr)) {

--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -36,4 +36,4 @@ function test(ca, next) {
 
 const array = [ca1, ca2];
 const string = ca1 + '\n' + ca2;
-test(array, () => test(string, () => {}));
+test(array, () => { return test(string, () => {}); });

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -13,7 +13,7 @@ const handler = {
 const proxyObj = new Proxy(target, handler);
 
 // Inspecting the proxy should not actually walk it's properties
-assert.doesNotThrow(() => util.inspect(proxyObj, opts));
+assert.doesNotThrow(() => { return util.inspect(proxyObj, opts); });
 
 // getProxyDetails is an internal method, not intended for public use.
 // This is here to test that the internals are working correctly.
@@ -31,7 +31,7 @@ assert.strictEqual(processUtil.getProxyDetails({}), undefined);
 // and the get function on the handler object defined above
 // is actually invoked.
 assert.throws(
-  () => util.inspect(proxyObj)
+  () => { return util.inspect(proxyObj); }
 );
 
 // Yo dawg, I heard you liked Proxy so I put a Proxy

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -254,7 +254,7 @@ value.aprop = 42;
 assert.strictEqual(util.inspect(value), '{ [Function: value] aprop: 42 }');
 
 // Anonymous function with properties
-value = (() => function() {})();
+value = (() => { return function() {}; })();
 value.aprop = 42;
 assert.strictEqual(util.inspect(value), '{ [Function] aprop: 42 }');
 
@@ -931,4 +931,4 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
   }, /"options" must be an object/);
 }
 
-assert.doesNotThrow(() => util.inspect(process));
+assert.doesNotThrow(() => { return util.inspect(process); });

--- a/test/parallel/test-util-sigint-watchdog.js
+++ b/test/parallel/test-util-sigint-watchdog.js
@@ -50,7 +50,7 @@ if (common.isWindows) {
     assert.strictEqual(hadPendingSignals1, false);
     assert.strictEqual(hadPendingSignals2, true);
   }));
-}].reduceRight((a, b) => common.mustCall(b).bind(null, a))();
+}].reduceRight((a, b) => { return common.mustCall(b).bind(null, a); })();
 
 function waitForPendingSignal(cb) {
   if (binding.watchdogHasPendingSigint())

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -28,7 +28,9 @@ const expectedHeapSpaces = [
   'large_object_space'
 ];
 const heapSpaceStatistics = v8.getHeapSpaceStatistics();
-const actualHeapSpaceNames = heapSpaceStatistics.map((s) => s.space_name);
+const actualHeapSpaceNames = heapSpaceStatistics.map(
+  (s) => { return s.space_name; }
+);
 assert.deepStrictEqual(actualHeapSpaceNames.sort(), expectedHeapSpaces.sort());
 heapSpaceStatistics.forEach((heapSpace) => {
   assert.strictEqual(typeof heapSpace.space_name, 'string');

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -83,6 +83,6 @@ assert.strictEqual(ctx.x, undefined);  // Not copied out by cloneProperty().
 assert.strictEqual(vm.runInContext('x', ctx), 42);
 vm.runInContext('x = 0', ctx);                      // Does not throw but x...
 assert.strictEqual(vm.runInContext('x', ctx), 42);  // ...should be unaltered.
-assert.throws(() => vm.runInContext('"use strict"; x = 0', ctx),
+assert.throws(() => { return vm.runInContext('"use strict"; x = 0', ctx); },
               /Cannot assign to read only property 'x'/);
 assert.strictEqual(vm.runInContext('x', ctx), 42);

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -18,7 +18,9 @@ for (const test of tests) {
     continue;
 
   if (test.failure) {
-    assert.throws(() => new URL(test.input, test.base), /Invalid URL/);
+    assert.throws(() => {
+      return new URL(test.input, test.base);
+    }, /Invalid URL/);
   } else {
     assert.doesNotThrow(() => {
       const url = new URL(test.input, test.base);

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -21,7 +21,7 @@ params = new URLSearchParams(params);
 assert.strictEqual(params + '', 'a=b');
 
 // URLSearchParams constructor, empty.
-assert.throws(() => URLSearchParams(), TypeError,
+assert.throws(() => { return URLSearchParams(); }, TypeError,
               'Calling \'URLSearchParams\' without \'new\' should throw.');
 // assert.throws(() => new URLSearchParams(DOMException.prototype), TypeError);
 assert.throws(() => {

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -15,12 +15,12 @@ assert.strictEqual(sp.toString(), '');
 assert.strictEqual(m.search, '');
 
 assert(!sp.has('a'));
-values.forEach((i) => sp.set('a', i));
+values.forEach((i) => { return sp.set('a', i); });
 assert(sp.has('a'));
 assert.strictEqual(sp.get('a'), '[object Object]');
 sp.delete('a');
 assert(!sp.has('a'));
-values.forEach((i) => sp.append('a', i));
+values.forEach((i) => { return sp.append('a', i); });
 assert(sp.has('a'));
 assert.strictEqual(sp.getAll('a').length, 6);
 assert.strictEqual(sp.get('a'), 'a');

--- a/test/parallel/test-zlib-close-after-error.js
+++ b/test/parallel/test-zlib-close-after-error.js
@@ -9,7 +9,7 @@ const decompress = zlib.createGunzip(15);
 
 decompress.on('error', common.mustCall((err) => {
   assert.strictEqual(decompress._closed, true);
-  assert.doesNotThrow(() => decompress.close());
+  assert.doesNotThrow(() => { return decompress.close(); });
 }));
 
 assert.strictEqual(decompress._closed, false);

--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -50,7 +50,7 @@ fs.createReadStream(pmmFileGz)
   .on('error', (err) => {
     assert.ifError(err);
   })
-  .on('data', (data) => pmmResultBuffers.push(data))
+  .on('data', (data) => { return pmmResultBuffers.push(data); })
   .on('finish', common.mustCall(() => {
     assert.deepStrictEqual(Buffer.concat(pmmResultBuffers), pmmExpected,
                            'result should match original random garbage');
@@ -64,7 +64,7 @@ fs.createReadStream(pmmFileGz)
     .on('error', (err) => {
       assert.ifError(err);
     })
-    .on('data', (data) => resultBuffers.push(data))
+    .on('data', (data) => { return resultBuffers.push(data); })
     .on('finish', common.mustCall(() => {
       assert.strictEqual(
         Buffer.concat(resultBuffers).toString(),

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -28,7 +28,7 @@ data = Buffer.concat([
   Buffer(10).fill(0)
 ]);
 
-assert.throws(() => zlib.gunzipSync(data));
+assert.throws(() => { return zlib.gunzipSync(data); });
 
 zlib.gunzip(data, common.mustCall((err, result) => {
   assert(err);
@@ -42,7 +42,7 @@ data = Buffer.concat([
   Buffer([0x1f, 0x8b, 0xff, 0xff])
 ]);
 
-assert.throws(() => zlib.gunzipSync(data));
+assert.throws(() => { return zlib.gunzipSync(data); });
 
 zlib.gunzip(data, common.mustCall((err, result) => {
   assert(err);

--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -24,7 +24,7 @@ const inputString = 'ΩΩLorem ipsum dolor sit amet, consectetur adipiscing eli'
   zlib[methods.comp](inputString, function(err, compressed) {
     assert(!err);
     const truncated = compressed.slice(0, compressed.length / 2);
-    const toUTF8 = (buffer) => buffer.toString('utf-8');
+    const toUTF8 = (buffer) => { return buffer.toString('utf-8'); };
 
     // sync sanity
     assert.doesNotThrow(function() {

--- a/test/parallel/test-zlib-unzip-one-byte-chunks.js
+++ b/test/parallel/test-zlib-unzip-one-byte-chunks.js
@@ -14,7 +14,7 @@ const unzip = zlib.createUnzip()
   .on('error', (err) => {
     assert.ifError(err);
   })
-  .on('data', (data) => resultBuffers.push(data))
+  .on('data', (data) => { return resultBuffers.push(data); })
   .on('finish', common.mustCall(() => {
     assert.deepStrictEqual(Buffer.concat(resultBuffers).toString(), 'abcdef',
                            'result should match original string');

--- a/test/pummel/test-crypto-timing-safe-equal-benchmarks.js
+++ b/test/pummel/test-crypto-timing-safe-equal-benchmarks.js
@@ -69,13 +69,15 @@ function getTValue(compareFunc) {
 
 // Returns the mean of an array
 function mean(array) {
-  return array.reduce((sum, val) => sum + val, 0) / array.length;
+  return array.reduce((sum, val) => { return sum + val; }, 0) / array.length;
 }
 
 // Returns the sample standard deviation of an array
 function standardDeviation(array) {
   const arrMean = mean(array);
-  const total = array.reduce((sum, val) => sum + Math.pow(val - arrMean, 2), 0);
+  const total = array.reduce((sum, val) => {
+    return sum + Math.pow(val - arrMean, 2);
+  }, 0);
   return Math.sqrt(total / (array.length - 1));
 }
 
@@ -92,7 +94,7 @@ function combinedStandardDeviation(array1, array2) {
 // a very long time to execute.
 function filterOutliers(array) {
   const arrMean = mean(array);
-  return array.filter((value) => value / arrMean < 50);
+  return array.filter((value) => { return value / arrMean < 50; });
 }
 
 // t_(0.99995, ∞)
@@ -115,7 +117,7 @@ assert(
 // As a sanity check to make sure the statistical tests are working, run the
 // same benchmarks again, this time with an unsafe comparison function. In this
 // case the t-value should be above the threshold.
-const unsafeCompare = (bufA, bufB) => bufA.equals(bufB);
+const unsafeCompare = (bufA, bufB) => { return bufA.equals(bufB); };
 const t2 = getTValue(unsafeCompare);
 assert(
   Math.abs(t2) > T_THRESHOLD,

--- a/test/tick-processor/tick-processor-base.js
+++ b/test/tick-processor/tick-processor-base.js
@@ -20,11 +20,11 @@ function runTest(test) {
   });
 
   let ticks = '';
-  proc.stdout.on('data', (chunk) => ticks += chunk);
+  proc.stdout.on('data', (chunk) => { return ticks += chunk; });
 
   // Try to match after timeout
   setTimeout(() => {
-    match(test.pattern, proc, () => ticks);
+    match(test.pattern, proc, () => { return ticks; });
   }, RETRY_TIMEOUT);
 }
 
@@ -41,14 +41,16 @@ function match(pattern, parent, ticks) {
   });
 
   let out = '';
-  proc.stdout.on('data', (chunk) => out += chunk);
+  proc.stdout.on('data', (chunk) => { return out += chunk; });
   proc.stdout.once('end', () => {
     proc.once('exit', () => {
       fs.unlinkSync(LOG_FILE);
 
       // Retry after timeout
       if (!pattern.test(out))
-        return setTimeout(() => match(pattern, parent, ticks), RETRY_TIMEOUT);
+        return setTimeout(() => {
+          return match(pattern, parent, ticks);
+        }, RETRY_TIMEOUT);
 
       parent.stdout.removeAllListeners();
       parent.kill();

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -48,8 +48,8 @@ function once(fn) {
 
 function verifyFiles(files, blockName, onprogress, ondone) {
   // must have a .cc and a .js to be a valid test
-  if (!Object.keys(files).some((name) => /\.cc$/.test(name)) ||
-      !Object.keys(files).some((name) => /\.js$/.test(name))) {
+  if (!Object.keys(files).some((name) => { return /\.cc$/.test(name); }) ||
+      !Object.keys(files).some((name) => { return /\.js$/.test(name); })) {
     return;
   }
 

--- a/tools/eslint-rules/align-function-arguments.js
+++ b/tools/eslint-rules/align-function-arguments.js
@@ -71,6 +71,8 @@ function checkArgumentAlignment(context, node) {
 
 module.exports = function(context) {
   return {
-    'CallExpression': (node) => checkArgumentAlignment(context, node)
+    'CallExpression': (node) => {
+      return checkArgumentAlignment(context, node);
+    }
   };
 };

--- a/tools/eslint-rules/align-multiline-assignment.js
+++ b/tools/eslint-rules/align-multiline-assignment.js
@@ -62,7 +62,7 @@ function testDeclaration(context, node) {
 
 module.exports = function(context) {
   return {
-    'AssignmentExpression': (node) => testAssignment(context, node),
-    'VariableDeclaration': (node) => testDeclaration(context, node)
+    'AssignmentExpression': (node) => { return testAssignment(context, node); },
+    'VariableDeclaration': (node) => { return testDeclaration(context, node); }
   };
 };

--- a/tools/eslint-rules/assert-throws-arguments.js
+++ b/tools/eslint-rules/assert-throws-arguments.js
@@ -54,7 +54,7 @@ module.exports = {
   },
   create: function(context) {
     return {
-      CallExpression: (node) => checkThrowsArguments(context, node)
+      CallExpression: (node) => { return checkThrowsArguments(context, node); }
     };
   }
 };

--- a/tools/eslint-rules/buffer-constructor.js
+++ b/tools/eslint-rules/buffer-constructor.js
@@ -19,7 +19,7 @@ function test(context, node) {
 
 module.exports = function(context) {
   return {
-    'NewExpression': (node) => test(context, node),
-    'CallExpression': (node) => test(context, node)
+    'NewExpression': (node) => { return test(context, node); },
+    'CallExpression': (node) => { return test(context, node); }
   };
 };

--- a/tools/eslint-rules/no-useless-regex-char-class-escape.js
+++ b/tools/eslint-rules/no-useless-regex-char-class-escape.js
@@ -155,30 +155,39 @@ module.exports = {
               // either edge of the character class. To account for this,
               // filter out '-' characters that appear in the middle of a
               // character class.
-              .filter((charInfo) => !(charInfo.text === '-' &&
-                                      (charInfo.index !== charClass.start &&
-                                       charInfo.index !== charClass.end)))
+              .filter((charInfo) => {
+                return !(charInfo.text === '-' &&
+                  (charInfo.index !== charClass.start &&
+                   charInfo.index !== charClass.end));
+              })
 
               // The '^' character is a special case if it's at the beginning
               // of the character class. To account for this, filter out '^'
               // characters that appear at the start of a character class.
               //
-              .filter((charInfo) => !(charInfo.text === '^' &&
-                                    charInfo.index === charClass.start))
+              .filter((charInfo) => {
+                return !(charInfo.text === '^' &&
+                  charInfo.index === charClass.start);
+              })
 
               // Filter out characters that aren't escaped.
-              .filter((charInfo) => charInfo.escaped)
+              .filter((charInfo) => { return charInfo.escaped; })
 
               // Filter out characters that are valid to escape, based on
               // their position in the regular expression.
-              .filter((charInfo) => !REGEX_CHARCLASS_ESCAPES.has(charInfo.text))
+              .filter((charInfo) => {
+                return !REGEX_CHARCLASS_ESCAPES.has(charInfo.text);
+              })
 
               // Filter out overridden character list.
-              .filter((charInfo) => !overrideSet.has(charInfo.text))
+              .filter((charInfo) => {
+                return !overrideSet.has(charInfo.text);
+              })
 
               // Report all the remaining characters.
-              .forEach((charInfo) =>
-                report(node, charInfo.index, charInfo.text));
+              .forEach((charInfo) => {
+                return report(node, charInfo.index, charInfo.text);
+              });
           });
       }
     }


### PR DESCRIPTION
tools: enable ESLint arrow-body-style rule
    
Always surround arrow function bodies that consist of a single expression in their own
block.
       
Arrow functions that are a single expression do not need to be their own
blocks. Use blocks in that situation for consistency and clarity.

The "use or do not use blocks" discussion came up in a pull request.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test benchmark lib

