### PR TITLE
test: improve the code in test-fs-access

### DIFF
--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -3,11 +3,11 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-var doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
-var readOnlyFile = path.join(common.tmpDir, 'read_only_file');
-var readWriteFile = path.join(common.tmpDir, 'read_write_file');
+const doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
+const readOnlyFile = path.join(common.tmpDir, 'read_only_file');
+const readWriteFile = path.join(common.tmpDir, 'read_write_file');
 
-var removeFile = function(file) {
+const removeFile = function(file) {
   try {
     fs.unlinkSync(file);
   } catch (err) {
@@ -15,7 +15,7 @@ var removeFile = function(file) {
   }
 };
 
-var createFileWithPerms = function(file, mode) {
+const createFileWithPerms = function(file, mode) {
   removeFile(file);
   fs.writeFileSync(file, '');
   fs.chmodSync(file, mode);
@@ -48,7 +48,7 @@ createFileWithPerms(readWriteFile, 0o666);
  * id, but that's fine. In this case, it is the responsability of the
  * continuous integration platform to take care of that.
  */
-var hasWriteAccessForReadonlyFile = false;
+let hasWriteAccessForReadonlyFile = false;
 if (!common.isWindows && process.getuid() === 0) {
   hasWriteAccessForReadonlyFile = true;
   try {
@@ -63,62 +63,62 @@ assert.strictEqual(typeof fs.R_OK, 'number');
 assert.strictEqual(typeof fs.W_OK, 'number');
 assert.strictEqual(typeof fs.X_OK, 'number');
 
-fs.access(__filename, function(err) {
-  assert.strictEqual(err, null, 'error should not exist');
-});
+fs.access(__filename, common.mustCall((err) => {
+  assert.ifError(err);
+}));
 
-fs.access(__filename, fs.R_OK, function(err) {
-  assert.strictEqual(err, null, 'error should not exist');
-});
+fs.access(__filename, fs.R_OK, common.mustCall((err) => {
+  assert.ifError(err);
+}));
 
-fs.access(doesNotExist, function(err) {
+fs.access(doesNotExist, common.mustCall((err) => {
   assert.notEqual(err, null, 'error should exist');
   assert.strictEqual(err.code, 'ENOENT');
   assert.strictEqual(err.path, doesNotExist);
-});
+}));
 
-fs.access(readOnlyFile, fs.F_OK | fs.R_OK, function(err) {
-  assert.strictEqual(err, null, 'error should not exist');
-});
+fs.access(readOnlyFile, fs.F_OK | fs.R_OK, common.mustCall((err) => {
+  assert.ifError(err);
+}));
 
-fs.access(readOnlyFile, fs.W_OK, function(err) {
+fs.access(readOnlyFile, fs.W_OK, common.mustCall((err) => {
   if (hasWriteAccessForReadonlyFile) {
-    assert.equal(err, null, 'error should not exist');
+    assert.ifError(err);
   } else {
     assert.notEqual(err, null, 'error should exist');
     assert.strictEqual(err.path, readOnlyFile);
   }
-});
+}));
 
-assert.throws(function() {
-  fs.access(100, fs.F_OK, function(err) {});
+assert.throws(() => {
+  fs.access(100, fs.F_OK, (err) => {});
 }, /path must be a string or Buffer/);
 
-assert.throws(function() {
+assert.throws(() => {
   fs.access(__filename, fs.F_OK);
 }, /"callback" argument must be a function/);
 
-assert.throws(function() {
+assert.throws(() => {
   fs.access(__filename, fs.F_OK, {});
 }, /"callback" argument must be a function/);
 
-assert.doesNotThrow(function() {
+assert.doesNotThrow(() => {
   fs.accessSync(__filename);
 });
 
-assert.doesNotThrow(function() {
+assert.doesNotThrow(() => {
   var mode = fs.F_OK | fs.R_OK | fs.W_OK;
 
   fs.accessSync(readWriteFile, mode);
 });
 
-assert.throws(function() {
+assert.throws(() => {
   fs.accessSync(doesNotExist);
-}, function(err) {
+}, (err) => {
   return err.code === 'ENOENT' && err.path === doesNotExist;
 });
 
-process.on('exit', function() {
+process.on('exit', () => {
   removeFile(readOnlyFile);
   removeFile(readWriteFile);
 });


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

##### Description of change

* use const and let instead of var
* use common.mustCall to control functions execution
* use assert.ifError instead of assert.strictEqual for errors
* use arrow functions