### PR TITLE
test: fix broken assertion

### DIFF
--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -81,7 +81,8 @@ child.exec(nodejs + ' --eval "require(\'./test/parallel/test-cli-eval.js\')"',
 child.exec(nodejs + ' -e', common.mustCall(function(err, stdout, stderr) {
   assert.strictEqual(err.code, 9);
   assert.strictEqual(stdout, '');
-  assert(stderr.match(/node: -e requires an argument\n/));
+  assert.strictEqual(stderr.trim(),
+                     `${process.execPath}: -e requires an argument`);
 }));
 
 // empty program should do nothing


### PR DESCRIPTION
This commit fixes a broken assertion in `test-cli-eval.js`. b9adbf25a8cd6dc30becfe55269cb0ed846130eb introduced the break, and was landed even though CI showed that the test failed.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test