### PR TITLE
crypto: Add crypto.getEngines()

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1698,6 +1698,25 @@ is a bit field taking one of or a mix of the following flags (defined in
 * `crypto.constants.ENGINE_METHOD_ALL`
 * `crypto.constants.ENGINE_METHOD_NONE`
 
+### crypto.getEngines()
+<!-- YAML
+added: REPLACEME
+-->
+
+Returns an array of objects with id, name and flags of loaded engines.
+The flags value represents an integer of one of or a mix of the crypto
+constants described above.
+
+```js
+const crypto = require('crypto');
+console.log(crypto.getEngines());
+// Prints:
+//   [ { id: 'rdrand', name: 'Intel RDRAND engine', flags: 8 },
+//     { id: 'dynamic',
+//       name: 'Dynamic engine loading support',
+//       flags: 4 } ]
+```
+
 ### crypto.timingSafeEqual(a, b)
 <!-- YAML
 added: v6.6.0

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -650,6 +650,9 @@ exports.setEngine = function setEngine(id, flags) {
   return binding.setEngine(id, flags);
 };
 
+
+exports.getEngines = binding.getEngines;
+
 exports.randomBytes = exports.pseudoRandomBytes = randomBytes;
 
 exports.rng = exports.prng = randomBytes;

--- a/node.gyp
+++ b/node.gyp
@@ -691,6 +691,18 @@
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
         }],
       ]
+    },
+    {
+      # node test engine used in test/parallel/test-crypto-engine.js
+      'target_name': 'node_test_engine',
+      'type': 'loadable_module',
+      'conditions': [
+        ['node_use_openssl=="true" and '
+         'node_shared_openssl=="false" and '
+         'openssl_fips==""', { # fipsld fails to link libcrypto.a
+           'includes': ['test/fixtures/openssl_test_engine/node_test_engine.gypi'],
+         }],
+      ],
     }
   ], # end targets
 

