### PR TITLE
child_process: align fork/spawn stdio error msg 

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -18,7 +18,14 @@ const setupChannel = child_process.setupChannel;
 const ChildProcess = exports.ChildProcess = child_process.ChildProcess;
 
 function stdioStringToArray(option) {
-  return [option, option, option, 'ipc'];
+  switch (option) {
+    case 'ignore':
+    case 'pipe':
+    case 'inherit':
+      return [option, option, option, 'ipc'];
+    default:
+      throw new TypeError('Incorrect value of stdio option: ' + option);
+  }
 }
 
 exports.fork = function(modulePath /*, args, options*/) {
@@ -55,15 +62,7 @@ exports.fork = function(modulePath /*, args, options*/) {
   args = execArgv.concat([modulePath], args);
 
   if (typeof options.stdio === 'string') {
-    switch (options.stdio) {
-      case 'ignore':
-      case 'pipe':
-      case 'inherit':
-        options.stdio = stdioStringToArray(options.stdio);
-        break;
-      default:
-        throw new TypeError('Unknown stdio option');
-    }
+    options.stdio = stdioStringToArray(options.stdio);
   } else if (!Array.isArray(options.stdio)) {
     // Use a separate fd=3 for the IPC channel. Inherit stdin, stdout,
     // and stderr from the parent if silent isn't set.

--- a/test/parallel/test-child-process-fork-stdio-string-variant.js
+++ b/test/parallel/test-child-process-fork-stdio-string-variant.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 const fork = require('child_process').fork;
 
 const childScript = `${common.fixturesDir}/child-process-spawn-node`;
-const errorRegexp = /^TypeError: Unknown stdio option$/;
+const errorRegexp = /^TypeError: Incorrect value of stdio option:/;
 const malFormedOpts = {stdio: '33'};
 const payload = {hello: 'world'};
 const stringOpts = {stdio: 'pipe'};


### PR DESCRIPTION
fork()'s support for .stdio strings in 3268863 used a different
TypeError string from spawn, unnecessarily.
