### PR TITLE
doc: keepAliveMsecs refers to an initial delay not interval

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -102,8 +102,8 @@ added: v0.3.4
   Can have the following fields:
   * `keepAlive` {Boolean} Keep sockets around in a pool to be used by
     other requests in the future. Default = `false`
-  * `keepAliveMsecs` {Integer} When using HTTP KeepAlive, how often
-    to send TCP KeepAlive packets over sockets being kept alive.
+  * `keepAliveMsecs` {Integer} When using HTTP KeepAlive, the initial delay 
+    between the last data packet and the first TCP KeepAlive packet.
     Default = `1000`.  Only relevant if `keepAlive` is set to `true`.
   * `maxSockets` {Number} Maximum number of sockets to allow per
     host.  Default = `Infinity`.


### PR DESCRIPTION
To bring the http docs in-line with the net docs, `keepAliveMsecs`
should refer to the initial delay, rather than an interval between
keep alive probes.

There is currently no way to set the actual interval between keep
alive probes.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

Fixes: https://github.com/nodejs/node/issues/7335