### PR TITLE
v7.x backport - doc: correct vcbuild options for windows testing

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -121,7 +121,7 @@ Prerequisites:
 To run the tests:
 
 ```console
-> .\vcbuild test
+> .\vcbuild nosign test
 ```
 
 To test if Node.js was built correctly:
@@ -179,7 +179,7 @@ $ ./configure --with-intl=full-icu --download=all
 ##### Windows:
 
 ```console
-> .\vcbuild full-icu download-all
+> .\vcbuild nosign full-icu download-all
 ```
 
 #### Building without Intl support
@@ -196,7 +196,7 @@ $ ./configure --without-intl
 ##### Windows:
 
 ```console
-> .\vcbuild without-intl
+> .\vcbuild nosign without-intl
 ```
 
 #### Use existing installed ICU (Unix / OS X only):
@@ -239,7 +239,7 @@ First unpack latest ICU to `deps/icu`
 as `deps/icu` (You'll have: `deps/icu/source/...`)
 
 ```console
-> .\vcbuild full-icu
+> .\vcbuild nosign full-icu
 ```
 
 ## Building Node.js with FIPS-compliant OpenSSL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ $ ./configure && make -j4 test
 Windows:
 
 ```text
-> vcbuild test
+ .\vcbuild nosign test
 ```
 
 (See the [BUILDING.md](./BUILDING.md) for more details.)
@@ -175,11 +175,11 @@ Windows:
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-Running `make test`/`vcbuild test` will run the linter as well unless one or
+Running `make test`/`.\vcbuild nosign test` will run the linter as well unless one or
 more tests fail.
 
 If you want to run the linter without running tests, use
-`make lint`/`vcbuild jslint`.
+`make lint`/`.\vcbuild nosign jslint`.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:


### PR DESCRIPTION
Corrected parameter for running tests on Windows. Without the corrected
parameters, Windows users encounter an error about failing to sign the
build, "Failed to sign exe", which can be discouraging to new Windows
community members.

Reopened version of https://github.com/nodejs/node/pull/10112, I added `.\` and changed `test nosign`->`nosign test` as per comments in that PR (and also change commit message to be <50 chars).

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc, win