### PR TITLE
test: skip test-icu-transcode if ICU is not present

### DIFF
--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -1,8 +1,13 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const buffer = require('buffer');
 const assert = require('assert');
+
+if (!common.hasIntl) {
+  common.skip('icu punycode tests because ICU is not present.');
+  return;
+}
 
 const orig = Buffer.from('tést €', 'utf8');
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/9511. Use icu's punycode implementation to make sure ICU is present or not in a test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
+ test