### PR TITLE
events: avoid emit() eager deopt

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -6,7 +6,7 @@ const CLI = require('./_cli.js');
 
 const cli = CLI(`usage: ./node run.js [options] [--] <category> ...
   Run each benchmark in the <category> directory a single time, more than one
-  <categoty> directory can be specified.
+  <category> directory can be specified.
 
   --filter pattern          string to filter benchmark scripts
   --set    variable=value   set benchmark variable (can be repeated)

--- a/lib/events.js
+++ b/lib/events.js
@@ -148,7 +148,8 @@ EventEmitter.prototype.emit = function emit(type) {
 
   // If there is no 'error' event listener then throw.
   if (doError) {
-    er = arguments[1];
+    if (arguments.length > 1)
+      er = arguments[1];
     if (domain) {
       if (!er)
         er = new Error('Uncaught, unspecified "error" event');


### PR DESCRIPTION
This commit makes sure EventEmitter.emit() doesn't get deoptimized by V8.
The deopt happens when accessing out of bound indexes of the `arguments`
object.

This issue has been raised here: https://github.com/nodejs/node/issues/10323
and this specific case might become a more serious performance issue in
upcoming V8 releases.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
<!-- - [ ] documentation is changed or added-->
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
* events
* @nodejs/v8