### PR TITLE
test,util: remove lint workarounds

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -27,16 +27,13 @@ var simdFormatters;
 if (typeof global.SIMD === 'object' && global.SIMD !== null) {
   simdFormatters = new Map();
 
-  const make = (extractLane, count) => {
-    return (ctx, value, recurseTimes, visibleKeys, keys) => {
+  const make =
+    (extractLane, count) => (ctx, value, recurseTimes, visibleKeys, keys) => {
       const output = new Array(count);
       for (var i = 0; i < count; i += 1)
         output[i] = formatPrimitive(ctx, extractLane(value, i));
       return output;
     };
-  };
-
-  const SIMD = global.SIMD;  // Pacify eslint.
 
   const countPerType = {
     Bool16x8: 8,
@@ -52,7 +49,7 @@ if (typeof global.SIMD === 'object' && global.SIMD !== null) {
   };
 
   for (const key in countPerType) {
-    const type = SIMD[key];
+    const type = global.SIMD[key];
     simdFormatters.set(type, make(type.extractLane, countPerType[key]));
   }
 }

--- a/test/parallel/test-util-inspect-simd.js
+++ b/test/parallel/test-util-inspect-simd.js
@@ -1,11 +1,10 @@
 // Flags: --harmony_simd
+/* global SIMD */
 'use strict';
 
 require('../common');
 const assert = require('assert');
 const inspect = require('util').inspect;
-
-const SIMD = global.SIMD;  // Pacify eslint.
 
 assert.strictEqual(
     inspect(SIMD.Bool16x8()),


### PR DESCRIPTION
Remove assignments to `SIMD` that are only to pacify ESLint. Instead,
use either `global.SIMD` or provide an comment letting ESLint know in
cases where `SIMD` is guaranteed to be a defined global identifier.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test util