### PR TITLE
test: expand test coverage of fs.js

### DIFF
--- a/test/parallel/test-fs-truncate-sync.js
+++ b/test/parallel/test-fs-truncate-sync.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const tmp = common.tmpDir;
+
+common.refreshTmpDir();
+
+const filename = path.resolve(tmp, 'truncate-sync-file.txt');
+
+fs.writeFileSync(filename, 'hello world', 'utf8');
+
+const fd = fs.openSync(filename, 'r+');
+
+fs.truncateSync(fd, 5);
+assert(fs.readFileSync(fd).equals(Buffer.from('hello')));

--- a/test/parallel/test-fs-truncate-sync.js
+++ b/test/parallel/test-fs-truncate-sync.js
@@ -15,3 +15,6 @@ const fd = fs.openSync(filename, 'r+');
 
 fs.truncateSync(fd, 5);
 assert(fs.readFileSync(fd).equals(Buffer.from('hello')));
+
+fs.closeSync(fd);
+fs.unlinkSync(filename);

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -146,3 +146,14 @@ function testFtruncate(cb) {
     assert(fs.readFileSync(file4).equals(Buffer.from('Hi\u0000\u0000')));
   }));
 }
+
+{
+  const file5 = path.resolve(tmp, 'truncate-file-5.txt');
+  fs.writeFileSync(file5, 'Hi');
+  const fd = fs.openSync(file5, 'r+');
+  process.on('exit', () => fs.closeSync(fd));
+  fs.ftruncate(fd, undefined, common.mustCall(function(err) {
+    assert.ifError(err);
+    assert(fs.readFileSync(file5).equals(Buffer.from('')));
+  }));
+}


### PR DESCRIPTION
* test calling truncateSync() passing a file descriptor
* test calling truncate() passing undefined as the 2nd argument

Refs: https://coverage.nodejs.org/coverage-8ab561b2432bdae3/root/fs.js.html (line 673 and 692)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test