### PR TITLE
test: add msg validation to test-buffer-compare

### DIFF
--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -28,8 +28,11 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
 assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
-assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'));
+assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'),
+              /^TypeError: Arguments must be Buffers or Uint8Arrays$/);
 
-assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)));
+assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)),
+              /^TypeError: Arguments must be Buffers or Uint8Arrays$/);
 
-assert.throws(() => Buffer.alloc(1).compare('abc'));
+assert.throws(() => Buffer.alloc(1).compare('abc'),
+              /^TypeError: Argument must be a Buffer or Uint8Array$/);


### PR DESCRIPTION
added message validation to assert.throws

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test
