### PR TITLE
test: testing noAssert in buffer.write()

### DIFF
--- a/test/parallel/test-buffer-write-noassert.js
+++ b/test/parallel/test-buffer-write-noassert.js
@@ -1,0 +1,48 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// testing buffer write functions
+
+function write(funx, args, result, res) {
+  {
+    const buf = Buffer.alloc(9);
+    assert.strictEqual(buf[funx](...args), result);
+    assert.deepStrictEqual(buf, res);
+  }
+
+  {
+    const invalidArgs = Array.from(args);
+    invalidArgs[1] = -1;
+    assert.throws(
+      () => Buffer.alloc(9)[funx](...invalidArgs),
+      /^RangeError: (?:Index )?out of range(?: index)?$/
+    );
+  }
+
+  {
+    const buf2 = Buffer.alloc(9);
+    assert.strictEqual(buf2[funx](...args, true), result);
+    assert.deepStrictEqual(buf2, res);
+  }
+
+}
+
+write('writeInt8', [1, 0], 1, Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 0]));
+write('writeIntBE', [1, 1, 4], 5, Buffer.from([0, 0, 0, 0, 1, 0, 0, 0, 0]));
+write('writeIntLE', [1, 1, 4], 5, Buffer.from([0, 1, 0, 0, 0, 0, 0, 0, 0]));
+write('writeInt16LE', [1, 1], 3, Buffer.from([0, 1, 0, 0, 0, 0, 0, 0, 0]));
+write('writeInt16BE', [1, 1], 3, Buffer.from([0, 0, 1, 0, 0, 0, 0, 0, 0]));
+write('writeInt32LE', [1, 1], 5, Buffer.from([0, 1, 0, 0, 0, 0, 0, 0, 0]));
+write('writeInt32BE', [1, 1], 5, Buffer.from([0, 0, 0, 0, 1, 0, 0, 0, 0]));
+write('writeUInt8', [1, 0], 1, Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 0]));
+write('writeUIntLE', [1, 1, 4], 5, Buffer.from([0, 1, 0, 0, 0, 0, 0, 0, 0]));
+write('writeUIntBE', [1, 1, 4], 5, Buffer.from([0, 0, 0, 0, 1, 0, 0, 0, 0]));
+write('writeUInt16LE', [1, 1], 3, Buffer.from([0, 1, 0, 0, 0, 0, 0, 0, 0]));
+write('writeUInt16BE', [1, 1], 3, Buffer.from([0, 0, 1, 0, 0, 0, 0, 0, 0]));
+write('writeUInt32LE', [1, 1], 5, Buffer.from([0, 1, 0, 0, 0, 0, 0, 0, 0]));
+write('writeUInt32BE', [1, 1], 5, Buffer.from([0, 0, 0, 0, 1, 0, 0, 0, 0]));
+write('writeDoubleBE', [1, 1], 9, Buffer.from([0, 63, 240, 0, 0, 0, 0, 0, 0]));
+write('writeDoubleLE', [1, 1], 9, Buffer.from([0, 0, 0, 0, 0, 0, 0, 240, 63]));
+write('writeFloatBE', [1, 1], 5, Buffer.from([0, 63, 128, 0, 0, 0, 0, 0, 0]));
+write('writeFloatLE', [1, 1], 5, Buffer.from([0, 0, 0, 128, 63, 0, 0, 0, 0]));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

Test for `noAssert` in buffer.write() files and inluded `buffer.writeDouble*` and `buffer.writeFloat*` as it was not present in the first commit