### PR TITLE
v4 backport: support "--" after "-e" as end-of-options

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -10,7 +10,7 @@ To view this documentation as a manual page in your terminal, run `man node`.
 
 ## Synopsis
 
-`node [options] [v8 options] [script.js | -e "script"] [arguments]`
+`node [options] [v8 options] [script.js | -e "script"] [--] [arguments]`
 
 `node debug [script.js | -e "script" | <host>:<port>] …`
 
@@ -177,6 +177,14 @@ added: v0.11.15
 
 Specify ICU data load path. (overrides `NODE_ICU_DATA`)
 
+### `--`
+<!-- YAML
+added: REPLACEME
+-->
+
+Indicate the end of node options. Pass the rest of the arguments to the script.
+If no script filename or eval/print script is supplied prior to this, then
+the next argument will be used as a script filename.
 
 ## Environment Variables
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -37,6 +37,7 @@ node \- Server-side JavaScript runtime
 .RI [ script.js \ |
 .B -e
 .RI \&" script \&"]
+.B [--]
 .RI [ arguments ]
 .br
 .B node debug
@@ -132,6 +133,12 @@ Specify an alternative default TLS cipher list. (Requires Node.js to be built wi
 .BR \-\-icu\-data\-dir =\fIfile\fR
 Specify ICU data load path. (overrides \fBNODE_ICU_DATA\fR)
 
+.TP
+.BR \-\-\fR
+Indicate the end of node options. Pass the rest of the arguments to the script.
+
+If no script filename or eval/print script is supplied prior to this, then
+the next argument will be used as a script filename.
 
 .SH ENVIRONMENT VARIABLES
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3570,6 +3570,9 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js
+    } else if (strcmp(arg, "--") == 0) {
+      index += 1;
+      break;
     } else {
       // V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -11,6 +11,10 @@ const child = require('child_process');
 const path = require('path');
 const nodejs = '"' + process.execPath + '"';
 
+if (process.argv.length > 2) {
+  console.log(process.argv.slice(2).join(' '));
+  process.exit(0);
+}
 
 // replace \ by / because windows uses backslashes in paths, but they're still
 // interpreted as the escape character when put between quotes.
@@ -91,3 +95,38 @@ child.exec(nodejs + ` -e 'require("child_process").fork("${emptyFile}")'`,
       assert.strictEqual(stdout, '');
       assert.strictEqual(stderr, '');
     });
+
+[ '-arg1',
+  '-arg1 arg2 --arg3',
+  '--',
+  'arg1 -- arg2',
+].forEach(function(args) {
+
+  // Ensure that arguments are successfully passed to eval.
+  const opt = ' --eval "console.log(process.argv.slice(1).join(\' \'))"';
+  const cmd = `${nodejs}${opt} -- ${args}`;
+  child.exec(cmd, common.mustCall(function(err, stdout, stderr) {
+    assert.strictEqual(stdout, args + '\n');
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(err, null);
+  }));
+
+  // Ensure that arguments are successfully passed to print.
+  const popt = ' --print "process.argv.slice(1).join(\' \')"';
+  const pcmd = `${nodejs}${popt} -- ${args}`;
+  child.exec(pcmd, common.mustCall(function(err, stdout, stderr) {
+    assert.strictEqual(stdout, args + '\n');
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(err, null);
+  }));
+
+  // Ensure that arguments are successfully passed to a script.
+  // The first argument after '--' should be interpreted as a script
+  // filename.
+  const filecmd = `${nodejs} -- ${__filename} ${args}`;
+  child.exec(filecmd, common.mustCall(function(err, stdout, stderr) {
+    assert.strictEqual(stdout, args + '\n');
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(err, null);
+  }));
+});


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/commit/0a9f360c98e4864327888a5030d55f7b2cdcc6d9
When the double dash "--" appears after "-e <script>" on the
command line, it indicates the end of options and the beginning
of positional parameters for the script.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
