### PR TITLE
test: assert unused vars in test-cli-eval.js

### DIFF
--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -19,6 +19,7 @@ const filename = __filename.replace(/\\/g, '/');
 // assert that nothing is written to stdout
 child.exec(nodejs + ' --eval 42',
            function(err, stdout, stderr) {
+             assert.strictEqual(err, null);
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '');
            });
@@ -26,6 +27,7 @@ child.exec(nodejs + ' --eval 42',
 // assert that "42\n" is written to stderr
 child.exec(nodejs + ' --eval "console.error(42)"',
            function(err, stdout, stderr) {
+             assert.strictEqual(err, null);
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '42\n');
            });
@@ -36,12 +38,14 @@ child.exec(nodejs + ' --eval "console.error(42)"',
 
   child.exec(cmd + '42',
              function(err, stdout, stderr) {
+               assert.strictEqual(typeof err, 'object');
                assert.strictEqual(stdout, '42\n');
                assert.strictEqual(stderr, '');
              });
 
   child.exec(cmd + "'[]'", common.mustCall(
       function(err, stdout, stderr) {
+        assert.strictEqual(typeof err, 'object');
         assert.strictEqual(stdout, '[]\n');
         assert.strictEqual(stderr, '');
       }));
@@ -51,11 +55,15 @@ child.exec(nodejs + ' --eval "console.error(42)"',
 child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
            function(status, stdout, stderr) {
              assert.strictEqual(status.code, 42);
+             assert.strictEqual(
+               stdout, 'Loaded as a module, exiting with status code 42.\n');
+             assert.strictEqual(stderr, '');
            });
 
 // Check that builtin modules are pre-defined.
 child.exec(nodejs + ' --print "os.platform()"',
            function(status, stdout, stderr) {
+             assert.strictEqual(status, null);
              assert.strictEqual(stderr, '');
              assert.strictEqual(stdout.trim(), require('os').platform());
            });
@@ -64,16 +72,22 @@ child.exec(nodejs + ' --print "os.platform()"',
 child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
            function(status, stdout, stderr) {
              assert.strictEqual(status.code, 42);
+             assert.strictEqual(
+               stdout, 'Loaded as a module, exiting with status code 42.\n');
+             assert.strictEqual(stderr, '');
            });
 
 // Missing argument should not crash
 child.exec(nodejs + ' -e', common.mustCall(function(status, stdout, stderr) {
   assert.notStrictEqual(status, null);
   assert.strictEqual(status.code, 9);
+  assert.strictEqual(stdout, '');
+  assert(stderr.match(/node: -e requires an argument\n/));
 }));
 
 // empty program should do nothing
 child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
+  assert.strictEqual(status, null);
   assert.strictEqual(stdout, '');
   assert.strictEqual(stderr, '');
 });
