### PR TITLE
http: various performance improvements

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -61,7 +61,7 @@ WrkBenchmarker.prototype.create = function(options) {
 WrkBenchmarker.prototype.processResults = function(output) {
   const match = output.match(this.regexp);
   const result = match && +match[1];
-  if (!result) {
+  if (!isFinite(result)) {
     return undefined;
   } else {
     return result;
@@ -126,7 +126,7 @@ exports.run = function(options, callback) {
     }
 
     const result = benchmarker.processResults(stdout);
-    if (!result) {
+    if (result === undefined) {
       callback(new Error(`${options.benchmarker} produced strange output: ` +
                          stdout, code));
       return;

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -7,14 +7,16 @@ var bench = common.createBenchmark(main, {
   type: ['bytes', 'buffer'],
   length: [4, 1024, 102400],
   chunks: [0, 1, 4],  // chunks=0 means 'no chunked encoding'.
-  c: [50, 500]
+  c: [50, 500],
+  res: ['normal', 'setHeader', 'setHeaderWH']
 });
 
 function main(conf) {
   process.env.PORT = PORT;
   var server = require('./_http_simple.js');
   setTimeout(function() {
-    var path = '/' + conf.type + '/' + conf.length + '/' + conf.chunks;
+    var path = '/' + conf.type + '/' + conf.length + '/' + conf.chunks + '/' +
+               conf.res;
 
     bench.http({
       path: path,

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -131,8 +131,12 @@ function ClientRequest(options, cb) {
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
                       options.headers);
   } else if (self.getHeader('expect')) {
+    if (self._header) {
+      throw new Error('Can\'t render headers after they are sent to the ' +
+                      'client');
+    }
     self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
-                      self._renderHeaders());
+                      self._headers);
   }
 
   this._ended = false;
@@ -224,8 +228,11 @@ ClientRequest.prototype._finish = function _finish() {
 };
 
 ClientRequest.prototype._implicitHeader = function _implicitHeader() {
+  if (this._header) {
+    throw new Error('Can\'t render headers after they are sent to the client');
+  }
   this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
-                    this._renderHeaders());
+                    this._headers);
 };
 
 ClientRequest.prototype.abort = function abort() {

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -14,8 +14,8 @@ const debug = require('util').debuglog('http');
 exports.debug = debug;
 
 exports.CRLF = '\r\n';
-exports.chunkExpression = /chunk/i;
-exports.continueExpression = /100-continue/i;
+exports.chunkExpression = /(?:^|\W)chunked(?:$|\W)/i;
+exports.continueExpression = /(?:^|\W)100-continue(?:$|\W)/i;
 exports.methods = methods;
 
 const kOnHeaders = HTTPParser.kOnHeaders | 0;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -119,6 +119,146 @@ function _addHeaderLines(headers, n) {
 }
 
 
+// This function is used to help avoid the lowercasing of a field name if it
+// matches a 'traditional cased' version of a field name. It then returns the
+// lowercased name to both avoid calling toLowerCase() a second time and to
+// indicate whether the field was a 'no duplicates' field. If a field is not a
+// 'no duplicates' field, a `0` byte is prepended as a flag. The one exception
+// to this is the Set-Cookie header which is indicated by a `1` byte flag, since
+// it is an 'array' field and thus is treated differently in _addHeaderLines().
+// TODO: perhaps http_parser could be returning both raw and lowercased versions
+// of known header names to avoid us having to call toLowerCase() for those
+// headers.
+/* eslint-disable max-len */
+// 'array' header list is taken from:
+// https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
+/* eslint-enable max-len */
+function matchKnownFields(field) {
+  var low = false;
+  while (true) {
+    switch (field) {
+      case 'Content-Type':
+      case 'content-type':
+        return 'content-type';
+      case 'Content-Length':
+      case 'content-length':
+        return 'content-length';
+      case 'User-Agent':
+      case 'user-agent':
+        return 'user-agent';
+      case 'Referer':
+      case 'referer':
+        return 'referer';
+      case 'Host':
+      case 'host':
+        return 'host';
+      case 'Authorization':
+      case 'authorization':
+        return 'authorization';
+      case 'Proxy-Authorization':
+      case 'proxy-authorization':
+        return 'proxy-authorization';
+      case 'If-Modified-Since':
+      case 'if-modified-since':
+        return 'if-modified-since';
+      case 'If-Unmodified-Since':
+      case 'if-unmodified-since':
+        return 'if-unmodified-since';
+      case 'From':
+      case 'from':
+        return 'from';
+      case 'Location':
+      case 'location':
+        return 'location';
+      case 'Max-Forwards':
+      case 'max-forwards':
+        return 'max-forwards';
+      case 'Retry-After':
+      case 'retry-after':
+        return 'retry-after';
+      case 'ETag':
+      case 'etag':
+        return 'etag';
+      case 'Last-Modified':
+      case 'last-modified':
+        return 'last-modified';
+      case 'Server':
+      case 'server':
+        return 'server';
+      case 'Age':
+      case 'age':
+        return 'age';
+      case 'Expires':
+      case 'expires':
+        return 'expires';
+      case 'Set-Cookie':
+      case 'set-cookie':
+        return '\u0001';
+      // The fields below are not used in _addHeaderLine(), but they are common
+      // headers where we can avoid toLowerCase() if the mixed or lower case
+      // versions match the first time through.
+      case 'Transfer-Encoding':
+      case 'transfer-encoding':
+        return '\u0000transfer-encoding';
+      case 'Date':
+      case 'date':
+        return '\u0000date';
+      case 'Connection':
+      case 'connection':
+        return '\u0000connection';
+      case 'Cache-Control':
+      case 'cache-control':
+        return '\u0000cache-control';
+      case 'Vary':
+      case 'vary':
+        return '\u0000vary';
+      case 'Content-Encoding':
+      case 'content-encoding':
+        return '\u0000content-encoding';
+      case 'Cookie':
+      case 'cookie':
+        return '\u0000cookie';
+      case 'Origin':
+      case 'origin':
+        return '\u0000origin';
+      case 'Upgrade':
+      case 'upgrade':
+        return '\u0000upgrade';
+      case 'Expect':
+      case 'expect':
+        return '\u0000expect';
+      case 'If-Match':
+      case 'if-match':
+        return '\u0000if-match';
+      case 'If-None-Match':
+      case 'if-none-match':
+        return '\u0000if-none-match';
+      case 'Accept':
+      case 'accept':
+        return '\u0000accept';
+      case 'Accept-Encoding':
+      case 'accept-encoding':
+        return '\u0000accept-encoding';
+      case 'Accept-Language':
+      case 'accept-language':
+        return '\u0000accept-language';
+      case 'X-Forwarded-For':
+      case 'x-forwarded-for':
+        return '\u0000x-forwarded-for';
+      case 'X-Forwarded-Host':
+      case 'x-forwarded-host':
+        return '\u0000x-forwarded-host';
+      case 'X-Forwarded-Proto':
+      case 'x-forwarded-proto':
+        return '\u0000x-forwarded-proto';
+      default:
+        if (low)
+          return '\u0000' + field;
+        field = field.toLowerCase();
+        low = true;
+    }
+  }
+}
 // Add the given (field, value) pair to the message
 //
 // Per RFC2616, section 4.2 it is acceptable to join multiple instances of the
@@ -128,51 +268,27 @@ function _addHeaderLines(headers, n) {
 // always joined.
 IncomingMessage.prototype._addHeaderLine = _addHeaderLine;
 function _addHeaderLine(field, value, dest) {
-  field = field.toLowerCase();
-  switch (field) {
-    // Array headers:
-    case 'set-cookie':
-      if (dest[field] !== undefined) {
-        dest[field].push(value);
-      } else {
-        dest[field] = [value];
-      }
-      break;
-
-    /* eslint-disable max-len */
-    // list is taken from:
-    // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
-    /* eslint-enable max-len */
-    case 'content-type':
-    case 'content-length':
-    case 'user-agent':
-    case 'referer':
-    case 'host':
-    case 'authorization':
-    case 'proxy-authorization':
-    case 'if-modified-since':
-    case 'if-unmodified-since':
-    case 'from':
-    case 'location':
-    case 'max-forwards':
-    case 'retry-after':
-    case 'etag':
-    case 'last-modified':
-    case 'server':
-    case 'age':
-    case 'expires':
-      // drop duplicates
-      if (dest[field] === undefined)
-        dest[field] = value;
-      break;
-
-    default:
-      // make comma-separated list
-      if (typeof dest[field] === 'string') {
-        dest[field] += ', ' + value;
-      } else {
-        dest[field] = value;
-      }
+  field = matchKnownFields(field);
+  var flag = field.charCodeAt(0);
+  if (flag === 0) {
+    field = field.slice(1);
+    // Make comma-separated list
+    if (typeof dest[field] === 'string') {
+      dest[field] += ', ' + value;
+    } else {
+      dest[field] = value;
+    }
+  } else if (flag === 1) {
+    // Array header -- only Set-Cookie at the moment
+    if (dest['set-cookie'] !== undefined) {
+      dest['set-cookie'].push(value);
+    } else {
+      dest['set-cookie'] = [value];
+    }
+  } else {
+    // Drop duplicates
+    if (dest[field] === undefined)
+      dest[field] = value;
   }
 }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -13,14 +13,6 @@ const checkInvalidHeaderChar = common._checkInvalidHeaderChar;
 const CRLF = common.CRLF;
 const debug = common.debug;
 
-
-const automaticHeaders = {
-  connection: true,
-  'content-length': true,
-  'transfer-encoding': true,
-  date: true
-};
-
 var RE_FIELDS = new RegExp('^(?:Connection|Transfer-Encoding|Content-Length|' +
                            'Date|Expect|Trailer|Upgrade)$', 'i');
 var RE_CONN_VALUES = /(?:^|\W)close|upgrade(?:$|\W)/ig;
@@ -64,7 +56,9 @@ function OutgoingMessage() {
   this.shouldKeepAlive = true;
   this.useChunkedEncodingByDefault = true;
   this.sendDate = false;
-  this._removedHeader = {};
+  this._removedConnection = false;
+  this._removedContLen = false;
+  this._removedTE = false;
 
   this._contentLength = null;
   this._hasBody = true;
@@ -279,7 +273,7 @@ function _storeHeader(firstLine, headers) {
   }
 
   // keep-alive logic
-  if (this._removedHeader.connection) {
+  if (this._removedConnection) {
     this._last = true;
     this.shouldKeepAlive = false;
   } else if (!state.connection) {
@@ -300,11 +294,11 @@ function _storeHeader(firstLine, headers) {
     } else if (!this.useChunkedEncodingByDefault) {
       this._last = true;
     } else {
-          !this._removedHeader['content-length'] &&
       if (!state.trailer &&
+          !this._removedContLen &&
           typeof this._contentLength === 'number') {
-      } else if (!this._removedHeader['transfer-encoding']) {
         state.header += 'Content-Length: ' + this._contentLength + CRLF;
+      } else if (!this._removedTE) {
         state.header += 'Transfer-Encoding: chunked\r\n';
         this.chunkedEncoding = true;
       } else {
@@ -405,8 +399,20 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   const key = name.toLowerCase();
   this._headers[key] = [name, value];
 
-  if (automaticHeaders[key])
-    this._removedHeader[key] = false;
+  switch (key.length) {
+    case 10:
+      if (key === 'connection')
+        this._removedConnection = false;
+      break;
+    case 14:
+      if (key === 'content-length')
+        this._removedContLen = false;
+      break;
+    case 17:
+      if (key === 'transfer-encoding')
+        this._removedTE = false;
+      break;
+  }
 };
 
 
@@ -435,10 +441,24 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
 
   var key = name.toLowerCase();
 
-  if (key === 'date')
-    this.sendDate = false;
-  else if (automaticHeaders[key])
-    this._removedHeader[key] = true;
+  switch (key.length) {
+    case 10:
+      if (key === 'connection')
+        this._removedConnection = true;
+      break;
+    case 14:
+      if (key === 'content-length')
+        this._removedContLen = true;
+      break;
+    case 17:
+      if (key === 'transfer-encoding')
+        this._removedTE = true;
+      break;
+    case 4:
+      if (key === 'date')
+        this.sendDate = false;
+      break;
+  }
 
   if (this._headers) {
     delete this._headers[key];

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -11,18 +11,8 @@ const checkIsHttpToken = common._checkIsHttpToken;
 const checkInvalidHeaderChar = common._checkInvalidHeaderChar;
 
 const CRLF = common.CRLF;
-const trfrEncChunkExpression = common.chunkExpression;
 const debug = common.debug;
 
-const upgradeExpression = /^Upgrade$/i;
-const transferEncodingExpression = /^Transfer-Encoding$/i;
-const contentLengthExpression = /^Content-Length$/i;
-const dateExpression = /^Date$/i;
-const expectExpression = /^Expect$/i;
-const trailerExpression = /^Trailer$/i;
-const connectionExpression = /^Connection$/i;
-const connCloseExpression = /(^|\W)close(\W|$)/i;
-const connUpgradeExpression = /(^|\W)upgrade(\W|$)/i;
 
 const automaticHeaders = {
   connection: true,
@@ -31,6 +21,10 @@ const automaticHeaders = {
   date: true
 };
 
+var RE_FIELDS = new RegExp('^(?:Connection|Transfer-Encoding|Content-Length|' +
+                           'Date|Expect|Trailer|Upgrade)$', 'i');
+var RE_CONN_VALUES = /(?:^|\W)close|upgrade(?:$|\W)/ig;
+var RE_TE_CHUNKED = common.chunkExpression;
 
 var dateCache;
 function utcDate() {
@@ -83,7 +77,6 @@ function OutgoingMessage() {
   this.connection = null;
   this._header = null;
   this._headers = null;
-  this._headerNames = {};
 
   this._onPendingData = null;
 }
@@ -198,57 +191,72 @@ function _storeHeader(firstLine, headers) {
   // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
   // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
   var state = {
-    sentConnectionHeader: false,
-    sentConnectionUpgrade: false,
-    sentContentLengthHeader: false,
-    sentTransferEncodingHeader: false,
-    sentDateHeader: false,
-    sentExpect: false,
-    sentTrailer: false,
-    sentUpgrade: false,
-    messageHeader: firstLine
+    connection: false,
+    connUpgrade: false,
+    contLen: false,
+    te: false,
+    date: false,
+    expect: false,
+    trailer: false,
+    upgrade: false,
+    header: firstLine
   };
 
+  var field;
+  var key;
+  var value;
   var i;
   var j;
-  var field;
-  var value;
-  if (headers instanceof Array) {
-    for (i = 0; i < headers.length; ++i) {
+  if (headers === this._headers) {
+    for (key in headers) {
+      var entry = headers[key];
+      field = entry[0];
+      value = entry[1];
+
+      if (value instanceof Array) {
+        for (j = 0; j < value.length; j++) {
+          storeHeader(this, state, field, value[j], false);
+        }
+      } else {
+        storeHeader(this, state, field, value, false);
+      }
+    }
+  } else if (headers instanceof Array) {
+    for (i = 0; i < headers.length; i++) {
       field = headers[i][0];
       value = headers[i][1];
 
       if (value instanceof Array) {
         for (j = 0; j < value.length; j++) {
-          storeHeader(this, state, field, value[j]);
+          storeHeader(this, state, field, value[j], true);
         }
       } else {
-        storeHeader(this, state, field, value);
+        storeHeader(this, state, field, value, true);
       }
     }
   } else if (headers) {
     var keys = Object.keys(headers);
-    for (i = 0; i < keys.length; ++i) {
+    for (i = 0; i < keys.length; i++) {
       field = keys[i];
       value = headers[field];
 
       if (value instanceof Array) {
         for (j = 0; j < value.length; j++) {
-          storeHeader(this, state, field, value[j]);
+          storeHeader(this, state, field, value[j], true);
         }
       } else {
-        storeHeader(this, state, field, value);
+        storeHeader(this, state, field, value, true);
       }
     }
   }
 
   // Are we upgrading the connection?
-  if (state.sentConnectionUpgrade && state.sentUpgrade)
+  if (state.connUpgrade && state.upgrade)
     this.upgrading = true;
 
   // Date header
-  if (this.sendDate && !state.sentDateHeader) {
-    state.messageHeader += 'Date: ' + utcDate() + CRLF;
+  if (this.sendDate && !state.date) {
+    state.header += 'Date: ' + utcDate() + CRLF;
   }
 
   // Force the connection to close when the response is a 204 No Content or
@@ -274,33 +282,30 @@ function _storeHeader(firstLine, headers) {
   if (this._removedHeader.connection) {
     this._last = true;
     this.shouldKeepAlive = false;
-  } else if (!state.sentConnectionHeader) {
+  } else if (!state.connection) {
     var shouldSendKeepAlive = this.shouldKeepAlive &&
-        (state.sentContentLengthHeader ||
-         this.useChunkedEncodingByDefault ||
-         this.agent);
+        (state.contLen || this.useChunkedEncodingByDefault || this.agent);
     if (shouldSendKeepAlive) {
-      state.messageHeader += 'Connection: keep-alive\r\n';
+      state.header += 'Connection: keep-alive\r\n';
     } else {
       this._last = true;
-      state.messageHeader += 'Connection: close\r\n';
+      state.header += 'Connection: close\r\n';
     }
   }
 
-  if (!state.sentContentLengthHeader && !state.sentTransferEncodingHeader) {
+  if (!state.contLen && !state.te) {
     if (!this._hasBody) {
       // Make sure we don't end the 0\r\n\r\n at the end of the message.
       this.chunkedEncoding = false;
     } else if (!this.useChunkedEncodingByDefault) {
       this._last = true;
     } else {
-      if (!state.sentTrailer &&
           !this._removedHeader['content-length'] &&
+      if (!state.trailer &&
           typeof this._contentLength === 'number') {
-        state.messageHeader += 'Content-Length: ' + this._contentLength +
-                               '\r\n';
       } else if (!this._removedHeader['transfer-encoding']) {
-        state.messageHeader += 'Transfer-Encoding: chunked\r\n';
+        state.header += 'Content-Length: ' + this._contentLength + CRLF;
+        state.header += 'Transfer-Encoding: chunked\r\n';
         this.chunkedEncoding = true;
       } else {
         // We should only be able to get here if both Content-Length and
@@ -311,70 +316,94 @@ function _storeHeader(firstLine, headers) {
     }
   }
 
-  this._header = state.messageHeader + CRLF;
+  this._header = state.header + CRLF;
   this._headerSent = false;
 
   // wait until the first body chunk, or close(), is sent to flush,
   // UNLESS we're sending Expect: 100-continue.
-  if (state.sentExpect) this._send('');
+  if (state.expect) this._send('');
 }
 
-function storeHeader(self, state, field, value) {
-  if (!checkIsHttpToken(field)) {
-    throw new TypeError(
-      'Header name must be a valid HTTP Token ["' + field + '"]');
-  }
-  if (checkInvalidHeaderChar(value)) {
-    debug('Header "%s" contains invalid characters', field);
-    throw new TypeError('The header content contains invalid characters');
-  }
-  state.messageHeader += field + ': ' + escapeHeaderValue(value) + CRLF;
-
-  if (connectionExpression.test(field)) {
-    state.sentConnectionHeader = true;
-    if (connCloseExpression.test(value)) {
-      self._last = true;
-    } else {
-      self.shouldKeepAlive = true;
+function storeHeader(self, state, field, value, validate) {
+  if (validate) {
+    if (!checkIsHttpToken(field)) {
+      throw new TypeError(
+        'Header name must be a valid HTTP Token ["' + field + '"]');
     }
-    if (connUpgradeExpression.test(value))
-      state.sentConnectionUpgrade = true;
-  } else if (transferEncodingExpression.test(field)) {
-    state.sentTransferEncodingHeader = true;
-    if (trfrEncChunkExpression.test(value)) self.chunkedEncoding = true;
+    if (value === undefined) {
+      throw new Error('Header "%s" value must not be undefined', field);
+    } else if (checkInvalidHeaderChar(value)) {
+      debug('Header "%s" contains invalid characters', field);
+      throw new TypeError('The header content contains invalid characters');
+    }
+  }
+  state.header += field + ': ' + escapeHeaderValue(value) + CRLF;
+  matchHeader(self, state, field, value);
+}
 
-  } else if (contentLengthExpression.test(field)) {
-    state.sentContentLengthHeader = true;
-  } else if (dateExpression.test(field)) {
-    state.sentDateHeader = true;
-  } else if (expectExpression.test(field)) {
-    state.sentExpect = true;
-  } else if (trailerExpression.test(field)) {
-    state.sentTrailer = true;
-  } else if (upgradeExpression.test(field)) {
-    state.sentUpgrade = true;
+function matchConnValue(self, state, value) {
+  var sawClose = false;
+  var m = RE_CONN_VALUES.exec(value);
+  while (m) {
+    if (m[0].length === 5)
+      sawClose = true;
+    else
+      state.connUpgrade = true;
+    m = RE_CONN_VALUES.exec(value);
+  }
+  if (sawClose)
+    self._last = true;
+  else
+    self.shouldKeepAlive = true;
+}
+
+function matchHeader(self, state, field, value) {
+  var m = RE_FIELDS.exec(field);
+  if (!m)
+    return;
+  var len = m[0].length;
+  if (len === 10) {
+    state.connection = true;
+    matchConnValue(self, state, value);
+  } else if (len === 17) {
+    state.te = true;
+    if (RE_TE_CHUNKED.test(value)) self.chunkedEncoding = true;
+  } else if (len === 14) {
+    state.contLen = true;
+  } else if (len === 4) {
+    state.date = true;
+  } else if (len === 6) {
+    state.expect = true;
+  } else if (len === 7) {
+    var ch = m[0].charCodeAt(0);
+    if (ch === 85 || ch === 117)
+      state.upgrade = true;
+    else
+      state.trailer = true;
   }
 }
 
-
-OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
+function validateHeader(msg, name, value) {
   if (!checkIsHttpToken(name))
     throw new TypeError(
       'Header name must be a valid HTTP Token ["' + name + '"]');
   if (value === undefined)
     throw new Error('"value" required in setHeader("' + name + '", value)');
-  if (this._header)
+  if (msg._header)
     throw new Error('Can\'t set headers after they are sent.');
   if (checkInvalidHeaderChar(value)) {
     debug('Header "%s" contains invalid characters', name);
     throw new TypeError('The header content contains invalid characters');
   }
-  if (this._headers === null)
+}
+OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
+  validateHeader(this, name, value);
+
+  if (!this._headers)
     this._headers = {};
 
-  var key = name.toLowerCase();
-  this._headers[key] = value;
-  this._headerNames[key] = name;
+  const key = name.toLowerCase();
+  this._headers[key] = [name, value];
 
   if (automaticHeaders[key])
     this._removedHeader[key] = false;
@@ -388,7 +417,10 @@ OutgoingMessage.prototype.getHeader = function getHeader(name) {
 
   if (!this._headers) return;
 
-  return this._headers[name.toLowerCase()];
+  var entry = this._headers[name.toLowerCase()];
+  if (!entry)
+    return;
+  return entry[1];
 };
 
 
@@ -410,29 +442,9 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
 
   if (this._headers) {
     delete this._headers[key];
-    delete this._headerNames[key];
   }
 };
 
-
-OutgoingMessage.prototype._renderHeaders = function _renderHeaders() {
-  if (this._header) {
-    throw new Error('Can\'t render headers after they are sent to the client');
-  }
-
-  var headersMap = this._headers;
-  if (!headersMap) return {};
-
-  var headers = {};
-  var keys = Object.keys(headersMap);
-  var headerNames = this._headerNames;
-
-  for (var i = 0, l = keys.length; i < l; i++) {
-    var key = keys[i];
-    headers[headerNames[key]] = headersMap[key];
-  }
-  return headers;
-};
 
 OutgoingMessage.prototype._implicitHeader = function _implicitHeader() {
   throw new Error('_implicitHeader() method is not implemented');
@@ -492,6 +504,7 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
         this.connection.cork();
         process.nextTick(connectionCorkNT, this.connection);
       }
+
       this._send(len.toString(16), 'latin1', null);
       this._send(crlf_buf, null, null);
       this._send(chunk, encoding, null);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -136,36 +136,32 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
 
 OutgoingMessage.prototype._writeRaw = _writeRaw;
 function _writeRaw(data, encoding, callback) {
+  const conn = this.connection;
+  if (conn && conn.destroyed) {
+    // The socket was destroyed. If we're still trying to write to it,
+    // then we haven't gotten the 'close' event yet.
+    return false;
+  }
+
   if (typeof encoding === 'function') {
     callback = encoding;
     encoding = null;
   }
 
-  var connection = this.connection;
-  if (connection &&
-      connection._httpMessage === this &&
-      connection.writable &&
-      !connection.destroyed) {
+  if (conn && conn._httpMessage === this && conn.writable && !conn.destroyed) {
     // There might be pending data in the this.output buffer.
-    var outputLength = this.output.length;
-    if (outputLength > 0) {
-      this._flushOutput(connection);
-    } else if (data.length === 0) {
+    if (this.output.length) {
+      this._flushOutput(conn);
+    } else if (!data.length) {
       if (typeof callback === 'function')
         process.nextTick(callback);
       return true;
     }
-
     // Directly write to socket.
-    return connection.write(data, encoding, callback);
-  } else if (connection && connection.destroyed) {
-    // The socket was destroyed.  If we're still trying to write to it,
-    // then we haven't gotten the 'close' event yet.
-    return false;
-  } else {
-    // buffer, as long as we're not destroyed.
-    return this._buffer(data, encoding, callback);
+    return conn.write(data, encoding, callback);
   }
+  // Buffer, as long as we're not destroyed.
+  return this._buffer(data, encoding, callback);
 }
 
 
@@ -477,6 +473,7 @@ Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
 });
 
 
+const crlf_buf = Buffer.from('\r\n');
 OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
   if (this.finished) {
     var err = new Error('write after end');
@@ -582,9 +579,6 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
     this._trailer += field + ': ' + escapeHeaderValue(value) + CRLF;
   }
 };
-
-
-const crlf_buf = Buffer.from('\r\n');
 
 function onFinish(outmsg) {
   outmsg.emit('finish');

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -161,7 +161,6 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
 
 ServerResponse.prototype.writeHead = writeHead;
 function writeHead(statusCode, reason, obj) {
-  var headers;
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999)
     throw new RangeError(`Invalid status code: ${statusCode}`);
@@ -177,17 +176,25 @@ function writeHead(statusCode, reason, obj) {
   }
   this.statusCode = statusCode;
 
+  var headers;
   if (this._headers) {
     // Slow-case: when progressive API and header fields are passed.
+    var k;
     if (obj) {
       var keys = Object.keys(obj);
       for (var i = 0; i < keys.length; i++) {
-        var k = keys[i];
+        k = keys[i];
         if (k) this.setHeader(k, obj[k]);
       }
     }
+    if (k === undefined) {
+      if (this._header) {
+        throw new Error('Can\'t render headers after they are sent to the ' +
+                        'client');
+      }
+    }
     // only progressive api is used
-    headers = this._renderHeaders();
+    headers = this._headers;
   } else {
     // only writeHead() called
     headers = obj;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -162,6 +162,9 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
 ServerResponse.prototype.writeHead = writeHead;
 function writeHead(statusCode, reason, obj) {
   var headers;
+  statusCode |= 0;
+  if (statusCode < 100 || statusCode > 999)
+    throw new RangeError(`Invalid status code: ${statusCode}`);
 
   if (typeof reason === 'string') {
     // writeHead(statusCode, reasonPhrase[, headers])
@@ -190,17 +193,13 @@ function writeHead(statusCode, reason, obj) {
     headers = obj;
   }
 
-  statusCode |= 0;
-  if (statusCode < 100 || statusCode > 999)
-    throw new RangeError(`Invalid status code: ${statusCode}`);
-
   if (common._checkInvalidHeaderChar(this.statusMessage))
     throw new Error('Invalid character in statusMessage.');
 
   var statusLine = 'HTTP/1.1 ' + statusCode + ' ' + this.statusMessage + CRLF;
 
   if (statusCode === 204 || statusCode === 304 ||
-      (100 <= statusCode && statusCode <= 199)) {
+      (statusCode >= 100 && statusCode <= 199)) {
     // RFC 2616, 10.2.5:
     // The 204 response MUST NOT include a message-body, and thus is always
     // terminated by the first empty line after the header fields.

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -170,8 +170,8 @@ function writeHead(statusCode, reason, obj) {
     this.statusMessage = reason;
   } else {
     // writeHead(statusCode[, headers])
-    this.statusMessage =
-        this.statusMessage || STATUS_CODES[statusCode] || 'unknown';
+    if (!this.statusMessage)
+      this.statusMessage = STATUS_CODES[statusCode] || 'unknown';
     obj = reason;
   }
   this.statusCode = statusCode;
@@ -514,9 +514,8 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   // so that we don't become overwhelmed by a flood of
   // pipelined requests that may never be resolved.
   if (!socket._paused) {
-    var needPause = socket._writableState.needDrain ||
-        state.outgoingData >= socket._writableState.highWaterMark;
-    if (needPause) {
+    var ws = socket._writableState;
+    if (ws.needDrain || state.outgoingData >= ws.highWaterMark) {
       socket._paused = true;
       // We also need to pause the parser, but don't do that until after
       // the call to execute, because we may still be processing the last
@@ -542,9 +541,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
 
   // When we're finished writing the response, check if this is the last
   // response, if so destroy the socket.
-  var finish =
-    resOnFinish.bind(undefined, req, res, socket, state);
-  res.on('finish', finish);
+  res.on('finish', resOnFinish.bind(undefined, req, res, socket, state));
 
   if (req.headers.expect !== undefined &&
       (req.httpVersionMajor === 1 && req.httpVersionMinor === 1)) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -284,9 +284,11 @@ function decodeChunk(state, chunk, encoding) {
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
   if (!isBuf) {
-    chunk = decodeChunk(state, chunk, encoding);
-    if (chunk instanceof Buffer)
+    var newChunk = decodeChunk(state, chunk, encoding);
+    if (chunk !== newChunk) {
       encoding = 'buffer';
+      chunk = newChunk;
+    }
   }
   var len = state.objectMode ? 1 : chunk.length;
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -16,13 +16,6 @@ util.inherits(Writable, Stream);
 
 function nop() {}
 
-function WriteReq(chunk, encoding, cb) {
-  this.chunk = chunk;
-  this.encoding = encoding;
-  this.callback = cb;
-  this.next = null;
-}
-
 function WritableState(options, stream) {
   options = options || {};
 
@@ -113,7 +106,9 @@ function WritableState(options, stream) {
 
   // allocate the first CorkedRequest, there is always
   // one allocated and free to use, and we maintain at most two
-  this.corkedRequestsFree = new CorkedRequest(this);
+  var corkReq = { next: null, entry: null, finish: undefined };
+  corkReq.finish = onCorkedFinish.bind(undefined, corkReq, this);
+  this.corkedRequestsFree = corkReq;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
@@ -304,7 +299,7 @@ function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
 
   if (state.writing || state.corked) {
     var last = state.lastBufferedRequest;
-    state.lastBufferedRequest = new WriteReq(chunk, encoding, cb);
+    state.lastBufferedRequest = { chunk, encoding, callback: cb, next: null };
     if (last) {
       last.next = state.lastBufferedRequest;
     } else {
@@ -423,7 +418,9 @@ function clearBuffer(stream, state) {
       state.corkedRequestsFree = holder.next;
       holder.next = null;
     } else {
-      state.corkedRequestsFree = new CorkedRequest(state);
+      var corkReq = { next: null, entry: null, finish: undefined };
+      corkReq.finish = onCorkedFinish.bind(undefined, corkReq, state);
+      state.corkedRequestsFree = corkReq;
     }
   } else {
     // Slow case, write chunks one-by-one
@@ -526,14 +523,6 @@ function endWritable(stream, state, cb) {
   }
   state.ended = true;
   stream.writable = false;
-}
-
-// It seems a linked list but it is not
-// there will be only 2 of these for each stream
-function CorkedRequest(state) {
-  this.next = null;
-  this.entry = null;
-  this.finish = onCorkedFinish.bind(undefined, this, state);
 }
 
 function onCorkedFinish(corkReq, state, err) {


### PR DESCRIPTION
These commits bring 3-11% performance increase (this is on top of the performance improvements made recently in https://github.com/nodejs/node/pull/10445, https://github.com/nodejs/node/pull/10443, and https://github.com/nodejs/node/pull/6533). The performance increases are greater when you start setting/adding more headers than the http benchmarks currently use (just 2 currently).

When using the 'simple' http benchmark, I had to reduce the http client benchmarker duration by half (5 seconds) and reduce the number of runs to 10 (from the default of 30) to get the results back in a reasonable amount of time, especially with the newly added benchmark parameter. This allowed me to finish benchmarking in a little over 4.5 hours, whereas before with the original duration and 30 runs it was still running after 18 hours (when it technically should have finished -- even taking into account overhead since a single run doesn't last *exactly* the duration specified).

With that being said, here are the results with those modified benchmarking settings:

<details><p>

```
                                                                                               improvement significant      p.value
 http/simple.js res="normal" c=50 chunks=0 length=1024 type="buffer" benchmarker="wrk"              7.32 %         *** 3.688222e-09
 http/simple.js res="normal" c=50 chunks=0 length=1024 type="bytes" benchmarker="wrk"               6.33 %         *** 2.198646e-07
 http/simple.js res="normal" c=50 chunks=0 length=102400 type="buffer" benchmarker="wrk"            5.98 %         *** 8.444083e-09
 http/simple.js res="normal" c=50 chunks=0 length=102400 type="bytes" benchmarker="wrk"             1.71 %             5.654903e-02
 http/simple.js res="normal" c=50 chunks=0 length=4 type="buffer" benchmarker="wrk"                 6.75 %         *** 4.882309e-06
 http/simple.js res="normal" c=50 chunks=0 length=4 type="bytes" benchmarker="wrk"                  8.36 %         *** 5.103912e-10
 http/simple.js res="normal" c=50 chunks=1 length=1024 type="buffer" benchmarker="wrk"              7.00 %         *** 5.923557e-08
 http/simple.js res="normal" c=50 chunks=1 length=1024 type="bytes" benchmarker="wrk"               5.91 %         *** 9.026994e-07
 http/simple.js res="normal" c=50 chunks=1 length=102400 type="buffer" benchmarker="wrk"            6.87 %         *** 5.115533e-10
 http/simple.js res="normal" c=50 chunks=1 length=102400 type="bytes" benchmarker="wrk"            -0.56 %             4.997734e-01
 http/simple.js res="normal" c=50 chunks=1 length=4 type="buffer" benchmarker="wrk"                 7.06 %         *** 9.929058e-07
 http/simple.js res="normal" c=50 chunks=1 length=4 type="bytes" benchmarker="wrk"                  7.99 %         *** 1.538373e-09
 http/simple.js res="normal" c=50 chunks=4 length=1024 type="buffer" benchmarker="wrk"              9.10 %         *** 1.348325e-07
 http/simple.js res="normal" c=50 chunks=4 length=1024 type="bytes" benchmarker="wrk"               0.23 %             5.229137e-01
 http/simple.js res="normal" c=50 chunks=4 length=102400 type="buffer" benchmarker="wrk"            7.51 %         *** 1.106307e-11
 http/simple.js res="normal" c=50 chunks=4 length=102400 type="bytes" benchmarker="wrk"             1.12 %             2.529282e-01
 http/simple.js res="normal" c=50 chunks=4 length=4 type="buffer" benchmarker="wrk"                 9.56 %         *** 9.803919e-09
 http/simple.js res="normal" c=50 chunks=4 length=4 type="bytes" benchmarker="wrk"                  0.06 %             8.710531e-01
 http/simple.js res="normal" c=500 chunks=0 length=1024 type="buffer" benchmarker="wrk"             7.50 %         *** 1.055653e-05
 http/simple.js res="normal" c=500 chunks=0 length=1024 type="bytes" benchmarker="wrk"              7.24 %         *** 6.617968e-08
 http/simple.js res="normal" c=500 chunks=0 length=102400 type="buffer" benchmarker="wrk"           5.83 %         *** 2.168064e-06
 http/simple.js res="normal" c=500 chunks=0 length=102400 type="bytes" benchmarker="wrk"            0.45 %             5.161448e-01
 http/simple.js res="normal" c=500 chunks=0 length=4 type="buffer" benchmarker="wrk"                8.66 %         *** 3.537589e-07
 http/simple.js res="normal" c=500 chunks=0 length=4 type="bytes" benchmarker="wrk"                 7.71 %         *** 1.655858e-06
 http/simple.js res="normal" c=500 chunks=1 length=1024 type="buffer" benchmarker="wrk"             5.22 %         *** 1.379880e-05
 http/simple.js res="normal" c=500 chunks=1 length=1024 type="bytes" benchmarker="wrk"              4.26 %         *** 1.961713e-06
 http/simple.js res="normal" c=500 chunks=1 length=102400 type="buffer" benchmarker="wrk"           7.52 %         *** 1.537612e-06
 http/simple.js res="normal" c=500 chunks=1 length=102400 type="bytes" benchmarker="wrk"            0.25 %             6.697942e-01
 http/simple.js res="normal" c=500 chunks=1 length=4 type="buffer" benchmarker="wrk"                7.42 %         *** 3.138037e-06
 http/simple.js res="normal" c=500 chunks=1 length=4 type="bytes" benchmarker="wrk"                 7.42 %         *** 2.934613e-06
 http/simple.js res="normal" c=500 chunks=4 length=1024 type="buffer" benchmarker="wrk"             7.27 %         *** 1.925539e-06
 http/simple.js res="normal" c=500 chunks=4 length=1024 type="bytes" benchmarker="wrk"              3.05 %         *** 3.470258e-06
 http/simple.js res="normal" c=500 chunks=4 length=102400 type="buffer" benchmarker="wrk"           8.53 %         *** 8.922735e-09
 http/simple.js res="normal" c=500 chunks=4 length=102400 type="bytes" benchmarker="wrk"            2.10 %           * 3.249854e-02
 http/simple.js res="normal" c=500 chunks=4 length=4 type="buffer" benchmarker="wrk"                9.68 %         *** 8.849623e-11
 http/simple.js res="normal" c=500 chunks=4 length=4 type="bytes" benchmarker="wrk"                 4.11 %         *** 2.105516e-04
 http/simple.js res="setHeader" c=50 chunks=0 length=1024 type="buffer" benchmarker="wrk"           8.17 %         *** 1.632875e-08
 http/simple.js res="setHeader" c=50 chunks=0 length=1024 type="bytes" benchmarker="wrk"            8.10 %         *** 3.557907e-08
 http/simple.js res="setHeader" c=50 chunks=0 length=102400 type="buffer" benchmarker="wrk"         5.60 %         *** 3.508730e-05
 http/simple.js res="setHeader" c=50 chunks=0 length=102400 type="bytes" benchmarker="wrk"          1.34 %           * 1.388335e-02
 http/simple.js res="setHeader" c=50 chunks=0 length=4 type="buffer" benchmarker="wrk"              8.41 %         *** 1.808168e-09
 http/simple.js res="setHeader" c=50 chunks=0 length=4 type="bytes" benchmarker="wrk"               7.22 %         *** 1.431984e-07
 http/simple.js res="setHeader" c=50 chunks=1 length=1024 type="buffer" benchmarker="wrk"           8.31 %         *** 8.101591e-08
 http/simple.js res="setHeader" c=50 chunks=1 length=1024 type="bytes" benchmarker="wrk"            6.02 %         *** 4.761886e-05
 http/simple.js res="setHeader" c=50 chunks=1 length=102400 type="buffer" benchmarker="wrk"         6.51 %         *** 3.062989e-07
 http/simple.js res="setHeader" c=50 chunks=1 length=102400 type="bytes" benchmarker="wrk"          0.24 %             7.525069e-01
 http/simple.js res="setHeader" c=50 chunks=1 length=4 type="buffer" benchmarker="wrk"              7.10 %         *** 1.525359e-06
 http/simple.js res="setHeader" c=50 chunks=1 length=4 type="bytes" benchmarker="wrk"               6.57 %         *** 8.604833e-09
 http/simple.js res="setHeader" c=50 chunks=4 length=1024 type="buffer" benchmarker="wrk"           9.10 %         *** 2.257903e-09
 http/simple.js res="setHeader" c=50 chunks=4 length=1024 type="bytes" benchmarker="wrk"           -0.59 %           * 3.725369e-02
 http/simple.js res="setHeader" c=50 chunks=4 length=102400 type="buffer" benchmarker="wrk"         8.10 %         *** 7.263169e-10
 http/simple.js res="setHeader" c=50 chunks=4 length=102400 type="bytes" benchmarker="wrk"          1.06 %             1.969950e-01
 http/simple.js res="setHeader" c=50 chunks=4 length=4 type="buffer" benchmarker="wrk"             11.29 %         *** 3.677319e-09
 http/simple.js res="setHeader" c=50 chunks=4 length=4 type="bytes" benchmarker="wrk"               0.72 %             5.166339e-02
 http/simple.js res="setHeader" c=500 chunks=0 length=1024 type="buffer" benchmarker="wrk"          8.78 %         *** 9.781154e-10
 http/simple.js res="setHeader" c=500 chunks=0 length=1024 type="bytes" benchmarker="wrk"           9.76 %         *** 1.518366e-10
 http/simple.js res="setHeader" c=500 chunks=0 length=102400 type="buffer" benchmarker="wrk"        6.38 %         *** 7.752881e-07
 http/simple.js res="setHeader" c=500 chunks=0 length=102400 type="bytes" benchmarker="wrk"         0.77 %             1.230367e-01
 http/simple.js res="setHeader" c=500 chunks=0 length=4 type="buffer" benchmarker="wrk"             5.72 %         *** 7.548957e-05
 http/simple.js res="setHeader" c=500 chunks=0 length=4 type="bytes" benchmarker="wrk"              7.88 %         *** 1.533032e-11
 http/simple.js res="setHeader" c=500 chunks=1 length=1024 type="buffer" benchmarker="wrk"          7.58 %         *** 7.720209e-08
 http/simple.js res="setHeader" c=500 chunks=1 length=1024 type="bytes" benchmarker="wrk"           6.57 %         *** 1.119938e-07
 http/simple.js res="setHeader" c=500 chunks=1 length=102400 type="buffer" benchmarker="wrk"        6.72 %         *** 6.689565e-07
 http/simple.js res="setHeader" c=500 chunks=1 length=102400 type="bytes" benchmarker="wrk"         1.32 %           * 2.304825e-02
 http/simple.js res="setHeader" c=500 chunks=1 length=4 type="buffer" benchmarker="wrk"             6.18 %         *** 2.418794e-06
 http/simple.js res="setHeader" c=500 chunks=1 length=4 type="bytes" benchmarker="wrk"              6.51 %         *** 4.905086e-05
 http/simple.js res="setHeader" c=500 chunks=4 length=1024 type="buffer" benchmarker="wrk"          7.99 %         *** 2.740359e-09
 http/simple.js res="setHeader" c=500 chunks=4 length=1024 type="bytes" benchmarker="wrk"           5.16 %         *** 2.070415e-06
 http/simple.js res="setHeader" c=500 chunks=4 length=102400 type="buffer" benchmarker="wrk"        8.49 %         *** 3.867745e-07
 http/simple.js res="setHeader" c=500 chunks=4 length=102400 type="bytes" benchmarker="wrk"         1.87 %          ** 4.240368e-03
 http/simple.js res="setHeader" c=500 chunks=4 length=4 type="buffer" benchmarker="wrk"             9.21 %         *** 3.996481e-09
 http/simple.js res="setHeader" c=500 chunks=4 length=4 type="bytes" benchmarker="wrk"              5.97 %         *** 6.721432e-09
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=1024 type="buffer" benchmarker="wrk"         7.90 %         *** 1.810239e-07
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=1024 type="bytes" benchmarker="wrk"          6.88 %         *** 3.428408e-06
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=102400 type="buffer" benchmarker="wrk"       5.32 %         *** 2.453555e-07
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=102400 type="bytes" benchmarker="wrk"        2.16 %           * 2.768038e-02
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=4 type="buffer" benchmarker="wrk"            7.95 %         *** 4.600429e-08
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=4 type="bytes" benchmarker="wrk"             9.72 %         *** 3.555558e-09
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=1024 type="buffer" benchmarker="wrk"         6.85 %         *** 6.685907e-09
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=1024 type="bytes" benchmarker="wrk"          6.59 %         *** 5.100999e-12
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=102400 type="buffer" benchmarker="wrk"       5.98 %         *** 1.976488e-08
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=102400 type="bytes" benchmarker="wrk"        0.34 %             7.409726e-01
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=4 type="buffer" benchmarker="wrk"            7.10 %         *** 1.609698e-08
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=4 type="bytes" benchmarker="wrk"             6.17 %         *** 4.184348e-06
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=1024 type="buffer" benchmarker="wrk"         7.86 %         *** 1.076794e-08
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=1024 type="bytes" benchmarker="wrk"         -0.17 %             6.353906e-01
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=102400 type="buffer" benchmarker="wrk"       7.40 %         *** 1.169940e-08
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=102400 type="bytes" benchmarker="wrk"        0.88 %             4.654874e-01
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=4 type="buffer" benchmarker="wrk"            8.24 %         *** 1.181670e-08
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=4 type="bytes" benchmarker="wrk"             0.06 %             8.565252e-01
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=1024 type="buffer" benchmarker="wrk"        6.76 %         *** 2.827915e-08
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=1024 type="bytes" benchmarker="wrk"         7.09 %         *** 2.026343e-07
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=102400 type="buffer" benchmarker="wrk"      6.91 %         *** 1.757360e-08
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=102400 type="bytes" benchmarker="wrk"       1.17 %             7.434941e-02
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=4 type="buffer" benchmarker="wrk"           6.97 %         *** 4.805588e-06
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=4 type="bytes" benchmarker="wrk"            7.47 %         *** 6.128214e-06
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=1024 type="buffer" benchmarker="wrk"        6.13 %         *** 4.073914e-06
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=1024 type="bytes" benchmarker="wrk"         5.01 %         *** 1.285283e-07
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=102400 type="buffer" benchmarker="wrk"      6.72 %         *** 7.269783e-07
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=102400 type="bytes" benchmarker="wrk"       1.74 %          ** 3.253656e-03
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=4 type="buffer" benchmarker="wrk"           5.71 %         *** 3.753727e-05
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=4 type="bytes" benchmarker="wrk"            5.92 %         *** 2.036796e-07
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=1024 type="buffer" benchmarker="wrk"        8.42 %         *** 1.564555e-09
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=1024 type="bytes" benchmarker="wrk"         4.12 %         *** 1.636968e-05
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=102400 type="buffer" benchmarker="wrk"      8.30 %         *** 1.528112e-08
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=102400 type="bytes" benchmarker="wrk"      -0.41 %             3.825369e-01
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=4 type="buffer" benchmarker="wrk"           9.25 %         *** 3.030151e-11
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=4 type="bytes" benchmarker="wrk"            5.56 %         *** 1.334783e-06
```
</p></details>

<br />

When adding 3 custom headers in the 'setHeaderWH' case for example, you can see a greater increase:

<details><p>

```
                                                                                               improvement significant      p.value
 http/simple.js res="normal" c=50 chunks=0 length=1024 type="buffer" benchmarker="wrk"              7.77 %         *** 1.601361e-05
 http/simple.js res="normal" c=50 chunks=0 length=1024 type="bytes" benchmarker="wrk"               9.08 %         *** 1.121818e-09
 http/simple.js res="normal" c=50 chunks=0 length=102400 type="buffer" benchmarker="wrk"            6.65 %         *** 1.661088e-05
 http/simple.js res="normal" c=50 chunks=0 length=102400 type="bytes" benchmarker="wrk"             0.63 %             3.675953e-01
 http/simple.js res="normal" c=50 chunks=0 length=4 type="buffer" benchmarker="wrk"                 6.36 %         *** 1.071347e-05
 http/simple.js res="normal" c=50 chunks=0 length=4 type="bytes" benchmarker="wrk"                  7.53 %         *** 1.164565e-07
 http/simple.js res="normal" c=50 chunks=1 length=1024 type="buffer" benchmarker="wrk"              7.89 %         *** 2.980547e-07
 http/simple.js res="normal" c=50 chunks=1 length=1024 type="bytes" benchmarker="wrk"               7.66 %         *** 8.650294e-08
 http/simple.js res="normal" c=50 chunks=1 length=102400 type="buffer" benchmarker="wrk"            6.14 %         *** 1.055995e-06
 http/simple.js res="normal" c=50 chunks=1 length=102400 type="bytes" benchmarker="wrk"             0.99 %             1.902222e-01
 http/simple.js res="normal" c=50 chunks=1 length=4 type="buffer" benchmarker="wrk"                 8.55 %         *** 9.155390e-10
 http/simple.js res="normal" c=50 chunks=1 length=4 type="bytes" benchmarker="wrk"                  6.76 %         *** 1.052775e-09
 http/simple.js res="normal" c=50 chunks=4 length=1024 type="buffer" benchmarker="wrk"              9.13 %         *** 2.542129e-08
 http/simple.js res="normal" c=50 chunks=4 length=1024 type="bytes" benchmarker="wrk"              -0.28 %             4.029347e-01
 http/simple.js res="normal" c=50 chunks=4 length=102400 type="buffer" benchmarker="wrk"            8.56 %         *** 1.195479e-09
 http/simple.js res="normal" c=50 chunks=4 length=102400 type="bytes" benchmarker="wrk"             3.24 %             1.101345e-01
 http/simple.js res="normal" c=50 chunks=4 length=4 type="buffer" benchmarker="wrk"                 8.85 %         *** 1.233388e-10
 http/simple.js res="normal" c=50 chunks=4 length=4 type="bytes" benchmarker="wrk"                 -0.06 %             8.685515e-01
 http/simple.js res="normal" c=500 chunks=0 length=1024 type="buffer" benchmarker="wrk"             8.42 %         *** 2.652444e-07
 http/simple.js res="normal" c=500 chunks=0 length=1024 type="bytes" benchmarker="wrk"              7.62 %         *** 1.331863e-06
 http/simple.js res="normal" c=500 chunks=0 length=102400 type="buffer" benchmarker="wrk"           6.48 %         *** 2.695242e-06
 http/simple.js res="normal" c=500 chunks=0 length=102400 type="bytes" benchmarker="wrk"            1.69 %          ** 6.529191e-03
 http/simple.js res="normal" c=500 chunks=0 length=4 type="buffer" benchmarker="wrk"                8.44 %         *** 8.656604e-10
 http/simple.js res="normal" c=500 chunks=0 length=4 type="bytes" benchmarker="wrk"                 8.50 %         *** 1.355492e-06
 http/simple.js res="normal" c=500 chunks=1 length=1024 type="buffer" benchmarker="wrk"             7.02 %         *** 9.199390e-06
 http/simple.js res="normal" c=500 chunks=1 length=1024 type="bytes" benchmarker="wrk"              5.14 %         *** 5.819643e-08
 http/simple.js res="normal" c=500 chunks=1 length=102400 type="buffer" benchmarker="wrk"           6.35 %         *** 1.255342e-06
 http/simple.js res="normal" c=500 chunks=1 length=102400 type="bytes" benchmarker="wrk"            0.18 %             6.315421e-01
 http/simple.js res="normal" c=500 chunks=1 length=4 type="buffer" benchmarker="wrk"                7.16 %         *** 9.359637e-07
 http/simple.js res="normal" c=500 chunks=1 length=4 type="bytes" benchmarker="wrk"                 9.56 %         *** 1.078578e-08
 http/simple.js res="normal" c=500 chunks=4 length=1024 type="buffer" benchmarker="wrk"             8.05 %         *** 5.406988e-08
 http/simple.js res="normal" c=500 chunks=4 length=1024 type="bytes" benchmarker="wrk"              6.16 %         *** 1.830028e-09
 http/simple.js res="normal" c=500 chunks=4 length=102400 type="buffer" benchmarker="wrk"           7.99 %         *** 3.395783e-07
 http/simple.js res="normal" c=500 chunks=4 length=102400 type="bytes" benchmarker="wrk"            1.44 %             1.194225e-01
 http/simple.js res="normal" c=500 chunks=4 length=4 type="buffer" benchmarker="wrk"                8.78 %         *** 1.523263e-09
 http/simple.js res="normal" c=500 chunks=4 length=4 type="bytes" benchmarker="wrk"                 5.10 %         *** 7.574540e-07
 http/simple.js res="setHeader" c=50 chunks=0 length=1024 type="buffer" benchmarker="wrk"           9.29 %         *** 1.280683e-08
 http/simple.js res="setHeader" c=50 chunks=0 length=1024 type="bytes" benchmarker="wrk"            9.95 %         *** 1.584752e-07
 http/simple.js res="setHeader" c=50 chunks=0 length=102400 type="buffer" benchmarker="wrk"         6.83 %         *** 1.742157e-08
 http/simple.js res="setHeader" c=50 chunks=0 length=102400 type="bytes" benchmarker="wrk"          1.38 %          ** 5.483820e-03
 http/simple.js res="setHeader" c=50 chunks=0 length=4 type="buffer" benchmarker="wrk"              8.05 %         *** 8.117180e-08
 http/simple.js res="setHeader" c=50 chunks=0 length=4 type="bytes" benchmarker="wrk"               8.39 %         *** 5.710765e-10
 http/simple.js res="setHeader" c=50 chunks=1 length=1024 type="buffer" benchmarker="wrk"           8.66 %         *** 1.183858e-08
 http/simple.js res="setHeader" c=50 chunks=1 length=1024 type="bytes" benchmarker="wrk"            5.46 %         *** 1.684719e-08
 http/simple.js res="setHeader" c=50 chunks=1 length=102400 type="buffer" benchmarker="wrk"         6.98 %         *** 1.822605e-09
 http/simple.js res="setHeader" c=50 chunks=1 length=102400 type="bytes" benchmarker="wrk"         -0.11 %             8.195283e-01
 http/simple.js res="setHeader" c=50 chunks=1 length=4 type="buffer" benchmarker="wrk"              8.25 %         *** 1.101647e-06
 http/simple.js res="setHeader" c=50 chunks=1 length=4 type="bytes" benchmarker="wrk"               7.55 %         *** 3.233031e-06
 http/simple.js res="setHeader" c=50 chunks=4 length=1024 type="buffer" benchmarker="wrk"           9.50 %         *** 6.194324e-09
 http/simple.js res="setHeader" c=50 chunks=4 length=1024 type="bytes" benchmarker="wrk"            0.44 %             2.160161e-01
 http/simple.js res="setHeader" c=50 chunks=4 length=102400 type="buffer" benchmarker="wrk"         9.00 %         *** 2.026993e-10
 http/simple.js res="setHeader" c=50 chunks=4 length=102400 type="bytes" benchmarker="wrk"          3.13 %          ** 1.171021e-03
 http/simple.js res="setHeader" c=50 chunks=4 length=4 type="buffer" benchmarker="wrk"              8.65 %         *** 2.244983e-07
 http/simple.js res="setHeader" c=50 chunks=4 length=4 type="bytes" benchmarker="wrk"               0.51 %             9.793385e-02
 http/simple.js res="setHeader" c=500 chunks=0 length=1024 type="buffer" benchmarker="wrk"          6.55 %         *** 1.372787e-05
 http/simple.js res="setHeader" c=500 chunks=0 length=1024 type="bytes" benchmarker="wrk"           9.26 %         *** 3.045767e-10
 http/simple.js res="setHeader" c=500 chunks=0 length=102400 type="buffer" benchmarker="wrk"        6.96 %         *** 9.700479e-06
 http/simple.js res="setHeader" c=500 chunks=0 length=102400 type="bytes" benchmarker="wrk"         0.93 %             5.513154e-02
 http/simple.js res="setHeader" c=500 chunks=0 length=4 type="buffer" benchmarker="wrk"             7.92 %         *** 9.842509e-07
 http/simple.js res="setHeader" c=500 chunks=0 length=4 type="bytes" benchmarker="wrk"              8.26 %         *** 2.497220e-07
 http/simple.js res="setHeader" c=500 chunks=1 length=1024 type="buffer" benchmarker="wrk"          6.43 %         *** 3.543546e-05
 http/simple.js res="setHeader" c=500 chunks=1 length=1024 type="bytes" benchmarker="wrk"           5.06 %         *** 3.949956e-06
 http/simple.js res="setHeader" c=500 chunks=1 length=102400 type="buffer" benchmarker="wrk"        8.19 %         *** 1.144397e-07
 http/simple.js res="setHeader" c=500 chunks=1 length=102400 type="bytes" benchmarker="wrk"         1.08 %          ** 4.206755e-03
 http/simple.js res="setHeader" c=500 chunks=1 length=4 type="buffer" benchmarker="wrk"             6.50 %         *** 1.028961e-07
 http/simple.js res="setHeader" c=500 chunks=1 length=4 type="bytes" benchmarker="wrk"              8.16 %         *** 1.984112e-10
 http/simple.js res="setHeader" c=500 chunks=4 length=1024 type="buffer" benchmarker="wrk"          8.34 %         *** 1.201055e-09
 http/simple.js res="setHeader" c=500 chunks=4 length=1024 type="bytes" benchmarker="wrk"           4.56 %         *** 3.211769e-06
 http/simple.js res="setHeader" c=500 chunks=4 length=102400 type="buffer" benchmarker="wrk"       10.43 %         *** 5.400673e-09
 http/simple.js res="setHeader" c=500 chunks=4 length=102400 type="bytes" benchmarker="wrk"         2.24 %           * 3.267481e-02
 http/simple.js res="setHeader" c=500 chunks=4 length=4 type="buffer" benchmarker="wrk"             9.89 %         *** 7.214477e-09
 http/simple.js res="setHeader" c=500 chunks=4 length=4 type="bytes" benchmarker="wrk"              5.40 %         *** 1.465118e-05
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=1024 type="buffer" benchmarker="wrk"        10.52 %         *** 8.904727e-10
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=1024 type="bytes" benchmarker="wrk"         10.94 %         *** 2.688616e-10
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=102400 type="buffer" benchmarker="wrk"       9.00 %         *** 6.729648e-09
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=102400 type="bytes" benchmarker="wrk"        1.81 %          ** 7.444911e-03
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=4 type="buffer" benchmarker="wrk"           11.95 %         *** 7.684982e-11
 http/simple.js res="setHeaderWH" c=50 chunks=0 length=4 type="bytes" benchmarker="wrk"            13.92 %         *** 8.301877e-11
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=1024 type="buffer" benchmarker="wrk"        10.40 %         *** 3.490284e-09
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=1024 type="bytes" benchmarker="wrk"         10.40 %         *** 5.392976e-11
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=102400 type="buffer" benchmarker="wrk"       9.55 %         *** 1.432894e-09
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=102400 type="bytes" benchmarker="wrk"        2.11 %           * 1.452478e-02
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=4 type="buffer" benchmarker="wrk"           11.19 %         *** 3.085235e-13
 http/simple.js res="setHeaderWH" c=50 chunks=1 length=4 type="bytes" benchmarker="wrk"            10.91 %         *** 2.346356e-11
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=1024 type="buffer" benchmarker="wrk"        12.13 %         *** 5.259254e-13
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=1024 type="bytes" benchmarker="wrk"          0.15 %             7.129618e-01
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=102400 type="buffer" benchmarker="wrk"      10.40 %         *** 1.480122e-10
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=102400 type="bytes" benchmarker="wrk"        1.51 %             1.786063e-01
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=4 type="buffer" benchmarker="wrk"           11.76 %         *** 2.442914e-10
 http/simple.js res="setHeaderWH" c=50 chunks=4 length=4 type="bytes" benchmarker="wrk"             0.40 %             2.534618e-01
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=1024 type="buffer" benchmarker="wrk"       10.31 %         *** 3.108517e-06
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=1024 type="bytes" benchmarker="wrk"        11.50 %         *** 3.775474e-09
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=102400 type="buffer" benchmarker="wrk"      7.27 %         *** 2.105709e-05
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=102400 type="bytes" benchmarker="wrk"       1.86 %           * 2.036897e-02
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=4 type="buffer" benchmarker="wrk"           9.54 %         *** 7.382276e-09
 http/simple.js res="setHeaderWH" c=500 chunks=0 length=4 type="bytes" benchmarker="wrk"           10.39 %         *** 3.321337e-09
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=1024 type="buffer" benchmarker="wrk"        9.89 %         *** 7.341164e-09
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=1024 type="bytes" benchmarker="wrk"        11.74 %         *** 2.112175e-12
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=102400 type="buffer" benchmarker="wrk"      9.05 %         *** 1.937033e-09
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=102400 type="bytes" benchmarker="wrk"       0.78 %             1.559825e-01
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=4 type="buffer" benchmarker="wrk"          10.72 %         *** 4.013310e-10
 http/simple.js res="setHeaderWH" c=500 chunks=1 length=4 type="bytes" benchmarker="wrk"            7.99 %         *** 1.059505e-07
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=1024 type="buffer" benchmarker="wrk"       11.64 %         *** 1.544061e-10
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=1024 type="bytes" benchmarker="wrk"         6.84 %         *** 5.051422e-09
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=102400 type="buffer" benchmarker="wrk"      9.51 %         *** 1.195116e-10
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=102400 type="bytes" benchmarker="wrk"       3.65 %         *** 2.064001e-06
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=4 type="buffer" benchmarker="wrk"          12.36 %         *** 9.105549e-11
 http/simple.js res="setHeaderWH" c=500 chunks=4 length=4 type="bytes" benchmarker="wrk"            6.36 %         *** 6.586488e-07
```
</p></details>

<br />

/cc @nodejs/http
/cc @nodejs/streams for stream changes
<s>CI: https://ci.nodejs.org/job/node-test-pull-request/5651/</s>
CI: https://ci.nodejs.org/job/node-test-pull-request/5652/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* http
* stream