### PR TITLE
doc: clarify memory sharing behavior of buffer ctor

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -348,15 +348,16 @@ deprecated: v6.0.0
 > [`Buffer.from(arrayBuffer[, byteOffset [, length]])`][`Buffer.from(arrayBuffer)`]
 > instead.
 
-* `arrayBuffer` {ArrayBuffer} The `.buffer` property of a [`TypedArray`] or
-  [`ArrayBuffer`]
-* `byteOffset` {Integer} Where to start copying from `arrayBuffer`. **Default:** `0`
-* `length` {Integer} How many bytes to copy from `arrayBuffer`.
+* `arrayBuffer` {ArrayBuffer} An [`ArrayBuffer`] or the `.buffer` property of a
+  [`TypedArray`].
+* `byteOffset` {Integer} Index of first byte to expose. **Default:** `0`
+* `length` {Integer} Number of bytes to expose.
   **Default:** `arrayBuffer.length - byteOffset`
 
-When passed a reference to the `.buffer` property of a [`TypedArray`] instance,
-the newly created `Buffer` will share the same allocated memory as the
-[`TypedArray`].
+This creates a view of the [`ArrayBuffer`] without copying the underlying
+memory. For example, when passed a reference to the `.buffer` property of a
+[`TypedArray`] instance, the newly created `Buffer` will share the same
+allocated memory as the [`TypedArray`].
 
 The optional `byteOffset` and `length` arguments specify a memory range within
 the `arrayBuffer` that will be shared by the `Buffer`.
@@ -719,15 +720,16 @@ A `TypeError` will be thrown if `array` is not an `Array`.
 added: v5.10.0
 -->
 
-* `arrayBuffer` {ArrayBuffer} The `.buffer` property of a [`TypedArray`] or
-  [`ArrayBuffer`]
-* `byteOffset` {Integer} Where to start copying from `arrayBuffer`. **Default:** `0`
-* `length` {Integer} How many bytes to copy from `arrayBuffer`.
+* `arrayBuffer` {ArrayBuffer} An [`ArrayBuffer`] or the `.buffer` property of a
+  [`TypedArray`].
+* `byteOffset` {Integer} Index of first byte to expose. **Default:** `0`
+* `length` {Integer} Number of bytes to expose.
   **Default:** `arrayBuffer.length - byteOffset`
 
-When passed a reference to the `.buffer` property of a [`TypedArray`] instance,
-the newly created `Buffer` will share the same allocated memory as the
-[`TypedArray`].
+This creates a view of the [`ArrayBuffer`] without copying the underlying
+memory. For example, when passed a reference to the `.buffer` property of a
+[`TypedArray`] instance, the newly created `Buffer` will share the same
+allocated memory as the [`TypedArray`].
 
 Example:
 


### PR DESCRIPTION
* Clarify that memory is always shared and never copied.
* Fix wording that sounded like ArrayBuffer has a buffer property.

Fixes #10770
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
docs (buffer)
