### PR TITLE
src: remove unnecessary req_wrap_obj

### DIFF
--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -99,11 +99,10 @@ void ConnectionWrap<WrapType, UVType>::AfterConnect(uv_connect_t* req,
     writable = uv_is_writable(req->handle) != 0;
   }
 
-  Local<Object> req_wrap_obj = req_wrap->object();
   Local<Value> argv[5] = {
     Integer::New(env->isolate(), status),
     wrap->object(),
-    req_wrap_obj,
+    req_wrap->object(),
     Boolean::New(env->isolate(), readable),
     Boolean::New(env->isolate(), writable)
   };


### PR DESCRIPTION
The req_wrap_obj is only used in one place which is setting up the
arguments for the MakeCallback call. Removing it to simplify the code
somewhat.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src