### PR TITLE
timers: use Maps for internal duration pooling

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -37,14 +37,14 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // operations as close to constant-time as possible.
 // (So that performance is not impacted by the number of scheduled timers.)
 //
-// Object maps are kept which contain linked lists keyed by their duration in
+// Maps are kept which contain linked lists keyed by their duration in
 // milliseconds.
 // The linked lists within also have some meta-properties, one of which is a
 // TimerWrap C++ handle, which makes the call after the duration to process the
 // list it is attached to.
 //
 //
-// ╔════ > Object Map
+// ╔════ > Map
 // ║
 // ╠══
 // ║ refedLists: { '40': { }, '320': { etc } } (keys of millisecond duration)
@@ -85,18 +85,17 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // other alternative timers architectures.
 
 
-// Object maps containing linked lists of timers, keyed and sorted by their
+// Maps containing linked lists of timers, keyed and sorted by their
 // duration in milliseconds.
 //
-// The difference between these two objects is that the former contains timers
+// The difference between these two Maps is that the former contains timers
 // that will keep the process open if they are the only thing left, while the
 // latter will not.
 //
 // - key = time in milliseconds
 // - value = linked list
-const refedLists = Object.create(null);
-const unrefedLists = Object.create(null);
-
+const refedLists = new Map();
+const unrefedLists = new Map();
 
 // Schedule or re-schedule a timer.
 // The item must have been enroll()'d first.
@@ -125,10 +124,11 @@ function insert(item, unrefed) {
   const lists = unrefed === true ? unrefedLists : refedLists;
 
   // Use an existing list if there is one, otherwise we need to make a new one.
-  var list = lists[msecs];
+  var list = lists.get(msecs);
   if (!list) {
     debug('no %d list was found in insert, creating a new one', msecs);
-    lists[msecs] = list = createTimersList(msecs, unrefed);
+    list = createTimersList(msecs, unrefed);
+    lists.set(msecs, list);
   }
 
   L.append(list, item);
@@ -220,10 +220,10 @@ function listOnTimeout() {
   // Either refedLists[msecs] or unrefedLists[msecs] may have been removed and
   // recreated since the reference to `list` was created. Make sure they're
   // the same instance of the list before destroying.
-  if (list._unrefed === true && list === unrefedLists[msecs]) {
-    delete unrefedLists[msecs];
-  } else if (list === refedLists[msecs]) {
-    delete refedLists[msecs];
+  if (list._unrefed === true && list === unrefedLists.get(msecs)) {
+    unrefedLists.delete(msecs);
+  } else if (list === refedLists.get(msecs)) {
+    refedLists.delete(msecs);
   }
 }
 
@@ -265,12 +265,12 @@ function listOnTimeoutNT(list) {
 function reuse(item) {
   L.remove(item);
 
-  var list = refedLists[item._idleTimeout];
+  var list = refedLists.get(item._idleTimeout);
   // if empty - reuse the watcher
   if (list && L.isEmpty(list)) {
     debug('reuse hit');
     list._timer.stop();
-    delete refedLists[item._idleTimeout];
+    refedLists.delete(item._idleTimeout);
     return list._timer;
   }
 


### PR DESCRIPTION
The ES benchmarks for maps show it fairly clearly as being faster, and I recall from other places that `Map`s are now supposed to be faster than Object Maps. As such, this PR switches timers' duration pooling to use `Map`s.

I did some initial benchmarking using the existing timers benchmarks and those from https://github.com/nodejs/node/pull/10925 which came up with some interesting results, but my machine was under other load at the time, so these are inconclusive:

```
                                                    improvement confidence      p.value
 timers/timers-breadth.js thousands=500                 -5.31 %        *** 4.071485e-06
 timers/timers-cancel-pooled.js thousands=500           -2.85 %         ** 1.209156e-03
 timers/timers-cancel-unpooled.js thousands=100       1507.75 %        *** 1.664058e-42
 timers/timers-depth.js thousands=1                      0.03 %            8.551970e-01
 timers/timers-insert-pooled.js thousands=500           -4.03 %        *** 1.004463e-06
 timers/timers-insert-unpooled.js thousands=100        -28.91 %        *** 4.867811e-38
```

_(This patch was made live during https://www.twitch.tv/videos/117984923 if you'd like to see me working on this in retrospect. :P)_

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers
