### PR TITLE
test: validate arguments to mustCall(), fix incorrect tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -424,7 +424,10 @@ function runCallChecks(exitCode) {
 
 
 exports.mustCall = function(fn, expected) {
-  if (typeof expected !== 'number') expected = 1;
+  if (expected === undefined)
+    expected = 1;
+  else if (typeof expected !== 'number')
+    throw new TypeError(`Invalid expected value: ${expected}`);
 
   const context = {
     expected: expected,

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -5,3 +5,11 @@ const assert = require('assert');
 common.globalCheck = false;
 global.gc = 42;  // Not a valid global unless --expose_gc is set.
 assert.deepStrictEqual(common.leakedGlobals(), ['gc']);
+
+assert.throws(function() {
+  common.mustCall(function() {}, 'foo');
+}, /^TypeError: Invalid expected value: foo$/);
+
+assert.throws(function() {
+  common.mustCall(function() {}, /foo/);
+}, /^TypeError: Invalid expected value: \/foo\/$/);

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -11,62 +11,62 @@ const server = http.Server(common.mustCall(function(req, res) {
     case 0:
       assert.throws(common.mustCall(() => {
         res.writeHead(-1);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 1:
       assert.throws(common.mustCall(() => {
         res.writeHead(Infinity);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 2:
       assert.throws(common.mustCall(() => {
         res.writeHead(NaN);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 3:
       assert.throws(common.mustCall(() => {
         res.writeHead({});
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 4:
       assert.throws(common.mustCall(() => {
         res.writeHead(99);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 5:
       assert.throws(common.mustCall(() => {
         res.writeHead(1000);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 6:
       assert.throws(common.mustCall(() => {
         res.writeHead('1000');
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 7:
       assert.throws(common.mustCall(() => {
         res.writeHead(null);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 8:
       assert.throws(common.mustCall(() => {
         res.writeHead(true);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 9:
       assert.throws(common.mustCall(() => {
         res.writeHead([]);
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 10:
       assert.throws(common.mustCall(() => {
         res.writeHead('this is not valid');
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       break;
     case 11:
       assert.throws(common.mustCall(() => {
         res.writeHead('404 this is not valid either');
-      }, /invalid status code/i));
+      }), /invalid status code/i);
       this.close();
       break;
     default:


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tests


Notes: this is a subset of the changes in #9031 as requested by @mscdex and @targos.
