### PR TITLE
doc: require two-factor authentication

### DIFF
--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -12,8 +12,12 @@ onboarding session.
 
 ## Fifteen minutes before the onboarding session
 
-* Prior to the onboarding session, add the new Collaborators to
-[the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators).
+* Prior to the onboarding session, add the new Collaborator to
+  [the Collaborators team](https://github.com/orgs/nodejs/teams/collaborators).
+  Note that this is the step that gives the account elevated privileges, so
+  do not perform this step (or any subsequent steps) unless two-factor
+  authentication is enabled on the new Collaborator's GitHub account.
+
 
 ## Onboarding session
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -5,9 +5,9 @@ onboarding session.
 
 ## One week before the onboarding session
 
-* Ask the new Collaborator if they are using two-factor authentication on their
-  GitHub account. If they are not, suggest that they enable it as their account
-  will have elevated privileges in many of the Node.js repositories.
+* Confirm that the new Collaborator is using two-factor authentication on their
+  GitHub account. Collaborator accounts have elevated privileges and are
+  required to use two-factor authentication.
 
 ## Fifteen minutes before the onboarding session
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -6,8 +6,9 @@ onboarding session.
 ## One week before the onboarding session
 
 * Confirm that the new Collaborator is using two-factor authentication on their
-  GitHub account. Collaborator accounts have elevated privileges and are
-  required to use two-factor authentication.
+  GitHub account. Without two-factor authentication enabled, accounts cannot be
+  given elevated privileges such as the ability to land code in the main
+  repository or to start continuous integration (CI) jobs.
 
 ## Fifteen minutes before the onboarding session
 

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -6,8 +6,8 @@ onboarding session.
 ## One week before the onboarding session
 
 * Confirm that the new Collaborator is using two-factor authentication on their
-  GitHub account. Without two-factor authentication enabled, accounts cannot be
-  given elevated privileges such as the ability to land code in the main
+  GitHub account. Unless two-factor authentication is enabled, do not give an
+  account elevated privileges such as the ability to land code in the main
   repository or to start continuous integration (CI) jobs.
 
 ## Fifteen minutes before the onboarding session


### PR DESCRIPTION
Collaborators have elevated privileges. The CTC now requires
Collaborator accounts to have two-factor authentication. This changes
wording in the onboarding documentation to make it clear that two-factor
authentication is required and not merely recommended.

/cc @nodejs/ctc 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc