### PR TITLE
test: add coverage for repl .clear + useGlobal

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -721,9 +721,7 @@ REPLServer.prototype.createContext = function() {
 
   Object.defineProperty(context, '_', {
     configurable: true,
-    get: () => {
-      return this.last;
-    },
+    get: () => this.last,
     set: (value) => {
       this.last = value;
       if (!this.underscoreAssigned) {
@@ -1266,9 +1264,10 @@ function defineDefaultCommands(repl) {
     help: 'Print this help message',
     action: function() {
       const names = Object.keys(this.commands).sort();
-      const longestNameLength = names.reduce((max, name) => {
-        return Math.max(max, name.length);
-      }, 0);
+      const longestNameLength = names.reduce(
+        (max, name) => Math.max(max, name.length),
+        0
+      );
       names.forEach((name) => {
         const cmd = this.commands[name];
         const spaces = ' '.repeat(longestNameLength - name.length + 3);


### PR DESCRIPTION
Add a test to cover situation where REPL is initialized with `useGlobal`
set to `true` and `.clear` is called. This adds coverage for code in
repl.js that is not currently covered.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl