### PR TITLE
test: improve module version mismatch error check

### DIFF
--- a/test/addons/node-module-version/test.js
+++ b/test/addons/node-module-version/test.js
@@ -4,8 +4,11 @@ const common = require('../../common');
 const assert = require('assert');
 
 const re = new RegExp(
-  'was compiled against a different Node.js version using\n' +
-  'NODE_MODULE_VERSION 42. This version of Node.js requires\n' +
-  `NODE_MODULE_VERSION ${process.versions.modules}.`);
+  '^Error: The module \'.+\'\n' +
+  'was compiled against a different Node\\.js version using\n' +
+  'NODE_MODULE_VERSION 42\\. This version of Node\\.js requires\n' +
+  `NODE_MODULE_VERSION ${process.versions.modules}. ` +
+  'Please try re-compiling or re-installing\n' +
+  'the module \\(for instance, using `npm rebuild` or `npm install`\\)\\.$');
 
 assert.throws(() => require(`./build/${common.buildType}/binding`), re);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/10606

Don't run the CI yet. The test will fail until #10606 lands.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test