### PR TITLE
test: increase coverage of _http_outgoing

### DIFF
--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -12,3 +12,63 @@ assert.strictEqual(
   typeof ClientRequest.prototype._implicitHeader, 'function');
 assert.strictEqual(
   typeof ServerResponse.prototype._implicitHeader, 'function');
+
+// validateHeader
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader();
+}, /^TypeError: Header name must be a valid HTTP Token \["undefined"\]$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader('test');
+}, /^Error: "value" required in setHeader\("test", value\)$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader(404);
+}, /^TypeError: Header name must be a valid HTTP Token \["404"\]$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader.call({_header: 'test'}, 'test', 'value');
+}, /^Error: Can't set headers after they are sent.$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader('200', 'あ');
+}, /^TypeError: The header content contains invalid characters$/);
+
+// write
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.write();
+}, /^Error: _implicitHeader\(\) method is not implemented$/);
+
+assert(OutgoingMessage.prototype.write.call({_header: 'test'}));
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.write.call({_header: 'test', _hasBody: 'test'});
+}, /^TypeError: First argument must be a string or Buffer$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.write.call({_header: 'test', _hasBody: 'test'}, 1);
+}, /^TypeError: First argument must be a string or Buffer$/);
+
+// addTrailers
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.addTrailers();
+}, /^TypeError: Cannot convert undefined or null to object$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.addTrailers({'あ': 'value'});
+}, /^TypeError: Trailer name must be a valid HTTP Token \["あ"\]$/);
+
+assert.throws(() => {
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.addTrailers({404: 'あ'});
+}, /^TypeError: The trailer content contains invalid characters$/);


### PR DESCRIPTION
validateHeader: https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L376
write: https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L477
addTrailers: https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L557

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test