### PR TITLE
test: increase timeout in break-on-uncaught

### DIFF
--- a/test/debugger/test-debug-break-on-uncaught.js
+++ b/test/debugger/test-debug-break-on-uncaught.js
@@ -73,6 +73,7 @@ function runScenario(scriptName, throwsOnLine, next) {
     client.connect(port);
   }
 
+  let interval;
   function runTest(client) {
     client.req(
       {
@@ -91,14 +92,15 @@ function runScenario(scriptName, throwsOnLine, next) {
 
         client.reqContinue(function(error) {
           assert.ifError(error);
-          setTimeout(assertHasPaused.bind(null, client), 100);
+          interval = setInterval(assertHasPaused.bind(null, client), 10);
         });
       }
     );
   }
 
   function assertHasPaused(client) {
-    assert(exceptions.length, 'no exceptions thrown, race condition in test?');
+    if (!exceptions.length) return;
+
     assert.strictEqual(exceptions.length, 1,
                        'debugger did not pause on exception');
     assert.strictEqual(exceptions[0].uncaught, true);
@@ -106,5 +108,6 @@ function runScenario(scriptName, throwsOnLine, next) {
     assert.strictEqual(exceptions[0].sourceLine + 1, throwsOnLine);
     asserted = true;
     client.reqContinue(assert.ifError);
+    clearInterval(interval);
   }
 }


### PR DESCRIPTION
As the failures suggest, this test expects the uncaught exception to
be thrown within 100 milliseconds, but on some of the test machines it
takes longer than that limit to notify the exception. Thats why the
test was failing.

This patch increases the timeout to three seconds, with platform
specific timeout value.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test

---

Refer: https://github.com/nodejs/node/pull/10456
