### PR TITLE
doc: add links to alternative versions of doc

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -2,7 +2,7 @@
 
 <!--introduced_in=v0.10.0-->
 
-Node.js Addons are dynamically-linked shared objects, written in C or C++, that
+Node.js Addons are dynamically-linked shared objects, written in C++, that
 can be loaded into Node.js using the [`require()`][require] function, and used
 just as if they were an ordinary Node.js module. They are used primarily to
 provide an interface between JavaScript running in Node.js and C/C++ libraries.

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1,6 +1,6 @@
 # C++ Addons
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 Node.js Addons are dynamically-linked shared objects, written in C or C++, that
 can be loaded into Node.js using the [`require()`][require] function, and used

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1,6 +1,8 @@
 # C++ Addons
 
-Node.js Addons are dynamically-linked shared objects, written in C++, that
+<!--doc_created=v0.10.0-->
+
+Node.js Addons are dynamically-linked shared objects, written in C or C++, that
 can be loaded into Node.js using the [`require()`][require] function, and used
 just as if they were an ordinary Node.js module. They are used primarily to
 provide an interface between JavaScript running in Node.js and C/C++ libraries.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1,5 +1,7 @@
 # Assert
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `assert` module provides a simple set of assertion tests that can be used to

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1,6 +1,6 @@
 # Assert
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,6 +1,6 @@
 # Buffer
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,5 +1,7 @@
 # Buffer
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 Prior to the introduction of [`TypedArray`] in ECMAScript 2015 (ES6), the

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1,6 +1,6 @@
 # Child Process
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1,5 +1,7 @@
 # Child Process
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `child_process` module provides the ability to spawn child processes in

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1,6 +1,6 @@
 # Command Line Options
 
-<!--doc_created=v5.9.1-->
+<!--introduced_in=v5.9.1-->
 <!--type=misc-->
 
 Node.js comes with a variety of CLI options. These options expose built-in

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1,5 +1,6 @@
 # Command Line Options
 
+<!--doc_created=v5.9.1-->
 <!--type=misc-->
 
 Node.js comes with a variety of CLI options. These options expose built-in

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -1,6 +1,6 @@
 # Cluster
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -1,5 +1,7 @@
 # Cluster
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 A single instance of Node.js runs in a single thread. To take advantage of

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -1,6 +1,6 @@
 # Console
 
-<!--doc_created=v0.10.13-->
+<!--introduced_in=v0.10.13-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -1,5 +1,7 @@
 # Console
 
+<!--doc_created=v0.10.13-->
+
 > Stability: 2 - Stable
 
 The `console` module provides a simple debugging console that is similar to the

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1,6 +1,6 @@
 # Crypto
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1,5 +1,7 @@
 # Crypto
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `crypto` module provides cryptographic functionality that includes a set of

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1,6 +1,6 @@
 # Crypto
 
-<!--introduced_in=v0.10.0-->
+<!--introduced_in=v0.3.6-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -1,5 +1,7 @@
 # Debugger
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!-- type=misc -->

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -1,6 +1,6 @@
 # Debugger
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -1,6 +1,6 @@
 # Debugger
 
-<!--introduced_in=v0.10.0-->
+<!--introduced_in=v0.9.12-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -1,5 +1,7 @@
 # UDP / Datagram Sockets
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!-- name=dgram -->

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -1,6 +1,6 @@
 # UDP / Datagram Sockets
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -1,5 +1,7 @@
 # DNS
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `dns` module contains functions belonging to two different categories:

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -1,6 +1,6 @@
 # DNS
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -1,6 +1,6 @@
 # About this Documentation
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 <!-- type=misc -->
 
 The goal of this documentation is to comprehensively explain the Node.js

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -1,5 +1,6 @@
 # About this Documentation
 
+<!--doc_created=v0.10.0-->
 <!-- type=misc -->
 
 The goal of this documentation is to comprehensively explain the Node.js

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -7,6 +7,8 @@ changes:
                  the first promise of a chain was created.
 -->
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 0 - Deprecated
 
 **This module is pending deprecation**. Once a replacement API has been

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -7,7 +7,7 @@ changes:
                  the first promise of a chain was created.
 -->
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 0 - Deprecated
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1,5 +1,6 @@
 # Errors
 
