### PR TITLE
Backport ALPN to v4.x LTS

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -177,7 +177,7 @@ CryptoStream.prototype._write = function _write(data, encoding, cb) {
     if (this.pair.encrypted._internallyPendingBytes())
       this.pair.encrypted.read(0);
 
-    // Get NPN and Server name when ready
+    // Get ALPN, NPN and Server name when ready
     this.pair.maybeInitFinished();
 
     // Whole buffer was written
@@ -273,7 +273,7 @@ CryptoStream.prototype._read = function _read(size) {
            bytesRead < size &&
            this.pair.ssl !== null);
 
-  // Get NPN and Server name when ready
+  // Get ALPN, NPN and Server name when ready
   this.pair.maybeInitFinished();
 
   // Create new buffer if previous was filled up
@@ -729,6 +729,13 @@ function SecurePair(context, isServer, requestCert, rejectUnauthorized,
     this.npnProtocol = null;
   }
 
+  if (process.features.tls_alpn && options.ALPNProtocols) {
+    // keep reference in secureContext not to be GC-ed
+    this.ssl._secureContext.alpnBuffer = options.ALPNProtocols;
+    this.ssl.setALPNrotocols(this.ssl._secureContext.alpnBuffer);
+    this.alpnProtocol = null;
+  }
+
   /* Acts as a r/w stream to the cleartext side of the stream. */
   this.cleartext = new CleartextStream(this, options.cleartext);
 
@@ -779,6 +786,10 @@ SecurePair.prototype.maybeInitFinished = function() {
   if (this.ssl && !this._secureEstablished && this.ssl.isInitFinished()) {
     if (process.features.tls_npn) {
       this.npnProtocol = this.ssl.getNegotiatedProtocol();
+    }
+
+    if (process.features.tls_alpn) {
+      this.alpnProtocol = this.ssl.getALPNNegotiatedProtocol();
     }
 
     if (process.features.tls_sni) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -258,6 +258,7 @@ function TLSSocket(socket, options) {
   this._SNICallback = null;
   this.servername = null;
   this.npnProtocol = null;
+  this.alpnProtocol = null;
   this.authorized = false;
   this.authorizationError = null;
 
@@ -486,6 +487,12 @@ TLSSocket.prototype._init = function(socket, wrap) {
   if (process.features.tls_npn && options.NPNProtocols)
     ssl.setNPNProtocols(options.NPNProtocols);
 
+  if (process.features.tls_alpn && options.ALPNProtocols) {
+    // keep reference in secureContext not to be GC-ed
+    ssl._secureContext.alpnBuffer = options.ALPNProtocols;
+    ssl.setALPNProtocols(ssl._secureContext.alpnBuffer);
+  }
+
   if (options.handshakeTimeout > 0)
     this.setTimeout(options.handshakeTimeout, this._handleTimeout);
 
@@ -590,6 +597,10 @@ TLSSocket.prototype._finishInit = function() {
 
   if (process.features.tls_npn) {
     this.npnProtocol = this._handle.getNegotiatedProtocol();
+  }
+
+  if (process.features.tls_alpn) {
+    this.alpnProtocol = this.ssl.getALPNNegotiatedProtocol();
   }
 
   if (process.features.tls_sni && this._tlsOptions.isServer) {
@@ -792,6 +803,7 @@ function Server(/* [options], listener */) {
       rejectUnauthorized: self.rejectUnauthorized,
       handshakeTimeout: timeout,
       NPNProtocols: self.NPNProtocols,
+      ALPNProtocols: self.ALPNProtocols,
       SNICallback: options.SNICallback || SNICallback
     });
 
@@ -902,6 +914,8 @@ Server.prototype.setOptions = function(options) {
     this.honorCipherOrder = true;
   if (secureOptions) this.secureOptions = secureOptions;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
+  if (options.ALPNProtocols)
+    tls.convertALPNProtocols(options.ALPNProtocols, this);
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
@@ -986,12 +1000,14 @@ exports.connect = function(/* [port, host], options, cb */) {
   assert(typeof options.checkServerIdentity === 'function');
 
   var hostname = options.servername ||
-                 options.host ||
-                 (options.socket && options.socket._host) ||
-                 'localhost';
-  const NPN = {};
-  const context = options.secureContext || tls.createSecureContext(options);
+      options.host ||
+      (options.socket && options.socket._host) ||
+      'localhost';
+  var NPN = {};
+  var ALPN = {};
+  var context = options.secureContext || tls.createSecureContext(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);
+  tls.convertALPNProtocols(options.ALPNProtocols, ALPN);
 
   var socket = new TLSSocket(options.socket, {
     pipe: options.path && !options.port,
@@ -1001,6 +1017,7 @@ exports.connect = function(/* [port, host], options, cb */) {
     rejectUnauthorized: options.rejectUnauthorized,
     session: options.session,
     NPNProtocols: NPN.NPNProtocols,
+    ALPNProtocols: ALPN.ALPNProtocols,
     requestOCSP: options.requestOCSP
   });
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -14,6 +14,13 @@ function Server(opts, requestListener) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }
 
+  if (process.features.tls_alpn && !opts.ALPNProtocols) {
+    // http/1.0 is not defined as Protocol IDs in IANA
+    // http://www.iana.org/assignments/tls-extensiontype-values
+    //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
+    opts.ALPNProtocols = ['http/1.1'];
+  }
+
   tls.Server.call(this, opts, http._connectionListener);
 
   this.httpAllowHalfOpen = false;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -32,27 +32,42 @@ exports.getCiphers = function() {
 
 // Convert protocols array into valid OpenSSL protocols list
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")
-exports.convertNPNProtocols = function convertNPNProtocols(NPNProtocols, out) {
-  // If NPNProtocols is Array - translate it into buffer
-  if (Array.isArray(NPNProtocols)) {
-    var buff = new Buffer(NPNProtocols.reduce(function(p, c) {
-      return p + 1 + Buffer.byteLength(c);
-    }, 0));
+function convertProtocols(protocols) {
+  var buff = new Buffer(protocols.reduce(function(p, c) {
+    return p + 1 + Buffer.byteLength(c);
+  }, 0));
 
-    NPNProtocols.reduce(function(offset, c) {
-      var clen = Buffer.byteLength(c);
-      buff[offset] = clen;
-      buff.write(c, offset + 1);
+  protocols.reduce(function(offset, c) {
+    var clen = Buffer.byteLength(c);
+    buff[offset] = clen;
+    buff.write(c, offset + 1);
 
-      return offset + 1 + clen;
-    }, 0);
+    return offset + 1 + clen;
+  }, 0);
 
-    NPNProtocols = buff;
+  return buff;
+}
+
+exports.convertNPNProtocols  = function(protocols, out) {
+  // If protocols is Array - translate it into buffer
+  if (Array.isArray(protocols)) {
+    protocols = convertProtocols(protocols);
   }
-
   // If it's already a Buffer - store it
-  if (NPNProtocols instanceof Buffer) {
-    out.NPNProtocols = Buffer.from(NPNProtocols);
+  if (protocols instanceof Buffer) {
+    out.NPNProtocols = protocols;
+  }
+};
+
+exports.convertALPNProtocols = function(protocols, out) {
+  // If protocols is Array - translate it into buffer
+  if (Array.isArray(protocols)) {
+    protocols = convertProtocols(protocols);
+  }
+  // If it's already a Buffer - store it
+  if (protocols instanceof Buffer) {
+    // copy new buffer not to be modified by user
+    out.ALPNProtocols = Buffer.from(protocols);
   }
 };
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -51,22 +51,19 @@ function convertProtocols(protocols) {
 exports.convertNPNProtocols  = function(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
-    protocols = convertProtocols(protocols);
-  }
-  // If it's already a Buffer - store it
-  if (protocols instanceof Buffer) {
-    out.NPNProtocols = protocols;
+    out.NPNProtocols = convertProtocols(protocols);
+  } else if (protocols instanceof Buffer) {
+    // Copy new buffer not to be modified by user.
+    out.NPNProtocols = Buffer.from(protocols);
   }
 };
 
 exports.convertALPNProtocols = function(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
-    protocols = convertProtocols(protocols);
-  }
-  // If it's already a Buffer - store it
-  if (protocols instanceof Buffer) {
-    // copy new buffer not to be modified by user
+    out.ALPNProtocols = convertProtocols(protocols);
+  } else if (protocols instanceof Buffer) {
+    // Copy new buffer not to be modified by user.
     out.ALPNProtocols = Buffer.from(protocols);
   }
 };

--- a/src/env.h
+++ b/src/env.h
@@ -134,6 +134,7 @@ namespace node {
   V(netmask_string, "netmask")                                                \
   V(nice_string, "nice")                                                      \
   V(nlink_string, "nlink")                                                    \
+  V(npn_buffer_string, "npnBuffer")                                           \
   V(nsname_string, "nsname")                                                  \
   V(ocsp_request_string, "OCSPRequest")                                       \
   V(offset_string, "offset")                                                  \
@@ -184,6 +185,7 @@ namespace node {
   V(serial_string, "serial")                                                  \
   V(scavenge_string, "scavenge")                                              \
   V(scopeid_string, "scopeid")                                                \
+  V(selected_npn_buffer_string, "selectedNpnBuffer")                          \
   V(sent_shutdown_string, "sentShutdown")                                     \
   V(serial_number_string, "serialNumber")                                     \
   V(service_string, "service")                                                \

--- a/src/env.h
+++ b/src/env.h
@@ -43,6 +43,7 @@ namespace node {
 // for the sake of convenience.  Strings should be ASCII-only.
 #define PER_ISOLATE_STRING_PROPERTIES(V)                                      \
   V(address_string, "address")                                                \
+  V(alpn_buffer_string, "alpnBuffer")                                         \
   V(args_string, "args")                                                      \
   V(argv_string, "argv")                                                      \
   V(arrow_message_string, "arrowMessage")                                     \
@@ -208,6 +209,7 @@ namespace node {
   V(timestamp_string, "timestamp")                                            \
   V(title_string, "title")                                                    \
   V(tls_npn_string, "tls_npn")                                                \
+  V(tls_alpn_string, "tls_alpn")                                              \
   V(tls_ocsp_string, "tls_ocsp")                                              \
   V(tls_sni_string, "tls_sni")                                                \
   V(tls_string, "tls")                                                        \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2707,6 +2707,13 @@ static Local<Object> GetFeatures(Environment* env) {
 #endif
   obj->Set(env->tls_npn_string(), tls_npn);
 
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+  Local<Boolean> tls_alpn = True(env->isolate());
+#else
+  Local<Boolean> tls_alpn = False(env->isolate());
+#endif
+  obj->Set(env->tls_alpn_string(), tls_alpn);
+
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   Local<Boolean> tls_sni = True(env->isolate());
 #else

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -935,6 +935,11 @@ void DefineOpenSSLConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, NPN_ENABLED);
 #endif
 
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+#define ALPN_ENABLED 1
+    NODE_DEFINE_CONSTANT(target, ALPN_ENABLED);
+#endif
+
 #ifdef RSA_PKCS1_PADDING
     NODE_DEFINE_CONSTANT(target, RSA_PKCS1_PADDING);
 #endif

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2073,8 +2073,8 @@ void SSLWrap<Base>::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
     return env->ThrowTypeError("Must give a Buffer as first argument");
 
-  Local<Value> npn_buffer =  Local<Value>::New(env->isolate(), args[0]);
-  bool r = w->object()->SetHiddenValue(env->npn_buffer_string(), npn_buffer);
+  bool r = w->object()->SetHiddenValue(env->npn_buffer_string(), args[0]);
+
   CHECK(r);
 }
 #endif  // OPENSSL_NPN_NEGOTIATED
@@ -2156,9 +2156,8 @@ void SSLWrap<Base>::SetALPNProtocols(
     int r = SSL_set_alpn_protos(w->ssl_, alpn_protos, alpn_protos_len);
     CHECK_EQ(r, 0);
   } else {
-    Local<Value> alpn_buffer =  Local<Value>::New(env->isolate(), args[0]);
-    bool ret = w->object()->SetHiddenValue(env->alpn_buffer_string(),
-                                           alpn_buffer);
+    bool ret = w->object()->SetHiddenValue(env->alpn_buffer_string(), args[0]);
+
     CHECK(ret);
     // Server should select ALPN protocol from list of advertised by client
     SSL_CTX_set_alpn_select_cb(w->ssl_->ctx, SelectALPNCallback, nullptr);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1960,14 +1960,17 @@ int SSLWrap<Base>::AdvertiseNextProtoCallback(SSL* s,
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  if (w->npn_protos_.IsEmpty()) {
+  Local<Value> npn_buffer =
+      w->object()->GetHiddenValue(env->npn_buffer_string());
+
+  if (npn_buffer.IsEmpty()) {
     // No initialization - no NPN protocols
     *data = reinterpret_cast<const unsigned char*>("");
     *len = 0;
   } else {
-    Local<Object> obj = PersistentToLocal(env->isolate(), w->npn_protos_);
-    *data = reinterpret_cast<const unsigned char*>(Buffer::Data(obj));
-    *len = Buffer::Length(obj);
+    CHECK(Buffer::HasInstance(npn_buffer));
+    *data = reinterpret_cast<const unsigned char*>(Buffer::Data(npn_buffer));
+    *len = Buffer::Length(npn_buffer);
   }
 
   return SSL_TLSEXT_ERR_OK;
@@ -1986,25 +1989,27 @@ int SSLWrap<Base>::SelectNextProtoCallback(SSL* s,
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  // Release old protocol handler if present
-  w->selected_npn_proto_.Reset();
+  Local<Value> npn_buffer =
+      w->object()->GetHiddenValue(env->npn_buffer_string());
 
-  if (w->npn_protos_.IsEmpty()) {
+  if (npn_buffer.IsEmpty()) {
     // We should at least select one protocol
     // If server is using NPN
     *out = reinterpret_cast<unsigned char*>(const_cast<char*>("http/1.1"));
     *outlen = 8;
 
     // set status: unsupported
-    w->selected_npn_proto_.Reset(env->isolate(), False(env->isolate()));
+    bool r = w->object()->SetHiddenValue(env->selected_npn_buffer_string(),
+                                         False(env->isolate()));
+    CHECK(r);
 
     return SSL_TLSEXT_ERR_OK;
   }
 
-  Local<Object> obj = PersistentToLocal(env->isolate(), w->npn_protos_);
+  CHECK(Buffer::HasInstance(npn_buffer));
   const unsigned char* npn_protos =
-      reinterpret_cast<const unsigned char*>(Buffer::Data(obj));
-  size_t len = Buffer::Length(obj);
+      reinterpret_cast<const unsigned char*>(Buffer::Data(npn_buffer));
+  size_t len = Buffer::Length(npn_buffer);
 
   int status = SSL_select_next_proto(out, outlen, in, inlen, npn_protos, len);
   Local<Value> result;
@@ -2022,8 +2027,9 @@ int SSLWrap<Base>::SelectNextProtoCallback(SSL* s,
       break;
   }
 
-  if (!result.IsEmpty())
-    w->selected_npn_proto_.Reset(env->isolate(), result);
+  bool r = w->object()->SetHiddenValue(env->selected_npn_buffer_string(),
+                                       result);
+  CHECK(r);
 
   return SSL_TLSEXT_ERR_OK;
 }
@@ -2036,9 +2042,12 @@ void SSLWrap<Base>::GetNegotiatedProto(
   ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
 
   if (w->is_client()) {
-    if (w->selected_npn_proto_.IsEmpty() == false) {
-      args.GetReturnValue().Set(w->selected_npn_proto_);
-    }
+    Local<Value> selected_npn_buffer =
+        w->object()->GetHiddenValue(w->env()->selected_npn_buffer_string());
+
+    if (selected_npn_buffer.IsEmpty() == false)
+      args.GetReturnValue().Set(selected_npn_buffer);
+
     return;
   }
 
@@ -2062,9 +2071,11 @@ void SSLWrap<Base>::SetNPNProtocols(const FunctionCallbackInfo<Value>& args) {
   Environment* env = w->ssl_env();
 
   if (args.Length() < 1 || !Buffer::HasInstance(args[0]))
-    return w->env()->ThrowTypeError("Must give a Buffer as first argument");
+    return env->ThrowTypeError("Must give a Buffer as first argument");
 
-  w->npn_protos_.Reset(args.GetIsolate(), args[0].As<Object>());
+  Local<Value> npn_buffer =  Local<Value>::New(env->isolate(), args[0]);
+  bool r = w->object()->SetHiddenValue(env->npn_buffer_string(), npn_buffer);
+  CHECK(r);
 }
 #endif  // OPENSSL_NPN_NEGOTIATED
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -193,10 +193,6 @@ class SSLWrap {
       next_sess_ = nullptr;
     }
 
-#ifdef OPENSSL_NPN_NEGOTIATED
-    npn_protos_.Reset();
-    selected_npn_proto_.Reset();
-#endif
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
     sni_context_.Reset();
 #endif
@@ -312,11 +308,6 @@ class SSLWrap {
 #ifdef NODE__HAVE_TLSEXT_STATUS_CB
   v8::Persistent<v8::Object> ocsp_response_;
 #endif  // NODE__HAVE_TLSEXT_STATUS_CB
-
-#ifdef OPENSSL_NPN_NEGOTIATED
-  v8::Persistent<v8::Object> npn_protos_;
-  v8::Persistent<v8::Value> selected_npn_proto_;
-#endif  // OPENSSL_NPN_NEGOTIATED
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   v8::Persistent<v8::Value> sni_context_;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -5,9 +5,7 @@
 #include "node_crypto_clienthello.h"  // ClientHelloParser
 #include "node_crypto_clienthello-inl.h"
 
-#ifdef OPENSSL_NPN_NEGOTIATED
 #include "node_buffer.h"
-#endif
 
 #include "env.h"
 #include "async-wrap.h"
@@ -202,6 +200,7 @@ class SSLWrap {
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
     sni_context_.Reset();
 #endif
+
 #ifdef NODE__HAVE_TLSEXT_STATUS_CB
     ocsp_response_.Reset();
 #endif  // NODE__HAVE_TLSEXT_STATUS_CB
@@ -272,6 +271,16 @@ class SSLWrap {
                                      unsigned int inlen,
                                      void* arg);
 #endif  // OPENSSL_NPN_NEGOTIATED
+
+  static void GetALPNNegotiatedProto(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetALPNProtocols(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static int SelectALPNCallback(SSL* s,
+                                const unsigned char** out,
+                                unsigned char* outlen,
+                                const unsigned char* in,
+                                unsigned int inlen,
+                                void* arg);
   static int TLSExtStatusCallback(SSL* s, void* arg);
   static int SSLCertCallback(SSL* s, void* arg);
   static void SSLGetter(v8::Local<v8::String> property,

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -1,0 +1,540 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+
+if (!process.features.tls_alpn) {
+  console.error('Skipping because node compiled without OpenSSL or ' +
+                'with old OpenSSL version.');
+  process.exit(0);
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const tls = require('tls');
+
+function filenamePEM(n) {
+  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+}
+
+function loadPEM(n) {
+  return fs.readFileSync(filenamePEM(n));
+}
+
+var serverPort = common.PORT;
+var serverIP = common.localhostIPv4;
+
+function checkResults(result, expected) {
+  assert.strictEqual(result.server.ALPN, expected.server.ALPN);
+  assert.strictEqual(result.server.NPN, expected.server.NPN);
+  assert.strictEqual(result.client.ALPN, expected.client.ALPN);
+  assert.strictEqual(result.client.NPN, expected.client.NPN);
+}
+
+function runTest(clientsOptions, serverOptions, cb) {
+  serverOptions.key = loadPEM('agent2-key');
+  serverOptions.cert = loadPEM('agent2-cert');
+  var results = [];
+  var index = 0;
+  var server = tls.createServer(serverOptions, function(c) {
+    results[index].server = {ALPN: c.alpnProtocol, NPN: c.npnProtocol};
+  });
+
+  server.listen(serverPort, serverIP, function() {
+    connectClient(clientsOptions);
+  });
+
+  function connectClient(options) {
+    var opt = options.shift();
+    opt.port = serverPort;
+    opt.host = serverIP;
+    opt.rejectUnauthorized = false;
+
+    results[index] = {};
+    var client = tls.connect(opt, function() {
+      results[index].client = {ALPN: client.alpnProtocol,
+                               NPN: client.npnProtocol};
+      client.destroy();
+      if (options.length) {
+        index++;
+        connectClient(options);
+      } else {
+        server.close();
+        cb(results);
+      }
+    });
+  }
+
+}
+
+// Server: ALPN/NPN, Client: ALPN/NPN
+function Test1() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0],
+                 {server: {ALPN: 'a', NPN: false},
+                  client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: 'b', NPN: false},
+                  client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: false},
+                  client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test2();
+  });
+}
+
+// Server: ALPN/NPN, Client: ALPN
+function Test2() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0],
+                 {server: {ALPN: 'a', NPN: false},
+                  client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: 'b', NPN: false},
+                  client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: false},
+                  client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test3();
+  });
+}
+
+// Server: ALPN/NPN, Client: NPN
+function Test3() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by NPN
+    checkResults(results[0],
+                 {server: {ALPN: false, NPN: 'a'},
+                  client: {ALPN: false, NPN: 'a'}});
+    // nothing is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test4();
+  });
+}
+
+// Server: ALPN/NPN, Client: Nothing
+function Test4() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected by ALPN
+    checkResults(results[0],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[1],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test5();
+  });
+}
+
+// Server: ALPN, Client: ALPN/NPN
+function Test5() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0], {server: {ALPN: 'a', NPN: false},
+                              client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1], {server: {ALPN: 'b', NPN: false},
+                              client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2], {server: {ALPN: false, NPN: false},
+                              client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test6();
+  });
+}
+
+// Server: ALPN, Client: ALPN
+function Test6() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by ALPN
+    checkResults(results[0], {server: {ALPN: 'a', NPN: false},
+                              client: {ALPN: 'a', NPN: undefined}});
+    // 'b' is selected by ALPN
+    checkResults(results[1], {server: {ALPN: 'b', NPN: false},
+                              client: {ALPN: 'b', NPN: undefined}});
+    // nothing is selected by ALPN
+    checkResults(results[2], {server: {ALPN: false, NPN: false},
+                              client: {ALPN: false, NPN: undefined}});
+    // execute next test
+    Test7();
+  });
+}
+
+// Server: ALPN, Client: NPN
+function Test7() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected by ALPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN:  'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test8();
+  });
+}
+
+// Server: ALPN, Client: Nothing
+function Test8() {
+  var serverOptions = {
+    ALPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected by ALPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected by ALPN
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN:  'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test9();
+  });
+}
+
+// Server: NPN, Client: ALPN/NPN
+function Test9() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNrotocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by NPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: 'a'}});
+    // 'b' is selected by NPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'b'},
+                              client: {ALPN: false, NPN: 'b'}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test10();
+  });
+}
+
+// Server: NPN, Client: ALPN
+function Test10() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test11();
+  });
+}
+
+// Server: NPN, Client: NPN
+function Test11() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // 'a' is selected by NPN
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: 'a'}});
+    // 'b' is selected by NPN
+    checkResults(results[1], {server: {ALPN: false, NPN: 'b'},
+                              client: {ALPN: false, NPN: 'b'}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test12();
+  });
+}
+
+// Server: NPN, Client: Nothing
+function Test12() {
+  var serverOptions = {
+    NPNProtocols: ['a', 'b', 'c']
+  };
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test13();
+  });
+}
+
+// Server: Nothing, Client: ALPN/NPN
+function Test13() {
+  var serverOptions = {};
+
+  var clientsOptions = [{
+    ALPNrotocols: ['a', 'b', 'c'],
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e'],
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test14();
+  });
+}
+
+// Server: Nothing, Client: ALPN
+function Test14() {
+  var serverOptions = {};
+
+  var clientsOptions = [{
+    ALPNrotocols: ['a', 'b', 'c']
+  }, {
+    ALPNProtocols: ['c', 'b', 'e']
+  }, {
+    ALPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test15();
+  });
+}
+
+// Server: Nothing, Client: NPN
+function Test15() {
+  var serverOptions = {};
+
+  var clientsOptions = [{
+    NPNProtocols: ['a', 'b', 'c']
+  }, {
+    NPNProtocols: ['c', 'b', 'e']
+  }, {
+    NPNProtocols: ['first-priority-unsupported', 'x', 'y']
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'a'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'c'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
+    // execute next test
+    Test16();
+  });
+}
+
+// Server: Nothing, Client: Nothing
+function Test16() {
+  var serverOptions = {};
+
+  var clientsOptions = [{}, {}, {}];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // nothing is selected
+    checkResults(results[0], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[1], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
+    // nothing is selected
+    checkResults(results[2],
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
+  });
+}
+
+Test1();

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -99,8 +99,8 @@ function Test1() {
                   client: {ALPN: 'b', NPN: undefined}});
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: false},
-                  client: {ALPN: false, NPN: undefined}});
+                 {server: {ALPN: false, NPN: 'first-priority-unsupported'},
+                  client: {ALPN: false, NPN: false}});
     // execute next test
     Test2();
   });
