### PR TITLE
test: Use `common.hasIntl` in tests related to ICU

### DIFF
--- a/test/parallel/test-icu-punycode.js
+++ b/test/parallel/test-icu-punycode.js
@@ -1,6 +1,11 @@
 'use strict';
-
 const common = require('../common');
+
+if (!common.hasIntl) {
+  common.skip('missing Intl');
+  return;
+}
+
 const icu = getPunycode();
 const assert = require('assert');
 
@@ -10,11 +15,6 @@ function getPunycode() {
   } catch (err) {
     return undefined;
   }
-}
-
-if (!icu) {
-  common.skip('icu punycode tests because ICU is not present.');
-  return;
 }
 
 // Credit for list: http://www.i18nguy.com/markup/idna-examples.html

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -1,14 +1,14 @@
 // Flags: --expose_internals
 'use strict';
-
 const common = require('../common');
-const assert = require('assert');
-const readline = require('internal/readline');
 
-if (!process.binding('config').hasIntl) {
-  common.skip('missing intl... skipping test');
+if (!common.hasIntl) {
+  common.skip('missing Intl');
   return;
 }
+
+const assert = require('assert');
+const readline = require('internal/readline');
 
 // Test column width
 assert.strictEqual(readline.getStringWidth('a'), 1);

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const common = require('../common');
-const buffer = require('buffer');
-const assert = require('assert');
 
 if (!common.hasIntl) {
-  common.skip('icu punycode tests because ICU is not present.');
+  common.skip('missing Intl');
   return;
 }
 
+const buffer = require('buffer');
+const assert = require('assert');
 const orig = Buffer.from('tést €', 'utf8');
 
 // Test Transcoding

--- a/test/parallel/test-intl-v8BreakIterator.js
+++ b/test/parallel/test-intl-v8BreakIterator.js
@@ -1,11 +1,11 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.hasIntl || Intl.v8BreakIterator === undefined) {
-  return common.skip('no Intl');
+  return common.skip('missing Intl');
 }
 
+const assert = require('assert');
 const warning = 'Intl.v8BreakIterator is deprecated and will be removed soon.';
 common.expectWarning('DeprecationWarning', warning);
 

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -4,7 +4,7 @@ const common = require('../common');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.
-  common.skip('missing Intl... skipping test');
+  common.skip('missing Intl');
   return;
 }
 

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -4,7 +4,7 @@ const common = require('../common');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.
-  common.skip('missing Intl... skipping test');
+  common.skip('missing Intl');
   return;
 }
 


### PR DESCRIPTION
We should use `common.hasIntl` in tests for test cases which are related to ICU. This way we can easily find the test cases that are Intl dependent. Plus, it will be able to make the tests a little faster if we check `hasIntl` first.

Refs: https://github.com/nodejs/node/pull/10707#discussion_r96273895

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
+ test
+ intl