### PR TITLE
module: improve require() performance

### DIFF
--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -8,7 +8,8 @@ var benchmarkDirectory = path.join(tmpDirectory, 'nodejs-benchmark-module');
 
 var bench = common.createBenchmark(main, {
   thousands: [50],
-  fullPath: ['true', 'false']
+  fullPath: ['true', 'false'],
+  useCache: ['true', 'false']
 });
 
 function main(conf) {
@@ -31,22 +32,34 @@ function main(conf) {
   }
 
   if (conf.fullPath === 'true')
-    measureFull(n);
+    measureFull(n, conf.useCache === 'true');
   else
-    measureDir(n);
+    measureDir(n, conf.useCache === 'true');
 }
 
-function measureFull(n) {
+function measureFull(n, useCache) {
+  var i;
+  if (useCache) {
+    for (i = 0; i <= n; i++) {
+      require(benchmarkDirectory + i + '/index.js');
+    }
+  }
   bench.start();
-  for (var i = 0; i <= n; i++) {
+  for (i = 0; i <= n; i++) {
     require(benchmarkDirectory + i + '/index.js');
   }
   bench.end(n / 1e3);
 }
 
-function measureDir(n) {
+function measureDir(n, useCache) {
+  var i;
+  if (useCache) {
+    for (i = 0; i <= n; i++) {
+      require(benchmarkDirectory + i);
+    }
+  }
   bench.start();
-  for (var i = 0; i <= n; i++) {
+  for (i = 0; i <= n; i++) {
     require(benchmarkDirectory + i);
   }
   bench.end(n / 1e3);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1478,12 +1478,6 @@ fs.unwatchFile = function(filename, listener) {
 };
 
 
-// Regexp that finds the next portion of a (partial) path
-// result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
-const nextPartRe = isWindows ?
-  /(.*?)(?:[/\\]+|$)/g :
-  /(.*?)(?:[/]+|$)/g;
-
 // Regex to find the device root, including trailing slash. E.g. 'c:\\'.
 const splitRootRe = isWindows ?
   /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/ :
@@ -1498,6 +1492,21 @@ function encodeRealpathResult(result, options) {
   } else {
     return asBuffer.toString(options.encoding);
   }
+}
+
+// Finds the next portion of a (partial) path, up to the next path delimiter
+var nextPart;
+if (isWindows) {
+  nextPart = function nextPart(p, i) {
+    for (; i < p.length; ++i) {
+      const ch = p.charCodeAt(i);
+      if (ch === 92/*'\'*/ || ch === 47/*'/'*/)
+        return i;
+    }
+    return -1;
+  };
+} else {
+  nextPart = function nextPart(p, i) { return p.indexOf('/', i); };
 }
 
 fs.realpathSync = function realpathSync(p, options) {
@@ -1544,12 +1553,18 @@ fs.realpathSync = function realpathSync(p, options) {
   // NB: p.length changes.
   while (pos < p.length) {
     // find the next part
-    nextPartRe.lastIndex = pos;
-    var result = nextPartRe.exec(p);
+    var result = nextPart(p, pos);
     previous = current;
-    current += result[0];
-    base = previous + result[1];
-    pos = nextPartRe.lastIndex;
+    if (result === -1) {
+      var last = p.slice(pos);
+      current += last;
+      base = previous + last;
+      pos = p.length;
+    } else {
+      current += p.slice(pos, result + 1);
+      base = previous + p.slice(pos, result);
+      pos = result + 1;
+    }
 
     // continue if not a symlink
     if (knownHard[base] || (cache && cache.get(base) === base)) {
@@ -1658,12 +1673,18 @@ fs.realpath = function realpath(p, options, callback) {
     }
 
     // find the next part
-    nextPartRe.lastIndex = pos;
-    var result = nextPartRe.exec(p);
+    var result = nextPart(p, pos);
     previous = current;
-    current += result[0];
-    base = previous + result[1];
-    pos = nextPartRe.lastIndex;
+    if (result === -1) {
+      var last = p.slice(pos);
+      current += last;
+      base = previous + last;
+      pos = p.length;
+    } else {
+      current += p.slice(pos, result + 1);
+      base = previous + p.slice(pos, result);
+      pos = result + 1;
+    }
 
     // continue if not a symlink
     if (knownHard[base]) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1503,20 +1503,20 @@ function encodeRealpathResult(result, options) {
 fs.realpathSync = function realpathSync(p, options) {
   options = getOptions(options, {});
   handleError((p = getPathFromURL(p)));
+  if (typeof p !== 'string')
+    p += '';
   nullCheck(p);
-
-  p = p.toString('utf8');
   p = pathModule.resolve(p);
 
-  const seenLinks = {};
-  const knownHard = {};
   const cache = options[internalFS.realpathCacheKey];
-  const original = p;
-
   const maybeCachedResult = cache && cache.get(p);
   if (maybeCachedResult) {
     return maybeCachedResult;
   }
+
+  const seenLinks = {};
+  const knownHard = {};
+  const original = p;
 
   // current character position in p
   var pos;
@@ -1614,10 +1614,10 @@ fs.realpath = function realpath(p, options, callback) {
   options = getOptions(options, {});
   if (handleError((p = getPathFromURL(p)), callback))
     return;
+  if (typeof p !== 'string')
+    p += '';
   if (!nullCheck(p, callback))
     return;
-
-  p = p.toString('utf8');
   p = pathModule.resolve(p);
 
   const seenLinks = {};

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1572,7 +1572,7 @@ fs.realpathSync = function realpathSync(p, options) {
     }
 
     var resolvedLink;
-    const maybeCachedResolved = cache && cache.get(base);
+    var maybeCachedResolved = cache && cache.get(base);
     if (maybeCachedResolved) {
       resolvedLink = maybeCachedResolved;
     } else {
@@ -1585,8 +1585,8 @@ fs.realpathSync = function realpathSync(p, options) {
 
       // read the link if it wasn't read before
       // dev/ino always return 0 on windows, so skip the check.
-      let linkTarget = null;
-      let id;
+      var linkTarget = null;
+      var id;
       if (!isWindows) {
         id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
         if (seenLinks.hasOwnProperty(id)) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1527,21 +1527,16 @@ fs.realpathSync = function realpathSync(p, options) {
   // the partial path scanned in the previous round, with slash
   var previous;
 
-  start();
+  // Skip over roots
+  var m = splitRootRe.exec(p);
+  pos = m[0].length;
+  current = m[0];
+  base = m[0];
 
-  function start() {
-    // Skip over roots
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
-
-    // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
-      fs.lstatSync(base);
-      knownHard[base] = true;
-    }
+  // On windows, check that the root exists. On unix there is no need.
+  if (isWindows && !knownHard[base]) {
+    fs.lstatSync(base);
+    knownHard[base] = true;
   }
 
   // walk down the path, swapping out linked pathparts for their real
@@ -1595,7 +1590,18 @@ fs.realpathSync = function realpathSync(p, options) {
 
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
-    start();
+
+    // Skip over roots
+    m = splitRootRe.exec(p);
+    pos = m[0].length;
+    current = m[0];
+    base = m[0];
+
+    // On windows, check that the root exists. On unix there is no need.
+    if (isWindows && !knownHard[base]) {
+      fs.lstatSync(base);
+      knownHard[base] = true;
+    }
   }
 
   if (cache) cache.set(original, p);
@@ -1626,26 +1632,21 @@ fs.realpath = function realpath(p, options, callback) {
   // the partial path scanned in the previous round, with slash
   var previous;
 
-  start();
+  var m = splitRootRe.exec(p);
+  pos = m[0].length;
+  current = m[0];
+  base = m[0];
+  previous = '';
 
-  function start() {
-    // Skip over roots
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
-
-    // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
-      fs.lstat(base, function(err) {
-        if (err) return callback(err);
-        knownHard[base] = true;
-        LOOP();
-      });
-    } else {
-      process.nextTick(LOOP);
-    }
+  // On windows, check that the root exists. On unix there is no need.
+  if (isWindows && !knownHard[base]) {
+    fs.lstat(base, function(err) {
+      if (err) return callback(err);
+      knownHard[base] = true;
+      LOOP();
+    });
+  } else {
+    process.nextTick(LOOP);
   }
 
   // walk down the path, swapping out linked pathparts for their real
@@ -1711,7 +1712,22 @@ fs.realpath = function realpath(p, options, callback) {
   function gotResolvedLink(resolvedLink) {
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
-    start();
+    var m = splitRootRe.exec(p);
+    pos = m[0].length;
+    current = m[0];
+    base = m[0];
+    previous = '';
+
+    // On windows, check that the root exists. On unix there is no need.
+    if (isWindows && !knownHard[base]) {
+      fs.lstat(base, function(err) {
+        if (err) return callback(err);
+        knownHard[base] = true;
+        LOOP();
+      });
+    } else {
+      process.nextTick(LOOP);
+    }
   }
 };
 

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -8,23 +8,22 @@ exports = module.exports = {
 
 exports.requireDepth = 0;
 
-// Invoke with makeRequireFunction.call(module) where |module| is the
-// Module object to use as the context for the require() function.
-function makeRequireFunction() {
-  const Module = this.constructor;
-  const self = this;
+// Invoke with makeRequireFunction(module) where |module| is the Module object
+// to use as the context for the require() function.
+function makeRequireFunction(mod) {
+  const Module = mod.constructor;
 
   function require(path) {
     try {
       exports.requireDepth += 1;
-      return self.require(path);
+      return mod.require(path);
     } finally {
       exports.requireDepth -= 1;
     }
   }
 
   function resolve(request) {
-    return Module._resolveFilename(request, self);
+    return Module._resolveFilename(request, mod);
   }
 
   require.resolve = resolve;

--- a/lib/module.js
+++ b/lib/module.js
@@ -577,11 +577,11 @@ Module.prototype._compile = function(content, filename) {
     }
   }
   var dirname = path.dirname(filename);
-  var require = internalModule.makeRequireFunction.call(this);
-  var args = [this.exports, require, this, filename, dirname];
+  var require = internalModule.makeRequireFunction(this);
   var depth = internalModule.requireDepth;
   if (depth === 0) stat.cache = new Map();
-  var result = compiledWrapper.apply(this.exports, args);
+  var result = compiledWrapper.call(this.exports, this.exports, require, this,
+                                    filename, dirname);
   if (depth === 0) stat.cache = null;
   return result;
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -179,8 +179,8 @@ Module._findPath = function(request, paths, isMain) {
   }
 
   var exts;
-  const trailingSlash = request.length > 0 &&
-                        request.charCodeAt(request.length - 1) === 47/*/*/;
+  var trailingSlash = request.length > 0 &&
+                      request.charCodeAt(request.length - 1) === 47/*/*/;
 
   // For each path
   for (var i = 0; i < paths.length; i++) {
@@ -190,7 +190,7 @@ Module._findPath = function(request, paths, isMain) {
     var basePath = path.resolve(curPath, request);
     var filename;
 
-    const rc = stat(basePath);
+    var rc = stat(basePath);
     if (!trailingSlash) {
       if (rc === 0) {  // File.
         if (preserveSymlinks && !isMain) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -165,10 +165,11 @@ Module._findPath = function(request, paths, isMain) {
     return false;
   }
 
-  const cacheKey = JSON.stringify({request: request, paths: paths});
-  if (Module._pathCache[cacheKey]) {
-    return Module._pathCache[cacheKey];
-  }
+  var cacheKey = request + '\x00' +
+                (paths.length === 1 ? paths[0] : paths.join('\x00'));
+  var entry = Module._pathCache[cacheKey];
+  if (entry)
+    return entry;
 
   var exts;
   var trailingSlash = request.length > 0 &&

--- a/lib/module.js
+++ b/lib/module.js
@@ -326,14 +326,14 @@ if (process.platform === 'win32') {
 // 'index.' character codes
 var indexChars = [ 105, 110, 100, 101, 120, 46 ];
 var indexLen = indexChars.length;
-Module._resolveLookupPaths = function(request, parent) {
+Module._resolveLookupPaths = function(request, parent, newReturn) {
   if (NativeModule.nonInternalExists(request)) {
-    return [request, []];
+    debug('looking for %j in []', request);
+    return (newReturn ? null : [request, []]);
   }
 
-  var reqLen = request.length;
   // Check for relative path
-  if (reqLen < 2 ||
+  if (request.length < 2 ||
       request.charCodeAt(0) !== 46/*.*/ ||
       (request.charCodeAt(1) !== 46/*.*/ &&
        request.charCodeAt(1) !== 47/*/*/)) {
@@ -355,7 +355,8 @@ Module._resolveLookupPaths = function(request, parent) {
       }
     }
 
-    return [request, paths];
+    debug('looking for %j in %j', request, paths);
+    return (newReturn ? (paths.length > 0 ? paths : null) : [request, paths]);
   }
 
   // with --eval, parent.id is not set and parent.filename is null
@@ -363,7 +364,9 @@ Module._resolveLookupPaths = function(request, parent) {
     // make require('./path/to/foo') work - normally the path is taken
     // from realpath(__filename) but with eval there is no filename
     var mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
-    return [request, mainPaths];
+
+    debug('looking for %j in %j', request, mainPaths);
+    return (newReturn ? mainPaths : [request, mainPaths]);
   }
 
   // Is the parent an index module?
@@ -413,7 +416,9 @@ Module._resolveLookupPaths = function(request, parent) {
   debug('RELATIVE: requested: %s set ID to: %s from %s', request, id,
         parent.id);
 
-  return [id, [path.dirname(parent.filename)]];
+  var parentDir = [path.dirname(parent.filename)];
+  debug('looking for %j in %j', id, parentDir);
+  return (newReturn ? parentDir : [id, parentDir]);
 };
 
 
@@ -472,16 +477,12 @@ Module._resolveFilename = function(request, parent, isMain) {
     return request;
   }
 
-  var resolvedModule = Module._resolveLookupPaths(request, parent);
-  var id = resolvedModule[0];
-  var paths = resolvedModule[1];
+  var paths = Module._resolveLookupPaths(request, parent, true);
 
   // look up the filename first, since that's the cache key.
-  debug('looking for %j in %j', id, paths);
-
   var filename = Module._findPath(request, paths, isMain);
   if (!filename) {
-    var err = new Error("Cannot find module '" + request + "'");
+    var err = new Error(`Cannot find module '${request}'`);
     err.code = 'MODULE_NOT_FOUND';
     throw err;
   }
@@ -564,7 +565,7 @@ Module.prototype._compile = function(content, filename) {
     if (!resolvedArgv) {
       // we enter the repl if we're not given a filename argument.
       if (process.argv[1]) {
-        resolvedArgv = Module._resolveFilename(process.argv[1], null);
+        resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
       } else {
         resolvedArgv = 'repl';
       }

--- a/lib/module.js
+++ b/lib/module.js
@@ -33,14 +33,6 @@ const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;
 
-// If obj.hasOwnProperty has been overridden, then calling
-// obj.hasOwnProperty(prop) will break.
-// See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
-
 function stat(filename) {
   filename = path._makeLong(filename);
   const cache = stat.cache;
@@ -95,12 +87,12 @@ const debug = Module._debug;
 //   -> a/index.<ext>
 
 // check if the directory is a package.json dir
-const packageMainCache = {};
+const packageMainCache = Object.create(null);
 
 function readPackage(requestPath) {
-  if (hasOwnProperty(packageMainCache, requestPath)) {
-    return packageMainCache[requestPath];
-  }
+  const entry = packageMainCache[requestPath];
+  if (entry)
+    return entry;
 
   const jsonPath = path.resolve(requestPath, 'package.json');
   const json = internalModuleReadFile(path._makeLong(jsonPath));

--- a/lib/module.js
+++ b/lib/module.js
@@ -69,9 +69,9 @@ function Module(id, parent) {
 }
 module.exports = Module;
 
-Module._cache = {};
-Module._pathCache = {};
-Module._extensions = {};
+Module._cache = Object.create(null);
+Module._pathCache = Object.create(null);
+Module._extensions = Object.create(null);
 var modulePaths = [];
 Module.globalPaths = [];
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -712,7 +712,7 @@ REPLServer.prototype.createContext = function() {
   }
 
   const module = new Module('<repl>');
-  module.paths = Module._resolveLookupPaths('<repl>', parentModule)[1];
+  module.paths = Module._resolveLookupPaths('<repl>', parentModule, true) || [];
 
   const require = internalModule.makeRequireFunction(module);
   context.module = module;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -714,7 +714,7 @@ REPLServer.prototype.createContext = function() {
   const module = new Module('<repl>');
   module.paths = Module._resolveLookupPaths('<repl>', parentModule)[1];
 
-  const require = internalModule.makeRequireFunction.call(module);
+  const require = internalModule.makeRequireFunction(module);
   context.module = module;
   context.require = require;
 

--- a/test/parallel/test-module-relative-lookup.js
+++ b/test/parallel/test-module-relative-lookup.js
@@ -4,7 +4,12 @@ require('../common');
 const assert = require('assert');
 const _module = require('module'); // avoid collision with global.module
 const lookupResults = _module._resolveLookupPaths('./lodash');
-const paths = lookupResults[1];
+let paths = lookupResults[1];
 
 assert.strictEqual(paths[0], '.',
+                   'Current directory gets highest priority for local modules');
+
+paths = _module._resolveLookupPaths('./lodash', null, true);
+
+assert.strictEqual(paths && paths[0], '.',
                    'Current directory gets highest priority for local modules');


### PR DESCRIPTION
Benchmark results for the changes in this PR:

```
                                                                        improvement significant      p.value
 module/module-loader.js useCache="false" fullPath="false" thousands=50      5.67 %         *** 8.756066e-18
 module/module-loader.js useCache="false" fullPath="true" thousands=50       6.33 %         *** 1.120897e-16
 module/module-loader.js useCache="true" fullPath="false" thousands=50     125.20 %         *** 4.165830e-37
 module/module-loader.js useCache="true" fullPath="true" thousands=50      131.80 %         *** 2.755969e-34
```

First off, I recognize the `module` module is "locked" so I understand there is a possibility only some or none of these commits may be accepted. Either way I have initially marked this as semver-major because of a couple of changes, if they end up not being an issue I will happily remove the semver-major label:

The first is mscdex/io.js@eb3b7178fe8021de7dcb8402d3988cc11ac2a04d which changes the format of the key used in `Module._pathCache`. Instead of using JSON, a simple delimiter is used between the string values being used. This commit probably provides the single largest performance increase by itself, however I am not sure just how many people are making assumptions about the format of the cache keys themselves. A quick search on github at least reveals that there are people directly accessing `Module._pathCache`, but they seem to just be iterating over the properties and deleting them when they include some substring (typically a module name the user is wanting to "uncache", in addition to deleting from `require.cache`).

Secondly, there are the changes in mscdex/io.js@3d8528d5060d9cc27d1b335925d51622c5e87ec6, which may cause issues if anyone is both directly accessing any of those objects *and* using `obj.hasOwnProperty()`.

All of the other changes *should be* backwards compatible AFAIK.

CI: https://ci.nodejs.org/job/node-test-pull-request/5845/
CITGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/523/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* benchmark
* fs
* module