### PR TITLE
test: verify shell option internals

### DIFF
--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -35,3 +35,59 @@ const env = cp.spawnSync(`"${process.execPath}" -pe process.env.BAZ`, {
 });
 
 assert.strictEqual(env.stdout.toString().trim(), 'buzz');
+
+// Verify that the shell internals work properly across platforms.
+{
+  const originalComspec = process.env.comspec;
+
+  // Enable monkey patching process.platform.
+  const originalPlatform = process.platform;
+  let platform = null;
+  Object.defineProperty(process, 'platform', { get: () => platform });
+
+  function test(testPlatform, shell, shellOutput) {
+    platform = testPlatform;
+
+    const cmd = 'not_a_real_command';
+    const shellFlags = platform === 'win32' ? ['/d', '/s', '/c'] : ['-c'];
+    const outputCmd = platform === 'win32' ? `"${cmd}"` : cmd;
+    const windowsVerbatim = platform === 'win32' ? true : undefined;
+    const result = cp.spawnSync(cmd, { shell });
+
+    assert.strictEqual(result.file, shellOutput);
+    assert.deepStrictEqual(result.args,
+                           [shellOutput, ...shellFlags, outputCmd]);
+    assert.strictEqual(result.options.shell, shell);
+    assert.strictEqual(result.options.file, result.file);
+    assert.deepStrictEqual(result.options.args, result.args);
+    assert.strictEqual(result.options.windowsVerbatimArguments,
+                       windowsVerbatim);
+  }
+
+  // Test Unix platforms with the default shell.
+  test('darwin', true, '/bin/sh');
+
+  // Test Unix platforms with a user specified shell.
+  test('darwin', '/bin/csh', '/bin/csh');
+
+  // Test Android platforms.
+  test('android', true, '/system/bin/sh');
+
+  // Test Windows platforms with a user specified shell.
+  test('win32', 'powershell.exe', 'powershell.exe');
+
+  // Test Windows platforms with the default shell and no comspec.
+  delete process.env.comspec;
+  test('win32', true, 'cmd.exe');
+
+  // Test Windows platforms with the default shell and a comspec value.
+  process.env.comspec = 'powershell.exe';
+  test('win32', true, process.env.comspec);
+
+  // Restore the original value of process.platform.
+  platform = originalPlatform;
+
+  // Restore the original comspec environment variable if necessary.
+  if (originalComspec)
+    process.env.comspec = originalComspec;
+}


### PR DESCRIPTION
This commit adds code coverage to the internals associated with
the child_process shell option. This achieves the following:

- Increased code coverage, which is currently only reported
for Unix.
- Ensures that all six code paths are covered, including the
three Windows variations, and Android which is not tested at
all on CI.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test

CI: https://ci.nodejs.org/job/node-test-pull-request/5999/
CI: https://ci.nodejs.org/job/node-test-pull-request/6001/