### PR TITLE
test: improve test stream transform constructor

### DIFF
--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -21,12 +21,19 @@ const t = new Transform({
   flush: _flush
 });
 
+const t2 = new Transform({});
+
 t.end(Buffer.from('blerg'));
 t.resume();
 
-process.on('exit', function() {
+assert.throws(() => {
+  t2.end(Buffer.from('blerg'));
+}, /^Error: _transform\(\) is not implemented$/);
+
+
+process.on('exit', () => {
   assert.strictEqual(t._transform, _transform);
   assert.strictEqual(t._flush, _flush);
-  assert(_transformCalled);
-  assert(_flushCalled);
+  assert.strictEqual(_transformCalled, true);
+  assert.strictEqual(_flushCalled, true);
 });


### PR DESCRIPTION
* new test for the error when a transform function is not specified
* use let instead of var
* use assert.strictEqual instead of assert.equal
* use arrow functions

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