+<!--doc_created=v4.0.0-->
 <!--type=misc-->
 
 Applications running in Node.js will generally experience four categories of

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1,6 +1,6 @@
 # Errors
 
-<!--doc_created=v4.0.0-->
+<!--introduced_in=v4.0.0-->
 <!--type=misc-->
 
 Applications running in Node.js will generally experience four categories of

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1,6 +1,6 @@
 # Events
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1,5 +1,7 @@
 # Events
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--type=module-->

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1,6 +1,6 @@
 # File System
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1,5 +1,7 @@
 # File System
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=fs-->

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1,5 +1,6 @@
 # Global Objects
 
+<!--doc_created=v0.10.0-->
 <!-- type=misc -->
 
 These objects are available in all modules. The following variables may appear

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1,6 +1,6 @@
 # Global Objects
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 <!-- type=misc -->
 
 These objects are available in all modules. The following variables may appear

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1,5 +1,7 @@
 # HTTP
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 To use the HTTP server and client one must `require('http')`.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1,6 +1,6 @@
 # HTTP
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -1,5 +1,7 @@
 # HTTPS
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -1,6 +1,6 @@
 # HTTPS
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -1,6 +1,6 @@
 # Modules
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -1,5 +1,7 @@
 # Modules
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=module-->

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1,5 +1,7 @@
 # Net
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `net` module provides an asynchronous network API for creating stream-based

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1,6 +1,6 @@
 # Net
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -1,6 +1,6 @@
 # OS
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -1,5 +1,7 @@
 # OS
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `os` module provides a number of operating system-related utility methods.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -1,6 +1,6 @@
 # Path
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -1,5 +1,7 @@
 # Path
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `path` module provides utilities for working with file and directory paths.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1,6 +1,6 @@
 # Process
 
-<!-- doc_created=v0.10.0 -->
+<!-- introduced_in=v0.10.0 -->
 <!-- type=global -->
 
 The `process` object is a `global` that provides information about, and control

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1,5 +1,6 @@
 # Process
 
+<!-- doc_created=v0.10.0 -->
 <!-- type=global -->
 
 The `process` object is a `global` that provides information about, and control

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -6,6 +6,8 @@ changes:
     description: Accessing this module will now emit a deprecation warning.
 -->
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 0 - Deprecated
 
 **The version of the punycode module bundled in Node.js is being deprecated**.

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -6,7 +6,7 @@ changes:
     description: Accessing this module will now emit a deprecation warning.
 -->
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 0 - Deprecated
 

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -1,6 +1,6 @@
 # Query String
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -1,5 +1,7 @@
 # Query String
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=querystring-->

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -1,5 +1,7 @@
 # Readline
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `readline` module provides an interface for reading data from a [Readable][]

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -1,6 +1,6 @@
 # Readline
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -1,5 +1,7 @@
 # REPL
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `repl` module provides a Read-Eval-Print-Loop (REPL) implementation that

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -1,6 +1,6 @@
 # REPL
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1,6 +1,6 @@
 # Stream
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1,5 +1,7 @@
 # Stream
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 A stream is an abstract interface for working with streaming data in Node.js.

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -1,6 +1,6 @@
 # String Decoder
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -1,5 +1,7 @@
 # String Decoder
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `string_decoder` module provides an API for decoding `Buffer` objects into

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -1,5 +1,6 @@
 # Usage
 
