### PR TITLE
test: use common.fail() instead of assert(false)

### DIFF
--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const dns = require('dns');
 const net = require('net');
@@ -44,19 +44,9 @@ function checkWrap(req) {
 
 
 TEST(function test_reverse_bogus(done) {
-  let error;
-
-  try {
-    dns.reverse('bogus ip', function() {
-      assert.ok(false);
-    });
-  } catch (e) {
-    error = e;
-  }
-
-  assert.ok(error instanceof Error);
-  assert.strictEqual(error.errno, 'EINVAL');
-
+  assert.throws(() => {
+    dns.reverse('bogus ip', common.fail);
+  }, /^Error: getHostByAddr EINVAL$/);
   done();
 });
 
@@ -442,7 +432,7 @@ TEST(function test_lookup_all_mixed(done) {
       else if (isIPv6(ip.address))
         assert.strictEqual(ip.family, 6);
       else
-        assert(false);
+        common.fail('unexpected IP address');
     });
 
     done();

--- a/test/internet/test-tls-add-ca-cert.js
+++ b/test/internet/test-tls-add-ca-cert.js
@@ -38,7 +38,7 @@ tls.connect(opts, fail).on('error', common.mustCall((err) => {
 }));
 
 function fail() {
-  assert(false, 'should fail to connect');
+  common.fail('should fail to connect');
 }
 
 // New secure contexts have the well-known root CAs.

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -37,10 +37,10 @@ if (typeof process.argv[2] === 'string') {
   async_wrap.setupHooks({ init, pre, post, destroy });
   async_wrap.enable();
 
-  process.on('uncaughtException', () => assert.ok(0, 'UNREACHABLE'));
+  process.on('uncaughtException', common.fail);
 
   const d = domain.create();
-  d.on('error', () => assert.ok(0, 'UNREACHABLE'));
+  d.on('error', common.fail);
   d.run(() => {
     // Using randomBytes because timers are not yet supported.
     crypto.randomBytes(0, () => { });

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -21,8 +21,7 @@ if (process.argv[2] === 'child') {
 
   child.stderr.setEncoding('utf8');
   child.stderr.on('data', function(data) {
-    console.log('parent stderr: ' + data);
-    assert.ok(false);
+    common.fail(`Unexpected parent stderr: ${data}`);
   });
 
   // check if we receive both 'hello' at start and 'goodbye' at end

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -9,7 +9,6 @@
  */
 
 const common = require('../common');
-const assert = require('assert');
 const domain = require('domain');
 const child_process = require('child_process');
 
@@ -184,17 +183,16 @@ if (process.argv[2] === 'child') {
       test.expectedMessages.forEach(function(expectedMessage) {
         if (test.messagesReceived === undefined ||
           test.messagesReceived.indexOf(expectedMessage) === -1)
-          assert(false, 'test ' + test.fn.name +
-              ' should have sent message: ' + expectedMessage +
-              ' but didn\'t');
+          common.fail('test ' + test.fn.name + ' should have sent message: ' +
+                      expectedMessage + ' but didn\'t');
       });
 
       if (test.messagesReceived) {
         test.messagesReceived.forEach(function(receivedMessage) {
           if (test.expectedMessages.indexOf(receivedMessage) === -1) {
-            assert(false, 'test ' + test.fn.name +
-              ' should not have sent message: ' + receivedMessage +
-              ' but did');
+            common.fail('test ' + test.fn.name +
+                        ' should not have sent message: ' + receivedMessage +
+                        ' but did');
           }
         });
       }

--- a/test/parallel/test-http-conn-reset.js
+++ b/test/parallel/test-http-conn-reset.js
@@ -19,9 +19,7 @@ server.listen(0, options.host, common.mustCall(onListen));
 // do a GET request, expect it to fail
 function onListen() {
   options.port = this.address().port;
-  const req = http.request(options, function(res) {
-    assert.ok(false, 'this should never run');
-  });
+  const req = http.request(options, common.fail);
   req.on('error', common.mustCall(function(err) {
     assert.strictEqual(err.code, 'ECONNRESET');
   }));

--- a/test/parallel/test-http-double-content-length.js
+++ b/test/parallel/test-http-double-content-length.js
@@ -7,10 +7,7 @@ const assert = require('assert');
 // The callback should never be invoked because the server
 // should respond with a 400 Client Error when a double
 // Content-Length header is received.
-const server = http.createServer((req, res) => {
-  assert(false, 'callback should not have been invoked');
-  res.end();
-});
+const server = http.createServer(common.fail);
 server.on('clientError', common.mustCall((err, socket) => {
   assert(/^Parse Error/.test(err.message));
   assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const binding = process.binding('http_parser');
@@ -35,9 +35,7 @@ function newParser(type) {
   parser[kOnHeadersComplete] = function(info) {
   };
 
-  parser[kOnBody] = function(b, start, len) {
-    assert.ok(false, 'Function should not be called.');
-  };
+  parser[kOnBody] = common.fail;
 
   parser[kOnMessageComplete] = function() {
   };

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -35,7 +35,7 @@ server.listen(0, common.mustCall(() => {
     http.get(
       {port: server.address().port, headers: {'x-num': n}},
       (res) => {
-        assert(false, 'client allowed multiple content-length headers.');
+        common.fail('client allowed multiple content-length headers.');
       }
     ).on('error', common.mustCall((err) => {
       assert(/^Parse Error/.test(err.message));

--- a/test/parallel/test-net-error-twice.js
+++ b/test/parallel/test-net-error-twice.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -20,7 +20,7 @@ const srv = net.createServer(function onConnection(conn) {
   conn.on('error', function(err) {
     errs.push(err);
     if (errs.length > 1 && errs[0] === errs[1])
-      assert(false, 'We should not be emitting the same error twice');
+      common.fail('Should not emit the same error twice');
   });
   conn.on('close', function() {
     srv.unref();

--- a/test/parallel/test-net-reconnect-error.js
+++ b/test/parallel/test-net-reconnect-error.js
@@ -10,8 +10,7 @@ let disconnect_count = 0;
 const c = net.createConnection(common.PORT);
 
 c.on('connect', function() {
-  console.error('CLIENT connected');
-  assert.ok(false);
+  common.fail('client should not have connected');
 });
 
 c.on('error', function(e) {

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
@@ -39,7 +39,7 @@ function test(decode, uncork, multi, next) {
 
   const w = new stream.Writable({ decodeStrings: decode });
   w._write = function(chunk, e, cb) {
-    assert(false, 'Should not call _write');
+    common.fail('Should not call _write');
   };
 
   const expectChunks = decode ? [

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -14,9 +14,7 @@ const path = require('path');
 const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-const conn = tls.connect({cert: cert, key: key, port: common.PORT}, function() {
-  assert.ok(false); // callback should never be executed
-});
+const conn = tls.connect({cert, key, port: common.PORT}, common.fail);
 conn.on('error', function() {
 });
 assert.doesNotThrow(function() {

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -16,9 +16,7 @@ const server = tls.createServer({
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 }, function(c) {
 }).listen(0, common.mustCall(function() {
-  const c = tls.connect(this.address().port, function() {
-    assert(false, 'should not be called');
-  });
+  const c = tls.connect(this.address().port, common.fail);
 
   c.on('error', common.mustCall(function(err) {}));
 

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
@@ -33,9 +32,7 @@ const path = require('path');
     key: key,
     port: common.PORT,
     ciphers: 'rick-128-roll'
-  }, function() {
-    assert.ok(false); // callback should never be executed
-  });
+  }, common.fail);
 
   conn.on('error', common.mustCall(function() {}));
 }

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -20,9 +20,7 @@ const server = tls.createServer({
   const c = tls.connect({
     port: this.address().port,
     ciphers: 'RC4'
-  }, function() {
-    assert(false, 'should not be called');
-  });
+  }, common.fail);
 
   c.on('error', common.mustCall(function(err) {
     assert.notStrictEqual(err.code, 'ECONNRESET');

--- a/test/parallel/test-vm-syntax-error-message.js
+++ b/test/parallel/test-vm-syntax-error-message.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 
@@ -12,7 +12,7 @@ const p = child_process.spawn(process.execPath, [
 ]);
 
 p.stderr.on('data', function(data) {
-  assert(false, 'Unexpected stderr data: ' + data);
+  common.fail(`Unexpected stderr data: ${data}`);
 });
 
 let output = '';

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const url = require('url');
 const URL = url.URL;
@@ -35,5 +35,5 @@ assert.deepStrictEqual(c[2], ['z', '3']);
 a = new URL('http://a.b/c');
 b = a.searchParams;
 for (i of b) {
-  assert(false, 'should not be reached');
+  common.fail('should not be reached');
 }

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -93,16 +93,13 @@ setTimeout(function() {
 
 assert.doesNotThrow(
     function() {
-      function a() {
-        assert.ok(0); // should not run
-      }
       function b() {
         fs.unwatchFile(filenameThree, b);
         ++watchSeenThree;
       }
-      fs.watchFile(filenameThree, a);
+      fs.watchFile(filenameThree, common.fail);
       fs.watchFile(filenameThree, b);
-      fs.unwatchFile(filenameThree, a);
+      fs.unwatchFile(filenameThree, common.fail);
     }
 );
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test