### PR TITLE
test: improve code in test-https-strict

### DIFF
--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -23,60 +23,60 @@ function read(fname) {
 }
 
 // key1 is signed by ca1.
-var key1 = read('agent1-key.pem');
-var cert1 = read('agent1-cert.pem');
+const key1 = read('agent1-key.pem');
+const cert1 = read('agent1-cert.pem');
 
 // key2 has a self signed cert
-var key2 = read('agent2-key.pem');
-var cert2 = read('agent2-cert.pem');
+const key2 = read('agent2-key.pem');
+const cert2 = read('agent2-cert.pem');
 
 // key3 is signed by ca2.
-var key3 = read('agent3-key.pem');
-var cert3 = read('agent3-cert.pem');
+const key3 = read('agent3-key.pem');
+const cert3 = read('agent3-cert.pem');
 
-var ca1 = read('ca1-cert.pem');
-var ca2 = read('ca2-cert.pem');
+const ca1 = read('ca1-cert.pem');
+const ca2 = read('ca2-cert.pem');
 
 // different agents to use different CA lists.
 // this api is beyond bad.
-var agent0 = new https.Agent();
-var agent1 = new https.Agent({ ca: [ca1] });
-var agent2 = new https.Agent({ ca: [ca2] });
-var agent3 = new https.Agent({ ca: [ca1, ca2] });
+const agent0 = new https.Agent();
+const agent1 = new https.Agent({ ca: [ca1] });
+const agent2 = new https.Agent({ ca: [ca2] });
+const agent3 = new https.Agent({ ca: [ca1, ca2] });
 
-var options1 = {
+const options1 = {
   key: key1,
   cert: cert1
 };
 
-var options2 = {
+const options2 = {
   key: key2,
   cert: cert2
 };
 
-var options3 = {
+const options3 = {
   key: key3,
   cert: cert3
 };
 
-var server1 = server(options1);
-var server2 = server(options2);
-var server3 = server(options3);
+const server1 = server(options1);
+const server2 = server(options2);
+const server3 = server(options3);
 
-var listenWait = 0;
+let listenWait = 0;
 
 server1.listen(0, listening());
 server2.listen(0, listening());
 server3.listen(0, listening());
 
-var responseErrors = {};
-var expectResponseCount = 0;
-var responseCount = 0;
-var pending = 0;
+const responseErrors = {};
+let expectResponseCount = 0;
+let responseCount = 0;
+let pending = 0;
 
 
-function server(options, port) {
-  var s = https.createServer(options, handler);
+function server(options) {
+  const s = https.createServer(options, handler);
   s.requests = [];
   s.expectCount = 0;
   return s;
@@ -91,7 +91,7 @@ function handler(req, res) {
 
 function listening() {
   listenWait++;
-  return function() {
+  return () => {
     listenWait--;
     if (listenWait === 0) {
       allListening();
@@ -101,7 +101,7 @@ function listening() {
 
 function makeReq(path, port, error, host, ca) {
   pending++;
-  var options = {
+  const options = {
     port: port,
     path: path,
     ca: ca
@@ -125,9 +125,9 @@ function makeReq(path, port, error, host, ca) {
   if (host) {
     options.headers = { host: host };
   }
-  var req = https.get(options);
+  const req = https.get(options);
   expectResponseCount++;
-  var server = port === server1.address().port ? server1 :
+  const server = port === server1.address().port ? server1 :
       port === server2.address().port ? server2 :
       port === server3.address().port ? server3 :
       null;
@@ -135,9 +135,9 @@ function makeReq(path, port, error, host, ca) {
   if (!server) throw new Error('invalid port: ' + port);
   server.expectCount++;
 
-  req.on('response', function(res) {
+  req.on('response', (res) => {
     responseCount++;
-    assert.equal(res.connection.authorizationError, error);
+    assert.strictEqual(res.connection.authorizationError, error);
     responseErrors[path] = res.connection.authorizationError;
     pending--;
     if (pending === 0) {
@@ -195,10 +195,9 @@ function allListening() {
 
 }
 
-process.on('exit', function() {
-  console.error(responseErrors);
-  assert.equal(server1.requests.length, server1.expectCount);
-  assert.equal(server2.requests.length, server2.expectCount);
-  assert.equal(server3.requests.length, server3.expectCount);
-  assert.equal(responseCount, expectResponseCount);
+process.on('exit', () => {
+  assert.strictEqual(server1.requests.length, server1.expectCount);
+  assert.strictEqual(server2.requests.length, server2.expectCount);
+  assert.strictEqual(server3.requests.length, server3.expectCount);
+  assert.strictEqual(responseCount, expectResponseCount);
 });


### PR DESCRIPTION
* use let and const instead of var
* use assert.strictEqual instead of assert.equal

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
