### PR TITLE
process: add process.cpuUsage() - implementation, doc, tests

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -421,6 +421,29 @@ added: v0.7.2
 
 If `process.connected` is false, it is no longer possible to send messages.
 
+## process.cpuUsage([previousValue])
+
+Returns the user and system CPU time usage of the current process, in an object
+with properties `user` and `system`, whose values are microsecond values
+(millionth of a second). These values measure time spent in user and
+system code respectively, and may end up being greater than actual elapsed time
+if multiple CPU cores are performing work for this process.
+
+The result of a previous call to `process.cpuUsage()` can be passed as the
+argument to the function, to get a diff reading.
+
+```js
+const startUsage = process.cpuUsage();
+// { user: 38579, system: 6986 }
+
+// spin the CPU for 500 milliseconds
+const now = Date.now();
+while (Date.now() - now < 500);
+
+console.log(process.cpuUsage(startUsage));
+// { user: 514883, system: 11226 }
+```
+
 ## process.cwd()
 <!-- YAML
 added: v0.1.8

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -1,0 +1,67 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const result = process.cpuUsage();
+
+// Validate the result of calling with no previous value argument.
+validateResult(result);
+
+// Validate the result of calling with a previous value argument.
+validateResult(process.cpuUsage(result));
+
+// Ensure the results are >= the previous.
+let thisUsage;
+let lastUsage = process.cpuUsage();
+for (let i = 0; i < 10; i++) {
+  thisUsage = process.cpuUsage();
+  validateResult(thisUsage);
+  assert(thisUsage.user >= lastUsage.user);
+  assert(thisUsage.system >= lastUsage.system);
+  lastUsage = thisUsage;
+}
+
+// Ensure that the diffs are >= 0.
+let startUsage;
+let diffUsage;
+for (let i = 0; i < 10; i++) {
+  startUsage = process.cpuUsage();
+  diffUsage = process.cpuUsage(startUsage);
+  validateResult(startUsage);
+  validateResult(diffUsage);
+  assert(diffUsage.user >= 0);
+  assert(diffUsage.system >= 0);
+}
+
+// Ensure that an invalid shape for the previous value argument throws an error.
+assert.throws(function() { process.cpuUsage(1); });
+assert.throws(function() { process.cpuUsage({}); });
+assert.throws(function() { process.cpuUsage({ user: 'a' }); });
+assert.throws(function() { process.cpuUsage({ system: 'b' }); });
+assert.throws(function() { process.cpuUsage({ user: null, system: 'c' }); });
+assert.throws(function() { process.cpuUsage({ user: 'd', system: null }); });
+assert.throws(function() { process.cpuUsage({ user: -1, system: 2 }); });
+assert.throws(function() { process.cpuUsage({ user: 3, system: -2 }); });
+assert.throws(function() {
+  process.cpuUsage({
+    user: Number.POSITIVE_INFINITY,
+    system: 4
+  });
+});
+assert.throws(function() {
+  process.cpuUsage({
+    user: 5,
+    system: Number.NEGATIVE_INFINITY
+  });
+});
+
+// Ensure that the return value is the expected shape.
+function validateResult(result) {
+  assert.notEqual(result, null);
+
+  assert(Number.isFinite(result.user));
+  assert(Number.isFinite(result.system));
+
+  assert(result.user >= 0);
+  assert(result.system >= 0);
+}

--- a/test/pummel/test-process-cpuUsage.js
+++ b/test/pummel/test-process-cpuUsage.js
@@ -1,0 +1,30 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const start = process.cpuUsage();
+
+// Run a busy-loop for specified # of milliseconds.
+const RUN_FOR_MS = 500;
+
+// Define slop factor for checking maximum expected diff values.
+const SLOP_FACTOR = 2;
+
+// Run a busy loop.
+const now = Date.now();
+while (Date.now() - now < RUN_FOR_MS);
+
+// Get a diff reading from when we started.
+const diff = process.cpuUsage(start);
+
+const MICROSECONDS_PER_SECOND = 1000 * 1000;
+
+// Diff usages should be >= 0, <= ~RUN_FOR_MS millis.
+// Let's be generous with the slop factor, defined above, in case other things
+// are happening on this CPU. The <= check may be invalid if the node process
+// is making use of multiple CPUs, in which case, just remove it.
+assert(diff.user >= 0);
+assert(diff.user <= SLOP_FACTOR * RUN_FOR_MS * MICROSECONDS_PER_SECOND);
+
+assert(diff.system >= 0);
+assert(diff.system <= SLOP_FACTOR * RUN_FOR_MS * MICROSECONDS_PER_SECOND);


### PR DESCRIPTION
Add process.cpuUsage() method that returns the user and system
CPU time usage of the current process

This is a backport of #6157 to v4.x-staging

/cc @nodejs/lts @pmuellr 

notes: the original commit made changes in internal/bootstrap_node and internal/process... in v4.x these changes are all applied to src/node

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src