### PR TITLE
test: increase strictness for test-trace-event

### DIFF
--- a/test/parallel/test-trace-event.js
+++ b/test/parallel/test-trace-event.js
@@ -21,15 +21,19 @@ proc_no_categories.once('exit', common.mustCall(() => {
 
   proc.once('exit', common.mustCall(() => {
     assert(common.fileExists(FILE_NAME));
-    fs.readFile(FILE_NAME, (err, data) => {
+    fs.readFile(FILE_NAME, common.mustCall((err, data) => {
       const traces = JSON.parse(data.toString()).traceEvents;
       assert(traces.length > 0);
       // Values that should be present on all runs to approximate correctness.
-      assert(traces.some((trace) => { return trace.pid === proc.pid; }));
-      assert(traces.some((trace) => { return trace.cat === 'v8'; }));
       assert(traces.some((trace) => {
-        return trace.name === 'V8.ScriptCompiler';
+        if (trace.pid !== proc.pid)
+          return false;
+        if (trace.cat !== 'v8')
+          return false;
+        if (trace.name !== 'V8.ScriptCompiler')
+          return false;
+        return true;
       }));
-    });
+    }));
   }));
 }));


### PR DESCRIPTION
Change test-trace-event such that it checks that all expected values are
within the same trace object rather than scattered across multiple trace
objects.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test