### PR TITLE
meta: add references to DCO and CoC to issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,3 +21,10 @@ simple and free of external dependencies as you are able.
 * **Subsystem**:
 
 <!-- Enter your issue details below this comment. -->
+
+<!--
+  If this is your first contribution to the Node.js project, please take a moment
+  to review the Node.js Code of Conduct:
+
+  https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md 
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,8 +23,8 @@ simple and free of external dependencies as you are able.
 <!-- Enter your issue details below this comment. -->
 
 <!--
-  If this is your first contribution to the Node.js project, please take a moment
-  to review the Node.js Code of Conduct:
+If this is your first contribution to the Node.js project, please take a moment
+to review the Node.js Code of Conduct:
 
-  https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md 
+* https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,10 +15,13 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 - [ ] documentation is changed or added
 - [ ] commit message follows commit guidelines
 
-<!-- If this is your first contribution to Node.js, please also check the
-     following items -->
-- [ ] I have read and agree to the Node.js [Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md)
-- [ ] I have read and agree to the Node.js [Developer's Certificate of Origin](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) 
-
 ##### Affected core subsystem(s)
 <!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
+
+<!--
+If this is your first contribution to the Node.js project, please take a moment
+to review the Node.js Code of Conduct and Developer's Certificate of Origin:
+
+* https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
+* https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,10 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 - [ ] documentation is changed or added
 - [ ] commit message follows commit guidelines
 
+<!-- If this is your first contribution to Node.js, please also check the
+     following items -->
+- [ ] I have read and agree to the Node.js [Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md)
+- [ ] I have read and agree to the Node.js [Developer's Certificate of Origin](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) 
+
 ##### Affected core subsystem(s)
 <!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


### PR DESCRIPTION
Adds items to the PR checklist so that first time contributors can explicitly indicate that they have
read and agree to both the DCO and CoC.

This is largely just scratching an itch I've had for a while and is not in response to any particular
issue.

##### Checklist
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
meta