### PR TITLE
inspector: no crash when WS server can't start

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -556,9 +556,10 @@ void AgentImpl::WorkerRunIO() {
   }
   InspectorAgentDelegate delegate(this, script_path, script_name_, wait_);
   delegate_ = &delegate;
-  InspectorSocketServer server(&delegate, options_.port());
+  InspectorSocketServer server(&delegate,
+                               options_.host_name(),
+                               options_.port());
   if (!server.Start(&child_loop_)) {
-    fprintf(stderr, "Unable to open devtools socket: %s\n", uv_strerror(err));
     state_ = State::kError;  // Safe, main thread is waiting on semaphore
     uv_close(reinterpret_cast<uv_handle_t*>(&io_thread_req_), nullptr);
     uv_loop_close(&child_loop_);

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -24,9 +24,9 @@ void Escape(std::string* string) {
   }
 }
 
-std::string GetWsUrl(int port, const std::string& id) {
+std::string GetWsUrl(const std::string& host, int port, const std::string& id) {
   char buf[1024];
-  snprintf(buf, sizeof(buf), "127.0.0.1:%d/%s", port, id.c_str());
+  snprintf(buf, sizeof(buf), "%s:%d/%s", host.c_str(), port, id.c_str());
   return buf;
 }
 
@@ -74,7 +74,8 @@ void OnBufferAlloc(uv_handle_t* handle, size_t len, uv_buf_t* buf) {
   buf->len = len;
 }
 
-void PrintDebuggerReadyMessage(int port,
+void PrintDebuggerReadyMessage(const std::string& host,
+                               int port,
                                const std::vector<std::string>& ids,
                                FILE* out) {
   if (out == NULL) {
@@ -92,7 +93,8 @@ void PrintDebuggerReadyMessage(int port,
   for (const std::string& id : ids) {
     fprintf(out,
             "    chrome-devtools://devtools/bundled/inspector.html?"
-            "experiments=true&v8only=true&ws=%s\n", GetWsUrl(port, id).c_str());
+            "experiments=true&v8only=true&ws=%s\n",
+            GetWsUrl(host, port, id).c_str());
   }
   fflush(out);
 }
@@ -229,9 +231,11 @@ class SocketSession {
 };
 
 InspectorSocketServer::InspectorSocketServer(SocketServerDelegate* delegate,
+                                             const std::string& host,
                                              int port,
                                              FILE* out) : loop_(nullptr),
                                                           delegate_(delegate),
+                                                          host_(host),
                                                           port_(port),
                                                           server_(uv_tcp_t()),
                                                           closer_(nullptr),
@@ -284,7 +288,7 @@ void InspectorSocketServer::SessionTerminated(int session_id) {
   delegate_->EndSession(session_id);
   if (connected_sessions_.empty() &&
       uv_is_active(reinterpret_cast<uv_handle_t*>(&server_))) {
-    PrintDebuggerReadyMessage(port_, delegate_->GetTargetIds(), out_);
+    PrintDebuggerReadyMessage(host_, port_, delegate_->GetTargetIds(), out_);
   }
 }
 
@@ -337,7 +341,7 @@ void InspectorSocketServer::SendListResponse(InspectorSocket* socket) {
       }
     }
     if (!connected) {
-      std::string address = GetWsUrl(port_, id);
+      std::string address = GetWsUrl(host_, port_, id);
       std::ostringstream frontend_url;
       frontend_url << "chrome-devtools://devtools/bundled";
       frontend_url << "/inspector.html?experiments=true&v8only=true&ws=";
@@ -353,7 +357,7 @@ bool InspectorSocketServer::Start(uv_loop_t* loop) {
   loop_ = loop;
   sockaddr_in addr;
   uv_tcp_init(loop_, &server_);
-  uv_ip4_addr("0.0.0.0", port_, &addr);
+  uv_ip4_addr(host_.c_str(), port_, &addr);
   int err = uv_tcp_bind(&server_,
                         reinterpret_cast<const struct sockaddr*>(&addr), 0);
   if (err == 0)
@@ -363,11 +367,13 @@ bool InspectorSocketServer::Start(uv_loop_t* loop) {
                     SocketConnectedCallback);
   }
   if (err == 0 && connected_sessions_.empty()) {
-    PrintDebuggerReadyMessage(port_, delegate_->GetTargetIds(), out_);
+    PrintDebuggerReadyMessage(host_, port_, delegate_->GetTargetIds(), out_);
   }
   if (err != 0 && connected_sessions_.empty()) {
     if (out_ != NULL) {
-      fprintf(out_, "Unable to open devtools socket: %s\n", uv_strerror(err));
+      fprintf(out_, "Starting inspector on %s:%d failed: %s\n",
+              host_.c_str(), port_, uv_strerror(err));
+      fflush(out_);
     }
     uv_close(reinterpret_cast<uv_handle_t*>(&server_), nullptr);
     return false;

--- a/src/inspector_socket_server.h
+++ b/src/inspector_socket_server.h
@@ -33,6 +33,7 @@ class InspectorSocketServer {
  public:
   using ServerCallback = void (*)(InspectorSocketServer*);
   InspectorSocketServer(SocketServerDelegate* delegate,
+                        const std::string& host,
                         int port,
                         FILE* out = stderr);
   bool Start(uv_loop_t* loop);
@@ -65,6 +66,7 @@ class InspectorSocketServer {
 
   uv_loop_t* loop_;
   SocketServerDelegate* const delegate_;
+  const std::string host_;
   int port_;
   std::string path_;
   uv_tcp_t server_;

--- a/src/node.cc
+++ b/src/node.cc
@@ -4362,7 +4362,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   if (debug_enabled) {
     const char* path = argc > 1 ? argv[1] : nullptr;
     StartDebug(&env, path, debug_options);
-    if (debug_options.debugger_enabled() && !debugger_running)
+    if (!debugger_running)
       return 12;  // Signal internal error.
   }
 


### PR DESCRIPTION
This change also changes error message to make it consistent with the
one printed by the debugger.

Fixes: https://github.com/nodejs/node/issues/10858

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
inspector: now it uses host name from the debug options. Messages were slightly altered.
