### PR TITLE
Optimize cluster.setupMaster()

### DIFF
--- a/benchmark/cluster/setup-master.js
+++ b/benchmark/cluster/setup-master.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common.js');
+const cluster = require('cluster');
+
+const bench = common.createBenchmark(main, {
+  n: [1],
+  optionsIndex: [0, 1]
+});
+
+const options = [
+  undefined,
+  { exec: 'worker.js', args: ['--use', 'https'], silent: true }
+];
+
+function main(conf) {
+  const n = +conf.n;
+  const optionsIndex = +conf.optionsIndex;
+
+  var i = 0;
+
+  bench.start();
+  for (; i < n; i++) cluster.setupMaster(options[optionsIndex]);
+  bench.end(n);
+}

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -68,8 +68,8 @@ cluster.setupMaster = function(options) {
 
   initialized = true;
   schedulingPolicy = cluster.schedulingPolicy;  // Freeze policy.
-  assert(schedulingPolicy === SCHED_NONE || schedulingPolicy === SCHED_RR,
-         `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
+  if (schedulingPolicy !== SCHED_NONE && schedulingPolicy !== SCHED_RR)
+    assert(false, `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
 
   const hasDebugArg = process.execArgv.some((argv) => {
     return /^(--debug|--debug-brk)(=\d+)?$/.test(argv);

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -71,16 +71,12 @@ cluster.setupMaster = function(options) {
   if (schedulingPolicy !== SCHED_NONE && schedulingPolicy !== SCHED_RR)
     assert(false, `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
 
-  const hasDebugArg = process.execArgv.some((argv) => {
-    return /^(--debug|--debug-brk)(=\d+)?$/.test(argv);
-  });
-
   process.nextTick(setupSettingsNT, settings);
 
   // Send debug signal only if not started in debug mode, this helps a lot
   // on windows, because RegisterDebugHandler is not called when node starts
   // with --debug.* arg.
-  if (hasDebugArg)
+  if (process.execArgv.some((argv) => /^--debug(-brk)?(=\d+)?$/.test(argv)))
     return;
 
   process.on('internalMessage', (message) => {

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -49,7 +49,8 @@ cluster.setupMaster = function(options) {
     silent: false
   };
   settings = util._extend(settings, cluster.settings);
-  settings = util._extend(settings, options || {});
+  if (options)
+    settings = util._extend(settings, options);
 
   // Tell V8 to write profile data for each process to a separate file.
   // Without --logfile=v8-%p.log, everything ends up in a single, unusable


### PR DESCRIPTION
* add cluster.setupMaster() benchmark
*  do not call call `util._extend()` with `options` if `options` is `undefined`
* calling `assert()` is relatively expensive; check condition and only call assert if assertion will fail
* inline the check for CLI debugger arguments in the only place it is used

```console
$ node benchmark/compare.js  --runs 100 --old './node-old' --new './node-new' cluster > test.csv
$ cat test.csv | Rscript benchmark/compare.R bench
                                            improvement confidence      p.value
 cluster/setup-master.js optionsIndex=0 n=1      5.02 %        *** 0.0002622052
 cluster/setup-master.js optionsIndex=1 n=1      0.72 %            0.5565911325
$
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark cluster