### PR TITLE
timer,domain: maintain order of timers upon uncaught exception

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -156,11 +156,18 @@ function TimersList(msecs, unrefed) {
   this._timer = new TimerWrap();
   this._unrefed = unrefed;
   this.msecs = msecs;
+  this.nextTick = false;
 }
 
 function listOnTimeout() {
   var list = this._list;
   var msecs = list.msecs;
+
+  if (list.nextTick) {
+    list.nextTick = false;
+    process.nextTick(listOnTimeoutNT, list);
+    return;
+  }
 
   debug('timeout callback %d', msecs);
 
@@ -239,6 +246,14 @@ function tryOnTimeout(timer, list) {
   } finally {
     if (!threw) return;
 
+    // Postpone all later list events to next tick. We need to do this
+    // so that the events are called in the order they were created.
+    const lists = list._unrefed === true ? unrefedLists : refedLists;
+    for (var key in lists) {
+      if (key > list.msecs) {
+        lists[key].nextTick = true;
+      }
+    }
     // We need to continue processing after domain error handling
     // is complete, but not by using whatever domain was left over
     // when the timeout threw its exception.

--- a/test/parallel/test-domain-timers-uncaught-exception.js
+++ b/test/parallel/test-domain-timers-uncaught-exception.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that the timer callbacks are called in the order in which
+// they were created in the event of an unhandled exception in the domain.
+
+const domain = require('domain').create();
+const assert = require('assert');
+
+let first = false;
+
+domain.run(function() {
+  setTimeout(() => { throw new Error('FAIL'); }, 1);
+  setTimeout(() => { first = true; }, 1);
+  setTimeout(() => { assert.strictEqual(first, true); }, 2);
+
+  // Ensure that 2 ms have really passed
+  let i = 1e6;
+  while (i--);
+});
+
+domain.once('error', common.mustCall((err) => {
+  assert(err);
+  assert.strictEqual(err.message, 'FAIL');
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timer, domain, tests

##### Description of change
<!-- Provide a description of the change below this comment. -->
The issue in https://github.com/nodejs/node/issues/1271 shows that the callback for timers do not get called in
 the order they were created if the domain handles an "uncaught exception"
