### PR TITLE
lib: validate argument for punycode.encode and decode

### DIFF
--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -194,6 +194,9 @@ const adapt = function(delta, numPoints, firstTime) {
  * @returns {String} The resulting string of Unicode symbols.
  */
 const decode = function(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('Argument must be a string');
+  }
 	// Don't use UCS-2.
 	const output = [];
 	const inputLength = input.length;
@@ -285,6 +288,9 @@ const decode = function(input) {
  * @returns {String} The resulting Punycode string of ASCII-only symbols.
  */
 const encode = function(input) {
+  if (input === undefined || input === null) {
+    throw new TypeError('Argument must not be "undefined" and "null"');
+  }
 	const output = [];
 
 	// Convert the input in UCS-2 to an array of Unicode code points.

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -13,6 +13,12 @@ assert.strictEqual(
   'Willst du die Blthe des frhen, die Frchte des spteren Jahres-x9e96lkal'
 );
 assert.strictEqual(punycode.encode('日本語'), 'wgv71a119e');
+assert.throws(() => {
+  punycode.encode();
+}, /^TypeError: Argument must not be "undefined" and "null"$/);
+assert.throws(() => {
+  punycode.encode(null);
+}, /^TypeError: Argument must not be "undefined" and "null"$/);
 
 assert.strictEqual(punycode.decode('tda'), 'ü');
 assert.strictEqual(punycode.decode('Goethe-'), 'Goethe');
@@ -25,14 +31,20 @@ assert.strictEqual(
 );
 assert.strictEqual(punycode.decode('wgv71a119e'), '日本語');
 assert.throws(() => {
-  punycode.decode(' ');
-}, /^RangeError: Invalid input$/);
+  punycode.decode();
+}, /^TypeError: Argument must be a string$/);
+assert.throws(() => {
+  punycode.decode([]);
+}, /^TypeError: Argument must be a string$/);
 assert.throws(() => {
   punycode.decode('α-');
 }, /^RangeError: Illegal input >= 0x80 \(not a basic code point\)$/);
 assert.throws(() => {
   punycode.decode('あ');
 }, /^RangeError: Overflow: input needs wider integers to process$/);
+assert.throws(() => {
+  punycode.decode(' ');
+}, /^RangeError: Invalid input$/);
 
 // http://tools.ietf.org/html/rfc3492#section-7.1
 const tests = [


### PR DESCRIPTION
## Purpose
Unify error wording and make it easy to understand.

### encode
##### Current behavior
`punycode.encode()`

| argument's type| result|
| --------------- |:---------------:|
| number| `''` | 
| string | `''`| 
| boolean | `''`| 
| undefined| error | 
| null| error | 
| object | `''`| 
| array | `''`| 
| function | `''`| 

`punycode.encode` is occurred an error when the argument is `undefined` and `null`.

##### Error log
```
TypeError: Cannot read property 'length' of undefined
    at ucs2decode (punycode.js:104:23)
    at Object.encode (punycode.js:291:10)
    at repl:1:10
    at realRunInThisContextScript (vm.js:22:35)
    at sigintHandlersWrap (vm.js:98:12)
    at ContextifyScript.Script.runInThisContext (vm.js:24:12)
    at REPLServer.defaultEval (repl.js:346:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.onLine (repl.js:544:10)
```

Modify error's wording like below.
```
TypeError: Argument must not be "undefined" and "null"
    at Object.encode (punycode.js:292:11)
    at repl:1:10
    at ContextifyScript.Script.runInThisContext (vm.js:23:33)
    at REPLServer.defaultEval (repl.js:340:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.onLine (repl.js:537:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:189:7)
    at REPLServer.Interface._onLine (readline.js:238:10)
```

### decode
##### Current behavior
`punycode.decode()`

| argument's type| result|
| --------------- |:---------------:|
| number| error| 
| string | `''`| 
| boolean | error| 
| undefined| error | 
| null| error | 
| object | error| 
| array | `''`(only empty arrays are accepted)| 
| function | error| 

`punycode.decode` is occurred an error when the argument isn't `string` and `array`.
We accpeted only a string.

##### Error log
undefined, null
```
TypeError: Cannot read property 'length' of undefined
    at Object.decode (punycode.js:199:27)
    at repl:1:10
    at realRunInThisContextScript (vm.js:22:35)
    at sigintHandlersWrap (vm.js:98:12)
    at ContextifyScript.Script.runInThisContext (vm.js:24:12)
    at REPLServer.defaultEval (repl.js:346:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.onLine (repl.js:544:10)
    at emitOne (events.js:101:20)
```
number, boolean, object, function
```
TypeError: input.lastIndexOf is not a function
    at Object.decode (punycode.js:208:20)
    at repl:1:10
    at realRunInThisContextScript (vm.js:22:35)
    at sigintHandlersWrap (vm.js:98:12)
    at ContextifyScript.Script.runInThisContext (vm.js:24:12)
    at REPLServer.defaultEval (repl.js:346:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.onLine (repl.js:544:10)
    at emitOne (events.js:101:20)
```

Modify error's wording like below.

```
TypeError: Argument must be a string
    at Object.decode (punycode.js:198:11)
    at repl:1:10
    at ContextifyScript.Script.runInThisContext (vm.js:23:33)
    at REPLServer.defaultEval (repl.js:340:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.onLine (repl.js:537:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:189:7)
    at REPLServer.Interface._onLine (readline.js:238:10)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
punycode, test