### PR TITLE
src: move trace_event.h include to internal header

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -41,7 +41,6 @@
 
 #include "v8.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
-#include "tracing/trace_event.h"
 
 #define NODE_MAKE_VERSION(major, minor, patch)                                \
   ((major) * 0x1000 + (minor) * 0x100 + (patch))

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -8,6 +8,7 @@
 #include "util-inl.h"
 #include "uv.h"
 #include "v8.h"
+#include "tracing/trace_event.h"
 
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
Move the include from src/node.h to src/node_internals.h.

trace_event.h is not shipped in binary-only and headers-only tarballs,
making it currently impossible to build add-ons against them.

cc @richardlau @matthewloring 

CI: https://ci.nodejs.org/job/node-test-pull-request/5990/