### PR TITLE
test: update V8 flag in test

### DIFF
--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -139,7 +139,7 @@ childProcess.exec(
 // https://github.com/nodejs/node/issues/1691
 process.chdir(common.fixturesDir);
 childProcess.exec(
-  nodeBinary + ' ' + '--expose_debug_as=v8debug ' + '--require ' +
+  nodeBinary + ' ' + '--expose_natives_as=v8natives ' + '--require ' +
     fixture('cluster-preload.js') + ' ' + 'cluster-preload-test.js',
   function(err, stdout, stderr) {
     assert.ifError(err);


### PR DESCRIPTION
`--expose-debug-as` is going away in V8 5.8. Switch `test-preload.js` to a flag
that still exists.

R=@nodejs/v8

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test