### PR TITLE
doc: clarify the behavior of readFile with fd

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1347,7 +1347,8 @@ added: v0.1.29
   * `flag` {String} default = `'r'`
 * `callback` {Function}
 
-Asynchronously reads the entire contents of a file. Example:
+Asynchronously reads the entire contents of a file. If a file descriptor is
+specified as the `file`, it will read from the current file position. Example:
 
 ```js
 fs.readFile('/etc/passwd', (err, data) => {


### PR DESCRIPTION
Makes it explicit that readFile doesn't seek to the beginning.

This is related to #9671, but that issue is actually a combination of two issues.

1. On Windows, fs.read/write always updates the current file position, but on other OSes it doesn't when an explicit offset is specified.
2. `fs.readFile` reads from the current offset when called with an `fd` instead of from the beginning.

Fixing _at least one of the above_ would fix @jorangreef's issue. I tried fixing the second one in #9699, but that broke Linux and Mac OS tests (see #10809). This PR clarifies that it's not a bug but a feature.

Not sure which of the above mentioned issues should be mentioned in the commit message, if any.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc