### PR TITLE
WIP: lib: remove unnecessary bootstrap function?

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -393,9 +393,7 @@
   }
 
   function isDebugBreak() {
-    return process.execArgv.some((arg) => {
-      return arg.match(/^--debug-brk(=[0-9]*)?$/);
-    });
+    return process.execArgv.some((arg) => arg.match(/^--debug-brk(=[0-9]*)?$/));
   }
 
   function run(entryFunction) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -3269,7 +3269,7 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
   }
 
-  // --debug-brk
+  // --debug-brk, --inspect-brk
   if (debug_options.wait_for_connect()) {
     READONLY_PROPERTY(process, "_debugWaitConnect", True(env->isolate()));
   }


### PR DESCRIPTION
Remove `isDebugBreak()` from bootstrap_node.js. It is only called if
`process._debugWaitConnect` is true, but that only happens if the
`--debug-brk` CLI flag is being used, which is exactly what
`isDebugBreak()` is checking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib