### PR TITLE
url: do not decode arbitrary %2e sequences in paths

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1214,12 +1214,7 @@ namespace url {
               state = kFragment;
             }
           } else {
-            if (ch == '%' && p[1] == '2' && TO_LOWER(p[2]) == 'e') {
-              buffer += '.';
-              p += 2;
-            } else {
-              AppendOrEscape(&buffer, ch, DefaultEncodeSet);
-            }
+            AppendOrEscape(&buffer, ch, DefaultEncodeSet);
           }
           break;
         case kCannotBeBase:

--- a/test/fixtures/url-setter-tests.json
+++ b/test/fixtures/url-setter-tests.json
@@ -953,8 +953,8 @@
             "href": "view-source+http://example.net/home?lang=fr#nav",
             "new_value": "\\a\\%2E\\b\\%2e.\\c",
             "expected": {
-                "href": "view-source+http://example.net/\\a\\.\\b\\..\\c?lang=fr#nav",
-                "pathname": "/\\a\\.\\b\\..\\c"
+                "href": "view-source+http://example.net/\\a\\%2E\\b\\%2e.\\c?lang=fr#nav",
+                "pathname": "/\\a\\%2E\\b\\%2e.\\c"
             }
         },
         {
@@ -967,12 +967,12 @@
             }
         },
         {
-            "comment": "Bytes already percent-encoded are left as-is, except %2E.",
+            "comment": "Bytes already percent-encoded are left as-is, including %2E outside dotted segments.",
             "href": "http://example.net",
             "new_value": "%2e%2E%c3%89té",
             "expected": {
-                "href": "http://example.net/..%c3%89t%C3%A9",
-                "pathname": "/..%c3%89t%C3%A9"
+                "href": "http://example.net/%2e%2E%c3%89t%C3%A9",
+                "pathname": "/%2e%2E%c3%89t%C3%A9"
             }
         },
         {

--- a/test/fixtures/url-tests.json
+++ b/test/fixtures/url-tests.json
@@ -1787,7 +1787,7 @@
   {
     "input": "http://example.com/foo/%2e%2",
     "base": "about:blank",
-    "href": "http://example.com/foo/.%2",
+    "href": "http://example.com/foo/%2e%2",
     "origin": "http://example.com",
     "protocol": "http:",
     "username": "",
@@ -1795,14 +1795,14 @@
     "host": "example.com",
     "hostname": "example.com",
     "port": "",
-    "pathname": "/foo/.%2",
+    "pathname": "/foo/%2e%2",
     "search": "",
     "hash": ""
   },
   {
     "input": "http://example.com/foo/%2e./%2e%2e/.%2e/%2e.bar",
     "base": "about:blank",
-    "href": "http://example.com/..bar",
+    "href": "http://example.com/%2e.bar",
     "origin": "http://example.com",
     "protocol": "http:",
     "username": "",
@@ -1810,7 +1810,7 @@
     "host": "example.com",
     "hostname": "example.com",
     "port": "",
-    "pathname": "/..bar",
+    "pathname": "/%2e.bar",
     "search": "",
     "hash": ""
   },
@@ -2228,7 +2228,7 @@
   {
     "input": "http://www/foo%2Ehtml",
     "base": "about:blank",
-    "href": "http://www/foo.html",
+    "href": "http://www/foo%2Ehtml",
     "origin": "http://www",
     "protocol": "http:",
     "username": "",
@@ -2236,7 +2236,7 @@
     "host": "www",
     "hostname": "www",
     "port": "",
-    "pathname": "/foo.html",
+    "pathname": "/foo%2Ehtml",
     "search": "",
     "hash": ""
   },


### PR DESCRIPTION
Per a recent change to the URL spec, arbitrary %2e sequences
in URL paths that are not single or double dot segments are
not to be decoded.

Refs: https://github.com/whatwg/url/issues/87
Refs: https://github.com/whatwg/url/pull/156
Refs: https://github.com/w3c/web-platform-tests/commit/d93247d5cb7d70f80da8b154a171f4e3d50969f4
Fixes: https://github.com/nodejs/node/issues/10598

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
url