### PR TITLE
test: add fs-assert-encoding's test

### DIFF
--- a/test/parallel/test-fs-assert-encoding-error.js
+++ b/test/parallel/test-fs-assert-encoding-error.js
@@ -1,0 +1,76 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+const options = 'test';
+const noop = () => {};
+const unknownEncodingMessage = /^Error: Unknown encoding: test$/;
+
+assert.throws(() => {
+  fs.readFile('path', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.readFileSync('path', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.readdir('path', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.readdirSync('path', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.readlink('path', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.readlinkSync('path', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.writeFile('path', 'data', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.writeFileSync('path', 'data', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.appendFile('path', 'data', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.appendFileSync('path', 'data', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.watch('path', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.realpath('path', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.realpathSync('path', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.mkdtemp('path', options, noop);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.mkdtempSync('path', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.ReadStream('path', options);
+}, unknownEncodingMessage);
+
+assert.throws(() => {
+  fs.WriteStream('path', options);
+}, unknownEncodingMessage);


### PR DESCRIPTION
Check the error of `assertEncoding`.
Confirmed in every place being used.(a place where [getOptions](https://github.com/nodejs/node/blob/521767c88605cb6481ea98f396924e55f9dd22f4/lib/fs.js#L40) is used)
assetEncoding: https://github.com/nodejs/node/blob/521767c88605cb6481ea98f396924e55f9dd22f4/lib/internal/fs.js#L18

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test