### PR TITLE
test: allow testing uid and gid separately

### DIFF
--- a/test/parallel/test-child-process-uid-gid.js
+++ b/test/parallel/test-child-process-uid-gid.js
@@ -2,18 +2,16 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-
-if (!common.isWindows && process.getuid() === 0) {
-  common.skip('as this test should not be run as `root`');
-  return;
-}
-
 const expectedError = common.isWindows ? /\bENOTSUP\b/ : /\bEPERM\b/;
 
-assert.throws(() => {
-  spawn('echo', ['fhqwhgads'], {uid: 0});
-}, expectedError);
+if (common.isWindows || process.getuid() !== 0) {
+  assert.throws(() => {
+    spawn('echo', ['fhqwhgads'], {uid: 0});
+  }, expectedError);
+}
 
-assert.throws(() => {
-  spawn('echo', ['fhqwhgads'], {gid: 0});
-}, expectedError);
+if (common.isWindows || !process.getgroups().some((gid) => gid === 0)) {
+  assert.throws(() => {
+    spawn('echo', ['fhqwhgads'], {gid: 0});
+  }, expectedError);
+}


### PR DESCRIPTION
This commit lets the `uid` and `gid` options of `spawn()` to be tested independently of one another based on the user's uid and gid.

Fixes: https://github.com/nodejs/node/issues/10646

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test