### PR TITLE
deps: V8: fix backtrace for symbols

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 43
+#define V8_PATCH_LEVEL 44
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/mirror-debugger.js
+++ b/deps/v8/src/mirror-debugger.js
@@ -1515,7 +1515,7 @@ PropertyMirror.prototype.name = function() {
 
 
 PropertyMirror.prototype.toText = function() {
-  if (IS_SYMBOL(this.name_)) return %SymbolDescriptiveString(this.name_);
+  if (IS_SYMBOL(this.name_)) return %SymbolDescription(this.name_);
   return this.name_;
 };
 

--- a/deps/v8/test/mjsunit/debug-backtrace-text.js
+++ b/deps/v8/test/mjsunit/debug-backtrace-text.js
@@ -106,7 +106,7 @@ function listener(event, exec_state, event_data, data) {
         // 2: [anonymous]
         assertEquals("new Point(x=0, y=0)",
                      exec_state.frame(0).invocationText());
-        assertEquals("#<Object>[Symbol(Das Symbol)](x=0, y=0)",
+        assertEquals("#<Object>[Das Symbol](x=0, y=0)",
                      exec_state.frame(1).invocationText());
         assertEquals("[anonymous]()", exec_state.frame(2).invocationText());
         listenerCalled = true;


### PR DESCRIPTION
The cherry-pick of #7612 to v4.x (4369055) added in #9298 wasn't quite correct as it depends on a runtime function `%SymbolDescriptiveString` that doesn't exist on v4.x (V8 4.5). We can use `%SymbolDescription` instead.

It seems that the V8-CI was missed when when the #7612 was backported to `v4.x` so we didn't catch it at that point. At this point however, the V8-CI is no longer passing because of the V8 test failures caused by the above.

R=@hashseed, @nodejs/v8 
/cc @MylesBorins 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
deps: V8


