### PR TITLE
test: test hmac binding robustness

### DIFF
--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -8,6 +8,14 @@ if (!common.hasCrypto) {
 }
 const crypto = require('crypto');
 
+// Test for binding layer robustness
+{
+  const binding = process.binding('crypto');
+  const h = new binding.Hmac();
+  // Fail to init the Hmac with an algorithm.
+  assert.throws(() => h.update('hello'), /^TypeError: HmacUpdate fail$/);
+}
+
 // Test HMAC
 const h1 = crypto.createHmac('sha1', 'Node')
                .update('some data')


### PR DESCRIPTION
The Hmac binding layer is not documented as part of the API, and is not
intended to be used, but it should be robust to misuse, and contains
defensive checks for misuse. This test checks that updates without init
throw (as opposed to abort or misbehave in some other way).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test
