### PR TITLE
test: minor cleanup in test-fs-*-buffer tests

### DIFF
--- a/test/parallel/test-fs-read-buffer.js
+++ b/test/parallel/test-fs-read-buffer.js
@@ -16,6 +16,7 @@ function test(bufferAsync, bufferSync, expected) {
           expected.length,
           0,
           common.mustCall((err, bytesRead) => {
+            assert.ifError(err);
             assert.strictEqual(bytesRead, expected.length);
             assert.deepStrictEqual(bufferAsync, Buffer.from(expected));
           }));

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -10,17 +10,17 @@ common.refreshTmpDir();
 // fs.write with all parameters provided:
 {
   const filename = path.join(common.tmpDir, 'write1.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
-    const cb = common.mustCall(function(err, written) {
+    const cb = common.mustCall((err, written) => {
       assert.ifError(err);
 
       assert.strictEqual(expected.length, written);
       fs.closeSync(fd);
 
       var found = fs.readFileSync(filename, 'utf8');
-      assert.deepStrictEqual(expected.toString(), found);
+      assert.strictEqual(expected.toString(), found);
     });
 
     fs.write(fd, expected, 0, expected.length, null, cb);
@@ -30,17 +30,17 @@ common.refreshTmpDir();
 // fs.write with a buffer, without the length parameter:
 {
   const filename = path.join(common.tmpDir, 'write2.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
-    const cb = common.mustCall(function(err, written) {
+    const cb = common.mustCall((err, written) => {
       assert.ifError(err);
 
       assert.strictEqual(2, written);
       fs.closeSync(fd);
 
       const found = fs.readFileSync(filename, 'utf8');
-      assert.deepStrictEqual('lo', found);
+      assert.strictEqual('lo', found);
     });
 
     fs.write(fd, Buffer.from('hello'), 3, cb);
@@ -90,17 +90,17 @@ common.refreshTmpDir();
 // fs.write with offset and length passed as undefined followed by the callback:
 {
   const filename = path.join(common.tmpDir, 'write5.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
-    const cb = common.mustCall(function(err, written) {
+    const cb = common.mustCall((err, written) => {
       assert.ifError(err);
 
       assert.strictEqual(expected.length, written);
       fs.closeSync(fd);
 
       const found = fs.readFileSync(filename, 'utf8');
-      assert.deepStrictEqual(expected.toString(), found);
+      assert.strictEqual(expected.toString(), found);
     });
 
     fs.write(fd, expected, undefined, undefined, cb);
@@ -110,17 +110,17 @@ common.refreshTmpDir();
 // fs.write with a Uint8Array, without the offset and length parameters:
 {
   const filename = path.join(common.tmpDir, 'write6.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
-    const cb = common.mustCall(function(err, written) {
+    const cb = common.mustCall((err, written) => {
       assert.ifError(err);
 
       assert.strictEqual(expected.length, written);
       fs.closeSync(fd);
 
       const found = fs.readFileSync(filename, 'utf8');
-      assert.deepStrictEqual(expected.toString(), found);
+      assert.strictEqual(expected.toString(), found);
     });
 
     fs.write(fd, Uint8Array.from(expected), cb);


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

Following up from @thefourtheye’s comments in https://github.com/nodejs/node/pull/10593