### PR TITLE
test: add crypto's setEngine test

### DIFF
--- a/test/parallel/test-crypto-set-engine.js
+++ b/test/parallel/test-crypto-set-engine.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+assert.throws(() => {
+  crypto.setEngine(0, 100);
+}, /^TypeError: "id" argument should be a string$/);
+
+assert.throws(() => {
+  crypto.setEngine('id', '100');
+}, /^TypeError: "flags" argument should be a number, if present$/);


### PR DESCRIPTION
Add tests for `crypto.setEngine`.
https://github.com/nodejs/node/blob/master/lib/crypto.js#L621

There is not a normal test because I did not have an idea that how to designate the engine(path or id) in the test :'-(
`error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library`
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test