### PR TITLE
crypto: return result of openssl HMAC_Update instead of just true.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3684,8 +3684,8 @@ void Hmac::HmacInit(const FunctionCallbackInfo<Value>& args) {
 bool Hmac::HmacUpdate(const char* data, int len) {
   if (!initialised_)
     return false;
-  HMAC_Update(&ctx_, reinterpret_cast<const unsigned char*>(data), len);
-  return true;
+  int r = HMAC_Update(&ctx_, reinterpret_cast<const unsigned char*>(data), len);
+  return r == 1;
 }
 
 


### PR DESCRIPTION
Addresses coverity scan issue [55489](https://scan9.coverity.com/reports.htm#v30475/p10075/fileInstanceId=12280692&defectInstanceId=2400164&mergedDefectId=55489)

The existing tests pass but I did not add any new tests.  I did not see any existing tests around error handling of openssl functions nor any test harness to allow you to do so.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto