### PR TITLE
vm: improve performance of vm.runIn*()

### DIFF
--- a/benchmark/vm/run-in-context.js
+++ b/benchmark/vm/run-in-context.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1],
+  breakOnSigint: [0, 1],
+  withSigintListener: [0, 1]
+});
+
+const vm = require('vm');
+
+function main(conf) {
+  const n = +conf.n;
+  const options = conf.breakOnSigint ? {breakOnSigint: true} : {};
+  const withSigintListener = !!conf.withSigintListener;
+
+  process.removeAllListeners('SIGINT');
+  if (withSigintListener)
+    process.on('SIGINT', () => {});
+
+  var i = 0;
+
+  const contextifiedSandbox = vm.createContext();
+
+  common.v8ForceOptimization(vm.runInContext,
+                             '0', contextifiedSandbox, options);
+  bench.start();
+  for (; i < n; i++)
+    vm.runInContext('0', contextifiedSandbox, options);
+  bench.end(n);
+}

--- a/benchmark/vm/run-in-this-context.js
+++ b/benchmark/vm/run-in-this-context.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1],
+  breakOnSigint: [0, 1],
+  withSigintListener: [0, 1]
+});
+
+const vm = require('vm');
+
+function main(conf) {
+  const n = +conf.n;
+  const options = conf.breakOnSigint ? {breakOnSigint: true} : {};
+  const withSigintListener = !!conf.withSigintListener;
+
+  process.removeAllListeners('SIGINT');
+  if (withSigintListener)
+    process.on('SIGINT', () => {});
+
+  var i = 0;
+
+  common.v8ForceOptimization(vm.runInThisContext, '0', options);
+  bench.start();
+  for (; i < n; i++)
+    vm.runInThisContext('0', options);
+  bench.end(n);
+}

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -17,7 +17,7 @@ const realRunInThisContext = Script.prototype.runInThisContext;
 const realRunInContext = Script.prototype.runInContext;
 
 Script.prototype.runInThisContext = function(options) {
-  if (options && options.breakOnSigint) {
+  if (options && options.breakOnSigint && process._events.SIGINT) {
     return sigintHandlersWrap(realRunInThisContext, this, [options]);
   } else {
     return realRunInThisContext.call(this, options);
@@ -25,7 +25,7 @@ Script.prototype.runInThisContext = function(options) {
 };
 
 Script.prototype.runInContext = function(contextifiedSandbox, options) {
-  if (options && options.breakOnSigint) {
+  if (options && options.breakOnSigint && process._events.SIGINT) {
     return sigintHandlersWrap(realRunInContext, this,
                               [contextifiedSandbox, options]);
   } else {
@@ -82,8 +82,6 @@ function sigintHandlersWrap(fn, thisArg, argsArray) {
   // Using the internal list here to make sure `.once()` wrappers are used,
   // not the original ones.
   let sigintListeners = process._events.SIGINT;
-  if (!sigintListeners)
-    return fn.apply(thisArg, argsArray);
 
   if (Array.isArray(sigintListeners))
     sigintListeners = sigintListeners.slice();

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -18,10 +18,7 @@ const realRunInContext = Script.prototype.runInContext;
 
 Script.prototype.runInThisContext = function(options) {
   if (options && options.breakOnSigint) {
-    const realRunInThisContextScript = () => {
-      return realRunInThisContext.call(this, options);
-    };
-    return sigintHandlersWrap(realRunInThisContextScript);
+    return sigintHandlersWrap(realRunInThisContext, this, [options]);
   } else {
     return realRunInThisContext.call(this, options);
   }
@@ -29,10 +26,8 @@ Script.prototype.runInThisContext = function(options) {
 
 Script.prototype.runInContext = function(contextifiedSandbox, options) {
   if (options && options.breakOnSigint) {
-    const realRunInContextScript = () => {
-      return realRunInContext.call(this, contextifiedSandbox, options);
-    };
-    return sigintHandlersWrap(realRunInContextScript);
+    return sigintHandlersWrap(realRunInContext, this,
+                              [contextifiedSandbox, options]);
   } else {
     return realRunInContext.call(this, contextifiedSandbox, options);
   }
@@ -83,19 +78,22 @@ exports.isContext = binding.isContext;
 
 // Remove all SIGINT listeners and re-attach them after the wrapped function
 // has executed, so that caught SIGINT are handled by the listeners again.
-function sigintHandlersWrap(fn) {
+function sigintHandlersWrap(fn, thisArg, argsArray) {
   // Using the internal list here to make sure `.once()` wrappers are used,
   // not the original ones.
   let sigintListeners = process._events.SIGINT;
-  if (!Array.isArray(sigintListeners))
-    sigintListeners = sigintListeners ? [sigintListeners] : [];
-  else
+  if (!sigintListeners)
+    return fn.apply(thisArg, argsArray);
+
+  if (Array.isArray(sigintListeners))
     sigintListeners = sigintListeners.slice();
+  else
+    sigintListeners = [sigintListeners];
 
   process.removeAllListeners('SIGINT');
 
   try {
-    return fn();
+    return fn.apply(thisArg, argsArray);
   } finally {
     // Add using the public methods so that the `newListener` handler of
     // process can re-attach the listeners.


### PR DESCRIPTION
Optimize for common cases in `vm.runInContext()` and `vm.runInThisContext()` when `breakOnSigint` is set.

```console
$ node benchmark/compare.js --set 'n=10'  --old './node-old' --new './node-new' vm > bench.csv
$ cat bench.csv | Rscript benchmark/compare.R bench
                                                                     improvement confidence      p.value
 vm/run-in-context.js withSigintListener=0 breakOnSigint=0 n=10           1.12 %            0.5268470825
 vm/run-in-context.js withSigintListener=0 breakOnSigint=1 n=10           6.90 %         ** 0.0039743927
 vm/run-in-context.js withSigintListener=1 breakOnSigint=0 n=10           5.19 %        *** 0.0001940968
 vm/run-in-context.js withSigintListener=1 breakOnSigint=1 n=10          -0.84 %            0.6936019893
 vm/run-in-this-context.js withSigintListener=0 breakOnSigint=0 n=10      0.14 %            0.9651596335
 vm/run-in-this-context.js withSigintListener=0 breakOnSigint=1 n=10      9.27 %         ** 0.0058309681
 vm/run-in-this-context.js withSigintListener=1 breakOnSigint=0 n=10      1.13 %            0.5957890149
 vm/run-in-this-context.js withSigintListener=1 breakOnSigint=1 n=10      2.21 %            0.2564659136
$ 
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
vm benchmark