### PR TITLE
test: improve test-event-emitter-modify-in-emit

### DIFF
--- a/test/parallel/test-event-emitter-modify-in-emit.js
+++ b/test/parallel/test-event-emitter-modify-in-emit.js
@@ -3,7 +3,7 @@ require('../common');
 const assert = require('assert');
 const events = require('events');
 
-var callbacks_called = [];
+let callbacks_called = [];
 
 const e = new events.EventEmitter();
 
@@ -25,27 +25,27 @@ function callback3() {
 }
 
 e.on('foo', callback1);
-assert.equal(1, e.listeners('foo').length);
+assert.strictEqual(e.listeners('foo').length, 1);
 
 e.emit('foo');
-assert.equal(2, e.listeners('foo').length);
+assert.strictEqual(e.listeners('foo').length, 2);
 assert.deepStrictEqual(['callback1'], callbacks_called);
 
 e.emit('foo');
-assert.equal(0, e.listeners('foo').length);
+assert.strictEqual(e.listeners('foo').length, 0);
 assert.deepStrictEqual(['callback1', 'callback2', 'callback3'],
                        callbacks_called);
 
 e.emit('foo');
-assert.equal(0, e.listeners('foo').length);
+assert.strictEqual(e.listeners('foo').length, 0);
 assert.deepStrictEqual(['callback1', 'callback2', 'callback3'],
                        callbacks_called);
 
 e.on('foo', callback1);
 e.on('foo', callback2);
-assert.equal(2, e.listeners('foo').length);
+assert.strictEqual(e.listeners('foo').length, 2);
 e.removeAllListeners('foo');
-assert.equal(0, e.listeners('foo').length);
+assert.strictEqual(e.listeners('foo').length, 0);
 
 // Verify that removing callbacks while in emit allows emits to propagate to
 // all listeners
@@ -53,7 +53,7 @@ callbacks_called = [];
 
 e.on('foo', callback2);
 e.on('foo', callback3);
-assert.equal(2, e.listeners('foo').length);
+assert.strictEqual(2, e.listeners('foo').length);
 e.emit('foo');
 assert.deepStrictEqual(['callback2', 'callback3'], callbacks_called);
-assert.equal(0, e.listeners('foo').length);
+assert.strictEqual(0, e.listeners('foo').length);


### PR DESCRIPTION
* use let instead of var
* use assert.strictEqual instead of assert.equal

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
