### PR TITLE
util: runtime deprecation for util._extend()

### DIFF
--- a/benchmark/es/assign-vs-extend.js
+++ b/benchmark/es/assign-vs-extend.js
@@ -1,0 +1,50 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const internalUtil = require('internal/util');
+
+const bench = common.createBenchmark(main, {
+  method: ['Object.assign()', 'util._extend()'],
+  size: [5, 10, 15, 30],
+  n: [1e5]
+});
+
+function makeObject(size) {
+  var m = {};
+  for (var n = 0; n < size; n++)
+    m[`key${n}`] = n;
+  return m;
+}
+
+function useObjectAssign(n, obj) {
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    Object.assign({}, obj);
+  }
+  bench.end(n);
+}
+
+function useUtilExtend(n, obj) {
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    internalUtil._extend({}, obj);
+  }
+  bench.end(n);
+}
+
+function main(conf) {
+  const n = +conf.n;
+  const obj = makeObject(+conf.size);
+
+  switch (conf.method) {
+    case 'Object.assign()':
+      useObjectAssign(n, obj);
+      break;
+    case 'util._extend()':
+      useUtilExtend(n, obj);
+      break;
+    default:
+      throw new Error('Unexpected method');
+  }
+}

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const internalUtil = require('internal/util');
 const net = require('net');
 const util = require('util');
 const EventEmitter = require('events');
@@ -28,7 +29,7 @@ function Agent(options) {
   self.defaultPort = 80;
   self.protocol = 'http:';
 
-  self.options = util._extend({}, options);
+  self.options = internalUtil._extend({}, options);
 
   // don't confuse net and make it think that we're connecting to a pipe
   self.options.path = null;
@@ -120,8 +121,8 @@ Agent.prototype.addRequest = function addRequest(req, options) {
     };
   }
 
-  options = util._extend({}, options);
-  options = util._extend(options, this.options);
+  options = internalUtil._extend({}, options);
+  options = internalUtil._extend(options, this.options);
 
   if (!options.servername) {
     options.servername = options.host;
@@ -175,8 +176,8 @@ Agent.prototype.addRequest = function addRequest(req, options) {
 
 Agent.prototype.createSocket = function createSocket(req, options, cb) {
   var self = this;
-  options = util._extend({}, options);
-  options = util._extend(options, self.options);
+  options = internalUtil._extend({}, options);
+  options = internalUtil._extend(options, self.options);
 
   if (!options.servername) {
     options.servername = options.host;

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -13,6 +13,7 @@ const debug = common.debug;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const Agent = require('_http_agent');
 const Buffer = require('buffer').Buffer;
+const internalUtil = require('internal/util');
 const urlToOptions = require('internal/url').urlToOptions;
 
 // The actual list of disallowed characters in regexp form is more like:
@@ -55,7 +56,7 @@ function ClientRequest(options, cb) {
   } else if (options instanceof url.URL) {
     options = urlToOptions(options);
   } else {
-    options = util._extend({}, options);
+    options = internalUtil._extend({}, options);
   }
 
   var agent = options.agent;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('internal/util').assertCrypto(exports);
+const internalUtil = require('internal/util');
+internalUtil.assertCrypto(exports);
 
 const assert = require('assert');
 const crypto = require('crypto');
@@ -982,9 +983,9 @@ function normalizeConnectArgs(listArgs) {
   // the host/port/path args that it knows about, not the tls options.
   // This means that options.host overrides a host arg.
   if (listArgs[1] !== null && typeof listArgs[1] === 'object') {
-    options = util._extend(options, listArgs[1]);
+    options = internalUtil._extend(options, listArgs[1]);
   } else if (listArgs[2] !== null && typeof listArgs[2] === 'object') {
-    options = util._extend(options, listArgs[2]);
+    options = internalUtil._extend(options, listArgs[2]);
   }
 
   return (cb) ? [options, cb] : [options];
@@ -1006,7 +1007,7 @@ exports.connect = function(/* [port,] [host,] [options,] [cb] */) {
     minDHSize: 1024
   };
 
-  options = util._extend(defaults, options || {});
+  options = internalUtil._extend(defaults, options || {});
   if (!options.keepAlive)
     options.singleUse = true;
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -32,7 +32,7 @@ exports.fork = function(modulePath /*, args, options*/) {
     if (typeof arguments[pos] !== 'object') {
       throw new TypeError('Incorrect value of args option');
     } else {
-      options = util._extend({}, arguments[pos++]);
+      options = internalUtil._extend({}, arguments[pos++]);
     }
   }
 
@@ -133,7 +133,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (pos < arguments.length && typeof arguments[pos] === 'object') {
-    options = util._extend(options, arguments[pos++]);
+    options = internalUtil._extend(options, arguments[pos++]);
   } else if (pos < arguments.length && arguments[pos] == null) {
     pos++;
   }
@@ -495,7 +495,7 @@ function spawnSync(/*file, args, options*/) {
   options.stdio = _validateStdio(options.stdio || 'pipe', true).stdio;
 
   if (options.input) {
-    var stdin = options.stdio[0] = util._extend({}, options.stdio[0]);
+    var stdin = options.stdio[0] = internalUtil._extend({}, options.stdio[0]);
     stdin.input = options.input;
   }
 
@@ -503,7 +503,7 @@ function spawnSync(/*file, args, options*/) {
   for (i = 0; i < options.stdio.length; i++) {
     var input = options.stdio[i] && options.stdio[i].input;
     if (input != null) {
-      var pipe = options.stdio[i] = util._extend({}, options.stdio[i]);
+      var pipe = options.stdio[i] = internalUtil._extend({}, options.stdio[i]);
       if (isUint8Array(input))
         pipe.input = input;
       else if (typeof input === 'string')
@@ -535,7 +535,7 @@ function spawnSync(/*file, args, options*/) {
     result.error.spawnargs = opts.args.slice(1);
   }
 
-  util._extend(result, opts);
+  internalUtil._extend(result, opts);
 
   return result;
 }
@@ -555,7 +555,7 @@ function checkExecSyncError(ret) {
       err = new Error(msg);
     }
 
-    util._extend(err, ret);
+    internalUtil._extend(err, ret);
     return err;
   }
 

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -8,6 +8,7 @@
 const util = require('util');
 const EventEmitter = require('events');
 const inherits = util.inherits;
+const internalUtil = require('internal/util');
 
 // communicate with events module, but don't require that
 // module to have to load this one, since this module has
@@ -232,7 +233,7 @@ function intercepted(_this, self, cb, fnargs) {
 
   if (fnargs[0] && fnargs[0] instanceof Error) {
     var er = fnargs[0];
-    util._extend(er, {
+    internalUtil._extend(er, {
       domainBound: cb,
       domainThrown: false,
       domain: self

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -19,6 +19,7 @@ const internalFS = require('internal/fs');
 const assertEncoding = internalFS.assertEncoding;
 const stringToFlags = internalFS.stringToFlags;
 const SyncWriteStream = internalFS.SyncWriteStream;
+const internalUtil = require('internal/util');
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,
@@ -44,7 +45,7 @@ function getOptions(options, defaultOptions) {
   }
 
   if (typeof options === 'string') {
-    defaultOptions = util._extend({}, defaultOptions);
+    defaultOptions = internalUtil._extend({}, defaultOptions);
     defaultOptions.encoding = options;
     options = defaultOptions;
   } else if (typeof options !== 'object') {
@@ -1319,7 +1320,7 @@ fs.watchFile = function(filename, options, listener) {
   };
 
   if (options !== null && typeof options === 'object') {
-    options = util._extend(defaults, options);
+    options = internalUtil._extend(defaults, options);
   } else {
     listener = options;
     options = defaults;

--- a/lib/https.js
+++ b/lib/https.js
@@ -9,6 +9,7 @@ const util = require('util');
 const inherits = util.inherits;
 const debug = util.debuglog('https');
 const urlToOptions = require('internal/url').urlToOptions;
+const internalUtil = require('internal/util');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
@@ -74,7 +75,7 @@ function createConnection(port, host, options) {
     const session = this._getSession(options._agentKey);
     if (session) {
       debug('reuse session for %j', options._agentKey);
-      options = util._extend({
+      options = internalUtil._extend({
         session: session
       }, options);
     }
@@ -200,7 +201,7 @@ exports.request = function request(options, cb) {
   } else if (options instanceof url.URL) {
     options = urlToOptions(options);
   } else {
-    options = util._extend({}, options);
+    options = internalUtil._extend({}, options);
   }
   options._defaultAgent = globalAgent;
   return http.request(options, cb);

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -1,6 +1,5 @@
 'use strict';
 const assert = require('assert');
-const util = require('util');
 const EventEmitter = require('events');
 const Worker = require('internal/cluster/worker');
 const { internal, sendHelper } = require('internal/cluster/utils');
@@ -8,6 +7,7 @@ const cluster = new EventEmitter();
 const handles = {};
 const indexes = {};
 const noop = () => {};
+const internalUtil = require('internal/util');
 
 module.exports = cluster;
 
@@ -58,7 +58,7 @@ cluster._getServer = function(obj, options, cb) {
   else
     indexes[indexesKey]++;
 
-  const message = util._extend({
+  const message = internalUtil._extend({
     act: 'queryServer',
     index: indexes[indexesKey],
     data: null
@@ -136,7 +136,7 @@ function rr(message, indexesKey, cb) {
 
   function getsockname(out) {
     if (key)
-      util._extend(out, message.sockname);
+      internalUtil._extend(out, message.sockname);
 
     return 0;
   }

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -1,12 +1,12 @@
 'use strict';
 const assert = require('assert');
 const fork = require('child_process').fork;
-const util = require('util');
 const EventEmitter = require('events');
 const RoundRobinHandle = require('internal/cluster/round_robin_handle');
 const SharedHandle = require('internal/cluster/shared_handle');
 const Worker = require('internal/cluster/worker');
 const { internal, sendHelper, handles } = require('internal/cluster/utils');
+const internalUtil = require('internal/util');
 const keys = Object.keys;
 const cluster = new EventEmitter();
 const intercom = new EventEmitter();
@@ -48,8 +48,8 @@ cluster.setupMaster = function(options) {
     execArgv: process.execArgv,
     silent: false
   };
-  settings = util._extend(settings, cluster.settings);
-  settings = util._extend(settings, options || {});
+  settings = internalUtil._extend(settings, cluster.settings);
+  settings = internalUtil._extend(settings, options || {});
 
   // Tell V8 to write profile data for each process to a separate file.
   // Without --logfile=v8-%p.log, everything ends up in a single, unusable
@@ -106,11 +106,11 @@ function setupSettingsNT(settings) {
 }
 
 function createWorkerProcess(id, env) {
-  var workerEnv = util._extend({}, process.env);
+  var workerEnv = internalUtil._extend({}, process.env);
   var execArgv = cluster.settings.execArgv.slice();
   var debugPort = 0;
 
-  workerEnv = util._extend(workerEnv, env);
+  workerEnv = internalUtil._extend(workerEnv, env);
   workerEnv.NODE_UNIQUE_ID = '' + id;
 
   for (var i = 0; i < execArgv.length; i++) {
@@ -302,7 +302,7 @@ function queryServer(worker, message) {
 
   // Set custom server data
   handle.add(worker, (errno, reply, handle) => {
-    reply = util._extend({
+    reply = internalUtil._extend({
       errno: errno,
       key: key,
       ack: message.seq,

--- a/lib/internal/cluster/utils.js
+++ b/lib/internal/cluster/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-const util = require('util');
+const internalUtil = require('internal/util');
 
 module.exports = {
   sendHelper,
@@ -15,7 +15,7 @@ function sendHelper(proc, message, handle, cb) {
     return false;
 
   // Mark message as internal. See INTERNAL_PREFIX in lib/child_process.js
-  message = util._extend({ cmd: 'NODE_CLUSTER' }, message);
+  message = internalUtil._extend({ cmd: 'NODE_CLUSTER' }, message);
 
   if (typeof cb === 'function')
     callbacks[seq] = cb;

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const util = require('util');
 const debug = util.debuglog('repl');
+const internalUtil = require('internal/util');
 
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
@@ -20,7 +21,7 @@ function createRepl(env, opts, cb) {
     cb = opts;
     opts = null;
   }
-  opts = util._extend({
+  opts = internalUtil._extend({
     ignoreUndefined: false,
     terminal: process.stdout.isTTY,
     useGlobal: true,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -179,3 +179,15 @@ exports.toLength = function toLength(argument) {
   const len = toInteger(argument);
   return len <= 0 ? 0 : Math.min(len, Number.MAX_SAFE_INTEGER);
 };
+
+exports._extend = function(target, source) {
+  // Don't do anything if source isn't an object
+  if (source === null || typeof source !== 'object') return target;
+
+  var keys = Object.keys(source);
+  var i = keys.length;
+  while (i--) {
+    target[keys[i]] = source[keys[i]];
+  }
+  return target;
+};

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -6,7 +6,7 @@ const TTY = process.binding('tty_wrap').TTY;
 const isTTY = process.binding('tty_wrap').isTTY;
 const inherits = util.inherits;
 const errnoException = util._errnoException;
-
+const internalUtil = require('internal/util');
 
 exports.isatty = function(fd) {
   return isTTY(fd);
@@ -17,7 +17,7 @@ function ReadStream(fd, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(fd, options);
 
-  options = util._extend({
+  options = internalUtil._extend({
     highWaterMark: 0,
     readable: true,
     writable: false,

--- a/lib/util.js
+++ b/lib/util.js
@@ -970,17 +970,10 @@ exports.inherits = function(ctor, superCtor) {
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
 };
 
-exports._extend = function(target, source) {
-  // Don't do anything if source isn't an object
-  if (source === null || typeof source !== 'object') return target;
-
-  var keys = Object.keys(source);
-  var i = keys.length;
-  while (i--) {
-    target[keys[i]] = source[keys[i]];
-  }
-  return target;
-};
+exports._extend =
+  internalUtil.deprecate(
+    internalUtil._extend,
+    'util._extend is deprecated. Use Object.assign() instead');
 
 function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);


### PR DESCRIPTION
The `util._extend()` method was previously docs-only deprecated in Node.js 6.0.0. This PR moves the implementation of `_extend()` into `internal/util` and runtime-deprecates the `util._extend()` as the next step in the deprecation process.

(*Note*: I'm not necessarily advocating that we definitely should runtime deprecate this, only that this is the next logical step in the deprecation process if we want to discourage users from using it).

The PR also adds a new benchmark comparing `util._extend()` and `Object.assign()`. The benchmark shows that `util._extend()` is still currently significantly faster than `Object.assign()` so we don't want to yet switch our own internal uses.

For background, `util._extend()` was never intended to be a public API but users found it anyway and used it.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
util