### PR TITLE
test: improve the code in test-fs-read-stream

### DIFF
--- a/test/parallel/test-fs-read-stream-fd.js
+++ b/test/parallel/test-fs-read-stream-fd.js
@@ -3,21 +3,20 @@ const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
-var file = path.join(common.tmpDir, '/read_stream_fd_test.txt');
-var input = 'hello world';
-var output = '';
-var fd, stream;
+const file = path.join(common.tmpDir, '/read_stream_fd_test.txt');
+const input = 'hello world';
 
+let output = '';
 common.refreshTmpDir();
 fs.writeFileSync(file, input);
-fd = fs.openSync(file, 'r');
 
-stream = fs.createReadStream(null, { fd: fd, encoding: 'utf8' });
-stream.on('data', function(data) {
+const fd = fs.openSync(file, 'r');
+const stream = fs.createReadStream(null, { fd: fd, encoding: 'utf8' });
+
+stream.on('data', (data) => {
   output += data;
 });
 
-process.on('exit', function() {
-  fs.unlinkSync(file);
-  assert.equal(output, input);
+process.on('exit', () => {
+  assert.strictEqual(output, input);
 });


### PR DESCRIPTION

* use const and let instead of var
* use common.mustCall to control function execution
* use assert.strictEqual instead of assert.equal
* use arrow functions

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

