### PR TITLE
lib: remove unnecessary parameter for assertCrypto()

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('internal/util').assertCrypto(exports);
+require('internal/util').assertCrypto();
 
 const assert = require('assert');
 const EventEmitter = require('events');

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('internal/util').assertCrypto(exports);
+require('internal/util').assertCrypto();
 
 const assert = require('assert');
 const crypto = require('crypto');

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const internalUtil = require('internal/util');
-internalUtil.assertCrypto(exports);
+internalUtil.assertCrypto();
 
 exports.DEFAULT_ENCODING = 'buffer';
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('internal/util').assertCrypto(exports);
+require('internal/util').assertCrypto();
 
 const tls = require('tls');
 const url = require('url');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -97,7 +97,7 @@ exports.objectToString = function objectToString(o) {
 };
 
 const noCrypto = !process.versions.openssl;
-exports.assertCrypto = function(exports) {
+exports.assertCrypto = function() {
   if (noCrypto)
     throw new Error('Node.js is not compiled with openssl crypto support');
 };

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const internalUtil = require('internal/util');
-internalUtil.assertCrypto(exports);
+internalUtil.assertCrypto();
 
 const net = require('net');
 const url = require('url');


### PR DESCRIPTION
The `exports` parameter is unnecessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
_tls_legacy, _tls_wrap, crypto, https, internal/util, tls
