### PR TITLE
deps: cherry-pick a814b8a from upstream V8

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 4
 #define V8_BUILD_NUMBER 500
-#define V8_PATCH_LEVEL 45
+#define V8_PATCH_LEVEL 46
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -3449,9 +3449,16 @@ void MigrateFastToSlow(Handle<JSObject> object, Handle<Map> new_map,
   // Ensure that in-object space of slow-mode object does not contain random
   // garbage.
   int inobject_properties = new_map->GetInObjectProperties();
-  for (int i = 0; i < inobject_properties; i++) {
-    FieldIndex index = FieldIndex::ForPropertyIndex(*new_map, i);
-    object->RawFastPropertyAtPut(index, Smi::FromInt(0));
+  if (inobject_properties) {
+    Heap* heap = isolate->heap();
+    heap->ClearRecordedSlotRange(
+        object->address() + map->GetInObjectPropertyOffset(0),
+        object->address() + new_instance_size);
+
+    for (int i = 0; i < inobject_properties; i++) {
+      FieldIndex index = FieldIndex::ForPropertyIndex(*new_map, i);
+      object->RawFastPropertyAtPut(index, Smi::FromInt(0));
+    }
   }
 
   isolate->counters()->props_to_dictionary()->Increment();

--- a/deps/v8/test/mjsunit/regress/regress-666046.js
+++ b/deps/v8/test/mjsunit/regress/regress-666046.js
@@ -1,0 +1,57 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --expose-gc
+
+function P() {
+  this.a0 = {};
+  this.a1 = {};
+  this.a2 = {};
+  this.a3 = {};
+  this.a4 = {};
+}
+
+function A() {
+}
+
+var proto = new P();
+A.prototype = proto;
+
+function foo(o) {
+  return o.a0;
+}
+
+// Ensure |proto| is in old space.
+gc();
+gc();
+gc();
+
+// Ensure |proto| is marked as "should be fast".
+var o = new A();
+foo(o);
+foo(o);
+foo(o);
+assertTrue(%HasFastProperties(proto));
+
+// Contruct a double value that looks like a tagged pointer.
+var buffer = new ArrayBuffer(8);
+var int32view = new Int32Array(buffer);
+var float64view = new Float64Array(buffer);
+int32view[0] = int32view[1] = 0x40000001;
+var boom = float64view[0];
+
+
+// Write new space object.
+proto.a4 = {a: 0};
+// Immediately delete the field.
+delete proto.a4;
+
+// |proto| must sill be fast.
+assertTrue(%HasFastProperties(proto));
+
+// Add a double field instead of deleted a4 that looks like a tagged pointer.
+proto.boom = boom;
+
+// Boom!
+gc();


### PR DESCRIPTION
deps: cherry-pick a814b8a from upstream V8

Original commit message:
>   Merged: [heap] Clear recorded slots for inobject properties when migrating fast object to slow mode.
> 
>   Revision: a814b8aeaf2b56635054c96435972dce90576f62
> 
>   BUG=chromium:666046
>   LOG=N
>   NOTRY=true
>   NOPRESUBMIT=true
>   NOTREECHECKS=true
>   R=ulan@chromium.org
> 
>   Review URL: https://codereview.chromium.org/2549803002 .
> 
>   Cr-Commit-Position: refs/branch-heads/5.5@{#60}
>   Cr-Branched-From: 3cbd5838bd8376103daa45d69dade929ee4e0092-refs/heads/5.5.372@{#1}
>   Cr-Branched-From: b3c8b0ce2c9af0528837d8309625118d4096553b-refs/heads/master@{#40015}

R=@nodejs/v8

Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=666046.
This is also needed on `v6.x`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
deps: V8
