### PR TITLE
doc: mention cc-ing nodejs/python team for reviews

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -30,6 +30,7 @@
 | upgrading c-ares | @jbergstroem |
 | upgrading http-parser | @jbergstroem, @nodejs/http |
 | upgrading libuv | @saghul |
+| python code | @nodejs/python |
 | platform specific | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows} |
 
 


### PR DESCRIPTION
Add the @nodejs/python github team to the table of people to /cc for reviews on python code.

I was talking about this a while ago with @thefourtheye, and we did create the team, but I think we have (I have? :smile:) just forgotten to add the team to the table in `doc/onboarding-extras.md`.