### PR TITLE
test: improve test-fs-open-flags

### DIFF
--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -37,20 +37,27 @@ assert.strictEqual(stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
 ('+ +a +r +w rw wa war raw r++ a++ w++ x +x x+ rx rx+ wxx wax xwx xxx')
   .split(' ')
   .forEach(function(flags) {
-    assert.throws(function() { stringToFlags(flags); });
+    assert.throws(
+      () => stringToFlags(flags),
+      new RegExp(`^Error: Unknown file open flag: ${escapeRegExp(flags)}`)
+    );
   });
 
 assert.throws(
   () => stringToFlags({}),
-  /Unknown file open flag: \[object Object\]/
+  /^Error: Unknown file open flag: \[object Object\]$/
 );
 
 assert.throws(
   () => stringToFlags(true),
-  /Unknown file open flag: true/
+  /^Error: Unknown file open flag: true$/
 );
 
 assert.throws(
   () => stringToFlags(null),
-  /Unknown file open flag: null/
+  /^Error: Unknown file open flag: null$/
 );
+
+function escapeRegExp(string) {
+  return string.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+}


### PR DESCRIPTION
* use arrow funcion instead of function expression
* add second argumento to method assert.throws
* check error messages from beginning to the end using ^ and $

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test