### PR TITLE
V4 backport: don't squash signal handlers with --shared

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3957,6 +3957,7 @@ inline void PlatformInit() {
 
   CHECK_EQ(err, 0);
 
+#ifndef NODE_SHARED_MODE
   // Restore signal dispositions, the parent process may have changed them.
   struct sigaction act;
   memset(&act, 0, sizeof(act));
@@ -3970,6 +3971,7 @@ inline void PlatformInit() {
     act.sa_handler = (nr == SIGPIPE) ? SIG_IGN : SIG_DFL;
     CHECK_EQ(0, sigaction(nr, &act, nullptr));
   }
+#endif  // !NODE_SHARED_MODE
 
   RegisterSignalHandler(SIGINT, SignalExit, true);
   RegisterSignalHandler(SIGTERM, SignalExit, true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

    An application using node built as a shared library may legitimately
    implement its own signal handling routines. Current behaviour is
    to squash all signal handlers on node startup. This change will
    stop that behaviour when node is built as a shared library.
    
    PR-URL: https://github.com/nodejs/node/pull/10539
    Fixes: https://github.com/nodejs/node/issues/10520
    Refs: https://github.com/nodejs/node/pull/615
    Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
    Reviewed-By: Gibson Fahnestock <gibfahn@gmail.com>
    Reviewed-By: James M Snell <jasnell@gmail.com>
    Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>

PR to backport https://github.com/nodejs/node/commit/0f0f3d33309d3382deb33825fdffeb048f80ec18 to which won't land cleanly on v4.x. It would be good if we can squeeze this one into the 4.8.0.0 release - it adds an #ifdef which is specific to the build with --shared so should be low risk and I have some users using the shared library with v4.x who have experienced problems with this.

*Smiles sweetly at @MylesBorins* :-)