### PR TITLE
test: refactor test-stream-unshift-read-race

### DIFF
--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../common');
-var assert = require('assert');
+const common = require('../common');
+const assert = require('assert');
 
 // This test verifies that:
 // 1. unshift() does not cause colliding _read() calls.
@@ -9,19 +9,19 @@ var assert = require('assert');
 // 3. push() after the EOF signaling null is an error.
 // 4. _read() is not called after pushing the EOF null chunk.
 
-var stream = require('stream');
-var hwm = 10;
-var r = stream.Readable({ highWaterMark: hwm });
-var chunks = 10;
+const stream = require('stream');
+const hwm = 10;
+const r = stream.Readable({ highWaterMark: hwm });
+const chunks = 10;
 
-var data = Buffer.allocUnsafe(chunks * hwm + Math.ceil(hwm / 2));
-for (var i = 0; i < data.length; i++) {
-  var c = 'asdf'.charCodeAt(i % 4);
+const data = Buffer.allocUnsafe(chunks * hwm + Math.ceil(hwm / 2));
+for (let i = 0; i < data.length; i++) {
+  const c = 'asdf'.charCodeAt(i % 4);
   data[i] = c;
 }
 
-var pos = 0;
-var pushedNull = false;
+let pos = 0;
+let pushedNull = false;
 r._read = function(n) {
   assert(!pushedNull, '_read after null push');
 
@@ -30,7 +30,7 @@ r._read = function(n) {
 
   function push(fast) {
     assert(!pushedNull, 'push() after null push');
-    var c = pos >= data.length ? null : data.slice(pos, pos + n);
+    const c = pos >= data.length ? null : data.slice(pos, pos + n);
     pushedNull = c === null;
     if (fast) {
       pos += n;
@@ -41,7 +41,7 @@ r._read = function(n) {
         pos += n;
         r.push(c);
         if (c === null) pushError();
-      });
+      }, 1);
     }
   }
 };
@@ -49,29 +49,26 @@ r._read = function(n) {
 function pushError() {
   assert.throws(function() {
     r.push(Buffer.allocUnsafe(1));
-  });
+  }, /^Error: stream.push\(\) after EOF$/);
 }
 
 
-var w = stream.Writable();
-var written = [];
+const w = stream.Writable();
+const written = [];
 w._write = function(chunk, encoding, cb) {
   written.push(chunk.toString());
   cb();
 };
 
-var ended = false;
-r.on('end', function() {
-  assert(!ended, 'end emitted more than once');
+r.on('end', common.mustCall(function() {
   assert.throws(function() {
     r.unshift(Buffer.allocUnsafe(1));
-  });
-  ended = true;
+  }, /^Error: stream.unshift\(\) after end event$/);
   w.end();
-});
+}));
 
 r.on('readable', function() {
-  var chunk;
+  let chunk;
   while (null !== (chunk = r.read(10))) {
     w.write(chunk);
     if (chunk.length > 4)
@@ -79,21 +76,19 @@ r.on('readable', function() {
   }
 });
 
-var finished = false;
-w.on('finish', function() {
-  finished = true;
+w.on('finish', common.mustCall(function() {
   // each chunk should start with 1234, and then be asfdasdfasdf...
   // The first got pulled out before the first unshift('1234'), so it's
   // lacking that piece.
-  assert.equal(written[0], 'asdfasdfas');
-  var asdf = 'd';
+  assert.strictEqual(written[0], 'asdfasdfas');
+  let asdf = 'd';
   console.error('0: %s', written[0]);
-  for (var i = 1; i < written.length; i++) {
+  for (let i = 1; i < written.length; i++) {
     console.error('%s: %s', i.toString(32), written[i]);
-    assert.equal(written[i].slice(0, 4), '1234');
-    for (var j = 4; j < written[i].length; j++) {
-      var c = written[i].charAt(j);
-      assert.equal(c, asdf);
+    assert.strictEqual(written[i].slice(0, 4), '1234');
+    for (let j = 4; j < written[i].length; j++) {
+      const c = written[i].charAt(j);
+      assert.strictEqual(c, asdf);
       switch (asdf) {
         case 'a': asdf = 's'; break;
         case 's': asdf = 'd'; break;
@@ -102,11 +97,9 @@ w.on('finish', function() {
       }
     }
   }
-});
+}));
 
 process.on('exit', function() {
-  assert.equal(written.length, 18);
-  assert(ended, 'stream ended');
-  assert(finished, 'stream finished');
+  assert.strictEqual(written.length, 18);
   console.log('ok');
 });


### PR DESCRIPTION
* add RegExp as second argument to assert.throws()
* replace process.on('exit', ...) boolean checks with common.mustCall()
* assert.equal() -> assert.strictEqual()
* add 1 ms duration as second argument to setTimeout()
* var -> const

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test stream