### PR TITLE
test: fix process.title expectation

### DIFF
--- a/test/debugger/test-debugger-repl.js
+++ b/test/debugger/test-debugger-repl.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const repl = require('./helper-debugger-repl.js');
 
 repl.startDebugger('breakpoints.js');
@@ -57,7 +57,7 @@ addTest('c', [
 
 // Execute
 addTest('exec process.title', [
-  /node/
+  common.isFreeBSD || common.isOSX || common.isLinux ? /node/ : ''
 ]);
 
 // Execute


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

`process.title` would work properly only in FreeBSD, OSX, and Linux as
per test/parallel/test-setproctitle.js.

This patch makes sure that the test expects an empty string in other
platforms.

This patch helps fix the SmartOS failures in
https://ci.nodejs.org/job/node-test-commit/6962/ for
https://github.com/nodejs/node/pull/10456

---

cc @Trott 