### PR TITLE
url: make URLSearchParams properties spec-compliant

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -647,6 +647,35 @@ function getObjectFromParams(array) {
   return obj;
 }
 
+// Mainly to mitigate func-name-matching ESLint rule
+function defineIDLClass(proto, classStr, obj) {
+  // https://heycam.github.io/webidl/#dfn-class-string
+  Object.defineProperty(proto, Symbol.toStringTag, {
+    writable: false,
+    enumerable: false,
+    configurable: true,
+    value: classStr
+  });
+
+  // https://heycam.github.io/webidl/#es-operations
+  for (const key of Object.keys(obj)) {
+    Object.defineProperty(proto, key, {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: obj[key]
+    });
+  }
+  for (const key of Object.getOwnPropertySymbols(obj)) {
+    Object.defineProperty(proto, key, {
+      writable: true,
+      enumerable: false,
+      configurable: true,
+      value: obj[key]
+    });
+  }
+}
+
 class URLSearchParams {
   constructor(init = '') {
     if (init instanceof URLSearchParams) {
@@ -662,11 +691,39 @@ class URLSearchParams {
     this[context] = null;
   }
 
-  get [Symbol.toStringTag]() {
-    return this instanceof URLSearchParams ?
-      'URLSearchParams' : 'URLSearchParamsPrototype';
-  }
+  [util.inspect.custom](recurseTimes, ctx) {
+    if (!this || !(this instanceof URLSearchParams)) {
+      throw new TypeError('Value of `this` is not a URLSearchParams');
+    }
 
+    const separator = ', ';
+    const innerOpts = Object.assign({}, ctx);
+    if (recurseTimes !== null) {
+      innerOpts.depth = recurseTimes - 1;
+    }
+    const innerInspect = (v) => util.inspect(v, innerOpts);
+
+    const list = this[searchParams];
+    const output = [];
+    for (var i = 0; i < list.length; i += 2)
+      output.push(`${innerInspect(list[i])} => ${innerInspect(list[i + 1])}`);
+
+    const colorRe = /\u001b\[\d\d?m/g;
+    const length = output.reduce(
+      (prev, cur) => prev + cur.replace(colorRe, '').length + separator.length,
+      -separator.length
+    );
+    if (length > ctx.breakLength) {
+      return `${this.constructor.name} {\n  ${output.join(',\n  ')} }`;
+    } else if (output.length) {
+      return `${this.constructor.name} { ${output.join(separator)} }`;
+    } else {
+      return `${this.constructor.name} {}`;
+    }
+  }
+}
+
+defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   append(name, value) {
     if (!this || !(this instanceof URLSearchParams)) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
@@ -679,7 +736,7 @@ class URLSearchParams {
     value = String(value);
     this[searchParams].push(name, value);
     update(this[context], this);
-  }
+  },
 
   delete(name) {
     if (!this || !(this instanceof URLSearchParams)) {
@@ -700,7 +757,62 @@ class URLSearchParams {
       }
     }
     update(this[context], this);
-  }
+  },
+
+  get(name) {
+    if (!this || !(this instanceof URLSearchParams)) {
+      throw new TypeError('Value of `this` is not a URLSearchParams');
+    }
+    if (arguments.length < 1) {
+      throw new TypeError('"name" argument must be specified');
+    }
+
+    const list = this[searchParams];
+    name = String(name);
+    for (var i = 0; i < list.length; i += 2) {
+      if (list[i] === name) {
+        return list[i + 1];
+      }
+    }
+    return null;
+  },
+
+  getAll(name) {
+    if (!this || !(this instanceof URLSearchParams)) {
+      throw new TypeError('Value of `this` is not a URLSearchParams');
+    }
+    if (arguments.length < 1) {
+      throw new TypeError('"name" argument must be specified');
+    }
+
+    const list = this[searchParams];
+    const values = [];
+    name = String(name);
+    for (var i = 0; i < list.length; i += 2) {
+      if (list[i] === name) {
+        values.push(list[i + 1]);
+      }
+    }
+    return values;
+  },
+
+  has(name) {
+    if (!this || !(this instanceof URLSearchParams)) {
+      throw new TypeError('Value of `this` is not a URLSearchParams');
+    }
+    if (arguments.length < 1) {
+      throw new TypeError('"name" argument must be specified');
+    }
+
+    const list = this[searchParams];
+    name = String(name);
+    for (var i = 0; i < list.length; i += 2) {
+      if (list[i] === name) {
+        return true;
+      }
+    }
+    return false;
+  },
 
   set(name, value) {
     if (!this || !(this instanceof URLSearchParams)) {
@@ -740,62 +852,7 @@ class URLSearchParams {
     }
 
     update(this[context], this);
-  }
-
-  get(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
-      throw new TypeError('Value of `this` is not a URLSearchParams');
-    }
-    if (arguments.length < 1) {
-      throw new TypeError('"name" argument must be specified');
-    }
-
-    const list = this[searchParams];
-    name = String(name);
-    for (var i = 0; i < list.length; i += 2) {
-      if (list[i] === name) {
-        return list[i + 1];
-      }
-    }
-    return null;
-  }
-
-  getAll(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
-      throw new TypeError('Value of `this` is not a URLSearchParams');
-    }
-    if (arguments.length < 1) {
-      throw new TypeError('"name" argument must be specified');
-    }
-
-    const list = this[searchParams];
-    const values = [];
-    name = String(name);
-    for (var i = 0; i < list.length; i += 2) {
-      if (list[i] === name) {
-        values.push(list[i + 1]);
-      }
-    }
-    return values;
-  }
-
-  has(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
-      throw new TypeError('Value of `this` is not a URLSearchParams');
-    }
-    if (arguments.length < 1) {
-      throw new TypeError('"name" argument must be specified');
-    }
-
-    const list = this[searchParams];
-    name = String(name);
-    for (var i = 0; i < list.length; i += 2) {
-      if (list[i] === name) {
-        return true;
-      }
-    }
-    return false;
-  }
+  },
 
   // https://heycam.github.io/webidl/#es-iterators
   // Define entries here rather than [Symbol.iterator] as the function name
