### PR TITLE
tracing: fix TracingController cleanup

### DIFF
--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -56,7 +56,9 @@ void Agent::Stop() {
   // Perform final Flush on TraceBuffer. We don't want the tracing controller
   // to flush the buffer again on destruction of the V8::Platform.
   tracing_controller_->StopTracing();
-  delete tracing_controller_;
+  tracing_controller_->Initialize(nullptr);
+  tracing_controller_ = nullptr;
+
   // Thread should finish when the tracing loop is stopped.
   uv_thread_join(&thread_);
   v8::platform::SetTracingController(platform_, nullptr);


### PR DESCRIPTION
This fixes an incorrect deletion of the `TracingController` instance,
which in some environments could cause an error about an invalid
pointer passed to `free()`. The `TracingController` instance is
actually owned by a `unique_ptr` member of the platform, so calling
`platform::SetTracingController(nullptr)` is the correct way to
delete it. But before that, the `TraceBuffer` must be deleted in
order for the tracing loop to exit; that is accomplished by calling
`TracingController::Initialize(nullptr)`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tracing