### PR TITLE
http: use direct parameters instead

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -714,20 +714,14 @@ ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
   return this;
 };
 
-ClientRequest.prototype.setNoDelay = function setNoDelay() {
-  const argsLen = arguments.length;
-  const args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
-  this._deferToConnect('setNoDelay', args);
+ClientRequest.prototype.setNoDelay = function setNoDelay(noDelay) {
+  this._deferToConnect('setNoDelay', [noDelay]);
 };
-ClientRequest.prototype.setSocketKeepAlive = function setSocketKeepAlive() {
-  const argsLen = arguments.length;
-  const args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
-  this._deferToConnect('setKeepAlive', args);
-};
+
+ClientRequest.prototype.setSocketKeepAlive =
+    function setSocketKeepAlive(enable, initialDelay) {
+      this._deferToConnect('setKeepAlive', [enable, initialDelay]);
+    };
 
 ClientRequest.prototype.clearTimeout = function clearTimeout(cb) {
   this.setTimeout(0, cb);


### PR DESCRIPTION
When parameter count is fixed, use literal Array instance is more
simply and avoid arguments leak also.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http