@@ -806,7 +863,7 @@ class URLSearchParams {
     }
 
     return createSearchParamsIterator(this, 'key+value');
-  }
+  },
 
   forEach(callback, thisArg = undefined) {
     if (!this || !(this instanceof URLSearchParams)) {
@@ -827,7 +884,7 @@ class URLSearchParams {
       list = this[searchParams];
       i += 2;
     }
-  }
+  },
 
   // https://heycam.github.io/webidl/#es-iterable
   keys() {
@@ -836,7 +893,7 @@ class URLSearchParams {
     }
 
     return createSearchParamsIterator(this, 'key');
-  }
+  },
 
   values() {
     if (!this || !(this instanceof URLSearchParams)) {
@@ -844,8 +901,9 @@ class URLSearchParams {
     }
 
     return createSearchParamsIterator(this, 'value');
-  }
+  },
 
+  // https://heycam.github.io/webidl/#es-stringifier
   // https://url.spec.whatwg.org/#urlsearchparams-stringification-behavior
   toString() {
     if (!this || !(this instanceof URLSearchParams)) {
@@ -854,37 +912,14 @@ class URLSearchParams {
 
     return querystring.stringify(getObjectFromParams(this[searchParams]));
   }
-}
+});
+
 // https://heycam.github.io/webidl/#es-iterable-entries
