### PR TITLE
test: use realpath for NODE_TEST_DIR in common.js

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -373,7 +373,7 @@ Synchronous version of `spawnPwd`.
 ### tmpDir
 * return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
 
-Path to the 'tmp' directory.
+The realpath of the 'tmp' directory.
 
 ### tmpDirName
 * return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)

--- a/test/common.js
+++ b/test/common.js
@@ -12,7 +12,7 @@ const Timer = process.binding('timer_wrap').Timer;
 const execSync = require('child_process').execSync;
 
 const testRoot = process.env.NODE_TEST_DIR ?
-                   path.resolve(process.env.NODE_TEST_DIR) : __dirname;
+                   fs.realpathSync(process.env.NODE_TEST_DIR) : __dirname;
 
 exports.fixturesDir = path.join(__dirname, 'fixtures');
 exports.tmpDirName = 'tmp';

--- a/tools/test.py
+++ b/tools/test.py
@@ -1628,9 +1628,9 @@ def Main():
 
   tempdir = os.environ.get('NODE_TEST_DIR') or options.temp_dir
   if tempdir:
+    os.environ['NODE_TEST_DIR'] = tempdir
     try:
       os.makedirs(tempdir)
-      os.environ['NODE_TEST_DIR'] = tempdir
     except OSError as exception:
       if exception.errno != errno.EEXIST:
         print "Could not create the temporary directory", options.temp_dir


### PR DESCRIPTION
If you don't specify `NODE_TEST_DIR`, `common.tmpDir` will resolve to the
realpath of `node/test`.

If you do specify NODE_TEST_DIR (with the environment variable or by
running or by running tools/test.py --test-dir=x), common.tmpDir (which
is resolved from testRoot) uses the symbolic path (doesn't resolve
symlinks). This uses fs.realpathSync() to fix that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, common