### PR TITLE
doc: fix misleading language in vm docs

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -439,9 +439,9 @@ let code =
  vm.runInThisContext(code)(require);
  ```
 
-*Note*: The `require()` in the above case shares the state with context it is
-passed from. This may introduce risks when untrusted code is executed, e.g.
-altering objects from the calling thread's context in unwanted ways.
+*Note*: The `require()` in the above case shares the state with the context it
+is passed from. This may introduce risks when untrusted code is executed, e.g.
+altering objects in the context in unwanted ways.
 
 ## What does it mean to "contextify" an object?
 


### PR DESCRIPTION
As @mscdex noted, the note following the http.Server example in the vm documentation contains misleading language. This commit removes the incorrect reference to threads.

Fixes: #10697

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
