### PR TITLE
benchmark: add more thorough timers benchmarks

### DIFF
--- a/benchmark/timers/timers-cancel-pooled.js
+++ b/benchmark/timers/timers-cancel-pooled.js
@@ -1,0 +1,32 @@
+'use strict';
+var common = require('../common.js');
+var assert = require('assert');
+
+var bench = common.createBenchmark(main, {
+  thousands: [500],
+});
+
+function main(conf) {
+  var iterations = +conf.thousands * 1e3;
+
+  var timer = setTimeout(() => {}, 1);
+  for (var i = 0; i < iterations; i++) {
+    setTimeout(cb, 1);
+  }
+  var next = timer._idlePrev;
+  clearTimeout(timer);
+
+  bench.start();
+
+  for (var j = 0; j < iterations; j++) {
+    timer = next;
+    next = timer._idlePrev;
+    clearTimeout(timer);
+  }
+
+  bench.end(iterations / 1e3);
+}
+
+function cb() {
+  assert(false, 'Timer should not call callback');
+}

--- a/benchmark/timers/timers-cancel-unpooled.js
+++ b/benchmark/timers/timers-cancel-unpooled.js
@@ -1,0 +1,26 @@
+'use strict';
+var common = require('../common.js');
+var assert = require('assert');
+
+var bench = common.createBenchmark(main, {
+  thousands: [100],
+});
+
+function main(conf) {
+  var iterations = +conf.thousands * 1e3;
+
+  var timersList = [];
+  for (var i = 0; i < iterations; i++) {
+    timersList.push(setTimeout(cb, i + 1));
+  }
+
+  bench.start();
+  for (var j = 0; j < iterations + 1; j++) {
+    clearTimeout(timersList[j]);
+  }
+  bench.end(iterations / 1e3);
+}
+
+function cb() {
+  assert(false, 'Timer ' + this._idleTimeout + ' should not call callback');
+}

--- a/benchmark/timers/timers-insert-pooled.js
+++ b/benchmark/timers/timers-insert-pooled.js
@@ -1,0 +1,18 @@
+'use strict';
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {
+  thousands: [500],
+});
+
+function main(conf) {
+  var iterations = +conf.thousands * 1e3;
+
+  bench.start();
+
+  for (var i = 0; i < iterations; i++) {
+    setTimeout(() => {}, 1);
+  }
+
+  bench.end(iterations / 1e3);
+}

--- a/benchmark/timers/timers-insert-unpooled.js
+++ b/benchmark/timers/timers-insert-unpooled.js
@@ -1,0 +1,27 @@
+'use strict';
+var common = require('../common.js');
+var assert = require('assert');
+
+var bench = common.createBenchmark(main, {
+  thousands: [100],
+});
+
+function main(conf) {
+  var iterations = +conf.thousands * 1e3;
+
+  var timersList = [];
+
+  bench.start();
+  for (var i = 0; i < iterations; i++) {
+    timersList.push(setTimeout(cb, i + 1));
+  }
+  bench.end(iterations / 1e3);
+
+  for (var j = 0; j < iterations + 1; j++) {
+    clearTimeout(timersList[j]);
+  }
+}
+
+function cb() {
+  assert(false, 'Timer ' + this._idleTimeout + ' should not call callback');
+}

--- a/benchmark/timers/timers-timeout-pooled.js
+++ b/benchmark/timers/timers-timeout-pooled.js
@@ -1,0 +1,23 @@
+'use strict';
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {
+  thousands: [500],
+});
+
+function main(conf) {
+  var iterations = +conf.thousands * 1e3;
+  var count = 0;
+
+  for (var i = 0; i < iterations; i++) {
+    setTimeout(cb, 1);
+  }
+
+  bench.start();
+
+  function cb() {
+    count++;
+    if (count === iterations)
+      bench.end(iterations / 1e3);
+  }
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/9493

Adds some new benchmarks to test pooled and unpooled behavior of the insert, cancel, and timeout operations of Node timers.

This is missing an unpooled tests for timeout, since that is far more complex, and I would prefer to do it separately in all likelihood.

cc @misterdjules, @AndreasMadsen, @nodejs/benchmarking 

(This patch was made live during https://www.twitch.tv/nodesource/v/117497395 if you'd like to see me working on this in retrospect. :P)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark, timer