### PR TITLE
src: add NODE_NO_WARNINGS to --help output

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3536,6 +3536,7 @@ static void PrintHelp() {
          "                           (will extend linked-in data)\n"
 #endif
 #endif
+         "NODE_NO_WARNINGS           set to 1 to silence process warnings\n"
 #ifdef _WIN32
          "NODE_PATH                  ';'-separated list of directories\n"
 #else


### PR DESCRIPTION
This commit adds a description of the `NODE_NO_WARNINGS` environment variable to the `--help` output. This was overlooked in 49902124a9d697e441dbf724aa6b26bd98f75dd0.

Refs: https://github.com/nodejs/node/pull/10842

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

CI: https://ci.nodejs.org/job/node-test-pull-request/5997/