+<!--doc_created=v0.10.0-->
 <!--type=misc-->
 
 `node [options] [v8 options] [script.js | -e "script" | - ] [arguments]`

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -1,6 +1,6 @@
 # Usage
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 <!--type=misc-->
 
 `node [options] [v8 options] [script.js | -e "script" | - ] [arguments]`

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -1,5 +1,7 @@
 # Timers
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `timer` module exposes a global API for scheduling functions to

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -1,6 +1,6 @@
 # Timers
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1,5 +1,7 @@
 # TLS (SSL)
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `tls` module provides an implementation of the Transport Layer Security

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1,6 +1,6 @@
 # TLS (SSL)
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -1,6 +1,6 @@
 # TTY
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -1,5 +1,7 @@
 # TTY
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `tty` module provides the `tty.ReadStream` and `tty.WriteStream` classes.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1,6 +1,6 @@
 # URL
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1,5 +1,7 @@
 # URL
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `url` module provides utilities for URL resolution and parsing. It can be

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1,6 +1,6 @@
 # Util
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1,5 +1,7 @@
 # Util
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `util` module is primarily designed to support the needs of Node.js' own

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1,6 +1,6 @@
 # V8
 
-<!--doc_created=v4.0.0-->
+<!--introduced_in=v4.0.0-->
 
 The `v8` module exposes APIs that are specific to the version of [V8][]
 built into the Node.js binary. It can be accessed using:

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1,5 +1,7 @@
 # V8
 
+<!--doc_created=v4.0.0-->
+
 The `v8` module exposes APIs that are specific to the version of [V8][]
 built into the Node.js binary. It can be accessed using:
 

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -1,6 +1,6 @@
 # VM (Executing JavaScript)
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -1,5 +1,7 @@
 # VM (Executing JavaScript)
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=vm-->

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -1,6 +1,6 @@
 # Zlib
 
-<!--doc_created=v0.10.0-->
+<!--introduced_in=v0.10.0-->
 
 > Stability: 2 - Stable
 

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -1,5 +1,7 @@
 # Zlib
 
+<!--doc_created=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `zlib` module provides compression functionality implemented using Gzip and

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -561,6 +561,9 @@ th > *:last-child, td > *:last-child {
   #content {
     font-size: 3.5em;
   }
+  #gtoc {
+    font-size: 0.6em;
+  }
 }
 
 @media print {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -81,28 +81,61 @@ em code {
 
 #gtoc {
   font-size: .8em;
+  margin-bottom: 1em;
 }
 
-#alt-docs {
-  color: #666;
-  font-size: .75em;
+#gtoc ul {
+  list-style: none;
+  margin-left: 0;
 }
 
-#alt-docs a {
-  color: #666;
+#gtoc li {
+  display: inline;
 }
 
-#alt-docs a:hover {
-  background: none;
-  text-decoration: underline;
+li.version-picker {
+  position: relative;
 }
 
-#alt-docs a:active, #alt-docs a:link {
-  background: none;
+li.version-picker:hover > ol {
+  display: block;
 }
 
-#alt-docs b {
-  margin-left: .5em;
+li.version-picker a span {
+  font-size: .7em;
+}
+
+ol.version-picker {
+  background: #fff;
+  border: 1px #43853d solid;
+  border-radius: 2px;
+  display: none;
+  list-style: none;
+  position: absolute;
+  right: -2px;
+  width: 101%;
+}
+
+#gtoc ol.version-picker li {
+  display: block;
+}
+
+ol.version-picker li a {
+  border-radius: 0;
+  display: block;
+  margin: 0;
+  padding: .1em;
+  padding-left: 1em;
+}
+
+ol.version-picker li:first-child a {
+  border-top-right-radius: 1px;
+  border-top-left-radius: 1px;
+}
+
+ol.version-picker li:last-child a {
+  border-bottom-right-radius: 1px;
+  border-bottom-left-radius: 1px;
 }
 
 .line {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -97,7 +97,7 @@ em code {
   text-decoration: underline;
 }
 
-#alt-docs a:active {
+#alt-docs a:active, #alt-docs a:link {
   background: none;
 }
 

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -83,6 +83,28 @@ em code {
   font-size: .8em;
 }
 
