### PR TITLE
events: improve removeListener() performance

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -360,6 +360,8 @@ EventEmitter.prototype.removeListener =
           } else {
             delete events[type];
           }
+        } else if (position === 0) {
+          list.shift();
         } else {
           spliceOne(list, position);
         }


### PR DESCRIPTION
`array.shift()` seems to be faster than `arrayClone()` when the item to remove is at the front (at least with V8 5.4).

Comparing the results of the events/ee-add-remove.js benchmark shows ~7% improvement:

```
                                   improvement significant      p.value
 events/ee-add-remove.js n=2500000      7.25 %         *** 8.925155e-24
```

**NOTE:** I have not yet tested `array.shift()` performance on V8<5.4, so this may/may not be applicable to node versions prior to 7.0.0.

CI: https://ci.nodejs.org/job/node-test-pull-request/5660/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* events
