### PR TITLE
v6 backport: support "--" after "-e" as end-of-options

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -10,7 +10,7 @@ To view this documentation as a manual page in your terminal, run `man node`.
 
 ## Synopsis
 
-`node [options] [v8 options] [script.js | -e "script"] [arguments]`
+`node [options] [v8 options] [script.js | -e "script"] [--] [arguments]`
 
 `node debug [script.js | -e "script" | <host>:<port>] …`
 
@@ -250,6 +250,15 @@ added: v0.11.15
 -->
 
 Specify ICU data load path. (overrides `NODE_ICU_DATA`)
+
+### `--`
+<!-- YAML
+added: REPLACEME
+-->
+
+Indicate the end of node options. Pass the rest of the arguments to the script.
+If no script filename or eval/print script is supplied prior to this, then
+the next argument will be used as a script filename.
 
 ## Environment Variables
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -37,6 +37,7 @@ node \- Server-side JavaScript runtime
 .RI [ script.js \ |
 .B -e
 .RI \&" script \&"]
+.B [--]
 .RI [ arguments ]
 .br
 .B node debug
@@ -174,6 +175,13 @@ used to enable FIPS-compliant crypto if Node.js is built with
 .TP
 .BR \-\-icu\-data\-dir =\fIfile\fR
 Specify ICU data load path. (overrides \fBNODE_ICU_DATA\fR)
+
+.TP
+.BR \-\-\fR
+Indicate the end of node options. Pass the rest of the arguments to the script.
+
+If no script filename or eval/print script is supplied prior to this, then
+the next argument will be used as a script filename.
 
 .SH ENVIRONMENT VARIABLES
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3853,6 +3853,9 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js
+    } else if (strcmp(arg, "--") == 0) {
+      index += 1;
+      break;
     } else {
       // V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/commit/0a9f360c98e4864327888a5030d55f7b2cdcc6d9
When the double dash "--" appears after "-e <script>" on the
command line, it indicates the end of options and the beginning
of positional parameters for the script.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