+#alt-docs {
+  color: #666;
+  font-size: .75em;
+}
+
+#alt-docs a {
+  color: #666;
+}
+
+#alt-docs a:hover {
+  background: none;
+  text-decoration: underline;
+}
+
+#alt-docs a:active {
+  background: none;
+}
+
+#alt-docs b {
+  margin-left: .5em;
+}
+
 .line {
   width: calc(100% - 1em);
   display: block;

--- a/doc/template.html
+++ b/doc/template.html
@@ -23,14 +23,23 @@
       <header>
         <h1>Node.js __VERSION__ Documentation</h1>
         <div id="gtoc">
-          <p>
-            <a href="index.html" name="toc">Index</a> |
-            <a href="all.html">View on single page</a> |
-            <a href="__FILENAME__.json">View as JSON</a>
-          </p>
+          <ul>
+            <li>
+              <a href="index.html" name="toc">Index</a> |
+            </li>
+            <li>
+              <a href="all.html">View on single page</a> |
+            </li>
+            <li>
+              <a href="__FILENAME__.json">View as JSON</a> |
+            </li>
+            <li class="version-picker">
+              <a href="#">View another version <span>&#x25bc</span></a>
+              __ALTDOCS__
+            </li>
+          </ul>
         </div>
         <hr>
-        <div id="alt-docs">__ALTDOCS__</div>
       </header>
 
       <div id="toc">

--- a/doc/template.html
+++ b/doc/template.html
@@ -34,7 +34,7 @@
               <a href="__FILENAME__.json">View as JSON</a> |
             </li>
             <li class="version-picker">
-              <a href="#">View another version <span>&#x25bc</span></a>
+              <a href="#">View another version <span>&#x25bc;</span></a>
               __ALTDOCS__
             </li>
           </ul>

--- a/doc/template.html
+++ b/doc/template.html
@@ -30,6 +30,7 @@
           </p>
         </div>
         <hr>
+        <div id="alt-docs">__ALTDOCS__</div>
       </header>
 
       <div id="toc">

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -31,7 +31,7 @@ const typeParser = require('./type-parser.js');
 module.exports = toHTML;
 
 const STABILITY_TEXT_REG_EXP = /(.*:)\s*(\d)([\s\S]*)/;
-const DOC_CREATED_REG_EXP = /<!--introduced_in=v([0-9]+).([0-9]+).([0-9]+)-->/;
+const DOC_CREATED_REG_EXP = /<!--introduced_in( )?=( )?v([0-9]+)\.([0-9]+)\.([0-9]+)-->/;
 
 // customized heading without id attribute
 const renderer = new marked.Renderer();
@@ -199,16 +199,17 @@ function altDocs(filename) {
   let html = '';
 
   if (!docCreated) {
-    console.error('Failed to add alternative version links');
+    console.error(`Failed to add alternative version links to ${filename}`);
     return html;
   }
 
   function lte(v) {
-    if (docCreated[1] > v.num[0])
+    const ns = v.num.split('.');
+    if (docCreated[1] > +ns[0])
       return false;
-    if (docCreated[1] < v.num[0])
+    if (docCreated[1] < +ns[0])
       return true;
-    return docCreated[2] <= v.num.substr(2, 2);
+    return docCreated[2] <= +ns[1];
   }
 
   const versions = [

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -31,7 +31,7 @@ const typeParser = require('./type-parser.js');
 module.exports = toHTML;
 
 const STABILITY_TEXT_REG_EXP = /(.*:)\s*(\d)([\s\S]*)/;
-const DOC_CREATED_REG_EXP = /<!--introduced_in( )?=( )?v([0-9]+)\.([0-9]+)\.([0-9]+)-->/;
+const DOC_CREATED_REG_EXP = /<!--\s*introduced_in\s*=\s*v([0-9]+)\.([0-9]+)\.([0-9]+)\s*-->/;
 
 // customized heading without id attribute
 const renderer = new marked.Renderer();
@@ -219,7 +219,7 @@ function altDocs(filename) {
     { num: '5.x' },
     { num: '4.x', lts: true },
     { num: '0.12.x' },
-    { num: '0.10.x' },
+    { num: '0.10.x' }
   ];
 
   const host = 'https://nodejs.org';

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -215,7 +215,7 @@ function altDocs(filename) {
   const a = (v) => `<a href="${href(v)}">v${v}</a>`;
   const as = (vs) => vs.filter(lte).map(a).join(' / ');
 
-  html += '<b>Current:</b> ' + a('7.x');
+  html += 'View another version of this page <b>Current:</b> ' + a('7.x');
 
   const lts = as(['4.x', '6.x']);
   if (lts.length)
@@ -224,9 +224,6 @@ function altDocs(filename) {
   const unsupported = as(['0.10.x', '0.12.x', '5.x']);
   if (unsupported.length)
     html += ' <b>Unsupported:</b> ' + unsupported;
-
-  if (html.length)
-    html = 'View another version of this page ' + html;
 
   return html;
 }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -215,13 +215,15 @@ function altDocs(filename) {
   const a = (v) => `<a href="${href(v)}">v${v}</a>`;
   const as = (vs) => vs.filter(lte).map(a).join(' / ');
 
-  const lts = as(['0.12.x', '4.x', '6.x']);
-  if (lts.length)
-    html += '<b>LTS:</b> ' + lts;
+  html += '<b>Current:</b> ' + a('7.x');
 
-  const unsupported = as(['0.10.x', '5.x', '7.x']);
+  const lts = as(['4.x', '6.x']);
+  if (lts.length)
+    html += ' <b>LTS:</b> ' + lts;
+
+  const unsupported = as(['0.10.x', '0.12.x', '5.x']);
   if (unsupported.length)
-    html += '<b>Unsupported:</b> ' + unsupported;
+    html += ' <b>Unsupported:</b> ' + unsupported;
 
   if (html.length)
     html = 'View another version of this page ' + html;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -31,7 +31,7 @@ const typeParser = require('./type-parser.js');
 module.exports = toHTML;
 
 const STABILITY_TEXT_REG_EXP = /(.*:)\s*(\d)([\s\S]*)/;
-const DOC_CREATED_REG_EXP = /<!--doc_created=v([0-9]+).([0-9]+).([0-9]+)-->/;
+const DOC_CREATED_REG_EXP = /<!--introduced_in=v([0-9]+).([0-9]+).([0-9]+)-->/;
 
 // customized heading without id attribute
 const renderer = new marked.Renderer();

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -215,13 +215,13 @@ function altDocs(filename) {
   const a = (v) => `<a href="${href(v)}">v${v}</a>`;
   const as = (vs) => vs.filter(lte).map(a).join(' / ');
 
-  html += 'View another version of this page <b>Latest:</b> ' + a('7.x');
+  html += 'View another version of this page <b>Latest:</b> ' + a('8.x');
 
-  const lts = as(['4.x', '6.x']);
+  const lts = as(['6.x', '4.x']);
   if (lts.length)
     html += ' <b>LTS:</b> ' + lts;
 
-  const unsupported = as(['0.10.x', '0.12.x', '5.x']);
+  const unsupported = as(['7.x', '5.x', '0.12.x', '0.10.x']);
   if (unsupported.length)
     html += ' <b>Unsupported:</b> ' + unsupported;
 

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -215,7 +215,7 @@ function altDocs(filename) {
   const a = (v) => `<a href="${href(v)}">v${v}</a>`;
   const as = (vs) => vs.filter(lte).map(a).join(' / ');
 
-  html += 'View another version of this page <b>Current:</b> ' + a('7.x');
+  html += 'View another version of this page <b>Latest:</b> ' + a('7.x');
 
   const lts = as(['4.x', '6.x']);
   if (lts.length)


### PR DESCRIPTION
Each page of the api documentation should have links to other versions
of the same page. This will make it easier to switch between the current
"live" release at nodejs.org and LTS versions.

Fixes: https://github.com/nodejs/node/issues/10726

<img width="1002" alt="screen shot 2017-05-09 at 3 24 36 pm" src="https://cloud.githubusercontent.com/assets/6627780/25875319/ad61bcbe-34cb-11e7-8bf6-ccd8110af2d9.png">

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, tools
