### PR TITLE
util: avoid out-of-bounds arguments index access

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -173,8 +173,12 @@ function inspect(obj, opts) {
     stylize: stylizeNoColor
   };
   // legacy...
-  if (arguments[2] !== undefined) ctx.depth = arguments[2];
-  if (arguments[3] !== undefined) ctx.colors = arguments[3];
+  if (arguments.length >= 3 && arguments[2] !== undefined) {
+    ctx.depth = arguments[2];
+  }
+  if (arguments.length >= 4 && arguments[3] !== undefined) {
+    ctx.colors = arguments[3];
+  }
   if (typeof opts === 'boolean') {
     // legacy...
     ctx.showHidden = opts;


### PR DESCRIPTION
This updates util.inspect() to avoid accessing out-of-range indices of the `arguments` object, which is known to cause optimization bailout.

Based on an average of 10 runs of the benchmark in `benchmark/util/inspect.js`, this change improves the performance of `util.inspect` by about 10%.

Relates to https://github.com/nodejs/node/issues/10323

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util