### PR TITLE
doc: update http.md for consistency

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -60,11 +60,11 @@ options, all HTTP client requests will use the default
 [`http.globalAgent`].
 
 In addition to managing connection persistence for queued HTTP
-requests, an `Agent` can be used for pooling sockets across connections.
-When providing `{ keepAlive: true }` among the [constructor options],
-the `Agent` will not destroy sockets when the request queue has been
-emptied. Rather, it will pool these sockets for later requests on the
-same host and port.
+requests, an `Agent` can be used for pooling sockets across multiple
+client requests. When providing `{ keepAlive: true }` among the
+[constructor options], the `Agent` will not destroy sockets when
+the request queue has been emptied. Rather, it will pool these
+sockets for later requests on the same host and port.
 
 By providing `{ keepAlive: true }` as a constructor option to the the
 HTTP `Agent`, sockets will not only be pooled, but the HTTP header
@@ -76,7 +76,7 @@ When a socket is closed, whether by the user, or alternatively
 by the server, it is removed from the pool. Any unused sockets in the pool
 will be marked so as not to keep the Node.js process running.
 It is good practice, however, to [`destroy()`][] HTTP Keep-Alive
-agents when they are no longer in use, so that the sockets will be shut down.
+agents when they are no longer iqn use, so that the sockets will be shut down.
 
 Sockets are removed from an agent's pool when the socket emits either
 a `'close'` event or an `'agentRemove'` event. This means that if

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -48,25 +48,25 @@ list like the following:
 added: v0.3.4
 -->
 
-The HTTP Agent is used for pooling sockets used in HTTP client
+The HTTP `Agent` is used for pooling sockets used in HTTP client
 requests.
 
-The HTTP Agent also defaults client requests to using
+The HTTP `Agent` also defaults client requests to using
 `Connection: keep-alive`. If no pending HTTP requests are waiting on a
 socket to become free the socket is closed. This means that Node.js's
-pool has the benefit of keep-alive when under load but still does not
-require developers to manually close the HTTP clients using
-KeepAlive.
+pool has the benefit of HTTP Keep-Alive when under load but still does not
+require developers to manually close HTTP clients when using
+this option.
 
-If you opt into using HTTP KeepAlive, you can create an Agent object
-with that flag set to `true`.  (See the [constructor options][].)
-Then, the Agent will keep unused sockets in a pool for later use.  They
-will be explicitly marked so as to not keep the Node.js process running.
-However, it is still a good idea to explicitly [`destroy()`][] KeepAlive
-agents when they are no longer in use, so that the Sockets will be shut
-down.
+If you opt into using HTTP Keep-Alive, you can create an `Agent` instance,
+providing `{ keepAlive: true }` among the constructor options. (See the
+[constructor options][].) The `Agent` will then keep unused sockets in a
+pool for later use.  They will be explicitly marked so as to not keep the
+Node.js process running. However, it is still a good idea to explicitly
+[`destroy()`][] HTTP Keep-Alive agents when they are no longer in use, so that
+the Sockets will be shut down.
 
-Sockets are removed from the agent's pool when the socket emits either
+Sockets are removed from the `Agent`'s pool when the socket emits either
 a `'close'` event or a special `'agentRemove'` event. This means that if
 you intend to keep one HTTP request open for a long time and don't
 want it to stay in the pool you can do something along the lines of:
@@ -136,7 +136,7 @@ added: v0.11.4
 Produces a socket/stream to be used for HTTP requests.
 
 By default, this function is the same as [`net.createConnection()`][]. However,
-custom Agents may override this method in case greater flexibility is desired.
+custom agents may override this method in case greater flexibility is desired.
 
 A socket/stream can be supplied in one of two ways: by returning the
 socket/stream from this function, or by passing the socket/stream to `callback`.
@@ -151,7 +151,7 @@ added: v0.11.4
 Destroy any sockets that are currently in use by the agent.
 
 It is usually not necessary to do this.  However, if you are using an
-agent with KeepAlive enabled, then it is best to explicitly shut down
+agent with HTTP Keep-Alive enabled, then it is best to explicitly shut down
 the agent when you know that it will no longer be used.  Otherwise,
 sockets may hang open for quite a long time before the server
 terminates them.
