### PR TITLE
doc: add test naming information to guide

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -2,13 +2,12 @@
 
 ## What is a test?
 
-A test must be a node script that exercises a specific functionality provided
-by node and checks that it behaves as expected. It should exit with code `0` on success,
-otherwise it will fail. A test will fail if:
+Most tests in Node.js core are JavaScript programs that exercise a functionality
+provided by Node.js and check that it behaves as expected. Tests should exit
+with code `0` on success. A test will fail if:
 
 - It exits by setting `process.exitCode` to a non-zero number.
-  - This is most often done by having an assertion throw an uncaught
-    Error.
+  - This is usually done by having an assertion throw an uncaught Error.
   - Occasionally, using `process.exit(code)` may be appropriate.
 - It never exits. In this case, the test runner will terminate the test because
   it sets a maximum time limit.
@@ -205,3 +204,15 @@ require('../common');
 const assert = require('assert');
 const freelist = require('internal/freelist');
 ```
+
+## Naming Test Files
+
+Test files are named using kebab casing. The first component of the name is
+`test`. The second is the module or subsystem being tested. The third is usually
+the method or event name being tested. Subsequent components of the name add
+more information about what is being tested.
+
+For example, a test for the `beforeExit` event on the `process` object might be
+named `test-process-before-exit.js`. If the test specifically checked that arrow
+functions worked correctly with the `beforeExit` event, then it might be named
+`test-process-before-exit-arrow-functions.js`.


### PR DESCRIPTION
The guide for writing tests is missing information on how tests are
named. This adds that information.

There is also some copy-editing done on the first paragraph of the
guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc test