### PR TITLE
test: refactor test-crypto-padding-aes256

### DIFF
--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -11,18 +11,18 @@ const crypto = require('crypto');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 function aes256(decipherFinal) {
-  var iv = Buffer.from('00000000000000000000000000000000', 'hex');
-  var key = Buffer.from('0123456789abcdef0123456789abcdef' +
-                       '0123456789abcdef0123456789abcdef', 'hex');
+  const iv = Buffer.from('00000000000000000000000000000000', 'hex');
+  const key = Buffer.from('0123456789abcdef0123456789abcdef' +
+                         '0123456789abcdef0123456789abcdef', 'hex');
 
   function encrypt(val, pad) {
-    var c = crypto.createCipheriv('aes256', key, iv);
+    const c = crypto.createCipheriv('aes256', key, iv);
     c.setAutoPadding(pad);
     return c.update(val, 'utf8', 'latin1') + c.final('latin1');
   }
 
   function decrypt(val, pad) {
-    var c = crypto.createDecipheriv('aes256', key, iv);
+    const c = crypto.createDecipheriv('aes256', key, iv);
     c.setAutoPadding(pad);
     return c.update(val, 'latin1', 'utf8') + c[decipherFinal]('utf8');
   }
@@ -30,10 +30,10 @@ function aes256(decipherFinal) {
   // echo 0123456789abcdef0123456789abcdef \
   // | openssl enc -e -aes256 -nopad -K <key> -iv <iv> \
   // | openssl enc -d -aes256 -nopad -K <key> -iv <iv>
-  var plaintext = '0123456789abcdef0123456789abcdef'; // multiple of block size
-  var encrypted = encrypt(plaintext, false);
-  var decrypted = decrypt(encrypted, false);
-  assert.equal(decrypted, plaintext);
+  let plaintext = '0123456789abcdef0123456789abcdef'; // multiple of block size
+  let encrypted = encrypt(plaintext, false);
+  let decrypted = decrypt(encrypted, false);
+  assert.strictEqual(decrypted, plaintext);
 
   // echo 0123456789abcdef0123456789abcde \
   // | openssl enc -e -aes256 -K <key> -iv <iv> \
@@ -41,7 +41,7 @@ function aes256(decipherFinal) {
   plaintext = '0123456789abcdef0123456789abcde'; // not a multiple
   encrypted = encrypt(plaintext, true);
   decrypted = decrypt(encrypted, true);
-  assert.equal(decrypted, plaintext);
+  assert.strictEqual(decrypted, plaintext);
 }
 
 aes256('final');


### PR DESCRIPTION
- replace `var` with `const/let`
- replace `assert.equal()` with `assert.strictEqual()`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test