### PR TITLE
test,net: add tests for server.connections

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1132,9 +1132,8 @@ function Server(options, connectionListener) {
       return this._connections;
     }, 'Server.connections property is deprecated. ' +
        'Use Server.getConnections method instead.'),
-    set: internalUtil.deprecate((val) => {
-      return (this._connections = val);
-    }, 'Server.connections property is deprecated.'),
+    set: internalUtil.deprecate((val) => (this._connections = val),
+                                'Server.connections property is deprecated.'),
     configurable: true, enumerable: false
   });
 

--- a/test/parallel/test-net-server-connections-child-null.js
+++ b/test/parallel/test-net-server-connections-child-null.js
@@ -1,0 +1,44 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fork = require('child_process').fork;
+const net = require('net');
+
+if (process.argv[2] === 'child') {
+
+  process.on('message', (msg, socket) => {
+    socket.end('goodbye');
+  });
+
+  process.send('hello');
+
+} else {
+
+  const child = fork(process.argv[1], ['child']);
+
+  const runTest = common.mustCall(() => {
+
+    const server = net.createServer();
+
+    // server.connections should start as 0
+    assert.strictEqual(server.connections, 0);
+    server.on('connection', (socket) => {
+      child.send({what: 'socket'}, socket);
+    });
+    server.on('close', () => {
+      child.kill();
+    });
+
+    server.listen(0, common.mustCall(() => {
+      const connect = net.connect(server.address().port);
+
+      connect.on('close', common.mustCall(() => {
+        // now server.connections should be null
+        assert.strictEqual(server.connections, null);
+        server.close();
+      }));
+    }));
+  });
+
+  child.on('message', runTest);
+}

--- a/test/parallel/test-net-server-connections.js
+++ b/test/parallel/test-net-server-connections.js
@@ -1,10 +1,15 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const net = require('net');
 
 const server = new net.Server();
+
+const expectedWarning = 'Server.connections property is deprecated. ' +
+                        'Use Server.getConnections method instead.';
+
+common.expectWarning('DeprecationWarning', expectedWarning);
 
 // test that server.connections property is no longer enumerable now that it
 // has been marked as deprecated

--- a/test/parallel/test-net-server-connections.js
+++ b/test/parallel/test-net-server-connections.js
@@ -4,9 +4,10 @@ const assert = require('assert');
 
 const net = require('net');
 
-// test that server.connections property is no longer enumerable now that it
-// has been marked as deprecated
-
 const server = new net.Server();
 
+// test that server.connections property is no longer enumerable now that it
+// has been marked as deprecated
 assert.strictEqual(Object.keys(server).indexOf('connections'), -1);
+
+assert.strictEqual(server.connections, 0);


### PR DESCRIPTION
There were no tests confirming situations where server.connections
should return `null`. Add a test for that situation.

Expand existing server.connection test slightly to check value.

Refactor (mostly spacing) code for server.connections setter.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net