@@ -164,7 +164,7 @@ added: v0.11.4
 * {Object}
 
 An object which contains arrays of sockets currently awaiting use by
-the Agent when HTTP KeepAlive is used.  Do not modify.
+the agent when HTTP Keep-Alive is used.  Do not modify.
 
 ### agent.getName(options)
 <!-- YAML
@@ -179,8 +179,8 @@ added: v0.11.4
 * Returns: {String}
 
 Get a unique name for a set of request options, to determine whether a
-connection can be reused.  In the http agent, this returns
-`host:port:localAddress`.  In the https agent, the name includes the
+connection can be reused.  In the HTTP agent, this returns
+`host:port:localAddress`.  In the HTTPS agent, the name includes the
 CA, cert, ciphers, and other HTTPS/TLS-specific options that determine
 socket reusability.
 
@@ -191,7 +191,7 @@ added: v0.11.7
 
 * {Number}
 
-By default set to 256.  For Agents supporting HTTP KeepAlive, this
+By default set to 256.  For agents supporting HTTP Keep-Alive, this
 sets the maximum number of sockets that will be left open in the free
 state.
 
@@ -224,7 +224,7 @@ added: v0.3.6
 * {Object}
 
 An object which contains arrays of sockets currently in use by the
-Agent.  Do not modify.
+agent.  Do not modify.
 
 ## Class: http.ClientRequest
 <!-- YAML
@@ -652,7 +652,7 @@ added: v0.1.0
 * `response` {http.ServerResponse}
 
 Emitted each time there is a request. Note that there may be multiple requests
-per connection (in the case of keep-alive connections).
+per connection (in the case of HTTP Keep-Alive connections).
 
 ### Event: 'upgrade'
 <!-- YAML
@@ -1490,7 +1490,7 @@ added: v0.5.9
 
 * {http.Agent}
 
-Global instance of Agent which is used as the default for all HTTP client
+Global instance of `Agent` which is used as the default for all HTTP client
 requests.
 
 ## http.request(options[, callback])
@@ -1520,15 +1520,15 @@ added: v0.3.6
   * `headers` {Object} An object containing request headers.
   * `auth` {String} Basic authentication i.e. `'user:password'` to compute an
     Authorization header.
-  * `agent` {http.Agent|Boolean} Controls [`Agent`][] behavior. When an Agent
+  * `agent` {http.Agent|Boolean} Controls [`Agent`][] behavior. When an `Agent`
     is used request will default to `Connection: keep-alive`. Possible values:
    * `undefined` (default): use [`http.globalAgent`][] for this host and port.
    * `Agent` object: explicitly use the passed in `Agent`.
-   * `false`: opts out of connection pooling with an Agent, defaults request to
+   * `false`: opts out of connection pooling with an `Agent`, defaults request to
      `Connection: close`.
   * `createConnection` {Function} A function that produces a socket/stream to
-    use for the request when the `agent` option is not used. This can be used to
-    avoid creating a custom Agent class just to override the default
+    use for the request when the `Agent` option is not used. This can be used to
+    avoid creating a custom `Agent` class just to override the default
     `createConnection` function. See [`agent.createConnection()`][] for more
     details.
   * `timeout` {Integer}: A number specifying the socket timeout in milliseconds.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1664,4 +1664,4 @@ There are a few special headers that should be noted.
 [constructor options]: #http_new_agent_options
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
-[socket.unref()]: net.html#socket_unref
+[socket.unref()]: net.html#net_socket_unref

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -59,14 +59,14 @@ require developers to manually close HTTP clients when using
 this option.
 
 If you opt into using HTTP Keep-Alive, you can create an `Agent` instance,
-providing `{ keepAlive: true }` among the constructor options. (See the
-[constructor options][].) The `Agent` will then keep unused sockets in a
-pool for later use.  They will be explicitly marked so as to not keep the
+providing `{ keepAlive: true }` among the [constructor options][].
+The agent will then keep unused sockets in a pool for later use.  The
+unused sockets will be explicitly marked so as to not keep the
 Node.js process running. However, it is still a good idea to explicitly
 [`destroy()`][] HTTP Keep-Alive agents when they are no longer in use, so that
