### PR TITLE
lib: clarify get byteLength

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -662,10 +662,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   var len, ret;
   if (msg.chunkedEncoding) {
-    if (typeof chunk === 'string')
-      len = Buffer.byteLength(chunk, encoding);
-    else
-      len = chunk.length;
+    len = Buffer.byteLength(chunk, encoding);
 
     msg._send(len.toString(16), 'latin1', null);
     msg._send(crlf_buf, null, null);
@@ -748,10 +745,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
                                  ['string', 'buffer']);
     }
     if (!this._header) {
-      if (typeof chunk === 'string')
-        this._contentLength = Buffer.byteLength(chunk, encoding);
-      else
-        this._contentLength = chunk.length;
+      this._contentLength = Buffer.byteLength(chunk, encoding);
     }
     if (this.connection) {
       this.connection.cork();

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -315,7 +315,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
       child.stdout.setEncoding(encoding);
 
     child.stdout.on('data', function onChildStdout(chunk) {
-      stdoutLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
+      stdoutLen += Buffer.byteLength(chunk, encoding);
 
       if (stdoutLen > options.maxBuffer) {
         ex = new Error('stdout maxBuffer exceeded');
@@ -334,7 +334,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
       child.stderr.setEncoding(encoding);
 
     child.stderr.on('data', function onChildStderr(chunk) {
-      stderrLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
+      stderrLen += Buffer.byteLength(chunk, encoding);
 
       if (stderrLen > options.maxBuffer) {
         ex = new Error('stderr maxBuffer exceeded');

--- a/lib/net.js
+++ b/lib/net.js
@@ -821,10 +821,7 @@ protoGetter('bytesWritten', function bytesWritten() {
     return undefined;
 
   state.getBuffer().forEach(function(el) {
-    if (el.chunk instanceof Buffer)
-      bytes += el.chunk.length;
-    else
-      bytes += Buffer.byteLength(el.chunk, el.encoding);
+    bytes += Buffer.byteLength(el.chunk, el.encoding);
   });
 
   if (Array.isArray(data)) {
@@ -838,11 +835,7 @@ protoGetter('bytesWritten', function bytesWritten() {
         bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);
     }
   } else if (data) {
-    // Writes are either a string or a Buffer.
-    if (typeof data !== 'string')
-      bytes += data.length;
-    else
-      bytes += Buffer.byteLength(data, encoding);
+    bytes += Buffer.byteLength(data, encoding);
   }
 
   return bytes;


### PR DESCRIPTION
The Buffer.byteLength() accepts Buffer instance as parameter, so
the code can be simplified to Buffer.byteLength(value, encoding)
without type check.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net, _http_outgoing, child_process