### PR TITLE
src: make copies of startup environment variables

### DIFF
--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -46,11 +46,12 @@ void InitConfig(Local<Object> target,
   if (config_preserve_symlinks)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinks");
 
-  if (config_warning_file != nullptr) {
+  if (!config_warning_file.empty()) {
     Local<String> name = OneByteString(env->isolate(), "warningFile");
     Local<String> value = String::NewFromUtf8(env->isolate(),
-                                              config_warning_file,
-                                              v8::NewStringType::kNormal)
+                                              config_warning_file.data(),
+                                              v8::NewStringType::kNormal,
+                                              config_warning_file.size())
                                                 .ToLocalChecked();
     target->DefineOwnProperty(env->context(), name, value).FromJust();
   }

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -404,12 +404,8 @@ static void GetVersion(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-bool InitializeICUDirectory(const char* icu_data_path) {
-  if (icu_data_path != nullptr) {
-    flag_icu_data_dir = true;
-    u_setDataDirectory(icu_data_path);
-    return true;  // no error
-  } else {
+bool InitializeICUDirectory(const std::string& path) {
+  if (path.empty()) {
     UErrorCode status = U_ZERO_ERROR;
 #ifdef NODE_HAVE_SMALL_ICU
     // install the 'small' data.
@@ -418,6 +414,10 @@ bool InitializeICUDirectory(const char* icu_data_path) {
     // no small data, so nothing to do.
 #endif  // !NODE_HAVE_SMALL_ICU
     return (status == U_ZERO_ERROR);
+  } else {
+    flag_icu_data_dir = true;
+    u_setDataDirectory(path.c_str());
+    return true;  // No error.
   }
 }
 

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
+#include <string>
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
 
@@ -13,7 +14,7 @@ extern bool flag_icu_data_dir;
 
 namespace i18n {
 
-bool InitializeICUDirectory(const char* icu_data_path);
+bool InitializeICUDirectory(const std::string& path);
 
 int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 const char* input,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -13,6 +13,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <string>
+
 struct sockaddr;
 
 // Variation on NODE_DEFINE_CONSTANT that sets a String value.
@@ -45,7 +47,7 @@ extern bool config_preserve_symlinks;
 // Set in node.cc by ParseArgs when --redirect-warnings= is used.
 // Used to redirect warning output to a file rather than sending
 // it to stderr.
-extern const char* config_warning_file;
+extern std::string config_warning_file;  // NOLINT(runtime/string)
 
 // Tells whether it is safe to call v8::Isolate::GetCurrent().
 extern bool v8_initialized;


### PR DESCRIPTION
Mutations of the environment can invalidate pointers to environment
variables, so make `secure_getenv()` copy them out instead of returning
pointers.

cc @sam-github 

CI: https://ci.nodejs.org/job/node-test-pull-request/6087/