### PR TITLE
test,zlib: check string strategies

### DIFF
--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -83,7 +83,12 @@ assert.doesNotThrow(
 );
 
 assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_DEFAULT_STRATEGY}); }
+  () => { new zlib.Deflate({strategy: zlib.constants.Z_DEFAULT_STRATEGY}); }
+);
+
+// Valid strategies are integer values. Accepts equivalent string value too.
+assert.doesNotThrow(
+  () => { new zlib.Deflate({strategy: '' + zlib.constants.Z_RLE}); }
 );
 
 // Throws if opts.strategy is invalid


### PR DESCRIPTION
The Zlib constructor accepts strategy constants that are integers.
Current code will also work with string versions of those integers. Add
test for this situation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib test