### PR TITLE
zlib: be strict about what strategies are accepted

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -277,6 +277,12 @@ function isValidFlushFlag(flag) {
          flag === constants.Z_BLOCK;
 }
 
+const strategies = [constants.Z_FILTERED,
+                    constants.Z_HUFFMAN_ONLY,
+                    constants.Z_RLE,
+                    constants.Z_FIXED,
+                    constants.Z_DEFAULT_STRATEGY];
+
 // the Zlib class they all inherit from
 // This thing manages the queue of requests, and returns
 // true or false if there is anything in the queue when
@@ -326,15 +332,8 @@ function Zlib(opts, mode) {
     }
   }
 
-  if (opts.strategy) {
-    if (opts.strategy != constants.Z_FILTERED &&
-        opts.strategy != constants.Z_HUFFMAN_ONLY &&
-        opts.strategy != constants.Z_RLE &&
-        opts.strategy != constants.Z_FIXED &&
-        opts.strategy != constants.Z_DEFAULT_STRATEGY) {
-      throw new Error('Invalid strategy: ' + opts.strategy);
-    }
-  }
+  if (opts.strategy && !(strategies.includes(opts.strategy)))
+    throw new Error('Invalid strategy: ' + opts.strategy);
 
   if (opts.dictionary) {
     if (!(opts.dictionary instanceof Buffer)) {
@@ -378,7 +377,7 @@ function Zlib(opts, mode) {
   this.once('end', this.close);
 
   Object.defineProperty(this, '_closed', {
-    get: () => { return !this._handle; },
+    get: () => !this._handle,
     configurable: true,
     enumerable: true
   });
@@ -391,13 +390,8 @@ Zlib.prototype.params = function(level, strategy, callback) {
       level > constants.Z_MAX_LEVEL) {
     throw new RangeError('Invalid compression level: ' + level);
   }
-  if (strategy != constants.Z_FILTERED &&
-      strategy != constants.Z_HUFFMAN_ONLY &&
-      strategy != constants.Z_RLE &&
-      strategy != constants.Z_FIXED &&
-      strategy != constants.Z_DEFAULT_STRATEGY) {
+  if (!(strategies.includes(strategy)))
     throw new TypeError('Invalid strategy: ' + strategy);
-  }
 
   if (this._level !== level || this._strategy !== strategy) {
     var self = this;

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -86,6 +86,12 @@ assert.doesNotThrow(
   () => { new zlib.Deflate({ strategy: zlib.constants.Z_DEFAULT_STRATEGY}); }
 );
 
+// Throws if opt.strategy is the wrong type.
+assert.throws(
+  () => { new zlib.Deflate({strategy: '' + zlib.constants.Z_RLE }); },
+  /^Error: Invalid strategy: 3$/
+);
+
 // Throws if opts.strategy is invalid
 assert.throws(
   () => { new zlib.Deflate({strategy: 'this is a bogus strategy'}); },


### PR DESCRIPTION
Currently, strategy constants are integers but Node.js will accept
string versions of those integers. Users should be using the provided
zlib constants and not hardcoding numbers, strings, or anything else. As
such, Node.js should be strict about accepting only exactly those values
that are in the provided zlib constants.

Fixes: https://github.com/nodejs/node/issues/10932

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib