### PR TITLE
doc: child_process exec string is processed by shell

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -148,7 +148,18 @@ added: v0.1.90
 * Returns: {ChildProcess}
 
 Spawns a shell then executes the `command` within that shell, buffering any
-generated output.
+generated output. The `command` string passed to the exec function is processed
+directly by the shell and special characters (vary based on 
+[shell](https://en.wikipedia.org/wiki/List_of_command-line_interpreters))
+need to be dealt with accordingly:
+```js
+exec('"/path/to/test file/test.sh" arg1 arg2');
+//Double quotes are used so that the space in the path is not interpreted as 
+//multiple arguments
+
+exec('echo "The \\$HOME variable is $HOME"'); 
+//The $HOME variable is escaped in the first instance, but not in the second
+```
 
 **Note: Never pass unsanitised user input to this function. Any input
 containing shell metacharacters may be used to trigger arbitrary command


### PR DESCRIPTION
Updates the Child Process Exec function documentation to provide more
information regarding how to deal with strings containing spaces
so that those spaces are not interpreted as separate arguments.
Fixes: https://github.com/nodejs/node/issues/6803

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc