### PR TITLE
buffer: improve toJSON() performance

### DIFF
--- a/benchmark/buffers/buffer-tojson.js
+++ b/benchmark/buffers/buffer-tojson.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e4],
+  len: [0, 10, 256, 4 * 1024]
+});
+
+function main(conf) {
+  var n = +conf.n;
+  var buf = Buffer.allocUnsafe(+conf.len);
+
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    buf.toJSON();
+  bench.end(n);
+}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -804,10 +804,14 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
 
 
 Buffer.prototype.toJSON = function() {
-  return {
-    type: 'Buffer',
-    data: Array.prototype.slice.call(this, 0)
-  };
+  if (this.length) {
+    const data = [];
+    for (var i = 0; i < this.length; ++i)
+      data[i] = this[i];
+    return { type: 'Buffer', data };
+  } else {
+    return { type: 'Buffer', data: [] };
+  }
 };
 
 


### PR DESCRIPTION
Here are the results with the new, included benchmarks (I used a different `n` value for each input length for best test result reliability while making sure they finished in a reasonable amount of time):

```
                                           improvement confidence      p.value
 buffers/buffer-tojson.js len=0 n=10000000   2449.70 %        *** 1.312673e-26
 buffers/buffer-tojson.js len=10 n=1000000   3148.31 %        *** 1.136735e-13
 buffers/buffer-tojson.js len=256 n=100000   2717.46 %        *** 1.418324e-21
 buffers/buffer-tojson.js len=4096 n=10000   3121.78 %        *** 2.456344e-12
```

CI: https://ci.nodejs.org/job/node-test-pull-request/5945/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
