### PR TITLE
url: check forEach callback is a function

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -817,6 +817,9 @@ class URLSearchParams {
     if (arguments.length < 1) {
       throw new TypeError('The `callback` argument needs to be specified');
     }
+    if (typeof callback !== 'function') {
+      throw new TypeError('The `callback` argument must be a function');
+    }
 
     let list = this[searchParams];
 

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -672,8 +672,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 2) {
-      throw new TypeError(
-        'Both `name` and `value` arguments need to be specified');
+      throw new TypeError('"name" and "value" arguments must be specified');
     }
 
     name = String(name);
@@ -687,7 +686,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
-      throw new TypeError('The `name` argument needs to be specified');
+      throw new TypeError('"name" argument must be specified');
     }
 
     const list = this[searchParams];
@@ -708,8 +707,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 2) {
-      throw new TypeError(
-        'Both `name` and `value` arguments need to be specified');
+      throw new TypeError('"name" and "value" arguments must be specified');
     }
 
     const list = this[searchParams];
@@ -749,7 +747,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
-      throw new TypeError('The `name` argument needs to be specified');
+      throw new TypeError('"name" argument must be specified');
     }
 
     const list = this[searchParams];
@@ -767,7 +765,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
-      throw new TypeError('The `name` argument needs to be specified');
+      throw new TypeError('"name" argument must be specified');
     }
 
     const list = this[searchParams];
@@ -786,7 +784,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
-      throw new TypeError('The `name` argument needs to be specified');
+      throw new TypeError('"name" argument must be specified');
     }
 
     const list = this[searchParams];
@@ -815,7 +813,7 @@ class URLSearchParams {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (typeof callback !== 'function') {
-      throw new TypeError('The `callback` argument must be a function');
+      throw new TypeError('"callback" argument must be a function');
     }
 
     let list = this[searchParams];

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -814,9 +814,6 @@ class URLSearchParams {
     if (!this || !(this instanceof URLSearchParams)) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
-    if (arguments.length < 1) {
-      throw new TypeError('The `callback` argument needs to be specified');
-    }
     if (typeof callback !== 'function') {
       throw new TypeError('The `callback` argument must be a function');
     }

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -44,6 +44,16 @@ n = 0;
 for (val of sp.values()) {
   assert.strictEqual(val, String(values[n++]));
 }
+n = 0;
+sp.forEach(function(val, key, obj) {
+  assert.strictEqual(this, undefined);
+  assert.strictEqual(key, 'a');
+  assert.strictEqual(val, String(values[n++]));
+  assert.strictEqual(obj, sp);
+});
+sp.forEach(function() {
+  assert.strictEqual(this, m);
+}, m);
 
 m.search = '?a=a&b=b';
 assert.strictEqual(sp.toString(), 'a=a&b=b');

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -54,6 +54,8 @@ sp.forEach(function(val, key, obj) {
 sp.forEach(function() {
   assert.strictEqual(this, m);
 }, m);
+assert.throws(() => sp.forEach(), TypeError);
+assert.throws(() => sp.forEach(1), TypeError);
 
 m.search = '?a=a&b=b';
 assert.strictEqual(sp.toString(), 'a=a&b=b');

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -55,9 +55,9 @@ sp.forEach(function() {
   assert.strictEqual(this, m);
 }, m);
 assert.throws(() => sp.forEach(),
-              /^TypeError: The `callback` argument needs to be specified$/);
+              /^TypeError: "callback" argument must be a function$/);
 assert.throws(() => sp.forEach(1),
-              /^TypeError: The `callback` argument must be a function$/);
+              /^TypeError: "callback" argument must be a function$/);
 
 m.search = '?a=a&b=b';
 assert.strictEqual(sp.toString(), 'a=a&b=b');

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -54,8 +54,10 @@ sp.forEach(function(val, key, obj) {
 sp.forEach(function() {
   assert.strictEqual(this, m);
 }, m);
-assert.throws(() => sp.forEach(), TypeError);
-assert.throws(() => sp.forEach(1), TypeError);
+assert.throws(() => sp.forEach(),
+              /^TypeError: The `callback` argument needs to be specified$/);
+assert.throws(() => sp.forEach(1),
+              /^TypeError: The `callback` argument must be a function$/);
 
 m.search = '?a=a&b=b';
 assert.strictEqual(sp.toString(), 'a=a&b=b');


### PR DESCRIPTION
Currently, `URLSearchParams`' `forEach` function does not have a check to make sure that the type of the provided callback is a function. However, the [Web IDL spec](https://heycam.github.io/webidl/), to which this function should conform, insists that a TypeError be thrown if the callback is not callable.

This PR fulfills that requirement. Also included in this PR are additional tests for certain aspects of `forEach` that are defined in the spec but not yet tested.

----

Web IDL [defines](https://heycam.github.io/webidl/#es-forEach) `forEach` as the following:

```c
void forEach(Function callback, optional any thisArg);
```

`callback` therefore has type `Function`, which in turn is [defined](https://heycam.github.io/webidl/#Function) as a [callback function](https://heycam.github.io/webidl/#idl-callback-function):

```js
callback Function = any (any... arguments);
```

The [process](https://heycam.github.io/webidl/#es-to-callback-function) to convert an ECMAScript value to an IDL callback function then contains the following:

> 1. If the result of calling [IsCallable](https://tc39.github.io/ecma262/#sec-iscallable)(_V_) is **false** and the conversion to an IDL value is not being performed due to _V_ being assigned to an attribute whose type is a nullable callback function that is annotated with [[`TreatNonObjectAsNull`](https://heycam.github.io/webidl/#TreatNonObjectAsNull)], then throw a **TypeError**.

And since `callback` is not declared with [`TreatNonObjectAsNull`], `forEach` should throw a TypeError in case `callback` is not a function.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
url