### PR TITLE
test: avoid assigning this to variables

### DIFF
--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -32,12 +32,12 @@ if (cluster.isWorker) {
   // start worker
   var worker = cluster.fork();
 
-  var socket;
   // Disconnect worker when it is ready
   worker.once('listening', function() {
-    net.createConnection(common.PORT, common.localhostIPv4, function() {
-      socket = this;
-      this.on('data', function() {
+    const socket = net.createConnection(common.PORT, common.localhostIPv4);
+
+    socket.on('connect', function() {
+      socket.on('data', function() {
         console.log('got data from client');
         // socket definitely connected to worker if we got data
         worker.disconnect();

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -50,9 +50,8 @@ server.listen(0, options.host, function() {
       this.destroy();
     });
     req.setTimeout(50, function() {
-      var req = this;
       console.log('req#' + this.id + ' timeout');
-      req.abort();
+      this.abort();
       requests_done += 1;
     });
     req.end();

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -21,26 +21,24 @@ os.homedir = function() {
 class ActionStream extends stream.Stream {
   run(data) {
     const _iter = data[Symbol.iterator]();
-    const self = this;
-
-    function doAction() {
+    const doAction = () => {
       const next = _iter.next();
       if (next.done) {
         // Close the repl. Note that it must have a clean prompt to do so.
-        setImmediate(function() {
-          self.emit('keypress', '', { ctrl: true, name: 'd' });
+        setImmediate(() => {
+          this.emit('keypress', '', { ctrl: true, name: 'd' });
         });
         return;
       }
       const action = next.value;
 
       if (typeof action === 'object') {
-        self.emit('keypress', '', action);
+        this.emit('keypress', '', action);
       } else {
-        self.emit('data', action + '\n');
+        this.emit('data', action + '\n');
       }
       setImmediate(doAction);
-    }
+    };
     setImmediate(doAction);
   }
   resume() {}

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -102,24 +102,24 @@ SlowStream.prototype.pause = function() {
 };
 
 SlowStream.prototype.resume = function() {
-  var self = this;
-  if (self.ended) return;
-  self.emit('resume');
-  if (!self.chunk) return;
-  self.paused = false;
-  emit();
-  function emit() {
-    if (self.paused) return;
-    if (self.offset >= self.length) {
-      self.ended = true;
-      return self.emit('end');
+  const emit = () => {
+    if (this.paused) return;
+    if (this.offset >= this.length) {
+      this.ended = true;
+      return this.emit('end');
     }
-    var end = Math.min(self.offset + self.trickle, self.length);
-    var c = self.chunk.slice(self.offset, end);
-    self.offset += c.length;
-    self.emit('data', c);
+    var end = Math.min(this.offset + this.trickle, this.length);
+    var c = this.chunk.slice(this.offset, end);
+    this.offset += c.length;
+    this.emit('data', c);
     process.nextTick(emit);
-  }
+  };
+
+  if (this.ended) return;
+  this.emit('resume');
+  if (!this.chunk) return;
+  this.paused = false;
+  emit();
 };
 
 SlowStream.prototype.end = function(chunk) {


### PR DESCRIPTION
This commit removes assignments of this to a variable in the tests.

There are still two cases of `var self = this;` in the tests.
- `test/parallel/test-cluster-shared-handle-bind-error.js` - fixed in a separate currently open PR.
- `test/parallel/test-http-client-read-in-error.js` - I could fix this, but it actually seems more readable with `self`.

This could optionally be added to the linter moving forward.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test