### PR TITLE
tls: new tls.TLSSocket() supports sec ctx options

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -483,7 +483,12 @@ added: v0.11.4
     will be emitted on the socket before establishing a secure communication
   * `secureContext`: Optional TLS context object created with
     [`tls.createSecureContext()`][]. If a `secureContext` is _not_ provided, one
-    will be created by calling [`tls.createSecureContext()`][] with no options.
+    will be created by passing the entire `options` object to
+    `tls.createSecureContext()`. *Note*: In effect, all
+    [`tls.createSecureContext()`][] options can be provided, but they will be
+    _completely ignored_ unless the `secureContext` option is missing.
+  * ...: Optional [`tls.createSecureContext()`][] options can be provided, see
+    the `secureContext` option for more information.
 
 Construct a new `tls.TLSSocket` object from an existing TCP socket.
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -344,7 +344,7 @@ TLSSocket.prototype._wrapHandle = function(wrap) {
   // Wrap socket's handle
   var context = options.secureContext ||
                 options.credentials ||
-                tls.createSecureContext();
+                tls.createSecureContext(options);
   res = tls_wrap.wrap(handle._externalStream,
                       context.context,
                       !!options.isServer);

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 
-// Test a directly created TLS socket supports no options, and empty options.
+// Test directly created TLS sockets and options.
 
 const assert = require('assert');
 const join = require('path').join;
@@ -24,6 +24,16 @@ test({}, (err) => {
 
 test({secureContext: tls.createSecureContext({ca: keys.agent1.ca})}, (err) => {
   assert.ifError(err);
+});
+
+test({ca: keys.agent1.ca}, (err) => {
+  assert.ifError(err);
+});
+
+// Secure context options, like ca, are ignored if a sec ctx is explicitly
+// provided.
+test({secureContext: tls.createSecureContext(), ca: keys.agent1.ca}, (err) => {
+  assert.strictEqual(err.message, 'unable to verify the first certificate');
 });
 
 function test(client, callback) {

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -1,55 +1,59 @@
 'use strict';
 const common = require('../common');
+
+// Test a directly created TLS socket supports no options, and empty options.
+
 const assert = require('assert');
+const join = require('path').join;
+const {
+  connect, keys, tls
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
-  return;
+  process.exit(0);
 }
-const tls = require('tls');
 
-const fs = require('fs');
+test(undefined, (err) => {
+  assert.strictEqual(err.message, 'unable to verify the first certificate');
+});
 
-const sent = 'hello world';
+test({}, (err) => {
+  assert.strictEqual(err.message, 'unable to verify the first certificate');
+});
 
-const serverOptions = {
-  isServer: true,
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
-};
+test({secureContext: tls.createSecureContext({ca: keys.agent1.ca})}, (err) => {
+  assert.ifError(err);
+});
 
-function testSocketOptions(socket, socketOptions) {
-  let received = '';
-  const server = tls.createServer(serverOptions, function(s) {
-    s.on('data', function(chunk) {
-      received += chunk;
-    });
+function test(client, callback) {
+  callback = common.mustCall(callback);
+  connect({
+    server: {
+      key: keys.agent1.key,
+      cert: keys.agent1.cert,
+    },
+  }, function(err, pair, cleanup) {
+    assert.strictEqual(err.message, 'unable to verify the first certificate');
+    let recv = '';
+    pair.server.server.once('secureConnection', common.mustCall((conn) => {
+      conn.on('data', (data) => recv += data);
+      conn.on('end', common.mustCall(() => {
+        // Server sees nothing wrong with connection, even though the client's
+        // authentication of the server cert failed.
+        assert.strictEqual(recv, 'hello');
+        cleanup();
+      }));
+    }));
 
-    s.on('end', function() {
-      server.close();
-      s.destroy();
-      assert.strictEqual(received, sent);
-      setImmediate(runTests);
-    });
-  }).listen(0, function() {
-    const c = new tls.TLSSocket(socket, socketOptions);
-    c.connect(this.address().port, function() {
-      c.end(sent);
-    });
+    // Client doesn't support the 'secureConnect' event, and doesn't error if
+    // authentication failed. Caller must explicitly check for failure.
+    (new tls.TLSSocket(null, client)).connect(pair.server.server.address().port)
+      .on('connect', common.mustCall(function() {
+        this.end('hello');
+      }))
+      .on('secure', common.mustCall(function() {
+        callback(this.ssl.verifyError());
+      }));
   });
-
 }
-
-const testArgs = [
-  [],
-  [undefined, {}]
-];
-
-let n = 0;
-function runTests() {
-  if (n++ < testArgs.length) {
-    testSocketOptions.apply(null, testArgs[n]);
-  }
-}
-
-runTests();


### PR DESCRIPTION

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tls,test
