### PR TITLE
benchmark: don't lint autogenerated modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ test/disabled
 test/tmp*/
 tools/eslint
 node_modules
+benchmark/tmp/


### PR DESCRIPTION
Without this, you will be very sad when linting after having ran the benchmark/module/module-loader.js benchmark.

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* benchmark
* tools
