### PR TITLE
test: add http-common's test

### DIFF
--- a/test/parallel/test-http-common.js
+++ b/test/parallel/test-http-common.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const httpCommon = require('_http_common');
+const checkIsHttpToken = httpCommon._checkIsHttpToken;
+const checkInvalidHeaderChar = httpCommon._checkInvalidHeaderChar;
+
+// checkIsHttpToken
+assert(checkIsHttpToken('t'));
+assert(checkIsHttpToken('tt'));
+assert(checkIsHttpToken('ttt'));
+assert(checkIsHttpToken('tttt'));
+assert(checkIsHttpToken('ttttt'));
+
+assert.strictEqual(checkIsHttpToken(''), false);
+assert.strictEqual(checkIsHttpToken(' '), false);
+assert.strictEqual(checkIsHttpToken('あ'), false);
+assert.strictEqual(checkIsHttpToken('あa'), false);
+assert.strictEqual(checkIsHttpToken('aaaaあaaaa'), false);
+
+// checkInvalidHeaderChar
+assert(checkInvalidHeaderChar('あ'));
+assert(checkInvalidHeaderChar('aaaaあaaaa'));
+
+assert.strictEqual(checkInvalidHeaderChar(''), false);
+assert.strictEqual(checkInvalidHeaderChar(1), false);
+assert.strictEqual(checkInvalidHeaderChar(' '), false);
+assert.strictEqual(checkInvalidHeaderChar(false), false);
+assert.strictEqual(checkInvalidHeaderChar('t'), false);
+assert.strictEqual(checkInvalidHeaderChar('tt'), false);
+assert.strictEqual(checkInvalidHeaderChar('ttt'), false);
+assert.strictEqual(checkInvalidHeaderChar('tttt'), false);
+assert.strictEqual(checkInvalidHeaderChar('ttttt'), false);


### PR DESCRIPTION
Add a test of `checkIsHttpToken` and `checkInvalidHeaderChar`.

checkIsHttpToken: https://github.com/nodejs/node/blob/master/lib/_http_common.js#L267
checkInvalidHeaderChar: https://github.com/nodejs/node/blob/master/lib/_http_common.js#L318
Coverage: https://coverage.nodejs.org/coverage-57f6a106fbc69a47/root/_http_common.js.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test