### PR TITLE
test: add known_issues test for #10223

### DIFF
--- a/test/known_issues/test-vm-data-property-writable.js
+++ b/test/known_issues/test-vm-data-property-writable.js
@@ -1,0 +1,17 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/issues/10223
+
+require('../common');
+const vm = require('vm');
+const assert = require('assert');
+
+const context = vm.createContext({});
+
+const code = `
+   Object.defineProperty(this, 'foo', {value: 5});
+   Object.getOwnPropertyDescriptor(this, 'foo');
+`;
+
+const desc = vm.runInContext(code, context);
+
+assert.strictEqual(desc.writable, false);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tests

##### Description of change

Test addressing #10223 is added to the known_issues directory.
Writable attribute should be *false* by default.
 
In v6+ (reverted ```524f693```) it is set to *true* irrespective of whether 
it was set to *false* or left out in Object.defineProperty call.
It will be fixed with the 5.5 V8 API changes