@@ -132,8 +132,8 @@ function Test2() {
                   client: {ALPN: 'b', NPN: undefined}});
     // nothing is selected by ALPN
     checkResults(results[2],
-                 {server: {ALPN: false, NPN: false},
-                  client: {ALPN: false, NPN: undefined}});
+                 {server: {ALPN: false, NPN: 'http/1.1'},
+                  client: {ALPN: false, NPN: false}});
     // execute next test
     Test3();
   });
@@ -224,8 +224,9 @@ function Test5() {
     checkResults(results[1], {server: {ALPN: 'b', NPN: false},
                               client: {ALPN: 'b', NPN: undefined}});
     // nothing is selected by ALPN
-    checkResults(results[2], {server: {ALPN: false, NPN: false},
-                              client: {ALPN: false, NPN: undefined}});
+    checkResults(results[2], {server: {ALPN: false,
+                                       NPN: 'first-priority-unsupported'},
+                              client: {ALPN: false, NPN: false}});
     // execute next test
     Test6();
   });
@@ -253,8 +254,8 @@ function Test6() {
     checkResults(results[1], {server: {ALPN: 'b', NPN: false},
                               client: {ALPN: 'b', NPN: undefined}});
     // nothing is selected by ALPN
-    checkResults(results[2], {server: {ALPN: false, NPN: false},
-                              client: {ALPN: false, NPN: undefined}});
+    checkResults(results[2], {server: {ALPN: false, NPN: 'http/1.1'},
+                              client: {ALPN: false, NPN: false}});
     // execute next test
     Test7();
   });

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -17,3 +17,12 @@ const tls = require('tls');
   assert(buffer.equals(Buffer.from('abcd')));
   assert(out.NPNProtocols.equals(Buffer.from('efgh')));
 }
+
+{
+  const buffer = Buffer.from('abcd');
+  const out = {};
+  tls.convertALPNProtocols(buffer, out);
+  out.ALPNProtocols.write('efgh');
+  assert(buffer.equals(Buffer.from('abcd')));
+  assert(out.ALPNProtocols.equals(Buffer.from('efgh')));
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls,crypto

As listed in https://github.com/nodejs/LTS/issues/177, this backports the ALPN feature to v4.x LTS by cherry-picking four commits of 802a2e79e1adb22542ba12fba5e331e94277272d, 7eee37257fe708ec23e8be292047320491ac8361, 65030c77b7cbab05f73899823288197864a04d64 and c26b9af1e277ef94b9bb33d93e1779b0a35f41e2 from v6-staging with resolving several conflicts.


/CC @nodejs/crypto @MylesBorins 