### PR TITLE
doc: mention cc-ing nodejs/url team for reviews

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -13,6 +13,7 @@
 | `lib/{crypto,tls,https}` | @nodejs/crypto |
 | `lib/domains` | @misterdjules |
 | `lib/fs`, `src/{fs|file}` | @nodejs/fs |
+| `lib/internal/url`, `src/node_url` | @nodejs/url |
 | `lib/{_}http{*}` | @nodejs/http |
 | `lib/net` | @bnoordhuis, @indutny, @nodejs/streams |
 | `lib/{_}stream{s|*}` | @nodejs/streams |


### PR DESCRIPTION
Add the nodejs/url github team to the table of people to /cc for
reviews on the WHATWG URL code.

fyi @nodejs/url