### PR TITLE
http: remove pointless uses of arguments

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -382,8 +382,8 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
 
 
 OutgoingMessage.prototype.getHeader = function getHeader(name) {
-  if (arguments.length < 1) {
-    throw new Error('"name" argument is required for getHeader(name)');
+  if (typeof name !== 'string') {
+    throw new TypeError('"name" argument must be a string');
   }
 
   if (!this._headers) return;
@@ -393,8 +393,8 @@ OutgoingMessage.prototype.getHeader = function getHeader(name) {
 
 
 OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
-  if (arguments.length < 1) {
-    throw new Error('"name" argument is required for removeHeader(name)');
+  if (typeof name !== 'string') {
+    throw new TypeError('"name" argument must be a string');
   }
 
   if (this._header) {

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -11,43 +11,48 @@ const http = require('http');
 // <ClientRequest>.method
 // <ClientRequest>.path
 
-var testsComplete = 0;
-var test = 'headers';
-var content = 'hello world\n';
-var cookies = [
+let test = 'headers';
+const content = 'hello world\n';
+const cookies = [
   'session_token=; path=/; expires=Sun, 15-Sep-2030 13:48:52 GMT',
   'prefers_open_id=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT'
 ];
 
-var s = http.createServer(function(req, res) {
+const s = http.createServer(common.mustCall((req, res) => {
   switch (test) {
     case 'headers':
-      assert.throws(function() { res.setHeader(); });
-      assert.throws(function() { res.setHeader('someHeader'); });
-      assert.throws(function() { res.getHeader(); });
-      assert.throws(function() { res.removeHeader(); });
+      assert.throws(() => {
+        res.setHeader();
+      }, /^TypeError: Header name must be a valid HTTP Token \["undefined"\]$/);
+      assert.throws(() => {
+        res.setHeader('someHeader');
+      }, /^Error: "value" required in setHeader\("someHeader", value\)$/);
+      assert.throws(() => {
+        res.getHeader();
+      }, /^TypeError: "name" argument must be a string$/);
+      assert.throws(() => {
+        res.removeHeader();
+      }, /^TypeError: "name" argument must be a string$/);
 
       res.setHeader('x-test-header', 'testing');
       res.setHeader('X-TEST-HEADER2', 'testing');
       res.setHeader('set-cookie', cookies);
       res.setHeader('x-test-array-header', [1, 2, 3]);
 
-      var val1 = res.getHeader('x-test-header');
-      var val2 = res.getHeader('x-test-header2');
-      assert.equal(val1, 'testing');
-      assert.equal(val2, 'testing');
+      assert.strictEqual(res.getHeader('x-test-header'), 'testing');
+      assert.strictEqual(res.getHeader('x-test-header2'), 'testing');
 
       res.removeHeader('x-test-header2');
       break;
 
     case 'contentLength':
       res.setHeader('content-length', content.length);
-      assert.equal(content.length, res.getHeader('Content-Length'));
+      assert.strictEqual(res.getHeader('Content-Length'), content.length);
       break;
 
     case 'transferEncoding':
       res.setHeader('transfer-encoding', 'chunked');
-      assert.equal(res.getHeader('Transfer-Encoding'), 'chunked');
+      assert.strictEqual(res.getHeader('Transfer-Encoding'), 'chunked');
       break;
 
     case 'writeHead':
@@ -55,11 +60,14 @@ var s = http.createServer(function(req, res) {
       res.setHeader('x-foo', 'keyboard cat');
       res.writeHead(200, { 'x-foo': 'bar', 'x-bar': 'baz' });
       break;
+
+    default:
+      common.fail('Unknown test');
   }
 
   res.statusCode = 201;
   res.end(content);
-});
+}, 4));
 
 s.listen(0, nextTest);
 
@@ -69,64 +77,49 @@ function nextTest() {
     return s.close();
   }
 
-  var bufferedResponse = '';
+  let bufferedResponse = '';
 
-  http.get({ port: s.address().port }, function(response) {
-    console.log('TEST: ' + test);
-    console.log('STATUS: ' + response.statusCode);
-    console.log('HEADERS: ');
-    console.dir(response.headers);
-
+  http.get({ port: s.address().port }, common.mustCall((response) => {
     switch (test) {
       case 'headers':
-        assert.equal(response.statusCode, 201);
-        assert.equal(response.headers['x-test-header'],
-                     'testing');
-        assert.equal(response.headers['x-test-array-header'],
-                     [1, 2, 3].join(', '));
-        assert.deepStrictEqual(cookies,
-                               response.headers['set-cookie']);
-        assert.equal(response.headers['x-test-header2'] !== undefined, false);
-        // Make the next request
+        assert.strictEqual(response.statusCode, 201);
+        assert.strictEqual(response.headers['x-test-header'], 'testing');
+        assert.strictEqual(response.headers['x-test-array-header'],
+                           [1, 2, 3].join(', '));
+        assert.deepStrictEqual(cookies, response.headers['set-cookie']);
+        assert.strictEqual(response.headers['x-test-header2'], undefined);
         test = 'contentLength';
-        console.log('foobar');
         break;
 
       case 'contentLength':
-        assert.equal(response.headers['content-length'], content.length);
+        assert.strictEqual(+response.headers['content-length'], content.length);
         test = 'transferEncoding';
         break;
 
       case 'transferEncoding':
-        assert.equal(response.headers['transfer-encoding'], 'chunked');
+        assert.strictEqual(response.headers['transfer-encoding'], 'chunked');
         test = 'writeHead';
         break;
 
       case 'writeHead':
-        assert.equal(response.headers['x-foo'], 'bar');
-        assert.equal(response.headers['x-bar'], 'baz');
-        assert.equal(200, response.statusCode);
+        assert.strictEqual(response.headers['x-foo'], 'bar');
+        assert.strictEqual(response.headers['x-bar'], 'baz');
+        assert.strictEqual(response.statusCode, 200);
         test = 'end';
         break;
 
       default:
-        throw new Error('?');
+        common.fail('Unknown test');
     }
 
     response.setEncoding('utf8');
-    response.on('data', function(s) {
+    response.on('data', (s) => {
       bufferedResponse += s;
     });
 
-    response.on('end', function() {
-      assert.equal(content, bufferedResponse);
-      testsComplete++;
-      nextTest();
-    });
-  });
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(bufferedResponse, content);
+      common.mustCall(nextTest)();
+    }));
+  }));
 }
-
-
-process.on('exit', function() {
-  assert.equal(4, testsComplete);
-});


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
lib

Use of `arguments` generally only causes problems. This PR removes several uses that serve no purpose at all.