### PR TITLE
url: use symbol properties correctly in URL class

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -77,7 +77,7 @@ class TupleOrigin {
     return result;
   }
 
-  inspect() {
+  [util.inspect.custom]() {
     return `TupleOrigin {
       scheme: ${this[kScheme]},
       host: ${this[kHost]},
@@ -235,7 +235,7 @@ class URL {
     return (this[context].flags & binding.URL_FLAGS_CANNOT_BE_BASE) !== 0;
   }
 
-  inspect(depth, opts) {
+  [util.inspect.custom](depth, opts) {
     const ctx = this[context];
     var ret = 'URL {\n';
     ret += `  href: ${this.href}\n`;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -221,10 +221,11 @@ class URL {
     if (base !== undefined && !(base instanceof URL))
       base = new URL(String(base));
     parse(this, input, base);
-  }
 
-  get [Symbol.toStringTag]() {
-    return this instanceof URL ? 'URL' : 'URLPrototype';
+    Object.defineProperty(this, Symbol.toStringTag, {
+      configurable: true,
+      value: 'URL'
+    });
   }
 
   get [special]() {
@@ -313,6 +314,10 @@ Object.defineProperties(URL.prototype, {
         ret += `#${ctx.fragment}`;
       return ret;
     }
+  },
+  [Symbol.toStringTag]: {
+    configurable: true,
+    value: 'URLPrototype'
   },
   href: {
     enumerable: true,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -221,11 +221,6 @@ class URL {
     if (base !== undefined && !(base instanceof URL))
       base = new URL(String(base));
     parse(this, input, base);
-
-    Object.defineProperty(this, Symbol.toStringTag, {
-      configurable: true,
-      value: 'URL'
-    });
   }
 
   get [special]() {
@@ -317,7 +312,7 @@ Object.defineProperties(URL.prototype, {
   },
   [Symbol.toStringTag]: {
     configurable: true,
-    value: 'URLPrototype'
+    value: 'URL'
   },
   href: {
     enumerable: true,

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const util = require('util');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.
@@ -144,8 +145,8 @@ for (const test of allTests) {
   const url = test.url ? new URL(test.url) : new URL(test.input, test.base);
 
   for (const showHidden of [true, false]) {
-    const res = url.inspect(null, {
-      showHidden: showHidden
+    const res = util.inspect(url, {
+      showHidden
     });
 
     const lines = res.split('\n');

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -45,7 +45,7 @@ assert.strictEqual(url.searchParams, oldParams);  // [SameObject]
 // Note: this error message is subject to change in V8 updates
 assert.throws(() => url.origin = 'http://foo.bar.com:22',
               new RegExp('TypeError: Cannot set property origin of' +
-                         ' \\[object Object\\] which has only a getter'));
+                         ' \\[object URLPrototype\\] which has only a getter'));
 assert.strictEqual(url.origin, 'http://foo.bar.com:21');
 assert.strictEqual(url.toString(),
                    'http://user:pass@foo.bar.com:21/aaa/zzz?l=25#test');
@@ -121,7 +121,7 @@ assert.strictEqual(url.hash, '#abcd');
 // Note: this error message is subject to change in V8 updates
 assert.throws(() => url.searchParams = '?k=88',
               new RegExp('TypeError: Cannot set property searchParams of' +
-                         ' \\[object Object\\] which has only a getter'));
+                         ' \\[object URLPrototype\\] which has only a getter'));
 assert.strictEqual(url.searchParams, oldParams);
 assert.strictEqual(url.toString(),
                    'https://user2:pass2@foo.bar.org:23/aaa/bbb?k=99#abcd');

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -45,7 +45,7 @@ assert.strictEqual(url.searchParams, oldParams);  // [SameObject]
 // Note: this error message is subject to change in V8 updates
 assert.throws(() => url.origin = 'http://foo.bar.com:22',
               new RegExp('TypeError: Cannot set property origin of' +
-                         ' \\[object URLPrototype\\] which has only a getter'));
+                         ' \\[object URL\\] which has only a getter'));
 assert.strictEqual(url.origin, 'http://foo.bar.com:21');
 assert.strictEqual(url.toString(),
                    'http://user:pass@foo.bar.com:21/aaa/zzz?l=25#test');
@@ -121,7 +121,7 @@ assert.strictEqual(url.hash, '#abcd');
 // Note: this error message is subject to change in V8 updates
 assert.throws(() => url.searchParams = '?k=88',
               new RegExp('TypeError: Cannot set property searchParams of' +
-                         ' \\[object URLPrototype\\] which has only a getter'));
+                         ' \\[object URL\\] which has only a getter'));
 assert.strictEqual(url.searchParams, oldParams);
 assert.strictEqual(url.toString(),
                    'https://user2:pass2@foo.bar.org:23/aaa/bbb?k=99#abcd');

