### PR TITLE
doc: tls API for direct TLS socket use

### DIFF
--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -20,10 +20,16 @@ test(undefined, (err) => {
 
 test({}, (err) => {
   assert.strictEqual(err.message, 'unable to verify the first certificate');
+  // Properties never set on success or failure when tls.connect not used.
+  assert(!('authorized' in this), 'only supported for tls.connect');
+  assert(!('authorizationError' in this), 'only supported for tls.connect');
 });
 
 test({secureContext: tls.createSecureContext({ca: keys.agent1.ca})}, (err) => {
   assert.ifError(err);
+  // Properties never set on success or failure when tls.connect not used.
+  assert(!('authorized' in this), 'only supported for tls.connect');
+  assert(!('authorizationError' in this), 'only supported for tls.connect');
 });
 
 test({ca: keys.agent1.ca}, (err) => {
@@ -62,8 +68,9 @@ function test(client, callback) {
       .on('connect', common.mustCall(function() {
         this.end('hello');
       }))
+      .on('secureConnect', () => assert(0, 'only supported for tls.connect'))
       .on('secure', common.mustCall(function() {
-        callback(this.ssl.verifyError());
+        callback.call(this, this.ssl.verifyError());
       }));
   });
 }


### PR DESCRIPTION
Direct use of tls.TLSSocket to start a TLS session over an existing TCP connection was documented.
    
However, to use this connection securely it is necessary to validate and
authenticate the peer's certificate, and the documented events and
properties are implemented only for TLSSockets returned by
tls.connect(). In order to create secure connections, additional
undocumented APIs must be used, and these APIs are being called right
now by npm modules.

Fix: https://github.com/nodejs/node/issues/10555
Fix: https://github.com/nodejs/node/issues/11467

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tls,test,doc
