### PR TITLE
doc: fix confusing example in dns.md

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -10,12 +10,12 @@ This category contains only one function: [`dns.lookup()`][]. **Developers
 looking to perform name resolution in the same way that other applications on
 the same operating system behave should use [`dns.lookup()`][].**
 
-For example, looking up `nodejs.org`.
+For example, looking up `iana.org`.
 
 ```js
 const dns = require('dns');
 
-dns.lookup('nodejs.org', (err, addresses, family) => {
+dns.lookup('iana.org', (err, addresses, family) => {
   console.log('addresses:', addresses);
 });
 ```
@@ -28,13 +28,13 @@ functions do not use the same set of configuration files used by
 developers who do not want to use the underlying operating system's facilities
 for name resolution, and instead want to _always_ perform DNS queries.
 
-Below is an example that resolves `'nodejs.org'` then reverse resolves the IP
+Below is an example that resolves `'archive.org'` then reverse resolves the IP
 addresses that are returned.
 
 ```js
 const dns = require('dns');
 
-dns.resolve4('nodejs.org', (err, addresses) => {
+dns.resolve4('archive.org', (err, addresses) => {
   if (err) throw err;
 
   console.log(`addresses: ${JSON.stringify(addresses)}`);


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc, dns

Currently, the second example throws `Error: getHostByAddr ENOTFOUND [IP]`. Somebody even [posts a question](http://stackoverflow.com/questions/39691318/node-js-throwing-error-when-trying-to-reverse-resolve-ip-address) in stackoverflow.com for this very example recently.

Unfortunately,  more neutral hostnames (like `example.com` or `github.com`) produce the same error. So I've replaced `nodejs.org` by `google.com`. If I should use something else, please, tell me.

The previous adjacent example is edited for consistency.
