### PR TITLE
child_process: Allow an unlimited maxBuffer size in child_process

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -261,7 +261,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     child.stdout.on('data', function onChildStdout(chunk) {
       stdoutLen += encoding ? Buffer.byteLength(chunk, encoding) : chunk.length;
 
-      if (stdoutLen > options.maxBuffer) {
+      if (stdoutLen > options.maxBuffer && options.maxBuffer !== 0) {
         ex = new Error('stdout maxBuffer exceeded');
         kill();
       } else {


### PR DESCRIPTION
Allow unlimited buffer for child_process'

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process
