### PR TITLE
lib: refactor bootstrap_node.js regular expression

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -393,9 +393,7 @@
   }
 
   function isDebugBreak() {
-    return process.execArgv.some((arg) => {
-      return arg.match(/^--debug-brk(=[0-9]*)?$/);
-    });
+    return process.execArgv.some((arg) => /^--debug-brk(=[0-9]+)?$/.test(arg));
   }
 
   function run(entryFunction) {


### PR DESCRIPTION
* use `+` instead of `*` where one-or-more is required
* switch from String.prototype.match() to RegExp.prototype.test()

This is a very minor refactor, but I end up on this line of code more often then I expect to and I always want to tighten it up a bit, so I'm giving in to that urge.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib