### PR TITLE
build: add missing src/tracing header files

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -226,6 +226,9 @@
         'src/stream_base.h',
         'src/stream_base-inl.h',
         'src/stream_wrap.h',
+        'src/tracing/agent.h',
+        'src/tracing/node_trace_buffer.h',
+        'src/tracing/node_trace_writer.h',
         'src/tracing/trace_event.h'
         'src/tree.h',
         'src/util.h',


### PR DESCRIPTION
I noticed that only one header from src/tracing is included in the
sources list in node.gyp. Not sure if this is intentional or not so I
wanted to bring it up just in case this was overlooked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build