### PR TITLE
Test revisions

### DIFF
--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -1,7 +1,6 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
 const EE = require('events').EventEmitter;

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+
 const assert = require('assert');
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -1,6 +1,5 @@
 'use strict';
-require('../common');
-
+const common = require('../common');
 const assert = require('assert');
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
@@ -10,22 +9,17 @@ function runTest(highWaterMark, objectMode, produce) {
 
   const old = new EE();
   const r = new Readable({ highWaterMark: highWaterMark,
-                         objectMode: objectMode });
+                           objectMode: objectMode });
   assert.strictEqual(r, r.wrap(old));
 
-  let ended = false;
-  r.on('end', common.mustCall(function() {
-    ended = true;
-  }));
+  r.on('end', common.mustCall(function() {}));
 
   old.pause = function() {
-    console.error('old.pause()');
     old.emit('pause');
     flowing = false;
   };
 
   old.resume = function() {
-    console.error('old.resume()');
     old.emit('resume');
     flow();
   };
@@ -39,24 +33,20 @@ function runTest(highWaterMark, objectMode, produce) {
     while (flowing && chunks-- > 0) {
       const item = produce();
       expected.push(item);
-      console.log('old.emit', chunks, flowing);
       old.emit('data', item);
-      console.log('after emit', chunks, flowing);
     }
     if (chunks <= 0) {
       oldEnded = true;
-      console.log('old end', chunks, flowing);
       old.emit('end');
     }
   }
 
- const w = new Writable({ highWaterMark: highWaterMark * 2,
-                         objectMode: objectMode });
+  const w = new Writable({ highWaterMark: highWaterMark * 2,
+                           objectMode: objectMode });
   const written = [];
   w._write = function(chunk, encoding, cb) {
-    console.log('_write', chunk);
     written.push(chunk);
-    setTimeout(cb, 1000);
+    setTimeout(cb, 1);
   };
 
   w.on('finish', common.mustCall(function() {
@@ -68,16 +58,14 @@ function runTest(highWaterMark, objectMode, produce) {
   flow();
 
   function performAsserts() {
-    assert(ended);
     assert(oldEnded);
     assert.deepStrictEqual(written, expected);
   }
 }
 
-runTest(100, false, common.mustCall(function() { return Buffer.allocUnsafe(100); });
-runTest(10, false, common.mustCall(function() { return Buffer.from('xxxxxxxxxx'); }));
-runTest(1, true, common.mustCall(function() { return { foo: 'bar' }; }));
+runTest(100, false, function() { return Buffer.allocUnsafe(100); });
+runTest(10, false, function() { return Buffer.from('xxxxxxxxxx'); });
+runTest(1, true, function() { return { foo: 'bar' }; });
 
 const objectChunks = [ 5, 'a', false, 0, '', 'xyz', { x: 4 }, 7, [], 555 ];
-runTest(1, true, common.mustCall(function() { return objectChunks.shift(); }));
-
+runTest(1, true, function() { return objectChunks.shift(); });


### PR DESCRIPTION
test: implement callback wrapper `common.mustCall`

In `test/parallel/test-stream2-readable-wrap.js`:

* replace `process.on('exit', ...)` block by wrapping all callbacks with `common.mustCall`
* replace `assert.equal()` with `assert.strictEqual()`
* add a duration of 1 second to `setTimeout()` on line 61
* replace `var` with `const` or `let`

