### PR TITLE
events: optimize arrayClone by copying forward

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -477,9 +477,9 @@ function spliceOne(list, index) {
   list.pop();
 }
 
-function arrayClone(arr, i) {
-  var copy = new Array(i);
-  while (i--)
+function arrayClone(arr, n) {
+  var copy = new Array(n);
+  for (var i = 0; i < n; ++i)
     copy[i] = arr[i];
   return copy;
 }


### PR DESCRIPTION
It's slightly faster (and more readable) to copy array elements
in forward direction. This way it also avoids the ToBoolean and
the postfix count operation.

##### Checklist

- [x] `make -j4 test` (UNIX)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

events