### PR TITLE
build: add tracing/trace_event.h to tarballs

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -152,6 +152,7 @@ def headers(action):
     'src/node_object_wrap.h',
     'src/node_version.h',
   ], 'include/node/')
+  action(['src/tracing/trace_event.h'], 'include/node/tracing/')
 
   # Add the expfile that is created on AIX
   if sys.platform.startswith('aix'):


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
<!-- - [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added -->
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build

Discovered during https://github.com/nodejs/citgm/pull/226#issuecomment-274066280, which was attempting to build a native module (nodereport) against a recent nightly (node-v8.0.0-nightly2017011949902124a9).

Failing CITGM run: https://ci.nodejs.org/job/gibfahn-citgm-smoker-more-platforms/79/
e.g. https://ci.nodejs.org/job/gibfahn-citgm-smoker-more-platforms/MACHINE=ppcbe-ubuntu1404/79/console
```
verbose: using-node          | /home/iojs/build/workspace/gibfahn-citgm-smoker-more-platforms/MACHINE/ppcbe-ubuntu1404/node-v8.0.0-nightly2017011949902124a9-linux-ppc64/bin/node
verbose: using-npm           | /home/iojs/build/workspace/gibfahn-citgm-smoker-more-platforms/MACHINE/ppcbe-ubuntu1404/node-v8.0.0-nightly2017011949902124a9-linux-ppc64/bin/npm
warn: update-available    | v1.10.1 (current: v1.6.1)
warn:                     | npm install -g citgm     
info: npm:                | Downloading project: https://github.com/nodejs/nodereport/archive/v1.0.7.tar.gz
info: npm:                | Project downloaded nodereport-1.0.7.tgz
info: npm:                | install started     
verbose: npm-install:        | > nodereport@1.0.7 install /tmp/102cb0d9-43da-48cd-9cec-e9c40b469a9f/nodereport
verbose:                     | > node-gyp rebuild                                                             
verbose: npm-install:        | make: Entering directory `/tmp/102cb0d9-43da-48cd-9cec-e9c40b469a9f/nodereport/build'
verbose: npm-install:        | CXX(target) Release/obj.target/nodereport/src/node_report.o
warn: npm-install:        | In file included from ../node_modules/nan/nan.h:47:0,                                                                                        
warn:                     | from ../src/node_report.h:4,                                                                                                                 
warn:                     | from ../src/node_report.cc:1:                                                                                                                
warn:                     | /home/iojs/.node-gyp/8.0.0-nightly2017011949902124a9/include/node/node.h:44:33: fatal error: tracing/trace_event.h: No such file or directory
warn:                     | #include "tracing/trace_event.h"                                                                                                             
warn:                     | ^                                                                                                                                            
warn:                     | compilation terminated.                                                                                                                      
warn: npm-install:        | make: *** [Release/obj.target/nodereport/src/node_report.o] Error 1
verbose: npm-install:        | make: Leaving directory `/tmp/102cb0d9-43da-48cd-9cec-e9c40b469a9f/nodereport/build'
warn: npm-install:        | gyp ERR! build error
```

It looks like `node.h` was modifed by #9304 to include `tracing/trace_event.h` but `tracing/trace_event.h` is missing from the tarballs (both the [binary](https://nodejs.org/download/nightly/v8.0.0-nightly2017011949902124a9/node-v8.0.0-nightly2017011949902124a9-linux-ppc64.tar.gz) and [header](https://nodejs.org/download/nightly/v8.0.0-nightly2017011949902124a9/node-v8.0.0-nightly2017011949902124a9-headers.tar.gz) tarballs). 