@@ -81,21 +95,25 @@ child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
 // "\\-42" should be interpreted as an escaped expression, not a switch
 child.exec(nodejs + ' -p "\\-42"',
            function(err, stdout, stderr) {
+             assert.strictEqual(err, null);
              assert.strictEqual(stdout, '-42\n');
              assert.strictEqual(stderr, '');
            });
 
 child.exec(nodejs + ' --use-strict -p process.execArgv',
            function(status, stdout, stderr) {
+             assert.strictEqual(status, null);
              assert.strictEqual(
                stdout, "[ '--use-strict', '-p', 'process.execArgv' ]\n"
              );
+             assert.strictEqual(stderr, '');
            });
 
 // Regression test for https://github.com/nodejs/node/issues/3574
 const emptyFile = path.join(common.fixturesDir, 'empty.js');
 child.exec(nodejs + ` -e 'require("child_process").fork("${emptyFile}")'`,
            function(status, stdout, stderr) {
+             assert.strictEqual(status, null);
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '');
            });

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -53,8 +53,8 @@ child.exec(nodejs + ' --eval "console.error(42)"',
 
 // assert that module loading works
 child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
-           function(status, stdout, stderr) {
-             assert.strictEqual(status.code, 42);
+           function(err, stdout, stderr) {
+             assert.strictEqual(err.code, 42);
              assert.strictEqual(
                stdout, 'Loaded as a module, exiting with status code 42.\n');
              assert.strictEqual(stderr, '');
@@ -62,32 +62,31 @@ child.exec(nodejs + ' --eval "require(\'' + filename + '\')"',
 
 // Check that builtin modules are pre-defined.
 child.exec(nodejs + ' --print "os.platform()"',
-           function(status, stdout, stderr) {
-             assert.strictEqual(status, null);
+           function(err, stdout, stderr) {
+             assert.ifError(err);
              assert.strictEqual(stderr, '');
              assert.strictEqual(stdout.trim(), require('os').platform());
            });
 
 // module path resolve bug, regression test
 child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
-           function(status, stdout, stderr) {
-             assert.strictEqual(status.code, 42);
+           function(err, stdout, stderr) {
+             assert.strictEqual(err.code, 42);
              assert.strictEqual(
                stdout, 'Loaded as a module, exiting with status code 42.\n');
              assert.strictEqual(stderr, '');
            });
 
 // Missing argument should not crash
-child.exec(nodejs + ' -e', common.mustCall(function(status, stdout, stderr) {
-  assert.notStrictEqual(status, null);
-  assert.strictEqual(status.code, 9);
+child.exec(nodejs + ' -e', common.mustCall(function(err, stdout, stderr) {
+  assert.strictEqual(err.code, 9);
   assert.strictEqual(stdout, '');
   assert(stderr.match(/node: -e requires an argument\n/));
 }));
 
 // empty program should do nothing
-child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
-  assert.strictEqual(status, null);
+child.exec(nodejs + ' -e ""', function(err, stdout, stderr) {
+  assert.ifError(err);
   assert.strictEqual(stdout, '');
   assert.strictEqual(stderr, '');
 });
@@ -101,8 +100,8 @@ child.exec(nodejs + ' -p "\\-42"',
            });
 
 child.exec(nodejs + ' --use-strict -p process.execArgv',
-           function(status, stdout, stderr) {
-             assert.strictEqual(status, null);
+           function(err, stdout, stderr) {
+             assert.ifError(err);
              assert.strictEqual(
                stdout, "[ '--use-strict', '-p', 'process.execArgv' ]\n"
              );
@@ -112,8 +111,8 @@ child.exec(nodejs + ' --use-strict -p process.execArgv',
 // Regression test for https://github.com/nodejs/node/issues/3574
 const emptyFile = path.join(common.fixturesDir, 'empty.js');
 child.exec(nodejs + ` -e 'require("child_process").fork("${emptyFile}")'`,
-           function(status, stdout, stderr) {
-             assert.strictEqual(status, null);
+           function(err, stdout, stderr) {
+             assert.ifError(err);
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '');
            });

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -19,7 +19,7 @@ const filename = __filename.replace(/\\/g, '/');
 // assert that nothing is written to stdout
 child.exec(nodejs + ' --eval 42',
            function(err, stdout, stderr) {
-             assert.strictEqual(err, null);
+             assert.ifError(err);
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '');
            });
@@ -27,7 +27,7 @@ child.exec(nodejs + ' --eval 42',
 // assert that "42\n" is written to stderr
 child.exec(nodejs + ' --eval "console.error(42)"',
            function(err, stdout, stderr) {
-             assert.strictEqual(err, null);
+             assert.ifError(err);
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '42\n');
            });
@@ -38,14 +38,14 @@ child.exec(nodejs + ' --eval "console.error(42)"',
 
   child.exec(cmd + '42',
              function(err, stdout, stderr) {
-               assert.strictEqual(typeof err, 'object');
+               assert.ifError(err);
                assert.strictEqual(stdout, '42\n');
                assert.strictEqual(stderr, '');
              });
 
   child.exec(cmd + "'[]'", common.mustCall(
       function(err, stdout, stderr) {
-        assert.strictEqual(typeof err, 'object');
+        assert.ifError(err);
         assert.strictEqual(stdout, '[]\n');
         assert.strictEqual(stderr, '');
       }));
@@ -95,7 +95,7 @@ child.exec(nodejs + ' -e ""', function(status, stdout, stderr) {
 // "\\-42" should be interpreted as an escaped expression, not a switch
 child.exec(nodejs + ' -p "\\-42"',
            function(err, stdout, stderr) {
-             assert.strictEqual(err, null);
+             assert.ifError(err);
              assert.strictEqual(stdout, '-42\n');
              assert.strictEqual(stderr, '');
            });


### PR DESCRIPTION
Assert unused variables in test-cli-eval.js

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test
