### PR TITLE
test: refactor of zlib-from-gzip-with-trailing-garbage

### DIFF
--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -37,8 +37,11 @@ assert.throws(
   /^Error: unknown compression method$/
 );
 
-zlib.gunzip(data, common.mustCall((err) => {
-  assert(err);
+zlib.gunzip(data, common.mustCall((err, result) => {
+  assert(err instanceof Error);
+  assert.strictEqual(err.code, 'Z_DATA_ERROR');
+  assert.strictEqual(err.message, 'unknown compression method');
+  assert.strictEqual(result, undefined);
 }));
 
 // In this case the trailing junk is too short to be a gzip segment
@@ -54,6 +57,9 @@ assert.throws(
   /^Error: unknown compression method$/
 );
 
-zlib.gunzip(data, common.mustCall((err) => {
-  assert(err);
+zlib.gunzip(data, common.mustCall((err, result) => {
+  assert(err instanceof Error);
+  assert.strictEqual(err.code, 'Z_DATA_ERROR');
+  assert.strictEqual(err.message, 'unknown compression method');
+  assert.strictEqual(result, undefined);
 }));

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -12,11 +12,15 @@ let data = Buffer.concat([
   Buffer(10).fill(0)
 ]);
 
-assert.equal(zlib.gunzipSync(data).toString(), 'abcdef');
+assert.strictEqual(zlib.gunzipSync(data).toString(), 'abcdef');
 
 zlib.gunzip(data, common.mustCall((err, result) => {
   assert.ifError(err);
-  assert.equal(result, 'abcdef', 'result should match original string');
+  assert.strictEqual(
+    result.toString(),
+    'abcdef',
+    'result should match original string'
+  );
 }));
 
 // if the trailing garbage happens to look like a gzip header, it should
@@ -28,9 +32,12 @@ data = Buffer.concat([
   Buffer(10).fill(0)
 ]);
 
-assert.throws(() => zlib.gunzipSync(data));
+assert.throws(
+  () => zlib.gunzipSync(data),
+  /^Error: unknown compression method$/
+);
 
-zlib.gunzip(data, common.mustCall((err, result) => {
+zlib.gunzip(data, common.mustCall((err) => {
   assert(err);
 }));
 
@@ -42,8 +49,11 @@ data = Buffer.concat([
   Buffer([0x1f, 0x8b, 0xff, 0xff])
 ]);
 
-assert.throws(() => zlib.gunzipSync(data));
+assert.throws(
+  () => zlib.gunzipSync(data),
+  /^Error: unknown compression method$/
+);
 
-zlib.gunzip(data, common.mustCall((err, result) => {
+zlib.gunzip(data, common.mustCall((err) => {
   assert(err);
 }));


### PR DESCRIPTION
* use assert.strictEqual instead of assert.equal
* add RegExp in second argument of assert.throws
* removed unused arguments

##### Checklist

- [ x ] commit message follows commit guidelines