### PR TITLE
test-console: streamline arrow fn and refine inspect regex

### DIFF
--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -22,7 +22,7 @@ assert.doesNotThrow(function() {
 });
 
 // an Object with a custom .inspect() function
-const custom_inspect = { foo: 'bar', inspect: () => { return 'inspect'; } };
+const custom_inspect = { foo: 'bar', inspect: () => 'inspect' };
 
 const stdout_write = global.process.stdout.write;
 const stderr_write = global.process.stderr.write;
@@ -130,7 +130,7 @@ assert.strictEqual(errStrings.length, 0);
 
 assert.throws(() => {
   console.assert(false, 'should throw');
-}, /should throw/);
+}, /^AssertionError: should throw$/);
 
 assert.doesNotThrow(() => {
   console.assert(true, 'this should not throw');


### PR DESCRIPTION
removed unnecessary curly braces and return statement from the `inspect` arrow function

updated `assert.throws` regex to look for an exact match at the start of the string

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

