### PR TITLE
test: have inspector test pick an open port

### DIFF
--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -39,6 +39,9 @@ class InspectorSocketServer {
   void Stop(ServerCallback callback);
   void Send(int session_id, const std::string& message);
   void TerminateConnections(ServerCallback callback);
+  int port() {
+    return port_;
+  }
 
  private:
   static bool HandshakeCallback(InspectorSocket* socket,
@@ -62,7 +65,7 @@ class InspectorSocketServer {
 
   uv_loop_t* loop_;
   SocketServerDelegate* const delegate_;
-  const int port_;
+  int port_;
   std::string path_;
   uv_tcp_t server_;
   Closer* closer_;


### PR DESCRIPTION
This ensures that cctest can be ran concurrently with other instances of
cctest or while the node is ran with --inspect.

Ref: https://github.com/nodejs/node/issues/10858

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test, inspector - server now works with the port 0 and test leverages that.
