### PR TITLE
doc: remove duplicate properties bullet in readme

### DIFF
--- a/tools/doc/README.md
+++ b/tools/doc/README.md
@@ -99,10 +99,9 @@ This event is emitted on instances of SomeClass, not on the module itself.
 ```
 
 
-* Modules have (description, Properties, Functions, Classes, Examples)
-* Properties have (type, description)
-* Functions have (list of arguments, description)
 * Classes have (description, Properties, Methods, Events)
 * Events have (list of arguments, description)
+* Functions have (list of arguments, description)
 * Methods have (list of arguments, description)
+* Modules have (description, Properties, Functions, Classes, Examples)
 * Properties have (type, description)


### PR DESCRIPTION
Removed duplicate properties.type listing in `tools/doc/README.md` file.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
