### PR TITLE
Optimize child_process IPC for large data

### DIFF
--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -1,7 +1,7 @@
 'use strict';
 if (process.argv[2] === 'child') {
   const len = +process.argv[3];
-  const msg = `"${'.'.repeat(len)}"`;
+  const msg = '.'.repeat(len);
   const send = () => {
     while (process.send(msg));
     // Wait: backlog of unsent messages exceeds threshold
@@ -24,7 +24,7 @@ if (process.argv[2] === 'child') {
     const dur = +conf.dur;
     const len = +conf.len;
 
-    const options = { 'stdio': ['ignore', 'ignore', 'ignore', 'ipc'] };
+    const options = { 'stdio': ['ignore', 1, 2, 'ipc'] };
     const child = spawn(process.argv[0],
       [process.argv[1], 'child', len], options);
 

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -2,13 +2,19 @@
 if (process.argv[2] === 'child') {
   const len = +process.argv[3];
   const msg = `"${'.'.repeat(len)}"`;
-  while (true) {
-    process.send(msg);
-  }
+  const send = () => {
+    while (process.send(msg));
+    // Wait: backlog of unsent messages exceeds threshold
+    setTimeout(send, 20);
+  };
+  send();
 } else {
   const common = require('../common.js');
   const bench = common.createBenchmark(main, {
-    len: [64, 256, 1024, 4096, 32768],
+    len: [
+      64, 256, 1024, 4096, 16384, 65536,
+      65536 << 4, 65536 << 8
+    ],
     dur: [5]
   });
   const spawn = require('child_process').spawn;
@@ -29,8 +35,7 @@ if (process.argv[2] === 'child') {
 
     setTimeout(function() {
       child.kill();
-      const gbits = (bytes * 8) / (1024 * 1024 * 1024);
-      bench.end(gbits);
+      bench.end(bytes);
     }, dur * 1000);
   }
 }

--- a/benchmark/child_process/child-process-read-ipc.js
+++ b/benchmark/child_process/child-process-read-ipc.js
@@ -5,7 +5,7 @@ if (process.argv[2] === 'child') {
   const send = () => {
     while (process.send(msg));
     // Wait: backlog of unsent messages exceeds threshold
-    setTimeout(send, 20);
+    setImmediate(send);
   };
   send();
 } else {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -447,19 +447,19 @@ function setupChannel(target, channel) {
     // TODO(bnoordhuis) Check that nread > 0.
     if (pool) {
       // Linebreak is used as a message end sign
-      var lines = decoder.write(pool).split('\n');
-      var chunks = lines.slice(0, -1);
+      var chunks = decoder.write(pool).split('\n');
+      var numCompleteChunks = chunks.length - 1;
       // Last line does not have trailing linebreak
-      var incompleteChunk = lines[lines.length - 1];
-      if (chunks.length === 0) {
+      var incompleteChunk = chunks[numCompleteChunks];
+      if (numCompleteChunks === 0) {
         jsonBuffer += incompleteChunk;
         this.buffering = jsonBuffer.length !== 0;
         return;
       }
       chunks[0] = jsonBuffer + chunks[0];
 
-      chunks.forEach(function(json) {
-        var message = JSON.parse(json);
+      for (var i = 0; i < numCompleteChunks; i++) {
+        var message = JSON.parse(chunks[i]);
 
         // There will be at most one NODE_HANDLE message in every chunk we
         // read because SCM_RIGHTS messages don't get coalesced. Make sure
@@ -468,7 +468,7 @@ function setupChannel(target, channel) {
           handleMessage(target, message, recvHandle);
         else
           handleMessage(target, message, undefined);
-      });
+      }
       jsonBuffer = incompleteChunk;
       this.buffering = jsonBuffer.length !== 0;
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -446,13 +446,19 @@ function setupChannel(target, channel) {
   channel.onread = function(nread, pool, recvHandle) {
     // TODO(bnoordhuis) Check that nread > 0.
     if (pool) {
-      jsonBuffer += decoder.write(pool);
+      // Linebreak is used as a message end sign
+      var lines = decoder.write(pool).split('\n');
+      var chunks = lines.slice(0, -1);
+      // Last line does not have trailing linebreak
+      var incompleteChunk = lines[lines.length - 1];
+      if (chunks.length === 0) {
+        jsonBuffer += incompleteChunk;
+        this.buffering = jsonBuffer.length !== 0;
+        return;
+      }
+      chunks[0] = jsonBuffer + chunks[0];
 
-      var i, start = 0;
-
-      //Linebreak is used as a message end sign
-      while ((i = jsonBuffer.indexOf('\n', start)) >= 0) {
-        var json = jsonBuffer.slice(start, i);
+      chunks.forEach(function(json) {
         var message = JSON.parse(json);
 
         // There will be at most one NODE_HANDLE message in every chunk we
@@ -462,10 +468,8 @@ function setupChannel(target, channel) {
           handleMessage(target, message, recvHandle);
         else
           handleMessage(target, message, undefined);
-
-        start = i + 1;
-      }
-      jsonBuffer = jsonBuffer.slice(start);
+      });
+      jsonBuffer = incompleteChunk;
       this.buffering = jsonBuffer.length !== 0;
 
     } else {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -498,9 +498,10 @@ function setupChannel(target, channel) {
       var queue = target._handleQueue;
       target._handleQueue = null;
 
-      queue.forEach(function(args) {
+      for (var i = 0; i < queue.length; i++) {
+        var args = queue[i];
         target._send(args.message, args.handle, args.options, args.callback);
-      });
+      }
 
       // Process a pending disconnect (if any).
       if (!target.connected && target.channel && !target._handleQueue)


### PR DESCRIPTION
`jsonBuffer.indexOf('\n', start)` in `channel.onread` (`internal/child_process.js`) dramatically slows down when `jsonBuffer` is very large.
`jsonBuffer` does not contains linebreak before `jsonBuffer += decoder.write(pool)` call, so checking linebreaks in return value of `decoder.write(pool)` is enough to parse chunks.

This increases total bytes received in 5 secs by 2-4x in benchmark...!

I found this when developing vscode plugin which returns very large result (around 10MB):
https://github.com/rubyide/vscode-ruby/pull/107
Also vscode core has workaround for this bottleneck:
https://github.com/Microsoft/vscode/issues/6026#issuecomment-224808371

Also fixed benchmark script which only shows zero.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process

##### Benchmark result

Mac OS X 10.12.2
MacBook Pro (Retina, 15-inch, Mid 2014)
2.2 GHz Intel Core i7

Before:
child_process/child-process-read-ipc.js dur=5 len=64: 7,583,464
child_process/child-process-read-ipc.js dur=5 len=256: 10,687,553
child_process/child-process-read-ipc.js dur=5 len=1024: 6,279,313
child_process/child-process-read-ipc.js dur=5 len=4096: 6,319,896
child_process/child-process-read-ipc.js dur=5 len=16384: 6,482,388
child_process/child-process-read-ipc.js dur=5 len=65536: 8,580,203
child_process/child-process-read-ipc.js dur=5 len=1048576: 13,398,807
child_process/child-process-read-ipc.js dur=5 len=16777216: 0

After:
child_process/child-process-read-ipc.js dur=5 len=64: 9,131,734
child_process/child-process-read-ipc.js dur=5 len=256: 10,502,876
child_process/child-process-read-ipc.js dur=5 len=1024: 6,272,325
child_process/child-process-read-ipc.js dur=5 len=4096: 6,195,482
child_process/child-process-read-ipc.js dur=5 len=16384: 6,505,698
child_process/child-process-read-ipc.js dur=5 len=65536: 8,513,730
child_process/child-process-read-ipc.js dur=5 len=1048576: 40,615,305
child_process/child-process-read-ipc.js dur=5 len=16777216: 30,183,113


----

When setTimeout() in benchmark is 0:
(I have no idea why this produces quite different result.)

Before:
child_process/child-process-read-ipc.js dur=5 len=64: 11,924,365
child_process/child-process-read-ipc.js dur=5 len=256: 34,004,413
child_process/child-process-read-ipc.js dur=5 len=1024: 51,082,451
child_process/child-process-read-ipc.js dur=5 len=4096: 61,968,471
child_process/child-process-read-ipc.js dur=5 len=16384: 59,297,771
child_process/child-process-read-ipc.js dur=5 len=65536: 59,533,374
child_process/child-process-read-ipc.js dur=5 len=1048576: 6,704,920
child_process/child-process-read-ipc.js dur=5 len=16777216: 0

After:
child_process/child-process-read-ipc.js dur=5 len=64: 12,209,873
child_process/child-process-read-ipc.js dur=5 len=256: 36,964,340
child_process/child-process-read-ipc.js dur=5 len=1024: 50,775,987
child_process/child-process-read-ipc.js dur=5 len=4096: 79,817,420
child_process/child-process-read-ipc.js dur=5 len=16384: 92,115,253
child_process/child-process-read-ipc.js dur=5 len=65536: 105,704,985
child_process/child-process-read-ipc.js dur=5 len=1048576: 23,256,095
child_process/child-process-read-ipc.js dur=5 len=16777216: 0