### PR TITLE
timers: clarify lib/timer.js comment

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -72,7 +72,7 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // timeout later, thus only needing to be appended.
 // Removal from an object-property linked list is also virtually constant-time
 // as can be seen in the lib/internal/linkedlist.js implementation.
-// Timeouts only need to process any timers due to currently timeout, which will
+// Timeouts only need to process any timers currently due to expire, which will
 // always be at the beginning of the list for reasons stated above. Any timers
 // after the first one encountered that does not yet need to timeout will also
 // always be due to timeout at a later time.


### PR DESCRIPTION
I stumbled a little when reading the following line:
"Timeouts only need to process any timers due to currently timeout"
and want to suggest changing currently -> the current.

The rest of the changes are only formatting to adhere to the 80
characters code style.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers