### PR TITLE
Revert "src: don't overwrite non-writable vm globals"

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -383,22 +383,19 @@ class ContextifyContext {
     if (ctx->context_.IsEmpty())
       return;
 
-    auto attributes = PropertyAttribute::None;
     bool is_declared =
-        ctx->global_proxy()->GetRealNamedPropertyAttributes(ctx->context(),
-                                                            property)
-        .To(&attributes);
-    bool read_only =
-        static_cast<int>(attributes) &
-        static_cast<int>(PropertyAttribute::ReadOnly);
+        ctx->global_proxy()->HasRealNamedProperty(ctx->context(),
+                                                  property).FromJust();
+    bool is_contextual_store = ctx->global_proxy() != args.This();
 
-    if (is_declared && read_only)
-      return;
+    bool set_property_will_throw =
+        args.ShouldThrowOnError() &&
+        !is_declared &&
+        is_contextual_store;
 
-    if (!is_declared && args.ShouldThrowOnError())
-      return;
-
-    ctx->sandbox()->Set(property, value);
+    if (!set_property_will_throw) {
+      ctx->sandbox()->Set(property, value);
+    }
   }
 
 

--- a/test/known_issues/test-vm-global-non-writable-properties.js
+++ b/test/known_issues/test-vm-global-non-writable-properties.js
@@ -1,0 +1,16 @@
+'use strict';
+// https://github.com/nodejs/node/issues/10223
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const ctx = vm.createContext();
+vm.runInContext('Object.defineProperty(this, "x", { value: 42 })', ctx);
+assert.strictEqual(ctx.x, undefined);  // Not copied out by cloneProperty().
+assert.strictEqual(vm.runInContext('x', ctx), 42);
+vm.runInContext('x = 0', ctx);                      // Does not throw but x...
+assert.strictEqual(vm.runInContext('x', ctx), 42);  // ...should be unaltered.
+assert.throws(() => vm.runInContext('"use strict"; x = 0', ctx),
+              /Cannot assign to read only property 'x'/);
+assert.strictEqual(vm.runInContext('x', ctx), 42);

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -75,14 +75,3 @@ assert.throws(function() {
 // https://github.com/nodejs/node/issues/6158
 ctx = new Proxy({}, {});
 assert.strictEqual(typeof vm.runInNewContext('String', ctx), 'function');
-
-// https://github.com/nodejs/node/issues/10223
-ctx = vm.createContext();
-vm.runInContext('Object.defineProperty(this, "x", { value: 42 })', ctx);
-assert.strictEqual(ctx.x, undefined);  // Not copied out by cloneProperty().
-assert.strictEqual(vm.runInContext('x', ctx), 42);
-vm.runInContext('x = 0', ctx);                      // Does not throw but x...
-assert.strictEqual(vm.runInContext('x', ctx), 42);  // ...should be unaltered.
-assert.throws(() => vm.runInContext('"use strict"; x = 0', ctx),
-              /Cannot assign to read only property 'x'/);
-assert.strictEqual(vm.runInContext('x', ctx), 42);

--- a/test/parallel/test-vm-global-assignment.js
+++ b/test/parallel/test-vm-global-assignment.js
@@ -1,0 +1,15 @@
+'use strict';
+// Regression test for https://github.com/nodejs/node/issues/10806
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+const ctx = vm.createContext({ open() { } });
+const window = vm.runInContext('this', ctx);
+const other = 123;
+
+assert.notStrictEqual(window.open, other);
+window.open = other;
+assert.strictEqual(window.open, other);
+window.open = other;
+assert.strictEqual(window.open, other);


### PR DESCRIPTION
* This reverts commit 524f693. Fixes: #10806 #10492
* Moves the original tests from 524f693 to known_issues for now, adds the example from #10806

/cc @bnoordhuis @fhinkel 

CI: https://ci.nodejs.org/job/node-test-commit/7383/