### PR TITLE
test: allow for slow hosts in spawnSync() test

### DIFF
--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -1,11 +1,11 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const spawnSync = require('child_process').spawnSync;
 
 const TIMER = 200;
-const SLEEP = 5000;
+const SLEEP = common.platformTimeout(5000);
 
 switch (process.argv[2]) {
   case 'child':
@@ -19,7 +19,6 @@ switch (process.argv[2]) {
     const ret = spawnSync(process.execPath, [__filename, 'child'],
                         {timeout: TIMER});
     assert.strictEqual(ret.error.errno, 'ETIMEDOUT');
-    console.log(ret);
     const end = Date.now() - start;
     assert(end < SLEEP);
     assert(ret.status > 128 || ret.signal);


### PR DESCRIPTION
test-child-process-spawnsync-timeout failed from time to time on
Raspberry Pi devices. Use common.platformTimeout() to allow a little
more time to run on resource-constrained hosts.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process