### PR TITLE
src: reduce test_inspector_socket_server output

### DIFF
--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -214,12 +214,12 @@ class SocketSession {
 InspectorSocketServer::InspectorSocketServer(SocketServerDelegate* delegate,
                                              int port,
                                              FILE* out) : loop_(nullptr),
-                                                         delegate_(delegate),
-                                                         port_(port),
-                                                         server_(uv_tcp_t()),
-                                                         closer_(nullptr),
-                                                         next_session_id_(0),
-                                                         out_(out) { }
+                                                          delegate_(delegate),
+                                                          port_(port),
+                                                          server_(uv_tcp_t()),
+                                                          closer_(nullptr),
+                                                          next_session_id_(0),
+                                                          out_(out) { }
 
 
 // static

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -74,22 +74,27 @@ void OnBufferAlloc(uv_handle_t* handle, size_t len, uv_buf_t* buf) {
   buf->len = len;
 }
 
-void PrintDebuggerReadyMessage(int port, const std::vector<std::string>& ids) {
-  fprintf(stderr,
+void PrintDebuggerReadyMessage(int port,
+                               const std::vector<std::string>& ids,
+                               FILE* out) {
+  if (out == NULL) {
+    return;
+  }
+  fprintf(out,
           "Debugger listening on port %d.\n"
           "Warning: This is an experimental feature "
           "and could change at any time.\n",
           port);
   if (ids.size() == 1)
-    fprintf(stderr, "To start debugging, open the following URL in Chrome:\n");
+    fprintf(out, "To start debugging, open the following URL in Chrome:\n");
   if (ids.size() > 1)
-    fprintf(stderr, "To start debugging, open the following URLs in Chrome:\n");
+    fprintf(out, "To start debugging, open the following URLs in Chrome:\n");
   for (const std::string& id : ids) {
-    fprintf(stderr,
+    fprintf(out,
             "    chrome-devtools://devtools/bundled/inspector.html?"
             "experiments=true&v8only=true&ws=%s\n", GetWsUrl(port, id).c_str());
   }
-  fflush(stderr);
+  fflush(out);
 }
 
 void SendHttpResponse(InspectorSocket* socket, const std::string& response) {
@@ -207,12 +212,14 @@ class SocketSession {
 };
 
 InspectorSocketServer::InspectorSocketServer(SocketServerDelegate* delegate,
-                                             int port) : loop_(nullptr),
+                                             int port,
+                                             FILE* out) : loop_(nullptr),
                                                          delegate_(delegate),
                                                          port_(port),
                                                          server_(uv_tcp_t()),
                                                          closer_(nullptr),
-                                                         next_session_id_(0) { }
+                                                         next_session_id_(0),
+                                                         out_(out) { }
 
 
 // static
@@ -260,7 +267,7 @@ void InspectorSocketServer::SessionTerminated(int session_id) {
   delegate_->EndSession(session_id);
   if (connected_sessions_.empty() &&
       uv_is_active(reinterpret_cast<uv_handle_t*>(&server_))) {
-    PrintDebuggerReadyMessage(port_, delegate_->GetTargetIds());
+    PrintDebuggerReadyMessage(port_, delegate_->GetTargetIds(), out_);
   }
 }
 
@@ -337,10 +344,12 @@ bool InspectorSocketServer::Start(uv_loop_t* loop) {
                     SocketConnectedCallback);
   }
   if (err == 0 && connected_sessions_.empty()) {
-    PrintDebuggerReadyMessage(port_, delegate_->GetTargetIds());
+    PrintDebuggerReadyMessage(port_, delegate_->GetTargetIds(), out_);
   }
   if (err != 0 && connected_sessions_.empty()) {
-    fprintf(stderr, "Unable to open devtools socket: %s\n", uv_strerror(err));
+    if (out_ != NULL) {
+      fprintf(out_, "Unable to open devtools socket: %s\n", uv_strerror(err));
+    }
     uv_close(reinterpret_cast<uv_handle_t*>(&server_), nullptr);
     return false;
   }

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -32,7 +32,9 @@ class SocketServerDelegate {
 class InspectorSocketServer {
  public:
   using ServerCallback = void (*)(InspectorSocketServer*);
-  InspectorSocketServer(SocketServerDelegate* delegate, int port);
+  InspectorSocketServer(SocketServerDelegate* delegate,
+                        int port,
+                        FILE* out = stderr);
   bool Start(uv_loop_t* loop);
   void Stop(ServerCallback callback);
   void Send(int session_id, const std::string& message);
@@ -66,6 +68,7 @@ class InspectorSocketServer {
   Closer* closer_;
   std::map<int, SocketSession*> connected_sessions_;
   int next_session_id_;
+  FILE* out_;
 
   friend class SocketSession;
   friend class Closer;

--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -300,9 +300,9 @@ class SocketWrapper {
 class ServerHolder {
  public:
   template <typename Delegate>
-  ServerHolder(Delegate* delegate, int port)
+  ServerHolder(Delegate* delegate, int port, FILE* out = NULL)
                : closed(false), paused(false), sessions_terminated(false),
-                 server_(delegate, port) {
+                 server_(delegate, port, out) {
     delegate->Connect(&server_);
   }
 


### PR DESCRIPTION
Currently, when test/cctest/test_inspector_socket_server.cc is run there
is output written to stderr by src/inspector_socket_server.cc which is
interleaved with the gtest report:

Debugger listening on port 9229.
Warning: This is an experimental feature and could change at any time.
To start debugging, open the following URLs in Chrome:
  ...

The goal of this commit is to remove the above logged information
by introducing an out_ member in the InspectorSocketServer class
which defaults to stderr (keeping the current behavior).

Setting out_ to NULL is supported in which case nothing will be written
and is what the test has been configured with. When working on specific
test case the appropriate output stream can be specified for the
ServerHolder constructor to limit logging to that test case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src
