### PR TITLE
doc: Clarify msg when doc/api/cli.md not updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ PKGDIR=out/dist-osx
 release-only:
 	@if [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
 		`grep -q REPLACEME doc/api/*.md`; then \
-		echo 'Please update Added: tags in the documentation first.' ; \
+		echo 'Please update REPLACEME in Added: tags in doc/api/*.md (See doc/releases.md)' ; \
 		exit 1 ; \
 	fi
 	@if [ "$(shell git status --porcelain | egrep -v '^\?\? ')" = "" ]; then \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

The message printed out when the doc/api/cli.md file had not had the REPLACEME tags replaced could do with being made clearer. This PR updates it to indicate which the top level Makefile is checking for.

Cc: @bnoordhuis who put in the original message.