### PR TITLE
pipe: enable writev for pipe handles on Unix

### DIFF
--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -53,7 +53,11 @@ void PipeWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "hasRef", HandleWrap::HasRef);
 
+#ifdef _WIN32
   StreamWrap::AddMethods(env, t);
+#else
+  StreamWrap::AddMethods(env, t, StreamBase::kFlagHasWritev);
+#endif
 
   env->SetProtoMethod(t, "bind", Bind);
   env->SetProtoMethod(t, "listen", Listen);

--- a/test/parallel/test-pipe-writev.js
+++ b/test/parallel/test-pipe-writev.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+if (common.isWindows) {
+  common.skip('Unix-specific test');
+  return;
+}
+
+common.refreshTmpDir();
+
+const server = net.createServer((connection) => {
+  connection.on('error', (err) => {
+    throw err;
+  });
+
+  const writev = connection._writev.bind(connection);
+  connection._writev = common.mustCall(writev);
+
+  connection.cork();
+  connection.write('pi');
+  connection.write('ng');
+  connection.end();
+});
+
+server.on('error', (err) => {
+  throw err;
+});
+
+server.listen(common.PIPE, () => {
+  const client = net.connect(common.PIPE);
+
+  client.on('error', (err) => {
+    throw err;
+  });
+
+  client.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'ping');
+  }));
+
+  client.on('end', () => {
+    server.close();
+  });
+});


### PR DESCRIPTION
This PR enables `writev` for Unix Domain Sockets on supported platforms thus enabling cork/uncork functionality for them and increasing IPC performance.

Only those Unix-like systems that are confirmed to support the feature (Linux, macOS and FreeBSD) are explicitly listed in the define guard. If anyone has an opportunity to test it under other platforms supported by Node, the list should be expanded, inverted into list of platforms that do not support the feature or even changed to a simple Windows/Unix check.

It should fix #5095 and similar issues, but I haven't benchmarked this specific case and haven't prepared any public benchmarks yet. In my usecase it gives about 1.3–1.4x performance increase on Linux (but strangely the same performance on macOS).

**UPD**: after [discussion on IRC](http://logs.nodejs.org/node-dev/2017-01-08#22:20:49.669) and experiment on CI the patch is enabled on all platforms except Windows.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
pipe, stream_wrap