### PR TITLE
doc: make os api doc more consistent

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -26,6 +26,8 @@ A string constant defining the operating system-specific end-of-line marker:
 added: v0.5.0
 -->
 
+* Returns: {String}
+
 The `os.arch()` method returns a string identifying the operating system CPU
 architecture *for which the Node.js binary was compiled*.
 
@@ -36,6 +38,9 @@ The current possible values are: `'arm'`, `'arm64'`, `'ia32'`, `'mips'`,
 Equivalent to [`process.arch`][].
 
 ## os.constants
+<!-- YAML
+added: v6.3.0
+-->
 
 * {Object}
 


### PR DESCRIPTION
This adds a missing Returns to `os.arch()` as well as a missing added in
version to `os.constants`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc