### PR TITLE
test: Revert add option to use node in path

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -45,7 +45,6 @@ import errno
 import copy
 
 from os.path import join, dirname, abspath, basename, isdir, exists
-from distutils.spawn import find_executable
 from datetime import datetime
 from Queue import Queue, Empty
 
@@ -866,14 +865,6 @@ class Context(object):
     self.repeat = repeat
 
   def GetVm(self, arch, mode):
-    parser = BuildOptions()
-    (options, args) = parser.parse_args()
-    if not ProcessOptions(options):
-      parser.print_help()
-      return 1
-    if options.path:
-      name = find_executable("node")
-      return name
     if arch == 'none':
       name = 'out/Debug/node' if mode == 'debug' else 'out/Release/node'
     else:
@@ -1394,8 +1385,6 @@ def BuildOptions():
   result.add_option('--repeat',
       help='Number of times to repeat given tests',
       default=1, type="int")
-  result.add_option('--path',
-      help='Use node in the path rather than out/Release', default=False, action="store_true")
   return result
 
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tools

##### Description

This reverts commit 4198253a185e20b7a9d0fb363fabacece712200d, landed in
https://github.com/nodejs/node/pull/9674.

This fails at

  File "tools/test.py", line 1429, in ProcessOptions
  options.j = int(cores) if cores is not None else
    multiprocessing.cpu_count()

with the error

  NotImplementedError: cannot determine number of cpus

from

  File "...multiprocessing/__init__.py", line 136, in cpu_count
      raise NotImplementedError('cannot determine number of cpus')

on MacOS machines.
