### PR TITLE
removed unused arguments & switch '==' to '==='

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -35,7 +35,7 @@ const handleConversion = {
   'net.Native': {
     simultaneousAccepts: true,
 
-    send: function(message, handle, options) {
+    send: function(message, handle) {
       return handle;
     },
 
@@ -47,7 +47,7 @@ const handleConversion = {
   'net.Server': {
     simultaneousAccepts: true,
 
-    send: function(message, server, options) {
+    send: function(message, server) {
       return server._handle;
     },
 
@@ -132,7 +132,7 @@ const handleConversion = {
   'dgram.Native': {
     simultaneousAccepts: false,
 
-    send: function(message, handle, options) {
+    send: function(message, handle) {
       return handle;
     },
 
@@ -144,7 +144,7 @@ const handleConversion = {
   'dgram.Socket': {
     simultaneousAccepts: false,
 
-    send: function(message, socket, options) {
+    send: function(message, socket) {
       message.dgramType = socket.type;
 
       return socket._handle;
@@ -231,7 +231,7 @@ util.inherits(ChildProcess, EventEmitter);
 
 function flushStdio(subprocess) {
   if (subprocess.stdio == null) return;
-  subprocess.stdio.forEach(function(stream, fd, stdio) {
+  subprocess.stdio.forEach(function(stream) {
     if (!stream || !stream.readable || stream._readableState.readableListening)
       return;
     stream.resume();
@@ -887,7 +887,7 @@ function getSocketList(type, slave, key) {
 function maybeClose(subprocess) {
   subprocess._closesGot++;
 
-  if (subprocess._closesGot == subprocess._closesNeeded) {
+  if (subprocess._closesGot === subprocess._closesNeeded) {
     subprocess.emit('close', subprocess.exitCode, subprocess.signalCode);
   }
 }


### PR DESCRIPTION
removed 'options' arg from 'send' function in:
- handleconversion.'net.Native'
- handleconversion.'net.Server'
- handleconversion.'dgram.Native'
- handleconversion.'dgram.Socket'

removed 'fd' & 'stdio' args from 'flushStudio' function

altered if statement in 'maybeClose' function to use identity(===) rather than equality(==) operator for comparison of numeric values

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child-process
