### PR TITLE
Filter left trimmer v4.x

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 44
+#define V8_PATCH_LEVEL 45
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/heap/heap-inl.h
+++ b/deps/v8/src/heap/heap-inl.h
@@ -398,31 +398,6 @@ void Heap::CopyBlock(Address dst, Address src, int byte_size) {
             static_cast<size_t>(byte_size / kPointerSize));
 }
 
-bool Heap::PurgeLeftTrimmedObject(Object** object) {
-  HeapObject* current = reinterpret_cast<HeapObject*>(*object);
-  const MapWord map_word = current->map_word();
-  if (current->IsFiller() && !map_word.IsForwardingAddress()) {
-#ifdef DEBUG
-    // We need to find a FixedArrayBase map after walking the fillers.
-    while (current->IsFiller()) {
-      Address next = reinterpret_cast<Address>(current);
-      if (current->map() == one_pointer_filler_map()) {
-        next += kPointerSize;
-      } else if (current->map() == two_pointer_filler_map()) {
-        next += 2 * kPointerSize;
-      } else {
-        next += current->Size();
-      }
-      current = reinterpret_cast<HeapObject*>(next);
-    }
-    DCHECK(current->IsFixedArrayBase());
-#endif  // DEBUG
-    *object = nullptr;
-    return true;
-  }
-  return false;
-}
-
 void Heap::MoveBlock(Address dst, Address src, int byte_size) {
   DCHECK(IsAligned(byte_size, kPointerSize));
 

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -5316,6 +5316,49 @@ void Heap::IterateSmiRoots(ObjectVisitor* v) {
   v->Synchronize(VisitorSynchronization::kSmiRootList);
 }
 
+// We cannot avoid stale handles to left-trimmed objects, but can only make
+// sure all handles still needed are updated. Filter out a stale pointer
+// and clear the slot to allow post processing of handles (needed because
+// the sweeper might actually free the underlying page).
+class FixStaleLeftTrimmedHandlesVisitor : public ObjectVisitor {
+ public:
+  explicit FixStaleLeftTrimmedHandlesVisitor(Heap* heap) : heap_(heap) {
+    USE(heap_);
+  }
+
+  void VisitPointer(Object** p) override { FixHandle(p); }
+
+  void VisitPointers(Object** start, Object** end) override {
+    for (Object** p = start; p < end; p++) FixHandle(p);
+  }
+
+ private:
+  inline void FixHandle(Object** p) {
+    HeapObject* current = reinterpret_cast<HeapObject*>(*p);
+    if (!current->IsHeapObject()) return;
+    const MapWord map_word = current->map_word();
+    if (!map_word.IsForwardingAddress() && current->IsFiller()) {
+#ifdef DEBUG
+      // We need to find a FixedArrayBase map after walking the fillers.
+      while (current->IsFiller()) {
+        Address next = reinterpret_cast<Address>(current);
+        if (current->map() == heap_->one_pointer_filler_map()) {
+          next += kPointerSize;
+        } else if (current->map() == heap_->two_pointer_filler_map()) {
+          next += 2 * kPointerSize;
+        } else {
+          next += current->Size();
+        }
+        current = reinterpret_cast<HeapObject*>(next);
+      }
+      DCHECK(current->IsFixedArrayBase());
+#endif  // DEBUG
+      *p = nullptr;
+    }
+  }
+
+  Heap* heap_;
+};
 
 void Heap::IterateStrongRoots(ObjectVisitor* v, VisitMode mode) {
   v->VisitPointers(&roots_[0], &roots_[kStrongRootListLength]);
@@ -5339,6 +5382,8 @@ void Heap::IterateStrongRoots(ObjectVisitor* v, VisitMode mode) {
   v->Synchronize(VisitorSynchronization::kCompilationCache);
 
   // Iterate over local handles in handle scopes.
+  FixStaleLeftTrimmedHandlesVisitor left_trim_visitor(this);
+  isolate_->handle_scope_implementer()->Iterate(&left_trim_visitor);
   isolate_->handle_scope_implementer()->Iterate(v);
   isolate_->IterateDeferredHandles(v);
   v->Synchronize(VisitorSynchronization::kHandleScope);

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -590,12 +590,6 @@ class Heap {
   // jslimit_/real_jslimit_ variable in the StackGuard.
   void SetStackLimits();
 
-  // We cannot avoid stale handles to left-trimmed objects, but can only make
-  // sure all handles still needed are updated. Filter out a stale pointer
-  // and clear the slot to allow post processing of handles (needed because
-  // the sweeper might actually free the underlying page).
-  inline bool PurgeLeftTrimmedObject(Object** object);
-
   // Notifies the heap that is ok to start marking or other activities that
   // should not happen during deserialization.
   void NotifyDeserializationComplete();

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -590,6 +590,12 @@ class Heap {
   // jslimit_/real_jslimit_ variable in the StackGuard.
   void SetStackLimits();
 
+  // We cannot avoid stale handles to left-trimmed objects, but can only make
+  // sure all handles still needed are updated. Filter out a stale pointer
+  // and clear the slot to allow post processing of handles (needed because
+  // the sweeper might actually free the underlying page).
+  inline bool PurgeLeftTrimmedObject(Object** object);
+
   // Notifies the heap that is ok to start marking or other activities that
   // should not happen during deserialization.
   void NotifyDeserializationComplete();

--- a/deps/v8/src/heap/mark-compact.cc
+++ b/deps/v8/src/heap/mark-compact.cc
@@ -1650,8 +1650,6 @@ class RootMarkingVisitor : public ObjectVisitor {
 
     HeapObject* object = ShortCircuitConsString(p);
 
-    if (collector_->heap()->PurgeLeftTrimmedObject(p)) return;
-
     MarkBit mark_bit = Marking::MarkBitFrom(object);
     if (Marking::IsBlackOrGrey(mark_bit)) return;
 

--- a/deps/v8/src/heap/mark-compact.cc
+++ b/deps/v8/src/heap/mark-compact.cc
@@ -1650,31 +1650,7 @@ class RootMarkingVisitor : public ObjectVisitor {
 
     HeapObject* object = ShortCircuitConsString(p);
 
-    // We cannot avoid stale handles to left-trimmed objects, but can only make
-    // sure all handles still needed are updated. Filter out any stale pointers
-    // and clear the slot to allow post processing of handles (needed because
-    // the sweeper might actually free the underlying page).
-    if (object->IsFiller()) {
-#ifdef DEBUG
-      // We need to find a FixedArrayBase map after walking the fillers.
-      Heap* heap = collector_->heap();
-      HeapObject* current = object;
-      while (current->IsFiller()) {
-        Address next = reinterpret_cast<Address>(current);
-        if (current->map() == heap->one_pointer_filler_map()) {
-          next += kPointerSize;
-        } else if (current->map() == heap->two_pointer_filler_map()) {
-          next += 2 * kPointerSize;
-        } else {
-          next += current->Size();
-        }
-        current = reinterpret_cast<HeapObject*>(next);
-      }
-      DCHECK(current->IsFixedArrayBase());
-#endif  // DEBUG
-      *p = nullptr;
-      return;
-    }
+    if (collector_->heap()->PurgeLeftTrimmedObject(p)) return;
 
     MarkBit mark_bit = Marking::MarkBitFrom(object);
     if (Marking::IsBlackOrGrey(mark_bit)) return;

--- a/deps/v8/src/objects-inl.h
+++ b/deps/v8/src/objects-inl.h
@@ -1351,7 +1351,7 @@ Map* MapWord::ToMap() {
 }
 
 
-bool MapWord::IsForwardingAddress() {
+bool MapWord::IsForwardingAddress() const {
   return HAS_SMI_TAG(reinterpret_cast<Object*>(value_));
 }
 

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -1382,7 +1382,7 @@ class MapWord BASE_EMBEDDED {
   // True if this map word is a forwarding address for a scavenge
   // collection.  Only valid during a scavenge collection (specifically,
   // when all map words are heap object pointers, i.e. not during a full GC).
-  inline bool IsForwardingAddress();
+  inline bool IsForwardingAddress() const;
 
   // Create a map word from a forwarding address.
   static inline MapWord FromForwardingAddress(HeapObject* object);

--- a/deps/v8/test/mjsunit/regress/regress-620553.js
+++ b/deps/v8/test/mjsunit/regress/regress-620553.js
@@ -1,0 +1,17 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-gc
+
+var o0 = [];
+var o1 = [];
+var cnt = 0;
+o1.__defineGetter__(0, function() {
+  if (cnt++ > 2) return;
+  o0.shift();
+  gc();
+  o0.push(0);
+  o0.concat(o1);
+});
+o1[0];

--- a/deps/v8/test/mjsunit/regress/regress-621869.js
+++ b/deps/v8/test/mjsunit/regress/regress-621869.js
@@ -1,0 +1,18 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-gc
+
+var o0 = [];
+var o1 = [];
+var cnt = 0;
+var only_scavenge = true;
+o1.__defineGetter__(0, function() {
+  if (cnt++ > 2) return;
+  o0.shift();
+  gc(only_scavenge);
+  o0.push((64));
+  o0.concat(o1);
+});
+o1[0];


### PR DESCRIPTION
Backport of d800a65, 7a88ff3, and a715957 from V8 upstream to v4.x

These commits would not land cleanly on v4.x and needed to be manually reproduced. Due to the commits needing to be manually recreated I would appreciate a slightly more thorough review of this PR.

Conflicts:

* _6403bb2_:
  * Does not include changes to SLOW_DCHECK
* _d91c6ae_:
  * Does not include changes to `src/heap/scavenger.cc`
   - These changes would be reverted in 477fb96 so they can be considered a no-op
* _477fb96_:
  * Does not include changes to `src/heap/scavenger.cc`
   - this negates the changes not included in d91c6ae

/cc @ofrobots @nodejs/v8