### PR TITLE
test: guarantee test runs in test-readline-keys

### DIFF
--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const PassThrough = require('stream').PassThrough;
 const assert = require('assert');
 const inherits = require('util').inherits;
@@ -55,7 +55,7 @@ function addTest(sequences, expectedKeys) {
 
 const addKeyIntervalTest = (sequences, expectedKeys, interval = 550,
                             assertDelay = 550) => {
-  return (next) => () => {
+  const fn = common.mustCall((next) => () => {
 
     if (!Array.isArray(sequences)) {
       sequences = [ sequences ];
@@ -84,7 +84,8 @@ const addKeyIntervalTest = (sequences, expectedKeys, interval = 550,
       }
     };
     emitKeys(sequences);
-  };
+  });
+  return fn;
 };
 
 // regular alphanumerics


### PR DESCRIPTION
Use common.mustCall() to guarantee that test functions (created by a
factory function) are run.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test readline