### PR TITLE
doc: document use of Refs: for references

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -120,6 +120,7 @@ information regarding the change process:
   for an issue, and/or the hash and commit message if the commit fixes
   a bug in a previous commit. Multiple `Fixes:` lines may be added if
   appropriate.
+- A `Refs:` line referencing a URL for any relevant background.
 - A `Reviewed-By: Name <email>` line for yourself and any
   other Collaborators who have reviewed the change.
   - Useful for @mentions / contact list if something goes wrong in the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,10 +136,13 @@ Check the output of `git log --oneline files_that_you_changed` to find out
 what subsystem (or subsystems) your changes touch.
 
 If your patch fixes an open issue, you can add a reference to it at the end
-of the log. Use the `Fixes:` prefix and the full issue URL. For example:
+of the log. Use the `Fixes:` prefix and the full issue URL. For other references
+use `Refs:`. For example:
 
 ```txt
 Fixes: https://github.com/nodejs/node/issues/1337
+Refs: http://eslint.org/docs/rules/space-in-parens.html
+Refs: https://github.com/nodejs/node/pull/3615
 ```
 
 ### Step 4: Rebase


### PR DESCRIPTION
Standardise on Refs:

# Vote on this straw poll

http://www.strawpoll.me/12049231

(see https://github.com/nodejs/node/pull/10670#issuecomment-271069431)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

It seems that using `Refs:` or `Ref:` in commit messages isn't documented anywhere. I'd suggest we standardise on one or the other. I picked `Refs:` as it's more common, but either is fine.

```bash
➜  node git:(master) git log | grep Ref: | wc -l
     189
➜  node git:(master) git log | grep Refs: | wc -l
     262
```