### PR TITLE
doc: new TLSSocket has no secure context options

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -483,12 +483,8 @@ added: v0.11.4
     will be emitted on the socket before establishing a secure communication
   * `secureContext`: Optional TLS context object created with
     [`tls.createSecureContext()`][]. If a `secureContext` is _not_ provided, one
-    will be created by passing the entire `options` object to
-    `tls.createSecureContext()`. *Note*: In effect, all
-    [`tls.createSecureContext()`][] options can be provided, but they will be
-    _completely ignored_ unless the `secureContext` option is missing.
-  * ...: Optional [`tls.createSecureContext()`][] options can be provided, see
-    the `secureContext` option for more information.
+    will be created by calling [`tls.createSecureContext()`][] with no options.
+
 Construct a new `tls.TLSSocket` object from an existing TCP socket.
 
 ### Event: 'OCSPResponse'


### PR DESCRIPTION
Unlike all the other tls APIs, if any secure context configuration is
required, the caller is responsible for creating the context.

Corrects a doc regression introduced in caa7fa982affddcc. 

Fix https://github.com/nodejs/node/issues/10538


##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc,tls
