### PR TITLE
crypto: don't reference |freelist_max_len| in OpenSSL 1.1.0.

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -134,7 +134,9 @@ exports.createSecureContext = function createSecureContext(options, context) {
     }
   }
 
-  // Do not keep read/write buffers in free list
+  // Do not keep read/write buffers in free list for OpenSSL < 1.1.0. (For
+  // OpenSSL 1.1.0, buffers are malloced and freed without the use of a
+  // freelist.)
   if (options.singleUse) {
     c.singleUse = true;
     c.context.setFreeListLength(0);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1147,10 +1147,14 @@ void SecureContext::SetTicketKeys(const FunctionCallbackInfo<Value>& args) {
 
 
 void SecureContext::SetFreeListLength(const FunctionCallbackInfo<Value>& args) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L && !defined(OPENSSL_IS_BORINGSSL)
+  // |freelist_max_len| was removed in OpenSSL 1.1.0. In that version OpenSSL
+  // mallocs and frees buffers directly, without the use of a freelist.
   SecureContext* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
   wrap->ctx_->freelist_max_len = args[0]->Int32Value();
+#endif
 }
 
 


### PR DESCRIPTION
The |freelist_max_len| (and the freelist itself) has been removed in
OpenSSL 1.1.0. Thus this change will be necessary at some point but,
for now, it makes it a little easier to build with 1.1.0 without
breaking anything for previous versions of OpenSSL.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
crypto
