### PR TITLE
doc: note v5, v0.10, v0.12 EOL in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ release.
 
 <table>
 <tr>
-  <th><a href="doc/changelogs/CHANGELOG_V7.md">v7</a><sup>Current</sup></td>
-  <th title="LTS Until 2019-04"><a href="doc/changelogs/CHANGELOG_V6.md">v6</a><sup>LTS</sup</th>
+  <th><a href="doc/changelogs/CHANGELOG_V7.md">v7</a><sup>Current</sup></th>
+  <th title="LTS Until 2019-04"><a href="doc/changelogs/CHANGELOG_V6.md">v6</a><sup>LTS</sup></th>
   <th><a href="doc/changelogs/CHANGELOG_V5.md">v5</a></th>
   <th title="LTS Until 2018-04"><a href="doc/changelogs/CHANGELOG_V4.md">v4</a><sup>LTS</sup></th>
   <th title="LTS Until 2016-12-31"><a href="doc/changelogs/CHANGELOG_V012.md">v0.12</a><sup>LTS</sup></th>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ release.
 <tr>
   <th><a href="doc/changelogs/CHANGELOG_V7.md">v7</a><sup>Current</sup></th>
   <th title="LTS Until 2019-04"><a href="doc/changelogs/CHANGELOG_V6.md">v6</a><sup>LTS</sup></th>
-  <th><a href="doc/changelogs/CHANGELOG_V5.md">v5</a></th>
+  <th title="Unsupported Since 2016-07-01"><a href="doc/changelogs/CHANGELOG_V5.md">v5</a><sup>EOL</sup></th>
   <th title="LTS Until 2018-04"><a href="doc/changelogs/CHANGELOG_V4.md">v4</a><sup>LTS</sup></th>
-  <th title="LTS Until 2016-12-31"><a href="doc/changelogs/CHANGELOG_V012.md">v0.12</a><sup>LTS</sup></th>
-  <th title="LTS Until 2016-10-31" colspan="3"><a href="doc/changelogs/CHANGELOG_V010.md">v0.10</a><sup>LTS</sup></th>
+  <th title="Unsupported Since 2017-01-01"><a href="doc/changelogs/CHANGELOG_V012.md">v0.12</a><sup>EOL</sup></th>
+  <th title="Unsupported Since 2016-11-01" colspan="3"><a href="doc/changelogs/CHANGELOG_V010.md">v0.10</a><sup>EOL</sup></th>
 </tr>
 <tr>
     <td valign="top">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ release.
 <a href="doc/changelogs/CHANGELOG_V6.md#6.0.0">6.0.0</a><br/>
   </td>
   <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V5.md#5.11.1">5.11.1</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V5.md#5.11.1">5.11.1</a><br/>
 <a href="doc/changelogs/CHANGELOG_V5.md#5.11.0">5.11.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V5.md#5.10.1">5.10.1</a><br/>
 <a href="doc/changelogs/CHANGELOG_V5.md#5.10.0">5.10.0</a><br/>
@@ -107,7 +107,7 @@ release.
 <a href="doc/changelogs/CHANGELOG_V4.md#4.0.0">4.0.0</a><br/>
   </td>
   <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V012.md#0.12.18">0.12.18</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V012.md#0.12.18">0.12.18</a><br/>
 <a href="doc/changelogs/CHANGELOG_V012.md#0.12.17">0.12.17</a><br/>
 <a href="doc/changelogs/CHANGELOG_V012.md#0.12.16">0.12.16</a><br/>
 <a href="doc/changelogs/CHANGELOG_V012.md#0.12.15">0.12.15</a><br/>
@@ -128,7 +128,7 @@ release.
 <a href="doc/changelogs/CHANGELOG_V012.md#0.12.0">0.12.0</a><br/>
   </td>
   <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V010.md#0.10.48">0.10.48</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V010.md#0.10.48">0.10.48</a><br/>
 <a href="doc/changelogs/CHANGELOG_V010.md#0.10.47">0.10.47</a><br/>
 <a href="doc/changelogs/CHANGELOG_V010.md#0.10.46">0.10.46</a><br/>
 <a href="doc/changelogs/CHANGELOG_V010.md#0.10.45">0.10.45</a><br/>


### PR DESCRIPTION
The [CHANGELOG](https://github.com/nodejs/node/blob/master/CHANGELOG.md#nodejs-changelog) page looks like this now:
![spectacle zw3351](https://cloud.githubusercontent.com/assets/291301/21861773/568bf232-d847-11e6-8642-f6eef59aa5f0.png)

Seeing that, one might think that 0.12 and 0.10 are currently in the LTS.

So this commit makes it clear that v5, v0.10, and v0.12 are EOL and unsupported:
![spectacle rx3351](https://cloud.githubusercontent.com/assets/291301/21861755/3d7c59c6-d847-11e6-8d8c-71c6dc41fa19.png)
    
We probably don't want people seeing `LTS` badge next to those in the current Node.js repo and think that those are still supported. Not everyone is aware of the nodejs/LTS repo.
    
This also includes the dates for v5, v0.10 and v0.12 EOL:
 - 2016-07-01 for v5
 - 2016-11-01 for v0.10
 - 2017-01-01 for v0.12

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
