### PR TITLE
test: improve test-assert

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -209,11 +209,26 @@ assert.doesNotThrow(makeBlock(a.deepStrictEqual, /a/g, /a/g));
 assert.doesNotThrow(makeBlock(a.deepStrictEqual, /a/i, /a/i));
 assert.doesNotThrow(makeBlock(a.deepStrictEqual, /a/m, /a/m));
 assert.doesNotThrow(makeBlock(a.deepStrictEqual, /a/igm, /a/igm));
-assert.throws(makeBlock(a.deepStrictEqual, /ab/, /a/));
-assert.throws(makeBlock(a.deepStrictEqual, /a/g, /a/));
-assert.throws(makeBlock(a.deepStrictEqual, /a/i, /a/));
-assert.throws(makeBlock(a.deepStrictEqual, /a/m, /a/));
-assert.throws(makeBlock(a.deepStrictEqual, /a/igm, /a/im));
+assert.throws(
+  makeBlock(a.deepStrictEqual, /ab/, /a/),
+  /^AssertionError: \/ab\/ deepStrictEqual \/a\/$/
+);
+assert.throws(
+  makeBlock(a.deepStrictEqual, /a/g, /a/),
+  /^AssertionError: \/a\/g deepStrictEqual \/a\/$/
+);
+assert.throws(
+  makeBlock(a.deepStrictEqual, /a/i, /a/),
+  /^AssertionError: \/a\/i deepStrictEqual \/a\/$/
+);
+assert.throws(
+  makeBlock(a.deepStrictEqual, /a/m, /a/),
+  /^AssertionError: \/a\/m deepStrictEqual \/a\/$/
+);
+assert.throws(
+  makeBlock(a.deepStrictEqual, /a/igm, /a/im),
+  /^AssertionError: \/a\/gim deepStrictEqual \/a\/im$/
+);
 
 {
   const re1 = /a/;


### PR DESCRIPTION
Add RegExp to check assert throws the expected AssertionErrors.

For the one with multiple flags is ok to hardcode the flags since the
spec indicates the ordering will always be `gim`, here is the link:

http://www.ecma-international.org/ecma-262/6.0/#sec-get-regexp.prototype.flags

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
