### PR TITLE
test: don't connect to :: (use localhost instead)

### DIFF
--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -35,7 +35,7 @@ function getall() {
   if (count >= todo)
     return;
 
-  const req = net.connect(server.address().port, server.address().address);
+  const req = net.connect(server.address().port);
   req.resume();
   req.setTimeout(10, function() {
     req.destroy();

--- a/test/parallel/test-http-status-reason-invalid-chars.js
+++ b/test/parallel/test-http-status-reason-invalid-chars.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');
-const net = require('net');
 
 function explicit(req, res) {
   assert.throws(() => {
@@ -34,8 +33,7 @@ const server = http.createServer((req, res) => {
     implicit(req, res);
   }
 }).listen(0, common.mustCall(() => {
-  const addr = server.address().address;
-  const hostname = net.isIPv6(addr) ? `[${addr}1]` : addr;
+  const hostname = 'localhost';
   const url = `http://${hostname}:${server.address().port}`;
   let left = 2;
   const check = common.mustCall((res) => {


### PR DESCRIPTION
If a test does http.listen(0) or net.listen(0),
http.listen(0).address().address returns '::'. Some machines will
resolve this to localhost, but not all. Every machine should have
localhost defined in /etc/hosts (or equivalent), so it should always
resolve.

Fixes: https://github.com/nodejs/node/issues/7291

### Fixed

 - [test/parallel/test-http-status-reason-invalid-chars.js](https://github.com/nodejs/node/blob/master/test/parallel/test-http-status-reason-invalid-chars.js#L38)
The code currently resolves to `::1` if the machine has IPv6, and to `::` otherwise (so it fails on non-Linux IPv4 machines).

 - [test/gc/test-net-timeout.js](https://github.com/nodejs/node/blob/master/test/gc/test-net-timeout.js#L38)
This currently resolves to `::` everywhere. Removing that line makes it default to localhost.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

cc/ @cjihrig in reply to https://github.com/nodejs/node/pull/9572#discussion_r87693222, you can't use `server.address().address`.

cc/ @nodejs/testing 