### PR TITLE
lib: deprecate node --debug at runtime

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -511,6 +511,15 @@ Type: Documentation-only
 The `fs.SyncWriteStream` class was never intended to be a publicly accessible
 API.
 
+<a id="DEP0062"></a>
+### DEP0062: node --debug
+
+Type: Runtime
+
+`--debug` activates the legacy V8 debugger interface, which has been removed as
+of V8 5.8. It is replaced by Inspector which is activated with `--inspect`
+instead.
+
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -1,5 +1,10 @@
 'use strict';
 
+process.emitWarning(
+  'node --debug is deprecated. Please use node --inspect instead.',
+  'DeprecationWarning',
+  'DEP0062');
+
 const assert = require('assert');
 const net = require('net');
 const util = require('util');

--- a/test/parallel/test-debug-port-from-cmdline.js
+++ b/test/parallel/test-debug-port-from-cmdline.js
@@ -2,11 +2,18 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const os = require('os');
 
 const debugPort = common.PORT;
 const args = ['--interactive', '--debug-port=' + debugPort];
 const childOptions = { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] };
 const child = spawn(process.execPath, args, childOptions);
+
+const reDeprecationWarning = new RegExp(
+  /^\(node:\d+\) \[DEP0062\] DeprecationWarning: /.source +
+  /node --debug is deprecated. /.source +
+  /Please use node --inspect instead.$/.source
+);
 
 child.stdin.write("process.send({ msg: 'childready' });\n");
 
@@ -37,12 +44,20 @@ function processStderrLine(line) {
 }
 
 function assertOutputLines() {
-  const expectedLines = [
-    'Starting debugger agent.',
-    'Debugger listening on 127.0.0.1:' + debugPort,
+  // need a var so can swap the first two lines in following
+  // eslint-disable-next-line no-var
+  var expectedLines = [
+    /^Starting debugger agent.$/,
+    reDeprecationWarning,
+    new RegExp(`^Debugger listening on 127.0.0.1:${debugPort}$`)
   ];
+
+  if (os.platform() === 'win32') {
+    expectedLines[1] = expectedLines[0];
+    expectedLines[0] = reDeprecationWarning;
+  }
 
   assert.strictEqual(outputLines.length, expectedLines.length);
   for (let i = 0; i < expectedLines.length; i++)
-    assert(expectedLines[i].includes(outputLines[i]));
+    assert(expectedLines[i].test(outputLines[i]));
 }

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -8,7 +8,8 @@ const path = require('path');
 
 const port = common.PORT;
 const serverPath = path.join(common.fixturesDir, 'clustered-server', 'app.js');
-const args = [`--debug-port=${port}`, serverPath];
+// cannot use 'Flags: --no-deprecation' since it doesn't effect child
+const args = [`--debug-port=${port}`, '--no-deprecation', serverPath];
 const options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };
 const child = spawn(process.execPath, args, options);
 


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

lib, debug

---

This PR is a runtime deprecation for `node --debug`; it replaces https://github.com/nodejs/node/pull/10276. A docs deprecation landed previously at https://github.com/nodejs/node/pull/10320.

The @nodejs/diagnostics WG discussed in our [most recent meeting](https://github.com/nodejs/diagnostics/pull/80) whether to land a runtime deprecation in 7.x or 8.x and tentatively concluded that this depends on the version of V8 shipped with Node@8, see #9789 and #10117. That is, if Node@8 ships with V8 5.7 and thus the legacy Debugger remains available, we may be able to delay landing the runtime deprecation till 8.x as well.

But if Node@8 will ship with V8 5.8 and thus no legacy Debugger, we should include this deprecation in the next 7.x release. Even though we don't typically allow deprecations in the middle of a major, this would be an exception since it needs to be included before 8.x.

It was also raised that even if Node@8 will ship with V8 5.7 and the legacy Debugger, Node's policy is to deprecate for *two* major versions before removing a feature, so perhaps even in this case we should land the runtime deprecation already in a 7.x release.

@jasnell: Per https://github.com/nodejs/node/pull/10116, I'm reserving `DEP0062` for this deprecation, and will note in that thread too.

/cc @ofrobots 