### PR TITLE
test: mark test-tty-wrap as flaky for AIX

### DIFF
--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -4,3 +4,5 @@ prefix pseudo-tty
 # test issue only, covered under https://github.com/nodejs/node/issues/7973
 no_dropped_stdio           : SKIP
 no_interleaved_stdio       : SKIP
+# being investigated under https://github.com/nodejs/node/issues/9728
+test-tty-wrap              : FAIL, PASS


### PR DESCRIPTION
We have had https://github.com/nodejs/node/issues/9728
open for a while but the frequency of the failures
seems to be such that we should mark it as flaky
while we continue to investigate.

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
test
