### PR TITLE
test: require handler to be run in sigwinch test

### DIFF
--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -5,7 +5,7 @@ const originalRefreshSizeStderr = process.stderr._refreshSize;
 const originalRefreshSizeStdout = process.stdout._refreshSize;
 
 const wrap = (fn, ioStream, string) => {
-  return () => {
+  const wrapped = common.mustCall(() => {
     // The console.log() call prints a string that is in the .out file. In other
     // words, the console.log() is part of the test, not extraneous debugging.
     console.log(string);
@@ -16,7 +16,8 @@ const wrap = (fn, ioStream, string) => {
       if (!common.isSunOS || e.code !== 'EINVAL')
         throw e;
     }
-  };
+  });
+  return wrapped;
 };
 
 process.stderr._refreshSize = wrap(originalRefreshSizeStderr,


### PR DESCRIPTION
Use `common.mustCall()` to guarantee that the wrapped `_refreshSize()`
functions are invoked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tty