### PR TITLE
test: improve code in test-fs-write-file-sync

### DIFF
--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -3,9 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-var openCount = 0;
-var mode;
-var content;
+let openCount = 0;
+let mode;
+let content;
 
 // Need to hijack fs.open/close to make sure that things
 // get closed once they're opened.
@@ -28,39 +28,39 @@ if (common.isWindows) {
 common.refreshTmpDir();
 
 // Test writeFileSync
-var file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
+const file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
 
 fs.writeFileSync(file1, '123', {mode: mode});
 
 content = fs.readFileSync(file1, {encoding: 'utf8'});
-assert.equal('123', content);
+assert.strictEqual(content, '123');
 
-assert.equal(mode, fs.statSync(file1).mode & 0o777);
+assert.strictEqual(fs.statSync(file1).mode & 0o777, mode);
 
 // Test appendFileSync
-var file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
+const file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
 
 fs.appendFileSync(file2, 'abc', {mode: mode});
 
 content = fs.readFileSync(file2, {encoding: 'utf8'});
-assert.equal('abc', content);
+assert.strictEqual(content, 'abc');
 
-assert.equal(mode, fs.statSync(file2).mode & mode);
+assert.strictEqual(fs.statSync(file2).mode & mode, mode);
 
 // Test writeFileSync with file descriptor
-var file3 = path.join(common.tmpDir, 'testWriteFileSyncFd.txt');
+const file3 = path.join(common.tmpDir, 'testWriteFileSyncFd.txt');
 
-var fd = fs.openSync(file3, 'w+', mode);
+const fd = fs.openSync(file3, 'w+', mode);
 fs.writeFileSync(fd, '123');
 fs.closeSync(fd);
 
 content = fs.readFileSync(file3, {encoding: 'utf8'});
-assert.equal('123', content);
+assert.strictEqual(content, '123');
 
-assert.equal(mode, fs.statSync(file3).mode & 0o777);
+assert.strictEqual(fs.statSync(file3).mode & 0o777, mode);
 
 // Verify that all opened files were closed.
-assert.equal(0, openCount);
+assert.strictEqual(openCount, 0);
 
 function openSync() {
   openCount++;


### PR DESCRIPTION
* use let and const instead of var
* use assert.strictEqual instead of assert.equal

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
