### PR TITLE
url: ensure host setter matches parse for file url

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -434,7 +434,9 @@ Object.defineProperties(URL.prototype, {
         ctx.flags &= ~binding.URL_FLAGS_HAS_HOST;
         return;
       }
-      binding.parse(host, binding.kHost, null, ctx,
+      const override = ctx.scheme === 'file:' ?
+                       binding.kFileHost : binding.kHost;
+      binding.parse(host, override, null, ctx,
                     onParseHostComplete.bind(this));
     }
   },

--- a/test/fixtures/url-setter-tests.js
+++ b/test/fixtures/url-setter-tests.js
@@ -966,6 +966,17 @@ module.exports =
         //         "port": "12"
         //     }
         // }
+        {
+            "comment": "Port numbers in file URLs are ignored",
+            "href": "file:///example/foo",
+            "new_value": "example.net:81",
+            "expected": {
+                "href": "file://example.net:81/example/foo",
+                "host": "example.net:81",
+                "hostname": "example.net:81",
+                "port": ""
+            }
+        }
     ],
     "hostname": [
         {
@@ -1300,6 +1311,17 @@ module.exports =
         //         "port": "12"
         //     }
         // }
+        {
+            "comment": "Port numbers in file URLs are ignored",
+            "href": "file:///example/foo",
+            "new_value": "example.net:81",
+            "expected": {
+                "href": "file://example.net/example/foo",
+                "host": "example.net",
+                "hostname": "example.net",
+                "port": ""
+            }
+        }
     ],
     "port": [
         {

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -5996,5 +5996,19 @@ module.exports =
     "pathname": "d3958f5c-0777-0845-9dcf-2cb28783acaf",
     "search": "",
     "hash": ""
+  },
+  {
+    "input": "file://example.net:81/foo",
+    "base": "about:blank",
+    "href": "file://example.net:81/foo",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "example.net:81",
+    "hostname": "example.net:81",
+    "port": "",
+    "pathname": "/foo",
+    "search": "",
+    "hash": ""
   }
 ]

--- a/test/parallel/test-whatwg-url-filehostport.js
+++ b/test/parallel/test-whatwg-url-filehostport.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Technically, file URLs are not permitted to have a port. There is
+// currently an ambiguity in the URL spec. In the current spec
+// having a port in a file URL is undefined behavior. In the current
+// implementation, the port is ignored and handled as if it were part
+// of the host name. This will be changing once the ambiguity is
+// resolved in the spec. The spec change may involve either ignoring the
+// port if specified or throwing with an Invalid URL error if the port
+// is specified. For now, this test verifies the currently implemented
+// behavior.
+
+require('../common');
+const URL = require('url').URL;
+const assert = require('assert');
+
+const u = new URL('file://example.net:80/foo');
+
+assert.strictEqual(u.hostname, 'example.net:80');
+assert.strictEqual(u.port, '');
+
+u.host = 'example.com:81';
+
+assert.strictEqual(u.hostname, 'example.com:81');
+assert.strictEqual(u.port, '');
+
+u.hostname = 'example.org:81';
+
+assert.strictEqual(u.hostname, 'example.org');
+assert.strictEqual(u.port, '');


### PR DESCRIPTION
Technically, file URLs are not permitted to have a port. There is
currently an ambiguity in the URL spec. In the current spec
having a port in a file URL is undefined behavior. In the current
implementation, the port is ignored and handled as if it were part
of the host name. This will be changing once the ambiguity is
resolved in the spec. The spec change may involve either ignoring the
port if specified or throwing with an Invalid URL error if the port
is specified. For now, this test verifies the currently implemented
behavior.

Fixes: https://github.com/nodejs/node/issues/10608

/cc @domenic 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
url