-the Sockets will be shut down.
+the sockets will be shut down.
 
-Sockets are removed from the `Agent`'s pool when the socket emits either
+Sockets are removed from an agent's pool when the socket emits either
 a `'close'` event or a special `'agentRemove'` event. This means that if
 you intend to keep one HTTP request open for a long time and don't
 want it to stay in the pool you can do something along the lines of:
@@ -179,8 +179,8 @@ added: v0.11.4
 * Returns: {String}
 
 Get a unique name for a set of request options, to determine whether a
-connection can be reused.  In the HTTP agent, this returns
-`host:port:localAddress`.  In the HTTPS agent, the name includes the
+connection can be reused.  For an HTTP agent, this returns
+`host:port:localAddress`.  For an HTTPS agent, the name includes the
 CA, cert, ciphers, and other HTTPS/TLS-specific options that determine
 socket reusability.
 
@@ -1527,7 +1527,7 @@ added: v0.3.6
    * `false`: opts out of connection pooling with an `Agent`, defaults request to
      `Connection: close`.
   * `createConnection` {Function} A function that produces a socket/stream to
-    use for the request when the `Agent` option is not used. This can be used to
+    use for the request when the `agent` option is not used. This can be used to
     avoid creating a custom `Agent` class just to override the default
     `createConnection` function. See [`agent.createConnection()`][] for more
     details.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -74,9 +74,10 @@ from the client to the server.
 
 When a socket is closed, whether by the user, or alternatively
 by the server, it is removed from the pool. Any unused sockets in the pool
-will be marked so as not to keep the Node.js process running.
-It is good practice, however, to [`destroy()`][] HTTP Keep-Alive
-agents when they are no longer iqn use, so that the sockets will be shut down.
+will be marked so as not to keep the Node.js process running
+(see [socket.unref()]). It is good practice, however, to [`destroy()`][]
+a client `Agent` when it is no longer in use, so that the sockets
+will be shut down.
 
 Sockets are removed from an agent's pool when the socket emits either
 a `'close'` event or an `'agentRemove'` event. This means that if
@@ -1665,3 +1666,4 @@ There are a few special headers that should be noted.
 [constructor options]: #http_new_agent_options
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
+[socket.unref()]: net.html#socket_unref

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1537,12 +1537,10 @@ added: v0.3.6
   * `headers` {Object} An object containing request headers.
   * `auth` {String} Basic authentication i.e. `'user:password'` to compute an
     Authorization header.
-  * `agent` {http.Agent|Boolean} Controls [`Agent`][] behavior. When an `Agent`
-    is used request will default to `Connection: keep-alive`. Possible values:
+  * `agent` {http.Agent|Boolean} Controls [`Agent`][] behavior. Possible values:
    * `undefined` (default): use [`http.globalAgent`][] for this host and port.
    * `Agent` object: explicitly use the passed in `Agent`.
-   * `false`: opts out of connection pooling with an `Agent`, defaults request to
-     `Connection: close`.
+   * `false`: causes a new `Agent` with default values to be used.
   * `createConnection` {Function} A function that produces a socket/stream to
     use for the request when the `agent` option is not used. This can be used to
     avoid creating a custom `Agent` class just to override the default


### PR DESCRIPTION
The HTTP Keep-Alive text was inconsistent. These changes follow the
following rules

* When referring to flag used in code, it should always be written using
  backticks and in camel case. E.g. `keepAlive`.
* When referring to the mechanism Keep-Alive functionality as described
  in the HTTP 1.1 RFC, it is written as 'HTTP Keep-Alive', without the
  use of backticks.
* When referring to the request header, it should always use backticks
  and be written as `Connection: keep-alive`.

This commit also includes some changes to how `http.Agent` is
referenced. When `Agent` is used as a reference to an object or
instance, backticks should always be used.

Left somewhat unresolved is how to determine when to use "agent"
vs. "`Agent`". At the moment, the API documentation typically uses
"agent" when referring to a generic instance, and either `http.Agent` or
`Agent` when referring to a specific instance. But it's not really 100%
clear. I wonder if it would be best to just always use `Agent`.

Ref: https://github.com/nodejs/node/pull/10614
Fixes: https://github.com/nodejs/node/issues/10567

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