--- a/test/parallel/test-whatwg-url-tostringtag.js
+++ b/test/parallel/test-whatwg-url-tostringtag.js
@@ -10,9 +10,12 @@ const sp = url.searchParams;
 
 const test = [
   [toString.call(url), 'URL'],
-  [toString.call(Object.getPrototypeOf(url)), 'URLPrototype'],
   [toString.call(sp), 'URLSearchParams'],
-  [toString.call(Object.getPrototypeOf(sp)), 'URLSearchParamsPrototype']
+  [toString.call(Object.getPrototypeOf(sp)), 'URLSearchParamsPrototype'],
+  // Web IDL spec says we have to return 'URLPrototype', but it is too
+  // expensive to implement; therefore, use Chrome's behavior for now, until
+  // spec is changed.
+  [toString.call(Object.getPrototypeOf(url)), 'URL']
 ];
 
 test.forEach((row) => {


### PR DESCRIPTION
This PR has two commits, both concerning the usage of symbol properties.

The first is to avoid using a getter for `@@toStringTag`. It does mean that parts of #10562 are reverted. This is done for multiple reasons:

1. Web IDL says "the object must, at the time it is created, have a property whose name is the [@@toStringTag](https://tc39.github.io/ecma262/#sec-well-known-symbols) symbol and whose value is the specified string." This implies that the **object itself** must possess the property, not its [[Prototype]].

2. From the same quote above, the spec says the property must have a **value,** (not a getter). Elsewhere in the spec, the distinction between getter, setter, and value of a property is always well-defined, and there is no reason to assume otherwise for this instance.

3. <a id="ambiguity-of-descriptor">Ambiguity of behavior</a> when something like this happens:

   ```js
   Object.getOwnPropertyDescriptor(URL.prototype, Symbol.toStringTag).get();
   ```

   Web IDL is usually fairly strict with `this` values (see [operations/methods](https://heycam.github.io/webidl/#dfn-create-operation-function), [getters](https://heycam.github.io/webidl/#dfn-attribute-getter) and [setters](https://heycam.github.io/webidl/#dfn-attribute-setter)). In fact, all of the following will result in an error in the browser:

   ```js
   Object.getOwnPropertyDescriptor(URL.prototype, 'href').get();
   Object.getOwnPropertyDescriptor(URL.prototype, 'href').get.call(null);
   Object.getOwnPropertyDescriptor(URL.prototype, 'href').get.call(window);
   Object.getOwnPropertyDescriptor(URL.prototype, 'href').get.call({});
   ```

   However, because of the second concern above, no getter for `@@toStringTag` is defined in the spec, and therefore no algorithms exist for dealing with this situation: whether the getter should return `'URL'`, `'URLPrototype'`, `''`, `undefined`, or throw an error cannot be reasonably decided. Currently, even `Object.getOwnPropertyDescriptor(URL.prototype, Symbol.toStringTag).get.call(null)` returns `'URLPrototype'`, which makes little sense.

This change does also need to be applied to `URLSearchParams` class. I will do so in a subsequent PR.

The second is arguably less controversial. The issue is that an undocumented but public `inspect()` exists on `URL.prototype`, even though it is not part of the URL Standard. It was first raised by @watilde in https://github.com/nodejs/node/pull/10857#issuecomment-273265162. This PR fixes this issue by renaming the property to an internal symbol reserved for inspect method, which is already how `URLSearchParams`' inspection operates. Tests are adjusted accordingly.

/cc @nodejs/url, @watilde 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url-whatwg