### PR TITLE
test: add test-cluster-worker-deprecated

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -31,14 +31,12 @@ function Worker(options) {
   this.exitedAfterDisconnect = undefined;
 
   Object.defineProperty(this, 'suicide', {
-    get: internalUtil.deprecate(() => {
-      return this.exitedAfterDisconnect;
-    }, 'worker.suicide is deprecated. ' +
-       'Please use worker.exitedAfterDisconnect.'),
-    set: internalUtil.deprecate((val) => {
-      this.exitedAfterDisconnect = val;
-    }, 'worker.suicide is deprecated. ' +
-       'Please use worker.exitedAfterDisconnect.'),
+    get: internalUtil.deprecate(
+      () => this.exitedAfterDisconnect,
+      'worker.suicide is deprecated. Please use worker.exitedAfterDisconnect.'),
+    set: internalUtil.deprecate(
+      (val) => { this.exitedAfterDisconnect = val; },
+      'worker.suicide is deprecated. Please use worker.exitedAfterDisconnect.'),
     enumerable: true
   });
 

--- a/test/parallel/test-cluster-worker-deprecated.js
+++ b/test/parallel/test-cluster-worker-deprecated.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+
+const assert = require('assert');
+const cluster = require('cluster');
+
+const worker = new cluster.Worker();
+
+assert.strictEqual(worker.exitedAfterDisconnect, undefined);
+assert.strictEqual(worker.suicide, undefined);
+
+worker.exitedAfterDisconnect = 'recommended';
+assert.strictEqual(worker.exitedAfterDisconnect, 'recommended');
+assert.strictEqual(worker.suicide, 'recommended');
+
+worker.suicide = 'deprecated';
+assert.strictEqual(worker.exitedAfterDisconnect, 'deprecated');
+assert.strictEqual(worker.suicide, 'deprecated');


### PR DESCRIPTION
Add test to cover setter for deprecated cluster Worker property.
Previously, the setter was not being exercised in tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test cluster