### PR TITLE
process: add NODE_NO_WARNINGS environment variable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -301,6 +301,13 @@ added: v0.11.15
 Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small-icu support.
 
+### `NODE_NO_WARNINGS=1`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set to `1`, process warnings are silenced.
+
 ### `NODE_PRESERVE_SYMLINKS=1`
 <!-- YAML
 added: v7.1.0

--- a/doc/node.1
+++ b/doc/node.1
@@ -208,6 +208,10 @@ Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small\-icu support.
 
 .TP
+.BR NODE_NO_WARNINGS =\fI1\fR
+When set to \fI1\fR, process warnings are silenced.
+
+.TP
 .BR NODE_PATH =\fIpath\fR[:\fI...\fR]
 \':\'\-separated list of directories prefixed to the module search path.
 

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -5,7 +5,7 @@ const prefix = `(${process.release.name}:${process.pid}) `;
 exports.setup = setupProcessWarnings;
 
 function setupProcessWarnings() {
-  if (!process.noProcessWarnings) {
+  if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
     process.on('warning', (warning) => {
       if (!(warning instanceof Error)) return;
       const isDeprecation = warning.name === 'DeprecationWarning';

--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  process.emitWarning('foo');
+} else {
+  function test(env) {
+    const cmd = `${process.execPath} ${__filename} child`;
+
+    cp.exec(cmd, { env }, common.mustCall((err, stdout, stderr) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stdout, '');
+
+      if (env.NODE_NO_WARNINGS === '1')
+        assert.strictEqual(stderr, '');
+      else
+        assert(/Warning: foo$/.test(stderr.trim()));
+    }));
+  }
+
+  test({});
+  test(process.env);
+  test({ NODE_NO_WARNINGS: undefined });
+  test({ NODE_NO_WARNINGS: null });
+  test({ NODE_NO_WARNINGS: 'foo' });
+  test({ NODE_NO_WARNINGS: true });
+  test({ NODE_NO_WARNINGS: false });
+  test({ NODE_NO_WARNINGS: {} });
+  test({ NODE_NO_WARNINGS: [] });
+  test({ NODE_NO_WARNINGS: function() {} });
+  test({ NODE_NO_WARNINGS: 0 });
+  test({ NODE_NO_WARNINGS: -1 });
+  test({ NODE_NO_WARNINGS: '0' });
+  test({ NODE_NO_WARNINGS: '01' });
+  test({ NODE_NO_WARNINGS: '2' });
+  // Don't test the number 1 because it will come through as a string in the
+  // the child process environment.
+  test({ NODE_NO_WARNINGS: '1' });
+}


### PR DESCRIPTION
This commit adds support for a `NODE_NO_WARNINGS` environment variable, which duplicates the functionality of the `--no-warnings` command line flag.

Fixes: https://github.com/nodejs/node/issues/10802

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
process