### PR TITLE
test: improve test-fs-readfile-zero-byte-liar

### DIFF
--- a/test/parallel/test-fs-readfile-zero-byte-liar.js
+++ b/test/parallel/test-fs-readfile-zero-byte-liar.js
@@ -1,31 +1,31 @@
 'use strict';
 const common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
+const assert = require('assert');
+const fs = require('fs');
 
-var dataExpected = fs.readFileSync(__filename, 'utf8');
+const dataExpected = fs.readFileSync(__filename, 'utf8');
 
 // sometimes stat returns size=0, but it's a lie.
 fs._fstat = fs.fstat;
 fs._fstatSync = fs.fstatSync;
 
-fs.fstat = function(fd, cb) {
-  fs._fstat(fd, function(er, st) {
+fs.fstat = (fd, cb) => {
+  fs._fstat(fd, (er, st) => {
     if (er) return cb(er);
     st.size = 0;
     return cb(er, st);
   });
 };
 
-fs.fstatSync = function(fd) {
-  var st = fs._fstatSync(fd);
+fs.fstatSync = (fd) => {
+  const st = fs._fstatSync(fd);
   st.size = 0;
   return st;
 };
 
-var d = fs.readFileSync(__filename, 'utf8');
-assert.equal(d, dataExpected);
+const d = fs.readFileSync(__filename, 'utf8');
+assert.strictEqual(d, dataExpected);
 
-fs.readFile(__filename, 'utf8', common.mustCall(function(er, d) {
-  assert.equal(d, dataExpected);
+fs.readFile(__filename, 'utf8', common.mustCall((er, d) => {
+  assert.strictEqual(d, dataExpected);
 }));


### PR DESCRIPTION
* use const instead of var
* use assert.strictEqual instead of assert.equal
* use arrow functions

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