-URLSearchParams.prototype[Symbol.iterator] = URLSearchParams.prototype.entries;
-
-URLSearchParams.prototype[util.inspect.custom] =
-  function inspect(recurseTimes, ctx) {
-    const separator = ', ';
-    const innerOpts = Object.assign({}, ctx);
-    if (recurseTimes !== null) {
-      innerOpts.depth = recurseTimes - 1;
-    }
-    const innerInspect = (v) => util.inspect(v, innerOpts);
-
-    const list = this[searchParams];
-    const output = [];
-    for (var i = 0; i < list.length; i += 2)
-      output.push(`${innerInspect(list[i])} => ${innerInspect(list[i + 1])}`);
-
-    const colorRe = /\u001b\[\d\d?m/g;
-    const length = output.reduce(
-      (prev, cur) => prev + cur.replace(colorRe, '').length + separator.length,
-      -separator.length
-    );
-    if (length > ctx.breakLength) {
-      return `${this.constructor.name} {\n  ${output.join(',\n  ')} }`;
-    } else if (output.length) {
-      return `${this.constructor.name} { ${output.join(separator)} }`;
-    } else {
-      return `${this.constructor.name} {}`;
-    }
-  };
+Object.defineProperty(URLSearchParams.prototype, Symbol.iterator, {
+  writable: true,
+  configurable: true,
+  value: URLSearchParams.prototype.entries
+});
 
 // https://heycam.github.io/webidl/#dfn-default-iterator-object
 function createSearchParamsIterator(target, kind) {
@@ -898,7 +933,9 @@ function createSearchParamsIterator(target, kind) {
 }
 
 // https://heycam.github.io/webidl/#dfn-iterator-prototype-object
-const URLSearchParamsIteratorPrototype = Object.setPrototypeOf({
+const URLSearchParamsIteratorPrototype = Object.create(IteratorPrototype);
+
+defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParamsIterator', {
   next() {
     if (!this ||
         Object.getPrototypeOf(this) !== URLSearchParamsIteratorPrototype) {
@@ -937,7 +974,7 @@ const URLSearchParamsIteratorPrototype = Object.setPrototypeOf({
       done: false
     };
   },
-  [util.inspect.custom]: function inspect(recurseTimes, ctx) {
+  [util.inspect.custom](recurseTimes, ctx) {
     const innerOpts = Object.assign({}, ctx);
     if (recurseTimes !== null) {
       innerOpts.depth = recurseTimes - 1;
@@ -968,15 +1005,6 @@ const URLSearchParamsIteratorPrototype = Object.setPrototypeOf({
     }
     return `${this[Symbol.toStringTag]} {${outputStr} }`;
   }
-}, IteratorPrototype);
-
-// Unlike interface and its prototype object, both default iterator object and
-// iterator prototype object of an interface have the same class string.
-Object.defineProperty(URLSearchParamsIteratorPrototype, Symbol.toStringTag, {
-  value: 'URLSearchParamsIterator',
-  writable: false,
-  enumerable: false,
-  configurable: true
 });
 
 function originFor(url, base) {

--- a/test/parallel/test-whatwg-url-tostringtag.js
+++ b/test/parallel/test-whatwg-url-tostringtag.js
@@ -7,7 +7,7 @@ const toString = Object.prototype.toString;
 
 const url = new URL('http://example.org');
 const sp = url.searchParams;
-const spIterator  = sp.entries();
+const spIterator = sp.entries();
 
 const test = [
   [url, 'URL'],

--- a/test/parallel/test-whatwg-url-tostringtag.js
+++ b/test/parallel/test-whatwg-url-tostringtag.js
@@ -7,18 +7,24 @@ const toString = Object.prototype.toString;
 
 const url = new URL('http://example.org');
 const sp = url.searchParams;
+const spIterator  = sp.entries();
 
 const test = [
-  [toString.call(url), 'URL'],
-  [toString.call(sp), 'URLSearchParams'],
+  [url, 'URL'],
+  [sp, 'URLSearchParams'],
+  [spIterator, 'URLSearchParamsIterator'],
   // Web IDL spec says we have to return 'URLPrototype', but it is too
   // expensive to implement; therefore, use Chrome's behavior for now, until
   // spec is changed.
-  [toString.call(Object.getPrototypeOf(url)), 'URL'],
-  [toString.call(Object.getPrototypeOf(sp)), 'URLSearchParams']
+  [Object.getPrototypeOf(url), 'URL'],
+  [Object.getPrototypeOf(sp), 'URLSearchParams'],
+  [Object.getPrototypeOf(spIterator), 'URLSearchParamsIterator'],
 ];
 
-test.forEach((row) => {
-  assert.strictEqual(row[0], `[object ${row[1]}]`,
-                     `${row[0]} !== [object ${row[1]}]`);
+test.forEach(([obj, expected]) => {
+  assert.strictEqual(obj[Symbol.toStringTag], expected,
+                     `${obj[Symbol.toStringTag]} !== ${expected}`);
+  const str = toString.call(obj);
+  assert.strictEqual(str, `[object ${expected}]`,
+                     `${str} !== [object ${expected}]`);
 });

--- a/test/parallel/test-whatwg-url-tostringtag.js
+++ b/test/parallel/test-whatwg-url-tostringtag.js
@@ -11,11 +11,11 @@ const sp = url.searchParams;
 const test = [
   [toString.call(url), 'URL'],
   [toString.call(sp), 'URLSearchParams'],
-  [toString.call(Object.getPrototypeOf(sp)), 'URLSearchParamsPrototype'],
   // Web IDL spec says we have to return 'URLPrototype', but it is too
   // expensive to implement; therefore, use Chrome's behavior for now, until
   // spec is changed.
-  [toString.call(Object.getPrototypeOf(url)), 'URL']
+  [toString.call(Object.getPrototypeOf(url)), 'URL'],
+  [toString.call(Object.getPrototypeOf(sp)), 'URLSearchParams']
 ];
 
 test.forEach((row) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Define `URLSearchParams` methods as enumerable, writable, configurable, as have already been done to `URL` in #10408. Also adjust the `@@toStringTag` variable, as done to `URL` in #10906.

Fixes: #10799

<details><summary>Benchmark (no significant differences)</summary>

```
                                                              improvement confidence   p.value
 url/url-searchparams-parse.js n=100000 type="encodelast"          0.96 %            0.5252137
 url/url-searchparams-parse.js n=100000 type="encodemany"         -1.82 %            0.1068003
 url/url-searchparams-parse.js n=100000 type="manypairs"          -0.32 %            0.5695471
 url/url-searchparams-parse.js n=100000 type="multicharsep"       -0.65 %            0.4697857
 url/url-searchparams-parse.js n=100000 type="multivalue"         -1.08 %            0.4232083
 url/url-searchparams-parse.js n=100000 type="multivaluemany"     -1.11 %            0.1315487
 url/url-searchparams-parse.js n=100000 type="noencode"            0.19 %            0.8053736
```
</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url