--- a/src/env.h
+++ b/src/env.h
@@ -104,6 +104,7 @@ namespace node {
   V(emitting_top_level_domain_error_string, "_emittingTopLevelDomainError")   \
   V(exchange_string, "exchange")                                              \
   V(enumerable_string, "enumerable")                                          \
+  V(id_string, "id")                                                          \
   V(idle_string, "idle")                                                      \
   V(irq_string, "irq")                                                        \
   V(encoding_string, "encoding")                                              \

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -744,6 +744,7 @@ class ECDH : public BaseObject {
 bool EntropySource(unsigned char* buffer, size_t length);
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
+void GetEngines(const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif  // !OPENSSL_NO_ENGINE
 void InitCrypto(v8::Local<v8::Object> target);
 

--- a/test/fixtures/openssl_test_engine/node_test_engine.c
+++ b/test/fixtures/openssl_test_engine/node_test_engine.c
@@ -1,0 +1,14 @@
+#include <openssl/engine.h>
+
+static const char *engine_id = "node_test_engine";
+static const char *engine_name = "Node Test Engine for OpenSSL";
+
+static int bind(ENGINE *e, const char *id)
+{
+  ENGINE_set_id(e, engine_id);
+  ENGINE_set_name(e, engine_name);
+  return 1;
+}
+
+IMPLEMENT_DYNAMIC_BIND_FN(bind)
+IMPLEMENT_DYNAMIC_CHECK_FN()

--- a/test/fixtures/openssl_test_engine/node_test_engine.gypi
+++ b/test/fixtures/openssl_test_engine/node_test_engine.gypi
@@ -1,0 +1,39 @@
+{
+  'sources': ['node_test_engine.c'],
+  'conditions': [
+    ['OS=="mac"', {
+      'include_dirs': ['<(PRODUCT_DIR)/../../deps/openssl/openssl/include',],
+      'library_dirs': ['<(LIB_DIR)'],
+      'libraries': ['-lopenssl'],
+    }, 'OS=="win"', {
+      'dependencies': [
+        './deps/openssl/openssl.gyp:openssl',
+      ],
+      'include_dirs': ['<(PRODUCT_DIR)/../deps/openssl/openssl/include',],
+      'library_dirs': ['<(LIB_DIR)'],
+      'libraries': [
+        '-lkernel32.lib',
+        '-luser32.lib',
+        '-lgdi32.lib',
+        '-lwinspool.lib',
+        '-lcomdlg32.lib',
+        '-ladvapi32.lib',
+        '-lshell32.lib',
+        '-lole32.lib',
+        '-loleaut32.lib',
+        '-luuid.lib',
+        '-lodbc32.lib',
+        '-lDelayImp.lib',
+        '-lopenssl.lib',
+      ],
+    }, {
+      'library_dirs': ['<(LIB_DIR)/deps/openssl'],
+      'ldflags': ['-lopenssl'],
+      'include_dirs': ['<(PRODUCT_DIR)/../../deps/openssl/openssl/include',],
+    }],
+    [ 'OS in "freebsd openbsd netbsd solaris" or \
+    (OS=="linux" and target_arch!="ia32")', {
+      'cflags': ['-fPIC'],
+    }],
+  ],
+}

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -1,6 +1,10 @@
 'use strict';
 const common = require('../common');
 
+// This test ensures that a dynamic engine can be registered with
+// crypto.setEngine() and crypto.getEngines() obtains the list for
+// both builtin and dynamic engines.
+
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
@@ -8,7 +12,65 @@ if (!common.hasCrypto) {
 
 const assert = require('assert');
 const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
+let found = 0;
+
+// check builtin engine exists.
+// A dynamic engine is loaded by ENGINE_load_builtin_engines()
+// in InitCryptoOnce().
+crypto.getEngines().forEach((e) => {
+  if (e.id === 'dynamic')
+    found++;
+});
+
+assert.strictEqual(found, 1);
+
+// check set and get node test engine of
+// test/fixtures/openssl_test_engine/node_test_engine.c
+
+if (process.config.variables.node_shared_openssl) {
+  common.skip('node test engine cannot be built in shared openssl');
+  return;
+}
+
+if (process.config.variables.openssl_fips) {
+  common.skip('node test engine cannot be built in FIPS mode.');
+  return;
+}
+
+let engine_lib;
+
+if (common.isWindows) {
+  engine_lib = 'node_test_engine.dll';
+} else if (common.isAix) {
+  engine_lib = 'libnode_test_engine.a';
+} else if (process.platform === 'darwin') {
+  engine_lib = 'node_test_engine.so';
+} else {
+  engine_lib = 'libnode_test_engine.so';
+}
+
+const test_engine_id = 'node_test_engine';
+const test_engine_name = 'Node Test Engine for OpenSSL';
+const test_engine = path.join(path.dirname(process.execPath), engine_lib);
+
+assert.doesNotThrow(function() {
+  fs.accessSync(test_engine);
+}, 'node test engine ' + test_engine + ' is not found.');
+
+crypto.setEngine(test_engine);
+
+crypto.getEngines().forEach((e) => {
+  if (e.id === test_engine_id && e.name === test_engine_name &&
+      e.flags === crypto.constants.ENGINE_METHOD_ALL)
+    found++;
+});
+
+assert.strictEqual(found, 2);
+
+// Error Tests for setEngine
 assert.throws(function() {
   crypto.setEngine(true);
 }, /^TypeError: "id" argument should be a string$/);


### PR DESCRIPTION
This adds a new api to show the list of loaded engines of OpenSSL.
It also includes the test of dynamic engine for `crypto.setEngine()` and fixes missed test coverages as discussed in #10786.

A test engine is built from `test/fixtures/openssl_test_engine/` by adding a new target in node.gyp, but fipsld seems to have an error with linking  the test engine with `libcrypto.a` so that a dynamic engine test is skipped  in FIPS mode.

I've already made several CI tests and found that tests on Windows and arm were failed because test    engine files were lost in CI environment.  They can be solved by including`Release\node_test_engine.dll` in Windows tests and `out/Release/libnode_test_engine.so` in arm tests in `binary/binary.tar.gz` and `binary/binary.tar.xz` . I would like ask someone in @nodejs/build to help it.

In my local environments, tests in Win and arm are fine.

CC @nodejs/crypto and @jasnell 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto
