### PR TITLE
crypto,tls: fix mutability of return values

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -152,7 +152,7 @@ exports.cachedResult = function cachedResult(fn) {
   return () => {
     if (result === undefined)
       result = fn();
-    return result;
+    return result.slice();
   };
 };
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -22,9 +22,9 @@ exports.DEFAULT_CIPHERS =
 
 exports.DEFAULT_ECDH_CURVE = 'prime256v1';
 
-exports.getCiphers = internalUtil.cachedResult(() => {
-  return internalUtil.filterDuplicateStrings(binding.getSSLCiphers(), true);
-});
+exports.getCiphers = internalUtil.cachedResult(
+  () => internalUtil.filterDuplicateStrings(binding.getSSLCiphers(), true)
+);
 
 // Convert protocols array into valid OpenSSL protocols list
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -87,6 +87,20 @@ assert(crypto.getCurves().includes('secp384r1'));
 assert(!crypto.getCurves().includes('SECP384R1'));
 assertSorted(crypto.getCurves());
 
+// Modifying return value from get* functions should not mutate subsequent
+// return values.
+function testImmutability(fn) {
+  const list = fn();
+  const copy = [...list];
+  list.push('some-arbitrary-value');
+  assert.deepStrictEqual(fn(), copy);
+}
+
+testImmutability(crypto.getCiphers);
+testImmutability(tls.getCiphers);
+testImmutability(crypto.getHashes);
+testImmutability(crypto.getCurves);
+
 // Regression tests for #5725: hex input that's not a power of two should
 // throw, not assert in C++ land.
 assert.throws(function() {


### PR DESCRIPTION
If you alter the array returned by `tls.getCiphers()`,
`crypto.getCiphers()`, `crypto.getHashes()`, or `crypto.getCurves()`, it
will alter subsequent return values from those functions.

```js
'use strict';

const crypto = require('crypto');

var hashes = crypto.getHashes();

hashes.splice(0, hashes.length);

hashes.push('some-arbitrary-value');

console.log(crypto.getHashes()); // "['some-arbitrary-value']"
```

This is surprising. Change functions to return copy of array instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto tls test util