### PR TITLE
tls: do not crash on STARTTLS when OCSP requested

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -116,7 +116,7 @@ function requestOCSP(self, hello, ctx, cb) {
     ctx = self.server._sharedCreds;
 
   // TLS socket is using a `net.Server` instead of a tls.TLSServer.
-  // Some TLS properties will not be present.
+  // Some TLS properties like `server._sharedCreds` will not be present
   if (!ctx)
     return cb(null);
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -115,7 +115,8 @@ function requestOCSP(self, hello, ctx, cb) {
   if (!ctx)
     ctx = self.server._sharedCreds;
 
-  // Running on non-TLS server
+  // TLS socket is using a `net.Server` instead of a tls.TLSServer.
+  // Some TLS properties will not be present.
   if (!ctx)
     return cb(null);
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -114,6 +114,12 @@ function requestOCSP(self, hello, ctx, cb) {
 
   if (!ctx)
     ctx = self.server._sharedCreds;
+
+  // Running on non-TLS server
+  if (!ctx)
+    return cb(null);
+
+  // TODO(indutny): eventually disallow raw `SecureContext`
   if (ctx.context)
     ctx = ctx.context;
 

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -6,10 +6,13 @@ if (!common.hasCrypto) {
   return;
 }
 
+// Test asynchronous SNI+OCSP on TLSSocket created on with `server` set to
+// `net.Server` instead of `tls.Server`
+
 const assert = require('assert');
+const fs = require('fs');
 const net = require('net');
 const tls = require('tls');
-const fs = require('fs');
 
 const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
@@ -43,7 +46,7 @@ const server = net.createServer(common.mustCall((s) => {
     requestOCSP: true
   };
 
-  const client = tls.connect(opts, function() {
-    client.end();
+  tls.connect(opts, function() {
+    this.end();
   });
 });

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -1,13 +1,14 @@
 'use strict';
+
+// Test asynchronous SNI+OCSP on TLSSocket created with `server` set to
+// `net.Server` instead of `tls.Server`
+
 const common = require('../common');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-
-// Test asynchronous SNI+OCSP on TLSSocket created on with `server` set to
-// `net.Server` instead of `tls.Server`
 
 const assert = require('assert');
 const fs = require('fs');

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -1,0 +1,50 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+const fs = require('fs');
+
+const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
+const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+
+const server = net.createServer(common.mustCall((s) => {
+  const tlsSocket = new tls.TLSSocket(s, {
+    isServer: true,
+    server: server,
+
+    secureContext: tls.createSecureContext({
+      key: key,
+      cert: cert
+    }),
+
+    SNICallback: common.mustCall((hostname, callback) => {
+      assert.equal(hostname, 'test.test');
+
+      callback(null, null);
+    })
+  });
+
+  tlsSocket.on('secure', common.mustCall(() => {
+    console.log('hello');
+    tlsSocket.end();
+    server.close();
+  }));
+})).listen(0, () => {
+  const opts = {
+    servername: 'test.test',
+    port: server.address().port,
+    rejectUnauthorized: false,
+    requestOCSP: true
+  };
+
+  const client = tls.connect(opts, function() {
+    client.end();
+  });
+});

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -25,14 +25,13 @@ const server = net.createServer(common.mustCall((s) => {
     }),
 
     SNICallback: common.mustCall((hostname, callback) => {
-      assert.equal(hostname, 'test.test');
+      assert.deepEqual(hostname, 'test.test');
 
       callback(null, null);
     })
   });
 
   tlsSocket.on('secure', common.mustCall(() => {
-    console.log('hello');
     tlsSocket.end();
     server.close();
   }));

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -29,7 +29,7 @@ const server = net.createServer(common.mustCall((s) => {
     }),
 
     SNICallback: common.mustCall((hostname, callback) => {
-      assert.deepEqual(hostname, 'test.test');
+      assert.strictEqual(hostname, 'test.test');
 
       callback(null, null);
     })


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tls 

<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
`TLSSocket` should not have a hard dependency on `tls.Server`, since it
may be running without it in cases like `STARTTLS`.

Fix: #10704
