### PR TITLE
deps backport 7c3748a from upstream V8

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 89
+#define V8_PATCH_LEVEL 90
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/runtime/runtime-debug.cc
+++ b/deps/v8/src/runtime/runtime-debug.cc
@@ -584,7 +584,8 @@ RUNTIME_FUNCTION(Runtime_GetFrameDetails) {
     // Use the value from the stack.
     if (scope_info->LocalIsSynthetic(i)) continue;
     locals->set(local * 2, scope_info->LocalName(i));
-    Handle<Object> value = frame_inspector.GetExpression(i);
+    Handle<Object> value =
+        frame_inspector.GetExpression(scope_info->StackLocalIndex(i));
     // TODO(yangguo): We convert optimized out values to {undefined} when they
     // are passed to the debugger. Eventually we should handle them somehow.
     if (value->IsOptimizedOut()) value = isolate->factory()->undefined_value();

--- a/deps/v8/test/mjsunit/regress/regress-5071.js
+++ b/deps/v8/test/mjsunit/regress/regress-5071.js
@@ -1,0 +1,26 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-debug-as debug
+
+var Debug = debug.Debug;
+
+function listener(event, exec_state, event_data, data) {
+  assertEquals(2, exec_state.frameCount());
+  assertEquals("a", exec_state.frame(0).localName(0));
+  assertEquals("1", exec_state.frame(0).localValue(0).value());
+  assertEquals(1, exec_state.frame(0).localCount());
+}
+
+Debug.setListener(listener);
+
+function f() {
+  var a = 1;
+  {
+    let b = 2;
+    debugger;
+  }
+}
+
+f();


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
 deps

##### V8 commit:
https://github.com/v8/v8/commit/7c3748a9c46843ac26bd72dfdd3298e6907d0f6d

##### Description of change:

Backport of bugfix from upstream V8

Original commit message:
  load correct stack slot for frame details.

  R=bmeurer@chromium.org
  BUG=v8:5071

  Review URL: https://codereview.chromium.org/2045863002 .

  Cr-Commit-Position: refs/heads/master@{#36769}