### PR TITLE
doc: add note about max string length in buffer.toString

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1845,6 +1845,10 @@ console.log(buf2.toString('utf8', 0, 3));
 console.log(buf2.toString(undefined, 0, 3));
 ```
 
+_Note_: If the size of the resulting string would exceed an
+implementation-specific limit, this method will throw an Error. This limit is
+equal to `2^28 - 16` in V8.
+
 ### buf.toJSON()
 <!-- YAML
 added: v0.9.2


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/9489

I'm open to suggestions for the commit message that is currently > 50 chars.

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, buffer