### PR TITLE
fs: remove unused parameter for encodeRealpathResult

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1372,8 +1372,8 @@ const splitRootRe = isWindows ?
   /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/ :
   /^[/]*/;
 
-function encodeRealpathResult(result, options, err) {
-  if (!options || !options.encoding || options.encoding === 'utf8' || err)
+function encodeRealpathResult(result, options) {
+  if (!options || !options.encoding || options.encoding === 'utf8')
     return result;
   const asBuffer = Buffer.from(result);
   if (options.encoding === 'buffer') {


### PR DESCRIPTION
The third parameter `err` is not used anywhere.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs