### PR TITLE
test: update coverage for dgram.js

### DIFF
--- a/test/parallel/test-dgram-multicast-loopback.js
+++ b/test/parallel/test-dgram-multicast-loopback.js
@@ -6,17 +6,7 @@ const socket = dgram.createSocket('udp4');
 
 socket.bind(0);
 socket.on('listening', common.mustCall(() => {
-  const result = socket.setTTL(16);
+  const result = socket.setMulticastLoopback(16);
   assert.strictEqual(result, 16);
-
-  assert.throws(() => {
-    socket.setTTL('foo');
-  }, /^TypeError: Argument must be a number$/);
-
-  // TTL must be a number from > 0 to < 256
-  assert.throws(() => {
-    socket.setTTL(1000);
-  }, /^Error: setTTL EINVAL$/);
-
   socket.close();
 }));

--- a/test/parallel/test-dgram-multicast-setTTL.js
+++ b/test/parallel/test-dgram-multicast-setTTL.js
@@ -1,23 +1,23 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
-let thrown = false;
 
 socket.bind(0);
-socket.on('listening', function() {
-  socket.setMulticastTTL(16);
+socket.on('listening', common.mustCall(() => {
+  const result = socket.setMulticastTTL(16);
+  assert.strictEqual(result, 16);
 
   //Try to set an invalid TTL (valid ttl is > 0 and < 256)
-  try {
+  assert.throws(() => {
     socket.setMulticastTTL(1000);
-  } catch (e) {
-    thrown = true;
-  }
+  }, /^Error: setMulticastTTL EINVAL$/);
 
-  assert(thrown, 'Setting an invalid multicast TTL should throw some error');
+  assert.throws(() => {
+    socket.setMulticastTTL('foo');
+  }, /^TypeError: Argument must be a number$/);
 
   //close the socket
   socket.close();
-});
+}));


### PR DESCRIPTION
Create test-dgram-multicast-loopback.js for dgram.setMulticastLoopback.
Add a test which has an argument of an invalid number to test-dgram-setTTL.js.
https://github.com/nodejs/node/blob/master/lib/dgram.js#L464
Add a test which has an argument of a string to test-dgram-multicast-setTTL.js.
https://github.com/nodejs/node/blob/master/lib/dgram.js#L473

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test