### PR TITLE
Fix missing negation

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1306,7 +1306,7 @@ It is recommended that errors occurring during the processing of the
 `writable._write()` and `writable._writev()` methods are reported by invoking
 the callback and passing the error as the first argument. This will cause an
 `'error'` event to be emitted by the Writable. Throwing an Error from within
-`writable._write()` can result in expected and inconsistent behavior depending
+`writable._write()` can result in unexpected and inconsistent behavior depending
 on how the stream is being used.  Using the callback ensures consistent and
 predictable handling of errors.
 


### PR DESCRIPTION
This will fix #10710 by changing `..can result in expected` to `..can result in unexpected`
