### PR TITLE
test: increase coverage for stream's duplex

### DIFF
--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -5,27 +5,28 @@ const Duplex = require('stream').Transform;
 
 const stream = new Duplex({ objectMode: true });
 
+assert(Duplex() instanceof Duplex);
 assert(stream._readableState.objectMode);
 assert(stream._writableState.objectMode);
 
 let written;
 let read;
 
-stream._write = function(obj, _, cb) {
+stream._write = (obj, _, cb) => {
   written = obj;
   cb();
 };
 
-stream._read = function() {};
+stream._read = () => {};
 
-stream.on('data', function(obj) {
+stream.on('data', (obj) => {
   read = obj;
 });
 
 stream.push({ val: 1 });
 stream.end({ val: 2 });
 
-process.on('exit', function() {
+process.on('exit', () => {
   assert.strictEqual(read.val, 1);
   assert.strictEqual(written.val, 2);
 });


### PR DESCRIPTION
Make use of Arrow function.
Add a small test and this file's coverage is 100%.
https://github.com/nodejs/node/blob/a647d82f83ad5ddad5db7be2cc24c3d686121792/lib/_stream_duplex.js#L25
Coverage: https://coverage.nodejs.org/coverage-067be658f966dafe/root/_stream_duplex.js.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test