### PR TITLE
test: improve test-stream2-large-read-stall

### DIFF
--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -33,7 +33,9 @@ r.on('readable', function() {
                 rs.length);
 });
 
-r.on('end', common.mustCall(function() {}));
+r.on('end', common.mustCall(function() {
+  assert.strictEqual(pushes, PUSHCOUNT + 1);
+}));
 
 let pushes = 0;
 function push() {
@@ -49,7 +51,3 @@ function push() {
   if (r.push(Buffer.allocUnsafe(PUSHSIZE)))
     setTimeout(push, 1);
 }
-
-process.on('exit', function() {
-  assert.strictEqual(pushes, PUSHCOUNT + 1);
-});


### PR DESCRIPTION
* use const instead of var
* use assert.strictEqual instead of assert.equal
* use  common.mustCall instead of process.on( 'exit', fn )

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
