### PR TITLE
benchmark: keep decimals in results

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -195,8 +195,9 @@ function formatResult(data) {
     conf += ' ' + key + '=' + JSON.stringify(data.conf[key]);
   }
 
-  const rate = Math.floor(data.rate)
-                   .toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+  var rate = data.rate.toString().split('.');
+  rate[0] = rate[0].replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+  rate = (rate[1] ? rate.join('.') : rate[0]);
   return `${data.name}${conf}: ${rate}`;
 }
 

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -56,8 +56,9 @@ if (format === 'csv') {
       conf = conf.replace(/"/g, '""');
       console.log(`"${data.name}", "${conf}", ${data.rate}, ${data.time}`);
     } else {
-      const rate = Math.floor(data.rate)
-                       .toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+      var rate = data.rate.toString().split('.');
+      rate[0] = rate[0].replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+      rate = (rate[1] ? rate.join('.') : rate[0]);
       console.log(`${data.name} ${conf}: ${rate}`);
     }
   });


### PR DESCRIPTION
Some benchmarks' results are small values, so keeping decimals when running them manually (not comparing) can be helpful.

<s>Lint: https://ci.nodejs.org/job/node-test-linter/6124/</s>
Lint: https://ci.nodejs.org/job/node-test-linter/6125/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* benchmark
