### PR TITLE
src: add a missing space in node_os.cc

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -69,7 +69,7 @@ static void GetOSType(const FunctionCallbackInfo<Value>& args) {
   }
   rval = info.sysname;
 #else  // __MINGW32__
-  rval ="Windows_NT";
+  rval = "Windows_NT";
 #endif  // __POSIX__
 
   args.GetReturnValue().Set(OneByteString(env->isolate(), rval));


### PR DESCRIPTION
This PR makes a small stylistic fix adding a missing space in `GetOSType` function in `node_os.cc`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src