### PR TITLE
build: don't bundle deps/zlib if --shared-zlib set

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -908,7 +908,6 @@
             'HAVE_INSPECTOR=1',
           ],
           'dependencies': [
-            'deps/zlib/zlib.gyp:zlib',
             'v8_inspector_compress_protocol_json#host'
           ],
           'include_dirs': [
@@ -921,6 +920,11 @@
             'test/cctest/test_inspector_socket_server.cc'
           ],
           'conditions': [
+            [ 'node_shared_zlib=="false"', {
+              'dependencies': [
+                'deps/zlib/zlib.gyp:zlib',
+              ]
+            }],
             [ 'node_shared_openssl=="false"', {
               'dependencies': [
                 'deps/openssl/openssl.gyp:openssl'


### PR DESCRIPTION
Even if the --shared-zlib flag was used, the bundled deps/zlib was still
being compiled into the binary as it was required by the C++ test suite.

Fixes: https://github.com/nodejs/node/issues/10649


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, zlib

cc/ @bnoordhuis 