### PR TITLE
test: add TupleOrigin's test for url

### DIFF
--- a/test/parallel/test-url-tuple-origin.js
+++ b/test/parallel/test-url-tuple-origin.js
@@ -1,0 +1,17 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const url = require('url');
+
+// verify via originFor
+const originFor = url.originFor;
+const exampleURL = 'https://example.com';
+
+assert.strictEqual(originFor(exampleURL).scheme, 'https');
+assert.strictEqual(originFor(exampleURL).host, 'example.com');
+assert.strictEqual(originFor(exampleURL).port, undefined);
+assert.strictEqual(originFor(`${exampleURL}:1234`).port, 1234);
+assert.strictEqual(originFor(exampleURL).domain, null);
+assert.strictEqual(originFor(exampleURL).effectiveDomain, 'example.com');
+assert.strictEqual(originFor(exampleURL).toString(), exampleURL);
+assert.strictEqual(originFor(exampleURL).toString(false), exampleURL);


### PR DESCRIPTION
Increase coverage for TupleOrigin of url.

TupleOrigin: https://github.com/nodejs/node/blob/master/lib/internal/url.js#L42
Coverage: https://coverage.nodejs.org/coverage-ba776b3a56642d4c/root/internal/url.js.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test