### PR TITLE
doc: add version meta for SSL_CERT_DIR/FILE

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -400,6 +400,9 @@ If the [`--openssl-config`][] command line option is used, the environment
 variable is ignored.
 
 ### `SSL_CERT_DIR=dir`
+<!-- YAML
+added: REPLACEME
+-->
 
 If `--use-openssl-ca` is enabled, this overrides and sets OpenSSL's directory
 containing trusted certificates.
@@ -409,6 +412,9 @@ evironment variable will be inherited by any child processes, and if they use
 OpenSSL, it may cause them to trust the same CAs as node.
 
 ### `SSL_CERT_FILE=file`
+<!-- YAML
+added: REPLACEME
+-->
 
 If `--use-openssl-ca` is enabled, this overrides and sets OpenSSL's file
 containing trusted certificates.


### PR DESCRIPTION
The metadata markup for when SSL_CERT_DIR and SSL_CERT_FILE added in
33012e9866cbb43db562dd6a3feffe8cd4ec5838 is missing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
