### PR TITLE
buffer: improve compare() performance

### DIFF
--- a/benchmark/buffers/buffer-compare-instance-method.js
+++ b/benchmark/buffers/buffer-compare-instance-method.js
@@ -4,26 +4,80 @@ const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
   size: [16, 512, 1024, 4096, 16386],
+  args: [1, 2, 3, 4, 5],
   millions: [1]
 });
 
 function main(conf) {
   const iter = (conf.millions >>> 0) * 1e6;
   const size = (conf.size >>> 0);
-  const b0 = new Buffer(size).fill('a');
-  const b1 = new Buffer(size).fill('a');
+  const args = (conf.args >>> 0);
+  const b0 = Buffer.alloc(size, 'a');
+  const b1 = Buffer.alloc(size, 'a');
+  const b0Len = b0.length;
+  const b1Len = b1.length;
+  var i;
 
   b1[size - 1] = 'b'.charCodeAt(0);
 
   // Force optimization before starting the benchmark
-  b0.compare(b1);
+  switch (args) {
+    case 2:
+      b0.compare(b1, 0);
+      break;
+    case 3:
+      b0.compare(b1, 0, b1Len);
+      break;
+    case 4:
+      b0.compare(b1, 0, b1Len, 0);
+      break;
+    case 5:
+      b0.compare(b1, 0, b1Len, 0, b0Len);
+      break;
+    default:
+      b0.compare(b1);
+  }
   v8.setFlagsFromString('--allow_natives_syntax');
   eval('%OptimizeFunctionOnNextCall(b0.compare)');
-  b0.compare(b1);
-
-  bench.start();
-  for (var i = 0; i < iter; i++) {
-    b0.compare(b1);
+  switch (args) {
+    case 2:
+      b0.compare(b1, 0);
+      bench.start();
+      for (i = 0; i < iter; i++) {
+        b0.compare(b1, 0);
+      }
+      bench.end(iter / 1e6);
+      break;
+    case 3:
+      b0.compare(b1, 0, b1Len);
+      bench.start();
+      for (i = 0; i < iter; i++) {
+        b0.compare(b1, 0, b1Len);
+      }
+      bench.end(iter / 1e6);
+      break;
+    case 4:
+      b0.compare(b1, 0, b1Len, 0);
+      bench.start();
+      for (i = 0; i < iter; i++) {
+        b0.compare(b1, 0, b1Len, 0);
+      }
+      bench.end(iter / 1e6);
+      break;
+    case 5:
+      b0.compare(b1, 0, b1Len, 0, b0Len);
+      bench.start();
+      for (i = 0; i < iter; i++) {
+        b0.compare(b1, 0, b1Len, 0, b0Len);
+      }
+      bench.end(iter / 1e6);
+      break;
+    default:
+      b0.compare(b1);
+      bench.start();
+      for (i = 0; i < iter; i++) {
+        b0.compare(b1);
+      }
+      bench.end(iter / 1e6);
   }
-  bench.end(iter / 1e6);
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const binding = process.binding('buffer');
+const { compare: compare_, compareOffset } = binding;
 const { isArrayBuffer, isSharedArrayBuffer, isUint8Array } =
     process.binding('util');
 const bindingObj = {};
@@ -544,39 +545,45 @@ Buffer.prototype.compare = function compare(target,
                                             end,
                                             thisStart,
                                             thisEnd) {
-
   if (!isUint8Array(target))
     throw new TypeError('Argument must be a Buffer or Uint8Array');
+  if (arguments.length === 1)
+    return compare_(this, target);
 
   if (start === undefined)
     start = 0;
+  else if (start < 0)
+    throw new RangeError('out of range index');
+  else
+    start >>>= 0;
+
   if (end === undefined)
     end = target.length;
+  else if (end > target.length)
+    throw new RangeError('out of range index');
+  else
+    end >>>= 0;
+
   if (thisStart === undefined)
     thisStart = 0;
+  else if (thisStart < 0)
+    throw new RangeError('out of range index');
+  else
+    thisStart >>>= 0;
+
   if (thisEnd === undefined)
     thisEnd = this.length;
-
-  if (start < 0 ||
-      end > target.length ||
-      thisStart < 0 ||
-      thisEnd > this.length) {
+  else if (thisEnd > this.length)
     throw new RangeError('out of range index');
-  }
+  else
+    thisEnd >>>= 0;
 
-  if (thisStart >= thisEnd && start >= end)
-    return 0;
   if (thisStart >= thisEnd)
-    return -1;
-  if (start >= end)
+    return (start >= end ? 0 : -1);
+  else if (start >= end)
     return 1;
 
-  start >>>= 0;
-  end >>>= 0;
-  thisStart >>>= 0;
-  thisEnd >>>= 0;
-
-  return binding.compareOffset(this, target, start, thisStart, end, thisEnd);
+  return compareOffset(this, target, start, thisStart, end, thisEnd);
 };
 
 


### PR DESCRIPTION
Here are the results of the changes in this PR, using newly added benchmark parameters:

```
                                                                         improvement confidence      p.value
 buffers/buffer-compare-instance-method.js millions=20 args=1 size=1024      79.64 %        *** 1.708068e-23
 buffers/buffer-compare-instance-method.js millions=20 args=1 size=16       120.23 %        *** 4.789291e-22
 buffers/buffer-compare-instance-method.js millions=20 args=1 size=16386     29.41 %        *** 6.728233e-25
 buffers/buffer-compare-instance-method.js millions=20 args=1 size=4096      38.39 %        *** 4.356356e-22
 buffers/buffer-compare-instance-method.js millions=20 args=1 size=512       95.33 %        *** 2.836086e-27
 buffers/buffer-compare-instance-method.js millions=20 args=2 size=1024      36.68 %        *** 7.725875e-16
 buffers/buffer-compare-instance-method.js millions=20 args=2 size=16        41.81 %        *** 4.501507e-12
 buffers/buffer-compare-instance-method.js millions=20 args=2 size=16386     17.62 %        *** 1.637306e-23
 buffers/buffer-compare-instance-method.js millions=20 args=2 size=4096      24.56 %        *** 1.838687e-16
 buffers/buffer-compare-instance-method.js millions=20 args=2 size=512       36.07 %        *** 1.337825e-12
 buffers/buffer-compare-instance-method.js millions=20 args=3 size=1024      26.15 %        *** 1.077808e-10
 buffers/buffer-compare-instance-method.js millions=20 args=3 size=16        38.97 %        *** 1.267865e-12
 buffers/buffer-compare-instance-method.js millions=20 args=3 size=16386     14.94 %        *** 2.809292e-22
 buffers/buffer-compare-instance-method.js millions=20 args=3 size=4096      21.77 %        *** 7.859591e-12
 buffers/buffer-compare-instance-method.js millions=20 args=3 size=512       35.13 %        *** 1.176360e-14
 buffers/buffer-compare-instance-method.js millions=20 args=4 size=1024      24.45 %        *** 6.181133e-08
 buffers/buffer-compare-instance-method.js millions=20 args=4 size=16        35.20 %        *** 5.202743e-11
 buffers/buffer-compare-instance-method.js millions=20 args=4 size=16386     15.46 %        *** 5.231296e-23
 buffers/buffer-compare-instance-method.js millions=20 args=4 size=4096      19.14 %        *** 1.193200e-09
 buffers/buffer-compare-instance-method.js millions=20 args=4 size=512       32.69 %        *** 1.456810e-14
 buffers/buffer-compare-instance-method.js millions=20 args=5 size=1024      20.11 %        *** 8.825567e-08
 buffers/buffer-compare-instance-method.js millions=20 args=5 size=16        26.04 %        *** 3.350537e-10
 buffers/buffer-compare-instance-method.js millions=20 args=5 size=16386     13.36 %        *** 2.349793e-18
 buffers/buffer-compare-instance-method.js millions=20 args=5 size=4096      19.60 %        *** 8.104786e-12
 buffers/buffer-compare-instance-method.js millions=20 args=5 size=512       22.01 %        *** 1.282699e-08
```

CI: https://ci.nodejs.org/job/node-test-pull-request/5971/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* buffer
