### PR TITLE
test: refactor several parallel/test-timer tests

### DIFF
--- a/test/parallel/test-timers-args.js
+++ b/test/parallel/test-timers-args.js
@@ -7,7 +7,7 @@ function range(n) {
 }
 
 function timeout(nargs) {
-  var args = range(nargs);
+  const args = range(nargs);
   setTimeout.apply(null, [callback, 1].concat(args));
 
   function callback() {
@@ -17,8 +17,8 @@ function timeout(nargs) {
 }
 
 function interval(nargs) {
-  var args = range(nargs);
-  var timer = setTimeout.apply(null, [callback, 1].concat(args));
+  const args = range(nargs);
+  const timer = setTimeout.apply(null, [callback, 1].concat(args));
 
   function callback() {
     clearInterval(timer);

--- a/test/parallel/test-timers-immediate-queue.js
+++ b/test/parallel/test-timers-immediate-queue.js
@@ -6,15 +6,13 @@ const assert = require('assert');
 // but immediates queued while processing the current queue should happen
 // on the next turn of the event loop.
 
-// in v0.10 hit should be 1, because we only process one cb per turn
-// in v0.11 and beyond it should be the exact same size of QUEUE
-// if we're letting things recursively add to the immediate QUEUE hit will be
-// > QUEUE
+// hit should be the exact same size of QUEUE, if we're letting things
+// recursively add to the immediate QUEUE hit will be > QUEUE
 
-var ticked = false;
+let ticked = false;
 
-var hit = 0;
-var QUEUE = 1000;
+let hit = 0;
+const QUEUE = 1000;
 
 function run() {
   if (hit === 0)

--- a/test/parallel/test-timers-non-integer-delay.js
+++ b/test/parallel/test-timers-non-integer-delay.js
@@ -1,4 +1,6 @@
 'use strict';
+require('../common');
+
 /*
  * This test makes sure that non-integer timer delays do not make the process
  * hang. See https://github.com/joyent/node/issues/8065 and
@@ -15,13 +17,11 @@
  * it 100%.
  */
 
-require('../common');
+const TIMEOUT_DELAY = 1.1;
+const NB_TIMEOUTS_FIRED = 50;
 
-var TIMEOUT_DELAY = 1.1;
-var NB_TIMEOUTS_FIRED = 50;
-
-var nbTimeoutFired = 0;
-var interval = setInterval(function() {
+let nbTimeoutFired = 0;
+const interval = setInterval(function() {
   ++nbTimeoutFired;
   if (nbTimeoutFired === NB_TIMEOUTS_FIRED) {
     clearInterval(interval);

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -1,22 +1,22 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-var Timer = process.binding('timer_wrap').Timer;
 
-var N = 30;
+const Timer = process.binding('timer_wrap').Timer;
+const N = 30;
 
-var last_i = 0;
-var last_ts = 0;
+let last_i = 0;
+let last_ts = 0;
 
-var f = function(i) {
+const f = function(i) {
   if (i <= N) {
     // check order
-    assert.equal(i, last_i + 1, 'order is broken: ' + i + ' != ' +
+    assert.strictEqual(i, last_i + 1, 'order is broken: ' + i + ' != ' +
                  last_i + ' + 1');
     last_i = i;
 
     // check that this iteration is fired at least 1ms later than the previous
-    var now = Timer.now();
+    const now = Timer.now();
     console.log(i, now);
     assert(now >= last_ts + 1,
            'current ts ' + now + ' < prev ts ' + last_ts + ' + 1');

--- a/test/parallel/test-timers-uncaught-exception.js
+++ b/test/parallel/test-timers-uncaught-exception.js
@@ -6,17 +6,13 @@ const errorMsg = 'BAM!';
 // the first timer throws...
 setTimeout(common.mustCall(function() {
   throw new Error(errorMsg);
-}), 100);
+}), 1);
 
 // ...but the second one should still run
-setTimeout(common.mustCall(function() {}), 100);
+setTimeout(common.mustCall(function() {}), 1);
 
 function uncaughtException(err) {
   assert.strictEqual(err.message, errorMsg);
 }
 
 process.on('uncaughtException', common.mustCall(uncaughtException));
-
-process.on('exit', function() {
-  process.removeListener('uncaughtException', uncaughtException);
-});

--- a/test/parallel/test-timers-uncaught-exception.js
+++ b/test/parallel/test-timers-uncaught-exception.js
@@ -1,40 +1,22 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
-
-var exceptions = 0;
-var timer1 = 0;
-var timer2 = 0;
+const errorMsg = 'BAM!';
 
 // the first timer throws...
-console.error('set first timer');
-setTimeout(function() {
-  console.error('first timer');
-  timer1++;
-  throw new Error('BAM!');
-}, 100);
+setTimeout(common.mustCall(function() {
+  throw new Error(errorMsg);
+}), 100);
 
 // ...but the second one should still run
-console.error('set second timer');
-setTimeout(function() {
-  console.error('second timer');
-  assert.equal(timer1, 1);
-  timer2++;
-}, 100);
+setTimeout(common.mustCall(function() {}), 100);
 
 function uncaughtException(err) {
-  console.error('uncaught handler');
-  assert.equal(err.message, 'BAM!');
-  exceptions++;
+  assert.strictEqual(err.message, errorMsg);
 }
-process.on('uncaughtException', uncaughtException);
 
-var exited = false;
+process.on('uncaughtException', common.mustCall(uncaughtException));
+
 process.on('exit', function() {
-  assert(!exited);
-  exited = true;
   process.removeListener('uncaughtException', uncaughtException);
-  assert.equal(exceptions, 1);
-  assert.equal(timer1, 1);
-  assert.equal(timer2, 1);
 });


### PR DESCRIPTION
Change var to const/let. Simplify test-timers-uncaught-exception.

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

##### Description of change
<!-- Provide a description of the change below this comment. -->
Refactored several of the parallel/test-timer-* tests - mainly changing vars to const and adding common.mustCall() where possible. parallel/test-timers-uncaught-exception has been simplified. Any further suggestions for improvement are welcome 😄 