### PR TITLE
doc: add links for zlib convenience methods

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -460,7 +460,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Compress a Buffer or string with [Deflate][].
+Compress a [Buffer][] or string with [Deflate][].
 
 ### zlib.deflateRaw(buf[, options], callback)
 <!-- YAML
@@ -471,7 +471,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Compress a Buffer or string with [DeflateRaw][].
+Compress a [Buffer][] or string with [DeflateRaw][].
 
 ### zlib.gunzip(buf[, options], callback)
 <!-- YAML
@@ -482,7 +482,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with [Gunzip][].
+Decompress a [Buffer][] or string with [Gunzip][].
 
 ### zlib.gzip(buf[, options], callback)
 <!-- YAML
@@ -493,7 +493,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Compress a Buffer or string with [Gzip][].
+Compress a [Buffer][] or string with [Gzip][].
 
 ### zlib.inflate(buf[, options], callback)
 <!-- YAML
@@ -504,7 +504,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with [Inflate][].
+Decompress a [Buffer][] or string with [Inflate][].
 
 ### zlib.inflateRaw(buf[, options], callback)
 <!-- YAML
@@ -515,7 +515,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with [InflateRaw][].
+Decompress a [Buffer][] or string with [InflateRaw][].
 
 ### zlib.unzip(buf[, options], callback)
 <!-- YAML
@@ -526,7 +526,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with [Unzip][].
+Decompress a [Buffer][] or string with [Unzip][].
 
 [`Accept-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
 [`Content-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -460,7 +460,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Compress a Buffer or string with Deflate.
+Compress a Buffer or string with [Deflate][].
 
 ### zlib.deflateRaw(buf[, options], callback)
 <!-- YAML
@@ -471,7 +471,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Compress a Buffer or string with DeflateRaw.
+Compress a Buffer or string with [DeflateRaw][].
 
 ### zlib.gunzip(buf[, options], callback)
 <!-- YAML
@@ -482,7 +482,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with Gunzip.
+Decompress a Buffer or string with [Gunzip][].
 
 ### zlib.gzip(buf[, options], callback)
 <!-- YAML
@@ -493,7 +493,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Compress a Buffer or string with Gzip.
+Compress a Buffer or string with [Gzip][].
 
 ### zlib.inflate(buf[, options], callback)
 <!-- YAML
@@ -504,7 +504,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with Inflate.
+Decompress a Buffer or string with [Inflate][].
 
 ### zlib.inflateRaw(buf[, options], callback)
 <!-- YAML
@@ -515,7 +515,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with InflateRaw.
+Decompress a Buffer or string with [InflateRaw][].
 
 ### zlib.unzip(buf[, options], callback)
 <!-- YAML
@@ -526,7 +526,7 @@ added: v0.6.0
 added: v0.11.12
 -->
 
-Decompress a Buffer or string with Unzip.
+Decompress a Buffer or string with [Unzip][].
 
 [`Accept-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
 [`Content-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11


### PR DESCRIPTION
Add links to the engine classes for the zlib single-call convenience methods.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc