### PR TITLE
doc: update output examples in debugger.md

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -11,10 +11,10 @@ will be displayed indicating successful launch of the debugger:
 
 ```txt
 $ node debug myscript.js
-< debugger listening on port 5858
-connecting... ok
+< Debugger listening on 127.0.0.1:5858
+connecting to 127.0.0.1:5858 ... ok
 break in /home/indutny/Code/git/indutny/myscript.js:1
-  1 x = 5;
+> 1 global.x = 5;
   2 setTimeout(() => {
   3   debugger;
 debug>
@@ -28,7 +28,7 @@ enable a breakpoint at that position in the code:
 
 ```js
 // myscript.js
-x = 5;
+global.x = 5;
 setTimeout(() => {
   debugger;
   console.log('world');
@@ -40,25 +40,25 @@ Once the debugger is run, a breakpoint will occur at line 4:
 
 ```txt
 $ node debug myscript.js
-< debugger listening on port 5858
-connecting... ok
+< Debugger listening on 127.0.0.1:5858
+connecting to 127.0.0.1:5858 ... ok
 break in /home/indutny/Code/git/indutny/myscript.js:1
-  1 x = 5;
+> 1 global.x = 5;
   2 setTimeout(() => {
   3   debugger;
 debug> cont
 < hello
 break in /home/indutny/Code/git/indutny/myscript.js:3
-  1 x = 5;
+  1 global.x = 5;
   2 setTimeout(() => {
-  3   debugger;
+> 3   debugger;
   4   console.log('world');
   5 }, 1000);
 debug> next
 break in /home/indutny/Code/git/indutny/myscript.js:4
   2 setTimeout(() => {
   3   debugger;
-  4   console.log('world');
+> 4   console.log('world');
   5 }, 1000);
   6 console.log('hello');
 debug> repl
@@ -68,11 +68,11 @@ Press Ctrl + C to leave debug repl
 > 2+2
 4
 debug> next
-< world
 break in /home/indutny/Code/git/indutny/myscript.js:5
+< world
   3   debugger;
   4   console.log('world');
-  5 }, 1000);
+> 5 }, 1000);
   6 console.log('hello');
   7
 debug> quit
@@ -121,24 +121,26 @@ isn't loaded yet:
 
 ```txt
 $ node debug test/fixtures/break-in-module/main.js
-< debugger listening on port 5858
-connecting to port 5858... ok
+< Debugger listening on 127.0.0.1:5858
+connecting to 127.0.0.1:5858 ... ok
 break in test/fixtures/break-in-module/main.js:1
-  1 var mod = require('./mod.js');
+> 1 const mod = require('./mod.js');
   2 mod.hello();
   3 mod.hello();
-debug> setBreakpoint('mod.js', 23)
+debug> setBreakpoint('mod.js', 2)
 Warning: script 'mod.js' was not loaded yet.
-  1 var mod = require('./mod.js');
+> 1 const mod = require('./mod.js');
   2 mod.hello();
   3 mod.hello();
+  4 debugger;
+  5
+  6 });
 debug> c
-break in test/fixtures/break-in-module/mod.js:23
- 21
- 22 exports.hello = () => {
- 23   return 'hello from module';
- 24 };
- 25
+break in test/fixtures/break-in-module/mod.js:2
+  1 exports.hello = function() {
+> 2   return 'hello from module';
+  3 };
+  4
 debug>
 ```
 
@@ -203,8 +205,12 @@ $ node --inspect index.js
 Debugger listening on port 9229.
 Warning: This is an experimental feature and could change at any time.
 To start debugging, open the following URL in Chrome:
-    chrome-devtools://devtools/remote/serve_file/@60cd6e859b9f557d2312f5bf532f6aec5f284980/inspector.html?experiments=true&v8only=true&ws=localhost:9229/node
+    chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
 ```
+
+(In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
+at the end of the URL is generated on the fly, it varies in different
+debugging sessions)
 
 [Chrome Debugging Protocol]: https://chromedevtools.github.io/debugger-protocol-viewer/
 [TCP-based protocol]: #debugger_tcp_based_protocol


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc, debugger

* Update examples according to new debugger output (info added, lines reordered).
* Replace `x = 5;` by explicit `global.x = 5;` to stress the intent to create a global variable (needed for access from debug REPL).
* Add break marks (`>`) in output according to real output.
* Update also the Inspector example.

Some updates are done due to previous changes in `test/fixtures/break-in-module/main.js` and `test/fixtures/break-in-module/mod.js` files.