### PR TITLE
build: xz tarball extreme compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,7 @@ endif
 BINARYTAR=$(BINARYNAME).tar
 # OSX doesn't have xz installed by default, http://macpkg.sourceforge.net/
 XZ=$(shell which xz > /dev/null 2>&1; echo $$?)
-XZ_COMPRESSION ?= 9
+XZ_COMPRESSION ?= 9e
 PKG=$(TARNAME).pkg
 PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker
 PKGDIR=out/dist-osx


### PR DESCRIPTION
Take node v7.4.0 as example, tarball size improvements listed as below:

```
node-v7.4.0-darwin-x64.tar.xz     9176904 ->  9147884 (99.68%)
node-v7.4.0-headers.tar.xz         351224 ->   349612 (99.54%)
node-v7.4.0-linux-arm64.tar.xz    9271000 ->  9254748 (99.82%)
node-v7.4.0-linux-armv6l.tar.xz   9243504 ->  9227428 (99.82%)
node-v7.4.0-linux-armv7l.tar.xz   9246228 ->  9228732 (99.81%)
node-v7.4.0-linux-ppc64.tar.xz    9448476 ->  9411128 (99.60%)
node-v7.4.0-linux-ppc64le.tar.xz  9553876 ->  9521424 (99.66%)
node-v7.4.0-linux-s390x.tar.xz    9923212 ->  9901772 (99.78%)
node-v7.4.0-linux-x64.tar.xz     10318700 -> 10304396 (99.86%)
node-v7.4.0-linux-x86.tar.xz      9907848 ->  9886448 (99.78%)
node-v7.4.0-sunos-x86.tar.xz      9742620 ->  9732160 (99.89%)
node-v7.4.0.tar.xz               16611356 -> 16459192 (99.08%)
```

So that we can know that we can have the improvement on all the xz
tarball releases!

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build