### PR TITLE
HTTP response getHeader doc fix

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -907,9 +907,8 @@ added: v0.4.0
 * `name` {String}
 * Returns: {String}
 
-Reads out a header that's already been queued but not sent to the client.  Note
-that the name is case insensitive.  This can only be called before headers get
-implicitly flushed.
+Reads out a header that's already been queued but not sent to the client.
+Note that the name is case insensitive.
 
 Example:
 


### PR DESCRIPTION
According to https://github.com/nodejs/node/issues/10803
getHeader need not be called only before it is flushed implicitly.

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc